### PR TITLE
feat: add ease-notification-badge-count-sap

### DIFF
--- a/submissions/examples/ease-notification-badge-count-sap/README.md
+++ b/submissions/examples/ease-notification-badge-count-sap/README.md
@@ -1,0 +1,29 @@
+# Notification Badge Count
+
+A count badge on an icon button (e.g. cart) that bumps/pops with a spring
+animation each time the count updates, and hides itself entirely at zero.
+
+**Level:** Beginner
+
+## Usage
+
+Call `render()` after changing the JS `count` variable. It updates the
+badge text (capping display at "99+"), toggles visibility at zero, updates
+the button's `aria-label`, and replays the bump animation via a reflow reset.
+
+## Accessibility
+
+- The actual count is announced through the button's own `aria-label`
+  (e.g. "Cart, 2 items"), not conveyed by the badge's visual number alone.
+- At zero, the badge is hidden via a class that sets `display: none`
+  (removed from the accessibility tree, not just visually), and the label
+  updates to "Cart, 0 items" so state stays accurate.
+- `prefers-reduced-motion` disables the bump animation; the number and
+  `aria-label` still update correctly.
+
+## Notes
+
+- Count is capped at a "99+" display for large values while `aria-label`
+  still reads the exact count for anyone relying on it.
+- Bump animation is restarted via the standard reflow-reset technique (`void
+  countEl.offsetWidth`) so consecutive quick increments each get their own bump.

--- a/submissions/examples/ease-notification-badge-count-sap/demo.html
+++ b/submissions/examples/ease-notification-badge-count-sap/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Notification Badge Count</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Notification Badge Count</h1>
+
+    <button class="icon-btn" id="cartBtn" aria-label="Cart, 2 items">
+      🛒
+      <span class="badge-count" id="cartCount">2</span>
+    </button>
+
+    <div class="controls">
+      <button class="ctrl-btn" id="addBtn">Add item</button>
+      <button class="ctrl-btn" id="clearBtn">Clear cart</button>
+    </div>
+  </main>
+
+  <script>
+    const countEl = document.getElementById('cartCount');
+    const btn = document.getElementById('cartBtn');
+    let count = 2;
+
+    function render() {
+      countEl.textContent = count > 99 ? '99+' : count;
+      countEl.classList.toggle('is-hidden', count === 0);
+      btn.setAttribute('aria-label', `Cart, ${count} item${count === 1 ? '' : 's'}`);
+      countEl.classList.remove('bump');
+      void countEl.offsetWidth;
+      countEl.classList.add('bump');
+    }
+
+    document.getElementById('addBtn').addEventListener('click', () => {
+      count++;
+      render();
+    });
+
+    document.getElementById('clearBtn').addEventListener('click', () => {
+      count = 0;
+      render();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-notification-badge-count-sap/style.css
+++ b/submissions/examples/ease-notification-badge-count-sap/style.css
@@ -1,0 +1,87 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.icon-btn {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 1px solid #e2e8f0;
+  background: white;
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.icon-btn:hover { background: #f1f5f9; }
+
+.icon-btn:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+.badge-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #f8fafc;
+  transform: scale(1);
+}
+
+.badge-count.is-hidden { display: none; }
+
+.badge-count.bump {
+  animation: badge-bump 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes badge-bump {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.4); }
+  100% { transform: scale(1); }
+}
+
+.controls { display: flex; gap: 0.6rem; }
+
+.ctrl-btn {
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.ctrl-btn:hover { background: #f1f5f9; }
+
+@media (prefers-reduced-motion: reduce) {
+  .badge-count.bump { animation: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-notification-badge-count-sap`, a bump-animated count badge for icon buttons.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-notification-badge-count-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Exact count is exposed via the button's `aria-label`, kept accurate even
  when the visual badge caps display at "99+".
- Zero-count state hides the badge via `display: none` (not just opacity),
  and the label updates to reflect "0 items" rather than going stale.

## Feature Description

Adds a reusable bump-animated notification count badge component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.