### PR TITLE
feat: add pure CSS Ribbon Nav Bar component (#70619)

### DIFF
--- a/submissions/examples/css-ribbon-nav-bar-pure/README.md
+++ b/submissions/examples/css-ribbon-nav-bar-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Ribbon Nav Bar
+
+A horizontal navigation bar designed to look like a folded ribbon wrapping around its container, using advanced CSS border triangles and pseudo-elements.
+
+## Features
+- Pure CSS and HTML implementation without any JavaScript or SVG images.
+- **Component Architecture**: 
+  - **Negative Margins**: The `.ribbon-nav` is given a negative left and right margin (e.g., `-20px`), pulling it outside the bounds of its parent `.content-block`.
+  - **The Border Triangle Trick**: We use `::before` and `::after` on the navigation wrapper to create BOTH the hanging tail AND the dark folded shadow triangle simultaneously using massive CSS borders. By setting `border-width: 15px 20px 20px 20px` and carefully assigning colors to the top and side borders while leaving the others `transparent`, we can instantly slice a perfect "v-shape" tail and a folded shadow corner in one single CSS rule.
+  - **Z-Index Layering**: The pseudo-elements are pushed behind the main bar using `z-index: -1`, completing the illusion that the ribbon wraps around the back of the content container.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the ribbon colors, shadows, and content backgrounds.
+- Fully accessible semantic structure. The component uses a `<nav>` element with a proper `aria-label`, an unordered list (`<ul>`), and anchor links (`<a>`). It fully supports keyboard navigation and focus states.
+
+## Usage
+Open `demo.html` in your browser to view the folded ribbon navigation component.
+
+## Files
+- `demo.html`: The HTML structure defining the content container and the navigation list.
+- `style.css`: The styling, negative margins, and the `::before`/`::after` border geometry tricks.

--- a/submissions/examples/css-ribbon-nav-bar-pure/demo.html
+++ b/submissions/examples/css-ribbon-nav-bar-pure/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Ribbon Nav Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Ribbon Nav</h1>
+            <p class="subtitle">A horizontal navigation bar designed to look like a folded ribbon wrapping around its container, using advanced CSS border triangles and pseudo-elements.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              The 'content-block' simulates the main page container 
+              that the ribbon wraps around.
+            -->
+            <div class="content-block">
+                
+                <nav class="ribbon-nav" aria-label="Main Navigation">
+                    <ul class="ribbon-menu">
+                        <li class="ribbon-item">
+                            <a href="#" class="ribbon-link active">Home</a>
+                        </li>
+                        <li class="ribbon-item">
+                            <a href="#" class="ribbon-link">Products</a>
+                        </li>
+                        <li class="ribbon-item">
+                            <a href="#" class="ribbon-link">Services</a>
+                        </li>
+                        <li class="ribbon-item">
+                            <a href="#" class="ribbon-link">Pricing</a>
+                        </li>
+                        <li class="ribbon-item">
+                            <a href="#" class="ribbon-link">Contact</a>
+                        </li>
+                    </ul>
+                </nav>
+                
+                <div class="content-body">
+                    <h2>Welcome to the Ribbon</h2>
+                    <p>Notice how the navigation bar appears to wrap completely around this white content block. The shadow folds on the left and right edges are entirely rendered with CSS borders.</p>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-ribbon-nav-bar-pure/style.css
+++ b/submissions/examples/css-ribbon-nav-bar-pure/style.css
@@ -1,0 +1,209 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    
+    /* Content Block */
+    --content-bg: #ffffff;
+    --content-shadow: rgba(0, 0, 0, 0.1);
+    
+    /* Ribbon Colors */
+    --ribbon-main: #3b82f6;      /* Bright Blue */
+    --ribbon-dark: #1d4ed8;      /* Dark Blue (for the fold shadow) */
+    --ribbon-tail: #2563eb;      /* Medium Blue (for the tucked tails) */
+    --ribbon-text: #ffffff;
+    --ribbon-hover: #60a5fa;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --content-bg: #1e293b;
+        --content-shadow: rgba(0, 0, 0, 0.5);
+        
+        --ribbon-main: #2563eb;
+        --ribbon-dark: #1e3a8a;
+        --ribbon-tail: #1d4ed8;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0;
+}
+
+
+/* =========================================
+   Content Container
+   ========================================= */
+
+.content-block {
+    position: relative;
+    width: 100%;
+    max-width: 600px;
+    background-color: var(--content-bg);
+    border-radius: 8px;
+    box-shadow: 0 20px 25px -5px var(--content-shadow), 0 10px 10px -5px var(--content-shadow);
+    /* We need some top padding to accommodate the negative margin of the ribbon */
+    padding-top: 60px;
+}
+
+.content-body {
+    padding: 30px 40px 40px;
+}
+
+.content-body h2 {
+    margin-top: 0;
+    margin-bottom: 16px;
+}
+
+.content-body p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Ribbon Navigation
+   ========================================= */
+
+.ribbon-nav {
+    position: relative;
+    /* Pull the ribbon out to the left and right past the container */
+    margin-left: -20px;
+    margin-right: -20px;
+    
+    /* Lift it above the container */
+    z-index: 10;
+}
+
+.ribbon-menu {
+    display: flex;
+    justify-content: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    
+    background-color: var(--ribbon-main);
+    box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+}
+
+.ribbon-item {
+    margin: 0 5px;
+}
+
+.ribbon-link {
+    display: block;
+    padding: 16px 20px;
+    color: var(--ribbon-text);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.ribbon-link:hover,
+.ribbon-link:focus,
+.ribbon-link.active {
+    background-color: var(--ribbon-hover);
+    outline: none;
+}
+
+
+/* =========================================
+   The Ribbon Folds (Tails & Triangles)
+   ========================================= */
+
+/* 
+   We use ::before and ::after on the .ribbon-nav to create BOTH 
+   the hanging tail AND the folded shadow triangle simultaneously 
+   using massive CSS borders.
+*/
+.ribbon-nav::before,
+.ribbon-nav::after {
+    content: '';
+    position: absolute;
+    /* Push them down and behind the main ribbon bar */
+    top: 100%;
+    z-index: -1;
+    
+    /* 
+       The border trick: 
+       We create a rectangle using solid borders.
+       We use transparent borders to "cut" the ribbon tail shape.
+    */
+    border-style: solid;
+}
+
+/* Left Fold & Tail */
+.ribbon-nav::before {
+    left: 0;
+    /* 
+      Top border creates the dark shadow triangle (the fold).
+      Right border creates the main tail body.
+      Bottom border is transparent to cut the v-shape.
+      Left border is transparent to cut the v-shape.
+    */
+    border-width: 15px 20px 20px 20px;
+    border-color: var(--ribbon-dark) var(--ribbon-tail) transparent transparent;
+}
+
+/* Right Fold & Tail */
+.ribbon-nav::after {
+    right: 0;
+    /* 
+      Top border creates the dark shadow triangle.
+      Left border creates the main tail body.
+      Bottom/Right borders cut the v-shape.
+    */
+    border-width: 15px 20px 20px 20px;
+    border-color: var(--ribbon-dark) transparent transparent var(--ribbon-tail);
+}


### PR DESCRIPTION
### Description
This PR introduces a horizontal navigation bar designed to look like a folded ribbon wrapping around its container, using advanced CSS border triangles and pseudo-elements. Resolves issue #70619.

### Changes Made:
- Added `submissions/examples/css-ribbon-nav-bar-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the content container and the navigation list.
- Created `style.css` featuring the UI mechanics:
  - **Negative Margins**: The `.ribbon-nav` is given a negative left and right margin (e.g., `-20px`), pulling it outside the bounds of its parent `.content-block`.
  - **The Border Triangle Trick**: We use `::before` and `::after` on the navigation wrapper to create BOTH the hanging tail AND the dark folded shadow triangle simultaneously using massive CSS borders. By setting `border-width: 15px 20px 20px 20px` and carefully assigning colors to the top and side borders while leaving the others `transparent`, we can instantly slice a perfect "v-shape" tail and a folded shadow corner in one single CSS rule.
  - **Z-Index Layering**: The pseudo-elements are pushed behind the main bar using `z-index: -1`, completing the illusion that the ribbon wraps around the back of the content container.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the ribbon colors, shadows, and content backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the `::before`/`::after` border geometry tricks.
- Fully accessible semantic structure. The component uses a `<nav>` element with a proper `aria-label`, an unordered list (`<ul>`), and anchor links (`<a>`). It fully supports keyboard navigation and focus states.

Closes #70619
