### PR TITLE
feat: add simple empty state box demo

### DIFF
--- a/submissions/examples/simple-empty-state-box-kk/README.md
+++ b/submissions/examples/simple-empty-state-box-kk/README.md
@@ -1,0 +1,34 @@
+# Simple Empty State Box
+
+## What it does
+
+This submission creates a simple CSS-only empty state utility for no-data sections, placeholders, and content areas that have nothing to display yet.
+
+## How to use it
+
+Wrap the empty-state title and supporting text inside the shared container:
+
+```html
+<div class="simple-empty-state-box">
+  <h3>No projects yet</h3>
+  <p>Create your first project to get started.</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in dashboards, cards, profile sections, and grouped content areas where content may be temporarily empty.
+
+## Included features
+
+- Centered empty-state box utility
+- Practical no-data examples
+- Readable muted supporting text
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the empty-state utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/simple-empty-state-box-kk/demo.html
+++ b/submissions/examples/simple-empty-state-box-kk/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple Empty State Box</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Simple Empty State Box</p>
+          <h1>Clean no-data placeholders for cards, dashboards, and sections.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only empty state utility for
+            cases where a page, card, or section has no content to display
+            yet. It is simple, reusable, and easy to apply across many layouts.
+          </p>
+        </header>
+
+        <section class="empty-grid">
+          <div class="simple-empty-state-box">
+            <h3>No projects yet</h3>
+            <p>Create your first project to get started.</p>
+          </div>
+
+          <div class="simple-empty-state-box">
+            <h3>No recent activity</h3>
+            <p>Updates will appear here once actions are recorded.</p>
+          </div>
+
+          <div class="simple-empty-state-box">
+            <h3>No saved items</h3>
+            <p>Your saved resources will show up in this section.</p>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="simple-empty-state-box"&gt;
+  &lt;h3&gt;No projects yet&lt;/h3&gt;
+  &lt;p&gt;Create your first project to get started.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/simple-empty-state-box-kk/style.css
+++ b/submissions/examples/simple-empty-state-box-kk/style.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.62);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.empty-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.simple-empty-state-box,
+.usage-panel {
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--panel-soft);
+}
+
+.simple-empty-state-box {
+  text-align: center;
+}
+
+.simple-empty-state-box h3 {
+  margin: 0 0 0.4rem;
+}
+
+.simple-empty-state-box p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .empty-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Simple Empty State Box demo inside `submissions/examples/simple-empty-state-box-kk/`. This submission introduces a simple CSS-only empty state utility for no-data sections, placeholders, and grouped content areas.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only empty state box utility for displaying clean placeholders when a section has no content to show.

**How does a developer use it?**

```html
<div class="simple-empty-state-box">
  <h3>No projects yet</h3>
  <p>Create your first project to get started.</p>
</div>