### PR TITLE
feat: add ease-burette-titrate-drip (#73070)

### DIFF
--- a/submissions/examples/burette-titrate-drip-ns/README.md
+++ b/submissions/examples/burette-titrate-drip-ns/README.md
@@ -1,0 +1,16 @@
+# Burette Titrate Drip
+
+## What does this do?
+Renders a self-contained CSS-only `ease-burette-titrate-drip` demo: Burette titration dripping toward endpoint color.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-burette-titrate-drip`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-burette-titrate-drip">
+  <div class="ease-burette-titrate-drip__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/burette-titrate-drip-ns/demo.html
+++ b/submissions/examples/burette-titrate-drip-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Burette Titrate Drip — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Burette Titrate Drip demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Burette Titrate Drip</h1>
+      <p class="lede">Burette titration dripping toward endpoint color</p>
+    </header>
+
+    <section class="ease-burette-titrate-drip" data-demo="burette-titrate-drip" aria-live="polite">
+      <div class="ease-burette-titrate-drip__housing">
+        <div class="ease-burette-titrate-drip__bezel">
+          <div class="ease-burette-titrate-drip__face">
+            <div class="ease-burette-titrate-drip__readout">
+              <span class="ease-burette-titrate-drip__label">Burette Titrate Drip</span>
+              <span class="ease-burette-titrate-drip__value">LIVE</span>
+            </div>
+            <div class="ease-burette-titrate-drip__motion" aria-hidden="true">
+              <span class="ease-burette-titrate-drip__a"></span>
+              <span class="ease-burette-titrate-drip__b"></span>
+              <span class="ease-burette-titrate-drip__c"></span>
+              <span class="ease-burette-titrate-drip__d"></span>
+            </div>
+            <div class="ease-burette-titrate-drip__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-burette-titrate-drip__controls">
+          <button type="button" class="ease-burette-titrate-drip__btn primary">Engage</button>
+          <button type="button" class="ease-burette-titrate-drip__btn">Reset</button>
+          <label class="ease-burette-titrate-drip__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-burette-titrate-drip__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/burette-titrate-drip-ns/style.css
+++ b/submissions/examples/burette-titrate-drip-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #a78bfa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c4b5fd 18%, transparent), transparent 42%),
+    #120b1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-burette-titrate-drip {
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #120b1c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #120b1c 75%, #000);
+}
+
+.ease-burette-titrate-drip__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-burette-titrate-drip__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #120b1c 90%, #a78bfa);
+}
+
+.ease-burette-titrate-drip__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-burette-titrate-drip__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-burette-titrate-drip__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-burette-titrate-drip__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-burette-titrate-drip__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-burette-titrate-drip__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-burette-titrate-drip__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: burette_titrate_drip_meter 4.9s linear infinite;
+}
+
+.ease-burette-titrate-drip__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-burette-titrate-drip__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-burette-titrate-drip__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-burette-titrate-drip__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-burette-titrate-drip__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-burette-titrate-drip__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-burette-titrate-drip__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-burette-titrate-drip__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-burette-titrate-drip__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-burette-titrate-drip__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-burette-titrate-drip__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: burette_titrate_drip_status 2.3s ease-out infinite;
+}
+
+@keyframes burette_titrate_drip_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes burette_titrate_drip_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-burette-titrate-drip__a{position:absolute;inset:18% 10% 28% 10%;background:linear-gradient(90deg,#ef4444,#f59e0b,#22c55e,#3b82f6,#a855f7);opacity:.85;border-radius:4px}
+.ease-burette-titrate-drip__b{position:absolute;top:16%;bottom:26%;width:3px;background:var(--accent-2);box-shadow:0 0 12px var(--accent);animation:burette_titrate_drip_scan 4.5s linear infinite}
+.ease-burette-titrate-drip__c{position:absolute;left:12%;right:12%;bottom:14%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent) 35%,transparent);animation:burette_titrate_drip_glow 4.5s ease-in-out infinite}
+.ease-burette-titrate-drip__d{position:absolute;left:8%;top:12%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:burette_titrate_drip_dot 4.5s linear infinite}
+
+@keyframes burette_titrate_drip_scan{0%{left:12%}100%{left:86%}}@keyframes burette_titrate_drip_glow{0%,100%{opacity:.4}50%{opacity:1}}@keyframes burette_titrate_drip_dot{0%{transform:translateX(0)}100%{transform:translateX(420%)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-burette-titrate-drip__a,
+  .ease-burette-titrate-drip__b,
+  .ease-burette-titrate-drip__c,
+  .ease-burette-titrate-drip__d,
+  .ease-burette-titrate-drip__meters i::after,
+  .ease-burette-titrate-drip__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-burette-titrate-drip` CSS-only demo for #73070.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Burette titration dripping toward endpoint color

**How does a developer use it?**

```html
<section class="ease-burette-titrate-drip">
  <div class="ease-burette-titrate-drip__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/burette-titrate-drip-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73070
