### PR TITLE
Add ease-calendar-month-view component

### DIFF
--- a/submissions/examples/calendar-month-view-ij/README.md
+++ b/submissions/examples/calendar-month-view-ij/README.md
@@ -1,0 +1,11 @@
+# ease-calendar-month-view
+
+A calendar month view where the today cell glows, the event dots blink, and the day grid pops.
+
+## Run
+Open `demo.html` directly in a browser to watch the calendar.
+
+## Notes
+- Today pulses in the grid.
+- Event dots blink on dates.
+- The month header stays steady.

--- a/submissions/examples/calendar-month-view-ij/demo.html
+++ b/submissions/examples/calendar-month-view-ij/demo.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-calendar-month-view</title>
+</head>
+<body>
+<main class="cmv-card">
+  <header class="cmv-head">
+    <button class="cmv-nav" aria-label="previous month">&#8592;</button>
+    <h1 class="cmv-title">August 2026</h1>
+    <button class="cmv-nav" aria-label="next month">&#8594;</button>
+  </header>
+  <section class="cmv-weekdays" aria-label="weekday row">
+    <span>Mon</span>
+    <span>Tue</span>
+    <span>Wed</span>
+    <span>Thu</span>
+    <span>Fri</span>
+    <span>Sat</span>
+    <span>Sun</span>
+  </section>
+  <section class="cmv-grid" aria-label="calendar days">
+    <span class="cmv-day">1</span>
+    <span class="cmv-day">2</span>
+    <span class="cmv-day cmv-today">3</span>
+    <span class="cmv-day">4</span>
+    <span class="cmv-day">5</span>
+    <span class="cmv-day">6</span>
+    <span class="cmv-day">7</span>
+    <span class="cmv-day">8</span>
+    <span class="cmv-day">9</span>
+    <span class="cmv-day">10</span>
+    <span class="cmv-day cmv-event">11</span>
+    <span class="cmv-day">12</span>
+    <span class="cmv-day">13</span>
+    <span class="cmv-day">14</span>
+    <span class="cmv-day">15</span>
+    <span class="cmv-day cmv-event">16</span>
+    <span class="cmv-day">17</span>
+    <span class="cmv-day">18</span>
+    <span class="cmv-day">19</span>
+    <span class="cmv-day">20</span>
+    <span class="cmv-day">21</span>
+    <span class="cmv-day">22</span>
+    <span class="cmv-day">23</span>
+    <span class="cmv-day">24</span>
+    <span class="cmv-day">25</span>
+    <span class="cmv-day">26</span>
+    <span class="cmv-day">27</span>
+    <span class="cmv-day">28</span>
+    <span class="cmv-day">29</span>
+    <span class="cmv-day">30</span>
+    <span class="cmv-day">31</span>
+  </section>
+  <footer class="cmv-foot">
+    <span class="cmv-dot"></span>
+    <span class="cmv-hint">2 events this month</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/calendar-month-view-ij/style.css
+++ b/submissions/examples/calendar-month-view-ij/style.css
@@ -1,0 +1,18 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;direction:ltr}
+body{min-height:100vh;display:grid;place-items:center;background:#1a2436;font-family:'Georgia',serif}
+.cmv-card{width:296px;border-radius:16px;padding:16px;background:linear-gradient(180deg,#283250,#151d2e);color:#edf2fa;box-shadow:0 14px 34px rgba(10,14,26,.6)}
+.cmv-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.cmv-title{font-size:16px;color:#ffdca8}
+.cmv-nav{font-size:14px;color:#9fb4d4;background:#1d2740;border:none;border-radius:8px;padding:4px 10px}
+.cmv-weekdays{display:grid;grid-template-columns:repeat(7,1fr);gap:4px;margin-bottom:8px;font-size:10px;text-align:center;color:#8ba0c2;letter-spacing:1px}
+.cmv-weekdays span:nth-child(6),.cmv-weekdays span:nth-child(7){color:#d49a6a}
+.cmv-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
+.cmv-day{text-align:center;font-size:12px;padding:7px 0;border-radius:8px;background:#1d2740;color:#c8d7ec}
+.cmv-today{background:#3d5c86;color:#fff6e4;font-weight:700;animation:cmv-today-glow-calendar-month-view 2.4s ease-in-out infinite}
+.cmv-event{position:relative}
+.cmv-event::after{content:"";position:absolute;left:50%;bottom:3px;width:5px;height:5px;margin-left:-2px;border-radius:50%;background:#ffb64d;animation:cmv-dot-blink-calendar-month-view 1.6s steps(2) infinite}
+.cmv-foot{display:flex;align-items:center;gap:8px;margin-top:12px;font-size:11px;color:#9fb4d4}
+.cmv-dot{width:8px;height:8px;border-radius:50%;background:#ffb64d;animation:cmv-dot-blink-calendar-month-view 1.6s steps(2) infinite}
+@keyframes cmv-today-glow-calendar-month-view{0%,100%{box-shadow:0 0 0 rgba(61,92,134,0)}50%{box-shadow:0 0 12px rgba(255,182,77,.55)}}
+@keyframes cmv-dot-blink-calendar-month-view{0%,100%{opacity:.25}50%{opacity:1}}
+@keyframes cmv-cell-pop-calendar-month-view{0%{transform:scale(.92)}100%{transform:scale(1)}}


### PR DESCRIPTION
## Component: ease-calendar-month-view — today glows, dots blink, and grid pops

**Closes #74426**

### What this adds
A calendar month view where the today cell glows, the event dots blink, and the day grid pops.

### Acceptance Criteria covered
- Today cell glows
- Event dots blink
- Day cells pop in

### Files
- `submissions/examples/calendar-month-view-ij/demo.html`
- `submissions/examples/calendar-month-view-ij/style.css`
- `submissions/examples/calendar-month-view-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the today cell glow, the dots blink, and the grid pop.