### PR TITLE
feat: add muted section label demo

### DIFF
--- a/submissions/examples/muted-section-label-kk/README.md
+++ b/submissions/examples/muted-section-label-kk/README.md
@@ -1,0 +1,31 @@
+# Muted Section Label
+
+## What it does
+
+This submission creates a simple CSS-only muted section label utility for placing small subdued labels above headings or grouped content.
+
+## How to use it
+
+Apply the label class to a paragraph or inline text element:
+
+```html
+<p class="muted-section-label">Overview</p>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in dashboards, cards, forms, side panels, and grouped content sections.
+
+## Included features
+
+- Small muted uppercase label utility
+- Practical heading-and-section examples
+- Lightweight typography enhancement
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the muted label utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/muted-section-label-kk/demo.html
+++ b/submissions/examples/muted-section-label-kk/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Muted Section Label</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="muted-section-label">Overview</p>
+          <h1>Small subdued labels for grouped content and headings.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only typography utility for muted
+            uppercase section labels. It works well above headings in cards,
+            forms, dashboards, and side panels.
+          </p>
+        </header>
+
+        <section class="content-block">
+          <p class="muted-section-label">Profile</p>
+          <h2>Account Details</h2>
+          <p>Use a subtle section label to introduce grouped content without overwhelming the layout.</p>
+        </section>
+
+        <section class="content-block">
+          <p class="muted-section-label">Activity</p>
+          <h2>Recent Updates</h2>
+          <p>The label stays readable while keeping secondary visual priority compared to the main heading.</p>
+        </section>
+
+        <section class="content-block">
+          <p class="muted-section-label">Settings</p>
+          <h2>Notification Preferences</h2>
+          <p>This pattern is useful in dashboards, preference panels, and form sections.</p>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;p class="muted-section-label"&gt;Overview&lt;/p&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/muted-section-label-kk/style.css
+++ b/submissions/examples/muted-section-label-kk/style.css
@@ -1,0 +1,98 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(238, 243, 255, 0.56);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.muted-section-label,
+.snippet-label {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.content-block p {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.content-block {
+  padding: 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.content-block h2 {
+  margin: 0.45rem 0 0.35rem;
+  font-size: 1.18rem;
+}
+
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Muted Section Label demo inside `submissions/examples/muted-section-label-kk/`. This submission introduces a simple CSS-only typography utility for small subdued labels placed above headings or grouped content.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only muted section label utility for small uppercase text placed above headings and grouped content.

**How does a developer use it?**

```html
<p class="muted-section-label">Overview</p>