### PR TITLE
feat: add tiny meta line demo

### DIFF
--- a/submissions/examples/tiny-meta-line-kk/README.md
+++ b/submissions/examples/tiny-meta-line-kk/README.md
@@ -1,0 +1,31 @@
+# Tiny Meta Line
+
+## What it does
+
+This submission creates a simple CSS-only tiny metadata line utility for dates, authors, categories, statuses, reading time, and compact supporting details.
+
+## How to use it
+
+Apply the class directly to a metadata text line:
+
+```html
+<p class="tiny-meta-line">Updated today · 4 min read</p>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, article previews, activity rows, changelog items, and content blocks.
+
+## Included features
+
+- Tiny metadata text utility
+- Practical article and dashboard examples
+- Muted compact supporting text
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the meta-line utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/tiny-meta-line-kk/demo.html
+++ b/submissions/examples/tiny-meta-line-kk/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tiny Meta Line</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Tiny Meta Line</p>
+          <h1>Small metadata text for cards, articles, and activity rows.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only metadata line utility for
+            dates, authors, categories, statuses, reading time, and compact
+            supporting details.
+          </p>
+        </header>
+
+        <section class="meta-grid">
+          <article class="content-card">
+            <p class="tiny-meta-line">Updated today · 4 min read</p>
+            <h2>Product Update</h2>
+            <p>Use tiny metadata above titles to give quick context without adding visual weight.</p>
+          </article>
+
+          <article class="content-card">
+            <p class="tiny-meta-line">By Kriti · Frontend</p>
+            <h2>Design Notes</h2>
+            <p>This utility works well in article previews, changelog cards, and documentation blocks.</p>
+          </article>
+
+          <article class="content-card">
+            <p class="tiny-meta-line">Active · Last checked 2m ago</p>
+            <h2>Status Row</h2>
+            <p>Small metadata lines can also support dashboard widgets and activity summaries.</p>
+          </article>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;p class="tiny-meta-line"&gt;Updated today · 4 min read&lt;/p&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tiny-meta-line-kk/style.css
+++ b/submissions/examples/tiny-meta-line-kk/style.css
@@ -1,0 +1,110 @@
+:root {
+  color-scheme: dark;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.55);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.content-card p:not(.tiny-meta-line) {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.content-card,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.tiny-meta-line {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.content-card h2 {
+  margin: 0.45rem 0 0.4rem;
+  font-size: 1.15rem;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .meta-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Tiny Meta Line demo inside `submissions/examples/tiny-meta-line-kk/`. This submission introduces a simple CSS-only metadata line utility for dates, authors, categories, statuses, reading time, and compact supporting details.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only tiny metadata line utility for displaying dates, authors, categories, statuses, reading time, and compact supporting details.

**How does a developer use it?**

```html
<p class="tiny-meta-line">Updated today · 4 min read</p>