### PR TITLE
feat: add ease-drag-vertical-reorder-sap

### DIFF
--- a/submissions/examples/ease-drag-vertical-reorder-sap/README.md
+++ b/submissions/examples/ease-drag-vertical-reorder-sap/README.md
@@ -1,0 +1,32 @@
+# Drag Vertical Reorder
+
+A reorderable vertical list using native HTML5 Drag and Drop, plus a
+keyboard-accessible Alt+Up/Down fallback for moving items without a mouse.
+
+**Level:** Advanced
+
+## Usage
+
+Items are `draggable="true"` and `tabindex="0"`. Drag-and-drop reordering
+uses `dragstart`/`dragover`/`dragend`; keyboard reordering uses
+`Alt+ArrowUp`/`Alt+ArrowDown` on a focused item.
+
+## Accessibility
+
+- Native drag-and-drop alone is not keyboard-operable, so this component
+  adds an explicit `Alt+Up`/`Alt+Down` keyboard path that performs the same
+  reorder via `insertBefore`, kept independent of the drag handlers.
+- Items are focusable (`tabindex="0"`) with a visible `:focus-visible` outline.
+- `prefers-reduced-motion` removes the transform/box-shadow transition,
+  keeping only the opacity change during an active drag.
+- This demo omits `aria-live` position announcements for brevity; a
+  production version should announce "Moved to position X of Y" on each
+  keyboard reorder so screen reader users get confirmation of the new order.
+
+## Notes
+
+- `dragover` calculates whether the pointer is in the top or bottom half of
+  the hovered item to decide whether to insert before or after it, giving
+  smoother mid-drag reordering feedback than a fixed insert point.
+- Keyboard reordering directly manipulates the DOM order via `insertBefore`,
+  the same mechanism the pointer-drag path uses, so both stay consistent.

--- a/submissions/examples/ease-drag-vertical-reorder-sap/demo.html
+++ b/submissions/examples/ease-drag-vertical-reorder-sap/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Vertical Reorder</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Vertical Reorder</h1>
+
+    <ul class="reorder-list" id="reorderList">
+      <li class="reorder-item" draggable="true" tabindex="0">
+        <span class="drag-grip">⠿</span> Design mockups
+      </li>
+      <li class="reorder-item" draggable="true" tabindex="0">
+        <span class="drag-grip">⠿</span> Write documentation
+      </li>
+      <li class="reorder-item" draggable="true" tabindex="0">
+        <span class="drag-grip">⠿</span> Review pull requests
+      </li>
+      <li class="reorder-item" draggable="true" tabindex="0">
+        <span class="drag-grip">⠿</span> Ship release
+      </li>
+    </ul>
+
+    <p class="hint">Drag items, or focus one and press Alt+Up/Down.</p>
+  </main>
+
+  <script>
+    const list = document.getElementById('reorderList');
+    let dragEl = null;
+
+    list.addEventListener('dragstart', (e) => {
+      dragEl = e.target.closest('.reorder-item');
+      dragEl.classList.add('is-dragging');
+    });
+
+    list.addEventListener('dragend', () => {
+      dragEl?.classList.remove('is-dragging');
+      dragEl = null;
+    });
+
+    list.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      const target = e.target.closest('.reorder-item');
+      if (!target || target === dragEl) return;
+      const rect = target.getBoundingClientRect();
+      const before = (e.clientY - rect.top) < rect.height / 2;
+      list.insertBefore(dragEl, before ? target : target.nextSibling);
+    });
+
+    list.addEventListener('keydown', (e) => {
+      if (!e.altKey) return;
+      const item = e.target.closest('.reorder-item');
+      if (!item) return;
+      if (e.key === 'ArrowUp' && item.previousElementSibling) {
+        e.preventDefault();
+        list.insertBefore(item, item.previousElementSibling);
+        item.focus();
+      }
+      if (e.key === 'ArrowDown' && item.nextElementSibling) {
+        e.preventDefault();
+        list.insertBefore(item.nextElementSibling, item);
+        item.focus();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-vertical-reorder-sap/style.css
+++ b/submissions/examples/ease-drag-vertical-reorder-sap/style.css
@@ -1,0 +1,72 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(360px, 90vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.reorder-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reorder-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.8rem 1rem;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: grab;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.reorder-item:active { cursor: grabbing; }
+
+.reorder-item.is-dragging {
+  opacity: 0.4;
+  transform: scale(0.98);
+}
+
+.reorder-item:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.drag-grip {
+  color: #94a3b8;
+  font-size: 1rem;
+}
+
+.hint {
+  margin-top: 1.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reorder-item { transition: opacity 0.2s ease; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-vertical-reorder-sap`, a drag-to-reorder list with keyboard reorder support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-vertical-reorder-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Native HTML5 drag-and-drop is paired with an `Alt+Up`/`Alt+Down` keyboard
  reorder path, since drag-and-drop alone isn't keyboard-operable.
- README flags that `aria-live` position announcements on reorder would be a
  worthwhile follow-up for full screen-reader parity.

## Feature Description

Adds a reusable drag-to-reorder vertical list component with keyboard fallback.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.