### PR TITLE
feat: add ease-scroll-image-parallax-tilt-sap

### DIFF
--- a/submissions/examples/ease-scroll-image-parallax-tilt-sap/README.md
+++ b/submissions/examples/ease-scroll-image-parallax-tilt-sap/README.md
@@ -1,0 +1,34 @@
+# Scroll Image Parallax Tilt
+
+An image that drifts vertically and tilts slightly as the page scrolls,
+based on its position relative to the viewport, using scroll-driven
+transforms rather than fixed keyframe animation.
+
+**Level:** Advanced
+
+## Usage
+
+The `.tilt-img` is taller than its `.tilt-frame` container (`height: 130%`)
+so it has room to drift without exposing empty space. A scroll listener
+computes a 0–1 progress value from the frame's viewport position and maps
+it to a `translateY` + `rotate` transform.
+
+## Accessibility
+
+- The transform is driven purely by scroll position, not a looping
+  animation, so it never moves without direct user scrolling action.
+- `prefers-reduced-motion` is checked in JS before applying any transform on
+  scroll (the handler returns early), and CSS additionally forces
+  `transform: none !important` as a hard guarantee the image stays static
+  for motion-reduced users regardless of any residual inline style.
+- Scroll listener is `{ passive: true }` for scroll performance.
+
+## Notes
+
+- Progress calculation:
+  `(viewportHeight - elementTop) / (viewportHeight + elementHeight)`,
+  clamped to `[0, 1]` — gives a smooth 0→1 sweep as the element travels
+  through the viewport, independent of page length.
+- Oversized image (`height: 130%`) combined with `overflow: hidden` on the
+  frame is what allows the vertical drift without revealing gaps at the
+  frame edges.

--- a/submissions/examples/ease-scroll-image-parallax-tilt-sap/demo.html
+++ b/submissions/examples/ease-scroll-image-parallax-tilt-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Image Parallax Tilt</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Image Parallax Tilt</h1><p>Scroll down — the image drifts and tilts based on scroll position.</p></section>
+
+    <section class="tilt-section">
+      <div class="tilt-frame">
+        <img src="https://picsum.photos/seed/tilt/500/500" alt="Abstract architectural photo" class="tilt-img" id="tiltImg">
+      </div>
+    </section>
+
+    <section class="spacer"><p>More scroll space below.</p></section>
+  </main>
+
+  <script>
+    const img = document.getElementById('tiltImg');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function onScroll() {
+      if (reduceMotion) return;
+      const rect = img.parentElement.getBoundingClientRect();
+      const progress = (window.innerHeight - rect.top) / (window.innerHeight + rect.height);
+      const clamped = Math.min(Math.max(progress, 0), 1);
+      const translateY = (clamped - 0.5) * 60;
+      const rotate = (clamped - 0.5) * 10;
+      img.style.transform = `translateY(${translateY}px) rotate(${rotate}deg)`;
+    }
+
+    document.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-image-parallax-tilt-sap/style.css
+++ b/submissions/examples/ease-scroll-image-parallax-tilt-sap/style.css
@@ -1,0 +1,47 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  margin: 0;
+}
+
+.content { max-width: 700px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #64748b; }
+
+.tilt-section {
+  min-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tilt-frame {
+  width: 320px;
+  height: 320px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 25px 60px rgba(0,0,0,0.18);
+}
+
+.tilt-img {
+  width: 100%;
+  height: 130%;
+  object-fit: cover;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tilt-img { transform: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-image-parallax-tilt-sap`, a scroll-driven parallax drift + tilt effect for an image.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-image-parallax-tilt-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Reduced motion is enforced twice: the JS scroll handler returns early
  without computing/setting a transform, and CSS also forces
  `transform: none !important` as a hard backstop.
- Movement is purely scroll-position-driven (no autoplaying loop), so it
  only ever moves in direct response to the user's own scrolling.

## Feature Description

Adds a reusable scroll-driven parallax tilt image component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.