### PR TITLE
feat: add CSS online users sidebar (#70082)

### DIFF
--- a/submissions/examples/css-online-users-sidebar/README.md
+++ b/submissions/examples/css-online-users-sidebar/README.md
@@ -1,0 +1,106 @@
+# CSS Online Users Sidebar
+
+A sidebar listing members grouped by status (**Online**, **Away**,
+**Offline**), each with an avatar, a pulsing status dot, and a search
+input at the top. Pure CSS/HTML — no JavaScript.
+
+## Files
+
+- `demo.html` — sidebar with 3 status groups (7 users total) and a search box
+- `style.css` — layout, status-dot colors/pulse, and entrance animations
+- `README.md` — this file
+
+## How it works
+
+Each `.user-row` has a `.user-status` dot colored via a CSS custom
+property per status (`--online`, `--away`, `--offline`); the online dot
+also gets a looping `status-pulse` `@keyframes` ring, like a live
+presence indicator. Rows animate in with a short staggered `row-in`
+animation. The whole sidebar scrolls internally if the member list
+grows past its `max-height`.
+
+## Usage
+
+```html
+<aside class="users-sidebar" aria-label="Online users">
+  <div class="users-sidebar-header">
+    <h2>Members</h2>
+    <span class="users-count" aria-label="14 total members">14</span>
+  </div>
+
+  <div class="users-search">
+    <svg class="users-search-icon" viewBox="0 0 24 24" aria-hidden="true">...</svg>
+    <input type="search" class="users-search-input" placeholder="Search members" aria-label="Search members" />
+  </div>
+
+  <div class="users-group">
+    <p class="users-group-label">Online — 3</p>
+    <ul class="users-list" role="list">
+      <li class="user-row" tabindex="0">
+        <span class="user-avatar" aria-hidden="true">AK</span>
+        <span class="user-status online" aria-hidden="true"></span>
+        <span class="user-name">Aditi Kapoor</span>
+        <span class="sr-only">Online</span>
+      </li>
+    </ul>
+  </div>
+</aside>
+```
+
+Repeat `.users-group` blocks for each status tier, and `.user-row` for
+each member within a group.
+
+### About the search box
+
+The issue asks for a sidebar "with status dots and search." The status
+dots are fully CSS. The search box, though, can't actually filter the
+list in pure CSS — there's no CSS mechanism that reads what's typed
+into an `<input>` and hides/shows list items based on matching that
+text against arbitrary member names. That's a JavaScript (or server-side)
+capability, not something `:focus`, `:has()`, or any other selector can
+do against free-text content.
+
+So the search input here is included as real, usable, correctly-labeled
+markup (a proper `<input type="search">` with an icon and placeholder,
+styled to match the sidebar) but it's not wired to filter anything in
+this pure-CSS build — filtering would need a small JS listener on
+`input` to toggle a class per non-matching `.user-row`. Flagging this
+up front rather than have it be a surprise in review; happy to add that
+JS layer if the maintainer prefers a working filter over the CSS-only
+scope.
+
+### Accessibility
+
+- `aria-label="Online users"` on the `<aside>` identifies the whole
+  region for screen readers.
+- Each status dot is `aria-hidden` with a paired `.sr-only` text label
+  ("Online" / "Away" / "Offline") so status is announced as text, not
+  inferred from color alone.
+- The search input has a proper `aria-label` and placeholder, and
+  `type="search"` gets native semantics (including an OS-provided clear
+  button in most browsers).
+- Rows are focusable (`tabindex="0"`) with a visible `:focus-visible`
+  outline for keyboard users.
+- `role="list"` keeps list semantics explicit.
+
+### Responsive behavior
+
+At `max-width: 420px` the sidebar drops its fixed max-width and fills
+the available space instead, with slightly tighter padding.
+
+### Reduced motion
+
+`prefers-reduced-motion: reduce` disables the sidebar entrance, row
+entrance, and the online-status pulse ring.
+
+## Why it fits EaseMotion CSS
+
+Pure CSS/HTML, no JavaScript, no external assets, readable staggered
+`@keyframes` for entrances and the status pulse, and accessible/
+responsive markup — matching the repo's animation-first,
+accessible-by-default philosophy.
+
+## Notes
+
+- No existing files were modified — strictly additive, living entirely
+  in `submissions/examples/css-online-users-sidebar/`.

--- a/submissions/examples/css-online-users-sidebar/demo.html
+++ b/submissions/examples/css-online-users-sidebar/demo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Online Users Sidebar — EaseMotion-css</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="demo-heading">CSS Online Users Sidebar</p>
+
+  <aside class="users-sidebar" aria-label="Online users">
+    <div class="users-sidebar-header">
+      <h2>Members</h2>
+      <span class="users-count" aria-label="14 total members">14</span>
+    </div>
+
+    <div class="users-search">
+      <svg class="users-search-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" />
+        <path d="M21 21l-4.3-4.3" />
+      </svg>
+      <input
+        type="search"
+        class="users-search-input"
+        placeholder="Search members"
+        aria-label="Search members"
+      />
+    </div>
+
+    <div class="users-group">
+      <p class="users-group-label">Online — 3</p>
+      <ul class="users-list" role="list">
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">AK</span>
+          <span class="user-status online" aria-hidden="true"></span>
+          <span class="user-name">Aditi Kapoor</span>
+          <span class="sr-only">Online</span>
+        </li>
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">RS</span>
+          <span class="user-status online" aria-hidden="true"></span>
+          <span class="user-name">Rohan Shah</span>
+          <span class="sr-only">Online</span>
+        </li>
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">MJ</span>
+          <span class="user-status online" aria-hidden="true"></span>
+          <span class="user-name">Meera Joshi</span>
+          <span class="sr-only">Online</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="users-group">
+      <p class="users-group-label">Away — 2</p>
+      <ul class="users-list" role="list">
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">NV</span>
+          <span class="user-status away" aria-hidden="true"></span>
+          <span class="user-name">Neha Verma</span>
+          <span class="sr-only">Away</span>
+        </li>
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">SP</span>
+          <span class="user-status away" aria-hidden="true"></span>
+          <span class="user-name">Sameer Patil</span>
+          <span class="sr-only">Away</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="users-group">
+      <p class="users-group-label">Offline — 2</p>
+      <ul class="users-list" role="list">
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">TG</span>
+          <span class="user-status offline" aria-hidden="true"></span>
+          <span class="user-name">Tanvi Gupta</span>
+          <span class="sr-only">Offline</span>
+        </li>
+        <li class="user-row" tabindex="0">
+          <span class="user-avatar" aria-hidden="true">DK</span>
+          <span class="user-status offline" aria-hidden="true"></span>
+          <span class="user-name">Dev Kulkarni</span>
+          <span class="sr-only">Offline</span>
+        </li>
+      </ul>
+    </div>
+  </aside>
+
+</body>
+</html>

--- a/submissions/examples/css-online-users-sidebar/style.css
+++ b/submissions/examples/css-online-users-sidebar/style.css
@@ -1,0 +1,272 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 20px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.users-sidebar {
+  --online: #3ddc84;
+  --away: #f5a623;
+  --offline: #6b7280;
+
+  width: 100%;
+  max-width: 300px;
+  max-height: 520px;
+  overflow-y: auto;
+  background: #14181f;
+  border-radius: 16px;
+  padding: 18px 16px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4);
+  animation: sidebar-in 0.4s ease both;
+}
+
+@keyframes sidebar-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.users-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.users-sidebar-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.users-count {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #9aa4b2;
+  background: #1c2028;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.users-search {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.users-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  width: 15px;
+  height: 15px;
+  transform: translateY(-50%);
+  fill: none;
+  stroke: #9aa4b2;
+  stroke-width: 2;
+  stroke-linecap: round;
+  pointer-events: none;
+}
+
+.users-search-input {
+  width: 100%;
+  background: #1c2028;
+  border: 1px solid #262b35;
+  border-radius: 10px;
+  padding: 8px 10px 8px 32px;
+  font-size: 0.82rem;
+  color: #e6e6e6;
+  outline: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.users-search-input::placeholder {
+  color: #6b7280;
+}
+
+.users-search-input:focus-visible {
+  border-color: #4f8cff;
+  background: #20242d;
+}
+
+.users-search-input::-webkit-search-cancel-button {
+  filter: invert(60%);
+}
+
+.users-group + .users-group {
+  margin-top: 16px;
+}
+
+.users-group-label {
+  margin: 0 0 6px 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #9aa4b2;
+}
+
+.users-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.user-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  outline: none;
+  cursor: default;
+  transition: background-color 0.15s ease;
+  animation: row-in 0.3s ease both;
+}
+
+.users-list .user-row:nth-child(1) { animation-delay: 0.03s; }
+.users-list .user-row:nth-child(2) { animation-delay: 0.09s; }
+.users-list .user-row:nth-child(3) { animation-delay: 0.15s; }
+
+@keyframes row-in {
+  from {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.user-row:hover,
+.user-row:focus-visible {
+  background: #1c2028;
+}
+
+.user-row:focus-visible {
+  outline: 2px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+.user-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border-radius: 50%;
+  background: #262b35;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #cbd2db;
+}
+
+.user-status {
+  position: absolute;
+  left: 26px;
+  bottom: 6px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 2px solid #14181f;
+}
+
+.user-status.online {
+  background: var(--online);
+  box-shadow: 0 0 0 0 rgba(61, 220, 132, 0.5);
+  animation: status-pulse 2s ease-out infinite;
+}
+
+@keyframes status-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(61, 220, 132, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(61, 220, 132, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(61, 220, 132, 0);
+  }
+}
+
+.user-status.away {
+  background: var(--away);
+}
+
+.user-status.offline {
+  background: var(--offline);
+}
+
+.user-name {
+  font-size: 0.85rem;
+  color: #e6e6e6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.users-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.users-sidebar::-webkit-scrollbar-thumb {
+  background: #262b35;
+  border-radius: 999px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 420px) {
+  .users-sidebar {
+    max-width: 100%;
+    padding: 14px 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .users-sidebar,
+  .user-row,
+  .user-status.online {
+    animation: none;
+  }
+}


### PR DESCRIPTION
closes #70082
## Pull Request Description
Adds a "CSS Online Users Sidebar" component, as requested in issue #70082. A member list sidebar grouped by Online/Away/Offline status, each with an avatar, a pulsing status dot, and a styled search input at the top.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-online-users-sidebar/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A sidebar listing members grouped by status (Online/Away/Offline) with pulsing status dots, avatars, and a search input, plus staggered entrance animations.

**How does a developer use it?**
```html
<aside class="users-sidebar" aria-label="Online users">
  <div class="users-group">
    <p class="users-group-label">Online — 3</p>
    <ul class="users-list" role="list">
      <li class="user-row" tabindex="0">
        <span class="user-avatar" aria-hidden="true">AK</span>
        <span class="user-status online" aria-hidden="true"></span>
        <span class="user-name">Aditi Kapoor</span>
        <span class="sr-only">Online</span>
      </li>
    </ul>
  </div>
</aside>
```

**Why does it fit EaseMotion CSS?**
Pure CSS/HTML with no JavaScript, uses a looping `status-pulse` `@keyframes` for the live-presence dot plus staggered row-entrance animations, and includes accessible/responsive markup (`aria-label`, `.sr-only` status text, `:focus-visible`, `role="list"`, `prefers-reduced-motion`) — matching the repo's animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Same trade-off note as a couple of my other recent submissions: the issue asks for "search" alongside status dots, but pure CSS has no way to filter list content against typed input text — that's a JavaScript capability. I've included a fully-styled, correctly-labeled `<input type="search">` in the markup so it's ready to wire up, but flagged in the README that it isn't functional filtering in this CSS-only build. Happy to add a small JS listener on top if a working filter is preferred over the pure-CSS scope.