### PR TITLE
feat: add pure CSS Modal Morphing Shape component (#73428)

### DIFF
--- a/submissions/examples/css-modal-morphing-shape-pure/README.md
+++ b/submissions/examples/css-modal-morphing-shape-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Modal: Morphing Shape
+
+An organic, JavaScript-free modal utilizing the CSS checkbox hack, featuring continuous background shape manipulation via complex CSS border-radius animations.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to open or close the modal.
+- **Component Architecture**: 
+  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox.
+  - **The Morphing Mechanism**: The organic movement is achieved entirely without SVGs or JS libraries. Instead, it relies on animating complex, 8-point `border-radius` values using CSS `@keyframes`. For example: `border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%`. By transitioning between asymmetrical shapes, the browser interpolates the curves to simulate a sloshing liquid blob.
+  - **Background Integration**: The modal card itself utilizes `backdrop-filter: blur(16px)` to act as frosted glass. The morphing shapes (`.morph-shape`) sit *behind* the card (via `z-index: -1`) and are slightly blurred themselves. Their gradients shine through the frosted glass of the modal.
+  - **Component Consistency**: The trigger button and the primary modal action button share the `.morphing-border` class, meaning they also utilize the 8-point `border-radius` animation to stay on theme.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: dark`), adjusting background colors and text contrast while maintaining the vivid pink/purple and cyan/blue gradients of the morphing blobs.
+- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. The decorative background shapes are hidden from screen readers using `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the infinite morphing animations and reverting to standard rounded corners (`border-radius: 24px`) for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the "Summon Blob" button to trigger the checkbox hack and reveal the morphing modal.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox logic, the modal overlay, and the morphing background shapes.
+- `style.css`: The styling, the `:checked` sibling selector logic, the `backdrop-filter` properties, and the highly specific `border-radius` keyframe animations.

--- a/submissions/examples/css-modal-morphing-shape-pure/demo.html
+++ b/submissions/examples/css-modal-morphing-shape-pure/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Modal: Morphing Shape</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Modal: Morphing Blob</h1>
+            <p class="subtitle">An organic, JavaScript-free modal utilizing the checkbox hack, featuring continuous background shape manipulation via complex CSS border-radius animations.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Modal (Checkbox Hack)
+              The button is actually a <label> tied to a hidden checkbox.
+              When clicked, the checkbox state changes to :checked, which
+              triggers CSS sibling selectors to reveal the modal.
+            -->
+            <input type="checkbox" id="modal-toggle" class="modal-toggle-input" aria-hidden="true">
+            
+            <!-- Trigger Button -->
+            <label for="modal-toggle" class="btn-trigger morphing-border" role="button" tabindex="0">
+                Summon Blob
+            </label>
+            
+            <!-- Modal Overlay & Content -->
+            <div class="modal-overlay">
+                
+                <!-- Clicking the overlay closes the modal by untoggling the checkbox -->
+                <label for="modal-toggle" class="modal-backdrop" aria-label="Close modal"></label>
+                
+                <!-- The main modal wrapper -->
+                <div class="modal-wrapper">
+                    
+                    <!-- 
+                      [TECHNIQUE] Morphing Backgrounds
+                      These decorative elements sit behind the modal content.
+                      They utilize a complex 8-point border-radius animation
+                      to constantly shift their shape organically.
+                    -->
+                    <div class="morph-shape morph-1" aria-hidden="true"></div>
+                    <div class="morph-shape morph-2" aria-hidden="true"></div>
+                    
+                    <div class="modal-card" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                        
+                        <div class="modal-content">
+                            
+                            <h2 id="modal-title" class="modal-title">Organic UI</h2>
+                            
+                            <p class="modal-text">
+                                This interface relies on fluid, unpredictable geometry. The background shapes are animated using `@keyframes` that transition between highly specific, asymmetrical `border-radius` values (e.g., `30% 70% 70% 30% / 30% 30% 70% 70%`), creating a continuous morphing effect without the need for SVG manipulation or JavaScript calculations.
+                            </p>
+                            
+                            <div class="modal-actions">
+                                <label for="modal-toggle" class="btn-action outline">Absorb</label>
+                                <label for="modal-toggle" class="btn-action primary morphing-border">Expand</label>
+                            </div>
+                        </div>
+                        
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-morphing-shape-pure/style.css
+++ b/submissions/examples/css-modal-morphing-shape-pure/style.css
@@ -1,0 +1,318 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --text-primary: #0f172a;
+    
+    --modal-bg: rgba(255, 255, 255, 0.85); /* Semi-transparent to let the blobs show through slightly */
+    --modal-text: #0f172a;
+    --modal-text-muted: #475569;
+    
+    /* Blob Gradients */
+    --blob-1-start: #ff0080;
+    --blob-1-end: #7928ca;
+    
+    --blob-2-start: #00dfd8;
+    --blob-2-end: #007cf0;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        
+        --modal-bg: rgba(15, 23, 42, 0.85);
+        --modal-text: #f8fafc;
+        --modal-text-muted: #94a3b8;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'DM Sans', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.4rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+}
+
+.subtitle {
+    color: var(--modal-text-muted);
+    font-size: 1.15rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+    position: relative; 
+}
+
+
+/* =========================================
+   Trigger Button Styling
+   ========================================= */
+
+.btn-trigger {
+    display: inline-block;
+    padding: 16px 36px;
+    background: linear-gradient(135deg, var(--blob-1-start), var(--blob-1-end));
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 10px 20px rgba(121, 40, 202, 0.3);
+}
+
+.btn-trigger:hover {
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 15px 25px rgba(121, 40, 202, 0.4);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Modal Checkbox Logic
+   ========================================= */
+
+.modal-toggle-input {
+    display: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(8px);
+    cursor: pointer;
+}
+
+
+/* =========================================
+   Morphing Modal Architecture
+   ========================================= */
+
+.modal-wrapper {
+    position: relative;
+    width: 90%;
+    max-width: 500px;
+    
+    /* Pop-in animation */
+    transform: scale(0.9);
+    opacity: 0;
+    transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.4s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay .modal-wrapper {
+    transform: scale(1);
+    opacity: 1;
+}
+
+/* =========================================
+   [TECHNIQUE] The Morphing Shapes
+   ========================================= */
+
+.morph-shape {
+    position: absolute;
+    filter: blur(10px); /* Soften the edges a bit */
+    z-index: -1; /* Keep them behind the card */
+    opacity: 0.8;
+}
+
+.morph-1 {
+    width: 350px;
+    height: 350px;
+    top: -50px;
+    left: -50px;
+    background: linear-gradient(135deg, var(--blob-1-start), var(--blob-1-end));
+    
+    /* 
+       The core technique: 
+       We only animate the shape when the modal is open.
+    */
+}
+
+.morph-2 {
+    width: 300px;
+    height: 300px;
+    bottom: -40px;
+    right: -40px;
+    background: linear-gradient(135deg, var(--blob-2-start), var(--blob-2-end));
+    animation-delay: -2s; /* Desync the animations */
+}
+
+/* Start the animation only when the checkbox is checked */
+.modal-toggle-input:checked ~ .modal-overlay .morph-shape {
+    animation: morph-blob 8s ease-in-out infinite both alternate;
+}
+
+/* 
+   A shared class for elements that should constantly morph.
+   Used on the trigger button and the primary modal button.
+*/
+.morphing-border {
+    animation: morph-blob 6s ease-in-out infinite both alternate;
+}
+
+/* The Glass Card that sits in front of the blobs */
+.modal-card {
+    position: relative;
+    background-color: var(--modal-bg);
+    border-radius: 24px;
+    box-shadow: 
+        0 25px 50px -12px rgba(0, 0, 0, 0.25),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+    /* Frosted glass effect to interact with the blobs behind */
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    overflow: hidden;
+    z-index: 2;
+}
+
+/* =========================================
+   Modal Content
+   ========================================= */
+
+.modal-content {
+    padding: 48px;
+    text-align: center;
+}
+
+.modal-title {
+    color: var(--modal-text);
+    margin: 0 0 16px 0;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.modal-text {
+    color: var(--modal-text-muted);
+    font-size: 1.1rem;
+    line-height: 1.6;
+    margin: 0 0 40px 0;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+}
+
+.btn-action {
+    display: inline-block;
+    padding: 14px 28px;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-action.outline {
+    background-color: transparent;
+    color: var(--modal-text);
+    border: 2px solid rgba(148, 163, 184, 0.3);
+    border-radius: 30px;
+}
+
+.btn-action.outline:hover {
+    background-color: rgba(148, 163, 184, 0.1);
+}
+
+.btn-action.primary {
+    background: linear-gradient(135deg, var(--blob-2-start), var(--blob-2-end));
+    color: #ffffff;
+    border: none;
+    box-shadow: 0 4px 15px rgba(0, 124, 240, 0.3);
+}
+
+.btn-action.primary:hover {
+    box-shadow: 0 8px 20px rgba(0, 124, 240, 0.5);
+    transform: translateY(-2px);
+}
+
+
+/* =========================================
+   Keyframes (The Morphing Magic)
+   ========================================= */
+
+/* 
+   By defining specific 8-point border-radius values, we can
+   create organic shapes that continuously morph without SVGs.
+   Format: top-left top-right bottom-right bottom-left / top-left top-right bottom-right bottom-left
+*/
+@keyframes morph-blob {
+    0% {
+        border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
+    }
+    50% {
+        border-radius: 30% 60% 70% 40% / 50% 60% 30% 60%;
+    }
+    100% {
+        border-radius: 40% 60% 30% 70% / 60% 30% 70% 40%;
+    }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay {
+        transition: none;
+    }
+    .modal-wrapper {
+        transition: none;
+        transform: scale(1);
+    }
+    .morph-shape, .morphing-border {
+        animation: none !important;
+        border-radius: 24px; /* Fallback to standard rounding */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces an organic, JavaScript-free modal utilizing the CSS checkbox hack, featuring continuous background shape manipulation via complex CSS border-radius animations. Resolves issue #73428.

### Changes Made:
- Added `submissions/examples/css-modal-morphing-shape-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox logic, the modal overlay, and the morphing background shapes.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox, triggering CSS opacity/visibility rules on the modal overlay.
  - **The Morphing Mechanism**: The organic movement is achieved entirely without SVGs or JS libraries. Instead, it relies on animating complex, 8-point `border-radius` values using CSS `@keyframes`. For example: `border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%`. By transitioning between asymmetrical shapes, the browser interpolates the curves to simulate a sloshing liquid blob.
  - **Background Integration**: The modal card itself utilizes `backdrop-filter: blur(16px)` to act as frosted glass. The morphing shapes (`.morph-shape`) sit *behind* the card (via `z-index: -1`) and are slightly blurred themselves. Their gradients shine through the frosted glass of the modal.
  - **Component Consistency**: The trigger button and the primary modal action button share the `.morphing-border` class, meaning they also utilize the 8-point `border-radius` animation to stay on theme.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: dark`), adjusting background colors and text contrast while maintaining the vivid pink/purple and cyan/blue gradients of the morphing blobs.
- Added `README.md` documenting usage and the technical mechanics of the `backdrop-filter` properties, and the highly specific `border-radius` keyframe animations.
- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. The decorative background shapes are hidden from screen readers using `aria-hidden="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the infinite morphing animations and reverting to standard rounded corners (`border-radius: 24px`) for motion-sensitive users.

Closes #73428
