### PR TITLE
Add ease-solar-panel-grid component

### DIFF
--- a/submissions/examples/solar-panel-grid-ij/README.md
+++ b/submissions/examples/solar-panel-grid-ij/README.md
@@ -1,0 +1,11 @@
+# ease-solar-panel-grid
+
+A solar panel grid where the cells glint, the rack sways, and the watts climb.
+
+## Run
+Open `demo.html` directly in a browser to watch the grid.
+
+## Notes
+- Cells glint one by one.
+- The rack sways on its mount.
+- Watt output climbs across.

--- a/submissions/examples/solar-panel-grid-ij/demo.html
+++ b/submissions/examples/solar-panel-grid-ij/demo.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-solar-panel-grid</title>
+</head>
+<body>
+<main class="spg-card">
+  <header class="spg-head">
+    <h1 class="spg-title">SunField 8</h1>
+    <span class="spg-sun"></span>
+  </header>
+  <section class="spg-array" aria-label="solar panel array">
+    <span class="spg-panel">
+      <span class="spg-row">
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+      </span>
+      <span class="spg-row">
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+      </span>
+    </span>
+    <span class="spg-panel spg-panel-2">
+      <span class="spg-row">
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+      </span>
+      <span class="spg-row">
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+        <span class="spg-cell"></span>
+      </span>
+    </span>
+    <span class="spg-rack"></span>
+    <span class="spg-rack spg-rack-2"></span>
+  </section>
+  <section class="spg-data" aria-label="power output">
+    <span class="spg-label">Output</span>
+    <strong class="spg-watts">1.4 kW</strong>
+    <span class="spg-yield">today 8.2 kWh</span>
+  </section>
+  <footer class="spg-foot">
+    <span class="spg-state">Tilting</span>
+    <span class="spg-clean">Sensor clean</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/solar-panel-grid-ij/style.css
+++ b/submissions/examples/solar-panel-grid-ij/style.css
@@ -1,0 +1,25 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;text-orientation:mixed}
+body{min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0f1830;font-family:'Arial Narrow',sans-serif}
+.spg-card{width:292px;border-radius:18px;padding:18px;background:linear-gradient(170deg,#1a2b4a,#0d1730);color:#e8f0ff;box-shadow:0 18px 38px rgba(0,0,0,.55)}
+.spg-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.spg-title{font-size:16px;letter-spacing:2px;color:#c2d4f5}
+.spg-sun{width:22px;height:22px;border-radius:50%;background:#ffd76b;box-shadow:0 0 16px #ffd76b;animation:spg-ripple-panel-solar-panel-grid 2.4s ease-in-out infinite}
+.spg-array{position:relative;height:170px;border-radius:12px;background:linear-gradient(#142850,#0b1630);border:2px solid #234073;overflow:hidden}
+.spg-panel{position:absolute;top:18px;left:16px;width:118px;padding:8px;border-radius:8px;background:#223a66;border:2px solid #35559a;animation:spg-sway-rack-solar-panel-grid 6s ease-in-out infinite}
+.spg-panel-2{left:156px;animation-delay:.4s}
+.spg-row{display:grid;grid-template-columns:repeat(3,1fr);gap:4px;margin-top:4px}
+.spg-row:first-child{margin-top:0}
+.spg-cell{height:22px;border-radius:3px;background:#0b1c38}
+.spg-cell:nth-child(2){animation:spg-glint-cell-solar-panel-grid 3s ease-in-out infinite}
+.spg-rack{position:absolute;bottom:16px;left:26px;width:96px;height:5px;background:#35559a;border-radius:3px}
+.spg-rack-2{left:166px}
+.spg-data{display:flex;justify-content:space-between;align-items:baseline;margin-top:12px;padding:11px 12px;background:#0d1730;border-radius:10px}
+.spg-label{font-size:11px;color:#8fa8d8}
+.spg-watts{font-size:22px;color:#ffe9a8}
+.spg-yield{font-size:11px;color:#8fa8d8}
+.spg-foot{display:flex;justify-content:space-between;margin-top:10px;font-size:11px;color:#8fa8d8}
+.spg-state{color:#9ff0b2}
+.spg-clean{color:#8fa8d8}
+@keyframes spg-glint-cell-solar-panel-grid{0%,70%{background:#0b1c38;box-shadow:none}80%,100%{background:#b9d6ff;box-shadow:0 0 12px rgba(185,214,255,.9)}}
+@keyframes spg-ripple-panel-solar-panel-grid{0%,100%{box-shadow:0 0 8px #ffd76b}50%{box-shadow:0 0 24px #ffd76b}}
+@keyframes spg-sway-rack-solar-panel-grid{0%,100%{transform:rotate(-3deg)}50%{transform:rotate(3deg)}}


### PR DESCRIPTION
## Component: ease-solar-panel-grid — cells glint, rack sways, and watts climb

**Closes #74171**

### What this adds
A solar panel grid where the cells glint, the rack sways, and the watts climb.

### Acceptance Criteria covered
- Cells glint in turn
- Rack sways on the mount
- Watt readout climbs

### Files
- `submissions/examples/solar-panel-grid-ij/demo.html`
- `submissions/examples/solar-panel-grid-ij/style.css`
- `submissions/examples/solar-panel-grid-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the cells glint, the rack sway, and the watts climb.