### PR TITLE
feat: add basic text badge demo

### DIFF
--- a/submissions/examples/basic-text-badge-kk/README.md
+++ b/submissions/examples/basic-text-badge-kk/README.md
@@ -1,0 +1,31 @@
+# Basic Text Badge
+
+## What it does
+
+This submission creates a simple CSS-only text badge utility for small labels such as New, Beta, Draft, Featured, or Pro.
+
+## How to use it
+
+Apply the badge class directly to an inline element:
+
+```html
+<span class="basic-text-badge">New</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, headings, grouped content, simple status areas, and lightweight labeling patterns.
+
+## Included features
+
+- Small rounded badge utility
+- Soft, warm, and outline variations in the demo
+- Example title-and-badge usage layout
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the badge utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-text-badge-kk/demo.html
+++ b/submissions/examples/basic-text-badge-kk/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Text Badge</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Basic Text Badge</p>
+          <h1>Small rounded labels for headings, cards, and simple status text.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only text badge utility for
+            labels like New, Beta, Draft, Featured, or Pro. It is intentionally
+            simple, reusable, and easy to use across many interface patterns.
+          </p>
+        </header>
+
+        <section class="badge-row">
+          <span class="basic-text-badge">New</span>
+          <span class="basic-text-badge soft">Beta</span>
+          <span class="basic-text-badge warm">Featured</span>
+          <span class="basic-text-badge outline">Pro</span>
+        </section>
+
+        <section class="example-panel">
+          <div class="card-top">
+            <h2>Feature Block</h2>
+            <span class="basic-text-badge">Draft</span>
+          </div>
+          <p>
+            The badge can sit beside a title or inside a card to communicate a
+            small piece of contextual information without taking much space.
+          </p>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="basic-text-badge"&gt;New&lt;/span&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-text-badge-kk/style.css
+++ b/submissions/examples/basic-text-badge-kk/style.css
@@ -1,0 +1,136 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #a2b1ce;
+  --accent: #8fa7ff;
+  --accent-soft: rgba(143, 167, 255, 0.16);
+  --warm: #ffbf7a;
+  --warm-soft: rgba(255, 191, 122, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.example-panel p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.badge-row,
+.card-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.badge-row {
+  margin: 0.4rem 0;
+}
+
+.basic-text-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.basic-text-badge.soft {
+  background: var(--panel-soft);
+  color: var(--text);
+}
+
+.basic-text-badge.warm {
+  background: var(--warm-soft);
+  color: var(--warm);
+}
+
+.basic-text-badge.outline {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.example-panel,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.example-panel h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Text Badge demo inside `submissions/examples/basic-text-badge-kk/`. This submission introduces a simple CSS-only badge utility for small labels such as New, Beta, Draft, Featured, or Pro.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only basic text badge utility for small labels used in cards, headings, grouped content, and simple status areas.

**How does a developer use it?**

```html
<span class="basic-text-badge">New</span>