### PR TITLE
feat: add neumorphic soft shadow toggle switch (issue #73871)

### DIFF
--- a/submissions/examples/neumorphic-toggle-switch-gb/README.md
+++ b/submissions/examples/neumorphic-toggle-switch-gb/README.md
@@ -1,0 +1,33 @@
+﻿# Neumorphic Soft Shadow Toggle
+
+## Issue #73871
+
+A pure HTML & vanilla CSS checkbox/toggle switch featuring a Neumorphic Soft Shadow style — no JavaScript required for the toggle itself.
+
+## Features
+
+- **Pure CSS interaction** — built on a native `<input type="checkbox">` wrapped by a `<label>`, so it works with zero JS and is fully keyboard-accessible (`Tab` + `Space`).
+- **Neumorphic styling** — soft inset shadows on the track and dual light/dark drop shadows on the thumb create the classic embossed, soft-UI look.
+- **Smooth transitions** — the thumb slides using `transform: translateX(...)` with a bouncy `cubic-bezier` easing; only `transform` and `box-shadow`/`background` are animated, keeping the animation on the compositor (hardware accelerated, no layout thrashing).
+- **Dark mode compatible** — automatically adapts via the `[data-theme="dark"]` attribute set on `<html>` (the same toggle mechanism used elsewhere in EaseMotion CSS), switching to darker neumorphic shadows for a proper dark-surface emboss effect.
+- **Accessible states** — includes a visible `:focus-visible` outline for keyboard users and a `:disabled` state with reduced opacity and a `not-allowed` cursor.
+- **Reduced motion support** — respects `prefers-reduced-motion: reduce` by disabling the slide transition for users who've opted out of animation.
+
+## Usage
+
+```html
+<label class="ease-neu-toggle">
+  <input type="checkbox" class="ease-neu-toggle-input" />
+  <span class="ease-neu-toggle-track">
+    <span class="ease-neu-toggle-thumb"></span>
+  </span>
+  <span class="ease-neu-toggle-label">Your label here</span>
+</label>
+```
+
+Add `checked` to the input for a toggle that starts in the "on" state, or `disabled` for a locked/inactive toggle.
+
+## Files Included
+
+- `demo.html` — Interactive demonstration with three toggle states (default, pre-checked, disabled) and a light/dark theme switcher button.
+- `style.css` — Self-contained stylesheet with the neumorphic toggle component and its dark-mode variant.

--- a/submissions/examples/neumorphic-toggle-switch-gb/demo.html
+++ b/submissions/examples/neumorphic-toggle-switch-gb/demo.html
@@ -1,0 +1,90 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Neumorphic Soft Shadow Toggle</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2.5rem;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #e6e9ef;
+      transition: background 0.3s ease;
+    }
+    [data-theme="dark"] body {
+      background: #1a1d23;
+    }
+    .demo-title {
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: #334155;
+      transition: color 0.3s ease;
+    }
+    [data-theme="dark"] .demo-title {
+      color: #f1f5f9;
+    }
+    .demo-toggle-group {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      align-items: flex-start;
+    }
+    .demo-theme-btn {
+      padding: 0.6rem 1.25rem;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1 class="demo-title">Neumorphic Soft Shadow Toggle</h1>
+
+  <button class="demo-theme-btn" id="themeToggleBtn">Toggle Light/Dark Theme</button>
+
+  <div class="demo-toggle-group">
+    <label class="ease-neu-toggle">
+      <input type="checkbox" class="ease-neu-toggle-input" />
+      <span class="ease-neu-toggle-track">
+        <span class="ease-neu-toggle-thumb"></span>
+      </span>
+      <span class="ease-neu-toggle-label">Enable notifications</span>
+    </label>
+
+    <label class="ease-neu-toggle">
+      <input type="checkbox" class="ease-neu-toggle-input" checked />
+      <span class="ease-neu-toggle-track">
+        <span class="ease-neu-toggle-thumb"></span>
+      </span>
+      <span class="ease-neu-toggle-label">Auto-save drafts (default on)</span>
+    </label>
+
+    <label class="ease-neu-toggle">
+      <input type="checkbox" class="ease-neu-toggle-input" disabled />
+      <span class="ease-neu-toggle-track">
+        <span class="ease-neu-toggle-thumb"></span>
+      </span>
+      <span class="ease-neu-toggle-label">Locked setting (disabled)</span>
+    </label>
+  </div>
+
+  <script>
+    const btn = document.getElementById('themeToggleBtn');
+    const html = document.documentElement;
+    btn.addEventListener('click', () => {
+      const current = html.getAttribute('data-theme') || 'light';
+      html.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/neumorphic-toggle-switch-gb/style.css
+++ b/submissions/examples/neumorphic-toggle-switch-gb/style.css
@@ -1,0 +1,125 @@
+﻿/* ============================================================
+   EaseMotion CSS — Neumorphic Soft Shadow Toggle
+   Issue #73871 — pure CSS, no JS, hardware-accelerated
+   ============================================================ */
+
+.ease-neu-toggle {
+  --ease-neu-bg: #e6e9ef;
+  --ease-neu-shadow-light: rgba(255, 255, 255, 0.8);
+  --ease-neu-shadow-dark: rgba(163, 177, 198, 0.6);
+  --ease-neu-accent: linear-gradient(135deg, #6366f1, #8b5cf6);
+  --ease-neu-track-w: 60px;
+  --ease-neu-track-h: 32px;
+  --ease-neu-thumb-size: 24px;
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+  font-family: inherit;
+}
+
+.ease-neu-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ease-neu-toggle-track {
+  position: relative;
+  width: var(--ease-neu-track-w);
+  height: var(--ease-neu-track-h);
+  border-radius: 999px;
+  background: var(--ease-neu-bg);
+  box-shadow:
+    inset 4px 4px 8px var(--ease-neu-shadow-dark),
+    inset -4px -4px 8px var(--ease-neu-shadow-light);
+  transition: box-shadow 0.3s ease;
+}
+
+.ease-neu-toggle-thumb {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: var(--ease-neu-thumb-size);
+  height: var(--ease-neu-thumb-size);
+  border-radius: 50%;
+  background: var(--ease-neu-bg);
+  box-shadow:
+    3px 3px 6px var(--ease-neu-shadow-dark),
+    -3px -3px 6px var(--ease-neu-shadow-light);
+  transform: translateX(0);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    background 0.3s ease;
+  will-change: transform;
+}
+
+/* Checked state */
+.ease-neu-toggle-input:checked ~ .ease-neu-toggle-track {
+  box-shadow:
+    inset 2px 2px 5px rgba(99, 102, 241, 0.4),
+    inset -2px -2px 5px rgba(139, 92, 246, 0.25);
+}
+
+.ease-neu-toggle-input:checked ~ .ease-neu-toggle-track .ease-neu-toggle-thumb {
+  transform: translateX(calc(var(--ease-neu-track-w) - var(--ease-neu-thumb-size) - 8px));
+  background: var(--ease-neu-accent);
+  box-shadow:
+    3px 3px 6px var(--ease-neu-shadow-dark),
+    -3px -3px 6px var(--ease-neu-shadow-light),
+    0 0 10px rgba(99, 102, 241, 0.5);
+}
+
+/* Focus visibility for keyboard users */
+.ease-neu-toggle-input:focus-visible ~ .ease-neu-toggle-track {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+/* Disabled state */
+.ease-neu-toggle-input:disabled ~ .ease-neu-toggle-track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ease-neu-toggle:has(.ease-neu-toggle-input:disabled) {
+  cursor: not-allowed;
+}
+
+.ease-neu-toggle-label {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #334155;
+}
+
+/* Dark mode */
+[data-theme="light"] .ease-neu-toggle,
+[data-theme="dark"] .ease-neu-toggle {
+  --ease-neu-bg: #e6e9ef;
+}
+
+[data-theme="dark"] .ease-neu-toggle {
+  --ease-neu-bg: #2b2f36;
+  --ease-neu-shadow-light: rgba(255, 255, 255, 0.06);
+  --ease-neu-shadow-dark: rgba(0, 0, 0, 0.6);
+}
+
+[data-theme="dark"] .ease-neu-toggle-label {
+  color: #e2e8f0;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-neu-toggle-thumb,
+  .ease-neu-toggle-track {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure HTML & vanilla CSS checkbox/toggle switch featuring Neumorphic Soft Shadow styling, per the issue spec.

## Features
- Built on a native `<input type="checkbox">` + `<label>` — fully accessible via keyboard (`Tab` + `Space`), zero JS required for the toggle itself
- Soft inset shadows on the track and dual light/dark drop shadows on the thumb for the classic embossed neumorphic look
- Smooth `transform`-based slide animation with a bouncy easing curve — only `transform`/`box-shadow`/`background` animate, keeping it on the compositor (hardware accelerated)
- Dark mode support via `[data-theme="dark"]`
- `:focus-visible` outline for keyboard users, `:disabled` state styling
- Respects `prefers-reduced-motion: reduce`

## Related Issue
Closes #73871

## How to Test
1. Open `submissions/examples/neumorphic-toggle-switch-gb/demo.html`
2. Click each toggle — thumb should slide smoothly with the neumorphic shadow effect
3. Click "Toggle Light/Dark Theme" — verify the toggle switches to a dark-surface neumorphic style
4. Tab to a toggle with keyboard — confirm the focus outline appears
5. Note the third toggle is disabled and shows a `not-allowed` cursor

## Checklist
- [x] Pure HTML/CSS, no external JS
- [x] Dark mode compatible
- [x] Tested in browser
- [x] Linked related issue
- [x] Only files inside `submissions/` are modified