### PR TITLE
feat: add ease-cathetometer-scale-slide (#72927)

### DIFF
--- a/submissions/examples/cathetometer-scale-slide-ns/README.md
+++ b/submissions/examples/cathetometer-scale-slide-ns/README.md
@@ -1,0 +1,16 @@
+# Cathetometer Scale Slide
+
+## What does this do?
+Renders a self-contained CSS-only `ease-cathetometer-scale-slide` demo: Cathetometer telescope sliding on a vertical vernier scale.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-cathetometer-scale-slide`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-cathetometer-scale-slide">
+  <div class="ease-cathetometer-scale-slide__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/cathetometer-scale-slide-ns/demo.html
+++ b/submissions/examples/cathetometer-scale-slide-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cathetometer Scale Slide — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Cathetometer Scale Slide demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Cathetometer Scale Slide</h1>
+      <p class="lede">Cathetometer telescope sliding on a vertical vernier scale</p>
+    </header>
+
+    <section class="ease-cathetometer-scale-slide" data-demo="cathetometer-scale-slide" aria-live="polite">
+      <div class="ease-cathetometer-scale-slide__housing">
+        <div class="ease-cathetometer-scale-slide__bezel">
+          <div class="ease-cathetometer-scale-slide__face">
+            <div class="ease-cathetometer-scale-slide__readout">
+              <span class="ease-cathetometer-scale-slide__label">Cathetometer Scale Slide</span>
+              <span class="ease-cathetometer-scale-slide__value">LIVE</span>
+            </div>
+            <div class="ease-cathetometer-scale-slide__motion" aria-hidden="true">
+              <span class="ease-cathetometer-scale-slide__a"></span>
+              <span class="ease-cathetometer-scale-slide__b"></span>
+              <span class="ease-cathetometer-scale-slide__c"></span>
+              <span class="ease-cathetometer-scale-slide__d"></span>
+            </div>
+            <div class="ease-cathetometer-scale-slide__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-cathetometer-scale-slide__controls">
+          <button type="button" class="ease-cathetometer-scale-slide__btn primary">Engage</button>
+          <button type="button" class="ease-cathetometer-scale-slide__btn">Reset</button>
+          <label class="ease-cathetometer-scale-slide__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-cathetometer-scale-slide__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cathetometer-scale-slide-ns/style.css
+++ b/submissions/examples/cathetometer-scale-slide-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c4b5fd 18%, transparent), transparent 42%),
+    #120b1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-cathetometer-scale-slide {
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #120b1c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #120b1c 75%, #000);
+}
+
+.ease-cathetometer-scale-slide__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-cathetometer-scale-slide__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #120b1c 90%, #a78bfa);
+}
+
+.ease-cathetometer-scale-slide__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-cathetometer-scale-slide__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-cathetometer-scale-slide__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-cathetometer-scale-slide__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-cathetometer-scale-slide__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-cathetometer-scale-slide__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-cathetometer-scale-slide__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: cathetometer_scale_slide_meter 3.5s linear infinite;
+}
+
+.ease-cathetometer-scale-slide__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-cathetometer-scale-slide__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-cathetometer-scale-slide__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-cathetometer-scale-slide__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-cathetometer-scale-slide__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-cathetometer-scale-slide__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-cathetometer-scale-slide__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-cathetometer-scale-slide__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-cathetometer-scale-slide__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-cathetometer-scale-slide__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-cathetometer-scale-slide__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: cathetometer_scale_slide_status 2.3s ease-out infinite;
+}
+
+@keyframes cathetometer_scale_slide_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes cathetometer_scale_slide_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-cathetometer-scale-slide__a{position:absolute;left:12%;right:12%;top:48%;height:6px;border-radius:3px;background:var(--line)}
+.ease-cathetometer-scale-slide__b{position:absolute;top:38%;width:18%;height:26%;border-radius:8px;border:1px solid var(--line);background:color-mix(in srgb,var(--accent) 20%,var(--panel));animation:cathetometer_scale_slide_slide 3.1s ease-in-out infinite alternate}
+.ease-cathetometer-scale-slide__c{position:absolute;left:14%;top:22%;width:8px;height:56%;background:repeating-linear-gradient(180deg,var(--accent) 0 2px,transparent 2px 8px);opacity:.55}
+.ease-cathetometer-scale-slide__d{position:absolute;right:16%;bottom:18%;width:22%;height:8px;border-radius:4px;background:var(--accent);animation:cathetometer_scale_slide_mark 3.1s ease-in-out infinite alternate}
+
+@keyframes cathetometer_scale_slide_slide{from{left:14%}to{left:66%}}@keyframes cathetometer_scale_slide_mark{from{opacity:.35;transform:translateX(0)}to{opacity:1;transform:translateX(20px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cathetometer-scale-slide__a,
+  .ease-cathetometer-scale-slide__b,
+  .ease-cathetometer-scale-slide__c,
+  .ease-cathetometer-scale-slide__d,
+  .ease-cathetometer-scale-slide__meters i::after,
+  .ease-cathetometer-scale-slide__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-cathetometer-scale-slide` CSS-only demo for #72927.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Cathetometer telescope sliding on a vertical vernier scale

**How does a developer use it?**

```html
<section class="ease-cathetometer-scale-slide">
  <div class="ease-cathetometer-scale-slide__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/cathetometer-scale-slide-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #72927