### PR TITLE
feat: add basic input label demo

### DIFF
--- a/submissions/examples/basic-input-label-kk/README.md
+++ b/submissions/examples/basic-input-label-kk/README.md
@@ -1,0 +1,31 @@
+# Basic Input Label
+
+## What it does
+
+This submission creates a simple CSS-only input label utility for placing clean labels above text fields, selects, textareas, and grouped form controls.
+
+## How to use it
+
+Apply the label class directly to a form label:
+
+```html
+<label class="basic-input-label">Email Address</label>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in forms, settings panels, profile editors, and dashboard input sections.
+
+## Included features
+
+- Clean input-label utility
+- Practical field examples
+- Consistent readable label styling
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the label utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-input-label-kk/demo.html
+++ b/submissions/examples/basic-input-label-kk/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Input Label</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Basic Input Label</p>
+          <h1>Simple labels for form fields, settings panels, and editors.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only input label utility for
+            text fields, selects, textareas, and grouped form controls. It is
+            intentionally simple, readable, and easy to reuse across many form
+            layouts.
+          </p>
+        </header>
+
+        <section class="form-grid">
+          <div class="field-group">
+            <label class="basic-input-label">Email Address</label>
+            <input class="example-input" type="email" placeholder="name@example.com" />
+          </div>
+
+          <div class="field-group">
+            <label class="basic-input-label">Project Name</label>
+            <input class="example-input" type="text" placeholder="Project Alpha" />
+          </div>
+
+          <div class="field-group">
+            <label class="basic-input-label">Role</label>
+            <select class="example-input">
+              <option>Designer</option>
+              <option>Developer</option>
+              <option>Manager</option>
+            </select>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;label class="basic-input-label"&gt;Email Address&lt;/label&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-input-label-kk/style.css
+++ b/submissions/examples/basic-input-label-kk/style.css
@@ -1,0 +1,115 @@
+:root {
+  color-scheme: dark;
+  --bg: #09111f;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.field-group,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.basic-input-label {
+  display: inline-block;
+  margin-bottom: 0.45rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.example-input {
+  width: 100%;
+  padding: 0.82rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font: inherit;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Input Label demo inside `submissions/examples/basic-input-label-kk/`. This submission introduces a simple CSS-only label utility for text fields, selects, textareas, and grouped form controls.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only input label utility for placing clean labels above form fields and grouped input controls.

**How does a developer use it?**

```html
<label class="basic-input-label">Email Address</label>