### PR TITLE
feat: add ease-potentiometer-wiper-slide (#73015)

### DIFF
--- a/submissions/examples/potentiometer-wiper-slide-ns/README.md
+++ b/submissions/examples/potentiometer-wiper-slide-ns/README.md
@@ -1,0 +1,16 @@
+# Potentiometer Wiper Slide
+
+## What does this do?
+Renders a self-contained CSS-only `ease-potentiometer-wiper-slide` demo: Potentiometer wiper sliding along a resistive track.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-potentiometer-wiper-slide`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-potentiometer-wiper-slide">
+  <div class="ease-potentiometer-wiper-slide__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/potentiometer-wiper-slide-ns/demo.html
+++ b/submissions/examples/potentiometer-wiper-slide-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Potentiometer Wiper Slide — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Potentiometer Wiper Slide demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Potentiometer Wiper Slide</h1>
+      <p class="lede">Potentiometer wiper sliding along a resistive track</p>
+    </header>
+
+    <section class="ease-potentiometer-wiper-slide" data-demo="potentiometer-wiper-slide" aria-live="polite">
+      <div class="ease-potentiometer-wiper-slide__housing">
+        <div class="ease-potentiometer-wiper-slide__bezel">
+          <div class="ease-potentiometer-wiper-slide__face">
+            <div class="ease-potentiometer-wiper-slide__readout">
+              <span class="ease-potentiometer-wiper-slide__label">Potentiometer Wiper Slide</span>
+              <span class="ease-potentiometer-wiper-slide__value">LIVE</span>
+            </div>
+            <div class="ease-potentiometer-wiper-slide__motion" aria-hidden="true">
+              <span class="ease-potentiometer-wiper-slide__a"></span>
+              <span class="ease-potentiometer-wiper-slide__b"></span>
+              <span class="ease-potentiometer-wiper-slide__c"></span>
+              <span class="ease-potentiometer-wiper-slide__d"></span>
+            </div>
+            <div class="ease-potentiometer-wiper-slide__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-potentiometer-wiper-slide__controls">
+          <button type="button" class="ease-potentiometer-wiper-slide__btn primary">Engage</button>
+          <button type="button" class="ease-potentiometer-wiper-slide__btn">Reset</button>
+          <label class="ease-potentiometer-wiper-slide__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-potentiometer-wiper-slide__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/potentiometer-wiper-slide-ns/style.css
+++ b/submissions/examples/potentiometer-wiper-slide-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f97316 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fdba74 18%, transparent), transparent 42%),
+    #160d08;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-potentiometer-wiper-slide {
+  --accent: #f97316;
+  --accent-2: #fdba74;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160d08);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160d08 75%, #000);
+}
+
+.ease-potentiometer-wiper-slide__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-potentiometer-wiper-slide__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160d08 90%, #f97316);
+}
+
+.ease-potentiometer-wiper-slide__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-potentiometer-wiper-slide__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-potentiometer-wiper-slide__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-potentiometer-wiper-slide__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-potentiometer-wiper-slide__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-potentiometer-wiper-slide__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-potentiometer-wiper-slide__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: potentiometer_wiper_slide_meter 3.5s linear infinite;
+}
+
+.ease-potentiometer-wiper-slide__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-potentiometer-wiper-slide__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-potentiometer-wiper-slide__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-potentiometer-wiper-slide__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-potentiometer-wiper-slide__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-potentiometer-wiper-slide__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-potentiometer-wiper-slide__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-potentiometer-wiper-slide__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-potentiometer-wiper-slide__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-potentiometer-wiper-slide__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-potentiometer-wiper-slide__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: potentiometer_wiper_slide_status 2.3s ease-out infinite;
+}
+
+@keyframes potentiometer_wiper_slide_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes potentiometer_wiper_slide_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-potentiometer-wiper-slide__a{position:absolute;left:14%;top:28%;width:22%;height:18%;border:1px solid var(--line);border-radius:6px;background:color-mix(in srgb,var(--accent) 15%,transparent)}
+.ease-potentiometer-wiper-slide__b{position:absolute;right:14%;bottom:28%;width:22%;height:18%;border:1px solid var(--line);border-radius:6px;background:color-mix(in srgb,var(--accent-2) 15%,transparent)}
+.ease-potentiometer-wiper-slide__c{position:absolute;left:28%;top:36%;width:44%;height:3px;background:linear-gradient(90deg,var(--accent),var(--accent-2));transform-origin:left center;animation:potentiometer_wiper_slide_beam 3.1s ease-in-out infinite}
+.ease-potentiometer-wiper-slide__d{position:absolute;left:46%;top:22%;width:10px;height:10px;background:var(--accent);clip-path:polygon(50% 0,100% 50%,50% 100%,0 50%);animation:potentiometer_wiper_slide_hop 3.1s ease-in-out infinite}
+
+@keyframes potentiometer_wiper_slide_beam{0%,100%{transform:rotate(-28deg) scaleX(.85)}50%{transform:rotate(28deg) scaleX(1)}}@keyframes potentiometer_wiper_slide_hop{0%,100%{transform:translate(0,0)}50%{transform:translate(40px,48px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-potentiometer-wiper-slide__a,
+  .ease-potentiometer-wiper-slide__b,
+  .ease-potentiometer-wiper-slide__c,
+  .ease-potentiometer-wiper-slide__d,
+  .ease-potentiometer-wiper-slide__meters i::after,
+  .ease-potentiometer-wiper-slide__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-potentiometer-wiper-slide` CSS-only demo for #73015.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Potentiometer wiper sliding along a resistive track

**How does a developer use it?**

```html
<section class="ease-potentiometer-wiper-slide">
  <div class="ease-potentiometer-wiper-slide__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/potentiometer-wiper-slide-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73015
