### PR TITLE
feat: add pure CSS Modal Diamond Facet Edge component (#73441)

### DIFF
--- a/submissions/examples/css-modal-diamond-facet-edge-pure/README.md
+++ b/submissions/examples/css-modal-diamond-facet-edge-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Modal: Diamond Facet
+
+A sharp, JavaScript-free modal utilizing the CSS checkbox hack. Features `clip-path` polygons to create chamfered edges, mimicking a precision-cut gemstone instead of standard rounded corners.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to open or close the modal.
+- **Component Architecture**: 
+  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox.
+  - **The Facet Geometry**: The `.facet-shape` class uses `clip-path: polygon(...)` to slice off the four corners of the element, creating an octagon. The depth of the cut is easily controllable via the `--cut-size` CSS variable (set to 24px by default).
+  - **The Inner Glow (Fake Border)**: Standard CSS borders and `box-shadow` do not respect `clip-path` contours—they get chopped off. To fix this and create the illusion of a glowing 3D crystal edge, an absolutely positioned `.facet-inner-glow` pseudo-element is placed over the modal. It shares the exact same clip-path polygon (adjusted for a 4px inset) and applies an `inset box-shadow` to create the glowing border.
+  - **Drop Shadow Filter**: Because standard `box-shadow` is clipped, we use the CSS `filter: drop-shadow(...)` on the `.modal-card` to cast a realistic shadow based on its custom faceted geometry.
+  - **Component Consistency**: The trigger button and the primary modal action buttons share the `.facet-shape` (or `.facet-shape-small`) classes, ensuring the entire interaction model feels geometrically consistent.
+- **Theming & Dark Mode**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: dark`), adjusting background colors and text contrast while maintaining the vivid cyan/sky blue crystal accents.
+- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the scale/rotate transitions and instantly displaying the modal for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the "Inspect Gem" button to trigger the checkbox hack and reveal the faceted modal.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox logic, the modal overlay, and the inner-glow pseudo-element.
+- `style.css`: The styling, the `:checked` sibling selector logic, the `clip-path` geometry math, and the `filter: drop-shadow()` implementation.

--- a/submissions/examples/css-modal-diamond-facet-edge-pure/demo.html
+++ b/submissions/examples/css-modal-diamond-facet-edge-pure/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Modal: Diamond Facet</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Modal: Diamond Facet</h1>
+            <p class="subtitle">A sharp, JavaScript-free modal utilizing the checkbox hack. Features `clip-path` polygons to create chamfered edges, mimicking a precision-cut gemstone.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Modal (Checkbox Hack)
+              The button is actually a <label> tied to a hidden checkbox.
+              When clicked, the checkbox state changes to :checked, which
+              triggers CSS sibling selectors to reveal the modal.
+            -->
+            <input type="checkbox" id="modal-toggle" class="modal-toggle-input" aria-hidden="true">
+            
+            <!-- Trigger Button -->
+            <label for="modal-toggle" class="btn-trigger facet-shape" role="button" tabindex="0">
+                Inspect Gem
+            </label>
+            
+            <!-- Modal Overlay & Content -->
+            <div class="modal-overlay">
+                
+                <!-- Clicking the overlay closes the modal by untoggling the checkbox -->
+                <label for="modal-toggle" class="modal-backdrop" aria-label="Close modal"></label>
+                
+                <!-- 
+                  [TECHNIQUE] Diamond Facet Shape
+                  The .modal-card uses `clip-path: polygon(...)` to slice off 
+                  the four corners, creating an octagonal, faceted shape.
+                  A pseudo-element acts as the glossy inner border to enhance the 3D cut glass look.
+                -->
+                <div class="modal-card facet-shape" role="dialog" aria-labelledby="modal-title" aria-modal="true">
+                    
+                    <!-- The inner border pseudo-element equivalent for the faceted shape -->
+                    <div class="facet-inner-glow"></div>
+                    
+                    <div class="modal-content">
+                        
+                        <div class="icon-gem">
+                            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M6 3h12l4 6-10 12L2 9l4-6z"></path>
+                                <path d="M2 9h20"></path>
+                                <path d="m12 21-4-12"></path>
+                                <path d="m12 21 4-12"></path>
+                                <path d="M6 3v6"></path>
+                                <path d="M18 3v6"></path>
+                            </svg>
+                        </div>
+                        
+                        <h2 id="modal-title" class="modal-title">Precision Cut</h2>
+                        
+                        <p class="modal-text">
+                            Notice the corners. Standard UI relies on `border-radius` for soft, organic shapes. By utilizing `clip-path: polygon(20px 0, calc(100% - 20px) 0, ...)`, we create sharp, chamfered edges. Paired with strict gradients, it simulates the faceted surface of a cut diamond.
+                        </p>
+                        
+                        <div class="modal-actions">
+                            <label for="modal-toggle" class="btn-action outline facet-shape-small">Reject</label>
+                            <label for="modal-toggle" class="btn-action primary facet-shape-small">Appraise</label>
+                        </div>
+                    </div>
+                    
+                </div>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-modal-diamond-facet-edge-pure/style.css
+++ b/submissions/examples/css-modal-diamond-facet-edge-pure/style.css
@@ -1,0 +1,355 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@600&family=Karla:wght@400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f0f4f8;
+    --text-primary: #102a43;
+    
+    --modal-bg: #ffffff;
+    --modal-text: #102a43;
+    --modal-text-muted: #486581;
+    
+    /* Diamond/Crystal Theme Colors */
+    --facet-light: #e0f2fe; /* Light cyan */
+    --facet-border: #7dd3fc; /* Cyan border */
+    --accent: #0284c7; /* Sky 600 */
+    --accent-hover: #0369a1; /* Sky 700 */
+    
+    /* Variables for the polygon clip-path (size of the cut corner) */
+    --cut-size: 24px;
+    --cut-size-small: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a; /* Slate 900 */
+        --text-primary: #f8fafc;
+        
+        --modal-bg: #1e293b; /* Slate 800 */
+        --modal-text: #f8fafc;
+        --modal-text-muted: #94a3b8;
+        
+        --facet-light: #334155; /* Slate 700 */
+        --facet-border: #38bdf8; /* Sky 400 */
+        --accent: #38bdf8; /* Sky 400 */
+        --accent-hover: #7dd3fc; /* Sky 300 */
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* Karla for UI, Cinzel for sharp/elegant headers */
+    font-family: 'Karla', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Cinzel', serif;
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: 1px;
+}
+
+.subtitle {
+    color: var(--modal-text-muted);
+    font-size: 1.1rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 0;
+    min-height: 400px;
+    position: relative; 
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Clip-Path Facets
+   ========================================= */
+
+/* 
+   This creates an octagon by slicing off the 4 corners.
+   The --cut-size variable determines how deep the slice goes.
+*/
+.facet-shape {
+    clip-path: polygon(
+        var(--cut-size) 0, 
+        calc(100% - var(--cut-size)) 0, 
+        100% var(--cut-size), 
+        100% calc(100% - var(--cut-size)), 
+        calc(100% - var(--cut-size)) 100%, 
+        var(--cut-size) 100%, 
+        0 calc(100% - var(--cut-size)), 
+        0 var(--cut-size)
+    );
+    
+    /* Note: box-shadow does not work on clip-path elements directly. */
+}
+
+/* A smaller cut for buttons inside the modal */
+.facet-shape-small {
+    clip-path: polygon(
+        var(--cut-size-small) 0, 
+        calc(100% - var(--cut-size-small)) 0, 
+        100% var(--cut-size-small), 
+        100% calc(100% - var(--cut-size-small)), 
+        calc(100% - var(--cut-size-small)) 100%, 
+        var(--cut-size-small) 100%, 
+        0 calc(100% - var(--cut-size-small)), 
+        0 var(--cut-size-small)
+    );
+}
+
+/* =========================================
+   Trigger Button Styling
+   ========================================= */
+
+.btn-trigger {
+    display: inline-block;
+    padding: 16px 40px;
+    background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
+    color: #ffffff;
+    font-family: 'Cinzel', serif;
+    font-weight: 600;
+    font-size: 1.1rem;
+    letter-spacing: 2px;
+    cursor: pointer;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), filter 0.3s ease;
+}
+
+.btn-trigger:hover {
+    transform: scale(1.05);
+    /* Instead of box-shadow (which is clipped), we use drop-shadow filter */
+    filter: drop-shadow(0 10px 15px rgba(2, 132, 199, 0.4)) brightness(1.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    .btn-trigger { color: #020617; }
+    .btn-trigger:hover { filter: drop-shadow(0 10px 15px rgba(56, 189, 248, 0.4)) brightness(1.1); }
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Modal Checkbox Logic
+   ========================================= */
+
+.modal-toggle-input {
+    display: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1000;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease, visibility 0.4s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(15, 23, 42, 0.7);
+    backdrop-filter: blur(6px);
+    cursor: pointer;
+}
+
+
+/* =========================================
+   Diamond Modal Architecture
+   ========================================= */
+
+.modal-card {
+    position: relative;
+    width: 90%;
+    max-width: 480px;
+    background-color: var(--modal-bg);
+    
+    /* 
+       A sharp, precise rotation and scale in.
+       The drop-shadow filter is used because standard box-shadow 
+       is cut off by the clip-path polygon.
+    */
+    transform: scale(0.9) rotate(2deg);
+    filter: drop-shadow(0 25px 35px rgba(0, 0, 0, 0.3));
+    opacity: 0;
+    
+    transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1), 
+                opacity 0.4s ease, 
+                filter 0.5s ease;
+}
+
+.modal-toggle-input:checked ~ .modal-overlay .modal-card {
+    transform: scale(1) rotate(0deg);
+    filter: drop-shadow(0 25px 35px rgba(0, 0, 0, 0.5));
+    opacity: 1;
+}
+
+/* 
+   Because border-radius and standard borders don't follow clip-path contours well,
+   we create a fake "inner border" using an absolutely positioned element 
+   that also has the clip path applied, but is slightly smaller.
+*/
+.facet-inner-glow {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    right: 4px;
+    bottom: 4px;
+    background-color: transparent;
+    
+    /* Same polygon, but accounts for the 4px inset */
+    clip-path: polygon(
+        calc(var(--cut-size) - 2px) 0, 
+        calc(100% - var(--cut-size) + 2px) 0, 
+        100% calc(var(--cut-size) - 2px), 
+        100% calc(100% - var(--cut-size) + 2px), 
+        calc(100% - var(--cut-size) + 2px) 100%, 
+        calc(var(--cut-size) - 2px) 100%, 
+        0 calc(100% - var(--cut-size) + 2px), 
+        0 calc(var(--cut-size) - 2px)
+    );
+    
+    /* The glowing crystal edge */
+    box-shadow: inset 0 0 0 1px var(--facet-border);
+    pointer-events: none; /* Let clicks pass through to content */
+    z-index: 10;
+}
+
+
+/* =========================================
+   Modal Content
+   ========================================= */
+
+.modal-content {
+    position: relative;
+    z-index: 2;
+    padding: 48px;
+    text-align: center;
+    /* Create a subtle gradient background mimicking a gem interior */
+    background: radial-gradient(circle at center, transparent 0%, var(--facet-light) 150%);
+}
+
+.icon-gem {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    color: var(--accent);
+    margin-bottom: 24px;
+    /* Give the icon a faceted background too */
+    background-color: var(--facet-light);
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+}
+
+.modal-title {
+    font-family: 'Cinzel', serif;
+    color: var(--modal-text);
+    margin: 0 0 16px 0;
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+}
+
+.modal-text {
+    color: var(--modal-text-muted);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin: 0 0 40px 0;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+}
+
+.btn-action {
+    flex: 1;
+    padding: 14px 20px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-action.outline {
+    background-color: var(--facet-light);
+    color: var(--modal-text);
+    /* Simulating border using background since we clipped the button */
+    box-shadow: inset 0 0 0 1px var(--facet-border);
+}
+
+.btn-action.outline:hover {
+    background-color: transparent;
+    filter: brightness(0.9);
+}
+
+.btn-action.primary {
+    background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
+    color: #ffffff;
+}
+
+.btn-action.primary:hover {
+    filter: brightness(1.2);
+}
+
+@media (prefers-color-scheme: dark) {
+    .btn-action.outline:hover { filter: brightness(1.2); }
+    .btn-action.primary { color: #020617; }
+}
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .modal-overlay {
+        transition: none;
+    }
+    .modal-card {
+        transition: none;
+        transform: scale(1) rotate(0deg);
+    }
+    .btn-trigger, .btn-action {
+        transition: none !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a sharp, JavaScript-free modal utilizing the CSS checkbox hack. It features `clip-path` polygons to create chamfered edges, mimicking a precision-cut gemstone instead of standard rounded corners. Resolves issue #73441.

### Changes Made:
- Added `submissions/examples/css-modal-diamond-facet-edge-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox logic, the modal overlay, and the inner-glow pseudo-element.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The core functional logic relies on a hidden `<input type="checkbox">` and the general sibling combinator (`~`). When the user clicks the `<label>` button to open the modal, or clicks the backdrop/dismiss buttons to close it, they are actually toggling this hidden checkbox, triggering CSS opacity/visibility rules on the modal overlay.
  - **The Facet Geometry**: The `.facet-shape` class uses `clip-path: polygon(...)` to slice off the four corners of the element, creating an octagon. The depth of the cut is easily controllable via the `--cut-size` CSS variable (set to 24px by default).
  - **The Inner Glow (Fake Border)**: Standard CSS borders and `box-shadow` do not respect `clip-path` contours—they get chopped off. To fix this and create the illusion of a glowing 3D crystal edge, an absolutely positioned `.facet-inner-glow` pseudo-element is placed over the modal. It shares the exact same clip-path polygon (adjusted for a 4px inset) and applies an `inset box-shadow` to create the glowing border.
  - **Drop Shadow Filter**: Because standard `box-shadow` is clipped, we use the CSS `filter: drop-shadow(...)` on the `.modal-card` to cast a realistic shadow based on its custom faceted geometry.
  - **Component Consistency**: The trigger button and the primary modal action buttons share the `.facet-shape` (or `.facet-shape-small`) classes, ensuring the entire interaction model feels geometrically consistent.
  - **Theming & Dark Mode Supported**: Configured via CSS Custom Properties. The modal fully supports the OS-level system theme (`prefers-color-scheme: dark`), adjusting background colors and text contrast while maintaining the vivid cyan/sky blue crystal accents.
- Added `README.md` documenting usage and the technical mechanics of the `clip-path` geometry math and the `filter: drop-shadow()` implementation.
- Fully accessible semantic structure. The modal is designated with `role="dialog"` and `aria-modal="true"`. Honors the `prefers-reduced-motion` accessibility standard by freezing the scale/rotate transitions and instantly displaying the modal for motion-sensitive users.

Closes #73441
