### PR TITLE
Add ease-battery-meter component

### DIFF
--- a/submissions/examples/battery-meter-ij/README.md
+++ b/submissions/examples/battery-meter-ij/README.md
@@ -1,0 +1,11 @@
+# ease-battery-meter
+
+A battery meter where the cells drain, the tip pulses, and the percent blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the meter.
+
+## Notes
+- Cells drain toward empty.
+- The terminal tip pulses.
+- The percent blinks while low.

--- a/submissions/examples/battery-meter-ij/demo.html
+++ b/submissions/examples/battery-meter-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-battery-meter</title>
+</head>
+<body>
+<main class="btm-card">
+  <header class="btm-head">
+    <h1 class="btm-title">Power Cell</h1>
+    <span class="btm-health">Good</span>
+  </header>
+  <section class="btm-shell" aria-label="battery body">
+    <span class="btm-tip"></span>
+    <span class="btm-cell btm-cell-1"></span>
+    <span class="btm-cell btm-cell-2"></span>
+    <span class="btm-cell btm-cell-3"></span>
+    <span class="btm-cell btm-cell-4"></span>
+    <span class="btm-cell btm-cell-5"></span>
+  </section>
+  <section class="btm-read" aria-label="capacity readout">
+    <strong class="btm-pct">42%</strong>
+    <span class="btm-volts">3.96 V</span>
+  </section>
+  <section class="btm-mode" aria-label="mode toggle">
+    <span class="btm-switch btm-switch-on">CHARGE</span>
+    <span class="btm-switch">DRAIN</span>
+  </section>
+  <footer class="btm-foot">
+    <span class="btm-led">Draining</span>
+    <span class="btm-est">~2h left</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/battery-meter-ij/style.css
+++ b/submissions/examples/battery-meter-ij/style.css
@@ -1,0 +1,26 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;font-synthesis:none}
+body{min-height:100vh;display:grid;place-items:center;background:#141a1e;font-family:'Tahoma',sans-serif}
+.btm-card{width:272px;border-radius:18px;padding:18px;background:linear-gradient(165deg,#2a3138,#171c21);color:#e9eef3;box-shadow:0 16px 36px rgba(0,0,0,.5)}
+.btm-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.btm-title{font-size:16px;letter-spacing:1px;color:#c6d0da}
+.btm-health{font-size:11px;color:#a4f0b8;background:#12281b;padding:3px 9px;border-radius:9px}
+.btm-shell{position:relative;display:flex;align-items:flex-end;gap:6px;height:120px;padding:12px;border-radius:12px;background:#0f1418;border:3px solid #37434d}
+.btm-tip{position:absolute;top:-14px;right:-16px;width:26px;height:16px;border-radius:6px;background:#2f3a43;animation:btm-tip-pulse-battery-meter 2s ease-in-out infinite}
+.btm-cell{flex:1;border-radius:5px;background:#262f36}
+.btm-cell-1{height:20%;animation:btm-drain-cell-battery-meter 5s ease-in-out infinite}
+.btm-cell-2{height:34%;animation:btm-drain-cell-battery-meter 5s ease-in-out .4s infinite}
+.btm-cell-3{height:50%;animation:btm-drain-cell-battery-meter 5s ease-in-out .8s infinite}
+.btm-cell-4{height:66%;animation:btm-drain-cell-battery-meter 5s ease-in-out 1.2s infinite}
+.btm-cell-5{height:84%;animation:btm-drain-cell-battery-meter 5s ease-in-out 1.6s infinite}
+.btm-read{display:flex;justify-content:space-between;align-items:baseline;margin-top:12px;padding:10px 12px;background:#0f1418;border-radius:10px}
+.btm-pct{font-size:26px;color:#ffd166;animation:btm-low-blink-battery-meter 1s steps(2) infinite}
+.btm-volts{font-size:12px;color:#8fa0ae}
+.btm-mode{display:flex;gap:8px;margin-top:12px}
+.btm-switch{flex:1;text-align:center;font-size:11px;color:#8fa0ae;background:#1d242b;padding:6px 0;border-radius:8px}
+.btm-switch-on{color:#ffd166;background:#2a2410}
+.btm-foot{display:flex;justify-content:space-between;margin-top:10px;font-size:11px;color:#8fa0ae}
+.btm-led{color:#ffb3a0}
+.btm-est{color:#8fa0ae}
+@keyframes btm-drain-cell-battery-meter{0%,15%{background:#49c46a}40%,70%{background:#c49c3a}90%,100%{background:#a54a3a}}
+@keyframes btm-tip-pulse-battery-meter{0%,100%{box-shadow:0 0 0 rgba(160,190,220,0)}50%{box-shadow:0 0 10px rgba(160,190,220,.7)}}
+@keyframes btm-low-blink-battery-meter{0%,100%{opacity:.25}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-battery-meter — cells drain, tip pulses, and percent blinks

**Closes #74157**

### What this adds
A battery meter where the cells drain, the tip pulses, and the percent blinks.

### Acceptance Criteria covered
- Cells drain one by one
- Terminal tip pulses
- Percent blinks low

### Files
- `submissions/examples/battery-meter-ij/demo.html`
- `submissions/examples/battery-meter-ij/style.css`
- `submissions/examples/battery-meter-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the cells drain, the tip pulse, and the percent blink.