### PR TITLE
feat: add ease-pipette-meniscus (#73072)

### DIFF
--- a/submissions/examples/pipette-meniscus-ns/README.md
+++ b/submissions/examples/pipette-meniscus-ns/README.md
@@ -1,0 +1,16 @@
+# Pipette Meniscus
+
+## What does this do?
+Renders a self-contained CSS-only `ease-pipette-meniscus` demo: Pipette meniscus settling to a calibration mark.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-pipette-meniscus`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-pipette-meniscus">
+  <div class="ease-pipette-meniscus__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/pipette-meniscus-ns/demo.html
+++ b/submissions/examples/pipette-meniscus-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pipette Meniscus — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Pipette Meniscus demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Pipette Meniscus</h1>
+      <p class="lede">Pipette meniscus settling to a calibration mark</p>
+    </header>
+
+    <section class="ease-pipette-meniscus" data-demo="pipette-meniscus" aria-live="polite">
+      <div class="ease-pipette-meniscus__housing">
+        <div class="ease-pipette-meniscus__bezel">
+          <div class="ease-pipette-meniscus__face">
+            <div class="ease-pipette-meniscus__readout">
+              <span class="ease-pipette-meniscus__label">Pipette Meniscus</span>
+              <span class="ease-pipette-meniscus__value">LIVE</span>
+            </div>
+            <div class="ease-pipette-meniscus__motion" aria-hidden="true">
+              <span class="ease-pipette-meniscus__a"></span>
+              <span class="ease-pipette-meniscus__b"></span>
+              <span class="ease-pipette-meniscus__c"></span>
+              <span class="ease-pipette-meniscus__d"></span>
+            </div>
+            <div class="ease-pipette-meniscus__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-pipette-meniscus__controls">
+          <button type="button" class="ease-pipette-meniscus__btn primary">Engage</button>
+          <button type="button" class="ease-pipette-meniscus__btn">Reset</button>
+          <label class="ease-pipette-meniscus__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-pipette-meniscus__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pipette-meniscus-ns/style.css
+++ b/submissions/examples/pipette-meniscus-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #34d399 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #6ee7b7 18%, transparent), transparent 42%),
+    #07140f;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-pipette-meniscus {
+  --accent: #34d399;
+  --accent-2: #6ee7b7;
+  --panel: color-mix(in srgb, #e8eef6 7%, #07140f);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #07140f 75%, #000);
+}
+
+.ease-pipette-meniscus__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-pipette-meniscus__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #07140f 90%, #34d399);
+}
+
+.ease-pipette-meniscus__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-pipette-meniscus__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pipette-meniscus__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-pipette-meniscus__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-pipette-meniscus__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-pipette-meniscus__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-pipette-meniscus__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: pipette_meniscus_meter 2.8s linear infinite;
+}
+
+.ease-pipette-meniscus__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-pipette-meniscus__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-pipette-meniscus__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-pipette-meniscus__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-pipette-meniscus__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-pipette-meniscus__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-pipette-meniscus__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-pipette-meniscus__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-pipette-meniscus__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-pipette-meniscus__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-pipette-meniscus__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pipette_meniscus_status 2.3s ease-out infinite;
+}
+
+@keyframes pipette_meniscus_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes pipette_meniscus_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-pipette-meniscus__a{position:absolute;left:12%;right:12%;top:48%;height:6px;border-radius:3px;background:var(--line)}
+.ease-pipette-meniscus__b{position:absolute;top:38%;width:18%;height:26%;border-radius:8px;border:1px solid var(--line);background:color-mix(in srgb,var(--accent) 20%,var(--panel));animation:pipette_meniscus_slide 2.4s ease-in-out infinite alternate}
+.ease-pipette-meniscus__c{position:absolute;left:14%;top:22%;width:8px;height:56%;background:repeating-linear-gradient(180deg,var(--accent) 0 2px,transparent 2px 8px);opacity:.55}
+.ease-pipette-meniscus__d{position:absolute;right:16%;bottom:18%;width:22%;height:8px;border-radius:4px;background:var(--accent);animation:pipette_meniscus_mark 2.4s ease-in-out infinite alternate}
+
+@keyframes pipette_meniscus_slide{from{left:14%}to{left:66%}}@keyframes pipette_meniscus_mark{from{opacity:.35;transform:translateX(0)}to{opacity:1;transform:translateX(20px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pipette-meniscus__a,
+  .ease-pipette-meniscus__b,
+  .ease-pipette-meniscus__c,
+  .ease-pipette-meniscus__d,
+  .ease-pipette-meniscus__meters i::after,
+  .ease-pipette-meniscus__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pipette-meniscus` CSS-only demo for #73072.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Pipette meniscus settling to a calibration mark

**How does a developer use it?**

```html
<section class="ease-pipette-meniscus">
  <div class="ease-pipette-meniscus__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/pipette-meniscus-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73072
