### PR TITLE
feat: add foucault pendulum swing mesh gradient

### DIFF
--- a/submissions/examples/foucault-pendulum-swing-mesh-msm/README.md
+++ b/submissions/examples/foucault-pendulum-swing-mesh-msm/README.md
@@ -1,0 +1,28 @@
+# Foucault Pendulum Swing Mesh
+
+## What does this do?
+
+This submission creates a pure CSS mesh-gradient showcase inspired by a Foucault pendulum, with a suspended orb, sweeping light trail, and dark-mode-friendly glow.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="foucault-shell" aria-labelledby="foucault-title">
+  <div class="foucault-card">
+    <span class="foucault-kicker">CSS mesh gradient</span>
+    <h1 id="foucault-title">Foucault Pendulum Swing</h1>
+    <p>
+      Use this panel as a dramatic motion surface for landing pages or
+      dashboards.
+    </p>
+  </div>
+</section>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a polished, accessible motion background that communicates rhythm and precision without JavaScript, external assets, or framework dependencies.

--- a/submissions/examples/foucault-pendulum-swing-mesh-msm/demo.html
+++ b/submissions/examples/foucault-pendulum-swing-mesh-msm/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foucault Pendulum Swing Mesh</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="foucault-shell" aria-labelledby="foucault-title">
+      <section class="foucault-card" aria-describedby="foucault-copy">
+        <div class="foucault-orbit" aria-hidden="true">
+          <span class="foucault-cable"></span>
+          <span class="foucault-bob"></span>
+          <span class="foucault-trail"></span>
+        </div>
+
+        <span class="foucault-kicker">Pure CSS motion surface</span>
+        <h1 id="foucault-title">Foucault Pendulum Swing</h1>
+        <p id="foucault-copy">
+          A layered mesh gradient with a suspended neon pendulum, slow sweeping
+          motion, and responsive dark-mode contrast.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/foucault-pendulum-swing-mesh-msm/style.css
+++ b/submissions/examples/foucault-pendulum-swing-mesh-msm/style.css
@@ -1,0 +1,246 @@
+:root {
+  --foucault-bg: #05070f;
+  --foucault-ink: #f4f8ff;
+  --foucault-muted: #b6c2d8;
+  --foucault-panel: rgba(9, 16, 33, 0.78);
+  --foucault-cyan: #49f2ff;
+  --foucault-blue: #4178ff;
+  --foucault-violet: #a855f7;
+  --foucault-lime: #b8ff6a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--foucault-ink);
+  background: var(--foucault-bg);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+.foucault-shell {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(73, 242, 255, 0.28),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 84% 76%,
+      rgba(168, 85, 247, 0.24),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #03050d 0%, #111936 52%, #05070f 100%);
+  isolation: isolate;
+}
+
+.foucault-shell::before {
+  position: absolute;
+  inset: 9%;
+  z-index: -2;
+  content: "";
+  background:
+    linear-gradient(
+      120deg,
+      transparent,
+      rgba(255, 255, 255, 0.08),
+      transparent
+    ),
+    repeating-radial-gradient(
+      circle at 50% 44%,
+      rgba(73, 242, 255, 0.16) 0 1px,
+      transparent 1px 2.8rem
+    );
+  border-radius: 50%;
+  filter: blur(0.2rem);
+  opacity: 0.75;
+  transform: rotateX(64deg);
+}
+
+.foucault-shell::after {
+  position: absolute;
+  inset: auto 8% 7%;
+  z-index: -1;
+  height: 18rem;
+  content: "";
+  background:
+    radial-gradient(
+      ellipse at center,
+      rgba(184, 255, 106, 0.28),
+      transparent 44%
+    ),
+    radial-gradient(
+      ellipse at center,
+      rgba(65, 120, 255, 0.24),
+      transparent 68%
+    );
+  filter: blur(2.4rem);
+  opacity: 0.85;
+}
+
+.foucault-card {
+  position: relative;
+  width: min(45rem, 100%);
+  min-height: 33rem;
+  overflow: hidden;
+  padding: clamp(2rem, 5vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 2rem;
+  background:
+    radial-gradient(
+      circle at 26% 20%,
+      rgba(73, 242, 255, 0.18),
+      transparent 15rem
+    ),
+    radial-gradient(
+      circle at 84% 14%,
+      rgba(184, 255, 106, 0.18),
+      transparent 12rem
+    ),
+    linear-gradient(150deg, rgba(255, 255, 255, 0.12), transparent 42%),
+    var(--foucault-panel);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.5),
+    inset 0 0 4rem rgba(73, 242, 255, 0.1);
+  backdrop-filter: blur(1rem);
+}
+
+.foucault-orbit {
+  position: absolute;
+  top: -1rem;
+  right: clamp(2rem, 9vw, 5.5rem);
+  width: 16rem;
+  height: 24rem;
+  transform-origin: 50% 0;
+  animation: foucault-swing 5.8s ease-in-out infinite;
+}
+
+.foucault-cable {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 2px;
+  height: 18rem;
+  background: linear-gradient(
+    transparent,
+    rgba(244, 248, 255, 0.7),
+    transparent
+  );
+  box-shadow: 0 0 1rem rgba(73, 242, 255, 0.42);
+  transform: translateX(-50%);
+}
+
+.foucault-bob {
+  position: absolute;
+  top: 16.5rem;
+  left: 50%;
+  width: 4.2rem;
+  height: 4.2rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle at 35% 30%,
+      #ffffff,
+      var(--foucault-cyan) 32%,
+      #17346f 72%
+    ),
+    var(--foucault-cyan);
+  box-shadow:
+    0 0 1.5rem rgba(73, 242, 255, 0.82),
+    0 0 4rem rgba(168, 85, 247, 0.56);
+  transform: translateX(-50%);
+}
+
+.foucault-trail {
+  position: absolute;
+  right: -2.5rem;
+  bottom: 1.6rem;
+  left: -2.5rem;
+  height: 5rem;
+  border-bottom: 2px solid rgba(184, 255, 106, 0.46);
+  border-radius: 50%;
+  filter: drop-shadow(0 0 0.9rem rgba(184, 255, 106, 0.55));
+  transform: rotateX(62deg);
+}
+
+.foucault-kicker {
+  position: relative;
+  display: inline-flex;
+  margin-top: 9rem;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(73, 242, 255, 0.32);
+  border-radius: 999px;
+  color: var(--foucault-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.foucault-card h1 {
+  position: relative;
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(2.9rem, 9vw, 6.4rem);
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(73, 242, 255, 0.48),
+    0 0 3rem rgba(168, 85, 247, 0.36);
+}
+
+.foucault-card p {
+  position: relative;
+  max-width: 35rem;
+  margin: 1.25rem 0 0;
+  color: var(--foucault-muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+@keyframes foucault-swing {
+  0%,
+  100% {
+    transform: rotate(-10deg);
+  }
+
+  50% {
+    transform: rotate(10deg);
+  }
+}
+
+@media (max-width: 42rem) {
+  .foucault-shell {
+    padding: 1rem;
+  }
+
+  .foucault-card {
+    min-height: 36rem;
+    border-radius: 1.4rem;
+  }
+
+  .foucault-orbit {
+    right: 50%;
+    width: 12rem;
+    transform: translateX(50%);
+  }
+
+  .foucault-kicker {
+    margin-top: 12rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .foucault-orbit {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Foucault Pendulum Swing mesh gradient.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses layered radial gradients, a suspended neon pendulum, and reduced-motion-safe animation.

Closes #73839

## Changes Made
- Created `submissions/examples/foucault-pendulum-swing-mesh-msm/`.
- Added a responsive pendulum-inspired mesh gradient demo with semantic HTML.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx prettier --check submissions/examples/foucault-pendulum-swing-mesh-msm/**/*.{html,css,md}` - passed
- `npx stylelint submissions/examples/foucault-pendulum-swing-mesh-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.