### PR TITLE
feat: add CSS animated blueprint component

### DIFF
--- a/submissions/examples/css-animated-blueprint-aaniya22/README.md
+++ b/submissions/examples/css-animated-blueprint-aaniya22/README.md
@@ -1,0 +1,17 @@
+# css-animated-blueprint-aaniya22
+Pure CSS animated blueprint — technical drawing lines that sketch themselves into view using `stroke-dasharray`/`stroke-dashoffset`, like a blueprint being drawn by hand. No JavaScript required.
+
+## How to use
+```html
+<div class="ease-blueprint-aaniya22">
+  <svg class="ease-blueprint-svg-aaniya22" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+    <rect class="ease-blueprint-line-aaniya22 ease-blueprint-delay1-aaniya22" x="40" y="40" width="150" height="100" fill="none" />
+    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="60" x2="250" y2="30" />
+    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="140" x2="250" y2="110" />
+    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay3-aaniya22" x1="250" y1="30" x2="250" y2="110" />
+    <circle class="ease-blueprint-line-aaniya22 ease-blueprint-delay4-aaniya22" cx="115" cy="90" r="35" fill="none" />
+  </svg>
+</div>
+```
+
+Each shape's `stroke-dasharray`/`stroke-dashoffset` is animated on a staggered delay so lines appear to draw themselves in sequence, on a grid-paper blueprint background. Respects `prefers-reduced-motion` by showing the fully-drawn state with no animation.

--- a/submissions/examples/css-animated-blueprint-aaniya22/demo.html
+++ b/submissions/examples/css-animated-blueprint-aaniya22/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Animated Blueprint — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <p class="label">Pure CSS Animated Blueprint</p>
+  <div class="ease-blueprint-aaniya22">
+    <svg class="ease-blueprint-svg-aaniya22" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+      <rect class="ease-blueprint-line-aaniya22 ease-blueprint-delay1-aaniya22" x="40" y="40" width="150" height="100" fill="none" />
+      <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="60" x2="250" y2="30" />
+      <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="140" x2="250" y2="110" />
+      <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay3-aaniya22" x1="250" y1="30" x2="250" y2="110" />
+      <circle class="ease-blueprint-line-aaniya22 ease-blueprint-delay4-aaniya22" cx="115" cy="90" r="35" fill="none" />
+    </svg>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-animated-blueprint-aaniya22/style.css
+++ b/submissions/examples/css-animated-blueprint-aaniya22/style.css
@@ -1,0 +1,64 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  background: #0a1f33;
+  font-family: system-ui, sans-serif;
+  padding: 3rem 1.5rem;
+  color: #fff;
+}
+.label {
+  color: rgba(255,255,255,0.3);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  margin-bottom: -1.5rem;
+}
+/* ── Animated Blueprint ────────────────────────────────────── */
+.ease-blueprint-aaniya22 {
+  background:
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+  background-color: #0d3b66;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+.ease-blueprint-svg-aaniya22 {
+  width: 300px;
+  height: 200px;
+  display: block;
+}
+.ease-blueprint-line-aaniya22 {
+  fill: none;
+  stroke: #7dd3fc;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: ease-blueprint-draw-aaniya22 2s ease forwards infinite;
+}
+.ease-blueprint-delay1-aaniya22 { animation-delay: 0s; }
+.ease-blueprint-delay2-aaniya22 { animation-delay: 0.6s; }
+.ease-blueprint-delay3-aaniya22 { animation-delay: 1s; }
+.ease-blueprint-delay4-aaniya22 { animation-delay: 1.3s; }
+
+@keyframes ease-blueprint-draw-aaniya22 {
+  0% { stroke-dashoffset: 600; }
+  60%, 85% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -600; }
+}
+/* ── Reduced Motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-blueprint-line-aaniya22 {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS animated blueprint — technical drawing shapes that sketch themselves into view using stroke-dasharray/stroke-dashoffset on a grid-paper background. Closes #70113.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-animated-blueprint-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
An SVG-based technical drawing (rectangle, angled lines, circle) whose strokes animate into view in sequence, like a blueprint being hand-drawn, set against a grid-paper background.

**How does a developer use it?**
```html
<div class="ease-blueprint-aaniya22">
  <svg class="ease-blueprint-svg-aaniya22" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
    <rect class="ease-blueprint-line-aaniya22 ease-blueprint-delay1-aaniya22" x="40" y="40" width="150" height="100" fill="none" />
    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="60" x2="250" y2="30" />
    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay2-aaniya22" x1="190" y1="140" x2="250" y2="110" />
    <line class="ease-blueprint-line-aaniya22 ease-blueprint-delay3-aaniya22" x1="250" y1="30" x2="250" y2="110" />
    <circle class="ease-blueprint-line-aaniya22 ease-blueprint-delay4-aaniya22" cx="115" cy="90" r="35" fill="none" />
  </svg>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, zero dependencies — the draw-on effect is achieved entirely with `stroke-dasharray`/`stroke-dashoffset` and staggered `animation-delay`, no JS or canvas needed. A `prefers-reduced-motion` query shows the fully-drawn state immediately for users who prefer reduced motion. Class names stay readable and scoped with a unique suffix to avoid collisions.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
The shape set (rectangle, angled connector lines, circle) and timing were chosen to loosely resemble a technical drawing — happy to adjust the SVG paths or pacing if a different composition is preferred.