### PR TITLE
feat: add ease-hover-image-duotone-sap

### DIFF
--- a/submissions/examples/ease-hover-image-duotone-sap/README.md
+++ b/submissions/examples/ease-hover-image-duotone-sap/README.md
@@ -1,0 +1,30 @@
+# Hover Image Duotone
+
+Images that display as a stylized duotone (via CSS `filter`) by default and
+fade into their full natural color on hover, a common editorial/portfolio
+gallery effect.
+
+**Level:** Beginner
+
+## Usage
+
+Wrap an `<img>` in `.duotone-card`. The duotone look is achieved purely with
+a stacked `filter` (grayscale → sepia → hue-rotate → saturate → contrast) on
+the image, which resets to `filter: none` on hover.
+
+## Accessibility
+
+- Every image has real descriptive `alt` text — the duotone effect is purely
+  a visual style layer and doesn't stand in for meaningful alt content.
+- Effect triggers on `:focus-within` as well as `:hover`, so keyboard users
+  tabbing to a focusable element inside the card also see the full-color state.
+- `prefers-reduced-motion` removes the filter transition; the color change
+  still happens on hover/focus, just as an instant swap instead of a fade.
+
+## Notes
+
+- The duotone look is a single chained `filter` property, no SVG filter or
+  extra overlay element required, so it's cheap to apply broadly across a
+  gallery.
+- Demo uses a placeholder image service (`picsum.photos`); swap `src` for
+  real assets — the filter approach works with any photographic image.

--- a/submissions/examples/ease-hover-image-duotone-sap/demo.html
+++ b/submissions/examples/ease-hover-image-duotone-sap/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Image Duotone</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Image Duotone</h1>
+
+    <div class="duotone-grid">
+      <figure class="duotone-card">
+        <img src="https://picsum.photos/seed/duo1/360/240" alt="Mountain landscape at sunrise">
+      </figure>
+      <figure class="duotone-card">
+        <img src="https://picsum.photos/seed/duo2/360/240" alt="City street at night">
+      </figure>
+    </div>
+
+    <p class="hint">Hover to fade from duotone into full color.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-hover-image-duotone-sap/style.css
+++ b/submissions/examples/ease-hover-image-duotone-sap/style.css
@@ -1,0 +1,59 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.duotone-grid {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.duotone-card {
+  margin: 0;
+  width: 260px;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.08);
+}
+
+.duotone-card img {
+  display: block;
+  width: 100%;
+  height: 170px;
+  object-fit: cover;
+  filter: grayscale(1) sepia(0.4) hue-rotate(200deg) saturate(3) contrast(1.1);
+  transition: filter 0.5s ease;
+}
+
+.duotone-card:hover img,
+.duotone-card:focus-within img {
+  filter: none;
+}
+
+.hint {
+  margin-top: 1.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .duotone-card img { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-image-duotone-sap`, images that fade from a duotone filter into full color on hover.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-image-duotone-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Duotone effect is a single chained `filter` on the `<img>`, reset on hover
  — no SVG filter or extra DOM overlay needed.
- Effect triggers on `:focus-within` in addition to `:hover`, and every
  image carries real descriptive `alt` text independent of the visual style.

## Feature Description

Adds a reusable duotone-to-color hover effect for images.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.