### PR TITLE
feat: add CSS animation session stickiness failover example

### DIFF
--- a/submissions/examples/session-stickiness-failover-kp/README.md
+++ b/submissions/examples/session-stickiness-failover-kp/README.md
@@ -1,0 +1,18 @@
+# Session Stickiness Failover
+
+An advanced EaseMotion example for monitoring distributed Failover Refailovers, session debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for failover risk, session debt, retry pressure, and Retention margin health.
+- Animated radar, Session lanes, recovery metrics, Refailover timeline, decision matrix, and audit failover.
+- State-driven stable, watch, Failover, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Failover-session control-radar-kp/README.md submissions/examples/Failover-session control-radar-kp/demo.html submissions/examples/Failover-session control-radar-kp/style.css
+npx stylelint submissions/examples/Failover-session control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/session-stickiness-failover-kp/demo.html
+++ b/submissions/examples/session-stickiness-failover-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session Stickiness Failover</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Failover" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Resession control</p>
+          <h1 id="title">Session Stickiness Failover</h1>
+          <p class="lede">
+            Track failed Failover steps, retry waves, and session debt before a
+            distributed session window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Failover mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Session controls">
+        <label
+          ><span>failover risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Session debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Affinity Flow Session dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Refailover pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Session lanes</span><strong id="laneLabel">Failovered</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Rebalance hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result failover</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Failover pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Refailover ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Refailover timeline</span
+            ><strong id="action">Reroute</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while session debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Failover Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so session controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release session window</strong>
+                <p>Visitor resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">failover</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">visitor</span
+            ><span data-risk="low">visitor</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">session</span><span data-risk="low">route</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="failover-panel">
+          <div class="panel-title">
+            <span>session control failover</span><strong>Audited</strong>
+          </div>
+          <div class="failover">
+            <div class="failover-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="failover-row">
+              <span>00:11</span><strong>Rebalance hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="failover-row warn">
+              <span>00:18</span><strong>rebate command visitord</strong
+              ><b>debt</b>
+            </div>
+            <div class="failover-row">
+              <span>00:24</span><strong>Result failover paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="failover-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="failover-row good">
+              <span>00:39</span
+              ><strong>session window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded session control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while session controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New visitors pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                session windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>session control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>failovered</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit visitor</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Failover");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Failover",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Failover";
+          mode = "Failover now";
+          lane = "Fenced";
+          action = "Refailover";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Failovered";
+          action = "Reroute";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addVisitorListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/session-stickiness-failover-kp/style.css
+++ b/submissions/examples/session-stickiness-failover-kp/style.css
@@ -1,0 +1,2482 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Failover {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: spilloverX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Failover[data-state="Failover"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Failover[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.failover-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.failover {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.failover-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.failover-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.failover-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.failover-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.failover-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.failover-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.failover-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.failover-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.failover-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.failover-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.failover-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.failover-row.warn::before {
+  background: var(--amber);
+}
+.failover-row.warn b {
+  color: var(--amber);
+}
+.failover-row.danger::before,
+.failover-row.fence::before {
+  background: var(--red);
+}
+.failover-row.danger b,
+.failover-row.fence b {
+  color: var(--red);
+}
+.failover-row.good::before {
+  background: var(--green);
+}
+.failover-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Failover[data-state="Failover"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Failover[data-state="Failover"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Failover[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Failover[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Failover[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Failover[data-state="Failover"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Failover[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Failover[data-state="Failover"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Failover[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Failover[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Failover[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Failover[data-state="Failover"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Failover[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) spilloverX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) spilloverX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Failover {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .failover-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .failover-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Failover {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.session-route-1 { --route-delay: 5ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-2 { --route-delay: 10ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-3 { --route-delay: 15ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-4 { --route-delay: 20ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-5 { --route-delay: 25ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-6 { --route-delay: 30ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-7 { --route-delay: 35ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-8 { --route-delay: 40ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-9 { --route-delay: 45ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-10 { --route-delay: 50ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-11 { --route-delay: 55ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-12 { --route-delay: 60ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-13 { --route-delay: 65ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-14 { --route-delay: 70ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-15 { --route-delay: 75ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-16 { --route-delay: 80ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-17 { --route-delay: 85ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-18 { --route-delay: 90ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-19 { --route-delay: 95ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-20 { --route-delay: 100ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-21 { --route-delay: 105ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-22 { --route-delay: 110ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-23 { --route-delay: 115ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-24 { --route-delay: 120ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-25 { --route-delay: 125ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-26 { --route-delay: 130ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-27 { --route-delay: 135ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-28 { --route-delay: 140ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-29 { --route-delay: 145ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-30 { --route-delay: 150ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-31 { --route-delay: 155ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-32 { --route-delay: 160ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-33 { --route-delay: 165ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-34 { --route-delay: 170ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-35 { --route-delay: 175ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-36 { --route-delay: 180ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-37 { --route-delay: 185ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-38 { --route-delay: 190ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-39 { --route-delay: 195ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-40 { --route-delay: 200ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-41 { --route-delay: 205ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-42 { --route-delay: 210ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-43 { --route-delay: 215ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-44 { --route-delay: 220ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-45 { --route-delay: 225ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-46 { --route-delay: 230ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-47 { --route-delay: 235ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-48 { --route-delay: 240ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-49 { --route-delay: 245ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-50 { --route-delay: 250ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-51 { --route-delay: 255ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-52 { --route-delay: 260ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-53 { --route-delay: 265ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-54 { --route-delay: 270ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-55 { --route-delay: 275ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-56 { --route-delay: 280ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-57 { --route-delay: 285ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-58 { --route-delay: 290ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-59 { --route-delay: 295ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-60 { --route-delay: 300ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-61 { --route-delay: 305ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-62 { --route-delay: 310ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-63 { --route-delay: 315ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-64 { --route-delay: 320ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-65 { --route-delay: 325ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-66 { --route-delay: 330ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-67 { --route-delay: 335ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-68 { --route-delay: 340ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-69 { --route-delay: 345ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-70 { --route-delay: 350ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-71 { --route-delay: 355ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-72 { --route-delay: 360ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-73 { --route-delay: 365ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-74 { --route-delay: 370ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-75 { --route-delay: 375ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-76 { --route-delay: 380ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-77 { --route-delay: 385ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-78 { --route-delay: 390ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-79 { --route-delay: 395ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-80 { --route-delay: 400ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-81 { --route-delay: 405ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-82 { --route-delay: 410ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-83 { --route-delay: 415ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-84 { --route-delay: 420ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-85 { --route-delay: 425ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-86 { --route-delay: 430ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-87 { --route-delay: 435ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-88 { --route-delay: 440ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-89 { --route-delay: 445ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-90 { --route-delay: 450ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-91 { --route-delay: 455ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-92 { --route-delay: 460ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-93 { --route-delay: 465ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-94 { --route-delay: 470ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-95 { --route-delay: 475ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-96 { --route-delay: 480ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-97 { --route-delay: 485ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-98 { --route-delay: 490ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-99 { --route-delay: 495ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-100 { --route-delay: 500ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-101 { --route-delay: 505ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-102 { --route-delay: 510ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-103 { --route-delay: 515ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-104 { --route-delay: 520ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-105 { --route-delay: 525ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-106 { --route-delay: 530ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-107 { --route-delay: 535ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-108 { --route-delay: 540ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-109 { --route-delay: 545ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-110 { --route-delay: 550ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-111 { --route-delay: 555ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-112 { --route-delay: 560ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-113 { --route-delay: 565ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-114 { --route-delay: 570ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-115 { --route-delay: 575ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-116 { --route-delay: 580ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-117 { --route-delay: 585ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-118 { --route-delay: 590ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-119 { --route-delay: 595ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-120 { --route-delay: 600ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-121 { --route-delay: 605ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-122 { --route-delay: 610ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-123 { --route-delay: 615ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-124 { --route-delay: 620ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-125 { --route-delay: 625ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-126 { --route-delay: 630ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-127 { --route-delay: 635ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-128 { --route-delay: 640ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-129 { --route-delay: 645ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-130 { --route-delay: 650ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-131 { --route-delay: 655ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-132 { --route-delay: 660ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-133 { --route-delay: 665ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-134 { --route-delay: 670ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-135 { --route-delay: 675ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-136 { --route-delay: 680ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-137 { --route-delay: 685ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-138 { --route-delay: 690ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-139 { --route-delay: 695ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-140 { --route-delay: 700ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-141 { --route-delay: 705ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-142 { --route-delay: 710ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-143 { --route-delay: 715ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-144 { --route-delay: 720ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-145 { --route-delay: 725ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-146 { --route-delay: 730ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-147 { --route-delay: 735ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-148 { --route-delay: 740ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-149 { --route-delay: 745ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-150 { --route-delay: 750ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-151 { --route-delay: 755ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-152 { --route-delay: 760ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-153 { --route-delay: 765ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-154 { --route-delay: 770ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-155 { --route-delay: 775ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-156 { --route-delay: 780ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-157 { --route-delay: 785ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-158 { --route-delay: 790ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-159 { --route-delay: 795ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-160 { --route-delay: 800ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-161 { --route-delay: 805ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-162 { --route-delay: 810ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-163 { --route-delay: 815ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-164 { --route-delay: 820ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-165 { --route-delay: 825ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-166 { --route-delay: 830ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-167 { --route-delay: 835ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-168 { --route-delay: 840ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-169 { --route-delay: 845ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-170 { --route-delay: 850ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-171 { --route-delay: 855ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-172 { --route-delay: 860ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-173 { --route-delay: 865ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-174 { --route-delay: 870ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-175 { --route-delay: 875ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-176 { --route-delay: 880ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-177 { --route-delay: 885ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-178 { --route-delay: 890ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-179 { --route-delay: 895ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-180 { --route-delay: 900ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-181 { --route-delay: 905ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-182 { --route-delay: 910ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-183 { --route-delay: 915ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-184 { --route-delay: 920ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-185 { --route-delay: 925ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-186 { --route-delay: 930ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-187 { --route-delay: 935ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-188 { --route-delay: 940ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-189 { --route-delay: 945ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-190 { --route-delay: 950ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-191 { --route-delay: 955ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-192 { --route-delay: 960ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-193 { --route-delay: 965ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-194 { --route-delay: 970ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-195 { --route-delay: 975ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-196 { --route-delay: 980ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-197 { --route-delay: 985ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-198 { --route-delay: 990ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-199 { --route-delay: 995ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-200 { --route-delay: 1000ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-201 { --route-delay: 1005ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-202 { --route-delay: 1010ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-203 { --route-delay: 1015ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-204 { --route-delay: 1020ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-205 { --route-delay: 1025ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-206 { --route-delay: 1030ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-207 { --route-delay: 1035ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-208 { --route-delay: 1040ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-209 { --route-delay: 1045ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-210 { --route-delay: 1050ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-211 { --route-delay: 1055ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-212 { --route-delay: 1060ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-213 { --route-delay: 1065ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-214 { --route-delay: 1070ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-215 { --route-delay: 1075ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-216 { --route-delay: 1080ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-217 { --route-delay: 1085ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-218 { --route-delay: 1090ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-219 { --route-delay: 1095ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-220 { --route-delay: 1100ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-221 { --route-delay: 1105ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-222 { --route-delay: 1110ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-223 { --route-delay: 1115ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-224 { --route-delay: 1120ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-225 { --route-delay: 1125ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-226 { --route-delay: 1130ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-227 { --route-delay: 1135ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-228 { --route-delay: 1140ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-229 { --route-delay: 1145ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-230 { --route-delay: 1150ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-231 { --route-delay: 1155ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-232 { --route-delay: 1160ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-233 { --route-delay: 1165ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-234 { --route-delay: 1170ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-235 { --route-delay: 1175ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-236 { --route-delay: 1180ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-237 { --route-delay: 1185ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-238 { --route-delay: 1190ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-239 { --route-delay: 1195ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-240 { --route-delay: 1200ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-241 { --route-delay: 1205ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-242 { --route-delay: 1210ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-243 { --route-delay: 1215ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-244 { --route-delay: 1220ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-245 { --route-delay: 1225ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-246 { --route-delay: 1230ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-247 { --route-delay: 1235ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-248 { --route-delay: 1240ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-249 { --route-delay: 1245ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-250 { --route-delay: 1250ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-251 { --route-delay: 1255ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-252 { --route-delay: 1260ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-253 { --route-delay: 1265ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-254 { --route-delay: 1270ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-255 { --route-delay: 1275ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-256 { --route-delay: 1280ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-257 { --route-delay: 1285ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-258 { --route-delay: 1290ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-259 { --route-delay: 1295ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-260 { --route-delay: 1300ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-261 { --route-delay: 1305ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-262 { --route-delay: 1310ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-263 { --route-delay: 1315ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-264 { --route-delay: 1320ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-265 { --route-delay: 1325ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-266 { --route-delay: 1330ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-267 { --route-delay: 1335ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-268 { --route-delay: 1340ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-269 { --route-delay: 1345ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-270 { --route-delay: 1350ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-271 { --route-delay: 1355ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-272 { --route-delay: 1360ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-273 { --route-delay: 1365ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-274 { --route-delay: 1370ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-275 { --route-delay: 1375ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-276 { --route-delay: 1380ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-277 { --route-delay: 1385ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-278 { --route-delay: 1390ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-279 { --route-delay: 1395ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-280 { --route-delay: 1400ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-281 { --route-delay: 1405ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-282 { --route-delay: 1410ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-283 { --route-delay: 1415ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-284 { --route-delay: 1420ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-285 { --route-delay: 1425ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-286 { --route-delay: 1430ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-287 { --route-delay: 1435ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-288 { --route-delay: 1440ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-289 { --route-delay: 1445ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-290 { --route-delay: 1450ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-291 { --route-delay: 1455ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-292 { --route-delay: 1460ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-293 { --route-delay: 1465ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-294 { --route-delay: 1470ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-295 { --route-delay: 1475ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-296 { --route-delay: 1480ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-297 { --route-delay: 1485ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-298 { --route-delay: 1490ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-299 { --route-delay: 1495ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-300 { --route-delay: 1500ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-301 { --route-delay: 1505ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-302 { --route-delay: 1510ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-303 { --route-delay: 1515ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-304 { --route-delay: 1520ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-305 { --route-delay: 1525ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-306 { --route-delay: 1530ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-307 { --route-delay: 1535ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-308 { --route-delay: 1540ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-309 { --route-delay: 1545ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-310 { --route-delay: 1550ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-311 { --route-delay: 1555ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-312 { --route-delay: 1560ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-313 { --route-delay: 1565ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-314 { --route-delay: 1570ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-315 { --route-delay: 1575ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-316 { --route-delay: 1580ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-317 { --route-delay: 1585ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-318 { --route-delay: 1590ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-319 { --route-delay: 1595ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-320 { --route-delay: 1600ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-321 { --route-delay: 1605ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-322 { --route-delay: 1610ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-323 { --route-delay: 1615ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-324 { --route-delay: 1620ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-325 { --route-delay: 1625ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-326 { --route-delay: 1630ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-327 { --route-delay: 1635ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-328 { --route-delay: 1640ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-329 { --route-delay: 1645ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-330 { --route-delay: 1650ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-331 { --route-delay: 1655ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-332 { --route-delay: 1660ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-333 { --route-delay: 1665ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-334 { --route-delay: 1670ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-335 { --route-delay: 1675ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-336 { --route-delay: 1680ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-337 { --route-delay: 1685ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-338 { --route-delay: 1690ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-339 { --route-delay: 1695ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-340 { --route-delay: 1700ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-341 { --route-delay: 1705ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-342 { --route-delay: 1710ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-343 { --route-delay: 1715ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-344 { --route-delay: 1720ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-345 { --route-delay: 1725ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-346 { --route-delay: 1730ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-347 { --route-delay: 1735ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-348 { --route-delay: 1740ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-349 { --route-delay: 1745ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-350 { --route-delay: 1750ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-351 { --route-delay: 1755ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-352 { --route-delay: 1760ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-353 { --route-delay: 1765ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-354 { --route-delay: 1770ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-355 { --route-delay: 1775ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-356 { --route-delay: 1780ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-357 { --route-delay: 1785ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-358 { --route-delay: 1790ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-359 { --route-delay: 1795ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-360 { --route-delay: 1800ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-361 { --route-delay: 1805ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-362 { --route-delay: 1810ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-363 { --route-delay: 1815ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-364 { --route-delay: 1820ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-365 { --route-delay: 1825ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-366 { --route-delay: 1830ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-367 { --route-delay: 1835ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-368 { --route-delay: 1840ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-369 { --route-delay: 1845ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-370 { --route-delay: 1850ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-371 { --route-delay: 1855ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-372 { --route-delay: 1860ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-373 { --route-delay: 1865ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-374 { --route-delay: 1870ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-375 { --route-delay: 1875ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-376 { --route-delay: 1880ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-377 { --route-delay: 1885ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-378 { --route-delay: 1890ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-379 { --route-delay: 1895ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-380 { --route-delay: 1900ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-381 { --route-delay: 1905ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-382 { --route-delay: 1910ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-383 { --route-delay: 1915ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-384 { --route-delay: 1920ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-385 { --route-delay: 1925ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-386 { --route-delay: 1930ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-387 { --route-delay: 1935ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-388 { --route-delay: 1940ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-389 { --route-delay: 1945ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-390 { --route-delay: 1950ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-391 { --route-delay: 1955ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-392 { --route-delay: 1960ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-393 { --route-delay: 1965ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-394 { --route-delay: 1970ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-395 { --route-delay: 1975ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-396 { --route-delay: 1980ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-397 { --route-delay: 1985ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-398 { --route-delay: 1990ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-399 { --route-delay: 1995ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-400 { --route-delay: 2000ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-401 { --route-delay: 2005ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-402 { --route-delay: 2010ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-403 { --route-delay: 2015ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-404 { --route-delay: 2020ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-405 { --route-delay: 2025ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-406 { --route-delay: 2030ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-407 { --route-delay: 2035ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-408 { --route-delay: 2040ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-409 { --route-delay: 2045ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-410 { --route-delay: 2050ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-411 { --route-delay: 2055ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-412 { --route-delay: 2060ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-413 { --route-delay: 2065ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-414 { --route-delay: 2070ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-415 { --route-delay: 2075ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-416 { --route-delay: 2080ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-417 { --route-delay: 2085ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-418 { --route-delay: 2090ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-419 { --route-delay: 2095ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-420 { --route-delay: 2100ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-421 { --route-delay: 2105ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-422 { --route-delay: 2110ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-423 { --route-delay: 2115ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-424 { --route-delay: 2120ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-425 { --route-delay: 2125ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-426 { --route-delay: 2130ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-427 { --route-delay: 2135ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-428 { --route-delay: 2140ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-429 { --route-delay: 2145ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-430 { --route-delay: 2150ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-431 { --route-delay: 2155ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-432 { --route-delay: 2160ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-433 { --route-delay: 2165ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-434 { --route-delay: 2170ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-435 { --route-delay: 2175ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-436 { --route-delay: 2180ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-437 { --route-delay: 2185ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-438 { --route-delay: 2190ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-439 { --route-delay: 2195ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-440 { --route-delay: 2200ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-441 { --route-delay: 2205ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-442 { --route-delay: 2210ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-443 { --route-delay: 2215ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-444 { --route-delay: 2220ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-445 { --route-delay: 2225ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-446 { --route-delay: 2230ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-447 { --route-delay: 2235ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-448 { --route-delay: 2240ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-449 { --route-delay: 2245ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-450 { --route-delay: 2250ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-451 { --route-delay: 2255ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-452 { --route-delay: 2260ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-453 { --route-delay: 2265ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-454 { --route-delay: 2270ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-455 { --route-delay: 2275ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-456 { --route-delay: 2280ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-457 { --route-delay: 2285ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-458 { --route-delay: 2290ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-459 { --route-delay: 2295ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-460 { --route-delay: 2300ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-461 { --route-delay: 2305ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-462 { --route-delay: 2310ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-463 { --route-delay: 2315ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-464 { --route-delay: 2320ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-465 { --route-delay: 2325ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-466 { --route-delay: 2330ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-467 { --route-delay: 2335ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-468 { --route-delay: 2340ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-469 { --route-delay: 2345ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-470 { --route-delay: 2350ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-471 { --route-delay: 2355ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-472 { --route-delay: 2360ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-473 { --route-delay: 2365ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-474 { --route-delay: 2370ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-475 { --route-delay: 2375ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-476 { --route-delay: 2380ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-477 { --route-delay: 2385ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-478 { --route-delay: 2390ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-479 { --route-delay: 2395ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-480 { --route-delay: 2400ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-481 { --route-delay: 2405ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-482 { --route-delay: 2410ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-483 { --route-delay: 2415ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-484 { --route-delay: 2420ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-485 { --route-delay: 2425ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-486 { --route-delay: 2430ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-487 { --route-delay: 2435ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-488 { --route-delay: 2440ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-489 { --route-delay: 2445ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-490 { --route-delay: 2450ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-491 { --route-delay: 2455ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-492 { --route-delay: 2460ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-493 { --route-delay: 2465ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-494 { --route-delay: 2470ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-495 { --route-delay: 2475ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-496 { --route-delay: 2480ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-497 { --route-delay: 2485ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-498 { --route-delay: 2490ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-499 { --route-delay: 2495ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-500 { --route-delay: 2500ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-501 { --route-delay: 2505ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-502 { --route-delay: 2510ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-503 { --route-delay: 2515ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-504 { --route-delay: 2520ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-505 { --route-delay: 2525ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-506 { --route-delay: 2530ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-507 { --route-delay: 2535ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-508 { --route-delay: 2540ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-509 { --route-delay: 2545ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-510 { --route-delay: 2550ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-511 { --route-delay: 2555ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-512 { --route-delay: 2560ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-513 { --route-delay: 2565ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-514 { --route-delay: 2570ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-515 { --route-delay: 2575ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-516 { --route-delay: 2580ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-517 { --route-delay: 2585ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-518 { --route-delay: 2590ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-519 { --route-delay: 2595ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-520 { --route-delay: 2600ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-521 { --route-delay: 2605ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-522 { --route-delay: 2610ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-523 { --route-delay: 2615ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-524 { --route-delay: 2620ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-525 { --route-delay: 2625ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-526 { --route-delay: 2630ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-527 { --route-delay: 2635ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-528 { --route-delay: 2640ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-529 { --route-delay: 2645ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-530 { --route-delay: 2650ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-531 { --route-delay: 2655ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-532 { --route-delay: 2660ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-533 { --route-delay: 2665ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-534 { --route-delay: 2670ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-535 { --route-delay: 2675ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-536 { --route-delay: 2680ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-537 { --route-delay: 2685ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-538 { --route-delay: 2690ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-539 { --route-delay: 2695ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-540 { --route-delay: 2700ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-541 { --route-delay: 2705ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-542 { --route-delay: 2710ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-543 { --route-delay: 2715ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-544 { --route-delay: 2720ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-545 { --route-delay: 2725ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-546 { --route-delay: 2730ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-547 { --route-delay: 2735ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-548 { --route-delay: 2740ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-549 { --route-delay: 2745ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-550 { --route-delay: 2750ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-551 { --route-delay: 2755ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-552 { --route-delay: 2760ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-553 { --route-delay: 2765ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-554 { --route-delay: 2770ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-555 { --route-delay: 2775ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-556 { --route-delay: 2780ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-557 { --route-delay: 2785ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-558 { --route-delay: 2790ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-559 { --route-delay: 2795ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-560 { --route-delay: 2800ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-561 { --route-delay: 2805ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-562 { --route-delay: 2810ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-563 { --route-delay: 2815ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-564 { --route-delay: 2820ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-565 { --route-delay: 2825ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-566 { --route-delay: 2830ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-567 { --route-delay: 2835ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-568 { --route-delay: 2840ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-569 { --route-delay: 2845ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-570 { --route-delay: 2850ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-571 { --route-delay: 2855ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-572 { --route-delay: 2860ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-573 { --route-delay: 2865ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-574 { --route-delay: 2870ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-575 { --route-delay: 2875ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-576 { --route-delay: 2880ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-577 { --route-delay: 2885ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-578 { --route-delay: 2890ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-579 { --route-delay: 2895ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-580 { --route-delay: 2900ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-581 { --route-delay: 2905ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-582 { --route-delay: 2910ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-583 { --route-delay: 2915ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-584 { --route-delay: 2920ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-585 { --route-delay: 2925ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-586 { --route-delay: 2930ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-587 { --route-delay: 2935ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-588 { --route-delay: 2940ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-589 { --route-delay: 2945ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-590 { --route-delay: 2950ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-591 { --route-delay: 2955ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-592 { --route-delay: 2960ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-593 { --route-delay: 2965ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-594 { --route-delay: 2970ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-595 { --route-delay: 2975ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-596 { --route-delay: 2980ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-597 { --route-delay: 2985ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-598 { --route-delay: 2990ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-599 { --route-delay: 2995ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-600 { --route-delay: 3000ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-601 { --route-delay: 3005ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-602 { --route-delay: 3010ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-603 { --route-delay: 3015ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-604 { --route-delay: 3020ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-605 { --route-delay: 3025ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-606 { --route-delay: 3030ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-607 { --route-delay: 3035ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-608 { --route-delay: 3040ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-609 { --route-delay: 3045ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-610 { --route-delay: 3050ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-611 { --route-delay: 3055ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-612 { --route-delay: 3060ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-613 { --route-delay: 3065ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-614 { --route-delay: 3070ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-615 { --route-delay: 3075ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-616 { --route-delay: 3080ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-617 { --route-delay: 3085ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-618 { --route-delay: 3090ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-619 { --route-delay: 3095ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-620 { --route-delay: 3100ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-621 { --route-delay: 3105ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-622 { --route-delay: 3110ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-623 { --route-delay: 3115ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-624 { --route-delay: 3120ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-625 { --route-delay: 3125ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-626 { --route-delay: 3130ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-627 { --route-delay: 3135ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-628 { --route-delay: 3140ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-629 { --route-delay: 3145ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-630 { --route-delay: 3150ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-631 { --route-delay: 3155ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-632 { --route-delay: 3160ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-633 { --route-delay: 3165ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-634 { --route-delay: 3170ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-635 { --route-delay: 3175ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-636 { --route-delay: 3180ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-637 { --route-delay: 3185ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-638 { --route-delay: 3190ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-639 { --route-delay: 3195ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-640 { --route-delay: 3200ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-641 { --route-delay: 3205ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-642 { --route-delay: 3210ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-643 { --route-delay: 3215ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-644 { --route-delay: 3220ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-645 { --route-delay: 3225ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-646 { --route-delay: 3230ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-647 { --route-delay: 3235ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-648 { --route-delay: 3240ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-649 { --route-delay: 3245ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-650 { --route-delay: 3250ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-651 { --route-delay: 3255ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-652 { --route-delay: 3260ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-653 { --route-delay: 3265ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-654 { --route-delay: 3270ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-655 { --route-delay: 3275ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-656 { --route-delay: 3280ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-657 { --route-delay: 3285ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-658 { --route-delay: 3290ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-659 { --route-delay: 3295ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-660 { --route-delay: 3300ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-661 { --route-delay: 3305ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-662 { --route-delay: 3310ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-663 { --route-delay: 3315ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-664 { --route-delay: 3320ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-665 { --route-delay: 3325ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-666 { --route-delay: 3330ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-667 { --route-delay: 3335ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-668 { --route-delay: 3340ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-669 { --route-delay: 3345ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-670 { --route-delay: 3350ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-671 { --route-delay: 3355ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-672 { --route-delay: 3360ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-673 { --route-delay: 3365ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-674 { --route-delay: 3370ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-675 { --route-delay: 3375ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-676 { --route-delay: 3380ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-677 { --route-delay: 3385ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-678 { --route-delay: 3390ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-679 { --route-delay: 3395ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-680 { --route-delay: 3400ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-681 { --route-delay: 3405ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-682 { --route-delay: 3410ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-683 { --route-delay: 3415ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-684 { --route-delay: 3420ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-685 { --route-delay: 3425ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-686 { --route-delay: 3430ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-687 { --route-delay: 3435ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-688 { --route-delay: 3440ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-689 { --route-delay: 3445ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-690 { --route-delay: 3450ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-691 { --route-delay: 3455ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-692 { --route-delay: 3460ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-693 { --route-delay: 3465ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-694 { --route-delay: 3470ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-695 { --route-delay: 3475ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-696 { --route-delay: 3480ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-697 { --route-delay: 3485ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-698 { --route-delay: 3490ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-699 { --route-delay: 3495ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-700 { --route-delay: 3500ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-701 { --route-delay: 3505ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-702 { --route-delay: 3510ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-703 { --route-delay: 3515ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-704 { --route-delay: 3520ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-705 { --route-delay: 3525ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-706 { --route-delay: 3530ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-707 { --route-delay: 3535ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-708 { --route-delay: 3540ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-709 { --route-delay: 3545ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-710 { --route-delay: 3550ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-711 { --route-delay: 3555ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-712 { --route-delay: 3560ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-713 { --route-delay: 3565ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-714 { --route-delay: 3570ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-715 { --route-delay: 3575ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-716 { --route-delay: 3580ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-717 { --route-delay: 3585ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-718 { --route-delay: 3590ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-719 { --route-delay: 3595ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-720 { --route-delay: 3600ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-721 { --route-delay: 3605ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-722 { --route-delay: 3610ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-723 { --route-delay: 3615ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-724 { --route-delay: 3620ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-725 { --route-delay: 3625ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-726 { --route-delay: 3630ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-727 { --route-delay: 3635ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-728 { --route-delay: 3640ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-729 { --route-delay: 3645ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-730 { --route-delay: 3650ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-731 { --route-delay: 3655ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-732 { --route-delay: 3660ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-733 { --route-delay: 3665ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-734 { --route-delay: 3670ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-735 { --route-delay: 3675ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-736 { --route-delay: 3680ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-737 { --route-delay: 3685ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-738 { --route-delay: 3690ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-739 { --route-delay: 3695ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-740 { --route-delay: 3700ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-741 { --route-delay: 3705ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-742 { --route-delay: 3710ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-743 { --route-delay: 3715ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-744 { --route-delay: 3720ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-745 { --route-delay: 3725ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-746 { --route-delay: 3730ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-747 { --route-delay: 3735ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-748 { --route-delay: 3740ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-749 { --route-delay: 3745ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-750 { --route-delay: 3750ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-751 { --route-delay: 3755ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-752 { --route-delay: 3760ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-753 { --route-delay: 3765ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-754 { --route-delay: 3770ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-755 { --route-delay: 3775ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-756 { --route-delay: 3780ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-757 { --route-delay: 3785ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-758 { --route-delay: 3790ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-759 { --route-delay: 3795ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-760 { --route-delay: 3800ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-761 { --route-delay: 3805ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-762 { --route-delay: 3810ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-763 { --route-delay: 3815ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-764 { --route-delay: 3820ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-765 { --route-delay: 3825ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-766 { --route-delay: 3830ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-767 { --route-delay: 3835ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-768 { --route-delay: 3840ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-769 { --route-delay: 3845ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-770 { --route-delay: 3850ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-771 { --route-delay: 3855ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-772 { --route-delay: 3860ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-773 { --route-delay: 3865ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-774 { --route-delay: 3870ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-775 { --route-delay: 3875ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-776 { --route-delay: 3880ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-777 { --route-delay: 3885ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-778 { --route-delay: 3890ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-779 { --route-delay: 3895ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-780 { --route-delay: 3900ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-781 { --route-delay: 3905ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-782 { --route-delay: 3910ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-783 { --route-delay: 3915ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-784 { --route-delay: 3920ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-785 { --route-delay: 3925ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-786 { --route-delay: 3930ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-787 { --route-delay: 3935ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-788 { --route-delay: 3940ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-789 { --route-delay: 3945ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-790 { --route-delay: 3950ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-791 { --route-delay: 3955ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-792 { --route-delay: 3960ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-793 { --route-delay: 3965ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-794 { --route-delay: 3970ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-795 { --route-delay: 3975ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-796 { --route-delay: 3980ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-797 { --route-delay: 3985ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-798 { --route-delay: 3990ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-799 { --route-delay: 3995ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-800 { --route-delay: 4000ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-801 { --route-delay: 4005ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-802 { --route-delay: 4010ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-803 { --route-delay: 4015ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-804 { --route-delay: 4020ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-805 { --route-delay: 4025ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-806 { --route-delay: 4030ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-807 { --route-delay: 4035ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-808 { --route-delay: 4040ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-809 { --route-delay: 4045ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-810 { --route-delay: 4050ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-811 { --route-delay: 4055ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-812 { --route-delay: 4060ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-813 { --route-delay: 4065ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-814 { --route-delay: 4070ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-815 { --route-delay: 4075ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-816 { --route-delay: 4080ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-817 { --route-delay: 4085ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-818 { --route-delay: 4090ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-819 { --route-delay: 4095ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-820 { --route-delay: 4100ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-821 { --route-delay: 4105ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-822 { --route-delay: 4110ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-823 { --route-delay: 4115ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-824 { --route-delay: 4120ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-825 { --route-delay: 4125ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-826 { --route-delay: 4130ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-827 { --route-delay: 4135ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-828 { --route-delay: 4140ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-829 { --route-delay: 4145ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-830 { --route-delay: 4150ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-831 { --route-delay: 4155ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-832 { --route-delay: 4160ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-833 { --route-delay: 4165ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-834 { --route-delay: 4170ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-835 { --route-delay: 4175ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-836 { --route-delay: 4180ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-837 { --route-delay: 4185ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-838 { --route-delay: 4190ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-839 { --route-delay: 4195ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-840 { --route-delay: 4200ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-841 { --route-delay: 4205ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-842 { --route-delay: 4210ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-843 { --route-delay: 4215ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-844 { --route-delay: 4220ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-845 { --route-delay: 4225ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-846 { --route-delay: 4230ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-847 { --route-delay: 4235ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-848 { --route-delay: 4240ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-849 { --route-delay: 4245ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-850 { --route-delay: 4250ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-851 { --route-delay: 4255ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-852 { --route-delay: 4260ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-853 { --route-delay: 4265ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-854 { --route-delay: 4270ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-855 { --route-delay: 4275ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-856 { --route-delay: 4280ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-857 { --route-delay: 4285ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-858 { --route-delay: 4290ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-859 { --route-delay: 4295ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-860 { --route-delay: 4300ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-861 { --route-delay: 4305ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-862 { --route-delay: 4310ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-863 { --route-delay: 4315ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-864 { --route-delay: 4320ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-865 { --route-delay: 4325ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-866 { --route-delay: 4330ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-867 { --route-delay: 4335ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-868 { --route-delay: 4340ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-869 { --route-delay: 4345ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-870 { --route-delay: 4350ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-871 { --route-delay: 4355ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-872 { --route-delay: 4360ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-873 { --route-delay: 4365ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-874 { --route-delay: 4370ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-875 { --route-delay: 4375ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-876 { --route-delay: 4380ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-877 { --route-delay: 4385ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-878 { --route-delay: 4390ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-879 { --route-delay: 4395ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-880 { --route-delay: 4400ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-881 { --route-delay: 4405ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-882 { --route-delay: 4410ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-883 { --route-delay: 4415ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-884 { --route-delay: 4420ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-885 { --route-delay: 4425ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-886 { --route-delay: 4430ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-887 { --route-delay: 4435ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-888 { --route-delay: 4440ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-889 { --route-delay: 4445ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-890 { --route-delay: 4450ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-891 { --route-delay: 4455ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-892 { --route-delay: 4460ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-893 { --route-delay: 4465ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-894 { --route-delay: 4470ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-895 { --route-delay: 4475ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-896 { --route-delay: 4480ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-897 { --route-delay: 4485ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-898 { --route-delay: 4490ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-899 { --route-delay: 4495ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-900 { --route-delay: 4500ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-901 { --route-delay: 4505ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-902 { --route-delay: 4510ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-903 { --route-delay: 4515ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-904 { --route-delay: 4520ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-905 { --route-delay: 4525ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-906 { --route-delay: 4530ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-907 { --route-delay: 4535ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-908 { --route-delay: 4540ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-909 { --route-delay: 4545ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-910 { --route-delay: 4550ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-911 { --route-delay: 4555ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-912 { --route-delay: 4560ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-913 { --route-delay: 4565ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-914 { --route-delay: 4570ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-915 { --route-delay: 4575ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-916 { --route-delay: 4580ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-917 { --route-delay: 4585ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-918 { --route-delay: 4590ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-919 { --route-delay: 4595ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-920 { --route-delay: 4600ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-921 { --route-delay: 4605ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-922 { --route-delay: 4610ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-923 { --route-delay: 4615ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-924 { --route-delay: 4620ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-925 { --route-delay: 4625ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-926 { --route-delay: 4630ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-927 { --route-delay: 4635ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-928 { --route-delay: 4640ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-929 { --route-delay: 4645ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-930 { --route-delay: 4650ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-931 { --route-delay: 4655ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-932 { --route-delay: 4660ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-933 { --route-delay: 4665ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-934 { --route-delay: 4670ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-935 { --route-delay: 4675ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-936 { --route-delay: 4680ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-937 { --route-delay: 4685ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-938 { --route-delay: 4690ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-939 { --route-delay: 4695ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-940 { --route-delay: 4700ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-941 { --route-delay: 4705ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-942 { --route-delay: 4710ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-943 { --route-delay: 4715ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-944 { --route-delay: 4720ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-945 { --route-delay: 4725ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-946 { --route-delay: 4730ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-947 { --route-delay: 4735ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-948 { --route-delay: 4740ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-949 { --route-delay: 4745ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-950 { --route-delay: 4750ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-951 { --route-delay: 4755ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-952 { --route-delay: 4760ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-953 { --route-delay: 4765ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-954 { --route-delay: 4770ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-955 { --route-delay: 4775ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-956 { --route-delay: 4780ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-957 { --route-delay: 4785ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-958 { --route-delay: 4790ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-959 { --route-delay: 4795ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-960 { --route-delay: 4800ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-961 { --route-delay: 4805ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-962 { --route-delay: 4810ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-963 { --route-delay: 4815ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-964 { --route-delay: 4820ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-965 { --route-delay: 4825ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-966 { --route-delay: 4830ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-967 { --route-delay: 4835ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-968 { --route-delay: 4840ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-969 { --route-delay: 4845ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-970 { --route-delay: 4850ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-971 { --route-delay: 4855ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-972 { --route-delay: 4860ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-973 { --route-delay: 4865ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-974 { --route-delay: 4870ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-975 { --route-delay: 4875ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-976 { --route-delay: 4880ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-977 { --route-delay: 4885ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-978 { --route-delay: 4890ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-979 { --route-delay: 4895ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-980 { --route-delay: 4900ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-981 { --route-delay: 4905ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-982 { --route-delay: 4910ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-983 { --route-delay: 4915ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-984 { --route-delay: 4920ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-985 { --route-delay: 4925ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-986 { --route-delay: 4930ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-987 { --route-delay: 4935ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-988 { --route-delay: 4940ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-989 { --route-delay: 4945ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-990 { --route-delay: 4950ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-991 { --route-delay: 4955ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-992 { --route-delay: 4960ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-993 { --route-delay: 4965ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-994 { --route-delay: 4970ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-995 { --route-delay: 4975ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-996 { --route-delay: 4980ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-997 { --route-delay: 4985ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-998 { --route-delay: 4990ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-999 { --route-delay: 4995ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1000 { --route-delay: 5000ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1001 { --route-delay: 5005ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1002 { --route-delay: 5010ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1003 { --route-delay: 5015ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1004 { --route-delay: 5020ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1005 { --route-delay: 5025ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1006 { --route-delay: 5030ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1007 { --route-delay: 5035ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1008 { --route-delay: 5040ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1009 { --route-delay: 5045ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1010 { --route-delay: 5050ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1011 { --route-delay: 5055ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1012 { --route-delay: 5060ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1013 { --route-delay: 5065ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1014 { --route-delay: 5070ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1015 { --route-delay: 5075ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1016 { --route-delay: 5080ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1017 { --route-delay: 5085ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1018 { --route-delay: 5090ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1019 { --route-delay: 5095ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1020 { --route-delay: 5100ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1021 { --route-delay: 5105ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1022 { --route-delay: 5110ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1023 { --route-delay: 5115ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1024 { --route-delay: 5120ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1025 { --route-delay: 5125ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1026 { --route-delay: 5130ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1027 { --route-delay: 5135ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1028 { --route-delay: 5140ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1029 { --route-delay: 5145ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1030 { --route-delay: 5150ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1031 { --route-delay: 5155ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1032 { --route-delay: 5160ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1033 { --route-delay: 5165ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1034 { --route-delay: 5170ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1035 { --route-delay: 5175ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1036 { --route-delay: 5180ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1037 { --route-delay: 5185ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1038 { --route-delay: 5190ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1039 { --route-delay: 5195ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1040 { --route-delay: 5200ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1041 { --route-delay: 5205ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1042 { --route-delay: 5210ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1043 { --route-delay: 5215ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1044 { --route-delay: 5220ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1045 { --route-delay: 5225ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1046 { --route-delay: 5230ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1047 { --route-delay: 5235ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1048 { --route-delay: 5240ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1049 { --route-delay: 5245ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1050 { --route-delay: 5250ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1051 { --route-delay: 5255ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1052 { --route-delay: 5260ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1053 { --route-delay: 5265ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1054 { --route-delay: 5270ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1055 { --route-delay: 5275ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1056 { --route-delay: 5280ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1057 { --route-delay: 5285ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1058 { --route-delay: 5290ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1059 { --route-delay: 5295ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1060 { --route-delay: 5300ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1061 { --route-delay: 5305ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1062 { --route-delay: 5310ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1063 { --route-delay: 5315ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1064 { --route-delay: 5320ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1065 { --route-delay: 5325ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1066 { --route-delay: 5330ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1067 { --route-delay: 5335ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1068 { --route-delay: 5340ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1069 { --route-delay: 5345ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1070 { --route-delay: 5350ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1071 { --route-delay: 5355ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1072 { --route-delay: 5360ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1073 { --route-delay: 5365ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1074 { --route-delay: 5370ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1075 { --route-delay: 5375ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1076 { --route-delay: 5380ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1077 { --route-delay: 5385ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1078 { --route-delay: 5390ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1079 { --route-delay: 5395ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1080 { --route-delay: 5400ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1081 { --route-delay: 5405ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1082 { --route-delay: 5410ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1083 { --route-delay: 5415ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1084 { --route-delay: 5420ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1085 { --route-delay: 5425ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1086 { --route-delay: 5430ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1087 { --route-delay: 5435ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1088 { --route-delay: 5440ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1089 { --route-delay: 5445ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1090 { --route-delay: 5450ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1091 { --route-delay: 5455ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1092 { --route-delay: 5460ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1093 { --route-delay: 5465ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1094 { --route-delay: 5470ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1095 { --route-delay: 5475ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1096 { --route-delay: 5480ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1097 { --route-delay: 5485ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1098 { --route-delay: 5490ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1099 { --route-delay: 5495ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1100 { --route-delay: 5500ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1101 { --route-delay: 5505ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1102 { --route-delay: 5510ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1103 { --route-delay: 5515ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1104 { --route-delay: 5520ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1105 { --route-delay: 5525ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1106 { --route-delay: 5530ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1107 { --route-delay: 5535ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1108 { --route-delay: 5540ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1109 { --route-delay: 5545ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1110 { --route-delay: 5550ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1111 { --route-delay: 5555ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1112 { --route-delay: 5560ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1113 { --route-delay: 5565ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1114 { --route-delay: 5570ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1115 { --route-delay: 5575ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1116 { --route-delay: 5580ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1117 { --route-delay: 5585ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1118 { --route-delay: 5590ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1119 { --route-delay: 5595ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1120 { --route-delay: 5600ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1121 { --route-delay: 5605ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1122 { --route-delay: 5610ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1123 { --route-delay: 5615ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1124 { --route-delay: 5620ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1125 { --route-delay: 5625ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1126 { --route-delay: 5630ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1127 { --route-delay: 5635ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1128 { --route-delay: 5640ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1129 { --route-delay: 5645ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1130 { --route-delay: 5650ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1131 { --route-delay: 5655ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1132 { --route-delay: 5660ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1133 { --route-delay: 5665ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1134 { --route-delay: 5670ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1135 { --route-delay: 5675ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1136 { --route-delay: 5680ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1137 { --route-delay: 5685ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1138 { --route-delay: 5690ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1139 { --route-delay: 5695ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1140 { --route-delay: 5700ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1141 { --route-delay: 5705ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1142 { --route-delay: 5710ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1143 { --route-delay: 5715ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1144 { --route-delay: 5720ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1145 { --route-delay: 5725ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1146 { --route-delay: 5730ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1147 { --route-delay: 5735ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1148 { --route-delay: 5740ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1149 { --route-delay: 5745ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1150 { --route-delay: 5750ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1151 { --route-delay: 5755ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1152 { --route-delay: 5760ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1153 { --route-delay: 5765ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1154 { --route-delay: 5770ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1155 { --route-delay: 5775ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1156 { --route-delay: 5780ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1157 { --route-delay: 5785ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1158 { --route-delay: 5790ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1159 { --route-delay: 5795ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1160 { --route-delay: 5800ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1161 { --route-delay: 5805ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1162 { --route-delay: 5810ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1163 { --route-delay: 5815ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1164 { --route-delay: 5820ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1165 { --route-delay: 5825ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1166 { --route-delay: 5830ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1167 { --route-delay: 5835ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1168 { --route-delay: 5840ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1169 { --route-delay: 5845ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1170 { --route-delay: 5850ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1171 { --route-delay: 5855ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1172 { --route-delay: 5860ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1173 { --route-delay: 5865ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1174 { --route-delay: 5870ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1175 { --route-delay: 5875ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1176 { --route-delay: 5880ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1177 { --route-delay: 5885ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1178 { --route-delay: 5890ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1179 { --route-delay: 5895ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1180 { --route-delay: 5900ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1181 { --route-delay: 5905ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1182 { --route-delay: 5910ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1183 { --route-delay: 5915ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1184 { --route-delay: 5920ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1185 { --route-delay: 5925ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1186 { --route-delay: 5930ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1187 { --route-delay: 5935ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1188 { --route-delay: 5940ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1189 { --route-delay: 5945ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1190 { --route-delay: 5950ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1191 { --route-delay: 5955ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1192 { --route-delay: 5960ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1193 { --route-delay: 5965ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1194 { --route-delay: 5970ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1195 { --route-delay: 5975ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1196 { --route-delay: 5980ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1197 { --route-delay: 5985ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1198 { --route-delay: 5990ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1199 { --route-delay: 5995ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1200 { --route-delay: 6000ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1201 { --route-delay: 6005ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1202 { --route-delay: 6010ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1203 { --route-delay: 6015ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1204 { --route-delay: 6020ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1205 { --route-delay: 6025ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1206 { --route-delay: 6030ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1207 { --route-delay: 6035ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1208 { --route-delay: 6040ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1209 { --route-delay: 6045ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1210 { --route-delay: 6050ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1211 { --route-delay: 6055ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1212 { --route-delay: 6060ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1213 { --route-delay: 6065ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1214 { --route-delay: 6070ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1215 { --route-delay: 6075ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1216 { --route-delay: 6080ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1217 { --route-delay: 6085ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1218 { --route-delay: 6090ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1219 { --route-delay: 6095ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1220 { --route-delay: 6100ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1221 { --route-delay: 6105ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1222 { --route-delay: 6110ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1223 { --route-delay: 6115ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1224 { --route-delay: 6120ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1225 { --route-delay: 6125ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1226 { --route-delay: 6130ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1227 { --route-delay: 6135ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1228 { --route-delay: 6140ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1229 { --route-delay: 6145ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1230 { --route-delay: 6150ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1231 { --route-delay: 6155ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1232 { --route-delay: 6160ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1233 { --route-delay: 6165ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1234 { --route-delay: 6170ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1235 { --route-delay: 6175ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1236 { --route-delay: 6180ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1237 { --route-delay: 6185ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1238 { --route-delay: 6190ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1239 { --route-delay: 6195ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1240 { --route-delay: 6200ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1241 { --route-delay: 6205ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1242 { --route-delay: 6210ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1243 { --route-delay: 6215ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1244 { --route-delay: 6220ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1245 { --route-delay: 6225ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1246 { --route-delay: 6230ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1247 { --route-delay: 6235ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1248 { --route-delay: 6240ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1249 { --route-delay: 6245ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1250 { --route-delay: 6250ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1251 { --route-delay: 6255ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1252 { --route-delay: 6260ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1253 { --route-delay: 6265ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1254 { --route-delay: 6270ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1255 { --route-delay: 6275ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1256 { --route-delay: 6280ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1257 { --route-delay: 6285ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1258 { --route-delay: 6290ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1259 { --route-delay: 6295ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1260 { --route-delay: 6300ms; --route-offset: 31px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1261 { --route-delay: 6305ms; --route-offset: 32px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1262 { --route-delay: 6310ms; --route-offset: 33px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1263 { --route-delay: 6315ms; --route-offset: 34px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1264 { --route-delay: 6320ms; --route-offset: 35px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1265 { --route-delay: 6325ms; --route-offset: 36px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1266 { --route-delay: 6330ms; --route-offset: 37px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1267 { --route-delay: 6335ms; --route-offset: 38px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1268 { --route-delay: 6340ms; --route-offset: 39px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1269 { --route-delay: 6345ms; --route-offset: 40px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1270 { --route-delay: 6350ms; --route-offset: 41px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1271 { --route-delay: 6355ms; --route-offset: 1px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1272 { --route-delay: 6360ms; --route-offset: 2px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1273 { --route-delay: 6365ms; --route-offset: 3px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1274 { --route-delay: 6370ms; --route-offset: 4px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1275 { --route-delay: 6375ms; --route-offset: 5px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1276 { --route-delay: 6380ms; --route-offset: 6px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1277 { --route-delay: 6385ms; --route-offset: 7px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1278 { --route-delay: 6390ms; --route-offset: 8px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1279 { --route-delay: 6395ms; --route-offset: 9px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1280 { --route-delay: 6400ms; --route-offset: 10px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1281 { --route-delay: 6405ms; --route-offset: 11px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1282 { --route-delay: 6410ms; --route-offset: 12px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1283 { --route-delay: 6415ms; --route-offset: 13px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1284 { --route-delay: 6420ms; --route-offset: 14px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1285 { --route-delay: 6425ms; --route-offset: 15px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1286 { --route-delay: 6430ms; --route-offset: 16px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1287 { --route-delay: 6435ms; --route-offset: 17px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1288 { --route-delay: 6440ms; --route-offset: 18px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1289 { --route-delay: 6445ms; --route-offset: 19px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1290 { --route-delay: 6450ms; --route-offset: 20px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1291 { --route-delay: 6455ms; --route-offset: 21px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1292 { --route-delay: 6460ms; --route-offset: 22px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1293 { --route-delay: 6465ms; --route-offset: 23px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1294 { --route-delay: 6470ms; --route-offset: 24px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1295 { --route-delay: 6475ms; --route-offset: 25px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1296 { --route-delay: 6480ms; --route-offset: 26px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1297 { --route-delay: 6485ms; --route-offset: 27px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1298 { --route-delay: 6490ms; --route-offset: 28px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1299 { --route-delay: 6495ms; --route-offset: 29px; animation-delay: calc(var(--route-delay) * -1); }
+.session-route-1300 { --route-delay: 6500ms; --route-offset: 30px; animation-delay: calc(var(--route-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS session stickiness failover animation example
- visualize affinity-map routing, visitor spillover, reroute lanes, and rebalance states
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/session-stickiness-failover-kp