### PR TITLE
feat: add CSS Centered Content Card component

### DIFF
--- a/submissions/examples/css-css-centered-content-card-70390/README.md
+++ b/submissions/examples/css-css-centered-content-card-70390/README.md
@@ -1,0 +1,29 @@
+# CSS Centered Content Card
+
+Simple centered content card for focus pages.
+
+Closes #70390
+
+## Features
+
+- Simple centered content card.
+- Hover lift with shadow.
+- Keyboard focusable.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-centered-content-card-70390/demo.html
+++ b/submissions/examples/css-css-centered-content-card-70390/demo.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Centered Content Card - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <article class="ccc" aria-label="Centered content card" tabindex="0">
+      <h2 class="ccc-h">Welcome Back</h2>
+      <p class="ccc-p">A simple centered content card for focus pages.</p>
+    </article>
+  </body>
+</html>

--- a/submissions/examples/css-css-centered-content-card-70390/style.css
+++ b/submissions/examples/css-css-centered-content-card-70390/style.css
@@ -1,0 +1,71 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #101218;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --ccc-card: #171a26;
+  --ccc-accent: #818cf8;
+  --ccc-muted: #94a3b8;
+}
+.ccc {
+  background: var(--ccc-card);
+  border-radius: 14px;
+  padding: 2.5rem;
+  max-width: 380px;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
+  animation: ccc-in 0.5s ease both;
+}
+@keyframes ccc-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.ccc:hover,
+.ccc:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px -20px rgba(0, 0, 0, 0.6);
+  outline: none;
+}
+.ccc:focus-visible {
+  outline: 2px solid var(--ccc-accent);
+  outline-offset: 3px;
+}
+.ccc-h {
+  margin: 0 0 0.5rem;
+  color: var(--ccc-accent);
+  font-size: 1.4rem;
+}
+.ccc-p {
+  margin: 0;
+  color: var(--ccc-muted);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Centered Content Card

Simple centered content card for focus pages.

Closes #70390

## Files

- `submissions/examples/css-css-centered-content-card-70390/demo.html` - interactive demo markup.
- `submissions/examples/css-css-centered-content-card-70390/style.css` - all component styles and reduced-motion overrides.
- `submissions/examples/css-css-centered-content-card-70390/README.md` - documentation.

## Features

- Pure CSS, no JavaScript.
- Responsive across all screen sizes.
- Accessible with ARIA attributes and keyboard focus styles.
- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.

## Testing

- stylelint (repo ci config): no errors.
- htmlhint (repo config): no errors.
- prettier: formatted.
- Rendered locally in a browser.

Only new files under `submissions/examples/` are added; no existing files modified (single squashed commit).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._