### PR TITLE
feat: add CSS Breadcrumb Arrow Style component

### DIFF
--- a/submissions/examples/css-css-breadcrumb-arrow-style-70452/README.md
+++ b/submissions/examples/css-css-breadcrumb-arrow-style-70452/README.md
@@ -1,0 +1,29 @@
+# CSS Breadcrumb Arrow Style
+
+Breadcrumb navigation with arrow/chevron shape separators.
+
+Closes #70452
+
+## Features
+
+- Breadcrumb navigation with chevron arrow separators.
+- Current page indicator via aria-current.
+- Hover/focus color change.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-breadcrumb-arrow-style-70452/demo.html
+++ b/submissions/examples/css-css-breadcrumb-arrow-style-70452/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Breadcrumb Arrow Style - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav class="bca" aria-label="Breadcrumb">
+      <ol class="bca-list">
+        <li class="bca-item"><a href="#" class="bca-link">Home</a></li>
+        <li class="bca-item"><a href="#" class="bca-link">Docs</a></li>
+        <li class="bca-item">
+          <a href="#" class="bca-link" aria-current="page">Components</a>
+        </li>
+      </ol>
+    </nav>
+  </body>
+</html>

--- a/submissions/examples/css-css-breadcrumb-arrow-style-70452/style.css
+++ b/submissions/examples/css-css-breadcrumb-arrow-style-70452/style.css
@@ -1,0 +1,71 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #13131d;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --bca-accent: #38bdf8;
+  --bca-muted: #8b93a7;
+}
+.bca-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+}
+.bca-item {
+  display: flex;
+  align-items: center;
+}
+.bca-item:not(:last-child)::after {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-top: 2px solid var(--bca-muted);
+  border-right: 2px solid var(--bca-muted);
+  transform: rotate(45deg);
+  margin: 0 0.8rem;
+}
+.bca-link {
+  color: var(--bca-muted);
+  text-decoration: none;
+  font-size: 0.92rem;
+  padding: 0.3rem 0;
+  transition: color 0.25s;
+}
+.bca-link:hover,
+.bca-link:focus-visible {
+  color: var(--bca-accent);
+  outline: none;
+}
+.bca-link:focus-visible {
+  outline: 2px solid var(--bca-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.bca-link[aria-current="page"] {
+  color: var(--bca-accent);
+  font-weight: 600;
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Breadcrumb Arrow Style

Breadcrumb navigation with arrow/chevron shape separators.

Closes #70452

## Files

- `submissions/examples/css-css-breadcrumb-arrow-style-70452/demo.html` - interactive demo markup.
- `submissions/examples/css-css-breadcrumb-arrow-style-70452/style.css` - all component styles and reduced-motion overrides.
- `submissions/examples/css-css-breadcrumb-arrow-style-70452/README.md` - documentation.

## Features

- Pure CSS, no JavaScript.
- Responsive across all screen sizes.
- Accessible with ARIA attributes and keyboard focus styles.
- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.

## Testing

- stylelint (repo ci config): no errors.
- htmlhint (repo config): no errors.
- prettier: formatted.
- Rendered locally in a browser.

Only new files under `submissions/examples/` are added; no existing files modified (single squashed commit).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._