### PR TITLE
feat: add ease-siphon-prime-arc (#73002)

### DIFF
--- a/submissions/examples/siphon-prime-arc-ns/README.md
+++ b/submissions/examples/siphon-prime-arc-ns/README.md
@@ -1,0 +1,16 @@
+# Siphon Prime Arc
+
+## What does this do?
+Renders a self-contained CSS-only `ease-siphon-prime-arc` demo: Siphon priming then flowing over an inverted arc.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-siphon-prime-arc`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-siphon-prime-arc">
+  <div class="ease-siphon-prime-arc__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/siphon-prime-arc-ns/demo.html
+++ b/submissions/examples/siphon-prime-arc-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Siphon Prime Arc — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Siphon Prime Arc demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Siphon Prime Arc</h1>
+      <p class="lede">Siphon priming then flowing over an inverted arc</p>
+    </header>
+
+    <section class="ease-siphon-prime-arc" data-demo="siphon-prime-arc" aria-live="polite">
+      <div class="ease-siphon-prime-arc__housing">
+        <div class="ease-siphon-prime-arc__bezel">
+          <div class="ease-siphon-prime-arc__face">
+            <div class="ease-siphon-prime-arc__readout">
+              <span class="ease-siphon-prime-arc__label">Siphon Prime Arc</span>
+              <span class="ease-siphon-prime-arc__value">LIVE</span>
+            </div>
+            <div class="ease-siphon-prime-arc__motion" aria-hidden="true">
+              <span class="ease-siphon-prime-arc__a"></span>
+              <span class="ease-siphon-prime-arc__b"></span>
+              <span class="ease-siphon-prime-arc__c"></span>
+              <span class="ease-siphon-prime-arc__d"></span>
+            </div>
+            <div class="ease-siphon-prime-arc__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-siphon-prime-arc__controls">
+          <button type="button" class="ease-siphon-prime-arc__btn primary">Engage</button>
+          <button type="button" class="ease-siphon-prime-arc__btn">Reset</button>
+          <label class="ease-siphon-prime-arc__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-siphon-prime-arc__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/siphon-prime-arc-ns/style.css
+++ b/submissions/examples/siphon-prime-arc-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f59e0b 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fbbf24 18%, transparent), transparent 42%),
+    #140f08;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-siphon-prime-arc {
+  --accent: #f59e0b;
+  --accent-2: #fbbf24;
+  --panel: color-mix(in srgb, #e8eef6 7%, #140f08);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #140f08 75%, #000);
+}
+
+.ease-siphon-prime-arc__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-siphon-prime-arc__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #140f08 90%, #f59e0b);
+}
+
+.ease-siphon-prime-arc__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-siphon-prime-arc__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-siphon-prime-arc__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-siphon-prime-arc__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-siphon-prime-arc__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-siphon-prime-arc__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-siphon-prime-arc__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: siphon_prime_arc_meter 3.9s linear infinite;
+}
+
+.ease-siphon-prime-arc__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-siphon-prime-arc__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-siphon-prime-arc__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-siphon-prime-arc__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-siphon-prime-arc__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-siphon-prime-arc__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-siphon-prime-arc__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-siphon-prime-arc__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-siphon-prime-arc__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-siphon-prime-arc__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-siphon-prime-arc__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: siphon_prime_arc_status 2.3s ease-out infinite;
+}
+
+@keyframes siphon_prime_arc_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes siphon_prime_arc_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-siphon-prime-arc__a{position:absolute;left:12%;right:12%;top:48%;height:6px;border-radius:3px;background:var(--line)}
+.ease-siphon-prime-arc__b{position:absolute;top:38%;width:18%;height:26%;border-radius:8px;border:1px solid var(--line);background:color-mix(in srgb,var(--accent) 20%,var(--panel));animation:siphon_prime_arc_slide 3.45s ease-in-out infinite alternate}
+.ease-siphon-prime-arc__c{position:absolute;left:14%;top:22%;width:8px;height:56%;background:repeating-linear-gradient(180deg,var(--accent) 0 2px,transparent 2px 8px);opacity:.55}
+.ease-siphon-prime-arc__d{position:absolute;right:16%;bottom:18%;width:22%;height:8px;border-radius:4px;background:var(--accent);animation:siphon_prime_arc_mark 3.45s ease-in-out infinite alternate}
+
+@keyframes siphon_prime_arc_slide{from{left:14%}to{left:66%}}@keyframes siphon_prime_arc_mark{from{opacity:.35;transform:translateX(0)}to{opacity:1;transform:translateX(20px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-siphon-prime-arc__a,
+  .ease-siphon-prime-arc__b,
+  .ease-siphon-prime-arc__c,
+  .ease-siphon-prime-arc__d,
+  .ease-siphon-prime-arc__meters i::after,
+  .ease-siphon-prime-arc__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-siphon-prime-arc` CSS-only demo for #73002.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Siphon priming then flowing over an inverted arc

**How does a developer use it?**

```html
<section class="ease-siphon-prime-arc">
  <div class="ease-siphon-prime-arc__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/siphon-prime-arc-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73002
