### PR TITLE
feat: add ease-letterpress-platen-stamp (#73080)

### DIFF
--- a/submissions/examples/letterpress-platen-stamp-ns/README.md
+++ b/submissions/examples/letterpress-platen-stamp-ns/README.md
@@ -1,0 +1,16 @@
+# Letterpress Platen Stamp
+
+## What does this do?
+Renders a self-contained CSS-only `ease-letterpress-platen-stamp` demo: Letterpress platen stamping ink onto a forme.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-letterpress-platen-stamp`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-letterpress-platen-stamp">
+  <div class="ease-letterpress-platen-stamp__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/letterpress-platen-stamp-ns/demo.html
+++ b/submissions/examples/letterpress-platen-stamp-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Letterpress Platen Stamp — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Letterpress Platen Stamp demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Letterpress Platen Stamp</h1>
+      <p class="lede">Letterpress platen stamping ink onto a forme</p>
+    </header>
+
+    <section class="ease-letterpress-platen-stamp" data-demo="letterpress-platen-stamp" aria-live="polite">
+      <div class="ease-letterpress-platen-stamp__housing">
+        <div class="ease-letterpress-platen-stamp__bezel">
+          <div class="ease-letterpress-platen-stamp__face">
+            <div class="ease-letterpress-platen-stamp__readout">
+              <span class="ease-letterpress-platen-stamp__label">Letterpress Platen Stamp</span>
+              <span class="ease-letterpress-platen-stamp__value">LIVE</span>
+            </div>
+            <div class="ease-letterpress-platen-stamp__motion" aria-hidden="true">
+              <span class="ease-letterpress-platen-stamp__a"></span>
+              <span class="ease-letterpress-platen-stamp__b"></span>
+              <span class="ease-letterpress-platen-stamp__c"></span>
+              <span class="ease-letterpress-platen-stamp__d"></span>
+            </div>
+            <div class="ease-letterpress-platen-stamp__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-letterpress-platen-stamp__controls">
+          <button type="button" class="ease-letterpress-platen-stamp__btn primary">Engage</button>
+          <button type="button" class="ease-letterpress-platen-stamp__btn">Reset</button>
+          <label class="ease-letterpress-platen-stamp__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-letterpress-platen-stamp__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/letterpress-platen-stamp-ns/style.css
+++ b/submissions/examples/letterpress-platen-stamp-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #f97316 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #fdba74 18%, transparent), transparent 42%),
+    #160d08;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-letterpress-platen-stamp {
+  --accent: #f97316;
+  --accent-2: #fdba74;
+  --panel: color-mix(in srgb, #e8eef6 7%, #160d08);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #160d08 75%, #000);
+}
+
+.ease-letterpress-platen-stamp__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-letterpress-platen-stamp__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #160d08 90%, #f97316);
+}
+
+.ease-letterpress-platen-stamp__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-letterpress-platen-stamp__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-letterpress-platen-stamp__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-letterpress-platen-stamp__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-letterpress-platen-stamp__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-letterpress-platen-stamp__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-letterpress-platen-stamp__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: letterpress_platen_stamp_meter 4.2s linear infinite;
+}
+
+.ease-letterpress-platen-stamp__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-letterpress-platen-stamp__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-letterpress-platen-stamp__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-letterpress-platen-stamp__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-letterpress-platen-stamp__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-letterpress-platen-stamp__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-letterpress-platen-stamp__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-letterpress-platen-stamp__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-letterpress-platen-stamp__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-letterpress-platen-stamp__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-letterpress-platen-stamp__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: letterpress_platen_stamp_status 2.3s ease-out infinite;
+}
+
+@keyframes letterpress_platen_stamp_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes letterpress_platen_stamp_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-letterpress-platen-stamp__a{position:absolute;inset:18% 10% 28% 10%;background:linear-gradient(90deg,#ef4444,#f59e0b,#22c55e,#3b82f6,#a855f7);opacity:.85;border-radius:4px}
+.ease-letterpress-platen-stamp__b{position:absolute;top:16%;bottom:26%;width:3px;background:var(--accent-2);box-shadow:0 0 12px var(--accent);animation:letterpress_platen_stamp_scan 3.8s linear infinite}
+.ease-letterpress-platen-stamp__c{position:absolute;left:12%;right:12%;bottom:14%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent) 35%,transparent);animation:letterpress_platen_stamp_glow 3.8s ease-in-out infinite}
+.ease-letterpress-platen-stamp__d{position:absolute;left:8%;top:12%;width:10px;height:10px;border-radius:50%;background:var(--accent);animation:letterpress_platen_stamp_dot 3.8s linear infinite}
+
+@keyframes letterpress_platen_stamp_scan{0%{left:12%}100%{left:86%}}@keyframes letterpress_platen_stamp_glow{0%,100%{opacity:.4}50%{opacity:1}}@keyframes letterpress_platen_stamp_dot{0%{transform:translateX(0)}100%{transform:translateX(420%)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-letterpress-platen-stamp__a,
+  .ease-letterpress-platen-stamp__b,
+  .ease-letterpress-platen-stamp__c,
+  .ease-letterpress-platen-stamp__d,
+  .ease-letterpress-platen-stamp__meters i::after,
+  .ease-letterpress-platen-stamp__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-letterpress-platen-stamp` CSS-only demo for #73080.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Letterpress platen stamping ink onto a forme

**How does a developer use it?**

```html
<section class="ease-letterpress-platen-stamp">
  <div class="ease-letterpress-platen-stamp__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/letterpress-platen-stamp-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73080
