### PR TITLE
feat: add pure CSS Modal Cyberpunk Neon component (#73421)

### DIFF
--- a/submissions/examples/css-modal-cyberpunk-neon-pure/README.md
+++ b/submissions/examples/css-modal-cyberpunk-neon-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Modal: Cyberpunk Neon
+
+A high-voltage, JavaScript-free modal utilizing the CSS checkbox hack, featuring aggressive neon glows, scanlines, and CSS clip-path geometry.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to open or close the modal.
+- **Component Architecture**: 
+  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox.
+  - **Clipped Geometry**: The modal card and buttons utilize `clip-path: polygon()` to slice off the corners, creating the signature angular, hardware-style aesthetic common in cyberpunk designs.
+  - **Neon Accents**: Aggressive use of `box-shadow` and `text-shadow` across multiple layers simulates glowing neon tubes. A pseudo-element (`::before`) on the modal card traces the top and right edges with a solid neon pink line to emphasize the angular shape.
+  - **Scanline Overlay**: A `.scanlines` container sits over the modal background using a tightly packed `repeating-linear-gradient` to simulate the raster lines of an old CRT monitor or heads-up display.
+  - **Glitch Animation**: The `ONLINE` status text utilizes a stepped `@keyframes flicker` animation, rapidly dropping its opacity to `0.2` at specific percentage intervals to simulate a failing electrical connection.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The modal is inherently designed for a dark aesthetic, utilizing a stark black background (`#09090b`) to ensure the high-contrast cyan, pink, and yellow neon accents pop aggressively.
+- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. The decorative scanlines are hidden from screen readers using `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the text flicker animations and removing the modal pop-in transition for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the "INITIATE_UPLINK" button to trigger the checkbox hack and reveal the modal.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox logic, the modal overlay, the scanlines, and the system content.
+- `style.css`: The styling, the `:checked` sibling selector logic, the `clip-path` geometry, and the `repeating-linear-gradient` scanlines.

--- a/submissions/examples/css-modal-cyberpunk-neon-pure/demo.html
+++ b/submissions/examples/css-modal-cyberpunk-neon-pure/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Modal: Cyberpunk Neon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Modal: Cyberpunk Neon</h1>
+            <p class="subtitle">A high-voltage, JavaScript-free modal utilizing the checkbox hack, featuring aggressive neon glows, scanlines, and CSS clip-path geometry.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Modal (Checkbox Hack)
+              The button is actually a <label> tied to a hidden checkbox.
+              When clicked, the checkbox state changes to :checked, which
+              triggers CSS sibling selectors to reveal the modal.
+            -->
+            <input type="checkbox" id="modal-toggle" class="modal-toggle-input" aria-hidden="true">
+            
+            <!-- Trigger Button -->
+            <label for="modal-toggle" class="btn-trigger cyberpunk-border" role="button" tabindex="0">
+                INITIATE_UPLINK
+            </label>
+            
+            <!-- Modal Overlay & Content -->
+            <div class="modal-overlay">
+                
+                <!-- Clicking the overlay closes the modal by untoggling the checkbox -->
+                <label for="modal-toggle" class="modal-backdrop" aria-label="Close modal"></label>
+                
+                <div class="modal-card cyberpunk-border" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                    
+                    <!-- Scanline Overlay -->
+                    <div class="scanlines" aria-hidden="true"></div>
+                    
+                    <!-- Modal Content Layer -->
+                    <div class="modal-content">
+                        <div class="sys-header">
+                            <span class="sys-id">SYS.REQ // 0x7B9A</span>
+                            <span class="sys-status animate-flicker">ONLINE</span>
+                        </div>
+                        
+                        <h2 id="modal-title" class="modal-title">SYSTEM_BREACH_DETECTED</h2>
+                        
+                        <p class="modal-text">
+                            WARNING: Unauthorized access to mainframe terminal. The pure CSS modal has successfully initialized using the checkbox hack. Proceed with extreme caution.
+                        </p>
+                        
+                        <div class="modal-actions">
+                            <label for="modal-toggle" class="btn-action outline">ABORT</label>
+                            <label for="modal-toggle" class="btn-action primary">OVERRIDE</label>
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-cyberpunk-neon-pure/style.css
+++ b/submissions/examples/css-modal-cyberpunk-neon-pure/style.css
@@ -1,0 +1,363 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    /* Cyberpunk Theme */
+    --cp-bg: #09090b;
+    --cp-neon-cyan: #00f3ff;
+    --cp-neon-pink: #ff003c;
+    --cp-neon-yellow: #fcee0a;
+    
+    --cp-text: #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #050505;
+        --text-primary: #f8fafc;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* Rajdhani is an excellent, slightly squared tech font */
+    font-family: 'Rajdhani', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    font-family: 'Inter', sans-serif; /* Keep headers clean */
+}
+
+.subtitle {
+    color: #64748b;
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    font-family: 'Inter', sans-serif;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+    position: relative; 
+    
+    /* Give the demo area a dark, gritty background so the neon pops */
+    background-color: var(--cp-bg);
+    border-radius: 12px;
+    border: 1px solid rgba(255,255,255,0.05);
+}
+
+
+/* =========================================
+   Cyberpunk UI Elements
+   ========================================= */
+
+/* A shared class for the clipped, glowing border look */
+.cyberpunk-border {
+    position: relative;
+    background: transparent;
+    color: var(--cp-neon-cyan);
+    border: 1px solid var(--cp-neon-cyan);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 600;
+    
+    /* 
+       Aggressive neon glow using multi-layered box shadows
+    */
+    box-shadow: 
+        0 0 5px rgba(0, 243, 255, 0.2),
+        inset 0 0 5px rgba(0, 243, 255, 0.2);
+        
+    /* Classic cyberpunk clipped corner */
+    clip-path: polygon(
+        0 0, 
+        100% 0, 
+        100% calc(100% - 15px), 
+        calc(100% - 15px) 100%, 
+        0 100%
+    );
+}
+
+.btn-trigger {
+    display: inline-block;
+    padding: 16px 32px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    background-color: rgba(0, 243, 255, 0.05);
+    transition: all 0.3s ease;
+}
+
+.btn-trigger:hover {
+    background-color: var(--cp-neon-cyan);
+    color: var(--cp-bg);
+    box-shadow: 
+        0 0 15px var(--cp-neon-cyan),
+        inset 0 0 10px var(--cp-neon-cyan);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Modal Checkbox Logic
+   ========================================= */
+
+.modal-toggle-input {
+    display: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* Heavy, dark backdrop */
+    background-color: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(2px);
+    cursor: pointer;
+}
+
+
+/* =========================================
+   Cyberpunk Modal Styling
+   ========================================= */
+
+.modal-card {
+    position: relative;
+    width: 90%;
+    max-width: 500px;
+    background-color: var(--cp-bg);
+    
+    /* Override the base clipped corner for a larger cut */
+    clip-path: polygon(
+        0 0, 
+        calc(100% - 30px) 0, 
+        100% 30px, 
+        100% 100%, 
+        30px 100%, 
+        0 calc(100% - 30px)
+    );
+    
+    /* 
+       Glitchy pop-in animation:
+       Starts translated down, but snaps into place instantly rather than smoothly.
+    */
+    transform: translateY(40px);
+    opacity: 0;
+    transition: all 0.1s steps(3, end);
+}
+
+.modal-toggle-input:checked ~ .modal-overlay .modal-card {
+    transform: translateY(0);
+    opacity: 1;
+}
+
+/* 
+   A pseudo-element to create the thick, colorful border accent
+   that traces the top and right edges.
+*/
+.modal-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    border-top: 4px solid var(--cp-neon-pink);
+    border-right: 4px solid var(--cp-neon-pink);
+    pointer-events: none;
+    z-index: 2;
+}
+
+/* =========================================
+   Scanline Effect
+   ========================================= */
+
+.scanlines {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    pointer-events: none;
+    
+    /* Repeating linear gradient creates the CRT scanline effect */
+    background: repeating-linear-gradient(
+        0deg,
+        rgba(0, 0, 0, 0.15),
+        rgba(0, 0, 0, 0.15) 1px,
+        transparent 1px,
+        transparent 2px
+    );
+}
+
+
+/* =========================================
+   Modal Content
+   ========================================= */
+
+.modal-content {
+    position: relative;
+    z-index: 3;
+    padding: 40px;
+}
+
+.sys-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9rem;
+    color: var(--cp-neon-cyan);
+    margin-bottom: 24px;
+    border-bottom: 1px dashed rgba(0, 243, 255, 0.3);
+    padding-bottom: 8px;
+}
+
+.sys-status {
+    color: var(--cp-neon-yellow);
+}
+
+.modal-title {
+    color: var(--cp-neon-pink);
+    margin: 0 0 16px 0;
+    font-size: 2rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    text-shadow: 0 0 8px rgba(255, 0, 60, 0.4);
+}
+
+.modal-text {
+    color: var(--cp-text);
+    font-size: 1.1rem;
+    line-height: 1.6;
+    margin: 0 0 40px 0;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+}
+
+.btn-action {
+    display: inline-block;
+    padding: 12px 24px;
+    font-size: 1.1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    /* Consistent clipped aesthetic */
+    clip-path: polygon(
+        0 0, 
+        100% 0, 
+        100% calc(100% - 10px), 
+        calc(100% - 10px) 100%, 
+        0 100%
+    );
+}
+
+.btn-action.outline {
+    background: transparent;
+    color: var(--cp-text);
+    border: 1px solid var(--cp-text);
+}
+
+.btn-action.outline:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.btn-action.primary {
+    background-color: var(--cp-neon-pink);
+    color: var(--cp-bg);
+    border: 1px solid var(--cp-neon-pink);
+    box-shadow: 0 0 10px rgba(255, 0, 60, 0.5);
+}
+
+.btn-action.primary:hover {
+    background-color: #ff3366;
+    box-shadow: 0 0 20px rgba(255, 0, 60, 0.8);
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+
+@keyframes flicker {
+    0%, 19.999%, 22%, 62.999%, 64%, 64.999%, 70%, 100% {
+        opacity: 1;
+    }
+    20%, 21.999%, 63%, 63.999%, 65%, 69.999% {
+        opacity: 0.2;
+    }
+}
+
+.animate-flicker {
+    animation: flicker 3s infinite alternate;
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay {
+        transition: none;
+    }
+    .modal-card {
+        transition: none;
+        transform: translateY(0);
+    }
+    .animate-flicker {
+        animation: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a high-voltage, JavaScript-free modal utilizing the CSS checkbox hack, featuring aggressive neon glows, scanlines, and CSS clip-path geometry. Resolves issue #73421.

### Changes Made:
- Added `submissions/examples/css-modal-cyberpunk-neon-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox logic, the modal overlay, the scanlines, and the system content.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox, triggering CSS opacity/visibility rules on the modal overlay.
  - **Clipped Geometry**: The modal card and buttons utilize `clip-path: polygon()` to slice off the corners, creating the signature angular, hardware-style aesthetic common in cyberpunk designs.
  - **Neon Accents**: Aggressive use of `box-shadow` and `text-shadow` across multiple layers simulates glowing neon tubes. A pseudo-element (`::before`) on the modal card traces the top and right edges with a solid neon pink line to emphasize the angular shape.
  - **Scanline Overlay**: A `.scanlines` container sits over the modal background using a tightly packed `repeating-linear-gradient` to simulate the raster lines of an old CRT monitor or heads-up display.
  - **Glitch Animation**: The `ONLINE` status text utilizes a stepped `@keyframes flicker` animation, rapidly dropping its opacity to `0.2` at specific percentage intervals to simulate a failing electrical connection.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The modal is inherently designed for a dark aesthetic, utilizing a stark black background (`#09090b`) to ensure the high-contrast cyan, pink, and yellow neon accents pop aggressively.
- Added `README.md` documenting usage and the technical mechanics of the `clip-path` geometry, the `repeating-linear-gradient` scanlines, and the stepped `flicker` keyframes.
- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. The decorative scanlines are hidden from screen readers using `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the text flicker animations and removing the modal pop-in transition for motion-sensitive users.

Closes #73421
