### PR TITLE
feat: add pure CSS Popconfirm component (#70686)

### DIFF
--- a/submissions/examples/css-popconfirm-pure/README.md
+++ b/submissions/examples/css-popconfirm-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Popconfirm Component
+
+A confirmation popover component for destructive actions built entirely with the native HTML `popover` API and modern CSS animations, requiring absolutely no JavaScript.
+
+## Features
+- Pure CSS and HTML implementation without any JavaScript logic or event listeners.
+- **Component Architecture**: 
+  - **The Native Popover API**: The component uses the native HTML `popover` attribute to completely remove the confirmation dialog from the document flow and place it in the browser's top layer.
+  - **Declarative Triggers**: The "Delete Account" button opens the popover using `popovertarget="delete-confirm"`. The "Cancel" and "Yes" buttons inside the popover dismiss it natively using `popovertargetaction="hide"`.
+  - **Discrete Transitions**: To animate a popover, it must transition from `display: none` to `display: block` (and `overlay: none` to `overlay: auto`). Historically, this caused CSS transitions to instantly jump. By adding `transition-behavior: allow-discrete` to the `display` and `overlay` properties, the browser waits for the opacity/transform animations to finish before removing the element from the render tree.
+  - **The `@starting-style` Rule**: When the modal first opens, it enters the DOM instantly. The new `@starting-style` block defines the exact styles (`opacity: 0`, `transform: scale(0.95)`) that the element should hold at the very instant it becomes `display: block`. It then smoothly transitions to its natural `:popover-open` state.
+  - **Animated Backdrop**: The exact same `@starting-style` and discrete transition logic is applied to the native `::backdrop` pseudo-element to fade the dark overlay in and out synchronously with the popconfirm dialog.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the popover surface, text colors, and shadows.
+- Fully accessible semantic structure. Because it relies on the native HTML `popover` specification, it automatically inherits Focus Management, Esc-key to dismiss, and light-dismiss (clicking the backdrop). Honors the `prefers-reduced-motion` accessibility standard by disabling the `@starting-style` transitions for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your modern browser (Chrome 117+, Safari 17.5+). Click the "Delete Account" button to trigger the confirmation popover. Click outside or use the inner buttons to dismiss it.
+
+## Files
+- `demo.html`: The HTML structure defining the trigger button, the native `popover` element, and the dismiss buttons.
+- `style.css`: The styling, the discrete transitions, and the `@starting-style` entry animations.

--- a/submissions/examples/css-popconfirm-pure/demo.html
+++ b/submissions/examples/css-popconfirm-pure/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Popconfirm Component</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Popconfirm</h1>
+            <p class="subtitle">A confirmation popover for destructive actions built entirely with the native HTML <code>popover</code> attribute and CSS <code>@starting-style</code>.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="demo-card">
+                <h3>Account Settings</h3>
+                <p>Manage your account preferences and data.</p>
+                
+                <div class="actions-row">
+                    <button class="btn btn-secondary">Edit Profile</button>
+                    
+                    <!-- 
+                      [TECHNIQUE] Native Popover Trigger 
+                      The popovertarget attribute binds this button to the popover element,
+                      allowing it to open the popover without any JavaScript.
+                    -->
+                    <button class="btn btn-danger" popovertarget="delete-confirm">
+                        Delete Account
+                    </button>
+                </div>
+            </div>
+            
+            <!-- 
+              [TECHNIQUE] Native Popover Element
+              The popover attribute removes this element from the normal document flow
+              and places it in the top layer when triggered.
+            -->
+            <div id="delete-confirm" class="popconfirm" popover>
+                <div class="popconfirm-header">
+                    <div class="icon-warning">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                            <line x1="12" y1="9" x2="12" y2="13"></line>
+                            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                        </svg>
+                    </div>
+                    <strong>Delete this account?</strong>
+                </div>
+                
+                <p class="popconfirm-body">
+                    All of your data will be permanently removed. This action cannot be undone.
+                </p>
+                
+                <div class="popconfirm-actions">
+                    <!-- popovertargetaction="hide" ensures these buttons close the popover -->
+                    <button class="btn btn-sm btn-ghost" popovertarget="delete-confirm" popovertargetaction="hide">No, cancel</button>
+                    <button class="btn btn-sm btn-danger" popovertarget="delete-confirm" popovertargetaction="hide">Yes, delete</button>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-popconfirm-pure/style.css
+++ b/submissions/examples/css-popconfirm-pure/style.css
@@ -1,0 +1,269 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Popconfirm Variables */
+    --pop-bg: #ffffff;
+    --pop-border: #e2e8f0;
+    --pop-shadow: rgba(0, 0, 0, 0.1);
+    --pop-backdrop: rgba(0, 0, 0, 0.2);
+    
+    /* Buttons */
+    --btn-danger-bg: #ef4444;
+    --btn-danger-hover: #dc2626;
+    --btn-ghost-hover: #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --pop-bg: #1e293b;
+        --pop-border: #334155;
+        --pop-shadow: rgba(0, 0, 0, 0.5);
+        --pop-backdrop: rgba(0, 0, 0, 0.6);
+        
+        --btn-ghost-hover: #334155;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   Demo Card & Buttons
+   ========================================= */
+
+.demo-card {
+    background-color: var(--pop-bg);
+    border: 1px solid var(--pop-border);
+    border-radius: 12px;
+    padding: 24px;
+    width: 100%;
+    max-width: 400px;
+    box-shadow: 0 4px 6px -1px var(--pop-shadow);
+}
+
+.demo-card h3 {
+    margin: 0 0 8px 0;
+    font-size: 1.25rem;
+}
+
+.demo-card p {
+    margin: 0 0 24px 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.actions-row {
+    display: flex;
+    gap: 12px;
+}
+
+.btn {
+    appearance: none;
+    background: none;
+    border: 1px solid var(--pop-border);
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-secondary {
+    background-color: transparent;
+}
+.btn-secondary:hover {
+    background-color: var(--btn-ghost-hover);
+}
+
+.btn-danger {
+    background-color: var(--btn-danger-bg);
+    color: white;
+    border-color: transparent;
+}
+.btn-danger:hover {
+    background-color: var(--btn-danger-hover);
+}
+
+.btn-ghost {
+    border-color: transparent;
+}
+.btn-ghost:hover {
+    background-color: var(--btn-ghost-hover);
+}
+
+.btn-sm {
+    padding: 6px 12px;
+    font-size: 0.85rem;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Native Popconfirm
+   ========================================= */
+
+.popconfirm {
+    /* Basic Styling */
+    position: fixed;
+    margin: auto;
+    width: 280px;
+    padding: 16px;
+    background-color: var(--pop-bg);
+    border: 1px solid var(--pop-border);
+    border-radius: 8px;
+    box-shadow: 0 20px 25px -5px var(--pop-shadow), 0 10px 10px -5px var(--pop-shadow);
+    color: var(--text-primary);
+    
+    /* Layout */
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    
+    /* Native Popover resets */
+    inset: 0;
+    max-height: 100vh;
+    max-width: 100vw;
+}
+
+.popconfirm-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.icon-warning {
+    color: var(--btn-danger-bg);
+    display: flex;
+    align-items: center;
+}
+
+.popconfirm-body {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.popconfirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Native Popover Animations
+   Using @starting-style and discrete transitions
+   ========================================= */
+
+.popconfirm {
+    /* 1. Base transition (when closing) */
+    transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+                opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+                display 0.2s allow-discrete,
+                overlay 0.2s allow-discrete;
+                
+    /* Closed state styles */
+    opacity: 0;
+    transform: translateY(10px) scale(0.95);
+}
+
+/* 2. Open state styles */
+.popconfirm:popover-open {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    
+    /* When opening, the transition is the same */
+}
+
+/* 3. The starting style (the very first frame when display becomes block) */
+@starting-style {
+    .popconfirm:popover-open {
+        opacity: 0;
+        transform: translateY(10px) scale(0.95);
+    }
+}
+
+
+/* Backdrop Animation */
+.popconfirm::backdrop {
+    background-color: var(--pop-backdrop);
+    backdrop-filter: blur(2px);
+    transition: opacity 0.3s ease,
+                display 0.3s allow-discrete,
+                overlay 0.3s allow-discrete;
+    opacity: 0;
+}
+
+.popconfirm:popover-open::backdrop {
+    opacity: 1;
+}
+
+@starting-style {
+    .popconfirm:popover-open::backdrop {
+        opacity: 0;
+    }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .popconfirm,
+    .popconfirm::backdrop {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a confirmation popover component for destructive actions built entirely with the native HTML `popover` API and modern CSS animations, requiring absolutely no JavaScript. Resolves issue #70686.

### Changes Made:
- Added `submissions/examples/css-popconfirm-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the declarative trigger button, the native `popover` element, and the dismiss buttons.
- Created `style.css` featuring the UI mechanics:
  - **The Native Popover API**: The component uses the native HTML `popover` attribute to completely remove the confirmation dialog from the document flow and place it in the browser's top layer.
  - **Declarative Triggers**: The "Delete Account" button opens the popover using `popovertarget="delete-confirm"`. The "Cancel" and "Yes" buttons inside the popover dismiss it natively using `popovertargetaction="hide"`.
  - **Discrete Transitions**: To animate a popover, it must transition from `display: none` to `display: block` (and `overlay: none` to `overlay: auto`). Historically, this caused CSS transitions to instantly jump. By adding `transition-behavior: allow-discrete` to the `display` and `overlay` properties, the browser waits for the opacity/transform animations to finish before removing the element from the render tree.
  - **The `@starting-style` Rule**: When the modal first opens, it enters the DOM instantly. The new `@starting-style` block defines the exact styles (`opacity: 0`, `transform: scale(0.95)`) that the element should hold at the very instant it becomes `display: block`. It then smoothly transitions to its natural `:popover-open` state.
  - **Animated Backdrop**: The exact same `@starting-style` and discrete transition logic is applied to the native `::backdrop` pseudo-element to fade the dark overlay in and out synchronously with the popconfirm dialog.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the popover surface, text colors, and shadows.
- Added `README.md` documenting usage and the technical mechanics of discrete transitions and `@starting-style`.
- Fully accessible semantic structure. Because it relies on the native HTML `popover` specification, it automatically inherits Focus Management, Esc-key to dismiss, and light-dismiss (clicking the backdrop). Honors the `prefers-reduced-motion` accessibility standard by disabling the `@starting-style` transitions for motion-sensitive users.

Closes #70686
