### PR TITLE
feat: add pure CSS Loader Neumorphic Soft Shadow component (#73288)

### DIFF
--- a/submissions/examples/css-loader-neumorphic-soft-shadow-pure/README.md
+++ b/submissions/examples/css-loader-neumorphic-soft-shadow-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Loader: Neumorphic Soft Shadow
+
+A minimalist, accessible loader utilizing neumorphic soft UI design principles with perfectly balanced inset and drop shadows.
+
+## Features
+- Pure CSS and HTML implementation without any JavaScript.
+- **Component Architecture**: 
+  - **The Neumorphic Extrusion**: The `.neumorphic-container` shares the exact same background color as the `body`. The illusion of physical extrusion is created using two layered `box-shadow`s: a white/light shadow cast to the top-left, and a dark shadow cast to the bottom-right.
+  - **The Grooved Track**: The `.neu-loader-track` uses `inset` box shadows to invert the lighting logic. This makes it look like a physical groove carved deeply into the plastic surface of the container.
+  - **The Dynamic Playhead**: Inside the track sits the `.neu-loader-head`. This uses a bright accent color to contrast against the monochrome UI. It utilizes a `cubic-bezier` keyframe animation to slide back and forth, dynamically stretching its `width` as it accelerates through the center of the track to simulate motion blur and elasticity.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), cleanly transitioning the shadow colors from bright white/gray to deep charcoal/black, maintaining the extrusion illusion perfectly in dark mode.
+- Fully accessible semantic structure. The loader track is hidden from screen readers using `aria-hidden="true"`, and the container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by statically centering the playhead and stopping the text pulse for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser to view the neumorphic loading animation.
+
+## Files
+- `demo.html`: The HTML structure defining the container, track, and playhead elements.
+- `style.css`: The styling, the `inset` and extrusion `box-shadow` logic, and the elastic keyframe animation.

--- a/submissions/examples/css-loader-neumorphic-soft-shadow-pure/demo.html
+++ b/submissions/examples/css-loader-neumorphic-soft-shadow-pure/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Loader: Neumorphic Soft Shadow</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Loader: Neumorphic Soft Shadow</h1>
+            <p class="subtitle">A minimalist, accessible loader utilizing neumorphic soft UI design principles with perfectly balanced inset and drop shadows.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Neumorphic Base
+              The container must share the exact same background color as the body
+              to achieve the extruded plastic/soft UI look.
+            -->
+            <div class="neumorphic-container" aria-label="Loading content, neumorphic animation playing">
+                
+                <!-- 
+                  [TECHNIQUE] The Neumorphic Loader
+                  A physical-looking track with a moving playhead,
+                  created using layered box-shadows.
+                -->
+                <div class="neu-loader-track" aria-hidden="true">
+                    <div class="neu-loader-head"></div>
+                </div>
+                
+                <!-- A subtle pulsing text element to complement the physical loader -->
+                <div class="loading-text">Synchronizing Data...</div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-loader-neumorphic-soft-shadow-pure/style.css
+++ b/submissions/examples/css-loader-neumorphic-soft-shadow-pure/style.css
@@ -1,0 +1,201 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* 
+       Neumorphism requires the background color to be exactly the same
+       across the body and the components. We use a soft gray/blue.
+    */
+    --bg-color: #e0e5ec;
+    --text-primary: #4a5568;
+    
+    /* Neumorphic Shadows (Light Mode) */
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    
+    /* Accent Color */
+    --accent: #3b82f6;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Dark Mode Neumorphism */
+        --bg-color: #1a202c;
+        --text-primary: #a0aec0;
+        
+        --shadow-light: #2d3748;
+        --shadow-dark: #0f131a;
+        
+        --accent: #63b3ed;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    color: var(--text-primary);
+}
+
+.subtitle {
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    opacity: 0.8;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Neumorphic Container
+   ========================================= */
+
+.neumorphic-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 40px;
+    padding: 60px 80px;
+    border-radius: 30px;
+    
+    /* Must match the body background */
+    background-color: var(--bg-color);
+    
+    /* 
+       The core Neumorphic effect:
+       One shadow is light (top left), one shadow is dark (bottom right).
+       This makes the container appear to be extruded from the background.
+    */
+    box-shadow: 
+        12px 12px 24px var(--shadow-dark),
+        -12px -12px 24px var(--shadow-light);
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Neumorphic Loader Track
+   ========================================= */
+
+.neu-loader-track {
+    position: relative;
+    width: 250px;
+    height: 16px;
+    border-radius: 999px;
+    background-color: var(--bg-color);
+    
+    /* 
+       Using INSET shadows to make the track look like a groove 
+       carved into the plastic surface.
+    */
+    box-shadow: 
+        inset 6px 6px 12px var(--shadow-dark),
+        inset -6px -6px 12px var(--shadow-light);
+        
+    overflow: hidden;
+}
+
+/* The moving element inside the track */
+.neu-loader-head {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    height: 12px;
+    width: 40px;
+    border-radius: 999px;
+    
+    /* Give it an accent color so it stands out from the monochrome plastic */
+    background-color: var(--accent);
+    
+    /* 
+       A small drop shadow on the playhead itself so it looks like it's 
+       sitting inside the groove, not just painted on.
+    */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    
+    /* Ping-pong animation */
+    animation: slide 1.5s cubic-bezier(0.4, 0, 0.2, 1) infinite alternate;
+}
+
+.loading-text {
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--text-primary);
+    animation: pulse 2s ease-in-out infinite alternate;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes slide {
+    0% {
+        transform: translateX(0);
+        /* Stretch slightly when starting */
+        width: 30px; 
+    }
+    50% {
+        /* Stretch to max length in the middle of the track */
+        width: 80px;
+    }
+    100% {
+        /* 
+           Move to the end of the track. 
+           Calculated as: Track Width (250px) - Head Width (40px) - Left/Right Padding (4px)
+        */
+        transform: translateX(206px);
+        width: 40px;
+    }
+}
+
+@keyframes pulse {
+    0% { opacity: 0.5; }
+    100% { opacity: 1; }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .neu-loader-head {
+        animation: none !important;
+        /* Center it statically if motion is disabled */
+        left: 50%;
+        transform: translateX(-50%);
+        width: 80px;
+    }
+    .loading-text {
+        animation: none !important;
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a minimalist, accessible loader utilizing neumorphic soft UI design principles with perfectly balanced inset and drop shadows. Resolves issue #73288.

### Changes Made:
- Added `submissions/examples/css-loader-neumorphic-soft-shadow-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the container, track, and playhead elements.
- Created `style.css` featuring the UI mechanics:
  - **The Neumorphic Extrusion**: The `.neumorphic-container` shares the exact same background color as the `body`. The illusion of physical extrusion is created using two layered `box-shadow`s: a white/light shadow cast to the top-left, and a dark shadow cast to the bottom-right.
  - **The Grooved Track**: The `.neu-loader-track` uses `inset` box shadows to invert the lighting logic. This makes it look like a physical groove carved deeply into the plastic surface of the container.
  - **The Dynamic Playhead**: Inside the track sits the `.neu-loader-head`. This uses a bright accent color to contrast against the monochrome UI. It utilizes a `cubic-bezier` keyframe animation to slide back and forth, dynamically stretching its `width` as it accelerates through the center of the track to simulate motion blur and elasticity.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), cleanly transitioning the shadow colors from bright white/gray to deep charcoal/black, maintaining the extrusion illusion perfectly in dark mode.
- Added `README.md` documenting usage and the technical mechanics of the `inset` and extrusion `box-shadow` logic.
- Fully accessible semantic structure. The loader track is hidden from screen readers using `aria-hidden="true"`, and the container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by statically centering the playhead and stopping the text pulse for motion-sensitive users.

Closes #73288
