### PR TITLE
feat: add ease-oscilloscope-lissajous (#73053)

### DIFF
--- a/submissions/examples/oscilloscope-lissajous-ns/README.md
+++ b/submissions/examples/oscilloscope-lissajous-ns/README.md
@@ -1,0 +1,16 @@
+# Oscilloscope Lissajous
+
+## What does this do?
+Renders a self-contained CSS-only `ease-oscilloscope-lissajous` demo: Oscilloscope Lissajous figure blooming from two phases.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-oscilloscope-lissajous`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-oscilloscope-lissajous">
+  <div class="ease-oscilloscope-lissajous__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/oscilloscope-lissajous-ns/demo.html
+++ b/submissions/examples/oscilloscope-lissajous-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Oscilloscope Lissajous — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Oscilloscope Lissajous demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Oscilloscope Lissajous</h1>
+      <p class="lede">Oscilloscope Lissajous figure blooming from two phases</p>
+    </header>
+
+    <section class="ease-oscilloscope-lissajous" data-demo="oscilloscope-lissajous" aria-live="polite">
+      <div class="ease-oscilloscope-lissajous__housing">
+        <div class="ease-oscilloscope-lissajous__bezel">
+          <div class="ease-oscilloscope-lissajous__face">
+            <div class="ease-oscilloscope-lissajous__readout">
+              <span class="ease-oscilloscope-lissajous__label">Oscilloscope Lissajous</span>
+              <span class="ease-oscilloscope-lissajous__value">LIVE</span>
+            </div>
+            <div class="ease-oscilloscope-lissajous__motion" aria-hidden="true">
+              <span class="ease-oscilloscope-lissajous__a"></span>
+              <span class="ease-oscilloscope-lissajous__b"></span>
+              <span class="ease-oscilloscope-lissajous__c"></span>
+              <span class="ease-oscilloscope-lissajous__d"></span>
+            </div>
+            <div class="ease-oscilloscope-lissajous__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-oscilloscope-lissajous__controls">
+          <button type="button" class="ease-oscilloscope-lissajous__btn primary">Engage</button>
+          <button type="button" class="ease-oscilloscope-lissajous__btn">Reset</button>
+          <label class="ease-oscilloscope-lissajous__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-oscilloscope-lissajous__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/oscilloscope-lissajous-ns/style.css
+++ b/submissions/examples/oscilloscope-lissajous-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #fb7185 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fda4af 18%, transparent), transparent 42%),
+    #16080c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-oscilloscope-lissajous {
+  --accent: #fb7185;
+  --accent-2: #fda4af;
+  --panel: color-mix(in srgb, #e8eef6 7%, #16080c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #16080c 75%, #000);
+}
+
+.ease-oscilloscope-lissajous__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-oscilloscope-lissajous__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #16080c 90%, #fb7185);
+}
+
+.ease-oscilloscope-lissajous__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-oscilloscope-lissajous__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-oscilloscope-lissajous__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-oscilloscope-lissajous__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-oscilloscope-lissajous__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-oscilloscope-lissajous__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-oscilloscope-lissajous__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: oscilloscope_lissajous_meter 4.6s linear infinite;
+}
+
+.ease-oscilloscope-lissajous__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-oscilloscope-lissajous__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-oscilloscope-lissajous__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-oscilloscope-lissajous__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-oscilloscope-lissajous__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-oscilloscope-lissajous__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-oscilloscope-lissajous__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-oscilloscope-lissajous__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-oscilloscope-lissajous__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-oscilloscope-lissajous__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-oscilloscope-lissajous__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: oscilloscope_lissajous_status 2.3s ease-out infinite;
+}
+
+@keyframes oscilloscope_lissajous_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes oscilloscope_lissajous_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-oscilloscope-lissajous__a{position:absolute;inset:22%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 50%,transparent);animation:oscilloscope_lissajous_ring 4.15s ease-out infinite}
+.ease-oscilloscope-lissajous__b{position:absolute;inset:32%;border-radius:50%;background:radial-gradient(circle,var(--accent-2),transparent 70%);animation:oscilloscope_lissajous_core 4.15s ease-in-out infinite}
+.ease-oscilloscope-lissajous__c{position:absolute;left:18%;right:18%;top:48%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 6px,transparent 6px 12px);opacity:.5}
+.ease-oscilloscope-lissajous__d{position:absolute;left:48%;top:18%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:oscilloscope_lissajous_spark 4.15s linear infinite}
+
+@keyframes oscilloscope_lissajous_ring{0%{transform:scale(.85);opacity:.9}100%{transform:scale(1.25);opacity:0}}@keyframes oscilloscope_lissajous_core{0%,100%{transform:scale(.9);opacity:.55}50%{transform:scale(1.1);opacity:1}}@keyframes oscilloscope_lissajous_spark{0%{transform:rotate(0) translateX(0)}100%{transform:rotate(360deg) translateX(40px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-oscilloscope-lissajous__a,
+  .ease-oscilloscope-lissajous__b,
+  .ease-oscilloscope-lissajous__c,
+  .ease-oscilloscope-lissajous__d,
+  .ease-oscilloscope-lissajous__meters i::after,
+  .ease-oscilloscope-lissajous__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-oscilloscope-lissajous` CSS-only demo for #73053.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Oscilloscope Lissajous figure blooming from two phases

**How does a developer use it?**

```html
<section class="ease-oscilloscope-lissajous">
  <div class="ease-oscilloscope-lissajous__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/oscilloscope-lissajous-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73053
