### PR TITLE
feat: add ease-linotype-matrix-drop (#73083)

### DIFF
--- a/submissions/examples/linotype-matrix-drop-ns/README.md
+++ b/submissions/examples/linotype-matrix-drop-ns/README.md
@@ -1,0 +1,16 @@
+# Linotype Matrix Drop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-linotype-matrix-drop` demo: Linotype matrices dropping into a composing channel.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-linotype-matrix-drop`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-linotype-matrix-drop">
+  <div class="ease-linotype-matrix-drop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/linotype-matrix-drop-ns/demo.html
+++ b/submissions/examples/linotype-matrix-drop-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Linotype Matrix Drop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Linotype Matrix Drop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Linotype Matrix Drop</h1>
+      <p class="lede">Linotype matrices dropping into a composing channel</p>
+    </header>
+
+    <section class="ease-linotype-matrix-drop" data-demo="linotype-matrix-drop" aria-live="polite">
+      <div class="ease-linotype-matrix-drop__housing">
+        <div class="ease-linotype-matrix-drop__bezel">
+          <div class="ease-linotype-matrix-drop__face">
+            <div class="ease-linotype-matrix-drop__readout">
+              <span class="ease-linotype-matrix-drop__label">Linotype Matrix Drop</span>
+              <span class="ease-linotype-matrix-drop__value">LIVE</span>
+            </div>
+            <div class="ease-linotype-matrix-drop__motion" aria-hidden="true">
+              <span class="ease-linotype-matrix-drop__a"></span>
+              <span class="ease-linotype-matrix-drop__b"></span>
+              <span class="ease-linotype-matrix-drop__c"></span>
+              <span class="ease-linotype-matrix-drop__d"></span>
+            </div>
+            <div class="ease-linotype-matrix-drop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-linotype-matrix-drop__controls">
+          <button type="button" class="ease-linotype-matrix-drop__btn primary">Engage</button>
+          <button type="button" class="ease-linotype-matrix-drop__btn">Reset</button>
+          <label class="ease-linotype-matrix-drop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-linotype-matrix-drop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/linotype-matrix-drop-ns/style.css
+++ b/submissions/examples/linotype-matrix-drop-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #2dd4bf 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #5eead4 18%, transparent), transparent 42%),
+    #071412;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-linotype-matrix-drop {
+  --accent: #2dd4bf;
+  --accent-2: #5eead4;
+  --panel: color-mix(in srgb, #e8eef6 7%, #071412);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #071412 75%, #000);
+}
+
+.ease-linotype-matrix-drop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-linotype-matrix-drop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #071412 90%, #2dd4bf);
+}
+
+.ease-linotype-matrix-drop__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-linotype-matrix-drop__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-linotype-matrix-drop__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-linotype-matrix-drop__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-linotype-matrix-drop__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-linotype-matrix-drop__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-linotype-matrix-drop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: linotype_matrix_drop_meter 4.6s linear infinite;
+}
+
+.ease-linotype-matrix-drop__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-linotype-matrix-drop__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-linotype-matrix-drop__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-linotype-matrix-drop__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-linotype-matrix-drop__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-linotype-matrix-drop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-linotype-matrix-drop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-linotype-matrix-drop__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-linotype-matrix-drop__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-linotype-matrix-drop__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-linotype-matrix-drop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: linotype_matrix_drop_status 2.3s ease-out infinite;
+}
+
+@keyframes linotype_matrix_drop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes linotype_matrix_drop_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-linotype-matrix-drop__a{position:absolute;inset:18%;border-radius:50%;background:conic-gradient(var(--accent),var(--accent-2),#ef4444,#22c55e,var(--accent));animation:linotype_matrix_drop_spin 4.15s linear infinite}
+.ease-linotype-matrix-drop__b{position:absolute;inset:34%;border-radius:50%;background:var(--bg);border:1px solid var(--line)}
+.ease-linotype-matrix-drop__c{position:absolute;left:48%;top:16%;width:4px;height:18%;background:var(--accent-2);transform-origin:bottom center;animation:linotype_matrix_drop_spin 4.15s linear infinite reverse}
+.ease-linotype-matrix-drop__d{position:absolute;right:20%;bottom:20%;width:12%;height:8px;border-radius:4px;background:var(--accent);animation:linotype_matrix_drop_blink 4.15s steps(2) infinite}
+
+@keyframes linotype_matrix_drop_spin{to{transform:rotate(360deg)}}@keyframes linotype_matrix_drop_blink{50%{opacity:.25}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-linotype-matrix-drop__a,
+  .ease-linotype-matrix-drop__b,
+  .ease-linotype-matrix-drop__c,
+  .ease-linotype-matrix-drop__d,
+  .ease-linotype-matrix-drop__meters i::after,
+  .ease-linotype-matrix-drop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-linotype-matrix-drop` CSS-only demo for #73083.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Linotype matrices dropping into a composing channel

**How does a developer use it?**

```html
<section class="ease-linotype-matrix-drop">
  <div class="ease-linotype-matrix-drop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/linotype-matrix-drop-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73083
