### PR TITLE
Add ease-tic-tac-toe-board component

### DIFF
--- a/submissions/examples/tic-tac-toe-board-ij/README.md
+++ b/submissions/examples/tic-tac-toe-board-ij/README.md
@@ -1,0 +1,11 @@
+# ease-tic-tac-toe-board
+
+A tic tac toe board where the winning mark glows, the turn badge blinks, and the tally tracks.
+
+## Run
+Open `demo.html` directly in a browser to watch the board.
+
+## Notes
+- The winning cell glows.
+- The turn badge blinks.
+- The tally tracks rounds.

--- a/submissions/examples/tic-tac-toe-board-ij/demo.html
+++ b/submissions/examples/tic-tac-toe-board-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-tic-tac-toe-board</title>
+</head>
+<body>
+<main class="ttb-card">
+  <header class="ttb-top">
+    <h1 class="ttb-name">Tic Tac Toe</h1>
+    <span class="ttb-turn">X to move</span>
+  </header>
+  <section class="ttb-board" aria-label="game board">
+    <span class="ttb-cell ttb-x">X</span>
+    <span class="ttb-cell ttb-o">O</span>
+    <span class="ttb-cell ttb-x">X</span>
+    <span class="ttb-cell ttb-x">X</span>
+    <span class="ttb-cell ttb-o">O</span>
+    <span class="ttb-cell ttb-o">O</span>
+    <span class="ttb-cell ttb-o">O</span>
+    <span class="ttb-cell ttb-x">X</span>
+    <span class="ttb-cell ttb-x ttb-win">X</span>
+  </section>
+  <section class="ttb-score" aria-label="round tallies">
+    <span class="ttb-tally">X 3</span>
+    <span class="ttb-tally">O 2</span>
+    <span class="ttb-tally">Draw 4</span>
+  </section>
+  <footer class="ttb-foot">
+    <button class="ttb-reset">New round</button>
+    <span class="ttb-status">X wins this round</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/tic-tac-toe-board-ij/style.css
+++ b/submissions/examples/tic-tac-toe-board-ij/style.css
@@ -1,0 +1,19 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;line-height:1}
+body{min-height:100vh;display:grid;place-items:center;background:#241f33;font-family:'Trebuchet MS',sans-serif}
+.ttb-card{width:288px;border-radius:18px;padding:18px;background:linear-gradient(160deg,#38305a,#221d36);color:#f2edff;box-shadow:0 16px 36px rgba(16,12,30,.6)}
+.ttb-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.ttb-name{font-size:17px;letter-spacing:1px;color:#ffd98f}
+.ttb-turn{font-size:11px;color:#ffb38a;background:#33231d;padding:3px 9px;border-radius:8px;animation:ttb-status-blink-tic-tac-toe-board 2s steps(2) infinite}
+.ttb-board{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.ttb-cell{aspect-ratio:1;display:grid;place-items:center;font-size:30px;font-weight:700;border-radius:12px;background:#2a2440;border:2px solid #453c6b}
+.ttb-x{color:#7fe0c3}
+.ttb-o{color:#ff9d7a}
+.ttb-win{animation:ttb-win-glow-tic-tac-toe-board 1.6s ease-in-out infinite}
+.ttb-score{display:flex;justify-content:space-around;margin-top:14px;font-size:12px;color:#b9aee0}
+.ttb-tally{background:#201a33;padding:4px 12px;border-radius:8px}
+.ttb-foot{display:flex;justify-content:space-between;align-items:center;margin-top:12px}
+.ttb-reset{font-size:12px;color:#0d1411;background:#7fe0c3;border:none;border-radius:8px;padding:6px 12px}
+.ttb-status{font-size:11px;color:#c6b9ee}
+@keyframes ttb-win-glow-tic-tac-toe-board{0%,100%{box-shadow:0 0 0 rgba(127,224,195,0)}50%{box-shadow:0 0 14px rgba(127,224,195,.6)}}
+@keyframes ttb-status-blink-tic-tac-toe-board{0%,100%{opacity:1}50%{opacity:.4}}
+@keyframes ttb-mark-pop-tic-tac-toe-board{0%{transform:scale(.6)}100%{transform:scale(1)}}


### PR DESCRIPTION
## Component: ease-tic-tac-toe-board — mark glows, turn blinks, and tally tracks

**Closes #74427**

### What this adds
A tic tac toe board where the winning mark glows, the turn badge blinks, and the tally tracks.

### Acceptance Criteria covered
- Winning mark glows
- Turn badge blinks
- Score tally tracks

### Files
- `submissions/examples/tic-tac-toe-board-ij/demo.html`
- `submissions/examples/tic-tac-toe-board-ij/style.css`
- `submissions/examples/tic-tac-toe-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the mark glow, the turn blink, and the tally track.