### PR TITLE
feat: add ease-scroll-reveal-mask-text-sap

### DIFF
--- a/submissions/examples/ease-scroll-reveal-mask-text-sap/README.md
+++ b/submissions/examples/ease-scroll-reveal-mask-text-sap/README.md
@@ -1,0 +1,34 @@
+# Scroll Reveal Mask Text
+
+Heading lines that are clipped inside an overflow-hidden wrapper and slide
+up from below into view as they scroll into the viewport, a common
+editorial-site "masked text reveal" effect.
+
+**Level:** Intermediate
+
+## Usage
+
+Wrap each line of text in `.mask-line > span` (the outer `.mask-line` is
+`overflow: hidden` and acts as the mask; the inner `span` is what
+translates). An `IntersectionObserver` adds `.is-revealed` to each inner
+span once its line crosses 40% visibility.
+
+## Accessibility
+
+- The text content itself is present in the DOM from the start (not
+  injected after reveal), so it's readable immediately by screen readers
+  and non-JS/no-animation contexts — only the visual reveal is deferred.
+- Each line's animation triggers once (`unobserve` after triggering), so
+  scrolling back up and down doesn't repeatedly hide/reveal the text oddly.
+- `prefers-reduced-motion` sets the inner spans to their final
+  `translateY(0)` position immediately with no transition, so text is fully
+  visible without waiting on any scroll-triggered reveal.
+
+## Notes
+
+- The "mask" is just `overflow: hidden` on the line wrapper combined with
+  the inner span starting below its own line height (`translateY(110%)`),
+  so no clip-path or actual CSS mask is needed.
+- Because the observer only adds a class (not `visibility`/`display`), the
+  underlying text is always selectable/readable in the DOM even before the
+  visual animation completes.

--- a/submissions/examples/ease-scroll-reveal-mask-text-sap/demo.html
+++ b/submissions/examples/ease-scroll-reveal-mask-text-sap/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Reveal Mask Text</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="hero"><p>Scroll down to reveal the heading.</p></header>
+
+  <main class="content">
+    <h2 class="mask-heading">
+      <span class="mask-line"><span>Design with intention,</span></span>
+      <span class="mask-line"><span>build with clarity.</span></span>
+    </h2>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <script>
+    const lines = document.querySelectorAll('.mask-line > span');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-revealed');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.4 });
+
+    lines.forEach(line => observer.observe(line));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-mask-text-sap/style.css
+++ b/submissions/examples/ease-scroll-reveal-mask-text-sap/style.css
@@ -1,0 +1,57 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #fafaf9;
+  color: #1c1917;
+  margin: 0;
+}
+
+.hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #78716c;
+}
+
+.content {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2rem;
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mask-heading {
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
+  font-weight: 800;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.mask-line {
+  display: block;
+  overflow: hidden;
+}
+
+.mask-line span {
+  display: inline-block;
+  transform: translateY(110%);
+  transition: transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mask-line span.is-revealed {
+  transform: translateY(0);
+}
+
+.spacer { min-height: 50vh; display: flex; align-items: center; justify-content: center; color: #a8a29e; }
+
+@media (prefers-reduced-motion: reduce) {
+  .mask-line span {
+    transition: none;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-reveal-mask-text-sap`, scroll-triggered masked text-line reveal for headings.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-reveal-mask-text-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Text is present in the DOM from load (not injected post-reveal), so it's
  always readable by screen readers and in no-JS contexts — only the visual
  slide-up is deferred.
- Each line unobserves itself after its first reveal, so repeated
  scroll-past doesn't retrigger or glitch the animation.

## Feature Description

Adds a reusable scroll-triggered masked text reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.