### PR TITLE
Add ease-traffic-flow-dashboard component

### DIFF
--- a/submissions/examples/traffic-flow-dashboard-ij/README.md
+++ b/submissions/examples/traffic-flow-dashboard-ij/README.md
@@ -1,0 +1,11 @@
+# ease-traffic-flow-dashboard
+
+A traffic flow dashboard where the cars drive, the lanes pulse, and the ETA blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the dashboard.
+
+## Notes
+- Cars cruise along the lanes.
+- Congestion segments pulse.
+- The ETA badge blinks.

--- a/submissions/examples/traffic-flow-dashboard-ij/demo.html
+++ b/submissions/examples/traffic-flow-dashboard-ij/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-traffic-flow-dashboard</title>
+</head>
+<body>
+<main class="tfd-card">
+  <header class="tfd-top">
+    <h1 class="tfd-route">Downtown via 5th Ave</h1>
+    <span class="tfd-eta">ETA 24 min</span>
+  </header>
+  <section class="tfd-map" aria-label="traffic map">
+    <div class="tfd-lane tfd-lane-a">
+      <span class="tfd-car tfd-car-red"></span>
+      <span class="tfd-car tfd-car-blue"></span>
+    </div>
+    <div class="tfd-lane tfd-lane-b">
+      <span class="tfd-car tfd-car-yellow"></span>
+      <span class="tfd-car tfd-car-green"></span>
+      <span class="tfd-car tfd-car-silver"></span>
+    </div>
+    <div class="tfd-lane tfd-lane-c">
+      <span class="tfd-car tfd-car-teal"></span>
+    </div>
+    <span class="tfd-cross"></span>
+  </section>
+  <section class="tfd-congestion" aria-label="congestion levels">
+    <span class="tfd-seg tfd-seg-a">Lane A</span>
+    <span class="tfd-seg tfd-seg-b">Lane B</span>
+    <span class="tfd-seg tfd-seg-c">Lane C</span>
+  </section>
+  <footer class="tfd-foot">
+    <span class="tfd-light tfd-light-1">Red</span>
+    <span class="tfd-light tfd-light-2">Yellow</span>
+    <span class="tfd-light tfd-light-3">Green</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/traffic-flow-dashboard-ij/style.css
+++ b/submissions/examples/traffic-flow-dashboard-ij/style.css
@@ -1,0 +1,32 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;color-scheme:dark}
+body{min-height:100vh;display:grid;place-items:center;background:#12161c;font-family:'Arial',sans-serif}
+.tfd-card{width:304px;border-radius:18px;padding:16px;background:linear-gradient(165deg,#1d2531,#10151d);color:#e8eef6;box-shadow:0 16px 38px rgba(8,11,16,.6)}
+.tfd-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.tfd-route{font-size:15px;color:#ffd98f}
+.tfd-eta{font-size:12px;color:#8ff0c9;background:#12221c;padding:3px 9px;border-radius:8px;animation:tfd-eta-blink-traffic-flow-dashboard 2.2s steps(2) infinite}
+.tfd-map{position:relative;height:132px;border-radius:12px;background:#18212d;border:2px solid #243140;overflow:hidden}
+.tfd-lane{position:absolute;left:0;right:0;height:34px;border-bottom:1px dashed #34455c}
+.tfd-lane-a{top:8px}
+.tfd-lane-b{top:50px}
+.tfd-lane-c{top:92px}
+.tfd-car{position:absolute;top:6px;width:28px;height:16px;border-radius:5px}
+.tfd-car-red{left:0;background:#ff6b6b;animation:tfd-car-drive-traffic-flow-dashboard 4s linear infinite}
+.tfd-car-blue{left:36px;background:#5fb6ff;animation:tfd-car-drive-traffic-flow-dashboard 5.5s linear infinite}
+.tfd-car-yellow{left:14px;background:#ffd166;animation:tfd-car-drive-traffic-flow-dashboard 4.8s linear infinite}
+.tfd-car-green{left:72px;background:#7fe0a0;animation:tfd-car-drive-traffic-flow-dashboard 6.2s linear infinite}
+.tfd-car-silver{left:120px;background:#cfd8e4;animation:tfd-car-drive-traffic-flow-dashboard 5.1s linear infinite}
+.tfd-car-teal{left:48px;background:#3dd6c9;animation:tfd-car-drive-traffic-flow-dashboard 4.4s linear infinite}
+.tfd-cross{position:absolute;top:0;bottom:0;left:46%;width:6px;background:#f0c37a;opacity:.5}
+.tfd-congestion{display:flex;gap:8px;margin-top:12px}
+.tfd-seg{flex:1;text-align:center;font-size:10px;padding:5px 0;border-radius:8px;color:#c9d6e6}
+.tfd-seg-a{background:#5a2c2c;animation:tfd-congestion-fill-traffic-flow-dashboard 3.4s ease-in-out infinite}
+.tfd-seg-b{background:#5a4a26;animation:tfd-congestion-fill-traffic-flow-dashboard 4.6s ease-in-out infinite}
+.tfd-seg-c{background:#244d38;animation:tfd-congestion-fill-traffic-flow-dashboard 5.2s ease-in-out infinite}
+.tfd-foot{display:flex;justify-content:space-between;margin-top:12px;font-size:11px}
+.tfd-light{color:#aab8c8}
+.tfd-light-1{color:#ff7a7a}
+.tfd-light-2{color:#ffd166}
+.tfd-light-3{color:#7fe0a0}
+@keyframes tfd-car-drive-traffic-flow-dashboard{0%{transform:translateX(0)}100%{transform:translateX(296px)}}
+@keyframes tfd-congestion-fill-traffic-flow-dashboard{0%,100%{filter:brightness(.75)}50%{filter:brightness(1.3)}}
+@keyframes tfd-eta-blink-traffic-flow-dashboard{0%,100%{opacity:1}50%{opacity:.4}}


### PR DESCRIPTION
## Component: ease-traffic-flow-dashboard — cars drive, lanes pulse, and ETA blinks

**Closes #74429**

### What this adds
A traffic flow dashboard where the cars drive, the lanes pulse, and the ETA blinks.

### Acceptance Criteria covered
- Cars drive the lanes
- Congestion lanes pulse
- ETA badge blinks

### Files
- `submissions/examples/traffic-flow-dashboard-ij/demo.html`
- `submissions/examples/traffic-flow-dashboard-ij/style.css`
- `submissions/examples/traffic-flow-dashboard-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the cars drive, the lanes pulse, and the ETA blink.