### PR TITLE
feat: add ease-stadia-rod-read (#72956)

### DIFF
--- a/submissions/examples/stadia-rod-read-ns/README.md
+++ b/submissions/examples/stadia-rod-read-ns/README.md
@@ -1,0 +1,16 @@
+# Stadia Rod Read
+
+## What does this do?
+Renders a self-contained CSS-only `ease-stadia-rod-read` demo: Stadia hairs scanning a leveling rod for distance ticks.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-stadia-rod-read`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-stadia-rod-read">
+  <div class="ease-stadia-rod-read__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/stadia-rod-read-ns/demo.html
+++ b/submissions/examples/stadia-rod-read-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stadia Rod Read — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Stadia Rod Read demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Stadia Rod Read</h1>
+      <p class="lede">Stadia hairs scanning a leveling rod for distance ticks</p>
+    </header>
+
+    <section class="ease-stadia-rod-read" data-demo="stadia-rod-read" aria-live="polite">
+      <div class="ease-stadia-rod-read__housing">
+        <div class="ease-stadia-rod-read__bezel">
+          <div class="ease-stadia-rod-read__face">
+            <div class="ease-stadia-rod-read__readout">
+              <span class="ease-stadia-rod-read__label">Stadia Rod Read</span>
+              <span class="ease-stadia-rod-read__value">LIVE</span>
+            </div>
+            <div class="ease-stadia-rod-read__motion" aria-hidden="true">
+              <span class="ease-stadia-rod-read__a"></span>
+              <span class="ease-stadia-rod-read__b"></span>
+              <span class="ease-stadia-rod-read__c"></span>
+              <span class="ease-stadia-rod-read__d"></span>
+            </div>
+            <div class="ease-stadia-rod-read__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-stadia-rod-read__controls">
+          <button type="button" class="ease-stadia-rod-read__btn primary">Engage</button>
+          <button type="button" class="ease-stadia-rod-read__btn">Reset</button>
+          <label class="ease-stadia-rod-read__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-stadia-rod-read__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/stadia-rod-read-ns/style.css
+++ b/submissions/examples/stadia-rod-read-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c4b5fd 18%, transparent), transparent 42%),
+    #120b1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-stadia-rod-read {
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #120b1c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #120b1c 75%, #000);
+}
+
+.ease-stadia-rod-read__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-stadia-rod-read__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #120b1c 90%, #a78bfa);
+}
+
+.ease-stadia-rod-read__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-stadia-rod-read__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-stadia-rod-read__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-stadia-rod-read__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-stadia-rod-read__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-stadia-rod-read__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-stadia-rod-read__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: stadia_rod_read_meter 4.6s linear infinite;
+}
+
+.ease-stadia-rod-read__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-stadia-rod-read__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-stadia-rod-read__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-stadia-rod-read__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-stadia-rod-read__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-stadia-rod-read__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-stadia-rod-read__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-stadia-rod-read__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-stadia-rod-read__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-stadia-rod-read__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-stadia-rod-read__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: stadia_rod_read_status 2.3s ease-out infinite;
+}
+
+@keyframes stadia_rod_read_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes stadia_rod_read_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-stadia-rod-read__a{position:absolute;inset:18%;border-radius:50%;border:1px solid var(--line);background:repeating-conic-gradient(from 0deg,var(--line) 0 2deg,transparent 2deg 15deg)}
+.ease-stadia-rod-read__b{position:absolute;left:22%;top:42%;width:18%;height:10px;border-radius:3px;background:var(--accent);transform-origin:right center;animation:stadia_rod_read_pal 4.15s steps(2) infinite}
+.ease-stadia-rod-read__c{position:absolute;right:22%;top:42%;width:18%;height:10px;border-radius:3px;background:var(--accent-2);transform-origin:left center;animation:stadia_rod_read_pal2 4.15s steps(2) infinite}
+.ease-stadia-rod-read__d{position:absolute;left:48%;top:20%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:stadia_rod_read_tick 4.15s steps(2) infinite}
+
+@keyframes stadia_rod_read_pal{0%{transform:rotate(-18deg)}50%,100%{transform:rotate(12deg)}}@keyframes stadia_rod_read_pal2{0%{transform:rotate(18deg)}50%,100%{transform:rotate(-12deg)}}@keyframes stadia_rod_read_tick{0%,49%{opacity:1}50%,100%{opacity:.25}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stadia-rod-read__a,
+  .ease-stadia-rod-read__b,
+  .ease-stadia-rod-read__c,
+  .ease-stadia-rod-read__d,
+  .ease-stadia-rod-read__meters i::after,
+  .ease-stadia-rod-read__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-stadia-rod-read` CSS-only demo for #72956.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Stadia hairs scanning a leveling rod for distance ticks

**How does a developer use it?**

```html
<section class="ease-stadia-rod-read">
  <div class="ease-stadia-rod-read__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/stadia-rod-read-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #72956
