### PR TITLE
Add CSS Flower Bloom component (petal-by-petal bloom animation)

### DIFF
--- a/submissions/examples/css-flower-bloom/README.md
+++ b/submissions/examples/css-flower-bloom/README.md
@@ -1,0 +1,47 @@
+# CSS Flower Bloom
+
+A pure CSS flower that blooms petal by petal using staggered keyframe animations — no JavaScript required.
+
+## What it does
+
+On load, a flower blooms from the center outward: the stem and leaves are static, and eight petals fade and scale in one after another (staggered via a per-petal `--i` custom property), followed by the flower's center. A "Replay Bloom" button lets you reset and re-trigger the animation using the checkbox-hack pattern (no JS).
+
+## How to use it
+
+```html
+<div class="flower-bloom">
+  <input type="checkbox" id="bloom-toggle" class="bloom-toggle-input" checked>
+
+  <div class="flower" role="img" aria-label="A flower blooming petal by petal">
+    <div class="stem"></div>
+    <div class="leaf leaf-left"></div>
+    <div class="leaf leaf-right"></div>
+
+    <div class="petals">
+      <span class="petal" style="--i:0"></span>
+      <span class="petal" style="--i:1"></span>
+      <!-- ...repeat for however many petals, incrementing --i -->
+      <div class="flower-center"></div>
+    </div>
+  </div>
+
+  <label for="bloom-toggle" class="bloom-replay-btn" tabindex="0" role="button"
+         aria-label="Replay bloom animation">
+    Replay Bloom
+  </label>
+</div>
+```
+
+Each `.petal` needs an inline `--i` custom property (0, 1, 2, ...) to control its rotation angle and animation delay, so petals bloom in sequence around the flower rather than all at once.
+
+## Why it fits EaseMotion CSS
+
+- **Pure CSS, zero dependencies** — the replay interaction uses the checkbox-hack pattern instead of JavaScript, consistent with the library's zero-JS philosophy.
+- **Accessible** — the flower is exposed to assistive tech via `role="img"` and an `aria-label`, and the replay control is a real, keyboard-focusable, `focus-visible`-styled button (`tabindex="0"`, `role="button"`).
+- **Respects motion preferences** — a `prefers-reduced-motion` media query disables the bloom animation and shows the fully-bloomed static state instead.
+- **Responsive** — sized in relative units within a flexible container, so it scales cleanly across viewport sizes.
+- **Readable, semantic class names** — `petal`, `flower-center`, `bloom-replay-btn`, etc., in keeping with the library's human-readable naming conventions.
+
+## Notes
+
+Petal count is currently 8 (`--i:0` through `--i:7`), spaced 45° apart (`360 / 8`). To change the petal count, update both the number of `.petal` elements and the angle math in `style.css` (`--angle: calc(var(--i) * 45deg)`).

--- a/submissions/examples/css-flower-bloom/demo.html
+++ b/submissions/examples/css-flower-bloom/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Flower Bloom — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1 class="demo-heading">CSS Flower Bloom</h1>
+
+  <div class="flower-bloom">
+    <input type="checkbox" id="bloom-toggle" class="bloom-toggle-input" checked>
+
+    <div class="flower" role="img" aria-label="A flower blooming petal by petal">
+      <div class="stem"></div>
+      <div class="leaf leaf-left"></div>
+      <div class="leaf leaf-right"></div>
+
+      <div class="petals">
+        <span class="petal" style="--i:0"></span>
+        <span class="petal" style="--i:1"></span>
+        <span class="petal" style="--i:2"></span>
+        <span class="petal" style="--i:3"></span>
+        <span class="petal" style="--i:4"></span>
+        <span class="petal" style="--i:5"></span>
+        <span class="petal" style="--i:6"></span>
+        <span class="petal" style="--i:7"></span>
+        <div class="flower-center"></div>
+      </div>
+    </div>
+
+    <label for="bloom-toggle" class="bloom-replay-btn" tabindex="0" role="button"
+           aria-label="Replay bloom animation">
+      Replay Bloom
+    </label>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-flower-bloom/style.css
+++ b/submissions/examples/css-flower-bloom/style.css
@@ -1,0 +1,188 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #101610;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 24px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.flower-bloom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.bloom-toggle-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.flower {
+  position: relative;
+  width: 220px;
+  height: 260px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.stem {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 6px;
+  height: 140px;
+  background: linear-gradient(180deg, #3a8f4a, #2a6b38);
+  border-radius: 3px;
+  transform: translateX(-50%);
+}
+
+.leaf {
+  position: absolute;
+  bottom: 40px;
+  width: 34px;
+  height: 20px;
+  background: #3a8f4a;
+  border-radius: 0 100% 0 100%;
+}
+
+.leaf-left {
+  left: calc(50% - 34px);
+  transform: rotate(10deg);
+  border-radius: 100% 0 100% 0;
+}
+
+.leaf-right {
+  left: 50%;
+  transform: rotate(-10deg);
+}
+
+.petals {
+  position: relative;
+  bottom: 60px;
+  width: 100px;
+  height: 100px;
+}
+
+.petal {
+  --angle: calc(var(--i) * 45deg);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 46px;
+  height: 60px;
+  background: linear-gradient(180deg, #ff8fb1, #ff5c8a);
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  transform-origin: bottom center;
+  transform: translate(-50%, -100%) rotate(var(--angle)) scale(0);
+  opacity: 0;
+}
+
+.bloom-toggle-input:checked ~ .flower .petal {
+  animation: petal-bloom 0.5s ease forwards;
+  animation-delay: calc(var(--i) * 0.12s);
+}
+
+@keyframes petal-bloom {
+  0% {
+    transform: translate(-50%, -100%) rotate(var(--angle)) scale(0);
+    opacity: 0;
+  }
+  60% {
+    transform: translate(-50%, -100%) rotate(var(--angle)) scale(1.08);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -100%) rotate(var(--angle)) scale(1);
+    opacity: 1;
+  }
+}
+
+.flower-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  background: radial-gradient(circle, #ffd54f, #ffb300);
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  z-index: 2;
+}
+
+.bloom-toggle-input:checked ~ .flower .flower-center {
+  animation: center-pop 0.4s ease forwards;
+  animation-delay: 0.9s;
+}
+
+@keyframes center-pop {
+  from {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
+.bloom-replay-btn {
+  display: inline-block;
+  background: #1c2028;
+  color: #e6e6e6;
+  border: 1px solid #2a2f3a;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.bloom-replay-btn:hover {
+  background: #262b35;
+}
+
+.bloom-replay-btn:active {
+  transform: scale(0.96);
+}
+
+.bloom-replay-btn:focus-visible {
+  outline: 2px solid #4f8cff;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .petal,
+  .flower-center {
+    animation: none;
+    opacity: 1;
+    transform: translate(-50%, -100%) rotate(var(--angle)) scale(1);
+  }
+
+  .flower-center {
+    transform: translate(-50%, -50%) scale(1);
+  }
+}


### PR DESCRIPTION
closes #70100
## Pull Request Description
Adds a pure CSS flower component that blooms petal by petal using staggered keyframe animations, with a checkbox-hack "Replay Bloom" button to re-trigger the animation. Closes #70100.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-flower-bloom/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A CSS-only flower that blooms petal by petal via staggered keyframe animations, with a replay control to re-trigger the bloom — no JavaScript.

**How does a developer use it?**
```html
<div class="flower-bloom">
  <input type="checkbox" id="bloom-toggle" class="bloom-toggle-input" checked>

  <div class="flower" role="img" aria-label="A flower blooming petal by petal">
    <div class="stem"></div>
    <div class="leaf leaf-left"></div>
    <div class="leaf leaf-right"></div>

    <div class="petals">
      <span class="petal" style="--i:0"></span>
      <span class="petal" style="--i:1"></span>
      <!-- ...repeat, incrementing --i for each petal -->
      <div class="flower-center"></div>
    </div>
  </div>

  <label for="bloom-toggle" class="bloom-replay-btn" tabindex="0" role="button"
         aria-label="Replay bloom animation">
    Replay Bloom
  </label>
</div>
```

**Why does it fit EaseMotion CSS?**
It's a self-contained, semantically-named component (`petal`, `flower-center`, `bloom-replay-btn`) that relies entirely on CSS custom properties and keyframes for its staggered animation, uses the checkbox hack instead of JS for the replay interaction, respects `prefers-reduced-motion`, and keeps the replay control keyboard-accessible — all in line with the library's animation-first, zero-dependency philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Petal count is 8, spaced 45° apart via `--i` and `calc(var(--i) * 45deg)`. To change petal count, update both the number of `.petal` elements in the HTML and the angle math in `style.css`.