### PR TITLE
feat: add solar flare radial toggle

### DIFF
--- a/submissions/examples/solar-flare-radial-toggle-msm/README.md
+++ b/submissions/examples/solar-flare-radial-toggle-msm/README.md
@@ -1,0 +1,19 @@
+# Solar Flare Radial Toggle
+
+1. What does this do? Adds a warm solar-flare toggle switch with a radial glow that expands when the control is enabled.
+
+2. How is it used? Apply `.solar-toggle` to a label that wraps a checkbox and the visual track:
+
+```html
+<label class="solar-toggle">
+  <input type="checkbox" aria-label="Enable solar mode" />
+  <span class="track">
+    <span class="flare-ring"></span>
+    <span class="thumb">
+      <span class="core"></span>
+    </span>
+  </span>
+</label>
+```
+
+3. Why is it useful? It gives EaseMotion CSS a vivid toggle pattern with clear focus states, reduced-motion support, and a memorable radial animation that still works as plain HTML and CSS.

--- a/submissions/examples/solar-flare-radial-toggle-msm/demo.html
+++ b/submissions/examples/solar-flare-radial-toggle-msm/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solar Flare Radial Toggle</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="toggle-card" aria-labelledby="toggle-title">
+        <p class="eyebrow">CSS Toggle Variation</p>
+        <h1 id="toggle-title">Solar Flare Radial Toggle</h1>
+        <p class="description">
+          A warm radial toggle that blooms from ember to sunburst when enabled.
+        </p>
+
+        <label class="solar-toggle">
+          <input type="checkbox" aria-label="Enable solar mode" />
+          <span class="track">
+            <span class="flare-ring"></span>
+            <span class="thumb">
+              <span class="core"></span>
+            </span>
+          </span>
+        </label>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/solar-flare-radial-toggle-msm/style.css
+++ b/submissions/examples/solar-flare-radial-toggle-msm/style.css
@@ -1,0 +1,205 @@
+:root {
+  --solar-bg: #160b06;
+  --solar-card: #24110a;
+  --solar-card-border: rgba(255, 187, 92, 0.28);
+  --solar-orange: #ff7a1a;
+  --solar-gold: #ffd166;
+  --solar-cream: #fff4cf;
+  --solar-shadow: rgba(255, 119, 26, 0.48);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--solar-cream);
+  background:
+    radial-gradient(
+      circle at 50% 30%,
+      rgba(255, 122, 26, 0.2),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 20% 80%,
+      rgba(255, 209, 102, 0.13),
+      transparent 18rem
+    ),
+    linear-gradient(145deg, #090302 0%, var(--solar-bg) 52%, #2c1207 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.toggle-card {
+  width: min(100%, 34rem);
+  padding: 3rem;
+  text-align: center;
+  border: 1px solid var(--solar-card-border);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.07), transparent),
+    var(--solar-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--solar-gold);
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.95;
+}
+
+.description {
+  max-width: 25rem;
+  margin: 1rem auto 2.5rem;
+  color: rgba(255, 244, 207, 0.76);
+  font-family: Verdana, Geneva, sans-serif;
+  line-height: 1.7;
+}
+
+.solar-toggle {
+  display: inline-grid;
+  cursor: pointer;
+  place-items: center;
+}
+
+.solar-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}
+
+.track {
+  position: relative;
+  display: block;
+  width: 8.5rem;
+  height: 4.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 209, 102, 0.22);
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle at 26% 50%,
+      rgba(255, 122, 26, 0.26),
+      transparent 1.4rem
+    ),
+    linear-gradient(90deg, #32160c, #140806);
+  box-shadow:
+    inset 0 0.3rem 1rem rgba(0, 0, 0, 0.58),
+    0 0.8rem 2.2rem rgba(0, 0, 0, 0.35);
+  transition:
+    background 320ms ease,
+    border-color 320ms ease,
+    box-shadow 320ms ease;
+}
+
+.flare-ring {
+  position: absolute;
+  inset: 50% auto auto 1.1rem;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 209, 102, 0.48),
+    transparent 68%
+  );
+  opacity: 0;
+  transform: translateY(-50%) scale(0.3);
+  transition:
+    opacity 360ms ease,
+    transform 520ms cubic-bezier(0.2, 0.8, 0.25, 1);
+}
+
+.thumb {
+  position: absolute;
+  top: 0.53rem;
+  left: 0.55rem;
+  display: grid;
+  width: 3.15rem;
+  height: 3.15rem;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 30%,
+    var(--solar-cream),
+    var(--solar-gold) 24%,
+    var(--solar-orange) 58%,
+    #a43c0b
+  );
+  box-shadow:
+    0 0 1rem var(--solar-shadow),
+    0 0.4rem 1rem rgba(0, 0, 0, 0.45);
+  transition:
+    transform 420ms cubic-bezier(0.2, 0.8, 0.25, 1),
+    box-shadow 320ms ease;
+}
+
+.core {
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff8dc, #ff9f1c 58%, transparent 62%);
+  box-shadow: 0 0 1rem rgba(255, 244, 207, 0.8);
+}
+
+.solar-toggle input:checked + .track {
+  border-color: rgba(255, 209, 102, 0.62);
+  background:
+    radial-gradient(
+      circle at 76% 50%,
+      rgba(255, 209, 102, 0.42),
+      transparent 2.7rem
+    ),
+    linear-gradient(90deg, #5a1d09, #ff7a1a);
+  box-shadow:
+    inset 0 0.3rem 1rem rgba(130, 43, 7, 0.38),
+    0 0 2.2rem rgba(255, 122, 26, 0.5);
+}
+
+.solar-toggle input:checked + .track .thumb {
+  transform: translateX(4.25rem) rotate(180deg);
+  box-shadow:
+    0 0 1.3rem rgba(255, 244, 207, 0.8),
+    0 0 3rem rgba(255, 122, 26, 0.82);
+}
+
+.solar-toggle input:checked + .track .flare-ring {
+  opacity: 1;
+  transform: translate(4.55rem, -50%) scale(3.3);
+}
+
+.solar-toggle input:focus-visible + .track {
+  outline: 3px solid var(--solar-gold);
+  outline-offset: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track,
+  .thumb,
+  .flare-ring {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Solar Flare Radial Toggle component.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Covers keyboard focus visibility and `prefers-reduced-motion` support.

Closes #73894

## Changes Made
- Created `submissions/examples/solar-flare-radial-toggle-msm/`.
- Added a warm radial sunburst toggle demo with checkbox semantics.
- Documented usage and value in the submission README.

## Testing
- `npx prettier --check submissions/examples/solar-flare-radial-toggle-msm/**/*.{html,css,md}` - passed
- `npx stylelint submissions/examples/solar-flare-radial-toggle-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --cached --check` - passed before commit

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Keyboard users get a visible `:focus-visible` outline.
- Motion-sensitive users are respected via `prefers-reduced-motion: reduce`.
- No external CDN, framework, or generated files are included.