### PR TITLE
Add CSS message reaction tooltip component

### DIFF
--- a/submissions/examples/css-message-reaction-tooltip/README.md
+++ b/submissions/examples/css-message-reaction-tooltip/README.md
@@ -1,0 +1,28 @@
+=# CSS Message Reaction Tooltip
+
+A pure CSS message reaction tooltip component designed for messaging applications, chat windows, and collaboration platforms. Hovering or focusing on any reaction pill elevates a styled tooltip panel detailing the users who reacted with that emoji. Built without JavaScript dependencies.
+
+## How it works
+
+Reaction pills are styled as interactive button elements (`.ease-reaction-pill`). The tooltip overlay (`.ease-tooltip`) resides within the reaction container using `position: absolute; bottom: calc(100% + 8px)`. On `:hover` or `:focus-visible`, the tooltip opacity transitions from `0` to `1` accompanied by a smooth `translateY()` transform scaling to resting size via `cubic-bezier(0.16, 1, 0.3, 1)`.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-rxn-bg`: Outer surface background color (`#0f172a`)
+- `--ease-rxn-card-bg`: Chat card background color (`#1e293b`)
+- `--ease-rxn-pill-bg`: Unfocused pill surface (`#090a0f`)
+- `--ease-rxn-border`: Border line color (`#334155`)
+- `--ease-rxn-text`: Primary text color (`#f8fafc`)
+- `--ease-rxn-muted`: Subtitle description text color (`#94a3b8`)
+- `--ease-rxn-accent`: Primary sky-blue accent color (`#38bdf8`)
+- `--ease-rxn-tooltip-bg`: Dark popover backdrop color (`#020617`)
+- `--ease-rxn-duration`: Transition speed (`0.25s`)
+
+## Accessibility & Performance
+
+- Fully accessible using semantic markup, keyboard focus management (`tabindex="0"`, `:focus-visible`), and explicit `aria-label` declarations announcing emoji reaction counts and participant names to screen readers.
+- Includes complete `@media (prefers-reduced-motion: reduce)` support that disables transform shifts and scale transitions in favor of direct opacity fades.

--- a/submissions/examples/css-message-reaction-tooltip/demo.html
+++ b/submissions/examples/css-message-reaction-tooltip/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Message Reaction Tooltip — Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Chat UI Components</p>
+    <h1 class="ease-heading">Message Reaction Tooltip</h1>
+    <p class="ease-subtitle">Hover or focus on a reaction pill to view who reacted with each emoji.</p>
+
+    <div class="ease-chat-card" role="region" aria-label="Chat message thread">
+      <!-- Chat Message Header -->
+      <div class="ease-msg-header">
+        <div class="ease-avatar">
+          <span>NA</span>
+        </div>
+        <div class="ease-msg-info">
+          <span class="ease-author-name">Naura</span>
+          <span class="ease-msg-time">Today at 10:42 AM</span>
+        </div>
+      </div>
+
+      <!-- Chat Body -->
+      <p class="ease-msg-body">
+        Just merged the latest PR for EaseMotion CSS! Let me know if everything looks good on your end. 🚀
+      </p>
+
+      <!-- Reaction Pills Group -->
+      <div class="ease-reactions-group" aria-label="Message reactions">
+        <!-- Reaction 1 -->
+        <button type="button" class="ease-reaction-pill active" tabindex="0" aria-label="3 reactions with heart emoji. Reacted by Aubin, Naura, and You.">
+          <span class="ease-emoji">❤️</span>
+          <span class="ease-count">3</span>
+          <div class="ease-tooltip" role="tooltip">
+            <span class="ease-tooltip-title">Heart Reaction</span>
+            <span class="ease-tooltip-names">Aubin, Naura, You</span>
+          </div>
+        </button>
+
+        <!-- Reaction 2 -->
+        <button type="button" class="ease-reaction-pill" tabindex="0" aria-label="2 reactions with rocket emoji. Reacted by Saptarshi and Naura.">
+          <span class="ease-emoji">🚀</span>
+          <span class="ease-count">2</span>
+          <div class="ease-tooltip" role="tooltip">
+            <span class="ease-tooltip-title">Rocket Reaction</span>
+            <span class="ease-tooltip-names">Saptarshi, Naura</span>
+          </div>
+        </button>
+
+        <!-- Reaction 3 -->
+        <button type="button" class="ease-reaction-pill active" tabindex="0" aria-label="1 reaction with thumbs up emoji. Reacted by You.">
+          <span class="ease-emoji">👍</span>
+          <span class="ease-count">1</span>
+          <div class="ease-tooltip" role="tooltip">
+            <span class="ease-tooltip-title">Thumbs Up Reaction</span>
+            <span class="ease-tooltip-names">You</span>
+          </div>
+        </button>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-message-reaction-tooltip/style.css
+++ b/submissions/examples/css-message-reaction-tooltip/style.css
@@ -1,0 +1,243 @@
+:root {
+  --ease-rxn-bg: #0f172a;
+  --ease-rxn-card-bg: #1e293b;
+  --ease-rxn-pill-bg: #090a0f;
+  --ease-rxn-border: #334155;
+  --ease-rxn-text: #f8fafc;
+  --ease-rxn-muted: #94a3b8;
+  --ease-rxn-accent: #38bdf8;
+  --ease-rxn-active-bg: rgba(56, 189, 248, 0.12);
+  --ease-rxn-tooltip-bg: #020617;
+  
+  --ease-rxn-radius: 12px;
+  --ease-rxn-duration: 0.25s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #020617;
+  color: var(--ease-rxn-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-rxn-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-rxn-muted);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+/* Chat Card Surface */
+.ease-chat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: var(--ease-rxn-card-bg);
+  border: 1px solid var(--ease-rxn-border);
+  border-radius: var(--ease-rxn-radius);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+/* Chat Message Header */
+.ease-msg-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ease-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #38bdf8, #a855f7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: #020617;
+  flex-shrink: 0;
+}
+
+.ease-msg-info {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.ease-author-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ease-rxn-text);
+}
+
+.ease-msg-time {
+  font-size: 0.75rem;
+  color: var(--ease-rxn-muted);
+}
+
+/* Chat Message Text Body */
+.ease-msg-body {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ease-rxn-text);
+}
+
+/* Reactions Container */
+.ease-reactions-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+/* Reaction Pill Button */
+.ease-reaction-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  background: var(--ease-rxn-pill-bg);
+  border: 1px solid var(--ease-rxn-border);
+  border-radius: 20px;
+  color: var(--ease-rxn-text);
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--ease-rxn-duration) ease,
+              background-color var(--ease-rxn-duration) ease,
+              transform var(--ease-rxn-duration) ease;
+}
+
+.ease-reaction-pill:hover,
+.ease-reaction-pill:focus-visible {
+  border-color: var(--ease-rxn-accent);
+  transform: translateY(-2px);
+}
+
+.ease-reaction-pill.active {
+  background: var(--ease-rxn-active-bg);
+  border-color: var(--ease-rxn-accent);
+  color: var(--ease-rxn-accent);
+}
+
+.ease-emoji {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.ease-count {
+  font-weight: 600;
+}
+
+/* Tooltip Popup Layer */
+.ease-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px) scale(0.95);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--ease-rxn-tooltip-bg);
+  border: 1px solid var(--ease-rxn-border);
+  border-radius: 8px;
+  box-shadow: 0 10px 20px -5px rgba(0, 0, 0, 0.8);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  z-index: 10;
+  transition: opacity var(--ease-rxn-duration) ease,
+              transform var(--ease-rxn-duration) cubic-bezier(0.16, 1, 0.3, 1),
+              visibility 0s linear var(--ease-rxn-duration);
+}
+
+/* Tooltip Arrow Indicator */
+.ease-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--ease-rxn-tooltip-bg) transparent transparent transparent;
+}
+
+/* Reveal Tooltip on Hover / Keyboard Focus */
+.ease-reaction-pill:hover .ease-tooltip,
+.ease-reaction-pill:focus-visible .ease-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0) scale(1);
+  transition: opacity var(--ease-rxn-duration) ease,
+              transform var(--ease-rxn-duration) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-tooltip-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--ease-rxn-accent);
+  letter-spacing: 0.04em;
+}
+
+.ease-tooltip-names {
+  font-size: 0.78rem;
+  color: var(--ease-rxn-text);
+  font-weight: 500;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-chat-card {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-reaction-pill,
+  .ease-tooltip {
+    transition: none !important;
+    transform: none !important;
+  }
+  .ease-tooltip {
+    transform: translateX(-50%) !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #70201

Adds a pure CSS/HTML Message Reaction Tooltip component for chat and messaging interfaces featuring hover and focus-triggered popovers detailing user reaction lists.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-message-reaction-tooltip/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A chat reaction pill component with customizable CSS variables (`--ease-rxn-accent`, `--ease-rxn-duration`) that displays a floating tooltip list of reactors on hover or keyboard focus.
**Why does it fit?** Expands EaseMotion CSS showcase components with modern social and messaging UI interaction patterns built entirely with lightweight CSS.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full screen reader and keyboard accessibility (`tabindex="0"`, `:focus-visible`, `role="tooltip"`, `aria-label`) and `prefers-reduced-motion` fallbacks (disabling scale and translateY animations).