### PR TITLE
feat: add CSS alert summary card (#70070)

### DIFF
--- a/submissions/examples/css-alert-summary-card/README.md
+++ b/submissions/examples/css-alert-summary-card/README.md
@@ -1,0 +1,83 @@
+# CSS Alert Summary Card
+
+A compact summary card that groups **critical**, **warning**, and **info**
+alert counts into one glanceable component, with a subtotal footer. Pure
+CSS/HTML — no JavaScript. Counts are static markup here since real
+alert data would come from wherever the app tracks alerts; the card
+itself is just the display layer.
+
+## Files
+
+- `demo.html` — the card with 3 alert rows and a total footer
+- `style.css` — layout, color-coded rows, and entrance/hover animations
+- `README.md` — this file
+
+## How it works
+
+Each severity level is a `.alert-row` with a modifier class
+(`.critical`, `.warning`, `.info`) that drives its icon color and count
+badge color via CSS custom properties defined once on `.alert-summary-card`.
+The card and each row animate in on load (`card-in` / `row-in`
+`@keyframes`, staggered per row with `animation-delay`), and rows lift
+slightly and highlight on hover/focus.
+
+## Usage
+
+```html
+<section class="alert-summary-card" aria-labelledby="alert-summary-title">
+  <div class="alert-summary-header">
+    <h2 id="alert-summary-title">System Alerts</h2>
+    <span class="alert-summary-subtitle">Last 24 hours</span>
+  </div>
+
+  <ul class="alert-summary-list" role="list">
+    <li class="alert-row critical" tabindex="0">
+      <span class="alert-icon" aria-hidden="true"><!-- svg icon --></span>
+      <span class="alert-label">Critical</span>
+      <span class="alert-count" aria-label="4 critical alerts">4</span>
+    </li>
+  </ul>
+
+  <div class="alert-summary-footer">
+    <span class="alert-total-label">Total</span>
+    <span class="alert-total-count">30</span>
+  </div>
+</section>
+```
+
+Swap the counts, icons, and colors as needed — the three severity
+modifier classes are the only thing tying a row to its color scheme.
+
+### Accessibility
+
+- `aria-labelledby` ties the card to its heading for screen readers.
+- Each count has an explicit `aria-label` (e.g. "4 critical alerts") so
+  the number isn't announced without context.
+- Rows are focusable (`tabindex="0"`) with a visible `:focus-visible`
+  outline, so keyboard users get the same hover affordance as mouse
+  users.
+- `role="list"` on the `<ul>` keeps the semantics explicit across
+  browsers that sometimes strip list semantics from styled lists.
+
+### Responsive behavior
+
+Card padding and row padding tighten under `max-width: 420px` so it
+stays comfortable on narrow viewports; layout itself is already fluid
+via flexbox.
+
+### Reduced motion
+
+`prefers-reduced-motion: reduce` disables the entrance and hover-lift
+animations, leaving the card fully legible and static.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS/HTML, no JavaScript, no external assets, readable staggered
+`@keyframes` for the entrance animation, and accessible/responsive
+markup — matching the repo's animation-first, accessible-by-default
+philosophy.
+
+## Notes
+
+- No existing files were modified — strictly additive, living entirely
+  in `submissions/examples/css-alert-summary-card/`.

--- a/submissions/examples/css-alert-summary-card/demo.html
+++ b/submissions/examples/css-alert-summary-card/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Alert Summary Card — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">CSS Alert Summary Card</p>
+
+  <section class="alert-summary-card" aria-labelledby="alert-summary-title">
+    <div class="alert-summary-header">
+      <h2 id="alert-summary-title">System Alerts</h2>
+      <span class="alert-summary-subtitle">Last 24 hours</span>
+    </div>
+
+    <ul class="alert-summary-list" role="list">
+      <li class="alert-row critical" tabindex="0">
+        <span class="alert-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><path d="M12 2L1 21h22L12 2zm0 6v6m0 3h.01" /></svg>
+        </span>
+        <span class="alert-label">Critical</span>
+        <span class="alert-count" aria-label="4 critical alerts">4</span>
+      </li>
+
+      <li class="alert-row warning" tabindex="0">
+        <span class="alert-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><path d="M12 9v4m0 4h.01M4.5 20h15a1 1 0 0 0 .87-1.5l-7.5-13a1 1 0 0 0-1.74 0l-7.5 13A1 1 0 0 0 4.5 20z" /></svg>
+        </span>
+        <span class="alert-label">Warning</span>
+        <span class="alert-count" aria-label="9 warning alerts">9</span>
+      </li>
+
+      <li class="alert-row info" tabindex="0">
+        <span class="alert-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M12 16v-4m0-4h.01" /></svg>
+        </span>
+        <span class="alert-label">Info</span>
+        <span class="alert-count" aria-label="17 info alerts">17</span>
+      </li>
+    </ul>
+
+    <div class="alert-summary-footer">
+      <span class="alert-total-label">Total</span>
+      <span class="alert-total-count">30</span>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/css-alert-summary-card/style.css
+++ b/submissions/examples/css-alert-summary-card/style.css
@@ -1,0 +1,212 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 20px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.alert-summary-card {
+  --critical: #ff4d4f;
+  --warning: #f5a623;
+  --info: #4f8cff;
+
+  width: 100%;
+  max-width: 380px;
+  background: #161a22;
+  border-radius: 16px;
+  padding: 22px 22px 18px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4);
+  animation: card-in 0.4s ease both;
+}
+
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.alert-summary-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.alert-summary-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.alert-summary-subtitle {
+  font-size: 0.75rem;
+  color: #9aa4b2;
+}
+
+.alert-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alert-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #1c2028;
+  outline: none;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  animation: row-in 0.35s ease both;
+}
+
+.alert-summary-list .alert-row:nth-child(1) { animation-delay: 0.05s; }
+.alert-summary-list .alert-row:nth-child(2) { animation-delay: 0.15s; }
+.alert-summary-list .alert-row:nth-child(3) { animation-delay: 0.25s; }
+
+@keyframes row-in {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.alert-row:hover,
+.alert-row:focus-visible {
+  transform: translateX(2px);
+  background: #22262f;
+}
+
+.alert-row:focus-visible {
+  outline: 2px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+.alert-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex: none;
+}
+
+.alert-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.alert-row.critical .alert-icon { color: var(--critical); }
+.alert-row.warning .alert-icon { color: var(--warning); }
+.alert-row.info .alert-icon { color: var(--info); }
+
+.alert-label {
+  flex: 1;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.alert-count {
+  font-size: 0.85rem;
+  font-weight: 700;
+  min-width: 28px;
+  text-align: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.alert-row.critical .alert-count {
+  color: var(--critical);
+  background: rgba(255, 77, 79, 0.15);
+}
+
+.alert-row.warning .alert-count {
+  color: var(--warning);
+  background: rgba(245, 166, 35, 0.15);
+}
+
+.alert-row.info .alert-count {
+  color: var(--info);
+  background: rgba(79, 140, 255, 0.15);
+}
+
+.alert-summary-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid #232833;
+}
+
+.alert-total-label {
+  font-size: 0.8rem;
+  color: #9aa4b2;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.alert-total-count {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+@media (max-width: 420px) {
+  .alert-summary-card {
+    padding: 18px 16px 14px;
+  }
+  .alert-row {
+    padding: 9px 10px;
+  }
+  .alert-label {
+    font-size: 0.85rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .alert-summary-card,
+  .alert-row {
+    animation: none;
+  }
+  .alert-row:hover,
+  .alert-row:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
closes #70070
## Pull Request Description
Adds a "CSS Alert Summary Card" component, as requested in issue #70070. A compact card that groups critical, warning, and info alert counts into color-coded rows with a total footer, entrance animation, and hover/focus feedback.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-alert-summary-card/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A summary card grouping critical/warning/info alert counts into color-coded rows with a staggered entrance animation and a total footer.

**How does a developer use it?**
```html
<section class="alert-summary-card" aria-labelledby="alert-summary-title">
  <div class="alert-summary-header">
    <h2 id="alert-summary-title">System Alerts</h2>
  </div>
  <ul class="alert-summary-list" role="list">
    <li class="alert-row critical" tabindex="0">
      <span class="alert-icon" aria-hidden="true"><!-- svg --></span>
      <span class="alert-label">Critical</span>
      <span class="alert-count" aria-label="4 critical alerts">4</span>
    </li>
  </ul>
</section>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML with no JavaScript, uses readable staggered `@keyframes` for the card/row entrance, and includes accessible/responsive markup (`aria-labelledby`, per-count `aria-label`, `:focus-visible`, `role="list"`, `prefers-reduced-motion`) — matching the repo's animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Counts and icons are static in the demo since real alert data would come from wherever the consuming app tracks alerts — this component is purely the display layer. Happy to adjust the icon set or add more severity tiers if useful.