### PR TITLE
feat: add soft shadow card demo

### DIFF
--- a/submissions/examples/soft-shadow-card-kk/README.md
+++ b/submissions/examples/soft-shadow-card-kk/README.md
@@ -1,0 +1,34 @@
+# Soft Shadow Card
+
+## What it does
+
+This submission creates a simple CSS-only soft shadow card utility for grouped content, dashboard widgets, feature blocks, and profile cards.
+
+## How to use it
+
+Wrap the content inside the card class:
+
+```html
+<div class="soft-shadow-card">
+  <h3>Card Title</h3>
+  <p>Card content goes here.</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in dashboards, cards, grouped content sections, and surface-based layouts.
+
+## Included features
+
+- Rounded soft-shadow card utility
+- Muted variation included in the demo
+- Practical grouped-content layout example
+- Responsive card grid layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the card utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/soft-shadow-card-kk/demo.html
+++ b/submissions/examples/soft-shadow-card-kk/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Soft Shadow Card</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Soft Shadow Card</p>
+          <h1>Simple rounded content cards with a subtle elevated surface.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only card utility with rounded
+            corners, gentle shadow depth, and clean spacing. It works well for
+            profile cards, dashboard widgets, feature blocks, and general
+            grouped content.
+          </p>
+        </header>
+
+        <section class="card-grid">
+          <article class="soft-shadow-card">
+            <h2>Profile Summary</h2>
+            <p>Use a soft card surface for concise user details, activity summaries, or grouped profile information.</p>
+          </article>
+
+          <article class="soft-shadow-card muted">
+            <h2>Feature Highlight</h2>
+            <p>A muted variation helps create subtle visual contrast while preserving the same reusable structure.</p>
+          </article>
+
+          <article class="soft-shadow-card">
+            <h2>Dashboard Widget</h2>
+            <p>This pattern is useful for compact metrics, notes, settings content, and informational modules.</p>
+          </article>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="soft-shadow-card"&gt;
+  &lt;h3&gt;Card Title&lt;/h3&gt;
+  &lt;p&gt;Card content goes here.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/soft-shadow-card-kk/style.css
+++ b/submissions/examples/soft-shadow-card-kk/style.css
@@ -1,0 +1,115 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --panel-muted: rgba(255, 255, 255, 0.05);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.soft-shadow-card p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.soft-shadow-card {
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: var(--panel-soft);
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+}
+
+.soft-shadow-card.muted {
+  background: var(--panel-muted);
+}
+
+.soft-shadow-card h2 {
+  margin: 0 0 0.45rem;
+  font-size: 1.15rem;
+}
+
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Soft Shadow Card demo inside `submissions/examples/soft-shadow-card-kk/`. This submission introduces a simple CSS-only card utility with rounded corners, subtle shadow depth, and a clean surface for grouped content.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only soft-shadow card utility for content blocks, dashboard widgets, feature sections, and grouped information surfaces.

**How does a developer use it?**

```html
<div class="soft-shadow-card">
  <h3>Card Title</h3>
  <p>Card content goes here.</p>
</div>