### PR TITLE
feat: add CSS pull-down refresh component

### DIFF
--- a/submissions/examples/css-pull-down-refresh-aaniya22/README.md
+++ b/submissions/examples/css-pull-down-refresh-aaniya22/README.md
@@ -1,0 +1,20 @@
+# css-pull-down-refresh-aaniya22
+Pure CSS pull-down refresh indicator with a spinning icon animation. No JavaScript required — a hidden checkbox drives the "pulled" state for the demo, but the same `:checked ~` pattern can be swapped for a real touch/scroll-driven class toggle in production.
+
+## How to use
+```html
+<div class="ease-pull-refresh-aaniya22">
+  <input type="checkbox" id="pull-toggle-aaniya22" class="ease-pull-checkbox-aaniya22" />
+  <label for="pull-toggle-aaniya22" class="ease-pull-track-aaniya22">
+    <span class="ease-pull-icon-aaniya22">&#8635;</span>
+    <span class="ease-pull-text-aaniya22">Pull to refresh</span>
+  </label>
+  <div class="ease-pull-content-aaniya22">
+    <p>Content list item one</p>
+    <p>Content list item two</p>
+    <p>Content list item three</p>
+  </div>
+</div>
+```
+
+Checking the hidden checkbox reveals the refresh track (via `height` transition) and spins the refresh icon continuously with a CSS `@keyframes` animation — mimicking the classic pull-to-refresh interaction. Respects `prefers-reduced-motion` by disabling the spin.

--- a/submissions/examples/css-pull-down-refresh-aaniya22/demo.html
+++ b/submissions/examples/css-pull-down-refresh-aaniya22/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Pull-down Refresh — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <p class="label">Pure CSS Pull-down Refresh (check the box to simulate pulling)</p>
+  <div class="ease-pull-refresh-aaniya22">
+    <input type="checkbox" id="pull-toggle-aaniya22" class="ease-pull-checkbox-aaniya22" />
+    <label for="pull-toggle-aaniya22" class="ease-pull-track-aaniya22">
+      <span class="ease-pull-icon-aaniya22">&#8635;</span>
+      <span class="ease-pull-text-aaniya22">Pull to refresh</span>
+    </label>
+    <div class="ease-pull-content-aaniya22">
+      <p>Content list item one</p>
+      <p>Content list item two</p>
+      <p>Content list item three</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-pull-down-refresh-aaniya22/style.css
+++ b/submissions/examples/css-pull-down-refresh-aaniya22/style.css
@@ -1,0 +1,77 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+  padding: 3rem 1.5rem;
+  color: #fff;
+}
+.label {
+  color: rgba(255,255,255,0.3);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  margin-bottom: -1.5rem;
+}
+/* ── Pull-down Refresh ─────────────────────────────────────── */
+.ease-pull-refresh-aaniya22 {
+  width: 280px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+.ease-pull-checkbox-aaniya22 {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.ease-pull-track-aaniya22 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 0;
+  overflow: hidden;
+  cursor: pointer;
+  color: #38bdf8;
+  font-size: 0.85rem;
+  transition: height 0.4s ease;
+}
+.ease-pull-icon-aaniya22 {
+  display: inline-block;
+  font-size: 1.2rem;
+  transition: transform 0.4s ease;
+}
+.ease-pull-content-aaniya22 {
+  padding: 1.25rem;
+}
+.ease-pull-content-aaniya22 p {
+  padding: 0.5rem 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+/* Checked state: reveal the pull track and spin the icon */
+.ease-pull-checkbox-aaniya22:checked ~ .ease-pull-track-aaniya22 {
+  height: 3rem;
+}
+.ease-pull-checkbox-aaniya22:checked ~ .ease-pull-track-aaniya22 .ease-pull-icon-aaniya22 {
+  animation: ease-pull-spin-aaniya22 0.8s linear infinite;
+}
+@keyframes ease-pull-spin-aaniya22 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+/* ── Reduced Motion ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ease-pull-checkbox-aaniya22:checked ~ .ease-pull-track-aaniya22 .ease-pull-icon-aaniya22 {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure CSS pull-down refresh indicator with a spinning icon animation. Closes #70118.

---

## Type of Change
- [x] 🧩 New component

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/css-pull-down-refresh-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pull-down-to-refresh indicator that reveals a track with a continuously spinning refresh icon when "pulled."

**How does a developer use it?**
```html
<div class="ease-pull-refresh-aaniya22">
  <input type="checkbox" id="pull-toggle-aaniya22" class="ease-pull-checkbox-aaniya22" />
  <label for="pull-toggle-aaniya22" class="ease-pull-track-aaniya22">
    <span class="ease-pull-icon-aaniya22">&#8635;</span>
    <span class="ease-pull-text-aaniya22">Pull to refresh</span>
  </label>
  <div class="ease-pull-content-aaniya22">
    <p>Content list item one</p>
    <p>Content list item two</p>
    <p>Content list item three</p>
  </div>
</div>
```

**Why does it fit EaseMotion CSS?**
Pure CSS, zero dependencies — a hidden checkbox with a `:checked ~` sibling selector drives the pulled state, revealing the track via a `height` transition and spinning the icon with a CSS `@keyframes` animation. The same `:checked ~` pattern maps directly onto a real scroll/touch-driven class toggle in production. A `prefers-reduced-motion` query disables the spin for users who prefer reduced motion.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
For the demo, a checkbox toggle simulates the "pulled" state since this is pure CSS with no JS — in a real app the `:checked` trigger would be replaced by a class toggled on scroll/touch. Happy to adjust the interaction pattern if a different demo approach is preferred.