### PR TITLE
Add CSS Binary Rain Loader component

### DIFF
--- a/submissions/examples/css-binary-rain-loader/README.md
+++ b/submissions/examples/css-binary-rain-loader/README.md
@@ -1,0 +1,57 @@
+# CSS Binary Rain Loader
+
+A pure CSS loading indicator: columns of binary digits (0s and
+1s) fall continuously inside a bordered panel, evoking a
+Matrix-style "data stream" while content loads.
+
+## What it does
+
+Ten vertical text columns of binary characters animate downward
+on a staggered loop, fading in as they enter and out as they
+exit, giving the impression of falling binary rain. A gradient
+overlay at the top and bottom of the panel softens the entry and
+exit points. Below the panel, a "Loading" label cycles through
+animated dots.
+
+## How to use it
+
+```html
+<div class="binary-rain-loader" role="status" aria-live="polite" aria-label="Content is loading">
+  <div class="rain-columns">
+    <span class="rain-col" style="--i:0">1010110101</span>
+    <span class="rain-col" style="--i:1">0110101011</span>
+    <!-- ...repeat, incrementing --i for each column -->
+  </div>
+  <p class="rain-loading-label">Loading<span class="rain-dots" aria-hidden="true"></span></p>
+</div>
+```
+
+Each `.rain-col` needs an inline `--i` custom property (0, 1, 2,
+...) to stagger its animation delay so columns don't all fall in
+sync. The text content of each span can be any string of 0s and
+1s — vary the pattern per column for a more organic look.
+
+## Why it fits EaseMotion CSS
+
+- **Pure CSS, zero dependencies** — the falling animation and
+  dot cycling are both done with `@keyframes`, no JavaScript.
+- **Accessible** — the loader is announced to assistive tech via
+  `role="status"` and `aria-live="polite"`, and the decorative
+  dots are hidden from screen readers with `aria-hidden="true"`.
+- **Respects motion preferences** — a `prefers-reduced-motion`
+  media query stops the falling animation and dot cycling,
+  showing a static, low-opacity state instead.
+- **Readable, semantic class names** — `rain-col`,
+  `rain-columns`, `rain-loading-label`, etc.
+
+## Notes
+
+The animated loading dots use `@keyframes` on the CSS `content`
+property, which has limited cross-browser support (works
+reliably in Chromium-based browsers; Firefox and Safari may show
+static or inconsistent dot states). This does not affect the
+core rain animation, which uses standard `transform`/`opacity`
+keyframes supported everywhere.
+
+Column count is currently 10. To change it, add or remove
+`.rain-col` spans and update the `--i` values accordingly.

--- a/submissions/examples/css-binary-rain-loader/demo.html
+++ b/submissions/examples/css-binary-rain-loader/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Binary Rain Loader — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1 class="demo-heading">CSS Binary Rain Loader</h1>
+
+  <div class="binary-rain-loader" role="status" aria-live="polite" aria-label="Content is loading">
+    <div class="rain-columns">
+      <span class="rain-col" style="--i:0">1010110101</span>
+      <span class="rain-col" style="--i:1">0110101011</span>
+      <span class="rain-col" style="--i:2">1101010110</span>
+      <span class="rain-col" style="--i:3">0101101011</span>
+      <span class="rain-col" style="--i:4">1011010101</span>
+      <span class="rain-col" style="--i:5">0110101101</span>
+      <span class="rain-col" style="--i:6">1010110101</span>
+      <span class="rain-col" style="--i:7">0101101010</span>
+      <span class="rain-col" style="--i:8">1101010110</span>
+      <span class="rain-col" style="--i:9">0110101011</span>
+    </div>
+    <p class="rain-loading-label">Loading<span class="rain-dots" aria-hidden="true"></span></p>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/css-binary-rain-loader/style.css
+++ b/submissions/examples/css-binary-rain-loader/style.css
@@ -1,0 +1,136 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #05080a;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 24px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.binary-rain-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.rain-columns {
+  position: relative;
+  width: 280px;
+  height: 200px;
+  overflow: hidden;
+  background: #0a0f0c;
+  border-radius: 12px;
+  border: 1px solid #142018;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 8px;
+}
+
+.rain-col {
+  --delay: calc(var(--i) * 0.18s);
+  position: relative;
+  writing-mode: vertical-rl;
+  font-family: "Courier New", monospace;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 6px;
+  color: #3ddc84;
+  text-shadow: 0 0 6px rgba(61, 220, 132, 0.6);
+  opacity: 0.85;
+  transform: translateY(-100%);
+  animation: rain-fall 2.4s linear infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes rain-fall {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.85;
+  }
+  90% {
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}
+
+.rain-columns::before,
+.rain-columns::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 40px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.rain-columns::before {
+  top: 0;
+  background: linear-gradient(180deg, #0a0f0c, transparent);
+}
+
+.rain-columns::after {
+  bottom: 0;
+  background: linear-gradient(0deg, #0a0f0c, transparent);
+}
+
+.rain-loading-label {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #9aa4b2;
+  letter-spacing: 0.02em;
+}
+
+.rain-dots::after {
+  content: "";
+  display: inline-block;
+  width: 1.4em;
+  text-align: left;
+  animation: rain-dots-cycle 1.4s steps(4, end) infinite;
+}
+
+@keyframes rain-dots-cycle {
+  0% { content: ""; }
+  25% { content: "."; }
+  50% { content: ".."; }
+  75% { content: "..."; }
+  100% { content: ""; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rain-col {
+    animation: none;
+    transform: translateY(0);
+    opacity: 0.5;
+  }
+
+  .rain-dots::after {
+    animation: none;
+    content: "...";
+  }
+}


### PR DESCRIPTION
Closes #70106
## Pull Request Description
Adds a pure CSS "binary rain" loading indicator — columns of falling 0s and 1s inside a bordered panel, evoking a Matrix-style data stream while content loads. Closes #70106.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-binary-rain-loader/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS loading indicator where columns of binary digits (0s and 1s) fall continuously inside a bordered panel, with a "Loading…" label and animated dots below.

**How does a developer use it?**
```html
<div class="binary-rain-loader" role="status" aria-live="polite" aria-label="Content is loading">
  <div class="rain-columns">
    <span class="rain-col" style="--i:0">1010110101</span>
    <span class="rain-col" style="--i:1">0110101011</span>
    <!-- ...repeat, incrementing --i for each column -->
  </div>
  <p class="rain-loading-label">Loading<span class="rain-dots" aria-hidden="true"></span></p>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, zero dependencies — the falling rain effect and dot cycling are both driven entirely by `@keyframes`, no JavaScript. The loader is properly announced to assistive tech via `role="status"` and `aria-live="polite"`, decorative dots are hidden from screen readers, and a `prefers-reduced-motion` query provides a static fallback. Class names (`rain-col`, `rain-columns`, `rain-loading-label`) stay readable and semantic, in keeping with the library's animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The animated loading dots use `@keyframes` on the CSS `content` property, which has limited cross-browser support (reliable in Chromium, may render static/inconsistent in Firefox/Safari). This only affects the decorative dots — the core rain-fall animation uses standard `transform`/`opacity` keyframes with full support. Happy to swap the dots to a more portable technique (e.g. `::after` with `steps()` on `width`/`opacity`) if preferred.