### PR TITLE
feat: add CSS Swipe Navigation Indicator component

### DIFF
--- a/submissions/examples/css-css-swipe-navigation-indicator-70396/README.md
+++ b/submissions/examples/css-css-swipe-navigation-indicator-70396/README.md
@@ -1,0 +1,29 @@
+# CSS Swipe Navigation Indicator
+
+Swipe left/right indicator arrows for carousel navigation.
+
+Closes #70396
+
+## Features
+
+- Swipe left/right indicator arrows for carousel.
+- Dot indicators with active pill shape.
+- Accessible labeled buttons.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-swipe-navigation-indicator-70396/demo.html
+++ b/submissions/examples/css-css-swipe-navigation-indicator-70396/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Swipe Navigation Indicator - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="sni" aria-label="Swipe navigation indicator">
+      <button class="sni-arrow sni-prev" aria-label="Previous">&lsaquo;</button>
+      <ol class="sni-dots" aria-label="Slides">
+        <li class="sni-dot sni-on" aria-hidden="true"></li>
+        <li class="sni-dot" aria-hidden="true"></li>
+        <li class="sni-dot" aria-hidden="true"></li>
+      </ol>
+      <button class="sni-arrow sni-next" aria-label="Next">&rsaquo;</button>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-css-swipe-navigation-indicator-70396/style.css
+++ b/submissions/examples/css-css-swipe-navigation-indicator-70396/style.css
@@ -1,0 +1,88 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0d1018;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --sni-accent: #818cf8;
+  --sni-muted: #475569;
+  --sni-bg: rgba(255, 255, 255, 0.05);
+}
+.sni {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--sni-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.4rem 0.6rem;
+}
+.sni-arrow {
+  background: transparent;
+  border: none;
+  color: var(--sni-accent);
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  transition: background 0.25s;
+}
+.sni-arrow:hover,
+.sni-arrow:focus-visible {
+  background: rgba(129, 140, 248, 0.15);
+  outline: none;
+}
+.sni-arrow:focus-visible {
+  outline: 2px solid var(--sni-accent);
+  outline-offset: 1px;
+}
+.sni-dots {
+  list-style: none;
+  display: flex;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+.sni-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--sni-muted);
+  transition:
+    width 0.3s,
+    background 0.3s;
+}
+.sni-on {
+  width: 22px;
+  background: var(--sni-accent);
+  border-radius: 999px;
+  animation: sni-blink 1.5s ease-in-out infinite;
+}
+@keyframes sni-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Swipe Navigation Indicator

Swipe left/right indicator arrows for carousel navigation.

Closes #70396

## Files

- `submissions/examples/css-css-swipe-navigation-indicator-70396/demo.html` - interactive demo markup.
- `submissions/examples/css-css-swipe-navigation-indicator-70396/style.css` - all component styles and reduced-motion overrides.
- `submissions/examples/css-css-swipe-navigation-indicator-70396/README.md` - documentation.

## Features

- Pure CSS, no JavaScript.
- Responsive across all screen sizes.
- Accessible with ARIA attributes and keyboard focus styles.
- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.

## Testing

- stylelint (repo ci config): no errors.
- htmlhint (repo config): no errors.
- prettier: formatted.
- Rendered locally in a browser.

Only new files under `submissions/examples/` are added; no existing files modified (single squashed commit).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._