### PR TITLE
feat: add pure CSS Modal Neumorphic Soft Shadow component (#73423)

### DIFF
--- a/submissions/examples/css-modal-neumorphic-soft-shadow-pure/README.md
+++ b/submissions/examples/css-modal-neumorphic-soft-shadow-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Modal: Neumorphic Soft Shadow
+
+A smooth, tactile JavaScript-free modal utilizing the CSS checkbox hack and twin CSS box-shadows to simulate physical extrusion from the background.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to open or close the modal.
+- **Component Architecture**: 
+  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox.
+  - **Neumorphism (Soft UI)**: The foundational aesthetic is achieved by ensuring the background color of the modal card (`var(--bg-base)`) perfectly matches the background color of the page. 
+  - **Twin Drop Shadows**: To create the illusion of extrusion (a physical object pushing up from the surface), the modal card utilizes two distinct drop shadows applied simultaneously: `box-shadow: 20px 20px 40px var(--shadow-dark), -20px -20px 40px var(--shadow-light)`. 
+  - **Tactile Buttons**: The primary "Accept" button uses the standard extruded shadow style. The `:active` state swaps the standard shadow for an `inset` shadow, perfectly simulating a physical button being pressed down into the device. The secondary "Dismiss" button permanently uses the inset shadow to visually demote its hierarchy.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The neumorphic effect requires carefully calculated shadow colors. The component fully supports the OS-level system theme (`prefers-color-scheme: dark`), dynamically swapping the base gray/blue to a deep slate, and recalculating the light/dark shadow hex codes to ensure the physical extrusion illusion remains intact in low light.
+- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by removing the modal pop-in transition for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the "Extrude Modal" button to trigger the checkbox hack and reveal the modal.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox logic, the modal overlay, and the extruded elements.
+- `style.css`: The styling, the `:checked` sibling selector logic, the twin `box-shadow` setups, and the inset `:active` states.

--- a/submissions/examples/css-modal-neumorphic-soft-shadow-pure/demo.html
+++ b/submissions/examples/css-modal-neumorphic-soft-shadow-pure/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Modal: Neumorphic Soft Shadow</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Modal: Neumorphism</h1>
+            <p class="subtitle">A smooth, tactile JavaScript-free modal utilizing the checkbox hack and twin CSS box-shadows to simulate physical extrusion from the background.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Modal (Checkbox Hack)
+              The button is actually a <label> tied to a hidden checkbox.
+              When clicked, the checkbox state changes to :checked, which
+              triggers CSS sibling selectors to reveal the modal.
+            -->
+            <input type="checkbox" id="modal-toggle" class="modal-toggle-input" aria-hidden="true">
+            
+            <!-- Trigger Button -->
+            <label for="modal-toggle" class="btn-neumorphic" role="button" tabindex="0">
+                Extrude Modal
+            </label>
+            
+            <!-- Modal Overlay & Content -->
+            <div class="modal-overlay">
+                
+                <!-- Clicking the overlay closes the modal by untoggling the checkbox -->
+                <label for="modal-toggle" class="modal-backdrop" aria-label="Close modal"></label>
+                
+                <div class="modal-card" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                    
+                    <div class="modal-content">
+                        
+                        <div class="icon-extruded">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="12" y1="8" x2="12" y2="12"></line>
+                                <line x1="12" y1="16" x2="12.01" y2="16"></line>
+                            </svg>
+                        </div>
+                        
+                        <h2 id="modal-title" class="modal-title">Soft UI Architecture</h2>
+                        
+                        <p class="modal-text">
+                            This interface employs Neumorphism (Soft UI). By utilizing a background color identical to the parent container and applying twin contrasting drop shadows—one light, one dark—the modal appears to physically push out from the surface below it.
+                        </p>
+                        
+                        <div class="modal-actions">
+                            <label for="modal-toggle" class="btn-neumorphic-inset">Dismiss</label>
+                            <label for="modal-toggle" class="btn-neumorphic">Accept</label>
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-neumorphic-soft-shadow-pure/style.css
+++ b/submissions/examples/css-modal-neumorphic-soft-shadow-pure/style.css
@@ -1,0 +1,288 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* 
+       Neumorphism requires the background color of the elements
+       to perfectly match the background color of the page.
+    */
+    --bg-base: #e0e5ec; /* A soft, warm gray/blue */
+    
+    --text-primary: #2d3748;
+    --text-muted: #718096;
+    
+    /* 
+       The Twin Shadows: 
+       One light source from top-left, one dark shadow bottom-right.
+    */
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    
+    --accent: #4fd1c5;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #1a202c; /* Deep slate */
+        
+        --text-primary: #f7fafc;
+        --text-muted: #a0aec0;
+        
+        /* Shadows must be adjusted for dark mode */
+        --shadow-light: #2d3748; /* Slightly lighter than base */
+        --shadow-dark: #0d1117;  /* Much darker than base */
+        
+        --accent: #38b2ac;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* Nunito's rounded letterforms pair perfectly with soft UI */
+    font-family: 'Nunito', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: var(--text-muted);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+    position: relative; 
+}
+
+
+/* =========================================
+   Neumorphic Elements
+   ========================================= */
+
+.btn-neumorphic {
+    display: inline-block;
+    padding: 16px 32px;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-weight: 700;
+    font-size: 1.1rem;
+    border-radius: 12px;
+    cursor: pointer;
+    user-select: none;
+    transition: all 0.2s ease;
+    border: 1px solid transparent; /* Prevents layout shift on active */
+    
+    /* The core Neumorphic shadow */
+    box-shadow: 
+        8px 8px 16px var(--shadow-dark), 
+        -8px -8px 16px var(--shadow-light);
+}
+
+.btn-neumorphic:active {
+    /* When clicked, it presses into the surface */
+    box-shadow: 
+        inset 6px 6px 12px var(--shadow-dark), 
+        inset -6px -6px 12px var(--shadow-light);
+}
+
+.btn-neumorphic-inset {
+    display: inline-block;
+    padding: 16px 32px;
+    background-color: var(--bg-base);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 1.1rem;
+    border-radius: 12px;
+    cursor: pointer;
+    user-select: none;
+    transition: all 0.2s ease;
+    
+    /* Permanently indented style for secondary actions */
+    box-shadow: 
+        inset 6px 6px 12px var(--shadow-dark), 
+        inset -6px -6px 12px var(--shadow-light);
+}
+
+.btn-neumorphic-inset:hover {
+    color: var(--text-primary);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Modal Checkbox Logic
+   ========================================= */
+
+.modal-toggle-input {
+    display: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* 
+       A slightly darkening backdrop helps the modal stand out,
+       but we keep it subtle so the base background color still shows through.
+    */
+    background-color: rgba(0, 0, 0, 0.15);
+    cursor: pointer;
+}
+
+@media (prefers-color-scheme: dark) {
+    .modal-backdrop {
+        background-color: rgba(0, 0, 0, 0.4);
+    }
+}
+
+
+/* =========================================
+   Neumorphic Modal Styling
+   ========================================= */
+
+.modal-card {
+    position: relative;
+    width: 90%;
+    max-width: 450px;
+    
+    /* Must match the page background perfectly */
+    background-color: var(--bg-base);
+    border-radius: 24px;
+    
+    /* Large, soft Neumorphic shadow */
+    box-shadow: 
+        20px 20px 40px var(--shadow-dark), 
+        -20px -20px 40px var(--shadow-light);
+        
+    /* Initial state for pop-in animation */
+    transform: scale(0.95);
+    opacity: 0;
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s ease;
+}
+
+/* Pop the card in when the modal opens */
+.modal-toggle-input:checked ~ .modal-overlay .modal-card {
+    transform: scale(1);
+    opacity: 1;
+}
+
+/* =========================================
+   Modal Content
+   ========================================= */
+
+.modal-content {
+    padding: 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.icon-extruded {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background-color: var(--bg-base);
+    color: var(--accent);
+    margin-bottom: 24px;
+    
+    /* A raised circle for the icon */
+    box-shadow: 
+        8px 8px 16px var(--shadow-dark), 
+        -8px -8px 16px var(--shadow-light);
+}
+
+.modal-title {
+    color: var(--text-primary);
+    margin: 0 0 16px 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.modal-text {
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    margin: 0 0 40px 0;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    gap: 20px;
+}
+
+/* Specific overrides for modal buttons to ensure they fit nicely */
+.modal-actions .btn-neumorphic,
+.modal-actions .btn-neumorphic-inset {
+    flex: 1;
+    padding: 14px 20px;
+    font-size: 1rem;
+    border-radius: 12px;
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay {
+        transition: none;
+    }
+    .modal-card {
+        transition: none;
+        transform: scale(1);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a smooth, tactile JavaScript-free modal utilizing the CSS checkbox hack and twin CSS box-shadows to simulate physical extrusion from the background. Resolves issue #73423.

### Changes Made:
- Added `submissions/examples/css-modal-neumorphic-soft-shadow-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox logic, the modal overlay, and the extruded elements.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox, triggering CSS opacity/visibility rules on the modal overlay.
  - **Neumorphism (Soft UI)**: The foundational aesthetic is achieved by ensuring the background color of the modal card (`var(--bg-base)`) perfectly matches the background color of the page. 
  - **Twin Drop Shadows**: To create the illusion of extrusion (a physical object pushing up from the surface), the modal card utilizes two distinct drop shadows applied simultaneously: `box-shadow: 20px 20px 40px var(--shadow-dark), -20px -20px 40px var(--shadow-light)`. 
  - **Tactile Buttons**: The primary "Accept" button uses the standard extruded shadow style. The `:active` state swaps the standard shadow for an `inset` shadow, perfectly simulating a physical button being pressed down into the device. The secondary "Dismiss" button permanently uses the inset shadow to visually demote its hierarchy.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The neumorphic effect requires carefully calculated shadow colors. The component fully supports the OS-level system theme (`prefers-color-scheme: dark`), dynamically swapping the base gray/blue to a deep slate, and recalculating the light/dark shadow hex codes to ensure the physical extrusion illusion remains intact in low light.
- Added `README.md` documenting usage and the technical mechanics of the `:checked` sibling selector logic, the twin `box-shadow` setups, and the inset `:active` states.
- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by removing the modal pop-in transition for motion-sensitive users.

Closes #73423
