### PR TITLE
feat: add ease-schlieren-shock-ripple (#73099)

### DIFF
--- a/submissions/examples/schlieren-shock-ripple-ns/README.md
+++ b/submissions/examples/schlieren-shock-ripple-ns/README.md
@@ -1,0 +1,16 @@
+# Schlieren Shock Ripple
+
+## What does this do?
+Renders a self-contained CSS-only `ease-schlieren-shock-ripple` demo: Schlieren shock ripples shearing through density gradients.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-schlieren-shock-ripple`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-schlieren-shock-ripple">
+  <div class="ease-schlieren-shock-ripple__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/schlieren-shock-ripple-ns/demo.html
+++ b/submissions/examples/schlieren-shock-ripple-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Schlieren Shock Ripple — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Schlieren Shock Ripple demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Schlieren Shock Ripple</h1>
+      <p class="lede">Schlieren shock ripples shearing through density gradients</p>
+    </header>
+
+    <section class="ease-schlieren-shock-ripple" data-demo="schlieren-shock-ripple" aria-live="polite">
+      <div class="ease-schlieren-shock-ripple__housing">
+        <div class="ease-schlieren-shock-ripple__bezel">
+          <div class="ease-schlieren-shock-ripple__face">
+            <div class="ease-schlieren-shock-ripple__readout">
+              <span class="ease-schlieren-shock-ripple__label">Schlieren Shock Ripple</span>
+              <span class="ease-schlieren-shock-ripple__value">LIVE</span>
+            </div>
+            <div class="ease-schlieren-shock-ripple__motion" aria-hidden="true">
+              <span class="ease-schlieren-shock-ripple__a"></span>
+              <span class="ease-schlieren-shock-ripple__b"></span>
+              <span class="ease-schlieren-shock-ripple__c"></span>
+              <span class="ease-schlieren-shock-ripple__d"></span>
+            </div>
+            <div class="ease-schlieren-shock-ripple__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-schlieren-shock-ripple__controls">
+          <button type="button" class="ease-schlieren-shock-ripple__btn primary">Engage</button>
+          <button type="button" class="ease-schlieren-shock-ripple__btn">Reset</button>
+          <label class="ease-schlieren-shock-ripple__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-schlieren-shock-ripple__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/schlieren-shock-ripple-ns/style.css
+++ b/submissions/examples/schlieren-shock-ripple-ns/style.css
@@ -1,0 +1,223 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8eef6;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #eab308 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #facc15 18%, transparent), transparent 42%),
+    #14100a;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-schlieren-shock-ripple {
+  --accent: #eab308;
+  --accent-2: #facc15;
+  --panel: color-mix(in srgb, #e8eef6 7%, #14100a);
+  --line: color-mix(in srgb, #e8eef6 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #14100a 75%, #000);
+}
+
+.ease-schlieren-shock-ripple__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-schlieren-shock-ripple__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8eef6 5%, transparent), transparent 40%),
+    color-mix(in srgb, #14100a 90%, #eab308);
+}
+
+.ease-schlieren-shock-ripple__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    #0b0f14;
+  border: 1px solid var(--line);
+}
+
+.ease-schlieren-shock-ripple__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-schlieren-shock-ripple__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-schlieren-shock-ripple__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-schlieren-shock-ripple__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-schlieren-shock-ripple__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-schlieren-shock-ripple__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: schlieren_shock_ripple_meter 4.9s linear infinite;
+}
+
+.ease-schlieren-shock-ripple__meters i:nth-child(2)::after { animation-delay: 0.1s; }
+.ease-schlieren-shock-ripple__meters i:nth-child(3)::after { animation-delay: 0.2s; }
+.ease-schlieren-shock-ripple__meters i:nth-child(4)::after { animation-delay: 0.3s; }
+.ease-schlieren-shock-ripple__meters i:nth-child(5)::after { animation-delay: 0.4s; }
+.ease-schlieren-shock-ripple__meters i:nth-child(6)::after { animation-delay: 0.5s; }
+
+.ease-schlieren-shock-ripple__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-schlieren-shock-ripple__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8eef6 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+}
+
+.ease-schlieren-shock-ripple__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-schlieren-shock-ripple__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-schlieren-shock-ripple__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-schlieren-shock-ripple__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: schlieren_shock_ripple_status 2.3s ease-out infinite;
+}
+
+@keyframes schlieren_shock_ripple_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes schlieren_shock_ripple_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-schlieren-shock-ripple__a{position:absolute;inset:20%;border-radius:50%;border:1px solid var(--line)}
+.ease-schlieren-shock-ripple__b{position:absolute;left:50%;top:50%;width:42%;height:4px;background:var(--accent);transform-origin:left center;margin-left:-2px;animation:schlieren_shock_ripple_pivot 4.5s ease-in-out infinite alternate}
+.ease-schlieren-shock-ripple__c{position:absolute;left:12%;right:12%;bottom:18%;height:8px;background:repeating-linear-gradient(90deg,var(--accent-2) 0 2px,transparent 2px 12px);opacity:.5}
+.ease-schlieren-shock-ripple__d{position:absolute;left:48%;top:48%;width:10px;height:10px;border-radius:50%;background:var(--accent-2);transform:translate(-50%,-50%)}
+
+@keyframes schlieren_shock_ripple_pivot{from{transform:rotate(-50deg)}to{transform:rotate(50deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-schlieren-shock-ripple__a,
+  .ease-schlieren-shock-ripple__b,
+  .ease-schlieren-shock-ripple__c,
+  .ease-schlieren-shock-ripple__d,
+  .ease-schlieren-shock-ripple__meters i::after,
+  .ease-schlieren-shock-ripple__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-schlieren-shock-ripple` CSS-only demo for #73099.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Schlieren shock ripples shearing through density gradients

**How does a developer use it?**

```html
<section class="ease-schlieren-shock-ripple">
  <div class="ease-schlieren-shock-ripple__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/schlieren-shock-ripple-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #73099
