### PR TITLE
feat: add CSS split date input #70622

### DIFF
--- a/submissions/examples/r-split-date-input-70622/README.md
+++ b/submissions/examples/r-split-date-input-70622/README.md
@@ -1,0 +1,41 @@
+# CSS Split Date Input
+
+A responsive split date input component with separate day, month,
+and year fields.
+
+## Features
+
+- Pure HTML and CSS
+- Separate Day, Month, and Year fields
+- Numeric input modes for easier mobile entry
+- Date-specific autocomplete attributes
+- Responsive layout
+- Accessible labels
+- Visible keyboard focus states
+- Interactive button
+- Reduced-motion support
+- No JavaScript required
+
+## Files
+
+- `demo.html` - Date input markup
+- `style.css` - Complete styling
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+## Accessibility
+
+Each date field has its own visible label and accessible name.
+
+The component uses semantic form controls and provides visible
+`:focus` and `:focus-visible` styling.
+
+The `inputmode="numeric"` attribute helps mobile users enter
+numeric date values.
+
+## Browser Support
+
+Designed for modern browsers supporting CSS Grid, gradients,
+transitions, and media queries.

--- a/submissions/examples/r-split-date-input-70622/demo.html
+++ b/submissions/examples/r-split-date-input-70622/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Accessible CSS split date input component"
+  >
+  <title>CSS Split Date Input</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="date-card" aria-labelledby="date-title">
+      <div class="calendar-icon" aria-hidden="true">
+        <span></span>
+      </div>
+
+      <div class="content">
+        <p class="eyebrow">Date of birth</p>
+
+        <h1 id="date-title">When were you born?</h1>
+
+        <p class="description">
+          Enter your date using the three fields below.
+        </p>
+
+        <form class="date-form">
+          <div class="date-fields">
+            <div class="field">
+              <label for="day">Day</label>
+              <input
+                id="day"
+                name="day"
+                type="text"
+                inputmode="numeric"
+                autocomplete="bday-day"
+                maxlength="2"
+                placeholder="DD"
+                aria-label="Day"
+              >
+            </div>
+
+            <span class="separator" aria-hidden="true">/</span>
+
+            <div class="field">
+              <label for="month">Month</label>
+              <input
+                id="month"
+                name="month"
+                type="text"
+                inputmode="numeric"
+                autocomplete="bday-month"
+                maxlength="2"
+                placeholder="MM"
+                aria-label="Month"
+              >
+            </div>
+
+            <span class="separator" aria-hidden="true">/</span>
+
+            <div class="field year-field">
+              <label for="year">Year</label>
+              <input
+                id="year"
+                name="year"
+                type="text"
+                inputmode="numeric"
+                autocomplete="bday-year"
+                maxlength="4"
+                placeholder="YYYY"
+                aria-label="Year"
+              >
+            </div>
+          </div>
+
+          <p class="hint">
+            Example: 15 / 08 / 2002
+          </p>
+
+          <button type="submit">
+            Continue
+            <span aria-hidden="true">→</span>
+          </button>
+        </form>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/r-split-date-input-70622/style.css
+++ b/submissions/examples/r-split-date-input-70622/style.css
@@ -1,0 +1,659 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #eef3ff;
+  --card: #ffffff;
+  --primary: #536dfe;
+  --primary-dark: #4055d6;
+  --text: #1e2640;
+  --muted: #7b849e;
+  --border: #dce2f0;
+  --focus: rgba(83, 109, 254, 0.2);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 10% 20%,
+      rgba(83, 109, 254, 0.15),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at 90% 80%,
+      rgba(122, 90, 255, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 30px 20px;
+}
+
+.date-card {
+  width: min(560px, 100%);
+  display: grid;
+  grid-template-columns: 76px 1fr;
+  gap: 25px;
+  padding: 34px;
+  border: 1px solid rgba(83, 109, 254, 0.1);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow:
+    0 25px 65px rgba(50, 65, 110, 0.13),
+    0 5px 18px rgba(50, 65, 110, 0.06);
+}
+
+.calendar-icon {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background: linear-gradient(
+    145deg,
+    #697fff,
+    #4d63ec
+  );
+  box-shadow:
+    0 12px 25px rgba(83, 109, 254, 0.25);
+}
+
+.calendar-icon::before {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  width: 44px;
+  height: 36px;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.calendar-icon::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  width: 44px;
+  height: 10px;
+  border-radius: 6px 6px 0 0;
+  background: #dce2ff;
+}
+
+.calendar-icon span::before,
+.calendar-icon span::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  width: 5px;
+  height: 12px;
+  border-radius: 5px;
+  background: #fff;
+}
+
+.calendar-icon span::before {
+  left: 20px;
+}
+
+.calendar-icon span::after {
+  right: 20px;
+}
+
+.content {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: var(--primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.15rem);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+}
+
+.description {
+  margin: 10px 0 24px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.date-form {
+  width: 100%;
+}
+
+.date-fields {
+  display: grid;
+  grid-template-columns: minmax(70px, 1fr) 16px minmax(70px, 1fr) 16px minmax(100px, 1.35fr);
+  align-items: end;
+  gap: 8px;
+}
+
+.field {
+  min-width: 0;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 7px;
+  color: #69728c;
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.field input {
+  width: 100%;
+  height: 55px;
+  padding: 0 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 13px;
+  outline: none;
+  color: var(--text);
+  background: #fafbff;
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 750;
+  text-align: center;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.field input::placeholder {
+  color: #b0b7c9;
+  font-weight: 600;
+}
+
+.field input:hover {
+  border-color: #bcc6e2;
+  background: #fff;
+}
+
+.field input:focus {
+  border-color: var(--primary);
+  background: #fff;
+  box-shadow: 0 0 0 4px var(--focus);
+  transform: translateY(-1px);
+}
+
+.separator {
+  padding-bottom: 16px;
+  color: #aab2c5;
+  font-size: 1.2rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.hint {
+  margin: 12px 0 18px;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+button {
+  width: 100%;
+  min-height: 50px;
+  border: 0;
+  border-radius: 13px;
+  color: #fff;
+  background: linear-gradient(
+    135deg,
+    var(--primary),
+    #705cff
+  );
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow:
+    0 10px 22px rgba(83, 109, 254, 0.2);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+button span {
+  display: inline-block;
+  margin-left: 7px;
+  transition: transform 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 14px 28px rgba(83, 109, 254, 0.28);
+}
+
+button:hover span {
+  transform: translateX(4px);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(83, 109, 254, 0.3);
+  outline-offset: 3px;
+}
+
+@media (max-width: 560px) {
+  .date-card {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    padding: 25px;
+  }
+
+  .calendar-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .calendar-icon::before {
+    left: 9px;
+    top: 13px;
+    width: 38px;
+    height: 32px;
+  }
+
+  .calendar-icon::after {
+    left: 9px;
+    top: 13px;
+    width: 38px;
+  }
+
+  .calendar-icon span::before {
+    left: 18px;
+  }
+
+  .calendar-icon span::after {
+    right: 18px;
+  }
+}
+
+@media (max-width: 390px) {
+  .page {
+    padding: 18px 12px;
+  }
+
+  .date-card {
+    padding: 20px 16px;
+    border-radius: 22px;
+  }
+
+  .date-fields {
+    grid-template-columns: 1fr 10px 1fr 10px 1.35fr;
+    gap: 4px;
+  }
+
+  .field input {
+    height: 50px;
+    padding: 0 5px;
+    font-size: 0.92rem;
+  }
+
+  .separator {
+    font-size: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field input,
+  button,
+  button span {
+    transition: none;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #eef3ff;
+  --card: #ffffff;
+  --primary: #536dfe;
+  --primary-dark: #4055d6;
+  --text: #1e2640;
+  --muted: #7b849e;
+  --border: #dce2f0;
+  --focus: rgba(83, 109, 254, 0.2);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 10% 20%,
+      rgba(83, 109, 254, 0.15),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at 90% 80%,
+      rgba(122, 90, 255, 0.1),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 30px 20px;
+}
+
+.date-card {
+  width: min(560px, 100%);
+  display: grid;
+  grid-template-columns: 76px 1fr;
+  gap: 25px;
+  padding: 34px;
+  border: 1px solid rgba(83, 109, 254, 0.1);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow:
+    0 25px 65px rgba(50, 65, 110, 0.13),
+    0 5px 18px rgba(50, 65, 110, 0.06);
+}
+
+.calendar-icon {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background: linear-gradient(
+    145deg,
+    #697fff,
+    #4d63ec
+  );
+  box-shadow:
+    0 12px 25px rgba(83, 109, 254, 0.25);
+}
+
+.calendar-icon::before {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  width: 44px;
+  height: 36px;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.calendar-icon::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 15px;
+  width: 44px;
+  height: 10px;
+  border-radius: 6px 6px 0 0;
+  background: #dce2ff;
+}
+
+.calendar-icon span::before,
+.calendar-icon span::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  width: 5px;
+  height: 12px;
+  border-radius: 5px;
+  background: #fff;
+}
+
+.calendar-icon span::before {
+  left: 20px;
+}
+
+.calendar-icon span::after {
+  right: 20px;
+}
+
+.content {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: var(--primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.15rem);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+}
+
+.description {
+  margin: 10px 0 24px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.date-form {
+  width: 100%;
+}
+
+.date-fields {
+  display: grid;
+  grid-template-columns: minmax(70px, 1fr) 16px minmax(70px, 1fr) 16px minmax(100px, 1.35fr);
+  align-items: end;
+  gap: 8px;
+}
+
+.field {
+  min-width: 0;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 7px;
+  color: #69728c;
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.field input {
+  width: 100%;
+  height: 55px;
+  padding: 0 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 13px;
+  outline: none;
+  color: var(--text);
+  background: #fafbff;
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 750;
+  text-align: center;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.field input::placeholder {
+  color: #b0b7c9;
+  font-weight: 600;
+}
+
+.field input:hover {
+  border-color: #bcc6e2;
+  background: #fff;
+}
+
+.field input:focus {
+  border-color: var(--primary);
+  background: #fff;
+  box-shadow: 0 0 0 4px var(--focus);
+  transform: translateY(-1px);
+}
+
+.separator {
+  padding-bottom: 16px;
+  color: #aab2c5;
+  font-size: 1.2rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.hint {
+  margin: 12px 0 18px;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+button {
+  width: 100%;
+  min-height: 50px;
+  border: 0;
+  border-radius: 13px;
+  color: #fff;
+  background: linear-gradient(
+    135deg,
+    var(--primary),
+    #705cff
+  );
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow:
+    0 10px 22px rgba(83, 109, 254, 0.2);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+button span {
+  display: inline-block;
+  margin-left: 7px;
+  transition: transform 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 14px 28px rgba(83, 109, 254, 0.28);
+}
+
+button:hover span {
+  transform: translateX(4px);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(83, 109, 254, 0.3);
+  outline-offset: 3px;
+}
+
+@media (max-width: 560px) {
+  .date-card {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    padding: 25px;
+  }
+
+  .calendar-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .calendar-icon::before {
+    left: 9px;
+    top: 13px;
+    width: 38px;
+    height: 32px;
+  }
+
+  .calendar-icon::after {
+    left: 9px;
+    top: 13px;
+    width: 38px;
+  }
+
+  .calendar-icon span::before {
+    left: 18px;
+  }
+
+  .calendar-icon span::after {
+    right: 18px;
+  }
+}
+
+@media (max-width: 390px) {
+  .page {
+    padding: 18px 12px;
+  }
+
+  .date-card {
+    padding: 20px 16px;
+    border-radius: 22px;
+  }
+
+  .date-fields {
+    grid-template-columns: 1fr 10px 1fr 10px 1.35fr;
+    gap: 4px;
+  }
+
+  .field input {
+    height: 50px;
+    padding: 0 5px;
+    font-size: 0.92rem;
+  }
+
+  .separator {
+    font-size: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field input,
+  button,
+  button span {
+    transition: none;
+  }
+}
+
+


### PR DESCRIPTION
## Description

Implemented the CSS Split Date Input component for issue #70622.

## Changes

- Added separate day, month, and year fields.
- Added numeric input modes for mobile devices.
- Added date-specific autocomplete attributes.
- Added responsive styling.
- Added accessible field labels.
- Added keyboard focus states.
- Added interactive submit button.
- Added reduced-motion support.
- No JavaScript required.

## Files Added

- `submissions/examples/r-split-date-input-70622/demo.html`
- `submissions/examples/r-split-date-input-70622/style.css`
- `submissions/examples/r-split-date-input-70622/README.md`

## Testing

- Tested in a modern browser.
- Verified responsive behavior.
- Verified individual date fields.
- Verified keyboard focus states.
- Verified mobile-friendly numeric input configuration.
- Verified reduced-motion behavior.

Closes #70622