### PR TITLE
feat: add ease-pycnometer-fill (#72999)

### DIFF
--- a/submissions/examples/pycnometer-fill-ns/README.md
+++ b/submissions/examples/pycnometer-fill-ns/README.md
@@ -1,0 +1,16 @@
+# Pycnometer Fill
+
+## What does this do?
+Renders a self-contained CSS-only `ease-pycnometer-fill` demo: Pycnometer filling to the capillary mark.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-pycnometer-fill`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-pycnometer-fill">
+  <div class="ease-pycnometer-fill__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/pycnometer-fill-ns/demo.html
+++ b/submissions/examples/pycnometer-fill-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pycnometer Fill — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Pycnometer Fill demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Pycnometer Fill</h1>
+      <p class="lede">Pycnometer filling to the capillary mark</p>
+    </header>
+
+    <section class="ease-pycnometer-fill" data-demo="pycnometer-fill" aria-live="polite">
+      <div class="ease-pycnometer-fill__housing">
+        <div class="ease-pycnometer-fill__bezel">
+          <div class="ease-pycnometer-fill__face">
+            <div class="ease-pycnometer-fill__readout">
+              <span class="ease-pycnometer-fill__label">Pycnometer Fill</span>
+              <span class="ease-pycnometer-fill__value">LIVE</span>
+            </div>
+            <div class="ease-pycnometer-fill__motion" aria-hidden="true">
+              <span class="ease-pycnometer-fill__a"></span>
+              <span class="ease-pycnometer-fill__b"></span>
+              <span class="ease-pycnometer-fill__c"></span>
+              <span class="ease-pycnometer-fill__d"></span>
+            </div>
+            <div class="ease-pycnometer-fill__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-pycnometer-fill__controls">
+          <button type="button" class="ease-pycnometer-fill__btn primary">Engage</button>
+          <button type="button" class="ease-pycnometer-fill__btn">Reset</button>
+          <label class="ease-pycnometer-fill__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-pycnometer-fill__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pycnometer-fill-ns/style.css
+++ b/submissions/examples/pycnometer-fill-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #22d3ee 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #67e8f9 18%, transparent), transparent 42%),
+    #07131a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-pycnometer-fill {
+  --accent: #22d3ee;
+  --accent-2: #67e8f9;
+  --panel: color-mix(in srgb, #e8eef6 7%, #07131a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #07131a 75%, #000);
+}
+
+.ease-pycnometer-fill__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-pycnometer-fill__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #07131a 90%, #22d3ee);
+}
+
+.ease-pycnometer-fill__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-pycnometer-fill__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pycnometer-fill__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-pycnometer-fill__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-pycnometer-fill__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-pycnometer-fill__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-pycnometer-fill__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: pycnometer_fill_meter 3.5s linear infinite;
+}
+
+.ease-pycnometer-fill__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-pycnometer-fill__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-pycnometer-fill__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-pycnometer-fill__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-pycnometer-fill__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-pycnometer-fill__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-pycnometer-fill__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-pycnometer-fill__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-pycnometer-fill__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-pycnometer-fill__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-pycnometer-fill__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pycnometer_fill_status 2.3s ease-out infinite;
+}
+
+@keyframes pycnometer_fill_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes pycnometer_fill_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-pycnometer-fill__a{position:absolute;left:18%;top:30%;width:28%;height:12px;background:var(--accent);transform-origin:right center;animation:pycnometer_fill_in 3.1s ease-in-out infinite}
+.ease-pycnometer-fill__b{position:absolute;left:46%;top:24%;width:18%;aspect-ratio:1;clip-path:polygon(0 40%,100% 0,100% 100%,0 60%);background:color-mix(in srgb,var(--accent-2) 80%,#fff);animation:pycnometer_fill_prism 3.1s ease-in-out infinite}
+.ease-pycnometer-fill__c{position:absolute;left:62%;top:34%;width:24%;height:8px;background:linear-gradient(90deg,var(--accent),transparent);transform-origin:left center;animation:pycnometer_fill_out 3.1s ease-in-out infinite}
+.ease-pycnometer-fill__d{position:absolute;right:14%;top:20%;width:16%;height:40%;border:1px solid var(--line);border-radius:6px;background:repeating-linear-gradient(180deg,transparent 0 8px,color-mix(in srgb,var(--accent) 25%,transparent) 8px 9px)}
+
+@keyframes pycnometer_fill_in{0%,100%{transform:rotate(0)}50%{transform:rotate(-18deg)}}@keyframes pycnometer_fill_prism{0%,100%{filter:hue-rotate(0deg)}50%{filter:hue-rotate(40deg)}}@keyframes pycnometer_fill_out{0%,100%{transform:rotate(0) scaleX(.7)}50%{transform:rotate(22deg) scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pycnometer-fill__a,
+  .ease-pycnometer-fill__b,
+  .ease-pycnometer-fill__c,
+  .ease-pycnometer-fill__d,
+  .ease-pycnometer-fill__meters i::after,
+  .ease-pycnometer-fill__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pycnometer-fill` CSS-only demo for #72999.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Pycnometer filling to the capillary mark

**How does a developer use it?**

```html
<section class="ease-pycnometer-fill">
  <div class="ease-pycnometer-fill__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/pycnometer-fill-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #72999
