### PR TITLE
feat: add muted paragraph text demo

### DIFF
--- a/submissions/examples/muted-paragraph-text-kk/README.md
+++ b/submissions/examples/muted-paragraph-text-kk/README.md
@@ -1,0 +1,33 @@
+# Muted Paragraph Text
+
+## What it does
+
+This submission creates a simple CSS-only muted paragraph text utility for descriptions, helper text, supporting copy, and secondary content.
+
+## How to use it
+
+Apply the class directly to paragraph text:
+
+```html
+<p class="muted-paragraph-text">
+  This is supporting text for the section.
+</p>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, forms, dashboards, settings panels, and grouped content sections where secondary text needs softer emphasis.
+
+## Included features
+
+- Muted secondary paragraph text utility
+- Practical card and section examples
+- Readable helper-copy styling
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the muted text utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/muted-paragraph-text-kk/demo.html
+++ b/submissions/examples/muted-paragraph-text-kk/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Muted Paragraph Text</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Muted Paragraph Text</p>
+          <h1>Softer supporting copy for cards, sections, and helper text.</h1>
+          <p class="muted-paragraph-text">
+            This demo shows a lightweight CSS-only typography utility for
+            descriptions, helper copy, and secondary content that should remain
+            readable while having lower visual priority than headings.
+          </p>
+        </header>
+
+        <section class="content-grid">
+          <article class="content-block">
+            <h2>Profile Summary</h2>
+            <p class="muted-paragraph-text">
+              Use muted paragraph text to keep descriptions readable without
+              competing too strongly with primary section headings.
+            </p>
+          </article>
+
+          <article class="content-block">
+            <h2>Settings Help</h2>
+            <p class="muted-paragraph-text">
+              This pattern is useful for inline helper text in settings forms,
+              dashboards, and information panels.
+            </p>
+          </article>
+
+          <article class="content-block">
+            <h2>Card Description</h2>
+            <p class="muted-paragraph-text">
+              It works well anywhere you need softer secondary copy under a
+              title, label, or summary heading.
+            </p>
+          </article>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;p class="muted-paragraph-text"&gt;
+  This is supporting text for the section.
+&lt;/p&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/muted-paragraph-text-kk/style.css
+++ b/submissions/examples/muted-paragraph-text-kk/style.css
@@ -1,0 +1,103 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.62);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.muted-paragraph-text {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.content-block,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.content-block h2 {
+  margin: 0 0 0.45rem;
+  font-size: 1.15rem;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Muted Paragraph Text demo inside `submissions/examples/muted-paragraph-text-kk/`. This submission introduces a simple CSS-only typography utility for descriptions, helper text, supporting copy, and secondary content.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only muted paragraph text utility for softer secondary copy in cards, sections, helper text, and grouped content.

**How does a developer use it?**

```html
<p class="muted-paragraph-text">
  This is supporting text for the section.
</p>