### PR TITLE
feat: add pure CSS Loader Minimalist Outline component (#73301)

### DIFF
--- a/submissions/examples/css-loader-minimalist-outline-pure/README.md
+++ b/submissions/examples/css-loader-minimalist-outline-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Loader: Minimalist Outline
+
+A clean, ultra-modern loading spinner utilizing SVG stroke-dasharray animations for a precise, continuous outline trace.
+
+## Features
+- Pure CSS and HTML implementation relying on inline SVG stroke manipulation.
+- **Component Architecture**: 
+  - **SVG Foundation**: To achieve perfectly crisp, curved lines at any scale, the component uses an inline `<svg>` containing two `<circle>` elements (a subtle track and the animated trace).
+  - **Stroke Dasharray Magic**: The core animation relies on SVG `stroke-dasharray` and `stroke-dashoffset`. By setting both properties to the exact circumference of the circle (283 for a radius of 45), the stroke is completely hidden. 
+  - **The Tracing Animation**: The `@keyframes draw-line` animation manipulates the `stroke-dashoffset` down to 70 and back up to 283. This causes the stroke to elegantly draw itself in and then erase itself.
+  - **Dual Spin Dynamics**: To achieve the classic "chasing its own tail" dynamic feel, two rotations are happening simultaneously. The entire SVG container spins constantly using a `linear` keyframe, while the `<circle>` path itself spins using the `ease-in-out` keyframe alongside the stroke manipulation.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the stroke colors to remain legible and pleasing on dark backgrounds.
+- Fully accessible semantic structure. The decorative SVG is hidden from screen readers using `aria-hidden="true"`, and the loader container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by freezing all spinning and stroking animations, locking the loader into a clean, static half-circle for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser to view the minimalist outline loading animation.
+
+## Files
+- `demo.html`: The HTML structure defining the SVG, the background track circle, and the animated tracing circle.
+- `style.css`: The styling, the `stroke-dasharray` logic, and the dual-spin keyframe animations.

--- a/submissions/examples/css-loader-minimalist-outline-pure/demo.html
+++ b/submissions/examples/css-loader-minimalist-outline-pure/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Loader: Minimalist Outline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Loader: Minimalist Outline</h1>
+            <p class="subtitle">A clean, ultra-modern loading spinner utilizing SVG stroke-dasharray animations for a precise, continuous outline trace.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="loader-container" aria-label="Loading content, minimalist outline animation playing">
+                
+                <!-- 
+                  [TECHNIQUE] Minimalist Outline
+                  Using an inline SVG allows us to perfectly animate the stroke
+                  of a shape without any jagged CSS borders or clipping issues.
+                -->
+                <div class="outline-wrapper" aria-hidden="true">
+                    
+                    <svg class="minimalist-svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                        <!-- A subtle track in the background -->
+                        <circle class="outline-track" cx="50" cy="50" r="45"></circle>
+                        <!-- The animated tracing line -->
+                        <circle class="outline-trace" cx="50" cy="50" r="45"></circle>
+                    </svg>
+                    
+                </div>
+                
+                <div class="loading-text">Loading</div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-loader-minimalist-outline-pure/style.css
+++ b/submissions/examples/css-loader-minimalist-outline-pure/style.css
@@ -1,0 +1,198 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    --loader-bg: #ffffff;
+    
+    /* Outline Colors */
+    --outline-color: #3b82f6; /* Modern Blue */
+    --outline-track: #e2e8f0; /* Subtle Gray */
+    --outline-width: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        
+        --loader-bg: #1e293b;
+        --outline-color: #60a5fa; /* Lighter Blue for dark mode */
+        --outline-track: #334155;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+}
+
+
+/* =========================================
+   Loader Container
+   ========================================= */
+
+.loader-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 30px;
+    padding: 60px 100px;
+    background-color: var(--loader-bg);
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Minimalist Outline
+   ========================================= */
+
+.outline-wrapper {
+    width: 64px;
+    height: 64px;
+    /* The SVG itself spins continuously */
+    animation: svg-spin 2s linear infinite;
+}
+
+.minimalist-svg {
+    width: 100%;
+    height: 100%;
+    /* Ensure no clipping */
+    overflow: visible;
+}
+
+/* Base styles for both SVG circles */
+.outline-track, .outline-trace {
+    fill: none;
+    stroke-width: var(--outline-width);
+    /* Round the ends of the stroke for a polished look */
+    stroke-linecap: round;
+}
+
+.outline-track {
+    stroke: var(--outline-track);
+}
+
+/* 
+   The magic happens here:
+   Circumference of a circle with r=45 is 2 * PI * 45 = ~283.
+   We set dasharray to 283 so we have full control over the line drawing.
+*/
+.outline-trace {
+    stroke: var(--outline-color);
+    
+    stroke-dasharray: 283;
+    stroke-dashoffset: 283;
+    
+    /* Animate the stroke being drawn and erased */
+    animation: draw-line 1.5s ease-in-out infinite;
+    
+    /* Hardware acceleration */
+    transform-origin: center;
+    transform: translateZ(0);
+}
+
+.loading-text {
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--outline-color);
+    
+    /* A subtle pulse on the text matches the elegant vibe */
+    animation: text-pulse 1.5s ease-in-out infinite;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+/* Spin the entire SVG container continuously */
+@keyframes svg-spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+/* 
+   Draw the line, then erase the line.
+   Because the SVG itself is spinning, this creates the classic 
+   "chasing its own tail" loading effect.
+*/
+@keyframes draw-line {
+    0% {
+        stroke-dashoffset: 283;
+    }
+    50% {
+        stroke-dashoffset: 70; /* The line is mostly drawn */
+        transform: rotate(135deg); /* Spin the circle path itself for extra dynamic motion */
+    }
+    100% {
+        stroke-dashoffset: 283;
+        transform: rotate(450deg); /* Complete the internal spin */
+    }
+}
+
+@keyframes text-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .outline-wrapper, .outline-trace, .loading-text {
+        animation: none !important;
+    }
+    
+    /* Display a static half-circle for static users */
+    .outline-trace {
+        stroke-dashoffset: 141; /* ~50% of 283 */
+    }
+    
+    .loading-text {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a clean, ultra-modern loading spinner utilizing SVG stroke-dasharray animations for a precise, continuous outline trace. Resolves issue #73301.

### Changes Made:
- Added `submissions/examples/css-loader-minimalist-outline-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the SVG, the background track circle, and the animated tracing circle.
- Created `style.css` featuring the UI mechanics:
  - **SVG Foundation**: To achieve perfectly crisp, curved lines at any scale, the component uses an inline `<svg>` containing two `<circle>` elements (a subtle track and the animated trace).
  - **Stroke Dasharray Magic**: The core animation relies on SVG `stroke-dasharray` and `stroke-dashoffset`. By setting both properties to the exact circumference of the circle (283 for a radius of 45), the stroke is completely hidden. 
  - **The Tracing Animation**: The `@keyframes draw-line` animation manipulates the `stroke-dashoffset` down to 70 and back up to 283. This causes the stroke to elegantly draw itself in and then erase itself.
  - **Dual Spin Dynamics**: To achieve the classic "chasing its own tail" dynamic feel, two rotations are happening simultaneously. The entire SVG container spins constantly using a `linear` keyframe, while the `<circle>` path itself spins using the `ease-in-out` keyframe alongside the stroke manipulation.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. Automatically respects the OS-level system theme (`prefers-color-scheme: dark`), adapting the stroke colors to remain legible and pleasing on dark backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the `stroke-dasharray` logic and dual-spin keyframe animations.
- Fully accessible semantic structure. The decorative SVG is hidden from screen readers using `aria-hidden="true"`, and the loader container provides an `aria-label` detailing the loading status. Honors the `prefers-reduced-motion` accessibility standard by freezing all spinning and stroking animations, locking the loader into a clean, static half-circle for motion-sensitive users.

Closes #73301
