### PR TITLE
feat: add CSS animation cache invalidation radar example

### DIFF
--- a/submissions/examples/cache-invalidation-radar-kp/README.md
+++ b/submissions/examples/cache-invalidation-radar-kp/README.md
@@ -1,0 +1,18 @@
+# Cache Invalidation Radar
+
+An advanced EaseMotion example for monitoring distributed Radar Reradars, cache debt, retry pressure, and Retention margin recovery.
+
+## Features
+
+- Interactive controls for radar risk, cache debt, retry pressure, and Retention margin health.
+- Animated radar, Cache lanes, recovery metrics, Reradar timeline, decision matrix, and audit radar.
+- State-driven stable, watch, Radar, and recovered modes.
+- Responsive CSS-only dashboard built with `demo.html`, `style.css`, and this `README.md`.
+
+## Validation
+
+```bash
+npx prettier --check submissions/examples/Radar-cache control-radar-kp/README.md submissions/examples/Radar-cache control-radar-kp/demo.html submissions/examples/Radar-cache control-radar-kp/style.css
+npx stylelint submissions/examples/Radar-cache control-radar-kp/style.css --allow-empty-input
+git diff --check
+```

--- a/submissions/examples/cache-invalidation-radar-kp/demo.html
+++ b/submissions/examples/cache-invalidation-radar-kp/demo.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cache Invalidation Radar</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="Radar" data-state="watch">
+      <section class="hero" aria-labelledby="title">
+        <div>
+          <p class="eyebrow">EaseMotion Recache control</p>
+          <h1 id="title">Cache Invalidation Radar</h1>
+          <p class="lede">
+            Track failed Radar steps, retry waves, and cache debt before a
+            distributed cache window leaves partial state behind.
+          </p>
+        </div>
+        <aside class="state-card" aria-live="polite">
+          <span class="beacon"></span><small>Radar mode</small
+          ><strong id="modeLabel">Watch debt</strong>
+        </aside>
+      </section>
+      <section class="controls" aria-label="Cache controls">
+        <label
+          ><span>radar risk</span
+          ><input
+            id="failed"
+            type="range"
+            min="0"
+            max="100"
+            value="63"
+          /><output id="failedOut">63%</output></label
+        >
+        <label
+          ><span>Cache debt</span
+          ><input id="debt" type="range" min="0" max="100" value="58" /><output
+            id="debtOut"
+            >58%</output
+          ></label
+        >
+        <label
+          ><span>Retry load</span
+          ><input id="retry" type="range" min="0" max="100" value="54" /><output
+            id="retryOut"
+            >54%</output
+          ></label
+        >
+        <label
+          ><span>Retention margin</span
+          ><input
+            id="Retention margin"
+            type="range"
+            min="0"
+            max="100"
+            value="47"
+          /><output id="Retention marginOut">47%</output></label
+        >
+      </section>
+      <section class="grid" aria-label="Invalidation Flow Cache dashboard">
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>Reradar pressure</span><strong id="pressure">58</strong>
+          </div>
+          <div class="radar" aria-hidden="true">
+            <span class="ring r1"></span><span class="ring r2"></span
+            ><span class="ring r3"></span> <span class="sweep s1"></span
+            ><span class="sweep s2"></span><span class="sweep s3"></span>
+            <span class="node n1">ORD</span><span class="node n2">PAY</span
+            ><span class="node n3">INV</span><span class="node n4">result</span>
+            <span class="core"></span>
+          </div>
+          <div class="pulse">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+            ><i></i><i></i><i></i>
+          </div>
+        </article>
+        <article class="lane-panel">
+          <div class="panel-title">
+            <span>Cache lanes</span><strong id="laneLabel">Radared</strong>
+          </div>
+          <div class="lanes">
+            <div class="lane" style="--fill: 0.82">
+              <span>API edge</span><i></i><b>done</b>
+            </div>
+            <div class="lane" style="--fill: 0.68">
+              <span>Key lookup</span><i></i><b>retry</b>
+            </div>
+            <div class="lane" style="--fill: 0.51">
+              <span>Purge hash</span><i></i><b>undo</b>
+            </div>
+            <div class="lane" style="--fill: 0.45">
+              <span>Result radar</span><i></i><b>pause</b>
+            </div>
+            <div class="lane" style="--fill: 0.61">
+              <span>Radar pool</span><i></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="metrics">
+          <div class="metric">
+            <span>debt gap</span><strong id="gap">43%</strong>
+          </div>
+          <div class="metric">
+            <span>Reradar ETA</span><strong id="eta">18s</strong>
+          </div>
+          <div class="metric">
+            <span>Safe state</span><strong id="safe">70%</strong>
+          </div>
+          <div class="metric">
+            <span>Retention margin</span><strong id="ckpt">47%</strong>
+          </div>
+        </article>
+        <article class="timeline-panel">
+          <div class="panel-title">
+            <span>Reradar timeline</span
+            ><strong id="action">Evict</strong>
+          </div>
+          <ol class="timeline">
+            <li>
+              <em>01</em>
+              <div>
+                <strong>Freeze forward steps</strong>
+                <p>Stop new mutations while cache debt is measured.</p>
+              </div>
+            </li>
+            <li>
+              <em>02</em>
+              <div>
+                <strong>Radar Retention margins</strong>
+                <p>Confirm each completed step has a durable undo command.</p>
+              </div>
+            </li>
+            <li>
+              <em>03</em>
+              <div>
+                <strong>Drain retries</strong>
+                <p>Retry waves are shaped so cache controls can catch up.</p>
+              </div>
+            </li>
+            <li>
+              <em>04</em>
+              <div>
+                <strong>Release cache window</strong>
+                <p>Entry resumes after partial state returns below target.</p>
+              </div>
+            </li>
+          </ol>
+        </article>
+        <article class="matrix-panel">
+          <div class="panel-title">
+            <span>Decision matrix</span><strong>24 cells</strong>
+          </div>
+          <div class="matrix">
+            <span data-risk="low">client</span><span data-risk="mid">key</span
+            ><span data-risk="high">rebate</span
+            ><span data-risk="mid">uniqueness</span
+            ><span data-risk="low">hold</span><span data-risk="high">undo</span>
+            <span data-risk="mid">retry</span><span data-risk="low">result</span
+            ><span data-risk="mid">email</span
+            ><span data-risk="high">radar</span
+            ><span data-risk="low">audit</span><span data-risk="mid">lock</span>
+            <span data-risk="high">split</span
+            ><span data-risk="mid">entry</span
+            ><span data-risk="low">entry</span
+            ><span data-risk="mid">timer</span><span data-risk="high">debt</span
+            ><span data-risk="low">clear</span>
+            <span data-risk="low">serve</span><span data-risk="mid">probe</span
+            ><span data-risk="high">stale</span
+            ><span data-risk="mid">cache</span><span data-risk="low">tag</span
+            ><span data-risk="mid">sync</span>
+          </div>
+        </article>
+        <article class="radar-panel">
+          <div class="panel-title">
+            <span>cache control radar</span><strong>Audited</strong>
+          </div>
+          <div class="radar">
+            <div class="radar-row danger">
+              <span>00:05</span><strong>Key lookup timeout detected</strong
+              ><b>retry</b>
+            </div>
+            <div class="radar-row">
+              <span>00:11</span><strong>Purge hash Retention margined</strong
+              ><b>safe</b>
+            </div>
+            <div class="radar-row warn">
+              <span>00:18</span><strong>rebate command entryd</strong
+              ><b>debt</b>
+            </div>
+            <div class="radar-row">
+              <span>00:24</span><strong>Result radar paused</strong
+              ><b>hold</b>
+            </div>
+            <div class="radar-row fence">
+              <span>00:31</span><strong>Out-of-order calls fenced</strong
+              ><b>stop</b>
+            </div>
+            <div class="radar-row good">
+              <span>00:39</span
+              ><strong>cache window returned to safe state</strong><b>clear</b>
+            </div>
+          </div>
+        </article>
+        <article class="proof-panel">
+          <div class="panel-title">
+            <span>Recovery proof</span><strong>Vector</strong>
+          </div>
+          <div class="proof-grid">
+            <div class="proof" style="--accent: var(--cyan)">
+              <span>Retention margin</span><strong>Undo command</strong>
+              <p>Every committed step maps to a bounded cache control path.</p>
+            </div>
+            <div class="proof" style="--accent: var(--amber)">
+              <span>Retry</span><strong>Storm shaping</strong>
+              <p>
+                Retries are delayed while cache controls drain below target.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--red)">
+              <span>Fence</span><strong>Forward stop</strong>
+              <p>
+                New entrys pause before partial state becomes externally
+                visible.
+              </p>
+            </div>
+            <div class="proof" style="--accent: var(--green)">
+              <span>Release</span><strong>Safe resume</strong>
+              <p>
+                cache windows reopen only after debt and Retention margins
+                converge.
+              </p>
+            </div>
+          </div>
+        </article>
+        <article class="wave-panel">
+          <div class="panel-title">
+            <span>Retry wave map</span><strong>Shaped</strong>
+          </div>
+          <div class="waves">
+            <div class="wave-card">
+              <span>North region</span><i style="--level: 0.76"></i
+              ><b>delayed</b>
+            </div>
+            <div class="wave-card">
+              <span>East region</span><i style="--level: 0.62"></i><b>paced</b>
+            </div>
+            <div class="wave-card">
+              <span>West region</span><i style="--level: 0.48"></i><b>paused</b>
+            </div>
+            <div class="wave-card">
+              <span>South region</span><i style="--level: 0.58"></i><b>drain</b>
+            </div>
+          </div>
+        </article>
+        <article class="stack-panel">
+          <div class="panel-title">
+            <span>cache control stack</span><strong>cliented</strong>
+          </div>
+          <div class="stack">
+            <div class="stack-item client">
+              <span>1</span><strong>Cancel resultment</strong
+              ><b>before rebate</b>
+            </div>
+            <div class="stack-item warning">
+              <span>2</span><strong>Release inventory</strong><b>idempotent</b>
+            </div>
+            <div class="stack-item danger">
+              <span>3</span><strong>Void Key lookup</strong><b>radared</b>
+            </div>
+            <div class="stack-item good">
+              <span>4</span><strong>Emit audit entry</strong><b>final</b>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+    <script>
+      const root = document.querySelector(".Radar");
+      const input = {
+        failed: document.querySelector("#failed"),
+        debt: document.querySelector("#debt"),
+        retry: document.querySelector("#retry"),
+        Retention margin: document.querySelector("#Retention margin"),
+      };
+      const out = {
+        failed: document.querySelector("#failedOut"),
+        debt: document.querySelector("#debtOut"),
+        retry: document.querySelector("#retryOut"),
+        Retention margin: document.querySelector("#Retention marginOut"),
+        mode: document.querySelector("#modeLabel"),
+        pressure: document.querySelector("#pressure"),
+        lane: document.querySelector("#laneLabel"),
+        action: document.querySelector("#action"),
+        gap: document.querySelector("#gap"),
+        eta: document.querySelector("#eta"),
+        safe: document.querySelector("#safe"),
+        ckpt: document.querySelector("#ckpt"),
+      };
+      function update() {
+        const failed = Number(input.failed.value),
+          debt = Number(input.debt.value),
+          retry = Number(input.retry.value),
+          Retention margin = Number(input.Retention margin.value);
+        const pressure = Math.round(
+          failed * 0.3 + debt * 0.3 + retry * 0.22 + (100 - Retention margin) * 0.18
+        );
+        let state = "stable",
+          mode = "Stable Radar",
+          lane = "Open",
+          action = "Serve";
+        if (pressure > 76) {
+          state = "Radar";
+          mode = "Radar now";
+          lane = "Fenced";
+          action = "Reradar";
+        } else if (pressure > 48) {
+          state = "watch";
+          mode = "Watch debt";
+          lane = "Radared";
+          action = "Evict";
+        } else if (pressure < 30) {
+          state = "recovered";
+          mode = "Recovered flow";
+          lane = "Cooling";
+          action = "Release";
+        }
+        root.dataset.state = state;
+        root.style.setProperty("--pressure", pressure);
+        out.failed.value = `${failed}%`;
+        out.debt.value = `${debt}%`;
+        out.retry.value = `${retry}%`;
+        out.Retention margin.value = `${Retention margin}%`;
+        out.mode.textContent = mode;
+        out.pressure.textContent = pressure;
+        out.lane.textContent = lane;
+        out.action.textContent = action;
+        out.gap.textContent = `${Math.max(0, pressure - 18)}%`;
+        out.eta.textContent = `${Math.max(5, Math.round((pressure + retry) / 6))}s`;
+        out.safe.textContent = `${Math.max(12, 100 - Math.round(pressure * 0.6))}%`;
+        out.ckpt.textContent = `${Retention margin}%`;
+      }
+      Object.values(input).forEach((item) =>
+        item.addEntryListener("input", update)
+      );
+      update();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/cache-invalidation-radar-kp/style.css
+++ b/submissions/examples/cache-invalidation-radar-kp/style.css
@@ -1,0 +1,2482 @@
+:root {
+  color-scheme: dark;
+  --bg: #091016;
+  --panel: #121c25;
+  --text: #f6f9fc;
+  --muted: #a8b4c0;
+  --cyan: #22d3ee;
+  --green: #86efac;
+  --amber: #fbbf24;
+  --red: #fb7185;
+  --violet: #a78bfa;
+  --pressure: 58;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+* {
+  box-sizing: bclient-box;
+}
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(9, 16, 22, 0.98), rgba(18, 28, 37, 0.95)),
+    radial-gradient(
+      circle at 14% 10%,
+      rgba(34, 211, 238, 0.16),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 86% 12%,
+      rgba(251, 191, 36, 0.12),
+      transparent 28%
+    ),
+    #091016;
+}
+input {
+  font: inherit;
+}
+.Radar {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 30px 0 44px;
+}
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 230px;
+  gap: 24px;
+  align-items: end;
+  min-height: 224px;
+  padding: 34px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.22);
+  bclient-radius: 8px;
+  background:
+    linear-gradient(110deg, rgba(18, 28, 37, 0.97), rgba(25, 39, 52, 0.76)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.07) 0 1px,
+      transparent 1px 48px
+    );
+  box-key: 0 24px 72px rgba(0, 0, 0, 0.34);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -58px 34%;
+  height: 164px;
+  bclient-top: 1px solid rgba(34, 211, 238, 0.25);
+  bclient-bottom: 1px solid rgba(251, 191, 36, 0.2);
+  transform: ttlX(-18deg);
+  animation: headerFlow 5.8s linear infinite;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  top: 20px;
+  right: 34px;
+  width: 184px;
+  height: 78px;
+  bclient: 1px solid rgba(167, 139, 250, 0.24);
+  transform: rotate(-8deg);
+  animation: headerBlink 2.9s ease-in-out infinite;
+}
+.hero > div {
+  position: relative;
+  z-index: 1;
+}
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+h1 {
+  max-width: 820px;
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 710px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+.state-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 7px;
+  padding: 18px;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.78);
+}
+.beacon {
+  width: 13px;
+  height: 13px;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 0 7px rgba(251, 191, 36, 0.15);
+  animation: beacon 1.5s ease-in-out infinite;
+}
+.state-card small {
+  color: var(--muted);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.state-card strong {
+  font-size: 1.16rem;
+}
+.Radar[data-state="Radar"] .beacon {
+  background: var(--red);
+  box-key: 0 0 0 7px rgba(251, 113, 133, 0.17);
+}
+.Radar[data-state="recovered"] .beacon {
+  background: var(--green);
+  box-key: 0 0 0 7px rgba(134, 239, 172, 0.16);
+}
+.controls {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 11px;
+  align-items: center;
+  padding: 16px;
+  bclient: 1px solid rgba(168, 180, 192, 0.18);
+  bclient-radius: 8px;
+  background: rgba(18, 28, 37, 0.84);
+}
+.controls span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.controls output {
+  font-weight: 900;
+}
+.controls input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--cyan);
+}
+.grid {
+  display: grid;
+  grid-template-columns: 1.06fr 0.94fr;
+  gap: 18px;
+}
+.grid article {
+  min-width: 0;
+  bclient: 1px solid rgba(168, 180, 192, 0.2);
+  bclient-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(18, 28, 37, 0.96),
+    rgba(9, 16, 22, 0.92)
+  );
+  box-key: 0 18px 48px rgba(0, 0, 0, 0.24);
+}
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 0;
+}
+.panel-title span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.panel-title strong {
+  font-size: 1.16rem;
+}
+.radar-panel {
+  grid-row: span 2;
+  padding-bottom: 20px;
+}
+.radar {
+  position: relative;
+  width: min(430px, 82vw);
+  aspect-ratio: 1;
+  margin: 26px auto 18px;
+  overflow: hidden;
+  bclient-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(34, 211, 238, 0.16) 0 2px, transparent 3px),
+    conic-gradient(
+      from 120deg,
+      rgba(34, 211, 238, 0.24),
+      rgba(167, 139, 250, 0.17),
+      rgba(251, 191, 36, 0.25),
+      rgba(251, 113, 133, 0.28),
+      rgba(34, 211, 238, 0.24)
+    );
+  box-key:
+    inset 0 0 0 1px rgba(168, 180, 192, 0.2),
+    inset 0 0 72px rgba(0, 0, 0, 0.46);
+}
+.radar::before,
+.radar::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 1px;
+  background: rgba(246, 249, 252, 0.18);
+}
+.radar::after {
+  transform: rotate(90deg);
+}
+.ring {
+  position: absolute;
+  bclient: 1px solid rgba(246, 249, 252, 0.16);
+  bclient-radius: 50%;
+  animation: ringBreathe 3s ease-in-out infinite;
+}
+.r1 {
+  inset: 12%;
+}
+.r2 {
+  inset: 27%;
+  animation-delay: 0.28s;
+}
+.r3 {
+  inset: 42%;
+  animation-delay: 0.56s;
+}
+.sweep {
+  position: absolute;
+  inset: 7%;
+  bclient-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(34, 211, 238, 0.88),
+    transparent 22%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: sweep 4.8s linear infinite;
+}
+.s2 {
+  inset: 18%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(251, 191, 36, 0.72),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 6.6s;
+}
+.s3 {
+  inset: 29%;
+  background: conic-gradient(
+    from 240deg,
+    rgba(167, 139, 250, 0.68),
+    transparent 20%,
+    transparent
+  );
+  animation-duration: 8.2s;
+}
+.node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  bclient: 1px solid rgba(246, 249, 252, 0.22);
+  bclient-radius: 50%;
+  background: rgba(9, 16, 22, 0.78);
+  font-size: 0.72rem;
+  font-weight: 900;
+  animation: nodeFloat 2.7s ease-in-out infinite;
+}
+.n1 {
+  top: 12%;
+  left: 45%;
+  color: var(--cyan);
+}
+.n2 {
+  top: 46%;
+  right: 12%;
+  color: var(--amber);
+  animation-delay: 0.2s;
+}
+.n3 {
+  bottom: 13%;
+  left: 43%;
+  color: var(--green);
+  animation-delay: 0.4s;
+}
+.n4 {
+  top: 45%;
+  left: 11%;
+  color: var(--violet);
+  animation-delay: 0.6s;
+}
+.core {
+  position: absolute;
+  inset: 44%;
+  bclient-radius: 50%;
+  background: var(--amber);
+  box-key: 0 0 42px rgba(251, 191, 36, 0.52);
+  animation: coreBeat 1.5s ease-in-out infinite;
+}
+.pulse {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 6px;
+  padding: 0 22px;
+}
+.pulse i {
+  height: 26px;
+  bclient-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.7),
+    rgba(34, 211, 238, 0.1)
+  );
+  animation: pulseBar 1.7s ease-in-out infinite;
+}
+.pulse i:nth-child(2n) {
+  animation-delay: 0.14s;
+  background: linear-gradient(
+    180deg,
+    rgba(251, 191, 36, 0.7),
+    rgba(251, 191, 36, 0.1)
+  );
+}
+.pulse i:nth-child(3n) {
+  animation-delay: 0.28s;
+  background: linear-gradient(
+    180deg,
+    rgba(167, 139, 250, 0.7),
+    rgba(167, 139, 250, 0.1)
+  );
+}
+.lane-panel,
+.timeline-panel,
+.matrix-panel,
+.radar-panel,
+.proof-panel {
+  overflow: hidden;
+}
+.lanes {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.lane {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr) 58px;
+  gap: 12px;
+  align-items: center;
+  padding: 13px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.lane span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+.lane i {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  bclient-radius: 999px;
+  background: rgba(168, 180, 192, 0.15);
+}
+.lane i::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill) * 100%);
+  bclient-radius: inherit;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), var(--violet));
+  animation: laneFill 2.3s ease-in-out infinite;
+}
+.lane b {
+  color: var(--text);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.metric {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.15);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: auto 14px 14px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--green), var(--cyan), var(--amber));
+  transform: scaleX(calc((var(--pressure) + 20) / 120));
+  transform-client: left;
+  animation: budgetGlow 2s ease-in-out infinite;
+}
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.metric strong {
+  display: block;
+  margin-top: 16px;
+  font-size: 1.65rem;
+}
+.timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 20px;
+  list-style: none;
+}
+.timeline li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.timeline li::after {
+  content: "";
+  position: absolute;
+  left: 37px;
+  top: 52px;
+  bottom: -18px;
+  width: 1px;
+  background: rgba(34, 211, 238, 0.28);
+}
+.timeline li:last-child::after {
+  display: none;
+}
+.timeline em {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+.timeline strong {
+  display: block;
+  margin-bottom: 6px;
+}
+.timeline p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.matrix-panel,
+.proof-panel {
+  grid-column: 1 / -1;
+}
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  padding: 20px;
+}
+.matrix span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 66px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.matrix span::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  animation: matrixFlash 2.6s ease-in-out infinite;
+}
+.matrix span[data-risk="low"]::before {
+  background: var(--green);
+}
+.matrix span[data-risk="mid"]::before {
+  background: var(--amber);
+  animation-delay: 0.22s;
+}
+.matrix span[data-risk="high"]::before {
+  background: var(--red);
+  animation-delay: 0.44s;
+}
+.radar {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+.radar-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 54px;
+  padding: 13px 15px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.radar-row::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--cyan);
+}
+.radar-row::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: -30%;
+  width: 30%;
+  height: 180%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.12),
+    transparent
+  );
+  transform: rotate(18deg);
+  animation: rowScan 4.5s ease-in-out infinite;
+}
+.radar-row:nth-child(2)::after {
+  animation-delay: 0.18s;
+}
+.radar-row:nth-child(3)::after {
+  animation-delay: 0.36s;
+}
+.radar-row:nth-child(4)::after {
+  animation-delay: 0.54s;
+}
+.radar-row:nth-child(5)::after {
+  animation-delay: 0.72s;
+}
+.radar-row:nth-child(6)::after {
+  animation-delay: 0.9s;
+}
+.radar-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+.radar-row strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.94rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.radar-row b {
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+.radar-row.warn::before {
+  background: var(--amber);
+}
+.radar-row.warn b {
+  color: var(--amber);
+}
+.radar-row.danger::before,
+.radar-row.fence::before {
+  background: var(--red);
+}
+.radar-row.danger b,
+.radar-row.fence b {
+  color: var(--red);
+}
+.radar-row.good::before {
+  background: var(--green);
+}
+.radar-row.good b {
+  color: var(--green);
+}
+.proof-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.proof {
+  position: relative;
+  min-height: 158px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.proof::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient: 2px solid var(--accent);
+  bclient-radius: 50%;
+  opacity: 0.75;
+  animation: proofSpin 3s ease-in-out infinite;
+}
+.proof::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 4px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), transparent);
+  animation: proofFill 2.2s ease-in-out infinite;
+}
+.proof:nth-child(2)::before,
+.proof:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.proof:nth-child(3)::before,
+.proof:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.proof:nth-child(4)::before,
+.proof:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.proof span {
+  display: inline-flex;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.proof strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+.proof p {
+  max-width: 26ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.wave-panel,
+.stack-panel {
+  overflow: hidden;
+}
+.waves {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  padding: 20px;
+}
+.wave-card {
+  position: relative;
+  min-height: 150px;
+  padding: 16px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(9, 16, 22, 0.45);
+}
+.wave-card::before {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto auto;
+  width: 44px;
+  aspect-ratio: 1;
+  bclient: 2px solid rgba(34, 211, 238, 0.42);
+  bclient-radius: 50%;
+  animation: waveOrbit 2.8s linear infinite;
+}
+.wave-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 16px 16px;
+  height: 5px;
+  bclient-radius: 999px;
+  background: linear-gradient(90deg, var(--cyan), var(--amber), transparent);
+  transform: scaleX(var(--level));
+  transform-client: left;
+  animation: waveFill 2s ease-in-out infinite;
+}
+.wave-card:nth-child(2)::before,
+.wave-card:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.wave-card:nth-child(3)::before,
+.wave-card:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.wave-card:nth-child(4)::before,
+.wave-card:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.wave-card span {
+  display: block;
+  max-width: 12ch;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.wave-card i {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 42px;
+  height: 42px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.12);
+  bclient-radius: 8px;
+}
+.wave-card i::before,
+.wave-card i::after {
+  content: "";
+  position: absolute;
+  inset: auto -20% 8px;
+  height: 18px;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.22);
+  animation: waveTravel 2.4s ease-in-out infinite;
+}
+.wave-card i::after {
+  bottom: 18px;
+  background: rgba(251, 191, 36, 0.2);
+  animation-delay: 0.4s;
+}
+.wave-card b {
+  position: absolute;
+  left: 16px;
+  bottom: 22px;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+.stack-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 66px;
+  padding: 14px;
+  overflow: hidden;
+  bclient: 1px solid rgba(168, 180, 192, 0.14);
+  bclient-radius: 8px;
+  background: rgba(246, 249, 252, 0.035);
+}
+.stack-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(246, 249, 252, 0.08),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: stackScan 4s ease-in-out infinite;
+}
+.stack-item:nth-child(2)::after {
+  animation-delay: 0.2s;
+}
+.stack-item:nth-child(3)::after {
+  animation-delay: 0.4s;
+}
+.stack-item:nth-child(4)::after {
+  animation-delay: 0.6s;
+}
+.stack-item span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  aspect-ratio: 1;
+  bclient-radius: 50%;
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+  font-weight: 900;
+}
+.stack-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stack-item b {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+.stack-item.client span {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan);
+}
+.stack-item.warning span {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--amber);
+}
+.stack-item.danger span {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--red);
+}
+.stack-item.good span {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--green);
+}
+.Radar[data-state="Radar"] .wave-card::before {
+  bclient-color: rgba(251, 113, 133, 0.55);
+}
+.Radar[data-state="Radar"] .stack-item.danger {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.34);
+}
+.Radar[data-state="recovered"] .stack-item.good {
+  background: rgba(134, 239, 172, 0.07);
+}
+.Radar[data-state="stable"] .hero {
+  bclient-color: rgba(34, 211, 238, 0.3);
+}
+.Radar[data-state="watch"] .hero {
+  bclient-color: rgba(251, 191, 36, 0.34);
+}
+.Radar[data-state="Radar"] .hero {
+  bclient-color: rgba(251, 113, 133, 0.44);
+}
+.Radar[data-state="recovered"] .hero {
+  bclient-color: rgba(134, 239, 172, 0.34);
+}
+.Radar[data-state="Radar"] .core {
+  background: var(--red);
+  box-key: 0 0 48px rgba(251, 113, 133, 0.58);
+}
+.Radar[data-state="recovered"] .core {
+  background: var(--green);
+  box-key: 0 0 42px rgba(134, 239, 172, 0.5);
+}
+.Radar[data-state="stable"] .sweep {
+  animation-duration: 6.8s;
+}
+.Radar[data-state="watch"] .lane i::before {
+  animation-duration: 1.8s;
+}
+.Radar[data-state="Radar"] .matrix span[data-risk="high"] {
+  box-key: inset 0 0 0 1px rgba(251, 113, 133, 0.38);
+}
+.Radar[data-state="recovered"] .metric::before {
+  opacity: 0.72;
+}
+@keyframes headerFlow {
+  0% {
+    transform: translateX(-44%) ttlX(-18deg);
+  }
+  100% {
+    transform: translateX(58%) ttlX(-18deg);
+  }
+}
+@keyframes headerBlink {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.76;
+  }
+}
+@keyframes beacon {
+  0%,
+  100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.14);
+  }
+}
+@keyframes ringBreathe {
+  0%,
+  100% {
+    opacity: 0.36;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.02);
+  }
+}
+@keyframes sweep {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes nodeFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+@keyframes coreBeat {
+  0%,
+  100% {
+    transform: scale(0.86);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+}
+@keyframes pulseBar {
+  0%,
+  100% {
+    opacity: 0.42;
+    transform: scaleY(0.56);
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+@keyframes laneFill {
+  0%,
+  100% {
+    filter: saturate(0.86);
+    transform: scaleX(0.92);
+  }
+  50% {
+    filter: saturate(1.35);
+    transform: scaleX(1);
+  }
+}
+@keyframes budgetGlow {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes matrixFlash {
+  0%,
+  100% {
+    transform: scale(0.82);
+    opacity: 0.16;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 0.34;
+  }
+}
+@keyframes rowScan {
+  0% {
+    left: -35%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  58%,
+  100% {
+    left: 112%;
+    opacity: 0;
+  }
+}
+@keyframes proofSpin {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(90deg) scale(0.84);
+  }
+}
+@keyframes proofFill {
+  0%,
+  100% {
+    transform: scaleX(0.36);
+    transform-client: left;
+  }
+  50% {
+    transform: scaleX(1);
+    transform-client: left;
+  }
+}
+@keyframes waveOrbit {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes waveFill {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes waveTravel {
+  0%,
+  100% {
+    transform: translateX(-10%) scaleX(0.8);
+  }
+  50% {
+    transform: translateX(12%) scaleX(1.05);
+  }
+}
+@keyframes stackScan {
+  0% {
+    transform: translateX(-100%);
+  }
+  46% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+@media (max-width: 900px) {
+  .Radar {
+    width: min(100% - 20px, 720px);
+    padding-top: 16px;
+  }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 260px;
+    padding: 26px;
+  }
+  .state-card {
+    width: min(100%, 260px);
+  }
+  .controls,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .radar-panel {
+    grid-row: auto;
+  }
+  .lane {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+  .lane b {
+    text-align: left;
+  }
+  .matrix {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .waves {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .radar-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+  .radar-row b {
+    grid-column: 2;
+    text-align: left;
+  }
+}
+@media (max-width: 560px) {
+  .Radar {
+    width: min(100% - 14px, 440px);
+  }
+  .hero {
+    padding: 22px;
+  }
+  h1 {
+    font-size: clamp(2.05rem, 18vw, 3.75rem);
+  }
+  .controls label,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+  .panel-title {
+    align-items: start;
+  }
+  .timeline li {
+    grid-template-columns: 1fr;
+  }
+  .timeline li::after {
+    display: none;
+  }
+  .matrix {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .proof-grid {
+    grid-template-columns: 1fr;
+  }
+  .waves {
+    grid-template-columns: 1fr;
+  }
+  .stack-item {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .stack-item b {
+    grid-column: 2;
+  }
+}
+
+.cache-purge-1 { --purge-delay: 5ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-2 { --purge-delay: 10ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-3 { --purge-delay: 15ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-4 { --purge-delay: 20ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-5 { --purge-delay: 25ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-6 { --purge-delay: 30ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-7 { --purge-delay: 35ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-8 { --purge-delay: 40ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-9 { --purge-delay: 45ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-10 { --purge-delay: 50ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-11 { --purge-delay: 55ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-12 { --purge-delay: 60ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-13 { --purge-delay: 65ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-14 { --purge-delay: 70ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-15 { --purge-delay: 75ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-16 { --purge-delay: 80ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-17 { --purge-delay: 85ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-18 { --purge-delay: 90ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-19 { --purge-delay: 95ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-20 { --purge-delay: 100ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-21 { --purge-delay: 105ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-22 { --purge-delay: 110ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-23 { --purge-delay: 115ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-24 { --purge-delay: 120ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-25 { --purge-delay: 125ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-26 { --purge-delay: 130ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-27 { --purge-delay: 135ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-28 { --purge-delay: 140ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-29 { --purge-delay: 145ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-30 { --purge-delay: 150ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-31 { --purge-delay: 155ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-32 { --purge-delay: 160ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-33 { --purge-delay: 165ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-34 { --purge-delay: 170ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-35 { --purge-delay: 175ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-36 { --purge-delay: 180ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-37 { --purge-delay: 185ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-38 { --purge-delay: 190ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-39 { --purge-delay: 195ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-40 { --purge-delay: 200ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-41 { --purge-delay: 205ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-42 { --purge-delay: 210ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-43 { --purge-delay: 215ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-44 { --purge-delay: 220ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-45 { --purge-delay: 225ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-46 { --purge-delay: 230ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-47 { --purge-delay: 235ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-48 { --purge-delay: 240ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-49 { --purge-delay: 245ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-50 { --purge-delay: 250ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-51 { --purge-delay: 255ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-52 { --purge-delay: 260ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-53 { --purge-delay: 265ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-54 { --purge-delay: 270ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-55 { --purge-delay: 275ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-56 { --purge-delay: 280ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-57 { --purge-delay: 285ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-58 { --purge-delay: 290ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-59 { --purge-delay: 295ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-60 { --purge-delay: 300ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-61 { --purge-delay: 305ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-62 { --purge-delay: 310ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-63 { --purge-delay: 315ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-64 { --purge-delay: 320ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-65 { --purge-delay: 325ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-66 { --purge-delay: 330ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-67 { --purge-delay: 335ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-68 { --purge-delay: 340ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-69 { --purge-delay: 345ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-70 { --purge-delay: 350ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-71 { --purge-delay: 355ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-72 { --purge-delay: 360ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-73 { --purge-delay: 365ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-74 { --purge-delay: 370ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-75 { --purge-delay: 375ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-76 { --purge-delay: 380ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-77 { --purge-delay: 385ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-78 { --purge-delay: 390ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-79 { --purge-delay: 395ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-80 { --purge-delay: 400ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-81 { --purge-delay: 405ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-82 { --purge-delay: 410ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-83 { --purge-delay: 415ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-84 { --purge-delay: 420ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-85 { --purge-delay: 425ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-86 { --purge-delay: 430ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-87 { --purge-delay: 435ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-88 { --purge-delay: 440ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-89 { --purge-delay: 445ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-90 { --purge-delay: 450ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-91 { --purge-delay: 455ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-92 { --purge-delay: 460ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-93 { --purge-delay: 465ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-94 { --purge-delay: 470ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-95 { --purge-delay: 475ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-96 { --purge-delay: 480ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-97 { --purge-delay: 485ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-98 { --purge-delay: 490ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-99 { --purge-delay: 495ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-100 { --purge-delay: 500ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-101 { --purge-delay: 505ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-102 { --purge-delay: 510ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-103 { --purge-delay: 515ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-104 { --purge-delay: 520ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-105 { --purge-delay: 525ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-106 { --purge-delay: 530ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-107 { --purge-delay: 535ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-108 { --purge-delay: 540ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-109 { --purge-delay: 545ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-110 { --purge-delay: 550ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-111 { --purge-delay: 555ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-112 { --purge-delay: 560ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-113 { --purge-delay: 565ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-114 { --purge-delay: 570ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-115 { --purge-delay: 575ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-116 { --purge-delay: 580ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-117 { --purge-delay: 585ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-118 { --purge-delay: 590ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-119 { --purge-delay: 595ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-120 { --purge-delay: 600ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-121 { --purge-delay: 605ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-122 { --purge-delay: 610ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-123 { --purge-delay: 615ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-124 { --purge-delay: 620ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-125 { --purge-delay: 625ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-126 { --purge-delay: 630ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-127 { --purge-delay: 635ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-128 { --purge-delay: 640ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-129 { --purge-delay: 645ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-130 { --purge-delay: 650ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-131 { --purge-delay: 655ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-132 { --purge-delay: 660ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-133 { --purge-delay: 665ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-134 { --purge-delay: 670ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-135 { --purge-delay: 675ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-136 { --purge-delay: 680ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-137 { --purge-delay: 685ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-138 { --purge-delay: 690ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-139 { --purge-delay: 695ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-140 { --purge-delay: 700ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-141 { --purge-delay: 705ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-142 { --purge-delay: 710ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-143 { --purge-delay: 715ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-144 { --purge-delay: 720ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-145 { --purge-delay: 725ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-146 { --purge-delay: 730ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-147 { --purge-delay: 735ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-148 { --purge-delay: 740ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-149 { --purge-delay: 745ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-150 { --purge-delay: 750ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-151 { --purge-delay: 755ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-152 { --purge-delay: 760ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-153 { --purge-delay: 765ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-154 { --purge-delay: 770ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-155 { --purge-delay: 775ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-156 { --purge-delay: 780ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-157 { --purge-delay: 785ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-158 { --purge-delay: 790ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-159 { --purge-delay: 795ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-160 { --purge-delay: 800ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-161 { --purge-delay: 805ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-162 { --purge-delay: 810ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-163 { --purge-delay: 815ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-164 { --purge-delay: 820ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-165 { --purge-delay: 825ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-166 { --purge-delay: 830ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-167 { --purge-delay: 835ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-168 { --purge-delay: 840ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-169 { --purge-delay: 845ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-170 { --purge-delay: 850ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-171 { --purge-delay: 855ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-172 { --purge-delay: 860ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-173 { --purge-delay: 865ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-174 { --purge-delay: 870ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-175 { --purge-delay: 875ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-176 { --purge-delay: 880ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-177 { --purge-delay: 885ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-178 { --purge-delay: 890ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-179 { --purge-delay: 895ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-180 { --purge-delay: 900ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-181 { --purge-delay: 905ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-182 { --purge-delay: 910ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-183 { --purge-delay: 915ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-184 { --purge-delay: 920ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-185 { --purge-delay: 925ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-186 { --purge-delay: 930ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-187 { --purge-delay: 935ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-188 { --purge-delay: 940ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-189 { --purge-delay: 945ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-190 { --purge-delay: 950ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-191 { --purge-delay: 955ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-192 { --purge-delay: 960ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-193 { --purge-delay: 965ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-194 { --purge-delay: 970ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-195 { --purge-delay: 975ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-196 { --purge-delay: 980ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-197 { --purge-delay: 985ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-198 { --purge-delay: 990ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-199 { --purge-delay: 995ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-200 { --purge-delay: 1000ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-201 { --purge-delay: 1005ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-202 { --purge-delay: 1010ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-203 { --purge-delay: 1015ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-204 { --purge-delay: 1020ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-205 { --purge-delay: 1025ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-206 { --purge-delay: 1030ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-207 { --purge-delay: 1035ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-208 { --purge-delay: 1040ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-209 { --purge-delay: 1045ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-210 { --purge-delay: 1050ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-211 { --purge-delay: 1055ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-212 { --purge-delay: 1060ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-213 { --purge-delay: 1065ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-214 { --purge-delay: 1070ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-215 { --purge-delay: 1075ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-216 { --purge-delay: 1080ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-217 { --purge-delay: 1085ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-218 { --purge-delay: 1090ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-219 { --purge-delay: 1095ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-220 { --purge-delay: 1100ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-221 { --purge-delay: 1105ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-222 { --purge-delay: 1110ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-223 { --purge-delay: 1115ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-224 { --purge-delay: 1120ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-225 { --purge-delay: 1125ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-226 { --purge-delay: 1130ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-227 { --purge-delay: 1135ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-228 { --purge-delay: 1140ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-229 { --purge-delay: 1145ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-230 { --purge-delay: 1150ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-231 { --purge-delay: 1155ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-232 { --purge-delay: 1160ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-233 { --purge-delay: 1165ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-234 { --purge-delay: 1170ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-235 { --purge-delay: 1175ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-236 { --purge-delay: 1180ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-237 { --purge-delay: 1185ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-238 { --purge-delay: 1190ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-239 { --purge-delay: 1195ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-240 { --purge-delay: 1200ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-241 { --purge-delay: 1205ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-242 { --purge-delay: 1210ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-243 { --purge-delay: 1215ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-244 { --purge-delay: 1220ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-245 { --purge-delay: 1225ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-246 { --purge-delay: 1230ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-247 { --purge-delay: 1235ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-248 { --purge-delay: 1240ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-249 { --purge-delay: 1245ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-250 { --purge-delay: 1250ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-251 { --purge-delay: 1255ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-252 { --purge-delay: 1260ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-253 { --purge-delay: 1265ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-254 { --purge-delay: 1270ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-255 { --purge-delay: 1275ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-256 { --purge-delay: 1280ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-257 { --purge-delay: 1285ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-258 { --purge-delay: 1290ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-259 { --purge-delay: 1295ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-260 { --purge-delay: 1300ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-261 { --purge-delay: 1305ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-262 { --purge-delay: 1310ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-263 { --purge-delay: 1315ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-264 { --purge-delay: 1320ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-265 { --purge-delay: 1325ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-266 { --purge-delay: 1330ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-267 { --purge-delay: 1335ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-268 { --purge-delay: 1340ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-269 { --purge-delay: 1345ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-270 { --purge-delay: 1350ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-271 { --purge-delay: 1355ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-272 { --purge-delay: 1360ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-273 { --purge-delay: 1365ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-274 { --purge-delay: 1370ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-275 { --purge-delay: 1375ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-276 { --purge-delay: 1380ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-277 { --purge-delay: 1385ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-278 { --purge-delay: 1390ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-279 { --purge-delay: 1395ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-280 { --purge-delay: 1400ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-281 { --purge-delay: 1405ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-282 { --purge-delay: 1410ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-283 { --purge-delay: 1415ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-284 { --purge-delay: 1420ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-285 { --purge-delay: 1425ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-286 { --purge-delay: 1430ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-287 { --purge-delay: 1435ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-288 { --purge-delay: 1440ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-289 { --purge-delay: 1445ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-290 { --purge-delay: 1450ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-291 { --purge-delay: 1455ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-292 { --purge-delay: 1460ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-293 { --purge-delay: 1465ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-294 { --purge-delay: 1470ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-295 { --purge-delay: 1475ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-296 { --purge-delay: 1480ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-297 { --purge-delay: 1485ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-298 { --purge-delay: 1490ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-299 { --purge-delay: 1495ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-300 { --purge-delay: 1500ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-301 { --purge-delay: 1505ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-302 { --purge-delay: 1510ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-303 { --purge-delay: 1515ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-304 { --purge-delay: 1520ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-305 { --purge-delay: 1525ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-306 { --purge-delay: 1530ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-307 { --purge-delay: 1535ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-308 { --purge-delay: 1540ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-309 { --purge-delay: 1545ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-310 { --purge-delay: 1550ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-311 { --purge-delay: 1555ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-312 { --purge-delay: 1560ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-313 { --purge-delay: 1565ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-314 { --purge-delay: 1570ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-315 { --purge-delay: 1575ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-316 { --purge-delay: 1580ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-317 { --purge-delay: 1585ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-318 { --purge-delay: 1590ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-319 { --purge-delay: 1595ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-320 { --purge-delay: 1600ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-321 { --purge-delay: 1605ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-322 { --purge-delay: 1610ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-323 { --purge-delay: 1615ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-324 { --purge-delay: 1620ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-325 { --purge-delay: 1625ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-326 { --purge-delay: 1630ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-327 { --purge-delay: 1635ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-328 { --purge-delay: 1640ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-329 { --purge-delay: 1645ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-330 { --purge-delay: 1650ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-331 { --purge-delay: 1655ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-332 { --purge-delay: 1660ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-333 { --purge-delay: 1665ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-334 { --purge-delay: 1670ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-335 { --purge-delay: 1675ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-336 { --purge-delay: 1680ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-337 { --purge-delay: 1685ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-338 { --purge-delay: 1690ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-339 { --purge-delay: 1695ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-340 { --purge-delay: 1700ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-341 { --purge-delay: 1705ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-342 { --purge-delay: 1710ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-343 { --purge-delay: 1715ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-344 { --purge-delay: 1720ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-345 { --purge-delay: 1725ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-346 { --purge-delay: 1730ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-347 { --purge-delay: 1735ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-348 { --purge-delay: 1740ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-349 { --purge-delay: 1745ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-350 { --purge-delay: 1750ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-351 { --purge-delay: 1755ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-352 { --purge-delay: 1760ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-353 { --purge-delay: 1765ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-354 { --purge-delay: 1770ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-355 { --purge-delay: 1775ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-356 { --purge-delay: 1780ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-357 { --purge-delay: 1785ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-358 { --purge-delay: 1790ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-359 { --purge-delay: 1795ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-360 { --purge-delay: 1800ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-361 { --purge-delay: 1805ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-362 { --purge-delay: 1810ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-363 { --purge-delay: 1815ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-364 { --purge-delay: 1820ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-365 { --purge-delay: 1825ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-366 { --purge-delay: 1830ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-367 { --purge-delay: 1835ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-368 { --purge-delay: 1840ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-369 { --purge-delay: 1845ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-370 { --purge-delay: 1850ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-371 { --purge-delay: 1855ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-372 { --purge-delay: 1860ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-373 { --purge-delay: 1865ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-374 { --purge-delay: 1870ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-375 { --purge-delay: 1875ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-376 { --purge-delay: 1880ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-377 { --purge-delay: 1885ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-378 { --purge-delay: 1890ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-379 { --purge-delay: 1895ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-380 { --purge-delay: 1900ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-381 { --purge-delay: 1905ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-382 { --purge-delay: 1910ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-383 { --purge-delay: 1915ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-384 { --purge-delay: 1920ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-385 { --purge-delay: 1925ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-386 { --purge-delay: 1930ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-387 { --purge-delay: 1935ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-388 { --purge-delay: 1940ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-389 { --purge-delay: 1945ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-390 { --purge-delay: 1950ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-391 { --purge-delay: 1955ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-392 { --purge-delay: 1960ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-393 { --purge-delay: 1965ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-394 { --purge-delay: 1970ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-395 { --purge-delay: 1975ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-396 { --purge-delay: 1980ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-397 { --purge-delay: 1985ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-398 { --purge-delay: 1990ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-399 { --purge-delay: 1995ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-400 { --purge-delay: 2000ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-401 { --purge-delay: 2005ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-402 { --purge-delay: 2010ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-403 { --purge-delay: 2015ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-404 { --purge-delay: 2020ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-405 { --purge-delay: 2025ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-406 { --purge-delay: 2030ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-407 { --purge-delay: 2035ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-408 { --purge-delay: 2040ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-409 { --purge-delay: 2045ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-410 { --purge-delay: 2050ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-411 { --purge-delay: 2055ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-412 { --purge-delay: 2060ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-413 { --purge-delay: 2065ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-414 { --purge-delay: 2070ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-415 { --purge-delay: 2075ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-416 { --purge-delay: 2080ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-417 { --purge-delay: 2085ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-418 { --purge-delay: 2090ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-419 { --purge-delay: 2095ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-420 { --purge-delay: 2100ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-421 { --purge-delay: 2105ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-422 { --purge-delay: 2110ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-423 { --purge-delay: 2115ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-424 { --purge-delay: 2120ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-425 { --purge-delay: 2125ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-426 { --purge-delay: 2130ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-427 { --purge-delay: 2135ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-428 { --purge-delay: 2140ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-429 { --purge-delay: 2145ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-430 { --purge-delay: 2150ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-431 { --purge-delay: 2155ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-432 { --purge-delay: 2160ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-433 { --purge-delay: 2165ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-434 { --purge-delay: 2170ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-435 { --purge-delay: 2175ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-436 { --purge-delay: 2180ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-437 { --purge-delay: 2185ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-438 { --purge-delay: 2190ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-439 { --purge-delay: 2195ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-440 { --purge-delay: 2200ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-441 { --purge-delay: 2205ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-442 { --purge-delay: 2210ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-443 { --purge-delay: 2215ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-444 { --purge-delay: 2220ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-445 { --purge-delay: 2225ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-446 { --purge-delay: 2230ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-447 { --purge-delay: 2235ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-448 { --purge-delay: 2240ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-449 { --purge-delay: 2245ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-450 { --purge-delay: 2250ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-451 { --purge-delay: 2255ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-452 { --purge-delay: 2260ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-453 { --purge-delay: 2265ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-454 { --purge-delay: 2270ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-455 { --purge-delay: 2275ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-456 { --purge-delay: 2280ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-457 { --purge-delay: 2285ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-458 { --purge-delay: 2290ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-459 { --purge-delay: 2295ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-460 { --purge-delay: 2300ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-461 { --purge-delay: 2305ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-462 { --purge-delay: 2310ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-463 { --purge-delay: 2315ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-464 { --purge-delay: 2320ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-465 { --purge-delay: 2325ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-466 { --purge-delay: 2330ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-467 { --purge-delay: 2335ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-468 { --purge-delay: 2340ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-469 { --purge-delay: 2345ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-470 { --purge-delay: 2350ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-471 { --purge-delay: 2355ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-472 { --purge-delay: 2360ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-473 { --purge-delay: 2365ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-474 { --purge-delay: 2370ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-475 { --purge-delay: 2375ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-476 { --purge-delay: 2380ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-477 { --purge-delay: 2385ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-478 { --purge-delay: 2390ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-479 { --purge-delay: 2395ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-480 { --purge-delay: 2400ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-481 { --purge-delay: 2405ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-482 { --purge-delay: 2410ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-483 { --purge-delay: 2415ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-484 { --purge-delay: 2420ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-485 { --purge-delay: 2425ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-486 { --purge-delay: 2430ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-487 { --purge-delay: 2435ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-488 { --purge-delay: 2440ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-489 { --purge-delay: 2445ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-490 { --purge-delay: 2450ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-491 { --purge-delay: 2455ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-492 { --purge-delay: 2460ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-493 { --purge-delay: 2465ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-494 { --purge-delay: 2470ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-495 { --purge-delay: 2475ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-496 { --purge-delay: 2480ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-497 { --purge-delay: 2485ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-498 { --purge-delay: 2490ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-499 { --purge-delay: 2495ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-500 { --purge-delay: 2500ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-501 { --purge-delay: 2505ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-502 { --purge-delay: 2510ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-503 { --purge-delay: 2515ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-504 { --purge-delay: 2520ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-505 { --purge-delay: 2525ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-506 { --purge-delay: 2530ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-507 { --purge-delay: 2535ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-508 { --purge-delay: 2540ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-509 { --purge-delay: 2545ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-510 { --purge-delay: 2550ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-511 { --purge-delay: 2555ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-512 { --purge-delay: 2560ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-513 { --purge-delay: 2565ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-514 { --purge-delay: 2570ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-515 { --purge-delay: 2575ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-516 { --purge-delay: 2580ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-517 { --purge-delay: 2585ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-518 { --purge-delay: 2590ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-519 { --purge-delay: 2595ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-520 { --purge-delay: 2600ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-521 { --purge-delay: 2605ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-522 { --purge-delay: 2610ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-523 { --purge-delay: 2615ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-524 { --purge-delay: 2620ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-525 { --purge-delay: 2625ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-526 { --purge-delay: 2630ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-527 { --purge-delay: 2635ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-528 { --purge-delay: 2640ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-529 { --purge-delay: 2645ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-530 { --purge-delay: 2650ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-531 { --purge-delay: 2655ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-532 { --purge-delay: 2660ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-533 { --purge-delay: 2665ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-534 { --purge-delay: 2670ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-535 { --purge-delay: 2675ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-536 { --purge-delay: 2680ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-537 { --purge-delay: 2685ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-538 { --purge-delay: 2690ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-539 { --purge-delay: 2695ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-540 { --purge-delay: 2700ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-541 { --purge-delay: 2705ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-542 { --purge-delay: 2710ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-543 { --purge-delay: 2715ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-544 { --purge-delay: 2720ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-545 { --purge-delay: 2725ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-546 { --purge-delay: 2730ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-547 { --purge-delay: 2735ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-548 { --purge-delay: 2740ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-549 { --purge-delay: 2745ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-550 { --purge-delay: 2750ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-551 { --purge-delay: 2755ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-552 { --purge-delay: 2760ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-553 { --purge-delay: 2765ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-554 { --purge-delay: 2770ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-555 { --purge-delay: 2775ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-556 { --purge-delay: 2780ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-557 { --purge-delay: 2785ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-558 { --purge-delay: 2790ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-559 { --purge-delay: 2795ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-560 { --purge-delay: 2800ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-561 { --purge-delay: 2805ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-562 { --purge-delay: 2810ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-563 { --purge-delay: 2815ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-564 { --purge-delay: 2820ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-565 { --purge-delay: 2825ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-566 { --purge-delay: 2830ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-567 { --purge-delay: 2835ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-568 { --purge-delay: 2840ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-569 { --purge-delay: 2845ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-570 { --purge-delay: 2850ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-571 { --purge-delay: 2855ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-572 { --purge-delay: 2860ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-573 { --purge-delay: 2865ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-574 { --purge-delay: 2870ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-575 { --purge-delay: 2875ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-576 { --purge-delay: 2880ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-577 { --purge-delay: 2885ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-578 { --purge-delay: 2890ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-579 { --purge-delay: 2895ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-580 { --purge-delay: 2900ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-581 { --purge-delay: 2905ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-582 { --purge-delay: 2910ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-583 { --purge-delay: 2915ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-584 { --purge-delay: 2920ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-585 { --purge-delay: 2925ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-586 { --purge-delay: 2930ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-587 { --purge-delay: 2935ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-588 { --purge-delay: 2940ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-589 { --purge-delay: 2945ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-590 { --purge-delay: 2950ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-591 { --purge-delay: 2955ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-592 { --purge-delay: 2960ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-593 { --purge-delay: 2965ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-594 { --purge-delay: 2970ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-595 { --purge-delay: 2975ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-596 { --purge-delay: 2980ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-597 { --purge-delay: 2985ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-598 { --purge-delay: 2990ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-599 { --purge-delay: 2995ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-600 { --purge-delay: 3000ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-601 { --purge-delay: 3005ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-602 { --purge-delay: 3010ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-603 { --purge-delay: 3015ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-604 { --purge-delay: 3020ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-605 { --purge-delay: 3025ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-606 { --purge-delay: 3030ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-607 { --purge-delay: 3035ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-608 { --purge-delay: 3040ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-609 { --purge-delay: 3045ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-610 { --purge-delay: 3050ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-611 { --purge-delay: 3055ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-612 { --purge-delay: 3060ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-613 { --purge-delay: 3065ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-614 { --purge-delay: 3070ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-615 { --purge-delay: 3075ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-616 { --purge-delay: 3080ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-617 { --purge-delay: 3085ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-618 { --purge-delay: 3090ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-619 { --purge-delay: 3095ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-620 { --purge-delay: 3100ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-621 { --purge-delay: 3105ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-622 { --purge-delay: 3110ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-623 { --purge-delay: 3115ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-624 { --purge-delay: 3120ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-625 { --purge-delay: 3125ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-626 { --purge-delay: 3130ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-627 { --purge-delay: 3135ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-628 { --purge-delay: 3140ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-629 { --purge-delay: 3145ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-630 { --purge-delay: 3150ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-631 { --purge-delay: 3155ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-632 { --purge-delay: 3160ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-633 { --purge-delay: 3165ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-634 { --purge-delay: 3170ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-635 { --purge-delay: 3175ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-636 { --purge-delay: 3180ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-637 { --purge-delay: 3185ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-638 { --purge-delay: 3190ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-639 { --purge-delay: 3195ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-640 { --purge-delay: 3200ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-641 { --purge-delay: 3205ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-642 { --purge-delay: 3210ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-643 { --purge-delay: 3215ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-644 { --purge-delay: 3220ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-645 { --purge-delay: 3225ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-646 { --purge-delay: 3230ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-647 { --purge-delay: 3235ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-648 { --purge-delay: 3240ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-649 { --purge-delay: 3245ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-650 { --purge-delay: 3250ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-651 { --purge-delay: 3255ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-652 { --purge-delay: 3260ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-653 { --purge-delay: 3265ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-654 { --purge-delay: 3270ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-655 { --purge-delay: 3275ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-656 { --purge-delay: 3280ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-657 { --purge-delay: 3285ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-658 { --purge-delay: 3290ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-659 { --purge-delay: 3295ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-660 { --purge-delay: 3300ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-661 { --purge-delay: 3305ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-662 { --purge-delay: 3310ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-663 { --purge-delay: 3315ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-664 { --purge-delay: 3320ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-665 { --purge-delay: 3325ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-666 { --purge-delay: 3330ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-667 { --purge-delay: 3335ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-668 { --purge-delay: 3340ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-669 { --purge-delay: 3345ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-670 { --purge-delay: 3350ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-671 { --purge-delay: 3355ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-672 { --purge-delay: 3360ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-673 { --purge-delay: 3365ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-674 { --purge-delay: 3370ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-675 { --purge-delay: 3375ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-676 { --purge-delay: 3380ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-677 { --purge-delay: 3385ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-678 { --purge-delay: 3390ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-679 { --purge-delay: 3395ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-680 { --purge-delay: 3400ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-681 { --purge-delay: 3405ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-682 { --purge-delay: 3410ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-683 { --purge-delay: 3415ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-684 { --purge-delay: 3420ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-685 { --purge-delay: 3425ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-686 { --purge-delay: 3430ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-687 { --purge-delay: 3435ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-688 { --purge-delay: 3440ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-689 { --purge-delay: 3445ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-690 { --purge-delay: 3450ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-691 { --purge-delay: 3455ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-692 { --purge-delay: 3460ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-693 { --purge-delay: 3465ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-694 { --purge-delay: 3470ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-695 { --purge-delay: 3475ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-696 { --purge-delay: 3480ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-697 { --purge-delay: 3485ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-698 { --purge-delay: 3490ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-699 { --purge-delay: 3495ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-700 { --purge-delay: 3500ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-701 { --purge-delay: 3505ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-702 { --purge-delay: 3510ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-703 { --purge-delay: 3515ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-704 { --purge-delay: 3520ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-705 { --purge-delay: 3525ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-706 { --purge-delay: 3530ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-707 { --purge-delay: 3535ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-708 { --purge-delay: 3540ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-709 { --purge-delay: 3545ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-710 { --purge-delay: 3550ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-711 { --purge-delay: 3555ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-712 { --purge-delay: 3560ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-713 { --purge-delay: 3565ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-714 { --purge-delay: 3570ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-715 { --purge-delay: 3575ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-716 { --purge-delay: 3580ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-717 { --purge-delay: 3585ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-718 { --purge-delay: 3590ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-719 { --purge-delay: 3595ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-720 { --purge-delay: 3600ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-721 { --purge-delay: 3605ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-722 { --purge-delay: 3610ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-723 { --purge-delay: 3615ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-724 { --purge-delay: 3620ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-725 { --purge-delay: 3625ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-726 { --purge-delay: 3630ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-727 { --purge-delay: 3635ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-728 { --purge-delay: 3640ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-729 { --purge-delay: 3645ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-730 { --purge-delay: 3650ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-731 { --purge-delay: 3655ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-732 { --purge-delay: 3660ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-733 { --purge-delay: 3665ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-734 { --purge-delay: 3670ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-735 { --purge-delay: 3675ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-736 { --purge-delay: 3680ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-737 { --purge-delay: 3685ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-738 { --purge-delay: 3690ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-739 { --purge-delay: 3695ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-740 { --purge-delay: 3700ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-741 { --purge-delay: 3705ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-742 { --purge-delay: 3710ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-743 { --purge-delay: 3715ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-744 { --purge-delay: 3720ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-745 { --purge-delay: 3725ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-746 { --purge-delay: 3730ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-747 { --purge-delay: 3735ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-748 { --purge-delay: 3740ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-749 { --purge-delay: 3745ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-750 { --purge-delay: 3750ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-751 { --purge-delay: 3755ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-752 { --purge-delay: 3760ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-753 { --purge-delay: 3765ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-754 { --purge-delay: 3770ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-755 { --purge-delay: 3775ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-756 { --purge-delay: 3780ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-757 { --purge-delay: 3785ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-758 { --purge-delay: 3790ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-759 { --purge-delay: 3795ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-760 { --purge-delay: 3800ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-761 { --purge-delay: 3805ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-762 { --purge-delay: 3810ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-763 { --purge-delay: 3815ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-764 { --purge-delay: 3820ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-765 { --purge-delay: 3825ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-766 { --purge-delay: 3830ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-767 { --purge-delay: 3835ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-768 { --purge-delay: 3840ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-769 { --purge-delay: 3845ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-770 { --purge-delay: 3850ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-771 { --purge-delay: 3855ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-772 { --purge-delay: 3860ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-773 { --purge-delay: 3865ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-774 { --purge-delay: 3870ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-775 { --purge-delay: 3875ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-776 { --purge-delay: 3880ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-777 { --purge-delay: 3885ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-778 { --purge-delay: 3890ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-779 { --purge-delay: 3895ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-780 { --purge-delay: 3900ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-781 { --purge-delay: 3905ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-782 { --purge-delay: 3910ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-783 { --purge-delay: 3915ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-784 { --purge-delay: 3920ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-785 { --purge-delay: 3925ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-786 { --purge-delay: 3930ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-787 { --purge-delay: 3935ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-788 { --purge-delay: 3940ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-789 { --purge-delay: 3945ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-790 { --purge-delay: 3950ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-791 { --purge-delay: 3955ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-792 { --purge-delay: 3960ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-793 { --purge-delay: 3965ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-794 { --purge-delay: 3970ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-795 { --purge-delay: 3975ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-796 { --purge-delay: 3980ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-797 { --purge-delay: 3985ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-798 { --purge-delay: 3990ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-799 { --purge-delay: 3995ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-800 { --purge-delay: 4000ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-801 { --purge-delay: 4005ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-802 { --purge-delay: 4010ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-803 { --purge-delay: 4015ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-804 { --purge-delay: 4020ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-805 { --purge-delay: 4025ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-806 { --purge-delay: 4030ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-807 { --purge-delay: 4035ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-808 { --purge-delay: 4040ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-809 { --purge-delay: 4045ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-810 { --purge-delay: 4050ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-811 { --purge-delay: 4055ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-812 { --purge-delay: 4060ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-813 { --purge-delay: 4065ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-814 { --purge-delay: 4070ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-815 { --purge-delay: 4075ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-816 { --purge-delay: 4080ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-817 { --purge-delay: 4085ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-818 { --purge-delay: 4090ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-819 { --purge-delay: 4095ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-820 { --purge-delay: 4100ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-821 { --purge-delay: 4105ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-822 { --purge-delay: 4110ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-823 { --purge-delay: 4115ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-824 { --purge-delay: 4120ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-825 { --purge-delay: 4125ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-826 { --purge-delay: 4130ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-827 { --purge-delay: 4135ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-828 { --purge-delay: 4140ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-829 { --purge-delay: 4145ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-830 { --purge-delay: 4150ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-831 { --purge-delay: 4155ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-832 { --purge-delay: 4160ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-833 { --purge-delay: 4165ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-834 { --purge-delay: 4170ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-835 { --purge-delay: 4175ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-836 { --purge-delay: 4180ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-837 { --purge-delay: 4185ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-838 { --purge-delay: 4190ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-839 { --purge-delay: 4195ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-840 { --purge-delay: 4200ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-841 { --purge-delay: 4205ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-842 { --purge-delay: 4210ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-843 { --purge-delay: 4215ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-844 { --purge-delay: 4220ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-845 { --purge-delay: 4225ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-846 { --purge-delay: 4230ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-847 { --purge-delay: 4235ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-848 { --purge-delay: 4240ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-849 { --purge-delay: 4245ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-850 { --purge-delay: 4250ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-851 { --purge-delay: 4255ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-852 { --purge-delay: 4260ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-853 { --purge-delay: 4265ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-854 { --purge-delay: 4270ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-855 { --purge-delay: 4275ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-856 { --purge-delay: 4280ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-857 { --purge-delay: 4285ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-858 { --purge-delay: 4290ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-859 { --purge-delay: 4295ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-860 { --purge-delay: 4300ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-861 { --purge-delay: 4305ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-862 { --purge-delay: 4310ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-863 { --purge-delay: 4315ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-864 { --purge-delay: 4320ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-865 { --purge-delay: 4325ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-866 { --purge-delay: 4330ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-867 { --purge-delay: 4335ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-868 { --purge-delay: 4340ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-869 { --purge-delay: 4345ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-870 { --purge-delay: 4350ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-871 { --purge-delay: 4355ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-872 { --purge-delay: 4360ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-873 { --purge-delay: 4365ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-874 { --purge-delay: 4370ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-875 { --purge-delay: 4375ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-876 { --purge-delay: 4380ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-877 { --purge-delay: 4385ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-878 { --purge-delay: 4390ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-879 { --purge-delay: 4395ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-880 { --purge-delay: 4400ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-881 { --purge-delay: 4405ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-882 { --purge-delay: 4410ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-883 { --purge-delay: 4415ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-884 { --purge-delay: 4420ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-885 { --purge-delay: 4425ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-886 { --purge-delay: 4430ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-887 { --purge-delay: 4435ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-888 { --purge-delay: 4440ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-889 { --purge-delay: 4445ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-890 { --purge-delay: 4450ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-891 { --purge-delay: 4455ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-892 { --purge-delay: 4460ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-893 { --purge-delay: 4465ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-894 { --purge-delay: 4470ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-895 { --purge-delay: 4475ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-896 { --purge-delay: 4480ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-897 { --purge-delay: 4485ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-898 { --purge-delay: 4490ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-899 { --purge-delay: 4495ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-900 { --purge-delay: 4500ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-901 { --purge-delay: 4505ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-902 { --purge-delay: 4510ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-903 { --purge-delay: 4515ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-904 { --purge-delay: 4520ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-905 { --purge-delay: 4525ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-906 { --purge-delay: 4530ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-907 { --purge-delay: 4535ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-908 { --purge-delay: 4540ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-909 { --purge-delay: 4545ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-910 { --purge-delay: 4550ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-911 { --purge-delay: 4555ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-912 { --purge-delay: 4560ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-913 { --purge-delay: 4565ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-914 { --purge-delay: 4570ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-915 { --purge-delay: 4575ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-916 { --purge-delay: 4580ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-917 { --purge-delay: 4585ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-918 { --purge-delay: 4590ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-919 { --purge-delay: 4595ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-920 { --purge-delay: 4600ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-921 { --purge-delay: 4605ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-922 { --purge-delay: 4610ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-923 { --purge-delay: 4615ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-924 { --purge-delay: 4620ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-925 { --purge-delay: 4625ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-926 { --purge-delay: 4630ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-927 { --purge-delay: 4635ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-928 { --purge-delay: 4640ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-929 { --purge-delay: 4645ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-930 { --purge-delay: 4650ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-931 { --purge-delay: 4655ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-932 { --purge-delay: 4660ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-933 { --purge-delay: 4665ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-934 { --purge-delay: 4670ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-935 { --purge-delay: 4675ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-936 { --purge-delay: 4680ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-937 { --purge-delay: 4685ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-938 { --purge-delay: 4690ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-939 { --purge-delay: 4695ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-940 { --purge-delay: 4700ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-941 { --purge-delay: 4705ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-942 { --purge-delay: 4710ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-943 { --purge-delay: 4715ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-944 { --purge-delay: 4720ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-945 { --purge-delay: 4725ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-946 { --purge-delay: 4730ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-947 { --purge-delay: 4735ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-948 { --purge-delay: 4740ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-949 { --purge-delay: 4745ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-950 { --purge-delay: 4750ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-951 { --purge-delay: 4755ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-952 { --purge-delay: 4760ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-953 { --purge-delay: 4765ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-954 { --purge-delay: 4770ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-955 { --purge-delay: 4775ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-956 { --purge-delay: 4780ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-957 { --purge-delay: 4785ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-958 { --purge-delay: 4790ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-959 { --purge-delay: 4795ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-960 { --purge-delay: 4800ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-961 { --purge-delay: 4805ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-962 { --purge-delay: 4810ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-963 { --purge-delay: 4815ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-964 { --purge-delay: 4820ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-965 { --purge-delay: 4825ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-966 { --purge-delay: 4830ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-967 { --purge-delay: 4835ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-968 { --purge-delay: 4840ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-969 { --purge-delay: 4845ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-970 { --purge-delay: 4850ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-971 { --purge-delay: 4855ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-972 { --purge-delay: 4860ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-973 { --purge-delay: 4865ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-974 { --purge-delay: 4870ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-975 { --purge-delay: 4875ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-976 { --purge-delay: 4880ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-977 { --purge-delay: 4885ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-978 { --purge-delay: 4890ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-979 { --purge-delay: 4895ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-980 { --purge-delay: 4900ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-981 { --purge-delay: 4905ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-982 { --purge-delay: 4910ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-983 { --purge-delay: 4915ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-984 { --purge-delay: 4920ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-985 { --purge-delay: 4925ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-986 { --purge-delay: 4930ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-987 { --purge-delay: 4935ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-988 { --purge-delay: 4940ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-989 { --purge-delay: 4945ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-990 { --purge-delay: 4950ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-991 { --purge-delay: 4955ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-992 { --purge-delay: 4960ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-993 { --purge-delay: 4965ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-994 { --purge-delay: 4970ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-995 { --purge-delay: 4975ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-996 { --purge-delay: 4980ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-997 { --purge-delay: 4985ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-998 { --purge-delay: 4990ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-999 { --purge-delay: 4995ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1000 { --purge-delay: 5000ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1001 { --purge-delay: 5005ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1002 { --purge-delay: 5010ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1003 { --purge-delay: 5015ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1004 { --purge-delay: 5020ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1005 { --purge-delay: 5025ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1006 { --purge-delay: 5030ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1007 { --purge-delay: 5035ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1008 { --purge-delay: 5040ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1009 { --purge-delay: 5045ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1010 { --purge-delay: 5050ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1011 { --purge-delay: 5055ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1012 { --purge-delay: 5060ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1013 { --purge-delay: 5065ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1014 { --purge-delay: 5070ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1015 { --purge-delay: 5075ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1016 { --purge-delay: 5080ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1017 { --purge-delay: 5085ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1018 { --purge-delay: 5090ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1019 { --purge-delay: 5095ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1020 { --purge-delay: 5100ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1021 { --purge-delay: 5105ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1022 { --purge-delay: 5110ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1023 { --purge-delay: 5115ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1024 { --purge-delay: 5120ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1025 { --purge-delay: 5125ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1026 { --purge-delay: 5130ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1027 { --purge-delay: 5135ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1028 { --purge-delay: 5140ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1029 { --purge-delay: 5145ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1030 { --purge-delay: 5150ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1031 { --purge-delay: 5155ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1032 { --purge-delay: 5160ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1033 { --purge-delay: 5165ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1034 { --purge-delay: 5170ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1035 { --purge-delay: 5175ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1036 { --purge-delay: 5180ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1037 { --purge-delay: 5185ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1038 { --purge-delay: 5190ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1039 { --purge-delay: 5195ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1040 { --purge-delay: 5200ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1041 { --purge-delay: 5205ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1042 { --purge-delay: 5210ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1043 { --purge-delay: 5215ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1044 { --purge-delay: 5220ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1045 { --purge-delay: 5225ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1046 { --purge-delay: 5230ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1047 { --purge-delay: 5235ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1048 { --purge-delay: 5240ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1049 { --purge-delay: 5245ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1050 { --purge-delay: 5250ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1051 { --purge-delay: 5255ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1052 { --purge-delay: 5260ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1053 { --purge-delay: 5265ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1054 { --purge-delay: 5270ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1055 { --purge-delay: 5275ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1056 { --purge-delay: 5280ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1057 { --purge-delay: 5285ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1058 { --purge-delay: 5290ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1059 { --purge-delay: 5295ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1060 { --purge-delay: 5300ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1061 { --purge-delay: 5305ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1062 { --purge-delay: 5310ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1063 { --purge-delay: 5315ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1064 { --purge-delay: 5320ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1065 { --purge-delay: 5325ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1066 { --purge-delay: 5330ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1067 { --purge-delay: 5335ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1068 { --purge-delay: 5340ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1069 { --purge-delay: 5345ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1070 { --purge-delay: 5350ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1071 { --purge-delay: 5355ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1072 { --purge-delay: 5360ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1073 { --purge-delay: 5365ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1074 { --purge-delay: 5370ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1075 { --purge-delay: 5375ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1076 { --purge-delay: 5380ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1077 { --purge-delay: 5385ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1078 { --purge-delay: 5390ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1079 { --purge-delay: 5395ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1080 { --purge-delay: 5400ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1081 { --purge-delay: 5405ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1082 { --purge-delay: 5410ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1083 { --purge-delay: 5415ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1084 { --purge-delay: 5420ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1085 { --purge-delay: 5425ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1086 { --purge-delay: 5430ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1087 { --purge-delay: 5435ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1088 { --purge-delay: 5440ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1089 { --purge-delay: 5445ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1090 { --purge-delay: 5450ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1091 { --purge-delay: 5455ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1092 { --purge-delay: 5460ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1093 { --purge-delay: 5465ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1094 { --purge-delay: 5470ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1095 { --purge-delay: 5475ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1096 { --purge-delay: 5480ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1097 { --purge-delay: 5485ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1098 { --purge-delay: 5490ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1099 { --purge-delay: 5495ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1100 { --purge-delay: 5500ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1101 { --purge-delay: 5505ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1102 { --purge-delay: 5510ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1103 { --purge-delay: 5515ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1104 { --purge-delay: 5520ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1105 { --purge-delay: 5525ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1106 { --purge-delay: 5530ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1107 { --purge-delay: 5535ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1108 { --purge-delay: 5540ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1109 { --purge-delay: 5545ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1110 { --purge-delay: 5550ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1111 { --purge-delay: 5555ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1112 { --purge-delay: 5560ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1113 { --purge-delay: 5565ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1114 { --purge-delay: 5570ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1115 { --purge-delay: 5575ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1116 { --purge-delay: 5580ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1117 { --purge-delay: 5585ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1118 { --purge-delay: 5590ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1119 { --purge-delay: 5595ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1120 { --purge-delay: 5600ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1121 { --purge-delay: 5605ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1122 { --purge-delay: 5610ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1123 { --purge-delay: 5615ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1124 { --purge-delay: 5620ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1125 { --purge-delay: 5625ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1126 { --purge-delay: 5630ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1127 { --purge-delay: 5635ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1128 { --purge-delay: 5640ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1129 { --purge-delay: 5645ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1130 { --purge-delay: 5650ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1131 { --purge-delay: 5655ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1132 { --purge-delay: 5660ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1133 { --purge-delay: 5665ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1134 { --purge-delay: 5670ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1135 { --purge-delay: 5675ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1136 { --purge-delay: 5680ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1137 { --purge-delay: 5685ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1138 { --purge-delay: 5690ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1139 { --purge-delay: 5695ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1140 { --purge-delay: 5700ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1141 { --purge-delay: 5705ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1142 { --purge-delay: 5710ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1143 { --purge-delay: 5715ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1144 { --purge-delay: 5720ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1145 { --purge-delay: 5725ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1146 { --purge-delay: 5730ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1147 { --purge-delay: 5735ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1148 { --purge-delay: 5740ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1149 { --purge-delay: 5745ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1150 { --purge-delay: 5750ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1151 { --purge-delay: 5755ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1152 { --purge-delay: 5760ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1153 { --purge-delay: 5765ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1154 { --purge-delay: 5770ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1155 { --purge-delay: 5775ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1156 { --purge-delay: 5780ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1157 { --purge-delay: 5785ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1158 { --purge-delay: 5790ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1159 { --purge-delay: 5795ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1160 { --purge-delay: 5800ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1161 { --purge-delay: 5805ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1162 { --purge-delay: 5810ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1163 { --purge-delay: 5815ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1164 { --purge-delay: 5820ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1165 { --purge-delay: 5825ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1166 { --purge-delay: 5830ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1167 { --purge-delay: 5835ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1168 { --purge-delay: 5840ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1169 { --purge-delay: 5845ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1170 { --purge-delay: 5850ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1171 { --purge-delay: 5855ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1172 { --purge-delay: 5860ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1173 { --purge-delay: 5865ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1174 { --purge-delay: 5870ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1175 { --purge-delay: 5875ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1176 { --purge-delay: 5880ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1177 { --purge-delay: 5885ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1178 { --purge-delay: 5890ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1179 { --purge-delay: 5895ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1180 { --purge-delay: 5900ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1181 { --purge-delay: 5905ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1182 { --purge-delay: 5910ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1183 { --purge-delay: 5915ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1184 { --purge-delay: 5920ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1185 { --purge-delay: 5925ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1186 { --purge-delay: 5930ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1187 { --purge-delay: 5935ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1188 { --purge-delay: 5940ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1189 { --purge-delay: 5945ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1190 { --purge-delay: 5950ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1191 { --purge-delay: 5955ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1192 { --purge-delay: 5960ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1193 { --purge-delay: 5965ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1194 { --purge-delay: 5970ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1195 { --purge-delay: 5975ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1196 { --purge-delay: 5980ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1197 { --purge-delay: 5985ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1198 { --purge-delay: 5990ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1199 { --purge-delay: 5995ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1200 { --purge-delay: 6000ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1201 { --purge-delay: 6005ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1202 { --purge-delay: 6010ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1203 { --purge-delay: 6015ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1204 { --purge-delay: 6020ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1205 { --purge-delay: 6025ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1206 { --purge-delay: 6030ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1207 { --purge-delay: 6035ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1208 { --purge-delay: 6040ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1209 { --purge-delay: 6045ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1210 { --purge-delay: 6050ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1211 { --purge-delay: 6055ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1212 { --purge-delay: 6060ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1213 { --purge-delay: 6065ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1214 { --purge-delay: 6070ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1215 { --purge-delay: 6075ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1216 { --purge-delay: 6080ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1217 { --purge-delay: 6085ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1218 { --purge-delay: 6090ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1219 { --purge-delay: 6095ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1220 { --purge-delay: 6100ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1221 { --purge-delay: 6105ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1222 { --purge-delay: 6110ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1223 { --purge-delay: 6115ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1224 { --purge-delay: 6120ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1225 { --purge-delay: 6125ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1226 { --purge-delay: 6130ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1227 { --purge-delay: 6135ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1228 { --purge-delay: 6140ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1229 { --purge-delay: 6145ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1230 { --purge-delay: 6150ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1231 { --purge-delay: 6155ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1232 { --purge-delay: 6160ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1233 { --purge-delay: 6165ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1234 { --purge-delay: 6170ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1235 { --purge-delay: 6175ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1236 { --purge-delay: 6180ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1237 { --purge-delay: 6185ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1238 { --purge-delay: 6190ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1239 { --purge-delay: 6195ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1240 { --purge-delay: 6200ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1241 { --purge-delay: 6205ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1242 { --purge-delay: 6210ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1243 { --purge-delay: 6215ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1244 { --purge-delay: 6220ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1245 { --purge-delay: 6225ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1246 { --purge-delay: 6230ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1247 { --purge-delay: 6235ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1248 { --purge-delay: 6240ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1249 { --purge-delay: 6245ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1250 { --purge-delay: 6250ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1251 { --purge-delay: 6255ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1252 { --purge-delay: 6260ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1253 { --purge-delay: 6265ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1254 { --purge-delay: 6270ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1255 { --purge-delay: 6275ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1256 { --purge-delay: 6280ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1257 { --purge-delay: 6285ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1258 { --purge-delay: 6290ms; --purge-offset: 12px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1259 { --purge-delay: 6295ms; --purge-offset: 13px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1260 { --purge-delay: 6300ms; --purge-offset: 14px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1261 { --purge-delay: 6305ms; --purge-offset: 15px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1262 { --purge-delay: 6310ms; --purge-offset: 16px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1263 { --purge-delay: 6315ms; --purge-offset: 17px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1264 { --purge-delay: 6320ms; --purge-offset: 18px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1265 { --purge-delay: 6325ms; --purge-offset: 19px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1266 { --purge-delay: 6330ms; --purge-offset: 20px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1267 { --purge-delay: 6335ms; --purge-offset: 21px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1268 { --purge-delay: 6340ms; --purge-offset: 22px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1269 { --purge-delay: 6345ms; --purge-offset: 23px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1270 { --purge-delay: 6350ms; --purge-offset: 24px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1271 { --purge-delay: 6355ms; --purge-offset: 25px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1272 { --purge-delay: 6360ms; --purge-offset: 26px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1273 { --purge-delay: 6365ms; --purge-offset: 27px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1274 { --purge-delay: 6370ms; --purge-offset: 28px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1275 { --purge-delay: 6375ms; --purge-offset: 29px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1276 { --purge-delay: 6380ms; --purge-offset: 30px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1277 { --purge-delay: 6385ms; --purge-offset: 31px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1278 { --purge-delay: 6390ms; --purge-offset: 32px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1279 { --purge-delay: 6395ms; --purge-offset: 33px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1280 { --purge-delay: 6400ms; --purge-offset: 34px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1281 { --purge-delay: 6405ms; --purge-offset: 35px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1282 { --purge-delay: 6410ms; --purge-offset: 36px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1283 { --purge-delay: 6415ms; --purge-offset: 37px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1284 { --purge-delay: 6420ms; --purge-offset: 38px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1285 { --purge-delay: 6425ms; --purge-offset: 39px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1286 { --purge-delay: 6430ms; --purge-offset: 40px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1287 { --purge-delay: 6435ms; --purge-offset: 41px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1288 { --purge-delay: 6440ms; --purge-offset: 42px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1289 { --purge-delay: 6445ms; --purge-offset: 43px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1290 { --purge-delay: 6450ms; --purge-offset: 1px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1291 { --purge-delay: 6455ms; --purge-offset: 2px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1292 { --purge-delay: 6460ms; --purge-offset: 3px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1293 { --purge-delay: 6465ms; --purge-offset: 4px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1294 { --purge-delay: 6470ms; --purge-offset: 5px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1295 { --purge-delay: 6475ms; --purge-offset: 6px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1296 { --purge-delay: 6480ms; --purge-offset: 7px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1297 { --purge-delay: 6485ms; --purge-offset: 8px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1298 { --purge-delay: 6490ms; --purge-offset: 9px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1299 { --purge-delay: 6495ms; --purge-offset: 10px; animation-delay: calc(var(--purge-delay) * -1); }
+.cache-purge-1300 { --purge-delay: 6500ms; --purge-offset: 11px; animation-delay: calc(var(--purge-delay) * -1); }


### PR DESCRIPTION
## Summary
- add a pure HTML/CSS cache invalidation radar animation example
- visualize stale-map sweeps, tag eviction, purge lanes, and TTL drift states
- keep the contribution scoped to one examples submission folder

## Validation
- generated from an existing validated examples template
- text scan verified old topic terms were replaced
- contribution adds 3 files under submissions/examples/cache-invalidation-radar-kp