### PR TITLE
feat: add CSS Focus Indicator Ring v2 component

### DIFF
--- a/submissions/examples/css-css-focus-indicator-ring-v2-70369/README.md
+++ b/submissions/examples/css-css-focus-indicator-ring-v2-70369/README.md
@@ -1,0 +1,29 @@
+# CSS Focus Indicator Ring v2
+
+Enhanced accessible focus ring with offset and color.
+
+Closes #70369
+
+## Features
+
+- Enhanced accessible focus ring with offset and color.
+- Layered box-shadow for offset ring.
+- High-contrast accent.
+
+## Files
+
+- `demo.html` - interactive demo markup.
+- `style.css` - all component styles and reduced-motion overrides.
+- `README.md` - this document.
+
+## Usage
+
+Copy the markup from `demo.html` and link `style.css`. No JavaScript required.
+
+## Accessibility
+
+- Pure CSS, responsive across all screen sizes.
+- ARIA attributes and keyboard focus styles where interactive.
+- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.
+
+_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

--- a/submissions/examples/css-css-focus-indicator-ring-v2-70369/demo.html
+++ b/submissions/examples/css-css-focus-indicator-ring-v2-70369/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Focus Indicator Ring v2 - EaseMotion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="fir" aria-label="Focus indicator ring v2">
+      <button type="button" class="fir-btn">Focus Me</button>
+      <p class="fir-hint">
+        Tab to the button to see the enhanced focus ring with offset and color.
+      </p>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-css-focus-indicator-ring-v2-70369/style.css
+++ b/submissions/examples/css-css-focus-indicator-ring-v2-70369/style.css
@@ -1,0 +1,63 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0e111a;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  color: #e8ecf4;
+  padding: 2rem;
+}
+:root {
+  --fir-accent: #f59e0b;
+  --fir-muted: #94a3b8;
+}
+.fir {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+}
+.fir-btn {
+  background: #1e2230;
+  color: #e8ecf4;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 0.8rem 1.4rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    box-shadow 0.2s,
+    border-color 0.2s;
+}
+.fir-btn:hover {
+  border-color: rgba(245, 158, 11, 0.5);
+}
+.fir-btn:focus-visible {
+  outline: none;
+  border-color: var(--fir-accent);
+  box-shadow:
+    0 0 0 4px rgba(245, 158, 11, 0.3),
+    0 0 0 6px rgba(245, 158, 11, 0.15);
+}
+.fir-hint {
+  color: var(--fir-muted);
+  font-size: 0.82rem;
+  max-width: 260px;
+  text-align: center;
+  line-height: 1.4;
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## CSS Focus Indicator Ring v2

Enhanced accessible focus ring with offset and color.

Closes #70369

## Files

- `submissions/examples/css-css-focus-indicator-ring-v2-70369/demo.html` - interactive demo markup.
- `submissions/examples/css-css-focus-indicator-ring-v2-70369/style.css` - all component styles and reduced-motion overrides.
- `submissions/examples/css-css-focus-indicator-ring-v2-70369/README.md` - documentation.

## Features

- Pure CSS, no JavaScript.
- Responsive across all screen sizes.
- Accessible with ARIA attributes and keyboard focus styles.
- `prefers-reduced-motion: reduce` neutralizes motion for vestibular-sensitive users.

## Testing

- stylelint (repo ci config): no errors.
- htmlhint (repo config): no errors.
- prettier: formatted.
- Rendered locally in a browser.

Only new files under `submissions/examples/` are added; no existing files modified (single squashed commit).

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._