### PR TITLE
feat: add pure CSS Split Typography Section component (#70469)

### DIFF
--- a/submissions/examples/css-split-typography-section-pure/README.md
+++ b/submissions/examples/css-split-typography-section-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Split Typography Section
+
+A dramatic hero section featuring large typography that dynamically inverts its color as it spans across a split two-column background layout.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture**: 
+  - **The Split Background**: Instead of using complex grid structures to color the left and right sides of the screen independently, the `.split-typography-section` uses a single `linear-gradient` background with a hard color stop at exactly 50% (`linear-gradient(to right, black 50%, white 50%)`).
+  - **The Blend Mode Magic**: The typography and paragraph text is placed directly over this split background. By setting the text color to `#ffffff` and applying `mix-blend-mode: difference`, the browser mathematically inverts the text color based on whatever pixels are directly behind it. 
+    - Over the dark background (black), white - black = white text.
+    - Over the light background (white), white - white = black text.
+  - This eliminates the need for duplicated text layers with `overflow: hidden`, which is the traditional, messy way of achieving this effect.
+- **Responsive Behavior**: On mobile screens (`max-width: 768px`), the horizontal split layout naturally becomes too cramped. The CSS automatically rotates the background gradient to split vertically (`to bottom`), and collapses the paragraph text into a single column stack, maintaining the dramatic split typography effect across the horizontal axis instead.
+- Fully accessible semantic structure. Standard `<section>`, `<h1>`, and `<p>` tags are used. Honors the `prefers-reduced-motion` accessibility standard by freezing the typography slide-in animation for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser to view the split typography effect. Resize the window to see how it cleanly adapts to mobile portrait orientations.
+
+## Files
+- `demo.html`: The HTML structure defining the section container, the heading, and the two-column grid.
+- `style.css`: The styling, the 50% linear-gradient, and the `mix-blend-mode` rules.

--- a/submissions/examples/css-split-typography-section-pure/demo.html
+++ b/submissions/examples/css-split-typography-section-pure/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Split Typography Section</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+      [TECHNIQUE] Split Typography
+      The container has a 50/50 linear gradient background.
+      The text uses mix-blend-mode: difference to dynamically
+      invert its color based on the background it sits over.
+    -->
+    <section class="split-typography-section" aria-label="Split typography hero section">
+        
+        <div class="split-content">
+            
+            <!-- Large overlapping typography -->
+            <h1 class="split-heading">
+                CREATIVE<br>
+                <span>VISION</span>
+            </h1>
+            
+            <!-- A two-column grid layout for the supporting text -->
+            <div class="split-columns">
+                <div class="column col-left">
+                    <p>We believe that true innovation happens at the intersection of design and engineering. Our approach strips away the unnecessary, focusing entirely on pure, fundamental aesthetics.</p>
+                </div>
+                <div class="column col-right">
+                    <p>By leveraging native browser capabilities and modern CSS architecture, we craft experiences that are not only beautiful but incredibly performant and accessible to everyone.</p>
+                </div>
+            </div>
+            
+        </div>
+        
+    </section>
+
+</body>
+</html>

--- a/submissions/examples/css-split-typography-section-pure/style.css
+++ b/submissions/examples/css-split-typography-section-pure/style.css
@@ -1,0 +1,158 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --color-dark: #111111;
+    --color-light: #f8f9fa;
+    --color-accent: #ff4757;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Inter', sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* =========================================
+   [TECHNIQUE] The Split Section Background
+   ========================================= */
+
+.split-typography-section {
+    position: relative;
+    min-height: 100vh;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    
+    /* 
+       A hard color stop at 50% creates the perfect 
+       two-column split background without needing extra divs.
+    */
+    background: linear-gradient(
+        to right, 
+        var(--color-dark) 0%, 
+        var(--color-dark) 50%, 
+        var(--color-light) 50%, 
+        var(--color-light) 100%
+    );
+}
+
+.split-content {
+    width: 100%;
+    max-width: 1200px;
+    padding: 40px;
+    z-index: 10;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Split Typography (Difference Blend)
+   ========================================= */
+
+.split-heading {
+    margin: 0 0 60px 0;
+    font-size: clamp(4rem, 12vw, 10rem);
+    font-weight: 900;
+    line-height: 0.9;
+    letter-spacing: -2px;
+    text-transform: uppercase;
+    text-align: center;
+    
+    /* 
+       The Magic Sauce: 
+       By coloring the text white, and using mix-blend-mode: difference, 
+       the text will mathematically invert based on what is behind it.
+       Over the dark background (black), white - black = white text.
+       Over the light background (white), white - white = black text.
+    */
+    color: #ffffff;
+    mix-blend-mode: difference;
+    
+    /* Optional: Animate the text sliding in */
+    animation: slide-up 1s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* An accent color applied to a specific span inside the blend-mode container */
+.split-heading span {
+    color: var(--color-accent);
+}
+
+
+/* =========================================
+   The Two-Column Grid layout
+   ========================================= */
+
+.split-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 80px;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.column p {
+    font-size: 1.15rem;
+    line-height: 1.7;
+    margin: 0;
+    
+    /* Again, we use mix-blend-mode so we don't have to manually style left/right columns */
+    color: #ffffff;
+    mix-blend-mode: difference;
+    opacity: 0.8;
+}
+
+/* Responsive collapse */
+@media (max-width: 768px) {
+    /* Stack the background vertically instead on mobile */
+    .split-typography-section {
+        background: linear-gradient(
+            to bottom, 
+            var(--color-dark) 0%, 
+            var(--color-dark) 50%, 
+            var(--color-light) 50%, 
+            var(--color-light) 100%
+        );
+        padding: 40px 0;
+    }
+    
+    .split-columns {
+        grid-template-columns: 1fr;
+        gap: 40px;
+        text-align: center;
+        padding: 0 20px;
+    }
+    
+    /* On mobile, because the background is split vertically, 
+       we might need to adjust the typography positioning so it 
+       still crosses the horizontal split line. */
+    .split-heading {
+        margin: 60px 0;
+    }
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+@keyframes slide-up {
+    0% {
+        opacity: 0;
+        transform: translateY(40px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .split-heading {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a dramatic hero section featuring large typography that dynamically inverts its color as it spans across a split two-column background layout. Resolves issue #70469.

### Changes Made:
- Added `submissions/examples/css-split-typography-section-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the section container, the heading, and the two-column grid.
- Created `style.css` featuring the UI mechanics:
  - **The Split Background**: Instead of using complex grid structures to color the left and right sides of the screen independently, the `.split-typography-section` uses a single `linear-gradient` background with a hard color stop at exactly 50% (`linear-gradient(to right, black 50%, white 50%)`).
  - **The Blend Mode Magic**: The typography and paragraph text is placed directly over this split background. By setting the text color to `#ffffff` and applying `mix-blend-mode: difference`, the browser mathematically inverts the text color based on whatever pixels are directly behind it. This cleanly eliminates the need for duplicated text layers with `overflow: hidden`.
  - **Responsive Behavior**: On mobile screens (`max-width: 768px`), the horizontal split layout naturally becomes too cramped. The CSS automatically rotates the background gradient to split vertically (`to bottom`), and collapses the paragraph text into a single column stack, maintaining the dramatic split typography effect across the horizontal axis instead.
- Added `README.md` documenting usage and the technical mechanics of the `mix-blend-mode` rules.
- Fully accessible semantic structure. Standard `<section>`, `<h1>`, and `<p>` tags are used. Honors the `prefers-reduced-motion` accessibility standard by freezing the typography slide-in animation for motion-sensitive users.

Closes #70469
