### PR TITLE
feat: add pure CSS Slider Velvet Smooth Transition component (#73628)

### DIFF
--- a/submissions/examples/css-slider-velvet-smooth-pure/README.md
+++ b/submissions/examples/css-slider-velvet-smooth-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Slider: Velvet Smooth Transition
+
+A luxurious, JavaScript-free carousel utilizing the CSS radio button hack. Features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters to create a cinematic "focus pull" effect.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required for slider navigation or state management.
+- **Component Architecture**: 
+  - **The Radio Button Hack**: The core functional logic relies on a series of hidden `<input type="radio">` buttons and the general sibling combinator (`~`). By placing `<label>` elements inside the `.slider-controls` UI that correspond to these radio IDs, clicking a control node actually checks the hidden radio button. The CSS then detects which button is `:checked` and alters the slide visibility accordingly.
+  - **The Cinematic Entrance**: This slider explicitly avoids snappy or bouncy physics. Instead, it aims for weight and elegance. The `.slide` transitions use a long duration (`0.9s`) and a custom cubic-bezier (`0.25, 1, 0.5, 1`) that accelerates very slowly and decelerates gracefully.
+  - **Focus Pull Effect**: The initial/inactive state of a slide is slightly scaled up (`1.05`) and heavily blurred (`filter: blur(10px)`). When a slide becomes active, the `transform` and `filter` properties animate into place, simulating a camera pulling focus onto the new slide.
+  - **Continuous Zoom**: While a slide is active (`:checked`), a separate `@keyframes` animation is applied to its background image (`.slide-bg`), causing it to very slowly zoom in over 15 seconds. This adds a layer of subtle, continuous life to the composition even while the user is simply reading.
+- **Theming**: Configured via CSS Custom Properties. Supports both light and dark OS themes (`prefers-color-scheme`). The default aesthetic leans heavily into dark mode (deep plums, burgundies, and golds) to fit the "velvet" naming, but automatically adjusts to a lighter cream/gold palette if the user forces a light theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by freezing the blur/scale transitions and the continuous background zoom, opting instead for a simple instant opacity cross-fade for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Click the control dots below the slider to navigate between the slides using the pure CSS radio hack, and observe the cinematic focus pull.
+
+## Files
+- `demo.html`: The HTML structure defining the radio button state logic, the slider track, the background image containers, and the navigation controls.
+- `style.css`: The styling, the `:checked` sibling selector matrix for slide opacity/blur toggling, the specific `cubic-bezier` timing functions, and the continuous zoom animation.

--- a/submissions/examples/css-slider-velvet-smooth-pure/demo.html
+++ b/submissions/examples/css-slider-velvet-smooth-pure/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Slider: Velvet Smooth</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Slider: Velvet Smooth</h1>
+            <p class="subtitle">A luxurious, JavaScript-free carousel utilizing the CSS radio button hack. Features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Pure CSS Slider (Radio Hack)
+              By using hidden radio buttons and the general sibling combinator (~),
+              we can track which slide is currently active without JavaScript.
+            -->
+            <input type="radio" name="velvet-slider" id="slide-1" class="slider-radio" checked>
+            <input type="radio" name="velvet-slider" id="slide-2" class="slider-radio">
+            <input type="radio" name="velvet-slider" id="slide-3" class="slider-radio">
+
+            <div class="velvet-slider">
+                
+                <div class="slider-track">
+                    
+                    <!-- Slide 1 -->
+                    <div class="slide slide-1">
+                        <!-- Background image container for smooth scaling -->
+                        <div class="slide-bg slide-bg-1"></div>
+                        <div class="slide-content">
+                            <h2 class="slide-title">The Prelude</h2>
+                            <p class="slide-text">Notice the transition. It does not snap or bounce. The `transform`, `opacity`, and `filter` properties are synchronized over an 800ms duration using a `cubic-bezier(0.25, 1, 0.5, 1)` easing curve.</p>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 2 -->
+                    <div class="slide slide-2">
+                        <div class="slide-bg slide-bg-2"></div>
+                        <div class="slide-content">
+                            <h2 class="slide-title">The Focus Pull</h2>
+                            <p class="slide-text">The initial state of an incoming slide is slightly blurred and scaled up, creating a cinematic depth-of-field effect as it focuses into view.</p>
+                        </div>
+                    </div>
+                    
+                    <!-- Slide 3 -->
+                    <div class="slide slide-3">
+                        <div class="slide-bg slide-bg-3"></div>
+                        <div class="slide-content">
+                            <h2 class="slide-title">The Crescendo</h2>
+                            <p class="slide-text">The background images slowly zoom in perpetually while the slide is active, adding a layer of subtle, continuous life to the composition.</p>
+                        </div>
+                    </div>
+                    
+                </div>
+                
+                <!-- 
+                  Navigation Controls 
+                  These are labels tied to the radio buttons above.
+                -->
+                <div class="slider-controls">
+                    <label for="slide-1" class="control-node" aria-label="Go to slide 1"></label>
+                    <label for="slide-2" class="control-node" aria-label="Go to slide 2"></label>
+                    <label for="slide-3" class="control-node" aria-label="Go to slide 3"></label>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-slider-velvet-smooth-pure/style.css
+++ b/submissions/examples/css-slider-velvet-smooth-pure/style.css
@@ -1,0 +1,301 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Montserrat:wght@300;400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    /* Deep, luxurious velvet colors */
+    --bg-base: #181315; /* Extremely dark burgundy/brown */
+    --text-primary: #fdfbf7; /* Off-white / cream */
+    
+    --card-bg: #2a1b24; /* Deep velvet plum */
+    --card-text: #fdfbf7;
+    --card-text-muted: #b8a6ae;
+    
+    --accent: #d4af37; /* Metallic gold */
+    --accent-hover: #f3e5ab; /* Lighter gold */
+    
+    /* The Velvet Easing Curve - Very smooth, long deceleration */
+    --velvet-ease: cubic-bezier(0.25, 1, 0.5, 1);
+    --velvet-duration: 0.9s;
+}
+
+/* Velvet styling works best universally in a dark palette, but we adjust for light mode */
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg-base: #fdfbf7;
+        --text-primary: #2a1b24;
+        
+        --card-bg: #ffffff;
+        --card-text: #2a1b24;
+        --card-text-muted: #735d68;
+        
+        --accent: #9a7b4f; /* Darker gold for light bg */
+        --accent-hover: #725b39;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    /* 
+       Montserrat for UI elements (buttons/small text)
+       Cormorant for headings (elegant serif)
+    */
+    font-family: 'Montserrat', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 3rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: 1px;
+}
+
+.subtitle {
+    font-weight: 300;
+    color: var(--text-muted, #b8a6ae);
+    font-size: 1.1rem;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.8;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0 80px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pure CSS Slider Logic
+   ========================================= */
+
+.slider-radio {
+    display: none;
+}
+
+.velvet-slider {
+    position: relative;
+    width: 100%;
+    max-width: 800px;
+}
+
+.slider-track {
+    position: relative;
+    width: 100%;
+    /* Widescreen aspect ratio */
+    aspect-ratio: 16 / 7;
+    overflow: hidden;
+    border-radius: 4px; /* Minimal border radius for elegant look */
+    background-color: var(--card-bg);
+    
+    /* Deep, luxurious shadow */
+    box-shadow: 0 40px 100px rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(212, 175, 55, 0.15);
+}
+
+@media (prefers-color-scheme: light) {
+    .slider-track { box-shadow: 0 40px 100px rgba(42, 27, 36, 0.15); }
+}
+
+/* 
+   We stack the slides absolute. 
+   Instead of sliding horizontally, they transition using opacity, scale, and blur.
+*/
+.slide {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* 
+       Initial State (Out of focus):
+       Slightly larger, blurred, and faded out.
+    */
+    opacity: 0;
+    transform: scale(1.05);
+    filter: blur(10px);
+    
+    /* 
+       The magic is in the duration (0.9s) and the cubic-bezier (0.25, 1, 0.5, 1).
+       It creates a feeling of weight and luxury.
+    */
+    transition: 
+        opacity calc(var(--velvet-duration) - 0.2s) ease,
+        transform var(--velvet-duration) var(--velvet-ease), 
+        filter var(--velvet-duration) var(--velvet-ease);
+        
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* 
+   Active State Logic
+   Final State (In focus): Normal scale, no blur, fully visible.
+*/
+#slide-1:checked ~ .velvet-slider .slider-track .slide-1,
+#slide-2:checked ~ .velvet-slider .slider-track .slide-2,
+#slide-3:checked ~ .velvet-slider .slider-track .slide-3 {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+    pointer-events: auto;
+    z-index: 2;
+}
+
+/*
+  Outgoing State Logic (Wait, what?)
+  By default, when a slide loses the :checked state, it reverts to the initial state (blurring and scaling UP).
+  If we want it to recede (scale DOWN) as it fades out, we can apply specific rules to the non-checked slides.
+*/
+.slider-radio:not(:checked) ~ .velvet-slider .slider-track .slide {
+    /* Optional: make outgoing slides shrink away instead of blooming */
+    /* transform: scale(0.95); */ 
+}
+
+
+/* =========================================
+   Slide Background & Content Styling
+   ========================================= */
+
+.slide-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background-size: cover;
+    background-position: center;
+    /* Darken the background slightly so text is readable */
+    filter: brightness(0.4);
+}
+
+/* 
+   Placeholder gradients/colors since we don't have images.
+   In a real scenario, these would be high-res photography.
+*/
+.slide-bg-1 { background: radial-gradient(circle at center, #4a2b38, #181315); }
+.slide-bg-2 { background: radial-gradient(circle at center, #382b4a, #131318); }
+.slide-bg-3 { background: radial-gradient(circle at center, #4a3b2b, #181613); }
+
+/*
+   Continuous Zoom Effect
+   When a slide is active, its background slowly zooms in continuously.
+*/
+#slide-1:checked ~ .velvet-slider .slider-track .slide-1 .slide-bg,
+#slide-2:checked ~ .velvet-slider .slider-track .slide-2 .slide-bg,
+#slide-3:checked ~ .velvet-slider .slider-track .slide-3 .slide-bg {
+    animation: continuous-zoom 15s linear forwards;
+}
+
+@keyframes continuous-zoom {
+    0% { transform: scale(1); }
+    100% { transform: scale(1.15); }
+}
+
+.slide-content {
+    width: 80%;
+    max-width: 600px;
+    text-align: center;
+    z-index: 2;
+}
+
+.slide-title {
+    font-family: 'Cormorant Garamond', serif;
+    color: var(--card-text);
+    margin: 0 0 16px 0;
+    font-size: 2.5rem;
+    font-weight: 400;
+    font-style: italic;
+    text-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
+}
+
+.slide-text {
+    font-weight: 300;
+    color: rgba(253, 251, 247, 0.9); /* Force light text on the dark background images */
+    font-size: 1rem;
+    line-height: 1.8;
+    margin: 0;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.8);
+}
+
+
+/* =========================================
+   Slider Navigation Controls
+   ========================================= */
+
+.slider-controls {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    margin-top: 32px;
+}
+
+.control-node {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    
+    /* Hollow circle styling */
+    background-color: transparent;
+    border: 1px solid var(--card-text-muted);
+    
+    cursor: pointer;
+    transition: all 0.4s var(--velvet-ease);
+}
+
+.control-node:hover {
+    border-color: var(--accent);
+}
+
+/* 
+   Active state: Filled circle, gold colored
+*/
+#slide-1:checked ~ .velvet-slider .slider-controls .control-node:nth-child(1),
+#slide-2:checked ~ .velvet-slider .slider-controls .control-node:nth-child(2),
+#slide-3:checked ~ .velvet-slider .slider-controls .control-node:nth-child(3) {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    box-shadow: 0 0 10px rgba(212, 175, 55, 0.4);
+    transform: scale(1.2);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .slide {
+        transition: opacity 0.4s ease !important;
+        transform: scale(1) !important;
+        filter: blur(0) !important;
+    }
+    
+    .slide-bg {
+        animation: none !important;
+        transform: scale(1) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a luxurious, JavaScript-free carousel utilizing the CSS radio button hack. It features deep, rich colors and ultra-smooth, long-duration transitions combining scale, opacity, and blur filters to create a cinematic "focus pull" effect. Resolves issue #73628.

### Changes Made:
- Added `submissions/examples/css-slider-velvet-smooth-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the radio button state logic, the slider track, the background image containers, and the navigation controls.
- Created `style.css` featuring the UI mechanics:
  - **The Radio Button Hack**: The core functional logic relies on a series of hidden `<input type="radio">` buttons and the general sibling combinator (`~`). By placing `<label>` elements inside the `.slider-controls` UI that correspond to these radio IDs, clicking a control node actually checks the hidden radio button. The CSS then detects which button is `:checked` and alters the slide visibility accordingly.
  - **The Cinematic Entrance**: This slider explicitly avoids snappy or bouncy physics. Instead, it aims for weight and elegance. The `.slide` transitions use a long duration (`0.9s`) and a custom cubic-bezier (`0.25, 1, 0.5, 1`) that accelerates very slowly and decelerates gracefully.
  - **Focus Pull Effect**: The initial/inactive state of a slide is slightly scaled up (`1.05`) and heavily blurred (`filter: blur(10px)`). When a slide becomes active, the `transform` and `filter` properties animate into place, simulating a camera pulling focus onto the new slide.
  - **Continuous Zoom**: While a slide is active (`:checked`), a separate `@keyframes` animation is applied to its background image (`.slide-bg`), causing it to very slowly zoom in over 15 seconds. This adds a layer of subtle, continuous life to the composition even while the user is simply reading.
  - **Theming Supported**: Configured via CSS Custom Properties. Supports both light and dark OS themes (`prefers-color-scheme`). The default aesthetic leans heavily into dark mode (deep plums, burgundies, and golds) to fit the "velvet" naming, but automatically adjusts to a lighter cream/gold palette if the user forces a light theme.
- Added `README.md` documenting usage and the technical mechanics of the `:checked` sibling selector matrix for slide opacity/blur toggling, the specific `cubic-bezier` timing functions, and the continuous zoom animation.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by freezing the blur/scale transitions and the continuous background zoom, opting instead for a simple instant opacity cross-fade for motion-sensitive users.

Closes #73628
