### PR TITLE
feat: add synthwave grid line mesh gradient

### DIFF
--- a/submissions/examples/synthwave-grid-line-mesh-msm/README.md
+++ b/submissions/examples/synthwave-grid-line-mesh-msm/README.md
@@ -1,0 +1,28 @@
+# Synthwave Grid Line Mesh
+
+## What does this do?
+
+This submission creates a responsive pure CSS mesh-gradient hero card with neon synthwave grid lines, soft glow layers, and smooth motion.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="synthwave-grid-shell" aria-labelledby="synthwave-title">
+  <div class="synthwave-grid-card">
+    <span class="synthwave-grid-eyebrow">CSS mesh gradient</span>
+    <h1 id="synthwave-title">Synthwave Grid Line</h1>
+    <p>
+      Layered radial gradients and perspective grid lines create a retro neon
+      surface.
+    </p>
+  </div>
+</section>
+```
+
+## Why is it useful?
+
+The effect gives EaseMotion users a polished dark-mode-friendly background treatment that works without JavaScript, remote assets, or external frameworks. It is suitable for landing pages, dashboard headers, feature cards, and music or gaming UI sections.

--- a/submissions/examples/synthwave-grid-line-mesh-msm/demo.html
+++ b/submissions/examples/synthwave-grid-line-mesh-msm/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Synthwave Grid Line Mesh</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="synthwave-grid-shell" aria-labelledby="synthwave-title">
+      <section class="synthwave-grid-card" aria-describedby="synthwave-copy">
+        <span class="synthwave-grid-eyebrow">Pure CSS mesh gradient</span>
+        <h1 id="synthwave-title">Synthwave Grid Line</h1>
+        <p id="synthwave-copy">
+          A dark-mode-ready gradient panel with neon horizon lines, soft radial
+          glow, and hardware-friendly motion for expressive product surfaces.
+        </p>
+
+        <div class="synthwave-grid-actions" aria-label="Demo highlights">
+          <span>Radial mesh</span>
+          <span>Perspective grid</span>
+          <span>No JavaScript</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/synthwave-grid-line-mesh-msm/style.css
+++ b/submissions/examples/synthwave-grid-line-mesh-msm/style.css
@@ -1,0 +1,243 @@
+:root {
+  --synthwave-bg: #060716;
+  --synthwave-panel: rgba(13, 15, 44, 0.78);
+  --synthwave-ink: #f8fbff;
+  --synthwave-muted: #b7b8d9;
+  --synthwave-cyan: #32f6ff;
+  --synthwave-pink: #ff3dd7;
+  --synthwave-violet: #7b4dff;
+  --synthwave-amber: #ffb84d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--synthwave-ink);
+  background: var(--synthwave-bg);
+  font-family: "Trebuchet MS", "Lucida Sans Unicode", sans-serif;
+}
+
+.synthwave-grid-shell {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 50% 20%,
+      rgba(255, 61, 215, 0.34),
+      transparent 26rem
+    ),
+    radial-gradient(
+      circle at 15% 80%,
+      rgba(50, 246, 255, 0.22),
+      transparent 24rem
+    ),
+    linear-gradient(180deg, #080817 0%, #11143a 48%, #050613 100%);
+  isolation: isolate;
+}
+
+.synthwave-grid-shell::before,
+.synthwave-grid-shell::after {
+  position: absolute;
+  inset: auto -12vw -8vh;
+  height: 52vh;
+  content: "";
+  transform: perspective(38rem) rotateX(58deg);
+  transform-origin: bottom;
+  will-change: background-position, opacity;
+}
+
+.synthwave-grid-shell::before {
+  z-index: -2;
+  background-image:
+    linear-gradient(rgba(50, 246, 255, 0.45) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 61, 215, 0.38) 1px, transparent 1px);
+  background-size:
+    100% 2.3rem,
+    2.3rem 100%;
+  filter: drop-shadow(0 0 0.85rem rgba(255, 61, 215, 0.55));
+  animation: synthwave-grid-drift 8s linear infinite;
+  mask-image: linear-gradient(
+    transparent 0%,
+    #000 22%,
+    #000 88%,
+    transparent 100%
+  );
+}
+
+.synthwave-grid-shell::after {
+  z-index: -3;
+  background:
+    radial-gradient(
+      ellipse at center,
+      rgba(255, 184, 77, 0.46),
+      transparent 31%
+    ),
+    radial-gradient(
+      ellipse at center,
+      rgba(255, 61, 215, 0.36),
+      transparent 52%
+    );
+  filter: blur(3rem);
+  opacity: 0.75;
+  animation: synthwave-pulse 4.8s ease-in-out infinite;
+}
+
+.synthwave-grid-card {
+  position: relative;
+  width: min(42rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4.5rem);
+  border: 1px solid rgba(248, 251, 255, 0.18);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.13), transparent 36%),
+    radial-gradient(
+      circle at 82% 16%,
+      rgba(50, 246, 255, 0.28),
+      transparent 12rem
+    ),
+    radial-gradient(
+      circle at 10% 94%,
+      rgba(255, 61, 215, 0.26),
+      transparent 14rem
+    ),
+    var(--synthwave-panel);
+  box-shadow:
+    0 2.2rem 7rem rgba(0, 0, 0, 0.5),
+    inset 0 0 4rem rgba(123, 77, 255, 0.24);
+  backdrop-filter: blur(1.2rem);
+}
+
+.synthwave-grid-card::before {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background-image:
+    linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.16), transparent),
+    repeating-linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.06) 0 1px,
+      transparent 1px 0.75rem
+    );
+  opacity: 0.7;
+  pointer-events: none;
+  transform: translateX(-38%);
+  animation: synthwave-card-shimmer 6s ease-in-out infinite;
+}
+
+.synthwave-grid-eyebrow {
+  position: relative;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(50, 246, 255, 0.34);
+  border-radius: 999px;
+  color: var(--synthwave-cyan);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.synthwave-grid-card h1 {
+  position: relative;
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(3rem, 11vw, 6.9rem);
+  line-height: 0.88;
+  text-shadow:
+    0 0 1rem rgba(255, 61, 215, 0.62),
+    0 0 2.5rem rgba(50, 246, 255, 0.38);
+}
+
+.synthwave-grid-card p {
+  position: relative;
+  max-width: 36rem;
+  margin: 1.3rem 0 0;
+  color: var(--synthwave-muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+.synthwave-grid-actions {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.synthwave-grid-actions span {
+  padding: 0.7rem 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-size: 0.9rem;
+  box-shadow: inset 0 0 1.4rem rgba(50, 246, 255, 0.08);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.synthwave-grid-actions span:hover {
+  border-color: rgba(255, 61, 215, 0.55);
+  box-shadow: 0 0 1.6rem rgba(255, 61, 215, 0.28);
+  transform: translateY(-0.18rem);
+}
+
+@keyframes synthwave-grid-drift {
+  to {
+    background-position:
+      0 2.3rem,
+      2.3rem 0;
+  }
+}
+
+@keyframes synthwave-pulse {
+  50% {
+    opacity: 0.95;
+    transform: perspective(38rem) rotateX(58deg) scale(1.04);
+  }
+}
+
+@keyframes synthwave-card-shimmer {
+  50% {
+    transform: translateX(28%);
+  }
+}
+
+@media (max-width: 42rem) {
+  .synthwave-grid-shell {
+    padding: 1rem;
+  }
+
+  .synthwave-grid-card {
+    border-radius: 1.4rem;
+  }
+
+  .synthwave-grid-actions {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .synthwave-grid-shell::before,
+  .synthwave-grid-shell::after,
+  .synthwave-grid-card::before {
+    animation: none;
+  }
+
+  .synthwave-grid-actions span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Synthwave Grid Line mesh gradient.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses layered radial gradients, a perspective grid, neon glow, and reduced-motion-safe animation.

Closes #73840

## Changes Made
- Created `submissions/examples/synthwave-grid-line-mesh-msm/`.
- Added a responsive synthwave gradient feature card demo with semantic HTML.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx prettier --check submissions/examples/synthwave-grid-line-mesh-msm/**/*.{html,css,md}` - passed
- `npx stylelint submissions/examples/synthwave-grid-line-mesh-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.