### PR TITLE
feat: add pure CSS Loader Laser Ray Trace component (#73297)

### DIFF
--- a/submissions/examples/css-loader-laser-ray-trace-pure/README.md
+++ b/submissions/examples/css-loader-laser-ray-trace-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Loader: Laser Ray Trace
+
+A continuous, high-speed laser beam tracing the perimeter of a container, built purely with CSS conic gradients and mask compositing.
+
+## Features
+- Pure CSS and HTML implementation without any JavaScript, SVG paths, or `stroke-dashoffset` tricks.
+- **Component Architecture**: 
+  - **The Laser Edge Trick**: Tracing the perimeter of a rectangle purely in CSS is famously difficult without SVG. This component solves it using a layered compositing trick. 
+  - **The Spinning Beam**: A large `.laser-beam` div is placed at the back. It utilizes a `conic-gradient` that transitions sharply from transparent to solid cyan, creating a defined "laser head" and a fading "tail". A continuous linear rotation keyframe makes this gradient sweep in a circle.
+  - **The Solid Mask**: A solid `.laser-center` div is placed exactly over the spinning beam. By utilizing `inset: 2px;`, it perfectly covers the beam except for a 2px gap around the entire outer edge of the container. 
+  - **The Result**: Because only the outer 2px edge of the spinning conic gradient is visible, it perfectly creates the illusion of a laser beam rapidly tracing the rectangular border, automatically handling the difficult corner math without any complex keyframes.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The laser effect is intentionally designed for dark backgrounds (`--loader-bg: #020617;`) to maximize contrast and glow intensity.
+- Fully accessible semantic structure. The decorative bounding box is hidden from screen readers using `aria-hidden="true"`, and the loader container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by freezing the rotating beam and converting it into a static, glowing green border for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser to view the laser ray trace loading animation.
+
+## Files
+- `demo.html`: The HTML structure defining the wrapper, the spinning beam layer, and the masking center layer.
+- `style.css`: The styling, the `conic-gradient` beam logic, and the `inset` border masking trick.

--- a/submissions/examples/css-loader-laser-ray-trace-pure/demo.html
+++ b/submissions/examples/css-loader-laser-ray-trace-pure/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Loader: Laser Ray Trace</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Loader: Laser Ray Trace</h1>
+            <p class="subtitle">A continuous, high-speed laser beam tracing the perimeter of a container, built purely with CSS conic gradients and mask compositing.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="loader-container" aria-label="Loading content, laser ray trace animation playing">
+                
+                <!-- 
+                  [TECHNIQUE] Laser Ray Trace
+                  We use a solid dark inner container and a spinning conic gradient behind it
+                  that only peeks out at the edges, creating a continuous perimeter trace.
+                -->
+                <div class="laser-box" aria-hidden="true">
+                    
+                    <!-- The animated beam -->
+                    <div class="laser-beam"></div>
+                    
+                    <!-- The solid center that hides the middle of the beam -->
+                    <div class="laser-center">
+                        <span class="laser-text">SYSTEM SECURE</span>
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-loader-laser-ray-trace-pure/style.css
+++ b/submissions/examples/css-loader-laser-ray-trace-pure/style.css
@@ -1,0 +1,187 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    /* Loader colors - Designed for dark mode */
+    --loader-bg: #020617;
+    --laser-color: #10b981; /* Emerald green laser */
+    --laser-tail: rgba(16, 185, 129, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617;
+        --text-primary: #f8fafc;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Loader Container
+   ========================================= */
+
+.loader-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 80px 100px;
+    background-color: var(--loader-bg);
+    border-radius: 12px;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Laser Ray Trace
+   ========================================= */
+
+.laser-box {
+    position: relative;
+    width: 200px;
+    height: 60px;
+    
+    /* 
+       To prevent the spinning beam from sticking out of the corners, 
+       we hide the overflow of the spinning square gradient.
+    */
+    overflow: hidden;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+/* 
+   The beam is actually a large spinning conic gradient 
+   that sits behind the solid center.
+*/
+.laser-beam {
+    position: absolute;
+    /* Make it large enough to cover the rectangular box even while rotating */
+    top: -100px;
+    left: -50px;
+    width: 300px; 
+    height: 300px;
+    
+    /* 
+       A sharp conic gradient creates the 'head' of the laser,
+       fading out into a long tail.
+    */
+    background: conic-gradient(
+        from 0deg, 
+        transparent 0deg, 
+        var(--laser-tail) 270deg, 
+        var(--laser-color) 360deg
+    );
+    
+    animation: trace 2s linear infinite;
+    transform-origin: center center;
+}
+
+/* 
+   The solid center sits on top of the spinning beam,
+   leaving only a 2px gap around the edges. This creates 
+   the illusion that the beam is strictly tracing the border.
+*/
+.laser-center {
+    position: absolute;
+    /* 
+       By setting inset to 2px, we leave exactly 2px of the 
+       background visible around the entire perimeter.
+    */
+    inset: 2px;
+    background-color: var(--loader-bg);
+    border-radius: 2px;
+    z-index: 10;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.laser-text {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.85rem;
+    font-weight: bold;
+    letter-spacing: 2px;
+    color: var(--laser-color);
+    text-shadow: 0 0 8px var(--laser-color);
+    animation: pulse 2s ease-in-out infinite alternate;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes trace {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+@keyframes pulse {
+    0% { opacity: 0.6; }
+    100% { opacity: 1; text-shadow: 0 0 12px var(--laser-color); }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .laser-beam {
+        animation: none !important;
+        /* Replace the conic gradient with a solid border for static users */
+        background: var(--laser-color);
+        opacity: 0.5;
+    }
+    
+    .laser-text {
+        animation: none !important;
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a continuous, high-speed laser beam tracing the perimeter of a container, built purely with CSS conic gradients and mask compositing. Resolves issue #73297.

### Changes Made:
- Added `submissions/examples/css-loader-laser-ray-trace-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the wrapper, the spinning beam layer, and the masking center layer.
- Created `style.css` featuring the UI mechanics:
  - **The Laser Edge Trick**: Tracing the perimeter of a rectangle purely in CSS is famously difficult without SVG. This component solves it using a layered compositing trick. 
  - **The Spinning Beam**: A large `.laser-beam` div is placed at the back. It utilizes a `conic-gradient` that transitions sharply from transparent to solid emerald green, creating a defined "laser head" and a fading "tail". A continuous linear rotation keyframe makes this gradient sweep in a circle.
  - **The Solid Mask**: A solid `.laser-center` div is placed exactly over the spinning beam. By utilizing `inset: 2px;`, it perfectly covers the beam except for a 2px gap around the entire outer edge of the container. 
  - **The Result**: Because only the outer 2px edge of the spinning conic gradient is visible, it perfectly creates the illusion of a laser beam rapidly tracing the rectangular border, automatically handling the difficult corner math without any complex keyframes.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The laser effect is intentionally designed for dark backgrounds (`--loader-bg: #020617;`) to maximize contrast and glow intensity.
- Added `README.md` documenting usage and the technical mechanics of the `conic-gradient` beam logic and the `inset` border masking trick.
- Fully accessible semantic structure. The decorative bounding box is hidden from screen readers using `aria-hidden="true"`, and the loader container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by freezing the rotating beam and converting it into a static, glowing green border for motion-sensitive users.

Closes #73297
