### PR TITLE
feat: add ease-hover-underline-grow-sap

### DIFF
--- a/submissions/examples/ease-hover-underline-grow-sap/README.md
+++ b/submissions/examples/ease-hover-underline-grow-sap/README.md
@@ -1,0 +1,28 @@
+# Hover Underline Grow
+
+Nav links whose underline grows in from the left edge on hover/focus,
+instead of a plain always-on or instant-toggle underline.
+
+**Level:** Beginner
+
+## Usage
+
+Apply `.grow-link` to any inline link. The underline is a `::after`
+pseudo-element scaled via `transform: scaleX()` from `transform-origin: left`.
+
+## Accessibility
+
+- Effect triggers on `:focus-visible` as well as `:hover`, so keyboard users
+  tabbing through the nav see the same growing-underline feedback.
+- `:focus-visible` also adds a separate visible outline, so focus isn't
+  indicated by the underline animation alone.
+- `prefers-reduced-motion` removes the transition; the underline still
+  appears on hover/focus, just instantly instead of growing.
+
+## Notes
+
+- Uses `transform: scaleX()` (not `width`) for the grow animation, which is
+  compositor-friendly and avoids layout recalculation on every frame.
+- `transform-origin: left` ensures the line grows rightward from the start
+  of the word, matching reading direction for LTR text — mirror to `right`
+  for RTL contexts if needed.

--- a/submissions/examples/ease-hover-underline-grow-sap/demo.html
+++ b/submissions/examples/ease-hover-underline-grow-sap/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Underline Grow</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Underline Grow</h1>
+
+    <nav class="grow-nav" aria-label="Primary">
+      <a href="#" class="grow-link">Home</a>
+      <a href="#" class="grow-link">Products</a>
+      <a href="#" class="grow-link">About</a>
+      <a href="#" class="grow-link">Contact</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-hover-underline-grow-sap/style.css
+++ b/submissions/examples/ease-hover-underline-grow-sap/style.css
@@ -1,0 +1,62 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.grow-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.grow-link {
+  position: relative;
+  text-decoration: none;
+  color: #334155;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding-bottom: 4px;
+}
+
+.grow-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: #6366f1;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.grow-link:hover::after,
+.grow-link:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.grow-link:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grow-link::after { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-underline-grow-sap`, nav links with a grow-in underline on hover/focus.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-underline-grow-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Underline grows on `:focus-visible` as well as `:hover`, with a separate
  outline also shown, so keyboard users get parity with mouse users.
- Uses `transform: scaleX()` instead of animating `width`, keeping the
  effect off the layout/reflow path.

## Feature Description

Adds a reusable grow-in underline hover effect for nav links.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.