### PR TITLE
feat: add pure CSS Modal Velvet Smooth Transition component (#73440)

### DIFF
--- a/submissions/examples/css-modal-velvet-smooth-pure/README.md
+++ b/submissions/examples/css-modal-velvet-smooth-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Modal: Velvet Smooth Transition
+
+A luxurious, JavaScript-free modal utilizing the CSS checkbox hack. Features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters to create a cinematic "focus pull" effect.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to open or close the modal.
+- **Component Architecture**: 
+  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox.
+  - **The Cinematic Entrance**: This modal explicitly avoids snappy or bouncy physics. Instead, it aims for weight and elegance. The `.modal-card` transition uses a long duration (`0.8s`) and a custom cubic-bezier (`0.25, 1, 0.5, 1`) that accelerates very slowly and decelerates gracefully.
+  - **Focus Pull Effect**: The initial state of the modal is slightly scaled up (`1.05`) and heavily blurred (`filter: blur(10px)`). When the modal opens, the `transform` and `filter` properties animate into place, simulating a camera pulling focus onto the modal while the heavy, dark backdrop obscures the rest of the application.
+  - **Component Consistency**: This same `--velvet-ease` variable is applied to the hover states of all the buttons in the UI, ensuring the entire interaction model feels consistently smooth and deliberate.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: light/dark`). The default aesthetic leans heavily into dark mode (deep plums, burgundies, and golds) to fit the "velvet" naming, but automatically adjusts to a lighter cream/gold palette if the user forces a light theme.
+- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the scale/blur transitions and instantly displaying the modal for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the "Reveal Experience" button to trigger the checkbox hack and reveal the cinematic modal.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox logic, the modal overlay, and the semantic modal content.
+- `style.css`: The styling, the `:checked` sibling selector logic, the `filter: blur()` properties, and the highly specific `cubic-bezier` timing functions.

--- a/submissions/examples/css-modal-velvet-smooth-pure/demo.html
+++ b/submissions/examples/css-modal-velvet-smooth-pure/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Modal: Velvet Smooth</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Modal: Velvet Smooth</h1>
+            <p class="subtitle">A luxurious, JavaScript-free modal utilizing the checkbox hack. Features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Modal (Checkbox Hack)
+              The button is actually a <label> tied to a hidden checkbox.
+              When clicked, the checkbox state changes to :checked, which
+              triggers CSS sibling selectors to reveal the modal.
+            -->
+            <input type="checkbox" id="modal-toggle" class="modal-toggle-input" aria-hidden="true">
+            
+            <!-- Trigger Button -->
+            <label for="modal-toggle" class="btn-trigger" role="button" tabindex="0">
+                Reveal Experience
+            </label>
+            
+            <!-- Modal Overlay & Content -->
+            <div class="modal-overlay">
+                
+                <!-- Clicking the overlay closes the modal by untoggling the checkbox -->
+                <label for="modal-toggle" class="modal-backdrop" aria-label="Close modal"></label>
+                
+                <!-- 
+                  [TECHNIQUE] Velvet Smooth Transition
+                  This modal avoids snappy or bouncy physics entirely. 
+                  Instead, it uses a longer duration (0.7s) and a custom cubic-bezier
+                  that accelerates very slowly and decelerates gracefully.
+                  We also animate the `filter: blur()` property to create a cinematic "focus pull" effect.
+                -->
+                <div class="modal-card" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                    
+                    <div class="modal-content">
+                        
+                        <div class="icon-diamond">
+                            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M6 3h12l4 6-10 12L2 9l4-6z"></path>
+                                <path d="M2 9h20"></path>
+                                <path d="m12 21-4-12"></path>
+                                <path d="m12 21 4-12"></path>
+                                <path d="M6 3v6"></path>
+                                <path d="M18 3v6"></path>
+                            </svg>
+                        </div>
+                        
+                        <h2 id="modal-title" class="modal-title">Premium Access</h2>
+                        
+                        <p class="modal-text">
+                            Notice the entrance. It does not snap or bounce. The `transform`, `opacity`, and `filter` properties are synchronized over a 700ms duration using a `cubic-bezier(0.25, 1, 0.5, 1)` easing curve. The initial state is slightly blurred and scaled up, creating a cinematic depth-of-field effect as it focuses into view.
+                        </p>
+                        
+                        <div class="modal-actions">
+                            <label for="modal-toggle" class="btn-action outline">Decline</label>
+                            <label for="modal-toggle" class="btn-action primary">Accept Invitation</label>
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-velvet-smooth-pure/style.css
+++ b/submissions/examples/css-modal-velvet-smooth-pure/style.css
@@ -1,0 +1,327 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Montserrat:wght@300;400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Deep, luxurious velvet colors */
+    --bg-base: #181315; /* Extremely dark burgundy/brown */
+    --text-primary: #fdfbf7; /* Off-white / cream */
+    
+    --modal-bg: #2a1b24; /* Deep velvet plum */
+    --modal-text: #fdfbf7;
+    --modal-text-muted: #b8a6ae;
+    
+    --accent: #d4af37; /* Metallic gold */
+    --accent-hover: #f3e5ab; /* Lighter gold */
+    
+    /* The Velvet Easing Curve - Very smooth, long deceleration */
+    --velvet-ease: cubic-bezier(0.25, 1, 0.5, 1);
+    --velvet-duration: 0.8s;
+}
+
+/* Velvet styling works best universally in a dark palette, but we can adjust slightly for light mode if forced */
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg-base: #fdfbf7;
+        --text-primary: #2a1b24;
+        
+        --modal-bg: #ffffff;
+        --modal-text: #2a1b24;
+        --modal-text-muted: #735d68;
+        
+        --accent: #9a7b4f; /* Darker gold for light bg */
+        --accent-hover: #725b39;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* 
+       Montserrat for UI elements (buttons/small text)
+       Cormorant for headings (elegant serif)
+    */
+    font-family: 'Montserrat', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 3rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: 1px;
+}
+
+.subtitle {
+    font-weight: 300;
+    color: var(--modal-text-muted);
+    font-size: 1.1rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.8;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+    position: relative; 
+}
+
+
+/* =========================================
+   Trigger Button Styling
+   ========================================= */
+
+.btn-trigger {
+    display: inline-block;
+    padding: 18px 48px;
+    background-color: transparent;
+    color: var(--accent);
+    font-weight: 400;
+    font-size: 0.9rem;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    border: 1px solid var(--accent);
+    cursor: pointer;
+    
+    /* Smooth transitions for the button as well */
+    transition: all 0.6s var(--velvet-ease);
+}
+
+.btn-trigger:hover {
+    background-color: var(--accent);
+    color: var(--bg-base);
+    box-shadow: 0 10px 30px rgba(212, 175, 55, 0.15);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Modal Checkbox Logic
+   ========================================= */
+
+.modal-toggle-input {
+    display: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    opacity: 0;
+    visibility: hidden;
+    
+    /* 
+       The overlay transition is slightly faster than the modal card 
+       so the background darkens before the card finishes arriving.
+    */
+    transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* Very dark, solid backdrop to focus entirely on the modal */
+    background-color: rgba(10, 5, 8, 0.9);
+    backdrop-filter: blur(8px);
+    cursor: pointer;
+}
+
+@media (prefers-color-scheme: light) {
+    .modal-backdrop {
+        background-color: rgba(253, 251, 247, 0.85);
+    }
+}
+
+
+/* =========================================
+   [TECHNIQUE] Velvet Smooth Cinematic Transition
+   ========================================= */
+
+.modal-card {
+    position: relative;
+    width: 90%;
+    max-width: 500px;
+    background-color: var(--modal-bg);
+    border-radius: 4px; /* Minimal border radius for elegant look */
+    border: 1px solid rgba(212, 175, 55, 0.2);
+    box-shadow: 0 40px 100px rgba(0, 0, 0, 0.5);
+    
+    /* 
+       Initial State (Out of focus):
+       Slightly larger, blurred, and faded out.
+    */
+    transform: scale(1.05);
+    filter: blur(10px);
+    opacity: 0;
+    
+    /* 
+       The magic is in the duration (0.8s) and the cubic-bezier (0.25, 1, 0.5, 1).
+       It creates a feeling of weight and luxury, like a heavy velvet curtain opening.
+    */
+    transition: 
+        transform var(--velvet-duration) var(--velvet-ease), 
+        filter var(--velvet-duration) var(--velvet-ease), 
+        opacity calc(var(--velvet-duration) - 0.2s) ease;
+}
+
+@media (prefers-color-scheme: light) {
+    .modal-card {
+        box-shadow: 0 40px 100px rgba(42, 27, 36, 0.15);
+    }
+}
+
+/* 
+   Final State (In focus):
+   Normal scale, no blur, fully visible.
+*/
+.modal-toggle-input:checked ~ .modal-overlay .modal-card {
+    transform: scale(1);
+    filter: blur(0);
+    opacity: 1;
+}
+
+/* =========================================
+   Modal Content
+   ========================================= */
+
+.modal-content {
+    padding: 60px 50px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.icon-diamond {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: auto;
+    height: auto;
+    color: var(--accent);
+    margin-bottom: 30px;
+    opacity: 0.8;
+}
+
+.modal-title {
+    font-family: 'Cormorant Garamond', serif;
+    color: var(--modal-text);
+    margin: 0 0 16px 0;
+    font-size: 2.2rem;
+    font-weight: 400;
+    font-style: italic;
+}
+
+.modal-text {
+    font-weight: 300;
+    color: var(--modal-text-muted);
+    font-size: 0.95rem;
+    line-height: 1.8;
+    margin: 0 0 48px 0;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    gap: 20px;
+}
+
+.btn-action {
+    padding: 14px 32px;
+    font-weight: 400;
+    font-size: 0.8rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 0.4s var(--velvet-ease);
+}
+
+.btn-action.outline {
+    background-color: transparent;
+    color: var(--modal-text-muted);
+    border: none;
+    /* Subtle underline hover effect */
+    position: relative;
+}
+
+.btn-action.outline::after {
+    content: '';
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 1px;
+    background-color: var(--modal-text-muted);
+    transition: width 0.4s var(--velvet-ease);
+}
+
+.btn-action.outline:hover::after {
+    width: 40%;
+}
+
+.btn-action.primary {
+    background-color: var(--accent);
+    color: var(--bg-base);
+    border: none;
+    box-shadow: 0 4px 15px rgba(212, 175, 55, 0.2);
+}
+
+.btn-action.primary:hover {
+    background-color: var(--accent-hover);
+    box-shadow: 0 8px 25px rgba(212, 175, 55, 0.4);
+    transform: translateY(-2px);
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay {
+        transition: none;
+    }
+    .modal-card {
+        transition: none;
+        transform: scale(1);
+        filter: blur(0);
+    }
+    .btn-trigger, .btn-action {
+        transition: none !important;
+    }
+    .btn-trigger:hover, .btn-action.primary:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a luxurious, JavaScript-free modal utilizing the CSS checkbox hack. It features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters to create a cinematic "focus pull" effect. Resolves issue #73440.

### Changes Made:
- Added `submissions/examples/css-modal-velvet-smooth-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox logic, the modal overlay, and the semantic modal content.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox, triggering CSS opacity/visibility rules on the modal overlay.
  - **The Cinematic Entrance**: This modal explicitly avoids snappy or bouncy physics. Instead, it aims for weight and elegance. The `.modal-card` transition uses a long duration (`0.8s`) and a custom cubic-bezier (`0.25, 1, 0.5, 1`) that accelerates very slowly and decelerates gracefully.
  - **Focus Pull Effect**: The initial state of the modal is slightly scaled up (`1.05`) and heavily blurred (`filter: blur(10px)`). When the modal opens, the `transform` and `filter` properties animate into place, simulating a camera pulling focus onto the modal while the heavy, dark backdrop obscures the rest of the application.
  - **Component Consistency**: This same `--velvet-ease` variable is applied to the hover states of all the buttons in the UI, ensuring the entire interaction model feels consistently smooth and deliberate.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: light/dark`). The default aesthetic leans heavily into dark mode (deep plums, burgundies, and golds) to fit the "velvet" naming, but automatically adjusts to a lighter cream/gold palette if the user forces a light theme.
- Added `README.md` documenting usage and the technical mechanics of the `filter: blur()` properties and the highly specific `cubic-bezier` timing functions.
- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the scale/blur transitions and instantly displaying the modal for motion-sensitive users.

Closes #73440
