### PR TITLE
feat: add ease-card-expand-inline-sap

### DIFF
--- a/submissions/examples/ease-card-expand-inline-sap/README.md
+++ b/submissions/examples/ease-card-expand-inline-sap/README.md
@@ -1,0 +1,33 @@
+# Card Expand Inline
+
+An accordion-style card whose body smoothly grows/shrinks in place to reveal
+or hide detail content, with a rotating "+" icon indicator.
+
+**Level:** Intermediate
+
+## Usage
+
+Each card is a `.expand-header` button paired with an `.expand-body` panel.
+JS measures `scrollHeight` and animates the `height` property from `0` to
+that measured value (then to `auto` once open) since CSS can't natively
+transition to/from `auto`.
+
+## Accessibility
+
+- Header buttons use `aria-expanded` and `aria-controls`, kept in sync with
+  actual state.
+- The body panel is toggled with the `hidden` attribute in addition to
+  height, so collapsed content is fully removed from the accessibility tree
+  and tab order — not just visually clipped.
+- `:focus-visible` outline included on the header button.
+- `prefers-reduced-motion` removes both the icon rotation and the height
+  transition; expand/collapse still functions, just instantly.
+
+## Notes
+
+- Height animation follows the standard "measure `scrollHeight`, animate to
+  it, then set `height: auto`" pattern so content isn't clipped if it later
+  reflows (e.g. window resize) while expanded.
+- Uses `transitionend` to know when to finalize `height: auto` (opening) or
+  set `hidden = true` (closing), avoiding a hardcoded duration matching the
+  CSS transition length.

--- a/submissions/examples/ease-card-expand-inline-sap/demo.html
+++ b/submissions/examples/ease-card-expand-inline-sap/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Card Expand Inline</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Card Expand Inline</h1>
+
+    <div class="expand-list">
+      <div class="expand-card">
+        <button class="expand-header" aria-expanded="false" aria-controls="body-1">
+          <span>What is this component?</span>
+          <span class="expand-icon">+</span>
+        </button>
+        <div class="expand-body" id="body-1" hidden>
+          <p>A card that grows in place to reveal more detail, instead of navigating away or opening a modal.</p>
+        </div>
+      </div>
+
+      <div class="expand-card">
+        <button class="expand-header" aria-expanded="false" aria-controls="body-2">
+          <span>Does it need JavaScript?</span>
+          <span class="expand-icon">+</span>
+        </button>
+        <div class="expand-body" id="body-2" hidden>
+          <p>Yes — height is measured and animated via JS since CSS alone can't transition to/from `auto` height smoothly across browsers.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    document.querySelectorAll('.expand-header').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const body = document.getElementById(btn.getAttribute('aria-controls'));
+        const isOpen = btn.getAttribute('aria-expanded') === 'true';
+
+        if (isOpen) {
+          body.style.height = body.scrollHeight + 'px';
+          requestAnimationFrame(() => { body.style.height = '0px'; });
+          body.addEventListener('transitionend', function handler() {
+            body.hidden = true;
+            body.removeEventListener('transitionend', handler);
+          });
+          btn.setAttribute('aria-expanded', 'false');
+        } else {
+          body.hidden = false;
+          body.style.height = '0px';
+          requestAnimationFrame(() => { body.style.height = body.scrollHeight + 'px'; });
+          body.addEventListener('transitionend', function handler() {
+            body.style.height = 'auto';
+            body.removeEventListener('transitionend', handler);
+          });
+          btn.setAttribute('aria-expanded', 'true');
+        }
+        btn.classList.toggle('is-open', !isOpen);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-card-expand-inline-sap/style.css
+++ b/submissions/examples/ease-card-expand-inline-sap/style.css
@@ -1,0 +1,94 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(440px, 92vw); }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+  text-align: center;
+}
+
+.expand-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.expand-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.expand-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+  cursor: pointer;
+  text-align: left;
+}
+
+.expand-header:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
+.expand-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #eef2ff;
+  color: #4338ca;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition: transform 0.3s ease;
+}
+
+.expand-header.is-open .expand-icon {
+  transform: rotate(45deg);
+}
+
+.expand-body {
+  overflow: hidden;
+  height: 0px;
+  transition: height 0.3s ease;
+}
+
+.expand-body p {
+  margin: 0;
+  padding: 0 1.2rem 1.1rem;
+  font-size: 0.85rem;
+  color: #64748b;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expand-icon { transition: none; }
+  .expand-body { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-card-expand-inline-sap`, an inline-expanding accordion card component.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-card-expand-inline-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Header buttons carry proper `aria-expanded`/`aria-controls`, and bodies
  use `hidden` alongside the height animation so collapsed content leaves
  the accessibility tree, not just the visible layout.
- Height transition follows measure-`scrollHeight`-then-animate, finalizing
  to `height: auto` via `transitionend` rather than a guessed timeout.

## Feature Description

Adds a reusable inline-expanding accordion card component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.