### PR TITLE
feat: add CSS Underline Draw Button component

### DIFF
--- a/submissions/examples/css-css-underline-draw-button-70496/README.md
+++ b/submissions/examples/css-css-underline-draw-button-70496/README.md
@@ -1,0 +1,29 @@
+# CSS Underline Draw Button
+
+Underline animates from center outward on button hover.
+
+Closes #70496
+
+## Features
+
+- Underline animates from center outward on hover/focus.
+- Minimal transparent button.
+- Accessible focus ring.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-underline-draw-button-70496/demo.html
+++ b/submissions/examples/css-css-underline-draw-button-70496/demo.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Underline Draw Button - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="udb" aria-label="Underline draw button">
+      <button type="button" class="udb-btn">Get Started</button>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-css-underline-draw-button-70496/style.css
+++ b/submissions/examples/css-css-underline-draw-button-70496/style.css
@@ -1,0 +1,63 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #15131f;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --udb-accent: #818cf8;
+  --udb-sp: 0.35s;
+}
+.udb-btn {
+  position: relative;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--udb-accent);
+  padding: 0.5rem 0.2rem;
+}
+.udb-btn::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  bottom: 0;
+  height: 2px;
+  background: var(--udb-accent);
+  border-radius: 2px;
+  transition:
+    left var(--udb-sp) ease,
+    right var(--udb-sp) ease;
+}
+.udb-btn:hover::after,
+.udb-btn:focus-visible::after {
+  left: 0;
+  right: 0;
+}
+.udb-btn:focus-visible {
+  outline: none;
+}
+.udb-btn:focus-visible {
+  outline: 2px solid var(--udb-accent);
+  outline-offset: 5px;
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Underline Draw Button

Underline animates from center outward on button hover.

Closes #70496

## Files

- `submissions/examples/css-css-underline-draw-button-70496/demo.html` - interactive demo markup.
- `submissions/examples/css-css-underline-draw-button-70496/style.css` - all component styles and reduced-motion overrides.
- `submissions/examples/css-css-underline-draw-button-70496/README.md` - documentation.

## Features

- Pure CSS, no JavaScript.
- Responsive across all screen sizes.
- Accessible with ARIA attributes and keyboard focus styles.
- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.

## Testing

- stylelint (repo ci config): no errors.
- htmlhint (repo config): no errors.
- prettier: formatted.
- Rendered locally in a browser.

Only new files under `submissions/examples/` are added; no existing files modified (single squashed commit).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._