### PR TITLE
feat: add ease-pantograph-trace-arm (#73076)

### DIFF
--- a/submissions/examples/pantograph-trace-arm-ns/README.md
+++ b/submissions/examples/pantograph-trace-arm-ns/README.md
@@ -1,0 +1,16 @@
+# Pantograph Trace Arm
+
+## What does this do?
+Renders a self-contained CSS-only `ease-pantograph-trace-arm` demo: Pantograph arms tracing a scaled copy path.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-pantograph-trace-arm`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-pantograph-trace-arm">
+  <div class="ease-pantograph-trace-arm__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/pantograph-trace-arm-ns/demo.html
+++ b/submissions/examples/pantograph-trace-arm-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pantograph Trace Arm — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Pantograph Trace Arm demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Pantograph Trace Arm</h1>
+      <p class="lede">Pantograph arms tracing a scaled copy path</p>
+    </header>
+
+    <section class="ease-pantograph-trace-arm" data-demo="pantograph-trace-arm" aria-live="polite">
+      <div class="ease-pantograph-trace-arm__housing">
+        <div class="ease-pantograph-trace-arm__bezel">
+          <div class="ease-pantograph-trace-arm__face">
+            <div class="ease-pantograph-trace-arm__readout">
+              <span class="ease-pantograph-trace-arm__label">Pantograph Trace Arm</span>
+              <span class="ease-pantograph-trace-arm__value">LIVE</span>
+            </div>
+            <div class="ease-pantograph-trace-arm__motion" aria-hidden="true">
+              <span class="ease-pantograph-trace-arm__a"></span>
+              <span class="ease-pantograph-trace-arm__b"></span>
+              <span class="ease-pantograph-trace-arm__c"></span>
+              <span class="ease-pantograph-trace-arm__d"></span>
+            </div>
+            <div class="ease-pantograph-trace-arm__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-pantograph-trace-arm__controls">
+          <button type="button" class="ease-pantograph-trace-arm__btn primary">Engage</button>
+          <button type="button" class="ease-pantograph-trace-arm__btn">Reset</button>
+          <label class="ease-pantograph-trace-arm__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-pantograph-trace-arm__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pantograph-trace-arm-ns/style.css
+++ b/submissions/examples/pantograph-trace-arm-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #60a5fa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #93c5fd 18%, transparent), transparent 42%),
+    #08111c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-pantograph-trace-arm {
+  --accent: #60a5fa;
+  --accent-2: #93c5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #08111c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #08111c 75%, #000);
+}
+
+.ease-pantograph-trace-arm__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-pantograph-trace-arm__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #08111c 90%, #60a5fa);
+}
+
+.ease-pantograph-trace-arm__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-pantograph-trace-arm__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pantograph-trace-arm__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-pantograph-trace-arm__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-pantograph-trace-arm__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-pantograph-trace-arm__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-pantograph-trace-arm__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: pantograph_trace_arm_meter 3.5s linear infinite;
+}
+
+.ease-pantograph-trace-arm__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-pantograph-trace-arm__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-pantograph-trace-arm__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-pantograph-trace-arm__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-pantograph-trace-arm__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-pantograph-trace-arm__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-pantograph-trace-arm__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-pantograph-trace-arm__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-pantograph-trace-arm__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-pantograph-trace-arm__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-pantograph-trace-arm__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pantograph_trace_arm_status 2.3s ease-out infinite;
+}
+
+@keyframes pantograph_trace_arm_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes pantograph_trace_arm_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-pantograph-trace-arm__a{position:absolute;left:30%;top:18%;width:40%;height:64%;clip-path:polygon(50% 0,100% 100%,0 100%);background:color-mix(in srgb,var(--accent) 18%,transparent);border:1px solid var(--line)}
+.ease-pantograph-trace-arm__b{position:absolute;left:22%;top:22%;width:56%;height:4px;background:repeating-linear-gradient(90deg,var(--accent) 0 8px,transparent 8px 14px);transform-origin:left center;animation:pantograph_trace_arm_chain 3.1s linear infinite}
+.ease-pantograph-trace-arm__c{position:absolute;left:44%;width:12%;aspect-ratio:1;border-radius:50%;background:var(--accent-2);animation:pantograph_trace_arm_climb 3.1s ease-in-out infinite}
+.ease-pantograph-trace-arm__d{position:absolute;right:16%;bottom:16%;width:16%;height:8px;background:var(--accent);opacity:.6}
+
+@keyframes pantograph_trace_arm_chain{0%{transform:rotate(-20deg) translateX(0)}100%{transform:rotate(-20deg) translateX(12px)}}@keyframes pantograph_trace_arm_climb{0%{top:66%}100%{top:24%}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pantograph-trace-arm__a,
+  .ease-pantograph-trace-arm__b,
+  .ease-pantograph-trace-arm__c,
+  .ease-pantograph-trace-arm__d,
+  .ease-pantograph-trace-arm__meters i::after,
+  .ease-pantograph-trace-arm__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pantograph-trace-arm` CSS-only demo for #73076.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Pantograph arms tracing a scaled copy path

**How does a developer use it?**

```html
<section class="ease-pantograph-trace-arm">
  <div class="ease-pantograph-trace-arm__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/pantograph-trace-arm-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73076
