### PR TITLE
feat: add compact info row demo

### DIFF
--- a/submissions/examples/compact-info-row-kk/README.md
+++ b/submissions/examples/compact-info-row-kk/README.md
@@ -1,0 +1,34 @@
+# Compact Info Row
+
+## What it does
+
+This submission creates a simple CSS-only compact info row utility for displaying short label-value pairs in a clean horizontal layout.
+
+## How to use it
+
+Place the label and value inside a shared row container:
+
+```html
+<div class="compact-info-row">
+  <span class="info-label">Plan</span>
+  <span class="info-value">Pro</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in dashboards, settings panels, profile summaries, stat blocks, and compact information sections.
+
+## Included features
+
+- Compact label-value row utility
+- Clean horizontal alignment
+- Success value variation in the demo
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the info row utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/compact-info-row-kk/demo.html
+++ b/submissions/examples/compact-info-row-kk/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Compact Info Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Compact Info Row</p>
+          <h1>Clean label-value rows for summaries, settings, and profile details.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only info row utility for
+            displaying short label-value pairs in a compact, reusable format.
+            It works well in cards, dashboards, settings screens, and profile
+            summaries.
+          </p>
+        </header>
+
+        <section class="info-panel">
+          <div class="compact-info-row">
+            <span class="info-label">Plan</span>
+            <span class="info-value">Pro</span>
+          </div>
+          <div class="compact-info-row">
+            <span class="info-label">Status</span>
+            <span class="info-value success">Active</span>
+          </div>
+          <div class="compact-info-row">
+            <span class="info-label">Role</span>
+            <span class="info-value">Designer</span>
+          </div>
+          <div class="compact-info-row">
+            <span class="info-label">Storage</span>
+            <span class="info-value">12 GB used</span>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="compact-info-row"&gt;
+  &lt;span class="info-label"&gt;Plan&lt;/span&gt;
+  &lt;span class="info-value"&gt;Pro&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/compact-info-row-kk/style.css
+++ b/submissions/examples/compact-info-row-kk/style.css
@@ -1,0 +1,114 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(238, 243, 255, 0.62);
+  --body-muted: #a2b1ce;
+  --success: #77dda7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 820px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.info-panel,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.compact-info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0;
+}
+
+.compact-info-row + .compact-info-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.info-label {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.info-value {
+  color: var(--text);
+  font-weight: 600;
+  text-align: right;
+}
+
+.info-value.success {
+  color: var(--success);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Compact Info Row demo inside `submissions/examples/compact-info-row-kk/`. This submission introduces a simple CSS-only row utility for displaying short label-value pairs in dashboards, settings, profile summaries, and compact information sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only compact info row utility for displaying short label-value pairs in a clean horizontal layout.

**How does a developer use it?**

```html
<div class="compact-info-row">
  <span class="info-label">Plan</span>
  <span class="info-value">Pro</span>
</div>