### PR TITLE
Add CSS animated number odometer component

### DIFF
--- a/submissions/examples/css-animated-number-odometer/README.md
+++ b/submissions/examples/css-animated-number-odometer/README.md
@@ -1,0 +1,29 @@
+# CSS Animated Number Odometer
+
+A pure CSS mechanical odometer component that animates numerical counters with vertical rolling digit reels on load. Built entirely with CSS animations and transforms without JavaScript libraries.
+
+## How it works
+
+Each digit column (`.ease-digit-column`) acts as a masked viewport window (`overflow: hidden`). Inside, a vertical strip containing digits `0` through `9` (`.ease-digit-reel`) translates vertically along the Y-axis (`translateY`) using target keyframe utility classes (`.ease-roll-9`, `.ease-roll-4`, etc.) and staggered animation delays.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-odo-bg`: Main surface background (`#0f172a`)
+- `--ease-odo-card-bg`: Card panel background (`#1e293b`)
+- `--ease-odo-reel-bg`: Inner odometer inset frame (`#090a0f`)
+- `--ease-odo-border`: Boundary border line color (`#334155`)
+- `--ease-odo-text`: Primary digit text color (`#f8fafc`)
+- `--ease-odo-muted-text`: Subtitle description color (`#94a3b8`)
+- `--ease-odo-accent`: Sky-blue accent color (`#38bdf8`)
+- `--ease-odo-digit-height`: Fixed vertical line-height for individual digits (`2.8rem`)
+- `--ease-odo-duration`: Rolling animation duration (`2.2s`)
+- `--ease-odo-radius`: Corner radius (`12px`)
+
+## Accessibility & Performance
+
+- Fully accessible using semantic wrapper tags (`role="region"`) and descriptive `aria-label` declarations announcing the final numeric total directly to screen readers.
+- Full support for `@media (prefers-reduced-motion: reduce)` which disables roll animations and immediately displays final target digits.

--- a/submissions/examples/css-animated-number-odometer/demo.html
+++ b/submissions/examples/css-animated-number-odometer/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Animated Number Odometer — Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">System Analytics</p>
+    <h1 class="ease-heading">Active Subscribers</h1>
+    <p class="ease-subtitle">Pure CSS mechanical rolling odometer reel animating numbers on page load.</p>
+
+    <div class="ease-odometer-card">
+      <div 
+        class="ease-odometer" 
+        role="region" 
+        aria-label="Active subscriber count: 94,820"
+      >
+        <span class="ease-odometer-prefix">$</span>
+        
+        <!-- Digit 1: 9 -->
+        <div class="ease-digit-column">
+          <div class="ease-digit-reel ease-roll-9">
+            <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span>
+            <span>5</span><span>6</span><span>7</span><span>8</span><span>9</span>
+          </div>
+        </div>
+
+        <!-- Digit 2: 4 -->
+        <div class="ease-digit-column">
+          <div class="ease-digit-reel ease-roll-4">
+            <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span>
+            <span>5</span><span>6</span><span>7</span><span>8</span><span>9</span>
+          </div>
+        </div>
+
+        <span class="ease-odometer-comma">,</span>
+
+        <!-- Digit 3: 8 -->
+        <div class="ease-digit-column">
+          <div class="ease-digit-reel ease-roll-8">
+            <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span>
+            <span>5</span><span>6</span><span>7</span><span>8</span><span>9</span>
+          </div>
+        </div>
+
+        <!-- Digit 4: 2 -->
+        <div class="ease-digit-column">
+          <div class="ease-digit-reel ease-roll-2">
+            <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span>
+            <span>5</span><span>6</span><span>7</span><span>8</span><span>9</span>
+          </div>
+        </div>
+
+        <!-- Digit 5: 0 -->
+        <div class="ease-digit-column">
+          <div class="ease-digit-reel ease-roll-0">
+            <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span>
+            <span>5</span><span>6</span><span>7</span><span>8</span><span>9</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="ease-odometer-info">
+        <span class="ease-info-badge">Live Revenue</span>
+        <p class="ease-info-sub">+18.4% growth compared to last month</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-animated-number-odometer/style.css
+++ b/submissions/examples/css-animated-number-odometer/style.css
@@ -1,0 +1,208 @@
+:root {
+  --ease-odo-bg: #0f172a;
+  --ease-odo-card-bg: #1e293b;
+  --ease-odo-reel-bg: #090a0f;
+  --ease-odo-border: #334155;
+  --ease-odo-text: #f8fafc;
+  --ease-odo-muted-text: #94a3b8;
+  --ease-odo-accent: #38bdf8;
+  --ease-odo-digit-height: 2.8rem;
+  --ease-odo-duration: 2.2s;
+  --ease-odo-radius: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #020617;
+  color: var(--ease-odo-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 460px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-odo-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-odo-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+/* Card Container */
+.ease-odometer-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.8rem;
+  padding: 2.5rem 1.5rem;
+  background: var(--ease-odo-bg);
+  border: 1px solid var(--ease-odo-border);
+  border-radius: var(--ease-odo-radius);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+/* Odometer Container */
+.ease-odometer {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 2.2rem;
+  font-weight: 700;
+  background: var(--ease-odo-reel-bg);
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--ease-odo-border);
+  border-radius: var(--ease-odo-radius);
+  box-shadow: inset 0 4px 12px rgba(0, 0, 0, 0.8);
+  color: var(--ease-odo-text);
+}
+
+.ease-odometer-prefix,
+.ease-odometer-comma {
+  color: var(--ease-odo-accent);
+  line-height: var(--ease-odo-digit-height);
+}
+
+/* Single Digit Window Column */
+.ease-digit-column {
+  position: relative;
+  height: var(--ease-odo-digit-height);
+  width: 1.6rem;
+  overflow: hidden;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Vertical Roll Strip */
+.ease-digit-reel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-digit-reel span {
+  height: var(--ease-odo-digit-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Staggered Rolling Keyframe Classes */
+.ease-roll-0 {
+  animation: ease-roll-to-0 var(--ease-odo-duration) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ease-roll-2 {
+  animation: ease-roll-to-2 var(--ease-odo-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards;
+}
+
+.ease-roll-4 {
+  animation: ease-roll-to-4 var(--ease-odo-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.2s forwards;
+}
+
+.ease-roll-8 {
+  animation: ease-roll-to-8 var(--ease-odo-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.3s forwards;
+}
+
+.ease-roll-9 {
+  animation: ease-roll-to-9 var(--ease-odo-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.4s forwards;
+}
+
+/* Reel Roll Keyframe Transformations */
+@keyframes ease-roll-to-0 {
+  to { transform: translateY(0); }
+}
+
+@keyframes ease-roll-to-2 {
+  to { transform: translateY(calc(var(--ease-odo-digit-height) * -2)); }
+}
+
+@keyframes ease-roll-to-4 {
+  to { transform: translateY(calc(var(--ease-odo-digit-height) * -4)); }
+}
+
+@keyframes ease-roll-to-8 {
+  to { transform: translateY(calc(var(--ease-odo-digit-height) * -8)); }
+}
+
+@keyframes ease-roll-to-9 {
+  to { transform: translateY(calc(var(--ease-odo-digit-height) * -9)); }
+}
+
+/* Info Subtext */
+.ease-odometer-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ease-info-badge {
+  font-size: 0.75rem;
+  color: var(--ease-odo-accent);
+  background: rgba(56, 189, 248, 0.1);
+  padding: 0.25rem 0.6rem;
+  border-radius: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.ease-info-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-odo-muted-text);
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-odometer {
+    font-size: 1.7rem;
+    padding: 0.6rem 0.8rem;
+  }
+  :root {
+    --ease-odo-digit-height: 2.2rem;
+  }
+  .ease-digit-column {
+    width: 1.3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-digit-reel {
+    animation: none !important;
+  }
+  .ease-roll-0 { transform: translateY(0); }
+  .ease-roll-2 { transform: translateY(calc(var(--ease-odo-digit-height) * -2)); }
+  .ease-roll-4 { transform: translateY(calc(var(--ease-odo-digit-height) * -4)); }
+  .ease-roll-8 { transform: translateY(calc(var(--ease-odo-digit-height) * -8)); }
+  .ease-roll-9 { transform: translateY(calc(var(--ease-odo-digit-height) * -9)); }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #70210

Adds a pure CSS/HTML Mechanical Number Odometer component that simulates rolling mechanical digit reels on page load using CSS translateY keyframe transformations.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-animated-number-odometer/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A mechanical rolling counter component with customizable CSS variables (`--ease-odo-digit-height`, `--ease-odo-duration`) that animates vertical number strips through masked column viewports.
**Why does it fit?** Expands EaseMotion CSS showcase components with an aesthetic mechanical data counter UI pattern without external JavaScript dependencies.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full screen reader accessibility (`aria-label="Active subscriber count: 94,820"`) and `prefers-reduced-motion` fallbacks (disabling reel animations and rendering static final values).