### PR TITLE
[FEATURE] CSS Slide-over Panel v2 #70271

### DIFF
--- a/submissions/examples/css-slide-over-panel-v2-um/README.md
+++ b/submissions/examples/css-slide-over-panel-v2-um/README.md
@@ -1,0 +1,28 @@
+# CSS Slide-over Panel v2
+
+## 1. What does this do?
+This component renders a responsive sidebar slide-over drawer panel that enters smoothly from the left side of the screen upon button trigger, featuring a blurred backdrop click-to-close overlay.
+
+## 2. How is it used?
+Configure the input trigger checkbox and label wrappers to toggle states:
+```html
+<!-- Checkbox Trigger -->
+<input type="checkbox" id="drawer-trigger" class="drawer-trigger">
+
+<!-- Clickable Backdrop -->
+<label for="drawer-trigger" class="drawer-backdrop"></label>
+
+<!-- Left Slide-over Panel -->
+<div class="drawer-panel" role="dialog" aria-modal="true">
+  <header class="drawer-header">
+    <label for="drawer-trigger" class="btn-close" role="button">&times;</label>
+  </header>
+</div>
+
+<main class="dashboard-page">
+  <label for="drawer-trigger" class="btn-open" role="button">Open Panel</label>
+</main>
+```
+
+## 3. Why is it useful?
+It provides front-end developers with an accessible left-aligned navigation drawer built natively using checkbox states and CSS transform easing properties, removing bulky JS-driven sidebar plugins.

--- a/submissions/examples/css-slide-over-panel-v2-um/demo.html
+++ b/submissions/examples/css-slide-over-panel-v2-um/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Slide-over Panel v2 - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Drawer Checkbox Trigger -->
+  <input type="checkbox" id="drawer-trigger" class="drawer-trigger">
+
+  <!-- Backdrop click overlay (Clicking unchecks the checkbox because of label mapping) -->
+  <label for="drawer-trigger" class="drawer-backdrop" aria-hidden="true"></label>
+
+  <!-- Slide-over Drawer Panel (dialog landmark) -->
+  <div class="drawer-panel" role="dialog" aria-modal="true" aria-label="Settings and navigation menu panel">
+    
+    <div>
+      <header class="drawer-header">
+        <h2 class="drawer-title">Navigation</h2>
+        <!-- Close button label -->
+        <label for="drawer-trigger" class="btn-close" role="button" aria-label="Close drawer navigation" tabindex="0"
+               onkeydown="if(event.key === ' ' || event.key === 'Enter') document.getElementById('drawer-trigger').click()">&times;</label>
+      </header>
+
+      <!-- Menu links -->
+      <nav class="drawer-nav">
+        <a href="#" class="nav-link">Dashboard Summary</a>
+        <a href="#" class="nav-link">Account Details</a>
+        <a href="#" class="nav-link">Security Keys</a>
+        <a href="#" class="nav-link">Global Preferences</a>
+      </nav>
+    </div>
+
+    <!-- Drawer Footer -->
+    <footer class="drawer-footer">
+      <div class="user-avatar" aria-hidden="true"></div>
+      <div class="user-name">Sarah Connor</div>
+    </footer>
+
+  </div>
+
+  <!-- Main Dashboard Page view -->
+  <main class="dashboard-page" role="main">
+    <h1 class="title">Slide-over Panel</h1>
+    <p class="subtitle">Second variant enters smoothly from the left side of the viewport.</p>
+    
+    <!-- Open drawer trigger label -->
+    <label for="drawer-trigger" class="btn-open" role="button" tabindex="0"
+           onkeydown="if(event.key === ' ' || event.key === 'Enter') document.getElementById('drawer-trigger').click()">Open Panel</label>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-slide-over-panel-v2-um/style.css
+++ b/submissions/examples/css-slide-over-panel-v2-um/style.css
@@ -1,0 +1,242 @@
+/* Custom Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800&display=swap');
+
+:root {
+  --bg-color: #06060c;
+  --panel-bg: rgba(18, 18, 32, 0.85);
+  --border-color: rgba(255, 255, 255, 0.08);
+  --text-main: #ffffff;
+  --text-muted: #8d8da6;
+  --accent-color: #00f0ff;
+  --accent-alt: #ff007f;
+}
+
+/* Reset & Base Styles */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Outfit', sans-serif;
+  background-color: var(--bg-color);
+  background-image: 
+    radial-gradient(circle at 10% 20%, rgba(0, 240, 255, 0.04) 0%, transparent 40%),
+    radial-gradient(circle at 90% 80%, rgba(255, 0, 127, 0.04) 0%, transparent 40%);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  overflow: hidden;
+}
+
+/* Main Dashboard Page representation */
+.dashboard-page {
+  background: rgba(16, 16, 35, 0.6);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 40px 20px;
+  width: 100%;
+  max-width: 540px;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+  z-index: 5;
+}
+
+.title {
+  font-size: 1.8rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-alt));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-bottom: 25px;
+}
+
+/* Checkbox Trigger */
+.drawer-trigger {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+
+/* ==========================================
+   LEFT SIDE SLIDE-OVER PANEL SYSTEM
+   ========================================== */
+
+/* Dark Backdrop Overlay */
+.drawer-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(4, 4, 8, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Slide-over Drawer Panel */
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 320px;
+  height: 100vh;
+  background: var(--panel-bg);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border-right: 1.5px solid var(--border-color);
+  z-index: 200;
+  padding: 35px 25px;
+  transform: translateX(-100%); /* Positioned hidden offscreen to the left */
+  box-shadow: 25px 0 50px rgba(0,0,0,0.5);
+  transition: transform 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+/* Active trigger states */
+.drawer-trigger:checked ~ .drawer-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.drawer-trigger:checked ~ .drawer-panel {
+  transform: translateX(0); /* Slide in from the left */
+}
+
+/* Drawer Header */
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  padding-bottom: 20px;
+  margin-bottom: 25px;
+}
+
+.drawer-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent-color);
+  letter-spacing: 0.5px;
+}
+
+/* Close Drawer button */
+.btn-close {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-close:hover {
+  background: var(--accent-alt);
+  color: #fff;
+  box-shadow: 0 0 10px var(--accent-alt);
+}
+
+/* Navigation lists inside drawer */
+.drawer-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+.nav-link {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-main);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.01);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  padding: 10px 16px;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  background: rgba(0, 240, 255, 0.05);
+  border-color: rgba(0, 240, 255, 0.2);
+  color: var(--accent-color);
+  transform: translateX(4px);
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+}
+
+/* User footer segment */
+.drawer-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding-top: 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-alt));
+}
+
+.user-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+
+/* ==========================================
+   TRIGGER UTILITY BUTTONS
+   ========================================== */
+
+.btn-open {
+  display: inline-block;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #000;
+  background: var(--accent-color);
+  border: none;
+  padding: 12px 24px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.btn-open:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(0, 240, 255, 0.3);
+}
+
+.btn-open:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 4px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a responsive, pure HTML/CSS Slide-over Panel component that enters from the left side of the viewport.

Closes #70271

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside submissions/ (e.g., submissions/examples/your-feature-name/ or submissions/docs/your-feature-name/)
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to core/**
- [x] **No changes to components/**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A second slide-over sidebar panel variant entering from the left side of the viewport with a blurred backdrop overlay.

**How does a developer use it?**

```html
<input type="checkbox" id="drawer-trigger" class="drawer-trigger">
<label for="drawer-trigger" class="drawer-backdrop"></label>
<div class="drawer-panel" role="dialog" aria-modal="true">
  <label for="drawer-trigger" class="btn-close">&times;</label>
</div>
```

**Why does it fit EaseMotion CSS?**

It displays custom panel transformations and focus-visible outlines natively using CSS, replacing heavy JS drawer frameworks.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

---

## Notes for Maintainer

Fully self-contained navigation drawer utilizing native checkbox hack elements. Responsive and keyboard-focusable.