### PR TITLE
feat: add pure CSS Brutalist Form component (#70617)

### DIFF
--- a/submissions/examples/css-brutalist-form-pure/README.md
+++ b/submissions/examples/css-brutalist-form-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Brutalist Form
+
+A high-contrast, neobrutalism styled web form featuring stark typography, thick borders, solid block shadows, and a custom CSS checkbox implementation.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture**: 
+  - **Neobrutalism Aesthetics**: The form embraces raw HTML default colors combined with highly customized, unblurred CSS `box-shadow` properties to simulate 3D depth without gradients. A stark monochrome palette with one aggressive accent color (red) defines the style.
+  - **Dynamic Input Shadows**: The `.brutalist-input` fields have a subtle hard shadow that expands and changes border color on `:focus`, physically lifting the input upwards via a `transform: translate()` offset.
+  - **Custom Brutalist Checkbox**: The native HTML checkbox is hidden visually (but remains in the DOM for screen reader focus). A custom `.custom-checkbox` span is styled alongside it. Using the adjacent sibling combinator (`input:checked + span`), the checked state is rendered purely in CSS by drawing two intersecting absolute pseudo-elements to form an aggressive 'X' mark.
+  - **Button Compression**: The submit button uses the `:active` pseudo-class to reverse the box-shadow offset, making the button physically "compress" down into the page when clicked.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), cleanly inverting the solid black shadows to stark white shadows.
+- Fully accessible semantic structure. Standard `<form>`, `<label>`, and `<input>` associations ensure full screen reader compatibility, even for the custom styled checkbox.
+
+## Usage
+Open `demo.html` in your browser to interact with the brutalist form elements.
+
+## Files
+- `demo.html`: The HTML structure defining the form labels, inputs, and the custom checkbox setup.
+- `style.css`: The styling, hard shadows, monospaced typography, and interaction pseudo-classes.

--- a/submissions/examples/css-brutalist-form-pure/demo.html
+++ b/submissions/examples/css-brutalist-form-pure/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Brutalist Form</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Brutalist Form</h1>
+            <p class="subtitle">A high-contrast, brutalist-styled form featuring thick borders, hard shadows, and bold typography. No JavaScript required.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="brutalist-container">
+                <form class="brutalist-form" action="#" method="POST" aria-label="Subscription Form">
+                    
+                    <h2 class="form-title">JOIN THE CLUB.</h2>
+                    <p class="form-desc">NO SPAM. JUST PURE, UNADULTERATED CONTENT.</p>
+                    
+                    <div class="form-group">
+                        <label for="name" class="brutalist-label">FULL NAME</label>
+                        <input type="text" id="name" name="name" class="brutalist-input" placeholder="JANE DOE" required>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="email" class="brutalist-label">EMAIL ADDRESS</label>
+                        <input type="email" id="email" name="email" class="brutalist-input" placeholder="JANE@EXAMPLE.COM" required>
+                    </div>
+                    
+                    <div class="form-group checkbox-group">
+                        <!-- 
+                          [TECHNIQUE] Custom Brutalist Checkbox 
+                          Hiding the native checkbox and styling a custom box using the :checked pseudo-class.
+                        -->
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="terms" class="native-checkbox" required>
+                            <span class="custom-checkbox" aria-hidden="true"></span>
+                            <span class="checkbox-text">I AGREE TO THE HARSH TERMS & CONDITIONS</span>
+                        </label>
+                    </div>
+                    
+                    <button type="submit" class="brutalist-button">
+                        SUBSCRIBE NOW
+                    </button>
+                    
+                </form>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-brutalist-form-pure/style.css
+++ b/submissions/examples/css-brutalist-form-pure/style.css
@@ -1,0 +1,262 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Brutalist colors are typically high contrast, raw, and vibrant */
+    --bg-base: #f4f4f0;
+    --text-primary: #000000;
+    
+    --brutal-bg: #ffffff;
+    --brutal-border: #000000;
+    --brutal-accent: #ff3b30; /* Bright red */
+    --brutal-shadow: #000000; /* Solid black shadow */
+    
+    /* Neobrutalism offset sizes */
+    --shadow-offset: 6px;
+    --border-width: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #121212;
+        --text-primary: #ffffff;
+        
+        --brutal-bg: #1e1e1e;
+        --brutal-border: #ffffff;
+        --brutal-accent: #ff453a;
+        --brutal-shadow: #ffffff; /* Solid white shadow */
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* Monospace fonts are a staple of brutalist design */
+    font-family: 'Space Mono', monospace;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    border-bottom: var(--border-width) solid var(--text-primary);
+    display: inline-block;
+    padding-bottom: 5px;
+}
+
+.subtitle {
+    font-size: 1rem;
+    margin: 0 auto;
+    max-width: 600px;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Brutalist Container & Typography
+   ========================================= */
+
+.brutalist-container {
+    width: 100%;
+    max-width: 450px;
+    background-color: var(--brutal-bg);
+    border: var(--border-width) solid var(--brutal-border);
+    /* Hard, solid shadow without blur */
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 0 var(--brutal-shadow);
+    padding: 30px;
+}
+
+.form-title {
+    margin: 0 0 10px 0;
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.1;
+    text-transform: uppercase;
+    letter-spacing: -1px;
+}
+
+.form-desc {
+    margin: 0 0 30px 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--brutal-accent);
+}
+
+.form-group {
+    margin-bottom: 24px;
+}
+
+
+/* =========================================
+   Form Inputs
+   ========================================= */
+
+.brutalist-label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 700;
+    font-size: 1rem;
+    text-transform: uppercase;
+}
+
+.brutalist-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 16px;
+    font-family: inherit;
+    font-size: 1rem;
+    background-color: transparent;
+    color: var(--text-primary);
+    border: var(--border-width) solid var(--brutal-border);
+    /* Input starts with a smaller hard shadow */
+    box-shadow: 3px 3px 0 0 var(--brutal-shadow);
+    transition: all 0.1s ease-out;
+}
+
+.brutalist-input::placeholder {
+    color: var(--text-primary);
+    opacity: 0.3;
+}
+
+.brutalist-input:focus {
+    outline: none;
+    background-color: var(--bg-base);
+    /* Shadow expands and border turns accent color on focus */
+    box-shadow: 6px 6px 0 0 var(--brutal-shadow);
+    border-color: var(--brutal-accent);
+    transform: translate(-3px, -3px);
+}
+
+
+/* =========================================
+   Custom Checkbox
+   ========================================= */
+
+.checkbox-group {
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: flex-start;
+    cursor: pointer;
+    gap: 12px;
+}
+
+/* Hide the native checkbox visually but keep it focusable for screen readers */
+.native-checkbox {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.custom-checkbox {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+    border: var(--border-width) solid var(--brutal-border);
+    box-shadow: 3px 3px 0 0 var(--brutal-shadow);
+    background-color: transparent;
+    position: relative;
+    transition: all 0.1s;
+}
+
+/* Focus state for accessibility */
+.native-checkbox:focus + .custom-checkbox {
+    outline: 2px solid var(--brutal-accent);
+    outline-offset: 4px;
+}
+
+/* Checked state rendering the 'X' using pseudo-elements */
+.native-checkbox:checked + .custom-checkbox {
+    background-color: var(--brutal-accent);
+}
+
+.native-checkbox:checked + .custom-checkbox::before,
+.native-checkbox:checked + .custom-checkbox::after {
+    content: '';
+    position: absolute;
+    width: 80%;
+    height: var(--border-width);
+    background-color: var(--text-primary);
+    top: 50%;
+    left: 10%;
+    transform-origin: center;
+}
+
+.native-checkbox:checked + .custom-checkbox::before {
+    transform: translateY(-50%) rotate(45deg);
+}
+
+.native-checkbox:checked + .custom-checkbox::after {
+    transform: translateY(-50%) rotate(-45deg);
+}
+
+.checkbox-text {
+    font-size: 0.85rem;
+    font-weight: 700;
+    line-height: 1.4;
+    padding-top: 2px;
+}
+
+
+/* =========================================
+   Submit Button
+   ========================================= */
+
+.brutalist-button {
+    width: 100%;
+    padding: 16px;
+    font-family: inherit;
+    font-size: 1.1rem;
+    font-weight: 700;
+    background-color: var(--brutal-accent);
+    color: #ffffff; /* Typically keep text white on brutal red even in light mode */
+    border: var(--border-width) solid var(--brutal-border);
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 0 var(--brutal-shadow);
+    cursor: pointer;
+    text-transform: uppercase;
+    transition: all 0.1s;
+}
+
+@media (prefers-color-scheme: dark) {
+    .brutalist-button {
+        color: #000000; /* Dark mode high contrast */
+    }
+}
+
+.brutalist-button:hover {
+    background-color: var(--brutal-bg);
+    color: var(--text-primary);
+}
+
+/* Click / Active state - compresses the shadow */
+.brutalist-button:active {
+    box-shadow: 0 0 0 0 var(--brutal-shadow);
+    transform: translate(var(--shadow-offset), var(--shadow-offset));
+}


### PR DESCRIPTION
### Description
This PR introduces a high-contrast, neobrutalism styled web form featuring stark typography, thick borders, solid block shadows, and a custom CSS checkbox implementation. Resolves issue #70617.

### Changes Made:
- Added `submissions/examples/css-brutalist-form-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the form labels, inputs, and the custom checkbox setup.
- Created `style.css` featuring the UI mechanics:
  - **Neobrutalism Aesthetics**: The form embraces raw HTML default colors combined with highly customized, unblurred CSS `box-shadow` properties to simulate 3D depth without gradients. A stark monochrome palette with one aggressive accent color (red) defines the style.
  - **Dynamic Input Shadows**: The `.brutalist-input` fields have a subtle hard shadow that expands and changes border color on `:focus`, physically lifting the input upwards via a `transform: translate()` offset.
  - **Custom Brutalist Checkbox**: The native HTML checkbox is hidden visually (but remains in the DOM for screen reader focus). A custom `.custom-checkbox` span is styled alongside it. Using the adjacent sibling combinator (`input:checked + span`), the checked state is rendered purely in CSS by drawing two intersecting absolute pseudo-elements to form an aggressive 'X' mark.
  - **Button Compression**: The submit button uses the `:active` pseudo-class to reverse the box-shadow offset, making the button physically "compress" down into the page when clicked.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), cleanly inverting the solid black shadows to stark white shadows.
- Added `README.md` documenting usage and the technical mechanics of the custom checkbox adjacent sibling trick.
- Fully accessible semantic structure. Standard `<form>`, `<label>`, and `<input>` associations ensure full screen reader compatibility, even for the custom styled checkbox.

Closes #70617
