### PR TITLE
feat: add ease-capstan-bar-heave (#73097)

### DIFF
--- a/submissions/examples/capstan-bar-heave-ns/README.md
+++ b/submissions/examples/capstan-bar-heave-ns/README.md
@@ -1,0 +1,16 @@
+# Capstan Bar Heave
+
+## What does this do?
+Renders a self-contained CSS-only `ease-capstan-bar-heave` demo: Capstan bars heaving a cable around the drum.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-capstan-bar-heave`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-capstan-bar-heave">
+  <div class="ease-capstan-bar-heave__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/capstan-bar-heave-ns/demo.html
+++ b/submissions/examples/capstan-bar-heave-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Capstan Bar Heave — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Capstan Bar Heave demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Capstan Bar Heave</h1>
+      <p class="lede">Capstan bars heaving a cable around the drum</p>
+    </header>
+
+    <section class="ease-capstan-bar-heave" data-demo="capstan-bar-heave" aria-live="polite">
+      <div class="ease-capstan-bar-heave__housing">
+        <div class="ease-capstan-bar-heave__bezel">
+          <div class="ease-capstan-bar-heave__face">
+            <div class="ease-capstan-bar-heave__readout">
+              <span class="ease-capstan-bar-heave__label">Capstan Bar Heave</span>
+              <span class="ease-capstan-bar-heave__value">LIVE</span>
+            </div>
+            <div class="ease-capstan-bar-heave__motion" aria-hidden="true">
+              <span class="ease-capstan-bar-heave__a"></span>
+              <span class="ease-capstan-bar-heave__b"></span>
+              <span class="ease-capstan-bar-heave__c"></span>
+              <span class="ease-capstan-bar-heave__d"></span>
+            </div>
+            <div class="ease-capstan-bar-heave__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-capstan-bar-heave__controls">
+          <button type="button" class="ease-capstan-bar-heave__btn primary">Engage</button>
+          <button type="button" class="ease-capstan-bar-heave__btn">Reset</button>
+          <label class="ease-capstan-bar-heave__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-capstan-bar-heave__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/capstan-bar-heave-ns/style.css
+++ b/submissions/examples/capstan-bar-heave-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #60a5fa 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #93c5fd 18%, transparent), transparent 42%),
+    #08111c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-capstan-bar-heave {
+  --accent: #60a5fa;
+  --accent-2: #93c5fd;
+  --panel: color-mix(in srgb, #e8eef6 7%, #08111c);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #08111c 75%, #000);
+}
+
+.ease-capstan-bar-heave__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-capstan-bar-heave__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #08111c 90%, #60a5fa);
+}
+
+.ease-capstan-bar-heave__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-capstan-bar-heave__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-capstan-bar-heave__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-capstan-bar-heave__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-capstan-bar-heave__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-capstan-bar-heave__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-capstan-bar-heave__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: capstan_bar_heave_meter 4.6s linear infinite;
+}
+
+.ease-capstan-bar-heave__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-capstan-bar-heave__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-capstan-bar-heave__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-capstan-bar-heave__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-capstan-bar-heave__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-capstan-bar-heave__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-capstan-bar-heave__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-capstan-bar-heave__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-capstan-bar-heave__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-capstan-bar-heave__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-capstan-bar-heave__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: capstan_bar_heave_status 2.3s ease-out infinite;
+}
+
+@keyframes capstan_bar_heave_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes capstan_bar_heave_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-capstan-bar-heave__a{position:absolute;inset:20%;border-radius:50%;border:1px solid var(--line)}
+.ease-capstan-bar-heave__b{position:absolute;left:50%;top:50%;width:42%;height:4px;background:var(--accent);transform-origin:left center;margin-left:-2px;animation:capstan_bar_heave_pivot 4.15s ease-in-out infinite alternate}
+.ease-capstan-bar-heave__c{position:absolute;left:12%;right:12%;bottom:18%;height:8px;background:repeating-linear-gradient(90deg,var(--accent-2) 0 2px,transparent 2px 12px);opacity:.5}
+.ease-capstan-bar-heave__d{position:absolute;left:48%;top:48%;width:10px;height:10px;border-radius:50%;background:var(--accent-2);transform:translate(-50%,-50%)}
+
+@keyframes capstan_bar_heave_pivot{from{transform:rotate(-50deg)}to{transform:rotate(50deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-capstan-bar-heave__a,
+  .ease-capstan-bar-heave__b,
+  .ease-capstan-bar-heave__c,
+  .ease-capstan-bar-heave__d,
+  .ease-capstan-bar-heave__meters i::after,
+  .ease-capstan-bar-heave__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-capstan-bar-heave` CSS-only demo for #73097.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Capstan bars heaving a cable around the drum

**How does a developer use it?**

```html
<section class="ease-capstan-bar-heave">
  <div class="ease-capstan-bar-heave__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/capstan-bar-heave-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73097
