### PR TITLE
feat: add simple note box demo

### DIFF
--- a/submissions/examples/simple-note-box-kk/README.md
+++ b/submissions/examples/simple-note-box-kk/README.md
@@ -1,0 +1,34 @@
+# Simple Note Box
+
+## What it does
+
+This submission creates a simple CSS-only note box utility for short notes, reminders, tips, and contextual information.
+
+## How to use it
+
+Wrap the note title and supporting message inside the shared container:
+
+```html
+<div class="simple-note-box">
+  <strong>Note</strong>
+  <p>This setting can be changed later.</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in documentation pages, dashboards, forms, settings panels, and content sections.
+
+## Included features
+
+- Simple note box utility
+- Soft variation included in the demo
+- Practical note, tip, and reminder examples
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the note-box utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/simple-note-box-kk/demo.html
+++ b/submissions/examples/simple-note-box-kk/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple Note Box</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Simple Note Box</p>
+          <h1>Small reusable note containers for tips, reminders, and messages.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only note box utility for short
+            notes, reminders, tips, and contextual information in forms,
+            dashboards, documentation pages, and content sections.
+          </p>
+        </header>
+
+        <section class="note-grid">
+          <div class="simple-note-box">
+            <strong>Note</strong>
+            <p>This setting can be changed later from your account preferences.</p>
+          </div>
+
+          <div class="simple-note-box soft">
+            <strong>Tip</strong>
+            <p>Use short note boxes to keep helpful information close to the related content.</p>
+          </div>
+
+          <div class="simple-note-box">
+            <strong>Reminder</strong>
+            <p>Review the form before submitting changes to your workspace.</p>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="simple-note-box"&gt;
+  &lt;strong&gt;Note&lt;/strong&gt;
+  &lt;p&gt;This setting can be changed later.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/simple-note-box-kk/style.css
+++ b/submissions/examples/simple-note-box-kk/style.css
@@ -1,0 +1,113 @@
+:root {
+  color-scheme: dark;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --panel-muted: rgba(255, 255, 255, 0.05);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.62);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.note-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.simple-note-box,
+.usage-panel {
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--panel-soft);
+}
+
+.simple-note-box.soft {
+  background: var(--panel-muted);
+}
+
+.simple-note-box strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.simple-note-box p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .note-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Simple Note Box demo inside `submissions/examples/simple-note-box-kk/`. This submission introduces a simple CSS-only note box utility for short notes, reminders, tips, and contextual information.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only note box utility for displaying short notes, tips, reminders, and contextual messages.

**How does a developer use it?**

```html
<div class="simple-note-box">
  <strong>Note</strong>
  <p>This setting can be changed later.</p>
</div>