### PR TITLE
feat: add pure CSS Handwritten Form component (#70550)

### DIFF
--- a/submissions/examples/css-handwritten-form-pure/README.md
+++ b/submissions/examples/css-handwritten-form-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Handwritten Form
+
+A charming, notebook-style form utilizing a handwritten web font, minimalist underlined inputs, and a custom sketched checkbox.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture**: 
+  - **Handwritten Aesthetic**: The form heavily utilizes the Google Font 'Caveat' to simulate handwriting. The standard box-model styling on inputs is removed (`appearance: none; border: none; background: transparent;`) and replaced with a simple bottom border to create fill-in-the-blank style underlines.
+  - **Lined Paper Textarea**: The multiline `<textarea>` uses a CSS `repeating-linear-gradient` as its background image. By precisely matching the gradient stops (`2rem`) to the CSS `line-height` (`2rem`), it perfectly draws notebook lines directly under each row of handwritten text.
+  - **Sketched Custom Checkbox**: The native checkbox is visually hidden and replaced with a custom CSS square. To simulate a hand-drawn look, the border radius is made intentionally irregular (`border-radius: 4px 8px 3px 6px`). The checked state uses pseudo-elements to draw a slightly crooked checkmark (`transform: rotate(40deg) skewX(-10deg)`).
+  - **Imperfect Button**: The submit button uses a complex, 8-value `border-radius` configuration (e.g., `255px 15px 225px 15px/15px 225px 15px 255px`) to simulate a hand-drawn circle/box around the text.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the paper background from off-white to a dark slate chalkboard look, and swapping the ink colors for contrast.
+- Fully accessible semantic structure. The custom checkbox is paired with a visually hidden native input to preserve keyboard navigation and screen reader support.
+
+## Usage
+Open `demo.html` in your browser to view the handwritten form style.
+
+## Files
+- `demo.html`: The HTML structure defining the form, the inline labels, and the textarea.
+- `style.css`: The styling, Google font imports, and the lined paper gradient tricks.

--- a/submissions/examples/css-handwritten-form-pure/demo.html
+++ b/submissions/examples/css-handwritten-form-pure/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Handwritten Form</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Handwritten Form</h1>
+            <p class="subtitle">A charming, notebook-style form utilizing a handwritten web font, minimalist underlined inputs, and a custom sketched checkbox.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="notebook-container">
+                
+                <form class="handwritten-form" action="#" method="POST" aria-label="Contact Form">
+                    <h2 class="form-title">Drop me a line...</h2>
+                    
+                    <div class="form-group inline-group">
+                        <label for="name" class="handwritten-label">My name is</label>
+                        <input type="text" id="name" name="name" class="handwritten-input" placeholder="your name" required>
+                    </div>
+                    
+                    <div class="form-group inline-group">
+                        <label for="email" class="handwritten-label">and you can reach me at</label>
+                        <input type="email" id="email" name="email" class="handwritten-input email-input" placeholder="email address" required>
+                    </div>
+                    
+                    <div class="form-group block-group">
+                        <label for="message" class="handwritten-label">Here is what I wanted to say:</label>
+                        <!-- 
+                          [TECHNIQUE] Lined Paper Textarea
+                          The textarea has a repeating linear-gradient background to simulate notebook lines.
+                        -->
+                        <textarea id="message" name="message" class="handwritten-textarea" rows="4" required></textarea>
+                    </div>
+                    
+                    <div class="form-group checkbox-group">
+                        <!-- 
+                          [TECHNIQUE] Sketched Checkbox 
+                          Using a pseudo-element checkmark that looks hand-drawn.
+                        -->
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="newsletter" class="native-checkbox">
+                            <span class="custom-sketched-checkbox" aria-hidden="true"></span>
+                            <span class="checkbox-text">Sign me up for the weekly letters!</span>
+                        </label>
+                    </div>
+                    
+                    <button type="submit" class="handwritten-button">
+                        Send it! 
+                        <!-- Simple SVG arrow for extra flavor -->
+                        <svg class="send-arrow" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="5" y1="12" x2="19" y2="12"></line>
+                            <polyline points="12 5 19 12 12 19"></polyline>
+                        </svg>
+                    </button>
+                    
+                </form>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-handwritten-form-pure/style.css
+++ b/submissions/examples/css-handwritten-form-pure/style.css
@@ -1,0 +1,311 @@
+@import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;600&family=Inter:wght@400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Main Background */
+    --bg-base: #e2e8f0;
+    
+    /* Notebook Paper Theme */
+    --paper-bg: #fdfbf7;
+    --paper-line: #94a3b8;
+    --paper-shadow: rgba(0, 0, 0, 0.1);
+    
+    /* Ink Colors */
+    --ink-primary: #1e293b;
+    --ink-secondary: #334155;
+    --ink-accent: #2563eb; /* Blue pen color */
+    
+    /* System Font for the Header */
+    --font-system: 'Inter', sans-serif;
+    /* Handwritten Font for the Form */
+    --font-hand: 'Caveat', cursive;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        
+        /* Dark mode paper is more like slate/chalkboard */
+        --paper-bg: #1e293b;
+        --paper-line: #475569;
+        --paper-shadow: rgba(0, 0, 0, 0.5);
+        
+        /* Light ink for dark paper */
+        --ink-primary: #f8fafc;
+        --ink-secondary: #cbd5e1;
+        --ink-accent: #60a5fa;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: var(--font-system);
+    color: var(--ink-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: var(--ink-secondary);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Notebook Container
+   ========================================= */
+
+.notebook-container {
+    width: 100%;
+    max-width: 500px;
+    background-color: var(--paper-bg);
+    border-radius: 4px;
+    padding: 40px;
+    box-shadow: 2px 4px 15px var(--paper-shadow);
+    /* Subtle rotation for a casual look */
+    transform: rotate(-1deg);
+}
+
+.handwritten-form {
+    font-family: var(--font-hand);
+    font-size: 1.5rem;
+    color: var(--ink-primary);
+}
+
+.form-title {
+    font-size: 2.5rem;
+    font-weight: 600;
+    margin-top: 0;
+    margin-bottom: 30px;
+    color: var(--ink-accent);
+    /* Slight tilt for the title */
+    transform: rotate(-2deg);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Underline Inputs
+   ========================================= */
+
+.form-group {
+    margin-bottom: 25px;
+}
+
+.inline-group {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.handwritten-label {
+    line-height: 1.2;
+}
+
+.handwritten-input {
+    /* Remove standard box model styling */
+    appearance: none;
+    background: transparent;
+    border: none;
+    /* Apply only the bottom border for the underline */
+    border-bottom: 2px solid var(--paper-line);
+    border-radius: 0;
+    
+    font-family: var(--font-hand);
+    font-size: 1.5rem;
+    color: var(--ink-accent); /* Fill with 'blue pen' */
+    
+    padding: 0 5px 2px 5px;
+    outline: none;
+    transition: border-color 0.3s;
+}
+
+.handwritten-input:focus {
+    border-bottom-color: var(--ink-accent);
+}
+
+/* Adjust width for inline flow */
+#name { width: 180px; }
+.email-input { width: 220px; }
+
+
+/* =========================================
+   [TECHNIQUE] Lined Paper Textarea
+   ========================================= */
+
+.block-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.block-group .handwritten-label {
+    margin-bottom: 10px;
+}
+
+.handwritten-textarea {
+    appearance: none;
+    border: none;
+    background: transparent;
+    
+    font-family: var(--font-hand);
+    font-size: 1.5rem;
+    color: var(--ink-accent);
+    
+    width: 100%;
+    resize: vertical;
+    outline: none;
+    
+    /* 
+       Calculate line height and use repeating-linear-gradient 
+       to draw the notebook lines exactly matching the text spacing.
+    */
+    line-height: 2rem;
+    padding: 0 5px;
+    
+    background-image: repeating-linear-gradient(
+        transparent,
+        transparent calc(2rem - 2px),
+        var(--paper-line) calc(2rem - 2px),
+        var(--paper-line) 2rem
+    );
+}
+
+.handwritten-textarea:focus {
+    /* Highlight the lines slightly when focused */
+    background-image: repeating-linear-gradient(
+        transparent,
+        transparent calc(2rem - 2px),
+        var(--ink-accent) calc(2rem - 2px),
+        var(--ink-accent) 2rem
+    );
+}
+
+
+/* =========================================
+   Custom Sketched Checkbox
+   ========================================= */
+
+.checkbox-group {
+    margin-top: 30px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+}
+
+.native-checkbox {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.custom-sketched-checkbox {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+    /* Hand-drawn looking imperfect border */
+    border: 2px solid var(--ink-primary);
+    border-radius: 4px 8px 3px 6px; 
+    position: relative;
+    transition: all 0.2s;
+}
+
+.native-checkbox:focus + .custom-sketched-checkbox {
+    outline: 2px dashed var(--ink-accent);
+    outline-offset: 4px;
+}
+
+/* 
+   Draw a casual, slightly crooked checkmark
+*/
+.native-checkbox:checked + .custom-sketched-checkbox::after {
+    content: '';
+    position: absolute;
+    left: 6px;
+    top: 2px;
+    width: 8px;
+    height: 14px;
+    border: solid var(--ink-accent);
+    border-width: 0 3px 3px 0;
+    /* Irregular rotation for handwritten feel */
+    transform: rotate(40deg) skewX(-10deg);
+}
+
+
+/* =========================================
+   Handwritten Button
+   ========================================= */
+
+.handwritten-button {
+    background: transparent;
+    border: 2px solid var(--ink-primary);
+    /* Irregular border radius */
+    border-radius: 255px 15px 225px 15px/15px 225px 15px 255px;
+    
+    font-family: var(--font-hand);
+    font-size: 1.8rem;
+    font-weight: 600;
+    color: var(--ink-primary);
+    
+    padding: 8px 24px;
+    margin-top: 10px;
+    cursor: pointer;
+    
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    
+    transition: all 0.2s ease;
+}
+
+.send-arrow {
+    transition: transform 0.2s ease;
+}
+
+.handwritten-button:hover {
+    color: var(--ink-accent);
+    border-color: var(--ink-accent);
+    transform: rotate(2deg);
+}
+
+.handwritten-button:hover .send-arrow {
+    transform: translateX(5px);
+}
+
+.handwritten-button:active {
+    transform: scale(0.95);
+}


### PR DESCRIPTION
### Description
This PR introduces a charming, notebook-style form utilizing a handwritten web font, minimalist underlined inputs, and a custom sketched checkbox. Resolves issue #70550.

### Changes Made:
- Added `submissions/examples/css-handwritten-form-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the form, the inline labels, and the textarea.
- Created `style.css` featuring the UI mechanics:
  - **Handwritten Aesthetic**: The form heavily utilizes the Google Font 'Caveat' to simulate handwriting. The standard box-model styling on inputs is removed (`appearance: none; border: none; background: transparent;`) and replaced with a simple bottom border to create fill-in-the-blank style underlines.
  - **Lined Paper Textarea**: The multiline `<textarea>` uses a CSS `repeating-linear-gradient` as its background image. By precisely matching the gradient stops (`2rem`) to the CSS `line-height` (`2rem`), it perfectly draws notebook lines directly under each row of handwritten text.
  - **Sketched Custom Checkbox**: The native checkbox is visually hidden and replaced with a custom CSS square. To simulate a hand-drawn look, the border radius is made intentionally irregular (`border-radius: 4px 8px 3px 6px`). The checked state uses pseudo-elements to draw a slightly crooked checkmark (`transform: rotate(40deg) skewX(-10deg)`).
  - **Imperfect Button**: The submit button uses a complex, 8-value `border-radius` configuration (e.g., `255px 15px 225px 15px/15px 225px 15px 255px`) to simulate a hand-drawn circle/box around the text.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the paper background from off-white to a dark slate chalkboard look, and swapping the ink colors for contrast.
- Added `README.md` documenting usage and the technical mechanics of the lined paper gradient tricks.
- Fully accessible semantic structure. The custom checkbox is paired with a visually hidden native input to preserve keyboard navigation and screen reader support.

Closes #70550
