### PR TITLE
feat: add pure CSS Solar Charging Bar component (#70454)

### DIFF
--- a/submissions/examples/css-solar-charging-bar-pure/README.md
+++ b/submissions/examples/css-solar-charging-bar-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Solar Charging Bar
+
+A sci-fi inspired solar panel progress bar featuring dynamic sunshine glowing animations and CSS grid cell rendering.
+
+## Features
+- Pure CSS and HTML implementation.
+- **Component Architecture**: 
+  - **The Photovoltaic Grid Surface**: The underlying solar panel (`.solar-surface`) is constructed without any images or SVGs. It uses a base dark blue color overlaid with multiple `repeating-linear-gradient` definitions. These gradients draw a precise grid of thin, bright blue lines to simulate the conductive silver traces found on real solar cells.
+  - **The Sunshine Charge Fill**: The `.solar-charge-fill` element acts as the progress bar itself. It uses an absolute position over the grid. An `@keyframes` animation gradually scales its `width` from 0% to 100%. 
+  - **The Glowing Trail**: To simulate a surge of solar energy, the fill element uses a complex `linear-gradient` (creating a hot white/yellow 'core' at the leading edge, and a fading yellow trail behind it). Crucially, a heavy `box-shadow` is added to the leading edge, and `mix-blend-mode: screen` is applied. This blend mode forces the yellow glow to interact intensely with the blue solar grid underneath it, creating a highly convincing, bright sci-fi charging effect.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), subtly darkening the metallic frame and background colors.
+- Fully accessible semantic structure. The decorative charging fill is hidden from screen readers using `aria-hidden="true"`, and the container includes an `aria-label`. Honors the `prefers-reduced-motion` accessibility standard by freezing the charge fill at a static 75% width for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser to view the solar panel charging animation.
+
+## Files
+- `demo.html`: The HTML structure defining the metallic frame, the grid surface, and the charge fill element.
+- `style.css`: The styling, the `repeating-linear-gradient` grid logic, and the `mix-blend-mode` glowing animation.

--- a/submissions/examples/css-solar-charging-bar-pure/demo.html
+++ b/submissions/examples/css-solar-charging-bar-pure/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Solar Charging Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Solar Charging Bar</h1>
+            <p class="subtitle">A sci-fi inspired solar panel progress bar featuring dynamic sunshine glowing animations and CSS grid cell rendering.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="solar-panel-container" aria-label="Solar panel charging animation">
+                
+                <!-- The metallic frame holding the panel -->
+                <div class="solar-frame">
+                    
+                    <!-- 
+                      [TECHNIQUE] The Solar Grid Surface 
+                      Uses repeating linear gradients to draw the photovoltaic cells.
+                    -->
+                    <div class="solar-surface">
+                        
+                        <!-- 
+                          [TECHNIQUE] The Charging Fill (Sunshine)
+                          This element animates its width from 0 to 100% and uses 
+                          a bright yellow linear-gradient and box-shadow to simulate a glowing charge.
+                        -->
+                        <div class="solar-charge-fill" aria-hidden="true"></div>
+                        
+                    </div>
+                    
+                </div>
+                
+                <div class="charging-text">Absorbing Solar Energy...</div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-solar-charging-bar-pure/style.css
+++ b/submissions/examples/css-solar-charging-bar-pure/style.css
@@ -1,0 +1,203 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    /* Solar Frame */
+    --frame-light: #e2e8f0;
+    --frame-dark: #cbd5e1;
+    --frame-shadow: rgba(0, 0, 0, 0.1);
+    
+    /* Solar Cells */
+    --solar-base: #0f172a;
+    --solar-grid: #38bdf8;
+    
+    /* Sun Charge */
+    --sun-glow: rgba(250, 204, 21, 0.8);
+    --sun-core: #fef08a;
+    --sun-trail: rgba(250, 204, 21, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+        
+        --frame-light: #334155;
+        --frame-dark: #1e293b;
+        --frame-shadow: rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Solar Panel Construction
+   ========================================= */
+
+.solar-panel-container {
+    width: 100%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+/* The Metallic Frame */
+.solar-frame {
+    width: 100%;
+    height: 60px;
+    background: linear-gradient(to bottom, var(--frame-light), var(--frame-dark));
+    border-radius: 8px;
+    padding: 6px;
+    box-shadow: 
+        inset 0 1px 0 rgba(255,255,255,0.5),
+        0 8px 20px var(--frame-shadow);
+}
+
+/* 
+  [TECHNIQUE] The Photovoltaic Grid Surface
+  Using multiple repeating-linear-gradients to draw a highly precise 
+  grid of solar cells over a dark blue base. 
+*/
+.solar-surface {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background-color: var(--solar-base);
+    border-radius: 4px;
+    overflow: hidden;
+    
+    background-image: 
+        /* Horizontal cell division line */
+        linear-gradient(to bottom, transparent 48%, var(--solar-grid) 48%, var(--solar-grid) 52%, transparent 52%),
+        /* Vertical cell division lines */
+        repeating-linear-gradient(to right, transparent, transparent 30px, var(--solar-grid) 30px, var(--solar-grid) 32px);
+        
+    /* Inner shadow for depth */
+    box-shadow: inset 0 2px 10px rgba(0,0,0,0.8);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Sunshine Charge Fill
+   ========================================= */
+
+.solar-charge-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    /* We animate the width from 0 to 100% */
+    width: 0%;
+    
+    /* 
+       A complex linear gradient creates a hot 'sun core' at the leading edge, 
+       with a fading yellow trail behind it.
+    */
+    background: linear-gradient(to right, var(--sun-trail) 0%, var(--sun-glow) 95%, var(--sun-core) 100%);
+    
+    /* Glow effect spilling out from the leading edge */
+    box-shadow: 5px 0 15px var(--sun-glow);
+    
+    /* The blend mode makes the yellow glow interact intensely with the blue grid underneath */
+    mix-blend-mode: screen;
+    
+    /* Trigger the charge animation */
+    animation: charge-up 5s ease-in-out infinite;
+}
+
+.charging-text {
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--solar-grid);
+    /* Pulse the text opacity */
+    animation: pulse-text 2s ease-in-out infinite alternate;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes charge-up {
+    0% {
+        width: 0%;
+        opacity: 0.8;
+    }
+    40% {
+        /* Pause slightly in the middle like it's struggling to charge */
+        width: 40%;
+    }
+    50% {
+        width: 45%;
+    }
+    100% {
+        width: 100%;
+        opacity: 1;
+    }
+}
+
+@keyframes pulse-text {
+    0% { opacity: 0.4; }
+    100% { opacity: 1; }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .solar-charge-fill {
+        /* Set to a static 75% charge if animations are disabled */
+        animation: none !important;
+        width: 75%;
+    }
+    .charging-text {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a sci-fi inspired solar panel progress bar featuring dynamic sunshine glowing animations and CSS grid cell rendering. Resolves issue #70454.

### Changes Made:
- Added `submissions/examples/css-solar-charging-bar-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the metallic frame, the grid surface, and the charge fill element.
- Created `style.css` featuring the UI mechanics:
  - **The Photovoltaic Grid Surface**: The underlying solar panel (`.solar-surface`) is constructed without any images or SVGs. It uses a base dark blue color overlaid with multiple `repeating-linear-gradient` definitions. These gradients draw a precise grid of thin, bright blue lines to simulate the conductive silver traces found on real solar cells.
  - **The Sunshine Charge Fill**: The `.solar-charge-fill` element acts as the progress bar itself. It uses an absolute position over the grid. An `@keyframes` animation gradually scales its `width` from 0% to 100%. 
  - **The Glowing Trail**: To simulate a surge of solar energy, the fill element uses a complex `linear-gradient` (creating a hot white/yellow 'core' at the leading edge, and a fading yellow trail behind it). Crucially, a heavy `box-shadow` is added to the leading edge, and `mix-blend-mode: screen` is applied. This blend mode forces the yellow glow to interact intensely with the blue solar grid underneath it, creating a highly convincing, bright sci-fi charging effect.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), subtly darkening the metallic frame and background colors.
- Added `README.md` documenting usage and the technical mechanics of the `repeating-linear-gradient` grid logic and the `mix-blend-mode` glowing animation.
- Fully accessible semantic structure. The decorative charging fill is hidden from screen readers using `aria-hidden="true"`, and the container includes an `aria-label`. Honors the `prefers-reduced-motion` accessibility standard by freezing the charge fill at a static 75% width for motion-sensitive users.

Closes #70454
