### PR TITLE
feat: add CSS Grammar Check Underline component

### DIFF
--- a/submissions/examples/css-css-grammar-check-underline-70630/README.md
+++ b/submissions/examples/css-css-grammar-check-underline-70630/README.md
@@ -1,0 +1,29 @@
+# CSS Grammar Check Underline
+
+Green/red wavy underline for grammar correction display.
+
+Closes #70630
+
+## Features
+
+- Wavy underline via layered gradients for spelling errors vs style suggestions.
+- Hover/focus pulses the underline.
+- Keyboard accessible with tabindex and aria-labels.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-grammar-check-underline-70630/demo.html
+++ b/submissions/examples/css-css-grammar-check-underline-70630/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Grammar Check Underline - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="gcu" aria-label="Grammar check underline">
+      <h1 class="gcu-h">Grammar Check Underline</h1>
+      <p class="gcu-text">
+        This sentence has a
+        <span
+          class="gcu-w gcu-err"
+          tabindex="0"
+          role="button"
+          aria-label="Spelling error"
+          >definately</span
+        >
+        misspelled word and a
+        <span
+          class="gcu-w gcu-sty"
+          tabindex="0"
+          role="button"
+          aria-label="Style suggestion"
+          >theirfore</span
+        >
+        style suggestion.
+      </p>
+      <p class="gcu-hint">
+        Hover or focus a word to intensify the wavy underline.
+      </p>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-css-grammar-check-underline-70630/style.css
+++ b/submissions/examples/css-css-grammar-check-underline-70630/style.css
@@ -1,0 +1,90 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #1a1d2b;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --gcu-card: rgba(30, 34, 48, 0.9);
+  --gcu-muted: #9aa3bd;
+  --gcu-err: #ff5b6e;
+  --gcu-sty: #ffb13d;
+  --gcu-sp: 0.6s;
+}
+.gcu {
+  background: var(--gcu-card);
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 560px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.gcu-h {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+}
+.gcu-text {
+  line-height: 1.8;
+  font-size: 1.05rem;
+}
+.gcu-hint {
+  color: var(--gcu-muted);
+  font-size: 0.85rem;
+  margin-top: 1.5rem;
+}
+.gcu-w {
+  cursor: pointer;
+  border-radius: 3px;
+  background-image:
+    linear-gradient(45deg, transparent 65%, currentColor 80%, transparent 90%),
+    linear-gradient(-45deg, transparent 65%, currentColor 80%, transparent 90%);
+  background-size:
+    6px 4px,
+    6px 4px;
+  background-repeat: repeat-x;
+  background-position: 0 100%;
+  padding-bottom: 4px;
+  text-decoration: none;
+}
+.gcu-err {
+  color: var(--gcu-err);
+}
+.gcu-sty {
+  color: var(--gcu-sty);
+}
+.gcu-w:hover,
+.gcu-w:focus-visible {
+  outline: none;
+  animation: gcu-pulse var(--gcu-sp) ease-in-out infinite;
+}
+.gcu-w:hover,
+.gcu-w:focus-visible {
+  background-size:
+    8px 6px,
+    8px 6px;
+}
+@keyframes gcu-pulse {
+  0%,
+  100% {
+    background-position: 0 100%;
+  }
+  50% {
+    background-position: 12px 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Grammar Check Underline

Green/red wavy underline for grammar correction display.

Closes #70630

Pure CSS, responsive, accessible, reduced-motion safe.