### PR TITLE
✨ feat(toggles): add Synthwave Grid Line Toggle Variation #624 (#73892)

### DIFF
--- a/submissions/toggles/73892-synthwave-grid-toggle/demo.html
+++ b/submissions/toggles/73892-synthwave-grid-toggle/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Synthwave Grid Line Toggle #73892 Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background-color: #0d021a;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <label class="synth-toggle-wrapper">
+    <input type="checkbox" class="synth-toggle-input">
+    <span class="synth-toggle-track">
+      <span class="synth-toggle-thumb"></span>
+    </span>
+    <span class="synth-toggle-label">Synthwave Grid</span>
+  </label>
+
+</body>
+</html>

--- a/submissions/toggles/73892-synthwave-grid-toggle/style.css
+++ b/submissions/toggles/73892-synthwave-grid-toggle/style.css
@@ -1,0 +1,97 @@
+/* Custom CSS Variables for Synthwave Aesthetic */
+:root {
+  --synth-pink: #ff2a85;
+  --synth-cyan: #00f3ff;
+  --synth-purple: #1a0b2e;
+  --synth-grid: rgba(255, 42, 133, 0.25);
+  --synth-track-bg: #090314;
+}
+
+/* Base Toggle Container */
+.synth-toggle-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Hidden Native Checkbox */
+.synth-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Synthwave Grid Line Switch Track */
+.synth-toggle-track {
+  position: relative;
+  width: 64px;
+  height: 32px;
+  background-color: var(--synth-track-bg);
+  background-image: 
+    linear-gradient(var(--synth-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--synth-grid) 1px, transparent 1px);
+  background-size: 8px 8px;
+  border: 2px solid var(--synth-cyan);
+  border-radius: 20px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 0 10px rgba(0, 243, 255, 0.2);
+  will-change: border-color, box-shadow;
+}
+
+/* Toggle Thumb Knob */
+.synth-toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 22px;
+  height: 22px;
+  background: var(--synth-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--synth-cyan);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.3s ease, box-shadow 0.3s ease;
+  will-change: transform;
+}
+
+/* Checked State Styles */
+.synth-toggle-input:checked + .synth-toggle-track {
+  border-color: var(--synth-pink);
+  box-shadow: 0 0 15px rgba(255, 42, 133, 0.4);
+}
+
+.synth-toggle-input:checked + .synth-toggle-track .synth-toggle-thumb {
+  transform: translateX(32px);
+  background: var(--synth-pink);
+  box-shadow: 0 0 12px var(--synth-pink);
+}
+
+/* Focus State for Accessibility */
+.synth-toggle-input:focus-visible + .synth-toggle-track {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+}
+
+/* Label Styling */
+.synth-toggle-label {
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .synth-toggle-track,
+  .synth-toggle-thumb {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Creates a smooth, accessible, pure CSS toggle featuring a Synthwave Grid Line aesthetic.

## Changes Made
- Added `submissions/toggles/73892-synthwave-grid-toggle/style.css`
- Added `submissions/toggles/73892-synthwave-grid-toggle/demo.html`

## Checklist
- [x] Pure HTML & Vanilla CSS (no JS required).
- [x] Hardware accelerated transitions (`transform`, `opacity`).
- [x] `prefers-reduced-motion` supported for accessibility.
- [x] Tested locally and validated via repository scripts.

Fixes #73892