### PR TITLE
feat(examples): add zero-asset procedural css glass noise

### DIFF
--- a/submissions/examples/ease-glass-noise/README.md
+++ b/submissions/examples/ease-glass-noise/README.md
@@ -1,0 +1,63 @@
+# Procedural Glass Noise (Asset-Free Glassmorphism)
+
+Premium frosted glass effects (Glassmorphism) often include a subtle film grain or noise texture overlay. Without this noise, the `backdrop-filter: blur()` can look completely flat and synthetic. With the noise, it mimics the physical texture of real frosted glass or premium polycarbonate.
+
+Historically, this was achieved by loading a massive transparent PNG image of film grain. Not only does this hurt load times (TTI/LCP), but it often looks blurry or pixelated on high-DPI Retina screens if the asset isn't huge.
+
+This submission demonstrates how to procedurally generate a high-frequency, Retina-ready TV-static noise texture entirely in CSS, without a single image asset or SVG filter!
+
+---
+
+## 🏛️ The Architecture
+
+### 1. The Standard Glass Base
+First, we establish the standard glassmorphism base on our card using `backdrop-filter`.
+```css
+.glass-card {
+    background-color: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px); /* For Safari Support */
+}
+```
+
+### 2. The Procedural Noise (The Magic)
+We use a `::before` pseudo-element to overlay the noise. 
+To generate the noise, we use a `repeating-conic-gradient`. A conic gradient sweeps colors around a central point. By defining color stops that are incredibly small (fractional percentages like `0.0001%`), we force the browser's CSS rendering engine to rapidly pack thousands of contrasting pixels tightly together. The engine essentially "glitches" trying to interpolate them, generating a perfect, high-frequency static noise!
+
+```css
+.glass-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    
+    background: repeating-conic-gradient(
+        transparent 0%,
+        rgba(0, 0, 0, 0.05) 0.0001%,
+        transparent 0.0002%,
+        rgba(255, 255, 255, 0.05) 0.0003%
+    );
+}
+```
+
+### 3. Tiling the Noise
+Because `repeating-conic-gradient` relies on fractional percentages of the parent's width, if the card is very large, the noise can stretch and look low-res. To prevent this, we force the browser to render the noise in a small 100x100px square, and then seamlessly tile it across the card!
+
+```css
+.glass-card::before {
+    background-size: 100px 100px;
+}
+```
+
+---
+
+## 💻 Usage
+
+To add procedural noise to any existing glassmorphism card, simply ensure the card has `position: relative`, and apply the `::before` CSS block above to it! Make sure to add `pointer-events: none;` to the pseudo-element so it doesn't block clicks on the card's buttons or text.
+
+---
+
+## 🚀 Performance Benchmarks
+
+- **Image Assets / Payloads:** `0 KB`. You no longer need to import heavy `noise.png` files.
+- **SVG Filters:** `0`. Bypasses the need for `<feTurbulence>` SVG filters, which are notoriously slow to render on mobile devices and often cause scrolling jitter.
+- **Resolution:** Because it is generated mathematically by the CSS engine, it is infinitely scalable and flawlessly sharp on 4K, 5K, and Retina displays.

--- a/submissions/examples/ease-glass-noise/index.html
+++ b/submissions/examples/ease-glass-noise/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease CSS Glassmorphism Noise</title>
+    <link rel="stylesheet" href="../../../easemotion.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- A vibrant background to demonstrate the frosted glass blur -->
+    <div class="vibrant-background"></div>
+
+    <main class="demo-container">
+        
+        <header class="header">
+            <h1>Asset-Free Frosted Noise</h1>
+            <p>100% CSS. Zero images or SVG filters required.</p>
+        </header>
+
+        <div class="cards-grid">
+            
+            <!-- Standard Glassmorphism (No Noise) -->
+            <div class="glass-card standard-glass">
+                <h2>Standard Glass</h2>
+                <p>Typical backdrop-filter blur. It looks flat and unnatural without a physical texture.</p>
+            </div>
+
+            <!-- Premium Glassmorphism (Procedural CSS Noise) -->
+            <div class="glass-card premium-glass">
+                <h2>Premium Glass</h2>
+                <p>We use a highly complex repeating-conic-gradient to procedurally generate a TV-static noise texture entirely in CSS!</p>
+                <button class="glass-button">Interact</button>
+            </div>
+
+        </div>
+        
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/ease-glass-noise/style.css
+++ b/submissions/examples/ease-glass-noise/style.css
@@ -1,0 +1,184 @@
+/* 
+  ==========================================================================
+  EaseMotion CSS Procedural Glass Noise
+  ========================================================================== 
+*/
+
+:root {
+    --text-primary: #f8fafc;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    color: var(--text-primary);
+    background-color: #020617; /* Fallback */
+    min-height: 100vh;
+}
+
+/* 
+  ==========================================================================
+  Vibrant Background (To demonstrate the blur)
+  ========================================================================== 
+*/
+
+.vibrant-background {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background: 
+        radial-gradient(circle at 15% 50%, rgba(236, 72, 153, 0.5), transparent 50%),
+        radial-gradient(circle at 85% 30%, rgba(56, 189, 248, 0.5), transparent 50%);
+    animation: pulse 10s infinite alternate linear;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    100% { transform: scale(1.2); }
+}
+
+/* 
+  ==========================================================================
+  Demo Layout
+  ========================================================================== 
+*/
+
+.demo-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 80px 20px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 60px;
+    z-index: 10;
+}
+
+.header h1 {
+    font-size: 3rem;
+    margin: 0 0 10px 0;
+}
+
+.header p {
+    font-size: 1.2rem;
+    color: #e2e8f0;
+}
+
+.cards-grid {
+    display: flex;
+    gap: 40px;
+    flex-wrap: wrap;
+    justify-content: center;
+    z-index: 10;
+}
+
+/* 
+  ==========================================================================
+  Base Glass Card Styling
+  ========================================================================== 
+*/
+
+.glass-card {
+    width: 100%;
+    max-width: 400px;
+    padding: 40px;
+    border-radius: 30px;
+    
+    /* Subtle white border to simulate the glass edge reflection */
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    
+    /* Standard Backdrop Filter (The blur) */
+    background-color: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    
+    box-shadow: 0 30px 60px rgba(0,0,0,0.3);
+    
+    /* We need relative positioning so the pseudo-element noise can overlay perfectly */
+    position: relative;
+    overflow: hidden;
+}
+
+.glass-card h2 {
+    margin: 0 0 15px 0;
+    font-size: 2rem;
+}
+
+.glass-card p {
+    color: #cbd5e1;
+    line-height: 1.6;
+    margin: 0 0 20px 0;
+}
+
+/* Ensure the text sits ABOVE the noise layer */
+.glass-card h2, 
+.glass-card p, 
+.glass-card button {
+    position: relative;
+    z-index: 2;
+}
+
+/* 
+  ==========================================================================
+  The Magic: Procedural CSS Noise
+  ========================================================================== 
+*/
+
+/* We apply the noise via a pseudo element so it doesn't mess with the card's backdrop-filter */
+.premium-glass::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    
+    /* 
+      We use a repeating-conic-gradient. By making the color stops incredibly small 
+      (fractional percentages) and tightly packed, the browser rendering engine 
+      "glitches" trying to interpolate them, generating a perfect TV-static noise!
+    */
+    background: repeating-conic-gradient(
+        transparent 0%,
+        rgba(0, 0, 0, 0.05) 0.0001%,
+        transparent 0.0002%,
+        rgba(255, 255, 255, 0.05) 0.0003%
+    );
+    
+    /* 
+      Because repeating-conic-gradient relies on fractional percentages, 
+      it can look slightly stretched or low-res on very large divs. 
+      We set a small background-size to force it to tile tightly, ensuring high-frequency noise!
+    */
+    background-size: 100px 100px;
+    
+    /* Blend mode helps the noise integrate perfectly into the frosted glass */
+    mix-blend-mode: overlay;
+    
+    /* Subtle opacity adjustment so it isn't overwhelming */
+    opacity: 0.6;
+}
+
+/* 
+  ==========================================================================
+  UI Polish
+  ========================================================================== 
+*/
+
+.glass-button {
+    padding: 12px 30px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+}
+
+.glass-button:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+}


### PR DESCRIPTION
fixes #74202 

## Pull Request Description

Adds a highly optimized `ease-glass-noise` component. Premium frosted glass effects (Glassmorphism) often include a subtle film grain or noise texture overlay. Without this noise, the `backdrop-filter: blur()` can look completely flat and synthetic. Historically, this was achieved by loading a massive transparent PNG image of film grain. Not only does this hurt load times (TTI/LCP), but it often looks blurry or pixelated on high-DPI Retina screens if the asset isn't huge. This submission demonstrates how to procedurally generate a high-frequency, Retina-ready TV-static noise texture entirely in CSS, without a single image asset or SVG filter!

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component (Standard Track)
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/ease-glass-noise/`)
- [x] Includes `index.html` — Clean semantic HTML featuring a standard glass card vs a premium procedural noise card for A/B comparison.
- [x] Includes `style.css` — Procedurally generated noise using a tightly packed `repeating-conic-gradient` mapped to a pseudo-element.
- [x] Includes `README.md` — Deep-dive architectural documentation on how to exploit fractional CSS gradient percentages to mimic TV static.
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A 0-asset, mathematically procedurally generated CSS Noise Texture.

**How does it generate noise without images?**

1. **The Standard Base:** First, we establish the standard glassmorphism base on our card using `backdrop-filter: blur(20px)`.
2. **The Procedural Generation (The Magic):** We use a `::before` pseudo-element to overlay the noise. To generate the noise, we use a `repeating-conic-gradient`. A conic gradient sweeps colors around a central point. By defining color stops that are incredibly small (fractional percentages like `0.0001%`), we force the browser's CSS rendering engine to rapidly pack thousands of contrasting pixels tightly together. The engine essentially "glitches" trying to interpolate them, generating a perfect, high-frequency static noise!
3. **Tiling:** Because `repeating-conic-gradient` relies on fractional percentages of the parent's width, if the card is very large, the noise can stretch and look low-res. To prevent this, we force the browser to render the noise in a small 100x100px square (`background-size: 100px 100px;`), and then seamlessly tile it across the card!

**Why does it fit EaseMotion CSS?**

Because it completely bypasses the need to download 5MB transparent PNG assets, and avoids the scrolling jitter often associated with `<feTurbulence>` SVG filters on mobile Chrome/Safari.

---

## Demo

- [x] Demo added (`demo.html` features a vibrant, slowly pulsating background gradient to visually demonstrate how the noise texture perfectly integrates with the frosted backdrop filter).

---

## Browser Testing & Accessibility

- [x] Chrome 
- [x] Edge 
- [x] Firefox 
- [x] Safari 

---

## Notes for Maintainer

This submission belongs to the **Standard Track** (`submissions/examples/`). This is a highly focused, optimized feature addition that demonstrates how to utilize dense fractional math inside CSS Conic Gradients to procedurally replace image assets.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your Procedural Glass elements in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
