### PR TITLE
feat: add pure CSS Image Preview Overlay component (#70468)

### DIFF
--- a/submissions/examples/css-image-preview-overlay-pure/README.md
+++ b/submissions/examples/css-image-preview-overlay-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Image Preview Overlay
+
+A full-screen click-to-expand image lightbox with zoom animations, built entirely without JavaScript using the hidden checkbox trick.
+
+## Features
+- Pure CSS and HTML implementation without any JavaScript listeners.
+- **Component Architecture**: 
+  - **The Controller Trick**: The core logic relies on a visually hidden `<input type="checkbox" class="lightbox-toggle">`. 
+  - **The Thumbnail**: The image thumbnail is wrapped in a `<label>` linked to the checkbox. Clicking the thumbnail checks the box.
+  - **The Overlay**: The `.lightbox-overlay` is a fixed, full-screen container that is hidden by default using `opacity: 0; visibility: hidden; pointer-events: none;`. Inside, it contains the high-res image and additional `<label>` elements acting as close buttons (the dark background itself, and an X icon), which uncheck the box when clicked.
+  - **The CSS Logic**: When the hidden checkbox is checked, the CSS general sibling combinator targets the overlay (`.lightbox-toggle:checked ~ .lightbox-overlay`) and flips it to `opacity: 1; visibility: visible`.
+  - **Zoom Animation**: A `transform: scale(0.9)` is applied to the image container by default. When the overlay is triggered, it scales to `transform: scale(1)`, creating a smooth zoom-in effect powered by a `cubic-bezier` transition.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the background and text colors of the gallery view.
+- Fully accessible semantic structure. The hidden checkbox remains focusable for keyboard users (`tab`), and the labels include proper `aria-label` tags for screen reader context.
+
+## Usage
+Open `demo.html` in your browser. Click the image thumbnail to expand the high-resolution preview overlay. Click the dark background or the X icon to close it.
+
+## Files
+- `demo.html`: The HTML structure defining the hidden checkbox, the thumbnail label, and the fullscreen overlay container.
+- `style.css`: The styling, the `:checked` state logic, and the CSS scaling animations.

--- a/submissions/examples/css-image-preview-overlay-pure/demo.html
+++ b/submissions/examples/css-image-preview-overlay-pure/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Image Preview Overlay</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Image Preview Overlay</h1>
+            <p class="subtitle">A full-screen click-to-expand image lightbox with zoom animations, built entirely without JavaScript using the hidden checkbox trick.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="gallery">
+                
+                <!-- 
+                  [TECHNIQUE] The Pure CSS Lightbox
+                  1. A visually hidden checkbox controls the state.
+                  2. A <label> wraps the thumbnail image. Clicking it checks the box.
+                  3. The overlay is positioned absolutely/fixed.
+                  4. Another <label> acts as the close button/background overlay to uncheck the box.
+                -->
+                <div class="gallery-item">
+                    
+                    <input type="checkbox" id="lightbox-toggle-1" class="lightbox-toggle" aria-hidden="true">
+                    
+                    <!-- The Thumbnail (Clicking checks the box) -->
+                    <label for="lightbox-toggle-1" class="thumbnail-label" aria-label="Open image preview">
+                        <!-- We use a placeholder image from Unsplash for demonstration -->
+                        <img src="https://images.unsplash.com/photo-1682687220063-4742bd7fd538?q=80&w=600&auto=format&fit=crop" alt="Desert landscape thumbnail" class="thumbnail-img">
+                        
+                        <!-- Hover hint icon -->
+                        <div class="zoom-hint">
+                            <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line><line x1="11" y1="8" x2="11" y2="14"></line><line x1="8" y1="11" x2="14" y2="11"></line></svg>
+                        </div>
+                    </label>
+                    
+                    <!-- The Fullscreen Overlay (Hidden by default) -->
+                    <div class="lightbox-overlay">
+                        
+                        <!-- Clicking the dark background or the X will close it -->
+                        <label for="lightbox-toggle-1" class="lightbox-close-bg" aria-label="Close image preview"></label>
+                        <label for="lightbox-toggle-1" class="lightbox-close-btn" aria-label="Close image preview">
+                            <svg viewBox="0 0 24 24" width="32" height="32" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                        </label>
+                        
+                        <!-- The high-res image container that zooms in -->
+                        <div class="lightbox-content">
+                            <img src="https://images.unsplash.com/photo-1682687220063-4742bd7fd538?q=80&w=1600&auto=format&fit=crop" alt="Desert landscape full size" class="lightbox-img">
+                        </div>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-image-preview-overlay-pure/style.css
+++ b/submissions/examples/css-image-preview-overlay-pure/style.css
@@ -1,0 +1,234 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    /* Overlay colors */
+    --overlay-bg: rgba(0, 0, 0, 0.9);
+    --overlay-close: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Thumbnail
+   ========================================= */
+
+.gallery {
+    width: 100%;
+    max-width: 400px;
+}
+
+.gallery-item {
+    position: relative;
+    /* We don't hide overflow here because the overlay is fixed */
+}
+
+/* Visually hide the controller checkbox */
+.lightbox-toggle {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.thumbnail-label {
+    display: block;
+    position: relative;
+    cursor: zoom-in;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.thumbnail-label:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.2);
+}
+
+.thumbnail-img {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 4/3;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.thumbnail-label:hover .thumbnail-img {
+    transform: scale(1.05);
+}
+
+.zoom-hint {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.5);
+    background: rgba(0,0,0,0.6);
+    color: white;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+    transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.thumbnail-label:hover .zoom-hint {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+}
+
+/* Accessibility focus state */
+.lightbox-toggle:focus + .thumbnail-label {
+    outline: 3px solid #3b82f6;
+    outline-offset: 4px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Overlay Logic & Animation
+   ========================================= */
+
+.lightbox-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* Hidden State */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+/* The clickable dark background */
+.lightbox-close-bg {
+    position: absolute;
+    inset: 0;
+    background: var(--overlay-bg);
+    cursor: zoom-out;
+}
+
+/* The explicit X close button */
+.lightbox-close-btn {
+    position: absolute;
+    top: 30px;
+    right: 40px;
+    color: var(--overlay-close);
+    cursor: pointer;
+    z-index: 1002;
+    opacity: 0.7;
+    transition: opacity 0.2s, transform 0.2s;
+}
+
+.lightbox-close-btn:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.lightbox-content {
+    position: relative;
+    z-index: 1001;
+    max-width: 90vw;
+    max-height: 90vh;
+    
+    /* Animation State: Zoomed out */
+    transform: scale(0.9);
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.lightbox-img {
+    display: block;
+    max-width: 100%;
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 4px;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+/* 
+   The Magic Trigger: 
+   When the hidden checkbox is checked, make the overlay visible
+   and trigger the zoom animation on the inner content.
+*/
+.lightbox-toggle:checked ~ .lightbox-overlay {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.lightbox-toggle:checked ~ .lightbox-overlay .lightbox-content {
+    /* Animation State: Zoomed in */
+    transform: scale(1);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .thumbnail-label, .thumbnail-img, .zoom-hint,
+    .lightbox-overlay, .lightbox-content {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a full-screen click-to-expand image lightbox with zoom animations, built entirely without JavaScript using the hidden checkbox trick. Resolves issue #70468.

### Changes Made:
- Added `submissions/examples/css-image-preview-overlay-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the hidden checkbox, the thumbnail label, and the fullscreen overlay container.
- Created `style.css` featuring the UI mechanics:
  - **The Controller Trick**: The core logic relies on a visually hidden `<input type="checkbox" class="lightbox-toggle">`. 
  - **The Thumbnail**: The image thumbnail is wrapped in a `<label>` linked to the checkbox. Clicking the thumbnail checks the box.
  - **The Overlay**: The `.lightbox-overlay` is a fixed, full-screen container that is hidden by default using `opacity: 0; visibility: hidden; pointer-events: none;`. Inside, it contains the high-res image and additional `<label>` elements acting as close buttons (the dark background itself, and an X icon), which uncheck the box when clicked.
  - **The CSS Logic**: When the hidden checkbox is checked, the CSS general sibling combinator targets the overlay (`.lightbox-toggle:checked ~ .lightbox-overlay`) and flips it to `opacity: 1; visibility: visible`.
  - **Zoom Animation**: A `transform: scale(0.9)` is applied to the image container by default. When the overlay is triggered, it scales to `transform: scale(1)`, creating a smooth zoom-in effect powered by a `cubic-bezier` transition.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the background and text colors of the gallery view.
- Added `README.md` documenting usage and the technical mechanics of the `:checked` state logic and the scaling animations.
- Fully accessible semantic structure. The hidden checkbox remains focusable for keyboard users (`tab`), and the labels include proper `aria-label` tags for screen reader context.

Closes #70468
