### PR TITLE
feat: add pure CSS Chalkboard Card component (#70548)

### DIFF
--- a/submissions/examples/css-chalkboard-card-pure/README.md
+++ b/submissions/examples/css-chalkboard-card-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Chalkboard Card
+
+A realistic chalkboard aesthetic built with CSS gradients, text-shadow smudging, and decorative pure CSS doodles.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture**: 
+  - **The Wood Frame**: The `.chalkboard-card` uses thick solid borders for the wood frame. It utilizes a `repeating-linear-gradient` with low opacity to simulate a subtle wood grain texture, and inset shadows to create depth.
+  - **The Slate Surface**: The `.board-surface` uses a dark slate background combined with radial gradients and a fine repeating-linear-gradient to create a noisy, uneven chalkboard texture.
+  - **Erased Chalk Smudges**: To make the board look used, a `.chalk-smudges` layer is absolutely positioned over the surface. It uses several large, faint `radial-gradient` definitions (e.g., `rgba(255, 255, 255, 0.05)`) placed irregularly to simulate wiped chalk dust.
+  - **Chalk Typography & Doodles**: The text uses the Google Font 'Fredericka the Great' which naturally looks like a rough sketch. A faint white `text-shadow` is applied to simulate chalk dust falling off the letters. Additionally, pure CSS shapes (using the classic CSS border triangle trick) are used to draw decorative elements like stars and underlines.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), subtly darkening the slate and wood colors for high contrast environments.
+- Fully accessible semantic structure. The decorative CSS doodles are marked with `aria-hidden="true"`, and the entire card provides a high-level `aria-label` for screen reader context.
+
+## Usage
+Open `demo.html` in your browser to view the chalkboard daily special menu.
+
+## Files
+- `demo.html`: The HTML structure defining the chalkboard container and the menu list.
+- `style.css`: The styling, the radial gradient smudges, and the CSS shape doodles.

--- a/submissions/examples/css-chalkboard-card-pure/demo.html
+++ b/submissions/examples/css-chalkboard-card-pure/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Chalkboard Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Chalkboard Card</h1>
+            <p class="subtitle">A realistic chalkboard aesthetic built with CSS gradients, text-shadow smudging, and decorative pure CSS doodles.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="chalkboard-card" aria-label="A chalkboard with a daily special menu written on it">
+                
+                <!-- The wood frame is created with borders on the container -->
+                <div class="board-surface">
+                    
+                    <!-- 
+                      [TECHNIQUE] Chalk Smudges 
+                      Subtle white radial gradients on the background to simulate erased chalk dust.
+                    -->
+                    <div class="chalk-smudges"></div>
+                    
+                    <div class="chalk-content">
+                        <h2 class="chalk-title">Daily Special</h2>
+                        
+                        <ul class="chalk-menu">
+                            <li>Avocado Toast <span class="price">$8</span></li>
+                            <li>Matcha Latte <span class="price">$5</span></li>
+                            <li>Açaí Bowl <span class="price">$10</span></li>
+                        </ul>
+                        
+                        <!-- 
+                          [TECHNIQUE] CSS Doodles 
+                          Drawing a basic star and underline using only CSS borders.
+                        -->
+                        <div class="css-doodle-star" aria-hidden="true"></div>
+                        <p class="chalk-footer">Enjoy!</p>
+                        <div class="css-doodle-underline" aria-hidden="true"></div>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-chalkboard-card-pure/style.css
+++ b/submissions/examples/css-chalkboard-card-pure/style.css
@@ -1,0 +1,249 @@
+@import url('https://fonts.googleapis.com/css2?family=Fredericka+the+Great&family=Inter:wght@400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    /* Chalkboard Variables */
+    --board-bg: #2f4f4f; /* Dark Slate Gray */
+    --board-frame: #8b5a2b; /* Wood Brown */
+    --board-frame-shadow: rgba(0, 0, 0, 0.4);
+    
+    /* Chalk Colors */
+    --chalk-white: rgba(255, 255, 255, 0.9);
+    --chalk-yellow: rgba(255, 255, 153, 0.9);
+    --chalk-smudge: rgba(255, 255, 255, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        
+        --board-bg: #1a2f2f; /* Even darker green for dark mode context */
+        --board-frame: #5c3a21; /* Darker wood */
+        --board-frame-shadow: rgba(0, 0, 0, 0.8);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Chalkboard Container (Wood Frame)
+   ========================================= */
+
+.chalkboard-card {
+    width: 100%;
+    max-width: 400px;
+    
+    /* Wood Frame */
+    background-color: var(--board-frame);
+    /* Create depth on the frame */
+    border: 8px solid var(--board-frame);
+    border-radius: 8px;
+    box-shadow: 0 15px 25px var(--board-frame-shadow),
+                inset 0 0 10px rgba(0,0,0,0.8); /* Inner shadow on the frame edge */
+                
+    /* A subtle repeating linear gradient to give the wood a slight grain texture */
+    background-image: repeating-linear-gradient(
+        45deg,
+        transparent,
+        transparent 5px,
+        rgba(0, 0, 0, 0.05) 5px,
+        rgba(0, 0, 0, 0.05) 10px
+    );
+}
+
+/* =========================================
+   Board Surface (Slate)
+   ========================================= */
+
+.board-surface {
+    position: relative;
+    background-color: var(--board-bg);
+    border-radius: 2px;
+    padding: 30px;
+    min-height: 400px;
+    overflow: hidden;
+    
+    /* Slate texture using multiple radial gradients for a noisy, uneven look */
+    background-image: 
+        radial-gradient(circle at 50% 50%, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 100%),
+        repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.01) 2px, rgba(255,255,255,0.01) 4px);
+    
+    /* Inner shadow to recess the board into the frame */
+    box-shadow: inset 0 0 20px rgba(0,0,0,0.6);
+}
+
+/* 
+  [TECHNIQUE] Erased Chalk Smudges
+  Large, very faint radial gradients simulating chalk dust wiped across the board.
+*/
+.chalk-smudges {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: 
+        radial-gradient(circle at 20% 30%, var(--chalk-smudge) 0%, transparent 40%),
+        radial-gradient(circle at 80% 70%, var(--chalk-smudge) 0%, transparent 50%),
+        radial-gradient(circle at 50% 80%, var(--chalk-smudge) 0%, transparent 30%);
+    /* Swirl the smudges slightly */
+    transform: rotate(5deg);
+}
+
+
+/* =========================================
+   Chalk Typography
+   ========================================= */
+
+.chalk-content {
+    position: relative;
+    z-index: 10;
+    /* Fredericka the Great is a perfect rough, sketched chalk font */
+    font-family: 'Fredericka the Great', cursive;
+    color: var(--chalk-white);
+    
+    /* 
+       [TECHNIQUE] Chalk Text Shadow 
+       Adding a slight white blur behind the text simulates chalk dust falling off the letters.
+    */
+    text-shadow: 0 0 2px rgba(255,255,255,0.3);
+    text-align: center;
+}
+
+.chalk-title {
+    font-size: 2.5rem;
+    margin-top: 0;
+    margin-bottom: 20px;
+    color: var(--chalk-yellow);
+    /* Slightly crooked writing */
+    transform: rotate(-2deg);
+}
+
+.chalk-menu {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 30px 0;
+    text-align: left;
+    font-size: 1.5rem;
+    line-height: 2;
+}
+
+.chalk-menu li {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px dashed rgba(255,255,255,0.2);
+    margin-bottom: 15px;
+}
+
+.price {
+    color: var(--chalk-yellow);
+}
+
+.chalk-footer {
+    font-size: 2rem;
+    margin: 20px 0 10px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] CSS Doodles
+   ========================================= */
+
+/* Draw a sketchy underline */
+.css-doodle-underline {
+    width: 80%;
+    margin: 0 auto;
+    height: 10px;
+    /* Create a wavy, hand-drawn line using borders and border-radius */
+    border: solid var(--chalk-white);
+    border-width: 2px 0 0 0;
+    border-radius: 50%;
+    transform: rotate(2deg);
+}
+
+/* Draw a basic star doodle using CSS triangles (borders) */
+.css-doodle-star {
+    position: relative;
+    display: block;
+    color: var(--chalk-yellow);
+    width: 0;
+    height: 0;
+    border-right: 20px solid transparent;
+    border-bottom: 14px solid var(--chalk-yellow);
+    border-left: 20px solid transparent;
+    transform: rotate(35deg) scale(0.8);
+    margin: 20px auto 0 auto;
+}
+
+.css-doodle-star::before {
+    border-bottom: 16px solid var(--chalk-yellow);
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    position: absolute;
+    height: 0;
+    width: 0;
+    top: -9px;
+    left: -13px;
+    display: block;
+    content: '';
+    transform: rotate(-35deg);
+}
+
+.css-doodle-star::after {
+    position: absolute;
+    display: block;
+    color: var(--chalk-yellow);
+    top: 0.6px;
+    left: -21px;
+    width: 0;
+    height: 0;
+    border-right: 20px solid transparent;
+    border-bottom: 14px solid var(--chalk-yellow);
+    border-left: 20px solid transparent;
+    transform: rotate(-70deg);
+    content: '';
+}


### PR DESCRIPTION
### Description
This PR introduces a realistic chalkboard aesthetic card built with CSS gradients, text-shadow smudging, and decorative pure CSS doodles. Resolves issue #70548.

### Changes Made:
- Added `submissions/examples/css-chalkboard-card-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the chalkboard container and the menu list.
- Created `style.css` featuring the UI mechanics:
  - **The Wood Frame**: The `.chalkboard-card` uses thick solid borders for the wood frame. It utilizes a `repeating-linear-gradient` with low opacity to simulate a subtle wood grain texture, and inset shadows to create depth.
  - **The Slate Surface**: The `.board-surface` uses a dark slate background combined with radial gradients and a fine repeating-linear-gradient to create a noisy, uneven chalkboard texture.
  - **Erased Chalk Smudges**: To make the board look used, a `.chalk-smudges` layer is absolutely positioned over the surface. It uses several large, faint `radial-gradient` definitions (e.g., `rgba(255, 255, 255, 0.05)`) placed irregularly to simulate wiped chalk dust.
  - **Chalk Typography & Doodles**: The text uses the Google Font 'Fredericka the Great' which naturally looks like a rough sketch. A faint white `text-shadow` is applied to simulate chalk dust falling off the letters. Additionally, pure CSS shapes (using the classic CSS border triangle trick) are used to draw decorative elements like stars and underlines.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), subtly darkening the slate and wood colors for high contrast environments.
- Added `README.md` documenting usage and the technical mechanics of the radial gradient smudges and the CSS shape doodles.
- Fully accessible semantic structure. The decorative CSS doodles are marked with `aria-hidden="true"`, and the entire card provides a high-level `aria-label` for screen reader context.

Closes #70548
