### PR TITLE
feat: add ease-hover-3d-button-press-sap

### DIFF
--- a/submissions/examples/ease-hover-3d-button-press-sap/README.md
+++ b/submissions/examples/ease-hover-3d-button-press-sap/README.md
@@ -1,0 +1,34 @@
+# 3D Button Press
+
+Buttons with a solid drop-shadow "3D" base that physically compress
+downward on press, mimicking a real physical button (common in game UI and
+playful product sites).
+
+**Level:** Beginner
+
+## Usage
+
+Apply `.press-btn` plus a color modifier (`press-indigo`, `press-green`) to
+any `<button>`. The 3D effect is a solid `box-shadow` offset that shrinks to
+zero as the button moves down on `:active`.
+
+## Accessibility
+
+- Built on real `<button>` elements, so it's keyboard-operable by default —
+  the `:active` press state also triggers on Enter/Space activation, not
+  just mouse/touch press, since `:active` applies during keyboard
+  activation of buttons in modern browsers.
+- `:focus-visible` outline included, independent of the press-depth effect,
+  so focus is never indicated only by button color/shadow.
+- `prefers-reduced-motion` removes the `top`/`box-shadow` transition; the
+  button still visibly compresses on press (state change is instant rather
+  than eased), preserving the core press feedback without an animated glide.
+
+## Notes
+
+- Each color variant defines its own solid shadow color to match, so the
+  "3D depth" always reads correctly regardless of which variant is used.
+- The compress effect works by animating `top` (relative positioning) paired
+  with shrinking `box-shadow` to zero, rather than `transform: translateY`,
+  so the shadow's vertical offset and the button's visual position stay
+  perfectly in sync through the whole travel distance.

--- a/submissions/examples/ease-hover-3d-button-press-sap/demo.html
+++ b/submissions/examples/ease-hover-3d-button-press-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>3D Button Press</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>3D Button Press</h1>
+
+    <button class="press-btn press-indigo">Get Started</button>
+    <button class="press-btn press-green">Confirm</button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-hover-3d-button-press-sap/style.css
+++ b/submissions/examples/ease-hover-3d-button-press-sap/style.css
@@ -1,0 +1,63 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.press-btn {
+  padding: 0.9rem 2rem;
+  border-radius: 12px;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: white;
+  cursor: pointer;
+  position: relative;
+  top: 0;
+  transition: top 0.1s ease, box-shadow 0.1s ease;
+}
+
+.press-indigo {
+  background: #6366f1;
+  box-shadow: 0 6px 0 #4338ca;
+}
+
+.press-green {
+  background: #22c55e;
+  box-shadow: 0 6px 0 #15803d;
+}
+
+.press-btn:hover { filter: brightness(1.05); }
+
+.press-btn:active {
+  top: 6px;
+  box-shadow: 0 0 0 transparent;
+}
+
+.press-indigo:active { box-shadow: 0 0 0 #4338ca; }
+.press-green:active { box-shadow: 0 0 0 #15803d; }
+
+.press-btn:focus-visible {
+  outline: 2px solid #1e293b;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .press-btn { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-3d-button-press-sap`, buttons with a solid-shadow 3D press-down effect.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-3d-button-press-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Built on real `<button>` elements, so the `:active` press state applies
  during keyboard (Enter/Space) activation too, not just pointer press.
- Press effect animates `top` alongside a shrinking `box-shadow` (instead of
  `transform`), keeping the shadow depth and button position visually in
  sync through the full travel distance.

## Feature Description

Adds a reusable 3D press-down button component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.