### PR TITLE
feat: add CSS ticking digital clock (#70068)

### DIFF
--- a/submissions/examples/css-ticking-digital-clock/README.md
+++ b/submissions/examples/css-ticking-digital-clock/README.md
@@ -1,0 +1,92 @@
+# CSS Ticking Digital Clock
+
+A seven-segment digital clock built with pure CSS — no JavaScript, no SVG,
+no images. Each digit is a `<div>` with seven `<span>` "segments" shaped
+with `clip-path`, and every segment has its own `@keyframes` animation
+that turns it on/off to spell out the digits `0` through `9` in a loop,
+so the whole display looks like it's genuinely ticking.
+
+## Files
+
+- `demo.html` — the six-digit `HH:MM:SS` clock with blinking colons
+- `style.css` — segment shapes, glow styling, and all keyframe animations
+- `README.md` — this file
+
+## How it works
+
+Each digit box contains 7 absolutely-positioned `.segment` elements
+(`a` through `g`, matching the classic seven-segment naming convention).
+Every segment has its own `@keyframes seg-X-cycle` animation that toggles
+`opacity` between `0` and `1` at ten evenly-spaced keyframe stops — one
+stop per digit `0`-`9` — using tight percentage pairs (e.g. `10%, 19.6%`)
+so the transition reads as an instant digital "tick" rather than a fade.
+
+A faint `::before` ghost of the full display sits behind each digit
+(low-opacity red), the way real LED/LCD seven-segment displays show the
+unlit segments — a nice detail that also reinforces what's animating.
+
+## Usage
+
+```html
+<div class="ticking-clock" role="img" aria-label="Animated digital clock display">
+  <div class="clock-group">
+    <div class="digit speed-slow">
+      <span class="segment a"></span>
+      <span class="segment b"></span>
+      <span class="segment c"></span>
+      <span class="segment d"></span>
+      <span class="segment e"></span>
+      <span class="segment f"></span>
+      <span class="segment g"></span>
+    </div>
+  </div>
+</div>
+```
+
+Each `.digit` takes a speed modifier class — `speed-fast`, `speed-mid`,
+or `speed-slow` — which just changes `animation-duration` /
+`animation-delay` so the six digits don't all cycle in lockstep.
+
+### Why doesn't it show the real time?
+
+The issue asks for a "ticking digital clock display with live time," but
+pure CSS has no way to read the system clock — there's no CSS feature
+that can fetch the current time or drive a counter from real elapsed
+wall-clock time. That's fundamentally a JavaScript capability.
+
+To stay true to the "no JavaScript" constraint, I built this as a
+decorative, always-animating seven-segment clock: each digit loops
+through `0`-`9` continuously via CSS keyframes, so it looks and behaves
+like a ticking digital clock without ever claiming to show the actual
+current time. `aria-label` and `role="img"` make that explicit for
+assistive tech.
+
+If the maintainer would prefer an actually-live clock, that's a
+one-function addition on top of this same CSS — happy to add a small,
+clearly-separated JS enhancement layer if preferred over the pure-CSS
+illusion.
+
+### Accessibility
+
+- `role="img"` + `aria-label` describe the whole clock as a single
+  decorative unit and explicitly note it doesn't show real time, so
+  screen readers don't announce it as a live time widget.
+- No interactive elements, so no keyboard traps.
+- `prefers-reduced-motion: reduce` freezes all segments into a static
+  glyph instead of continuously animating.
+
+### Responsive behavior
+
+A `max-width: 420px` breakpoint shrinks digit and segment dimensions and
+tightens spacing so the clock stays legible on small screens.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS/HTML, no JavaScript, no external assets, readable per-segment
+`@keyframes`, and accessible/responsive markup — matching the repo's
+animation-first, accessible-by-default philosophy.
+
+## Notes
+
+- No existing files were modified — strictly additive, living entirely
+  in `submissions/examples/css-ticking-digital-clock/`.

--- a/submissions/examples/css-ticking-digital-clock/demo.html
+++ b/submissions/examples/css-ticking-digital-clock/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Ticking Digital Clock — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">CSS Ticking Digital Clock</p>
+
+  <div
+    class="ticking-clock"
+    role="img"
+    aria-label="Animated seven-segment digital clock display, decorative, does not show the real time"
+  >
+    <div class="clock-group">
+      <div class="digit speed-slow">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+      <div class="digit speed-mid">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+    </div>
+
+    <div class="clock-colon"><span></span><span></span></div>
+
+    <div class="clock-group">
+      <div class="digit speed-mid">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+      <div class="digit speed-fast">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+    </div>
+
+    <div class="clock-colon"><span></span><span></span></div>
+
+    <div class="clock-group">
+      <div class="digit speed-fast">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+      <div class="digit speed-fast">
+        <span class="segment a"></span>
+        <span class="segment b"></span>
+        <span class="segment c"></span>
+        <span class="segment d"></span>
+        <span class="segment e"></span>
+        <span class="segment f"></span>
+        <span class="segment g"></span>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-ticking-digital-clock/style.css
+++ b/submissions/examples/css-ticking-digital-clock/style.css
@@ -1,0 +1,277 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 20px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.ticking-clock {
+  --seg-on: #ff3b30;
+  --seg-off: rgba(255, 59, 48, 0.08);
+  --seg-glow: rgba(255, 59, 48, 0.55);
+
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 28px 34px;
+  background: #14181f;
+  border-radius: 18px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.clock-group {
+  display: flex;
+  gap: 6px;
+}
+
+.clock-colon {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  padding: 0 4px;
+  align-self: stretch;
+}
+
+.clock-colon span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--seg-on);
+  animation: colon-blink 1s steps(1, end) infinite;
+}
+
+@keyframes colon-blink {
+  0%, 49% {
+    opacity: 1;
+  }
+  50%, 100% {
+    opacity: 0.15;
+  }
+}
+
+.digit {
+  position: relative;
+  width: 46px;
+  height: 84px;
+}
+
+.digit::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--seg-off);
+  border-radius: 4px;
+}
+
+.segment {
+  position: absolute;
+  background: var(--seg-on);
+  opacity: 0;
+  filter: drop-shadow(0 0 4px var(--seg-glow));
+  transition: opacity 0.05s linear;
+  animation-timing-function: steps(1, end);
+  animation-iteration-count: infinite;
+}
+
+.segment.a,
+.segment.d,
+.segment.g {
+  left: 6px;
+  width: 34px;
+  height: 8px;
+  clip-path: polygon(10% 0, 90% 0, 100% 50%, 90% 100%, 10% 100%, 0 50%);
+}
+
+.segment.b,
+.segment.c,
+.segment.e,
+.segment.f {
+  width: 8px;
+  height: 34px;
+  clip-path: polygon(0 10%, 50% 0, 100% 10%, 100% 90%, 50% 100%, 0 90%);
+}
+
+.segment.a { top: 0; }
+.segment.g { top: 38px; }
+.segment.d { bottom: 0; }
+
+.segment.f { top: 6px; left: 0; }
+.segment.b { top: 6px; right: 0; }
+.segment.e { bottom: 6px; left: 0; }
+.segment.c { bottom: 6px; right: 0; }
+
+.segment.a { animation-name: seg-a-cycle; }
+.segment.b { animation-name: seg-b-cycle; }
+.segment.c { animation-name: seg-c-cycle; }
+.segment.d { animation-name: seg-d-cycle; }
+.segment.e { animation-name: seg-e-cycle; }
+.segment.f { animation-name: seg-f-cycle; }
+.segment.g { animation-name: seg-g-cycle; }
+
+.digit.speed-fast .segment { animation-duration: 4s; }
+.digit.speed-mid .segment { animation-duration: 9s; }
+.digit.speed-slow .segment { animation-duration: 16s; }
+
+.digit.speed-mid .segment { animation-delay: -1.3s; }
+.digit.speed-slow .segment { animation-delay: -2.7s; }
+
+@keyframes seg-a-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 0; }
+  20.0%, 29.6% { opacity: 1; }
+  30.0%, 39.6% { opacity: 1; }
+  40.0%, 49.6% { opacity: 0; }
+  50.0%, 59.6% { opacity: 1; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 1; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+@keyframes seg-b-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 1; }
+  20.0%, 29.6% { opacity: 1; }
+  30.0%, 39.6% { opacity: 1; }
+  40.0%, 49.6% { opacity: 1; }
+  50.0%, 59.6% { opacity: 0; }
+  60.0%, 69.6% { opacity: 0; }
+  70.0%, 79.6% { opacity: 1; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+@keyframes seg-c-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 1; }
+  20.0%, 29.6% { opacity: 0; }
+  30.0%, 39.6% { opacity: 1; }
+  40.0%, 49.6% { opacity: 1; }
+  50.0%, 59.6% { opacity: 1; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 1; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+@keyframes seg-d-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 0; }
+  20.0%, 29.6% { opacity: 1; }
+  30.0%, 39.6% { opacity: 1; }
+  40.0%, 49.6% { opacity: 0; }
+  50.0%, 59.6% { opacity: 1; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 0; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+@keyframes seg-e-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 0; }
+  20.0%, 29.6% { opacity: 1; }
+  30.0%, 39.6% { opacity: 0; }
+  40.0%, 49.6% { opacity: 0; }
+  50.0%, 59.6% { opacity: 0; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 0; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 0; }
+}
+
+@keyframes seg-f-cycle {
+  0.0%, 9.6% { opacity: 1; }
+  10.0%, 19.6% { opacity: 0; }
+  20.0%, 29.6% { opacity: 0; }
+  30.0%, 39.6% { opacity: 0; }
+  40.0%, 49.6% { opacity: 1; }
+  50.0%, 59.6% { opacity: 1; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 0; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+@keyframes seg-g-cycle {
+  0.0%, 9.6% { opacity: 0; }
+  10.0%, 19.6% { opacity: 0; }
+  20.0%, 29.6% { opacity: 1; }
+  30.0%, 39.6% { opacity: 1; }
+  40.0%, 49.6% { opacity: 1; }
+  50.0%, 59.6% { opacity: 1; }
+  60.0%, 69.6% { opacity: 1; }
+  70.0%, 79.6% { opacity: 0; }
+  80.0%, 89.6% { opacity: 1; }
+  90.0%, 99.6% { opacity: 1; }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 420px) {
+  .ticking-clock {
+    padding: 20px 16px;
+    gap: 4px;
+  }
+  .digit {
+    width: 34px;
+    height: 62px;
+  }
+  .segment.a,
+  .segment.d,
+  .segment.g {
+    left: 4px;
+    width: 26px;
+    height: 6px;
+  }
+  .segment.b,
+  .segment.c,
+  .segment.e,
+  .segment.f {
+    width: 6px;
+    height: 26px;
+  }
+  .segment.g { top: 28px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .segment,
+  .clock-colon span {
+    animation: none !important;
+  }
+  .segment.a, .segment.b, .segment.c,
+  .segment.d, .segment.f, .segment.g {
+    opacity: 1;
+  }
+  .segment.e { opacity: 0; }
+}


### PR DESCRIPTION
closes #70068
## Pull Request Description
Adds a "CSS Ticking Digital Clock" component, as requested in issue #70068. A pure-CSS seven-segment clock display where every digit continuously loops through 0-9 via per-segment `@keyframes` animations, giving the visual/behavioral effect of a ticking LED clock without any JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-ticking-digital-clock/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A six-digit `HH:MM:SS` seven-segment clock with blinking colons, where each segment (`a`-`g`) animates through the on/off pattern for digits 0-9 in a continuous loop.

**How does a developer use it?**
```html
<div class="ticking-clock" role="img" aria-label="Animated digital clock display">
  <div class="clock-group">
    <div class="digit speed-slow">
      <span class="segment a"></span>
      <span class="segment b"></span>
      <span class="segment c"></span>
      <span class="segment d"></span>
      <span class="segment e"></span>
      <span class="segment f"></span>
      <span class="segment g"></span>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML with no JavaScript, uses readable per-segment `@keyframes` animations (one per segment, ten keyframe stops for digits 0-9), and includes accessible/responsive markup (`role="img"`, descriptive `aria-label`, `:focus-visible`-safe with no interactive elements, `prefers-reduced-motion`) — matching the repo's animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Same constraint as a couple of my other recent submissions: pure CSS has no way to read the real system clock, so a strictly "no JavaScript" seven-segment display can't show actual live time. I built this as a decorative, always-animating clock — each digit continuously loops through 0-9 via CSS keyframes, giving the authentic "ticking LED" look and feel without ever claiming to show the current time (made explicit via `aria-label`). Happy to add a small, clearly-separated JS layer on top of this same CSS if an accurate live clock is preferred over the pure-CSS illusion.