### PR TITLE
Add style.css for css-notification-center example

### DIFF
--- a/submissions/examples/css-notification-center/style.css
+++ b/submissions/examples/css-notification-center/style.css
@@ -1,0 +1,322 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 24px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.notif-center {
+  --success: #3ddc84;
+  --info: #4f8cff;
+  --warning: #f5a623;
+  --error: #ff4d4f;
+
+  position: relative;
+}
+
+.notif-toggle-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.notif-bell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: #161a22;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.2s ease;
+}
+
+.notif-bell:hover {
+  background: #1c2028;
+}
+
+.notif-toggle-input:focus-visible + .notif-bell {
+  outline: 2px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+.notif-bell svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: #cbd2db;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.notif-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--error);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: badge-pop 0.3s ease 0.2s both;
+}
+
+@keyframes badge-pop {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+.notif-overlay {
+  position: fixed;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  cursor: default;
+}
+
+.notif-toggle-input:checked ~ .notif-overlay {
+  pointer-events: auto;
+}
+
+.notif-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 320px;
+  max-height: 420px;
+  overflow-y: auto;
+  background: #14181f;
+  border-radius: 16px;
+  padding: 16px 16px 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+
+  opacity: 0;
+  transform: translateY(-8px) scale(0.98);
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.notif-toggle-input:checked ~ .notif-panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.notif-panel-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.notif-panel-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.notif-panel-count {
+  font-size: 0.72rem;
+  color: #9aa4b2;
+}
+
+.notif-group + .notif-group {
+  margin-top: 14px;
+}
+
+.notif-group-label {
+  margin: 0 0 6px 2px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #9aa4b2;
+}
+
+.notif-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.notif-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 8px;
+  border-radius: 10px;
+  border-left: 3px solid transparent;
+  outline: none;
+  cursor: default;
+  transition: background-color 0.15s ease;
+}
+
+.notif-row:hover,
+.notif-row:focus-visible {
+  background: #1c2028;
+}
+
+.notif-row:focus-visible {
+  outline: 2px solid #4f8cff;
+  outline-offset: -2px;
+}
+
+.notif-row.success { border-left-color: var(--success); }
+.notif-row.info { border-left-color: var(--info); }
+.notif-row.warning { border-left-color: var(--warning); }
+.notif-row.error { border-left-color: var(--error); }
+
+.notif-row-icon {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+}
+
+.notif-row-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.notif-row.success .notif-row-icon svg { stroke: var(--success); }
+.notif-row.info .notif-row-icon svg { stroke: var(--info); }
+.notif-row.warning .notif-row-icon svg { stroke: var(--warning); }
+.notif-row.error .notif-row-icon svg { stroke: var(--error); }
+
+.notif-row-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.notif-row-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e6e6e6;
+}
+
+.notif-row-message {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: #9aa4b2;
+}
+
+.notif-row-time {
+  margin: 4px 0 0;
+  font-size: 0.68rem;
+  color: #5f6b7a;
+}
+
+.notif-row-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #4f8cff;
+  opacity: 0;
+}
+
+.notif-row.unread .notif-row-dot {
+  opacity: 1;
+}
+
+.notif-row.unread .notif-row-title {
+  color: #fff;
+}
+
+.notif-panel-footer {
+  position: sticky;
+  bottom: 0;
+  margin-top: 12px;
+  padding: 10px 0 4px;
+  background: #14181f;
+  border-top: 1px solid #232833;
+  text-align: center;
+}
+
+.notif-clear-btn {
+  background: none;
+  border: none;
+  color: #4f8cff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.notif-clear-btn:hover,
+.notif-clear-btn:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.notif-empty {
+  display: none;
+  padding: 24px 8px;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #5f6b7a;
+}
+
+.notif-panel::-webkit-scrollbar {
+  width: 6px;
+}
+
+.notif-panel::-webkit-scrollbar-thumb {
+  background: #232833;
+  border-radius: 999px;
+}
+
+.notif-panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@media (max-width: 420px) {
+  .notif-panel {
+    width: 88vw;
+    right: -8px;
+  }
+}


### PR DESCRIPTION
closes #70093
## Pull Request Description
Adds a CSS-only notification center dropdown (bell icon + badge + panel with grouped, categorized notifications) to the examples collection.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-notification-center/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [ ] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS notification center: a bell icon with an animated unread badge that toggles a dropdown panel of grouped, categorized notifications (success/info/warning/error), with hover/focus states, an unread indicator, and a footer action — no JavaScript required.

**How does a developer use it?**
```html
<div class="notif-center">
  <input type="checkbox" id="notif-toggle" class="notif-toggle-input">
  <label for="notif-toggle" class="notif-bell">
    <svg><!-- bell icon --></svg>
    <span class="notif-badge">3</span>
  </label>
  <label for="notif-toggle" class="notif-overlay"></label>

  <div class="notif-panel">
    <div class="notif-panel-header">
      <h2>Notifications</h2>
      <span class="notif-panel-count">3 new</span>
    </div>

    <div class="notif-group">
      <p class="notif-group-label">Today</p>
      <ul class="notif-list">
        <li class="notif-row success unread" tabindex="0">
          <span class="notif-row-icon"><svg><!-- icon --></svg></span>
          <span class="notif-row-text">
            <p class="notif-row-title">Payment received</p>
            <p class="notif-row-message">Your invoice was paid.</p>
            <p class="notif-row-time">2m ago</p>
          </span>
          <span class="notif-row-dot"></span>
        </li>
      </ul>
    </div>

    <div class="notif-panel-footer">
      <button class="notif-clear-btn">Clear all</button>
    </div>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a self-contained, human-readable component driven entirely by the checkbox hack — no JS dependency, semantic class names (`notif-row`, `notif-badge`, `unread`, etc.), and smooth, purposeful transitions (badge pop-in, panel fade/scale) that align with the animation-first philosophy of the library.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The scrollbar styling (`::-webkit-scrollbar`) is WebKit-only — Firefox will fall back to the default scrollbar. Happy to add `scrollbar-width`/`scrollbar-color` for Firefox parity if preferred.