### PR TITLE
feat: add plain heading block demo

### DIFF
--- a/submissions/examples/plain-heading-block-kk/README.md
+++ b/submissions/examples/plain-heading-block-kk/README.md
@@ -1,0 +1,34 @@
+# Plain Heading Block
+
+## What it does
+
+This submission creates a simple CSS-only heading block utility for pairing a section title with short supporting text.
+
+## How to use it
+
+Wrap the heading and supporting line inside the shared block container:
+
+```html
+<div class="plain-heading-block">
+  <h2>Section Title</h2>
+  <p>Short supporting text goes here.</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, grouped content sections, dashboards, forms, and page layout blocks.
+
+## Included features
+
+- Simple heading-plus-supporting-text utility
+- Practical section-heading examples
+- Consistent muted secondary copy styling
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the heading block utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/plain-heading-block-kk/demo.html
+++ b/submissions/examples/plain-heading-block-kk/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plain Heading Block</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Plain Heading Block</p>
+          <h1>Simple title-and-supporting-text groups for reusable section headers.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only heading block utility for
+            section titles paired with short supporting text. It works well in
+            cards, dashboards, forms, landing sections, and grouped content
+            layouts.
+          </p>
+        </header>
+
+        <section class="block-grid">
+          <div class="plain-heading-block">
+            <h2>Profile Overview</h2>
+            <p>Short supporting copy can provide context without adding visual clutter.</p>
+          </div>
+
+          <div class="plain-heading-block">
+            <h2>Billing Summary</h2>
+            <p>Use the same heading pattern across cards and sections for a more consistent layout.</p>
+          </div>
+
+          <div class="plain-heading-block">
+            <h2>Recent Activity</h2>
+            <p>This utility is useful anywhere a title and muted secondary line should appear together.</p>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="plain-heading-block"&gt;
+  &lt;h2&gt;Section Title&lt;/h2&gt;
+  &lt;p&gt;Short supporting text goes here.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/plain-heading-block-kk/style.css
+++ b/submissions/examples/plain-heading-block-kk/style.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.62);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.block-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.plain-heading-block,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.plain-heading-block h2 {
+  margin: 0 0 0.35rem;
+}
+
+.plain-heading-block p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .block-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Plain Heading Block demo inside `submissions/examples/plain-heading-block-kk/`. This submission introduces a simple CSS-only heading utility for pairing a section title with short supporting text.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only plain heading block utility for displaying a title with a short muted supporting line.

**How does a developer use it?**

```html
<div class="plain-heading-block">
  <h2>Section Title</h2>
  <p>Short supporting text goes here.</p>
</div>