### PR TITLE
feat: add ease-tour-barrel-unwind (#72969)

### DIFF
--- a/submissions/examples/tour-barrel-unwind-ns/README.md
+++ b/submissions/examples/tour-barrel-unwind-ns/README.md
@@ -1,0 +1,16 @@
+# Tour Barrel Unwind
+
+## What does this do?
+Renders a self-contained CSS-only `ease-tour-barrel-unwind` demo: CSS-only motion metaphor for tour barrel unwind.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-tour-barrel-unwind`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-tour-barrel-unwind">
+  <div class="ease-tour-barrel-unwind__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/tour-barrel-unwind-ns/demo.html
+++ b/submissions/examples/tour-barrel-unwind-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tour Barrel Unwind — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Tour Barrel Unwind demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Tour Barrel Unwind</h1>
+      <p class="lede">CSS-only motion metaphor for tour barrel unwind</p>
+    </header>
+
+    <section class="ease-tour-barrel-unwind" data-demo="tour-barrel-unwind" aria-live="polite">
+      <div class="ease-tour-barrel-unwind__housing">
+        <div class="ease-tour-barrel-unwind__bezel">
+          <div class="ease-tour-barrel-unwind__face">
+            <div class="ease-tour-barrel-unwind__readout">
+              <span class="ease-tour-barrel-unwind__label">Tour Barrel Unwind</span>
+              <span class="ease-tour-barrel-unwind__value">LIVE</span>
+            </div>
+            <div class="ease-tour-barrel-unwind__motion" aria-hidden="true">
+              <span class="ease-tour-barrel-unwind__a"></span>
+              <span class="ease-tour-barrel-unwind__b"></span>
+              <span class="ease-tour-barrel-unwind__c"></span>
+              <span class="ease-tour-barrel-unwind__d"></span>
+            </div>
+            <div class="ease-tour-barrel-unwind__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-tour-barrel-unwind__controls">
+          <button type="button" class="ease-tour-barrel-unwind__btn primary">Engage</button>
+          <button type="button" class="ease-tour-barrel-unwind__btn">Reset</button>
+          <label class="ease-tour-barrel-unwind__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-tour-barrel-unwind__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tour-barrel-unwind-ns/style.css
+++ b/submissions/examples/tour-barrel-unwind-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f97316 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fdba74 18%, transparent), transparent 42%),
+    #160d08;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-tour-barrel-unwind {
+  --accent: #f97316;
+  --accent-2: #fdba74;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160d08);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160d08 75%, #000);
+}
+
+.ease-tour-barrel-unwind__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-tour-barrel-unwind__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160d08 90%, #f97316);
+}
+
+.ease-tour-barrel-unwind__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-tour-barrel-unwind__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-tour-barrel-unwind__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-tour-barrel-unwind__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-tour-barrel-unwind__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-tour-barrel-unwind__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-tour-barrel-unwind__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: tour_barrel_unwind_meter 3.9s linear infinite;
+}
+
+.ease-tour-barrel-unwind__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-tour-barrel-unwind__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-tour-barrel-unwind__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-tour-barrel-unwind__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-tour-barrel-unwind__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-tour-barrel-unwind__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-tour-barrel-unwind__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-tour-barrel-unwind__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-tour-barrel-unwind__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-tour-barrel-unwind__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-tour-barrel-unwind__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: tour_barrel_unwind_status 2.3s ease-out infinite;
+}
+
+@keyframes tour_barrel_unwind_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes tour_barrel_unwind_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-tour-barrel-unwind__a{position:absolute;left:28%;top:22%;width:44%;aspect-ratio:1;border-radius:50%;border:8px solid color-mix(in srgb,var(--accent) 45%,transparent);animation:tour_barrel_unwind_spin 3.45s linear infinite}
+.ease-tour-barrel-unwind__b{position:absolute;left:40%;top:34%;width:20%;aspect-ratio:1;border-radius:50%;background:var(--accent-2);opacity:.8}
+.ease-tour-barrel-unwind__c{position:absolute;left:50%;top:18%;width:3px;height:30%;background:var(--accent);transform-origin:bottom center;animation:tour_barrel_unwind_spin 3.45s linear infinite}
+.ease-tour-barrel-unwind__d{position:absolute;left:16%;bottom:18%;width:28%;height:8px;border-radius:4px;background:linear-gradient(90deg,var(--accent),transparent);animation:tour_barrel_unwind_fade 3.45s ease-in-out infinite}
+
+@keyframes tour_barrel_unwind_spin{to{transform:rotate(360deg)}}@keyframes tour_barrel_unwind_fade{0%,100%{opacity:.3;transform:scaleX(.7)}50%{opacity:1;transform:scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tour-barrel-unwind__a,
+  .ease-tour-barrel-unwind__b,
+  .ease-tour-barrel-unwind__c,
+  .ease-tour-barrel-unwind__d,
+  .ease-tour-barrel-unwind__meters i::after,
+  .ease-tour-barrel-unwind__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-tour-barrel-unwind` CSS-only demo for #72969.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

CSS-only motion metaphor for tour barrel unwind

**How does a developer use it?**

```html
<section class="ease-tour-barrel-unwind">
  <div class="ease-tour-barrel-unwind__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/tour-barrel-unwind-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #72969
