### PR TITLE
feat: add origami paper fold 3d effect

### DIFF
--- a/submissions/examples/73707-origami-paper-fold/README.md
+++ b/submissions/examples/73707-origami-paper-fold/README.md
@@ -1,0 +1,30 @@
+# CSS 3D Effect: Origami Paper Fold
+
+A smooth, accessible, and performant pure CSS 3D animation inspired by
+folded origami paper.
+
+## Features
+
+- Pure HTML and Vanilla CSS
+- Origami-inspired paper folding
+- CSS 3D transforms
+- Perspective depth
+- Layered paper panels
+- Interactive fold movement on hover
+- Smooth transitions
+- Subtle floating animation
+- Light and dark mode support
+- Responsive layout
+- Hardware-friendly transforms
+- Accessible keyboard focus states
+- `prefers-reduced-motion` support
+- No JavaScript
+- No external libraries
+
+## Files
+
+```text
+73707-origami-paper-fold/
+├── README.md
+├── demo.html
+└── style.css

--- a/submissions/examples/73707-origami-paper-fold/demo.html
+++ b/submissions/examples/73707-origami-paper-fold/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Pure CSS 3D origami paper fold animation."
+  >
+  <title>Origami Paper Fold</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="origami-scene">
+    <section class="origami-wrapper" aria-labelledby="origami-title">
+      <div class="origami-card">
+        <div class="paper-panel panel-back" aria-hidden="true"></div>
+
+        <div class="paper-panel panel-left" aria-hidden="true"></div>
+
+        <div class="paper-panel panel-right" aria-hidden="true"></div>
+
+        <div class="paper-content">
+          <span class="eyebrow">PURE CSS • 3D</span>
+
+          <div class="paper-mark" aria-hidden="true">
+            <span></span>
+            <span></span>
+          </div>
+
+          <h1 id="origami-title">Origami</h1>
+
+          <p>
+            A layered paper-fold animation built entirely with
+            CSS 3D transforms and smooth transitions.
+          </p>
+
+          <button class="fold-button" type="button">
+            Unfold
+            <span aria-hidden="true">↗</span>
+          </button>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/73707-origami-paper-fold/style.css
+++ b/submissions/examples/73707-origami-paper-fold/style.css
@@ -1,0 +1,701 @@
+:root {
+  --background: #eef1f6;
+
+  --paper: #ffffff;
+  --paper-soft: #f7f8fb;
+  --paper-shadow: rgba(43, 50, 67, 0.2);
+
+  --text-primary: #202533;
+  --text-secondary: #6d7483;
+
+  --accent: #6558d9;
+  --accent-light: #8f84ff;
+
+  --fold-dark: #d9dce5;
+  --fold-light: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text-primary);
+  background: var(--background);
+}
+
+button {
+  font: inherit;
+}
+
+.origami-scene {
+  position: relative;
+
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  overflow: hidden;
+  isolation: isolate;
+
+  padding: 2rem;
+
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(101, 88, 217, 0.1),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 75%,
+      rgba(143, 132, 255, 0.09),
+      transparent 32%
+    ),
+    var(--background);
+}
+
+/* Subtle background grid */
+
+.origami-scene::before {
+  content: "";
+
+  position: absolute;
+  inset: 0;
+
+  z-index: -1;
+
+  background:
+    linear-gradient(
+      rgba(32, 37, 51, 0.025) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(32, 37, 51, 0.025) 1px,
+      transparent 1px
+    );
+
+  background-size: 60px 60px;
+
+  mask-image: radial-gradient(
+    ellipse at center,
+    black,
+    transparent 72%
+  );
+}
+
+/* Perspective stage */
+
+.origami-wrapper {
+  width: min(480px, 100%);
+
+  perspective: 1400px;
+}
+
+/* Main 3D object */
+
+.origami-card {
+  position: relative;
+
+  width: 100%;
+  min-height: 500px;
+
+  transform-style: preserve-3d;
+
+  border-radius: 8px;
+
+  transition:
+    transform 700ms cubic-bezier(0.2, 0.8, 0.25, 1),
+    box-shadow 700ms ease;
+
+  will-change: transform;
+}
+
+/* Hover creates the main perspective movement */
+
+.origami-wrapper:hover .origami-card {
+  transform:
+    rotateX(5deg)
+    rotateY(-6deg)
+    translateY(-8px)
+    translateZ(12px);
+
+  box-shadow:
+    35px 45px 70px rgba(43, 50, 67, 0.22);
+}
+
+/* Shared paper panels */
+
+.paper-panel {
+  position: absolute;
+
+  inset: 0;
+
+  border-radius: 8px;
+
+  transform-style: preserve-3d;
+
+  transform-origin: center;
+
+  pointer-events: none;
+}
+
+/* Back paper */
+
+.panel-back {
+  z-index: 0;
+
+  background:
+    linear-gradient(
+      145deg,
+      var(--paper-soft),
+      #e8eaf0
+    );
+
+  box-shadow:
+    20px 25px 55px var(--paper-shadow);
+
+  transform:
+    translateZ(-35px)
+    rotateX(2deg);
+}
+
+/* Left folded section */
+
+.panel-left {
+  z-index: 2;
+
+  width: 55%;
+  right: auto;
+
+  background:
+    linear-gradient(
+      135deg,
+      var(--paper),
+      var(--fold-dark)
+    );
+
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    72% 50%,
+    100% 100%,
+    0 100%
+  );
+
+  transform-origin: right center;
+
+  transition:
+    transform 750ms cubic-bezier(0.2, 0.8, 0.25, 1),
+    filter 750ms ease;
+}
+
+/* Right folded section */
+
+.panel-right {
+  z-index: 3;
+
+  left: auto;
+  width: 55%;
+
+  background:
+    linear-gradient(
+      225deg,
+      var(--fold-light),
+      var(--fold-dark)
+    );
+
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% 100%,
+    0 100%,
+    28% 50%
+  );
+
+  transform-origin: left center;
+
+  transition:
+    transform 750ms cubic-bezier(0.2, 0.8, 0.25, 1),
+    filter 750ms ease;
+}
+
+/* Fold movement */
+
+.origami-wrapper:hover .panel-left {
+  transform:
+    translateZ(25px)
+    rotateY(-18deg);
+
+  filter:
+    brightness(0.98)
+    drop-shadow(12px 12px 16px rgba(43, 50, 67, 0.12));
+}
+
+.origami-wrapper:hover .panel-right {
+  transform:
+    translateZ(35px)
+    rotateY(18deg);
+
+  filter:
+    brightness(1.01)
+    drop-shadow(-12px 12px 16px rgba(43, 50, 67, 0.12));
+}
+
+/* Fold seam */
+
+.origami-card::before {
+  content: "";
+
+  position: absolute;
+
+  z-index: 4;
+
+  top: 0;
+  bottom: 0;
+  left: 50%;
+
+  width: 1px;
+
+  background:
+    linear-gradient(
+      to bottom,
+      transparent,
+      rgba(100, 105, 120, 0.35),
+      transparent
+    );
+
+  transform:
+    translateX(-50%)
+    translateZ(45px);
+
+  opacity: 0.7;
+
+  pointer-events: none;
+}
+
+/* Content layer */
+
+.paper-content {
+  position: relative;
+
+  z-index: 5;
+
+  min-height: 500px;
+
+  display: flex;
+  flex-direction: column;
+
+  padding: 3rem;
+
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.86),
+      rgba(247, 248, 251, 0.78)
+    );
+
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    0 20px 45px rgba(43, 50, 67, 0.12);
+
+  transform:
+    translateZ(48px);
+
+  transition:
+    transform 700ms cubic-bezier(0.2, 0.8, 0.25, 1);
+
+  overflow: hidden;
+}
+
+.origami-wrapper:hover .paper-content {
+  transform:
+    translateZ(60px);
+}
+
+/* Decorative corner fold */
+
+.paper-content::after {
+  content: "";
+
+  position: absolute;
+
+  top: 0;
+  right: 0;
+
+  width: 100px;
+  height: 100px;
+
+  background:
+    linear-gradient(
+      135deg,
+      transparent 49%,
+      rgba(205, 209, 220, 0.8) 50%,
+      #ffffff 51%
+    );
+
+  opacity: 0.75;
+
+  pointer-events: none;
+}
+
+/* Eyebrow */
+
+.eyebrow {
+  position: relative;
+  z-index: 2;
+
+  color: var(--accent);
+
+  font-size: 0.68rem;
+  font-weight: 800;
+
+  letter-spacing: 0.18em;
+}
+
+/* Logo / paper mark */
+
+.paper-mark {
+  position: relative;
+  z-index: 2;
+
+  width: 78px;
+  height: 78px;
+
+  display: grid;
+  place-items: center;
+
+  margin-top: 3.2rem;
+
+  border-radius: 18px;
+
+  background: var(--paper);
+
+  box-shadow:
+    10px 12px 25px rgba(43, 50, 67, 0.14),
+    -5px -5px 15px rgba(255, 255, 255, 0.9);
+
+  transform:
+    translateZ(25px)
+    rotate(-2deg);
+
+  transition:
+    transform 500ms ease;
+}
+
+.origami-wrapper:hover .paper-mark {
+  transform:
+    translateZ(45px)
+    rotate(4deg);
+}
+
+.paper-mark span {
+  position: absolute;
+
+  width: 30px;
+  height: 30px;
+
+  background: var(--accent);
+
+  clip-path: polygon(
+    50% 0,
+    100% 100%,
+    0 100%
+  );
+}
+
+.paper-mark span:first-child {
+  transform: translate(-7px, -5px) rotate(15deg);
+}
+
+.paper-mark span:last-child {
+  background: var(--accent-light);
+
+  transform: translate(8px, 5px) rotate(-15deg);
+}
+
+/* Typography */
+
+h1 {
+  position: relative;
+  z-index: 2;
+
+  margin: 2rem 0 0;
+
+  font-size: clamp(3.5rem, 10vw, 5.5rem);
+  line-height: 0.85;
+
+  letter-spacing: -0.07em;
+
+  transform: translateZ(32px);
+
+  transition:
+    transform 700ms cubic-bezier(0.2, 0.8, 0.25, 1);
+}
+
+.origami-wrapper:hover h1 {
+  transform:
+    translateZ(50px);
+}
+
+.paper-content p {
+  position: relative;
+  z-index: 2;
+
+  max-width: 350px;
+
+  margin: 1.5rem 0 0;
+
+  color: var(--text-secondary);
+
+  font-size: 0.94rem;
+  line-height: 1.75;
+
+  transform: translateZ(25px);
+}
+
+/* Button */
+
+.fold-button {
+  position: relative;
+  z-index: 2;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+
+  width: fit-content;
+
+  margin-top: auto;
+
+  padding: 0.85rem 1.25rem;
+
+  border: 1px solid rgba(101, 88, 217, 0.22);
+  border-radius: 999px;
+
+  color: #ffffff;
+  background: var(--accent);
+
+  cursor: pointer;
+
+  box-shadow:
+    8px 10px 20px rgba(43, 50, 67, 0.15);
+
+  transform: translateZ(30px);
+
+  transition:
+    transform 200ms ease,
+    background-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.fold-button span {
+  font-size: 1rem;
+}
+
+.fold-button:hover {
+  background: #5649c9;
+
+  transform:
+    translateZ(35px)
+    translateY(-3px);
+
+  box-shadow:
+    10px 14px 25px rgba(43, 50, 67, 0.2);
+}
+
+.fold-button:active {
+  transform:
+    translateZ(30px)
+    translateY(0);
+}
+
+.fold-button:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+/* Subtle floating motion */
+
+@keyframes paper-float {
+  0% {
+    transform:
+      rotateX(0deg)
+      rotateY(0deg)
+      translateY(0);
+  }
+
+  100% {
+    transform:
+      rotateX(1deg)
+      rotateY(-1deg)
+      translateY(-4px);
+  }
+}
+
+.origami-card {
+  animation:
+    paper-float
+    6s
+    ease-in-out
+    infinite
+    alternate;
+}
+
+/* Responsive */
+
+@media (max-width: 640px) {
+  .origami-scene {
+    padding: 1rem;
+  }
+
+  .origami-card,
+  .paper-content {
+    min-height: 460px;
+  }
+
+  .paper-content {
+    padding: 2rem;
+  }
+
+  .paper-mark {
+    margin-top: 2.5rem;
+  }
+
+  .origami-wrapper:hover .origami-card {
+    transform:
+      rotateX(2deg)
+      rotateY(-3deg)
+      translateY(-5px);
+  }
+
+  .origami-wrapper:hover .panel-left {
+    transform:
+      translateZ(18px)
+      rotateY(-10deg);
+  }
+
+  .origami-wrapper:hover .panel-right {
+    transform:
+      translateZ(22px)
+      rotateY(10deg);
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .origami-card {
+    animation: none;
+  }
+
+  .origami-card,
+  .paper-panel,
+  .paper-content,
+  .paper-mark,
+  .fold-button,
+  h1 {
+    transition: none;
+  }
+
+  .origami-wrapper:hover .origami-card,
+  .origami-wrapper:hover .panel-left,
+  .origami-wrapper:hover .panel-right,
+  .origami-wrapper:hover .paper-content,
+  .origami-wrapper:hover .paper-mark,
+  .origami-wrapper:hover h1,
+  .fold-button:hover,
+  .fold-button:active {
+    transform: none;
+  }
+}
+
+/* Dark mode */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #11141c;
+
+    --paper: #242832;
+    --paper-soft: #1c2029;
+
+    --paper-shadow: rgba(0, 0, 0, 0.45);
+
+    --text-primary: #f2f4f8;
+    --text-secondary: #a7adba;
+
+    --fold-dark: #171b23;
+    --fold-light: #2d323d;
+
+    --border: rgba(255, 255, 255, 0.08);
+  }
+
+  .origami-scene::before {
+    background:
+      linear-gradient(
+        rgba(255, 255, 255, 0.018) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.018) 1px,
+        transparent 1px
+      );
+
+    background-size: 60px 60px;
+  }
+
+  .paper-content {
+    border-color: rgba(255, 255, 255, 0.08);
+
+    background:
+      linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.08),
+        rgba(255, 255, 255, 0.025)
+      ),
+      rgba(30, 34, 43, 0.96);
+
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 20px 45px rgba(0, 0, 0, 0.28);
+  }
+
+  .paper-mark {
+    background: #292e38;
+
+    box-shadow:
+      10px 12px 25px rgba(0, 0, 0, 0.35),
+      -5px -5px 15px rgba(255, 255, 255, 0.03);
+  }
+
+  .paper-content::after {
+    background:
+      linear-gradient(
+        135deg,
+        transparent 49%,
+        rgba(10, 12, 18, 0.8) 50%,
+        #303641 51%
+      );
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue that introduces a smooth, accessible, and performant **Origami Paper Fold 3D Effect** using pure HTML and Vanilla CSS.

### What does this PR do?

* Adds an origami-inspired 3D paper folding animation.
* Uses CSS `perspective` and `transform-style: preserve-3d` to create depth.
* Implements multiple independently moving paper panels.
* Uses `rotateY()` and `translateZ()` for realistic folding movement.
* Adds subtle hover-based unfolding interactions.
* Includes layered shadows and gradients to enhance the paper appearance.
* Adds a subtle floating animation for additional visual depth.
* Supports responsive layouts across different screen sizes.
* Supports both light and dark modes.
* Includes accessible keyboard focus states.
* Respects `prefers-reduced-motion` for accessibility.
* Uses hardware-friendly CSS transforms.
* Requires no JavaScript or external libraries.

### Files Added

* `README.md` — Documentation and implementation details.
* `demo.html` — Interactive demonstration of the Origami Paper Fold effect.
* `style.css` — Complete 3D transforms, fold panels, animations, responsive behavior, and accessibility support.

### Testing

* Tested the 3D animation in the browser.
* Verified the origami fold interaction.
* Verified perspective and layered depth.
* Verified responsive behavior.
* Verified light and dark mode support.
* Verified keyboard focus visibility.
* Verified `prefers-reduced-motion` behavior.
* Confirmed that no external JavaScript or libraries are required.

### Issue

Closes #73707
