### PR TITLE
feat: add ease-refractometer-prism-bend (#72925)

### DIFF
--- a/submissions/examples/refractometer-prism-bend-ns/README.md
+++ b/submissions/examples/refractometer-prism-bend-ns/README.md
@@ -1,0 +1,16 @@
+# Refractometer Prism Bend
+
+## What does this do?
+Renders a self-contained CSS-only `ease-refractometer-prism-bend` demo: Refractometer prism bending a sample beam through critical angle.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-refractometer-prism-bend`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-refractometer-prism-bend">
+  <div class="ease-refractometer-prism-bend__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/refractometer-prism-bend-ns/demo.html
+++ b/submissions/examples/refractometer-prism-bend-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Refractometer Prism Bend — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Refractometer Prism Bend demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Refractometer Prism Bend</h1>
+      <p class="lede">Refractometer prism bending a sample beam through critical angle</p>
+    </header>
+
+    <section class="ease-refractometer-prism-bend" data-demo="refractometer-prism-bend" aria-live="polite">
+      <div class="ease-refractometer-prism-bend__housing">
+        <div class="ease-refractometer-prism-bend__bezel">
+          <div class="ease-refractometer-prism-bend__face">
+            <div class="ease-refractometer-prism-bend__readout">
+              <span class="ease-refractometer-prism-bend__label">Refractometer Prism Bend</span>
+              <span class="ease-refractometer-prism-bend__value">LIVE</span>
+            </div>
+            <div class="ease-refractometer-prism-bend__motion" aria-hidden="true">
+              <span class="ease-refractometer-prism-bend__a"></span>
+              <span class="ease-refractometer-prism-bend__b"></span>
+              <span class="ease-refractometer-prism-bend__c"></span>
+              <span class="ease-refractometer-prism-bend__d"></span>
+            </div>
+            <div class="ease-refractometer-prism-bend__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-refractometer-prism-bend__controls">
+          <button type="button" class="ease-refractometer-prism-bend__btn primary">Engage</button>
+          <button type="button" class="ease-refractometer-prism-bend__btn">Reset</button>
+          <label class="ease-refractometer-prism-bend__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-refractometer-prism-bend__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/refractometer-prism-bend-ns/style.css
+++ b/submissions/examples/refractometer-prism-bend-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #140f08;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-refractometer-prism-bend {
+  --accent: #f59e0b;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #140f08);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #140f08 75%, #000);
+}
+
+.ease-refractometer-prism-bend__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-refractometer-prism-bend__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #140f08 90%, #f59e0b);
+}
+
+.ease-refractometer-prism-bend__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-refractometer-prism-bend__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-refractometer-prism-bend__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-refractometer-prism-bend__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-refractometer-prism-bend__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-refractometer-prism-bend__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-refractometer-prism-bend__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: refractometer_prism_bend_meter 3.1s linear infinite;
+}
+
+.ease-refractometer-prism-bend__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-refractometer-prism-bend__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-refractometer-prism-bend__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-refractometer-prism-bend__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-refractometer-prism-bend__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-refractometer-prism-bend__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-refractometer-prism-bend__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-refractometer-prism-bend__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-refractometer-prism-bend__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-refractometer-prism-bend__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-refractometer-prism-bend__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: refractometer_prism_bend_status 2.3s ease-out infinite;
+}
+
+@keyframes refractometer_prism_bend_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes refractometer_prism_bend_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-refractometer-prism-bend__a{position:absolute;left:18%;top:30%;width:28%;height:12px;background:var(--accent);transform-origin:right center;animation:refractometer_prism_bend_in 2.75s ease-in-out infinite}
+.ease-refractometer-prism-bend__b{position:absolute;left:46%;top:24%;width:18%;aspect-ratio:1;clip-path:polygon(0 40%,100% 0,100% 100%,0 60%);background:color-mix(in srgb,var(--accent-2) 80%,#fff);animation:refractometer_prism_bend_prism 2.75s ease-in-out infinite}
+.ease-refractometer-prism-bend__c{position:absolute;left:62%;top:34%;width:24%;height:8px;background:linear-gradient(90deg,var(--accent),transparent);transform-origin:left center;animation:refractometer_prism_bend_out 2.75s ease-in-out infinite}
+.ease-refractometer-prism-bend__d{position:absolute;right:14%;top:20%;width:16%;height:40%;border:1px solid var(--line);border-radius:6px;background:repeating-linear-gradient(180deg,transparent 0 8px,color-mix(in srgb,var(--accent) 25%,transparent) 8px 9px)}
+
+@keyframes refractometer_prism_bend_in{0%,100%{transform:rotate(0)}50%{transform:rotate(-18deg)}}@keyframes refractometer_prism_bend_prism{0%,100%{filter:hue-rotate(0deg)}50%{filter:hue-rotate(40deg)}}@keyframes refractometer_prism_bend_out{0%,100%{transform:rotate(0) scaleX(.7)}50%{transform:rotate(22deg) scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-refractometer-prism-bend__a,
+  .ease-refractometer-prism-bend__b,
+  .ease-refractometer-prism-bend__c,
+  .ease-refractometer-prism-bend__d,
+  .ease-refractometer-prism-bend__meters i::after,
+  .ease-refractometer-prism-bend__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-refractometer-prism-bend` CSS-only demo for #72925.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Refractometer prism bending a sample beam through critical angle

**How does a developer use it?**

```html
<section class="ease-refractometer-prism-bend">
  <div class="ease-refractometer-prism-bend__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/refractometer-prism-bend-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #72925