### PR TITLE
Add CSS Animated Radio Buttons component

### DIFF
--- a/submissions/examples/css-animated-radio/README.md
+++ b/submissions/examples/css-animated-radio/README.md
@@ -1,0 +1,62 @@
+# CSS Animated Radio Buttons
+
+A radio button group with custom, animated selection
+indicators — a bouncy dot pops in with a spring easing when an
+option is selected, no JavaScript required.
+
+## What it does
+
+Each radio option shows a custom circular indicator instead of
+the browser default. Selecting an option animates a small dot
+into the indicator with a springy, bouncy easing curve, and the
+selected option's card gets a highlighted border and background.
+
+## How to use it
+
+```html
+<fieldset class="radio-group">
+  <legend class="radio-group-legend">Choose a plan</legend>
+
+  <label class="radio-option">
+    <input type="radio" name="plan" class="radio-input" value="basic" checked>
+    <span class="radio-indicator"></span>
+    <span class="radio-label">Basic</span>
+  </label>
+
+  <label class="radio-option">
+    <input type="radio" name="plan" class="radio-input" value="pro">
+    <span class="radio-indicator"></span>
+    <span class="radio-label">Pro</span>
+  </label>
+</fieldset>
+```
+
+Group multiple `.radio-option` labels inside a `.radio-group`
+fieldset, giving each `.radio-input` the same `name` attribute
+so they behave as a single radio group.
+
+## Why it fits EaseMotion CSS
+
+- **Pure CSS, zero dependencies** — the animated selection state
+  is driven entirely by the `:checked` pseudo-class and CSS
+  transitions, no JavaScript.
+- **Accessible** — built on real `<input type="radio">` elements
+  inside a `<fieldset>`/`<legend>`, so keyboard navigation,
+  screen readers, and form semantics all work exactly as
+  expected out of the box. Focus is visible via
+  `:focus-visible`.
+- **Respects motion preferences** — a `prefers-reduced-motion`
+  media query removes the dot's spring transition for users who
+  prefer reduced motion.
+- **Readable, semantic class names** — `radio-option`,
+  `radio-indicator`, `radio-group-legend`, etc.
+
+## Notes
+
+The highlighted card border/background on the selected option
+uses the CSS `:has()` selector. This is well-supported in
+current Chrome, Edge, Safari, and Firefox 121+, but is a
+progressive enhancement — on older browsers without `:has()`
+support, the radio buttons remain fully functional and the dot
+indicator still animates correctly; only the extra card
+highlight is skipped.

--- a/submissions/examples/css-animated-radio/demo.html
+++ b/submissions/examples/css-animated-radio/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Animated Radio Buttons — EaseMotion CSS</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <h1 class="demo-heading">CSS Animated Radio Buttons</h1>
+
+  <fieldset class="radio-group">
+    <legend class="radio-group-legend">Choose a plan</legend>
+
+    <label class="radio-option">
+      <input type="radio" name="plan" class="radio-input" value="basic" checked>
+      <span class="radio-indicator"></span>
+      <span class="radio-label">Basic</span>
+    </label>
+
+    <label class="radio-option">
+      <input type="radio" name="plan" class="radio-input" value="pro">
+      <span class="radio-indicator"></span>
+      <span class="radio-label">Pro</span>
+    </label>
+
+    <label class="radio-option">
+      <input type="radio" name="plan" class="radio-input" value="team">
+      <span class="radio-indicator"></span>
+      <span class="radio-label">Team</span>
+    </label>
+  </fieldset>
+
+</body>
+</html>

--- a/submissions/examples/css-animated-radio/style.css
+++ b/submissions/examples/css-animated-radio/style.css
@@ -1,0 +1,123 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 20px;
+  gap: 24px;
+}
+
+.demo-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #9aa4b2;
+  text-transform: uppercase;
+}
+
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.radio-group-legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e6e6e6;
+  margin-bottom: 4px;
+  padding: 0;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #161a22;
+  border: 1px solid #232833;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.radio-option:hover {
+  border-color: #2f3646;
+}
+
+.radio-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.radio-indicator {
+  position: relative;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #4a5568;
+  transition: border-color 0.2s ease;
+}
+
+.radio-indicator::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #4f8cff;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.radio-input:checked ~ .radio-indicator {
+  border-color: #4f8cff;
+}
+
+.radio-input:checked ~ .radio-indicator::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.radio-input:checked ~ .radio-label {
+  color: #fff;
+  font-weight: 600;
+}
+
+.radio-option:has(.radio-input:checked) {
+  border-color: #4f8cff;
+  background: #161f2e;
+}
+
+.radio-input:focus-visible ~ .radio-indicator {
+  outline: 2px solid #9ec3ff;
+  outline-offset: 3px;
+}
+
+.radio-label {
+  font-size: 0.9rem;
+  color: #9aa4b2;
+  transition: color 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radio-indicator::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a radio button group with custom, animated selection indicators — a bouncy dot pops in with spring easing when an option is selected. Closes #68204.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-animated-radio/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A radio button group with custom circular indicators where selecting an option animates a dot into place with a springy, bouncy easing curve, and highlights the selected option's card.

**How does a developer use it?**
```html
<fieldset class="radio-group">
  <legend class="radio-group-legend">Choose a plan</legend>

  <label class="radio-option">
    <input type="radio" name="plan" class="radio-input" value="basic" checked>
    <span class="radio-indicator"></span>
    <span class="radio-label">Basic</span>
  </label>

  <label class="radio-option">
    <input type="radio" name="plan" class="radio-input" value="pro">
    <span class="radio-indicator"></span>
    <span class="radio-label">Pro</span>
  </label>
</fieldset>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, zero dependencies — the animated selection state is driven entirely by `:checked` and CSS transitions. Built on real `<input type="radio">` elements inside a `<fieldset>`/`<legend>`, so keyboard navigation, screen readers, and form semantics work out of the box, with visible `:focus-visible` states. A `prefers-reduced-motion` query removes the spring transition for users who prefer reduced motion. Class names (`radio-option`, `radio-indicator`, `radio-group-legend`) stay readable and semantic.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The selected-card highlight uses the CSS `:has()` selector, well-supported in current Chrome/Edge/Safari/Firefox 121+, but treated as a progressive enhancement — on older browsers without `:has()` support, the radio buttons remain fully functional and the dot indicator still animates; only the extra card highlight is skipped.