### PR TITLE
feat: add ease-wilson-cloud-trail (#73029)

### DIFF
--- a/submissions/examples/wilson-cloud-trail-ns/README.md
+++ b/submissions/examples/wilson-cloud-trail-ns/README.md
@@ -1,0 +1,16 @@
+# Wilson Cloud Trail
+
+## What does this do?
+Renders a self-contained CSS-only `ease-wilson-cloud-trail` demo: Wilson cloud chamber trails blooming along particle paths.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-wilson-cloud-trail`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-wilson-cloud-trail">
+  <div class="ease-wilson-cloud-trail__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/wilson-cloud-trail-ns/demo.html
+++ b/submissions/examples/wilson-cloud-trail-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wilson Cloud Trail — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Wilson Cloud Trail demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Wilson Cloud Trail</h1>
+      <p class="lede">Wilson cloud chamber trails blooming along particle paths</p>
+    </header>
+
+    <section class="ease-wilson-cloud-trail" data-demo="wilson-cloud-trail" aria-live="polite">
+      <div class="ease-wilson-cloud-trail__housing">
+        <div class="ease-wilson-cloud-trail__bezel">
+          <div class="ease-wilson-cloud-trail__face">
+            <div class="ease-wilson-cloud-trail__readout">
+              <span class="ease-wilson-cloud-trail__label">Wilson Cloud Trail</span>
+              <span class="ease-wilson-cloud-trail__value">LIVE</span>
+            </div>
+            <div class="ease-wilson-cloud-trail__motion" aria-hidden="true">
+              <span class="ease-wilson-cloud-trail__a"></span>
+              <span class="ease-wilson-cloud-trail__b"></span>
+              <span class="ease-wilson-cloud-trail__c"></span>
+              <span class="ease-wilson-cloud-trail__d"></span>
+            </div>
+            <div class="ease-wilson-cloud-trail__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-wilson-cloud-trail__controls">
+          <button type="button" class="ease-wilson-cloud-trail__btn primary">Engage</button>
+          <button type="button" class="ease-wilson-cloud-trail__btn">Reset</button>
+          <label class="ease-wilson-cloud-trail__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-wilson-cloud-trail__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/wilson-cloud-trail-ns/style.css
+++ b/submissions/examples/wilson-cloud-trail-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #34d399 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #6ee7b7 18%, transparent), transparent 42%),
+    #07140f;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-wilson-cloud-trail {
+  --accent: #34d399;
+  --accent-2: #6ee7b7;
+  --panel: color-mix(in srgb, #e8eef6 7%, #07140f);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #07140f 75%, #000);
+}
+
+.ease-wilson-cloud-trail__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-wilson-cloud-trail__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #07140f 90%, #34d399);
+}
+
+.ease-wilson-cloud-trail__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-wilson-cloud-trail__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-wilson-cloud-trail__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-wilson-cloud-trail__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-wilson-cloud-trail__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-wilson-cloud-trail__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-wilson-cloud-trail__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: wilson_cloud_trail_meter 3.1s linear infinite;
+}
+
+.ease-wilson-cloud-trail__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-wilson-cloud-trail__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-wilson-cloud-trail__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-wilson-cloud-trail__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-wilson-cloud-trail__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-wilson-cloud-trail__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-wilson-cloud-trail__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-wilson-cloud-trail__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-wilson-cloud-trail__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-wilson-cloud-trail__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-wilson-cloud-trail__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: wilson_cloud_trail_status 2.3s ease-out infinite;
+}
+
+@keyframes wilson_cloud_trail_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes wilson_cloud_trail_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-wilson-cloud-trail__a{position:absolute;left:10%;right:10%;top:30%;height:40%;background:linear-gradient(180deg,transparent,color-mix(in srgb,var(--accent) 18%,transparent));overflow:hidden}
+.ease-wilson-cloud-trail__b{position:absolute;left:8%;right:8%;top:42%;height:3px;background:var(--accent);filter:blur(0.5px);animation:wilson_cloud_trail_wave 2.75s ease-in-out infinite}
+.ease-wilson-cloud-trail__c{position:absolute;left:8%;right:8%;top:50%;height:2px;background:var(--accent-2);opacity:.6;animation:wilson_cloud_trail_wave 2.75s ease-in-out infinite .2s}
+.ease-wilson-cloud-trail__d{position:absolute;left:20%;top:24%;width:14px;height:14px;border-radius:50%;border:2px solid var(--accent);animation:wilson_cloud_trail_shock 2.75s linear infinite}
+
+@keyframes wilson_cloud_trail_wave{0%,100%{transform:translateY(0) scaleX(1)}50%{transform:translateY(18px) scaleX(1.05)}}@keyframes wilson_cloud_trail_shock{0%{transform:translate(0,0);opacity:1}100%{transform:translate(220%,90%);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-wilson-cloud-trail__a,
+  .ease-wilson-cloud-trail__b,
+  .ease-wilson-cloud-trail__c,
+  .ease-wilson-cloud-trail__d,
+  .ease-wilson-cloud-trail__meters i::after,
+  .ease-wilson-cloud-trail__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-wilson-cloud-trail` CSS-only demo for #73029.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Wilson cloud chamber trails blooming along particle paths

**How does a developer use it?**

```html
<section class="ease-wilson-cloud-trail">
  <div class="ease-wilson-cloud-trail__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/wilson-cloud-trail-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73029
