### PR TITLE
Add ease-speed-ometer-gauge component

### DIFF
--- a/submissions/examples/speed-ometer-gauge-ij/README.md
+++ b/submissions/examples/speed-ometer-gauge-ij/README.md
@@ -1,0 +1,11 @@
+# ease-speed-ometer-gauge
+
+A speedometer gauge where the needle sweeps, the readout blinks, and the odometer ticks.
+
+## Run
+Open `demo.html` directly in a browser to watch the gauge.
+
+## Notes
+- The needle sweeps the dial.
+- The digital readout blinks.
+- The odometer ticks along.

--- a/submissions/examples/speed-ometer-gauge-ij/demo.html
+++ b/submissions/examples/speed-ometer-gauge-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-speed-ometer-gauge</title>
+</head>
+<body>
+<main class="sog-panel">
+  <header class="sog-top">
+    <h1 class="sog-model">Roadster GT</h1>
+    <span class="sog-gear">Drive</span>
+  </header>
+  <section class="sog-dial" aria-label="speedometer dial">
+    <div class="sog-face">
+      <span class="sog-tick sog-tick-1">0</span>
+      <span class="sog-tick sog-tick-2">40</span>
+      <span class="sog-tick sog-tick-3">90</span>
+      <span class="sog-tick sog-tick-4">140</span>
+      <span class="sog-tick sog-tick-5">180</span>
+      <span class="sog-needle"></span>
+      <span class="sog-hub"></span>
+    </div>
+    <strong class="sog-readout">96 km/h</strong>
+  </section>
+  <section class="sog-bottom">
+    <span class="sog-fuel">Fuel 62%</span>
+    <span class="sog-odo">123 456 km</span>
+    <span class="sog-temp">Temp 88C</span>
+  </section>
+  <footer class="sog-foot">
+    <span class="sog-warn">Traction on</span>
+    <span class="sog-trip">Trip 204 km</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/speed-ometer-gauge-ij/style.css
+++ b/submissions/examples/speed-ometer-gauge-ij/style.css
@@ -1,0 +1,25 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;font-variant-numeric:tabular-nums}
+body{min-height:100vh;display:grid;place-items:center;background:#0e1a2b;font-family:'Segoe UI',sans-serif}
+.sog-panel{width:302px;border-radius:22px;padding:20px;background:radial-gradient(circle at 50% 0%,#1b2f47,#0b1524);color:#e8f1fb;box-shadow:0 18px 42px rgba(4,12,24,.7)}
+.sog-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.sog-model{font-size:16px;letter-spacing:1px;color:#cfe0f2}
+.sog-gear{font-size:11px;color:#ffd9a0;background:#2a1e12;padding:3px 10px;border-radius:9px}
+.sog-dial{text-align:center}
+.sog-face{position:relative;width:208px;height:208px;margin:0 auto;border-radius:50%;background:conic-gradient(from 210deg,#ffd27a 0 30deg,#1c3247 30deg 360deg);border:6px solid #122238}
+.sog-tick{position:absolute;font-size:12px;color:#a9c2dc;font-weight:700}
+.sog-tick-1{top:14px;left:22px}
+.sog-tick-2{top:34px;right:24px}
+.sog-tick-3{right:10px;top:94px}
+.sog-tick-4{right:30px;bottom:24px}
+.sog-tick-5{left:30px;bottom:14px}
+.sog-needle{position:absolute;left:50%;bottom:50%;width:4px;height:76px;margin-left:-2px;background:#ffb84d;transform-origin:50% 100%;animation:sog-needle-sweep-speed-ometer-gauge 5s ease-in-out infinite}
+.sog-hub{position:absolute;left:50%;bottom:50%;width:16px;height:16px;margin:-8px;border-radius:50%;background:#f2c577}
+.sog-readout{display:block;font-size:28px;margin-top:10px;color:#8ff0c9;animation:sog-readout-blink-speed-ometer-gauge 2s steps(2) infinite}
+.sog-bottom{display:flex;justify-content:space-between;margin-top:14px;font-size:11px;color:#8aa6c2}
+.sog-odo{font-size:12px;color:#f0c98f;animation:sog-odo-tick-speed-ometer-gauge 3s steps(2) infinite}
+.sog-foot{display:flex;justify-content:space-between;margin-top:10px;font-size:10px;color:#6e88a3}
+.sog-warn{color:#ffb38a}
+.sog-temp{color:#9fc9e8}
+@keyframes sog-needle-sweep-speed-ometer-gauge{0%{transform:rotate(0deg)}45%{transform:rotate(58deg)}75%{transform:rotate(22deg)}100%{transform:rotate(0deg)}}
+@keyframes sog-readout-blink-speed-ometer-gauge{0%,100%{opacity:1}50%{opacity:.45}}
+@keyframes sog-odo-tick-speed-ometer-gauge{0%,100%{color:#f0c98f}50%{color:#9a7c4e}}


### PR DESCRIPTION
## Component: ease-speed-ometer-gauge — needle sweeps, readout blinks, and odometer ticks

**Closes #74425**

### What this adds
A speedometer gauge where the needle sweeps, the readout blinks, and the odometer ticks.

### Acceptance Criteria covered
- Needle sweeps the dial
- Digital readout blinks
- Odometer ticks along

### Files
- `submissions/examples/speed-ometer-gauge-ij/demo.html`
- `submissions/examples/speed-ometer-gauge-ij/style.css`
- `submissions/examples/speed-ometer-gauge-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the needle sweep, the readout blink, and the odometer tick.