### PR TITLE
feat: add solar flare radial mesh gradient

### DIFF
--- a/submissions/examples/solar-flare-radial-mesh-msm/README.md
+++ b/submissions/examples/solar-flare-radial-mesh-msm/README.md
@@ -1,0 +1,16 @@
+# Solar Flare Radial Mesh Gradient
+
+1. What does this do? Adds a solar-inspired mesh gradient panel made from layered radial gradients, a soft animated flare, and subtle grid texture.
+
+2. How is it used? Apply `.mesh-panel` to a feature section and place content inside `.mesh-content`:
+
+```html
+<section class="mesh-panel">
+  <div class="mesh-orb" aria-hidden="true"></div>
+  <div class="mesh-content">
+    <h1>Solar Flare Radial</h1>
+  </div>
+</section>
+```
+
+3. Why is it useful? It gives EaseMotion CSS a dramatic but lightweight hero/card background pattern that uses plain CSS, degrades gracefully, and respects reduced-motion preferences.

--- a/submissions/examples/solar-flare-radial-mesh-msm/demo.html
+++ b/submissions/examples/solar-flare-radial-mesh-msm/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solar Flare Radial Mesh Gradient</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-stage">
+      <section class="mesh-panel" aria-labelledby="mesh-title">
+        <div class="mesh-orb" aria-hidden="true"></div>
+        <div class="mesh-content">
+          <p class="label">Mesh Gradient Variation</p>
+          <h1 id="mesh-title">Solar Flare Radial</h1>
+          <p>
+            Layered radial color fields create a luminous flare surface for hero
+            sections, cards, and feature callouts.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/solar-flare-radial-mesh-msm/style.css
+++ b/submissions/examples/solar-flare-radial-mesh-msm/style.css
@@ -1,0 +1,166 @@
+:root {
+  --flare-ink: #170905;
+  --flare-card: #2a1008;
+  --flare-orange: #ff6f1a;
+  --flare-gold: #ffd166;
+  --flare-rose: #ff3d5a;
+  --flare-cream: #fff7d6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  color: var(--flare-cream);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(255, 111, 26, 0.28),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #070201, var(--flare-ink));
+}
+
+.demo-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.mesh-panel {
+  position: relative;
+  width: min(100%, 46rem);
+  min-height: 25rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 209, 102, 0.25);
+  border-radius: 2.25rem;
+  background:
+    radial-gradient(
+      circle at 18% 24%,
+      rgba(255, 209, 102, 0.95) 0 9%,
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at 72% 20%,
+      rgba(255, 61, 90, 0.75) 0 8%,
+      transparent 32%
+    ),
+    radial-gradient(
+      circle at 80% 78%,
+      rgba(255, 111, 26, 0.9) 0 12%,
+      transparent 38%
+    ),
+    radial-gradient(
+      circle at 30% 85%,
+      rgba(255, 183, 77, 0.72) 0 10%,
+      transparent 34%
+    ),
+    linear-gradient(135deg, #471607, var(--flare-card) 54%, #070201);
+  box-shadow:
+    0 2.5rem 7rem rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.mesh-panel::before,
+.mesh-panel::after {
+  position: absolute;
+  inset: -35%;
+  content: "";
+  pointer-events: none;
+}
+
+.mesh-panel::before {
+  background: conic-gradient(
+    from 45deg,
+    transparent,
+    rgba(255, 247, 214, 0.24),
+    transparent,
+    rgba(255, 111, 26, 0.28),
+    transparent
+  );
+  filter: blur(2rem);
+  opacity: 0.65;
+  animation: flare-spin 18s linear infinite;
+}
+
+.mesh-panel::after {
+  background-image:
+    linear-gradient(rgba(255, 247, 214, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 247, 214, 0.08) 1px, transparent 1px);
+  background-size: 3rem 3rem;
+  mask-image: radial-gradient(circle, #000 35%, transparent 72%);
+}
+
+.mesh-orb {
+  position: absolute;
+  right: -5rem;
+  bottom: -6rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 32%,
+    #fff8dc,
+    var(--flare-gold) 22%,
+    var(--flare-orange) 52%,
+    transparent 70%
+  );
+  filter: blur(0.2rem);
+  opacity: 0.9;
+  animation: flare-pulse 4.5s ease-in-out infinite;
+}
+
+.mesh-content {
+  position: relative;
+  z-index: 1;
+  max-width: 29rem;
+  padding: clamp(2rem, 7vw, 4.5rem);
+}
+
+.label {
+  margin: 0 0 1rem;
+  color: var(--flare-gold);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2.8rem, 8vw, 6.5rem);
+  line-height: 0.9;
+}
+
+.mesh-content p:last-child {
+  margin: 1.35rem 0 0;
+  color: rgba(255, 247, 214, 0.78);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+@keyframes flare-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes flare-pulse {
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mesh-panel::before,
+  .mesh-orb {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Solar Flare Radial Mesh Gradient.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses layered radial gradients, a subtle grid texture, and reduced-motion-safe animation.

Closes #73841

## Changes Made
- Created `submissions/examples/solar-flare-radial-mesh-msm/`.
- Added a mesh-gradient feature panel demo with semantic HTML.
- Documented usage and value in the submission README.

## Testing
- `npx prettier --check submissions/examples/solar-flare-radial-mesh-msm/**/*.{html,css,md}` - passed
- `npx stylelint submissions/examples/solar-flare-radial-mesh-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Respects `prefers-reduced-motion: reduce`.
- Uses local CSS only; no CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.