### PR TITLE
Add ease-kiosk-menu component

### DIFF
--- a/submissions/examples/kiosk-menu-ij/README.md
+++ b/submissions/examples/kiosk-menu-ij/README.md
@@ -1,0 +1,11 @@
+# ease-kiosk-menu
+
+A touch kiosk menu where the banner slides, the items glow, and the cart ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the menu.
+
+## Notes
+- The promo banner scrolls by.
+- Items brighten on touch.
+- The order cart counts up.

--- a/submissions/examples/kiosk-menu-ij/demo.html
+++ b/submissions/examples/kiosk-menu-ij/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-kiosk-menu</title>
+</head>
+<body>
+<main class="kmn-card">
+  <section class="kmn-banner" aria-label="promo banner">
+    <span class="kmn-banner-text">Taco Tuesday</span>
+  </section>
+  <section class="kmn-tabs" aria-label="menu categories">
+    <span class="kmn-tab kmn-tab-on">Drinks</span>
+    <span class="kmn-tab">Food</span>
+    <span class="kmn-tab">Snacks</span>
+  </section>
+  <section class="kmn-list" aria-label="menu items">
+    <span class="kmn-item">
+      <span class="kmn-icon">C</span>
+      <span class="kmn-name">Cold Brew</span>
+      <span class="kmn-price">$4</span>
+    </span>
+    <span class="kmn-item">
+      <span class="kmn-icon">L</span>
+      <span class="kmn-name">Lemonade</span>
+      <span class="kmn-price">$3</span>
+    </span>
+    <span class="kmn-item">
+      <span class="kmn-icon">M</span>
+      <span class="kmn-name">Matcha</span>
+      <span class="kmn-price">$5</span>
+    </span>
+    <span class="kmn-item">
+      <span class="kmn-icon">S</span>
+      <span class="kmn-name">Smoothie</span>
+      <span class="kmn-price">$6</span>
+    </span>
+  </section>
+  <section class="kmn-cart" aria-label="order cart">
+    <span class="kmn-cart-label">Your order</span>
+    <strong class="kmn-cart-total">$18</strong>
+    <span class="kmn-cart-badge">3</span>
+  </section>
+  <footer class="kmn-foot">
+    <span class="kmn-hint">Touch an item</span>
+    <span class="kmn-check">Pay now</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/kiosk-menu-ij/style.css
+++ b/submissions/examples/kiosk-menu-ij/style.css
@@ -1,0 +1,24 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;font-kerning:none}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#1c1a24;font-family:'Verdana',sans-serif}
+.kmn-card{width:292px;border-radius:18px;padding:18px;background:linear-gradient(170deg,#2c2740,#181527);color:#f0edf8;box-shadow:0 16px 38px rgba(0,0,0,.55)}
+.kmn-banner{position:relative;height:44px;border-radius:10px;background:linear-gradient(90deg,#ff8a3d,#ffd166);overflow:hidden}
+.kmn-banner-text{position:absolute;top:12px;left:100%;white-space:nowrap;color:#241a10;font-weight:700;font-size:14px;animation:kmn-banner-slide-kiosk-menu 6s linear infinite}
+.kmn-tabs{display:flex;gap:8px;margin-top:12px}
+.kmn-tab{flex:1;text-align:center;font-size:12px;color:#c9c2e0;background:#241f38;padding:6px 0;border-radius:8px}
+.kmn-tab-on{color:#ffe9b8;background:#3a2f1e}
+.kmn-list{display:flex;flex-direction:column;gap:8px;margin-top:12px}
+.kmn-item{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:10px;padding:9px 10px;border-radius:10px;background:#221d35;transition:transform .2s}
+.kmn-item:hover{transform:translateX(6px);background:#2e2746}
+.kmn-icon{width:26px;height:26px;border-radius:50%;display:grid;place-items:center;background:#4a3f6e;color:#ffe9b8;font-size:13px;animation:kmn-icon-pulse-kiosk-menu 2s ease-in-out infinite}
+.kmn-name{font-size:13px;color:#e3def2}
+.kmn-price{font-size:13px;color:#ffe9b8;font-weight:700}
+.kmn-cart{display:flex;align-items:center;gap:10px;margin-top:12px;padding:11px 12px;border-radius:10px;background:#181426}
+.kmn-cart-label{font-size:12px;color:#b9b2d6}
+.kmn-cart-total{flex:1;text-align:right;font-size:18px;color:#ffd166}
+.kmn-cart-badge{min-width:22px;height:22px;padding:0 6px;border-radius:11px;display:grid;place-items:center;background:#ff8a3d;color:#241a10;font-size:12px;font-weight:700;animation:kmn-item-glow-kiosk-menu 1.4s ease-in-out infinite}
+.kmn-foot{display:flex;justify-content:space-between;margin-top:12px;font-size:11px;color:#a49cc4}
+.kmn-hint{color:#b9b2d6}
+.kmn-check{color:#0f0a05;background:#ff8a3d;padding:3px 10px;border-radius:8px;font-weight:700}
+@keyframes kmn-banner-slide-kiosk-menu{0%{transform:translateX(0)}100%{transform:translateX(-230px)}}
+@keyframes kmn-icon-pulse-kiosk-menu{0%,100%{transform:scale(1)}50%{transform:scale(1.2)}}
+@keyframes kmn-item-glow-kiosk-menu{0%,100%{box-shadow:0 0 0 rgba(255,138,61,0)}50%{box-shadow:0 0 12px rgba(255,138,61,.8)}}


### PR DESCRIPTION
## Component: ease-kiosk-menu — banner slides, items glow, and cart ticks

**Closes #74117**

### What this adds
A touch kiosk menu where the banner slides, the items glow, and the cart ticks.

### Acceptance Criteria covered
- Banner slides across
- Menu items glow on hover
- Order cart ticks up

### Files
- `submissions/examples/kiosk-menu-ij/demo.html`
- `submissions/examples/kiosk-menu-ij/style.css`
- `submissions/examples/kiosk-menu-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the banner slide, the items glow, and the cart tick.