### PR TITLE
feat: add diamond facet edge effect #73811

### DIFF
--- a/submissions/examples/diamond-facet-edge/README.md
+++ b/submissions/examples/diamond-facet-edge/README.md
@@ -1,0 +1,21 @@
+# Diamond Facet Edge
+
+A smooth, lightweight Diamond Facet Edge particle effect built entirely with HTML and vanilla CSS.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript or external dependencies
+- Smooth 3D facet animation
+- CSS transforms for hardware-friendly motion
+- Dark and light mode support
+- Responsive layout
+- Respects `prefers-reduced-motion`
+
+## Files
+
+```text
+diamond-facet-edge/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/diamond-facet-edge/demo.html
+++ b/submissions/examples/diamond-facet-edge/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="Pure CSS Diamond Facet Edge particle effect."
+  />
+  <title>Diamond Facet Edge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="diamond-scene">
+    <div class="diamond-particle" aria-hidden="true">
+      <span class="diamond-facet"></span>
+      <span class="diamond-facet"></span>
+      <span class="diamond-facet"></span>
+      <span class="diamond-facet"></span>
+    </div>
+
+    <section class="diamond-content">
+      <h1>Diamond Facet</h1>
+      <p>Pure CSS particle effect.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/diamond-facet-edge/style.css
+++ b/submissions/examples/diamond-facet-edge/style.css
@@ -1,0 +1,189 @@
+:root {
+  --diamond-bg: #080b16;
+  --diamond-surface: rgba(18, 25, 43, 0.72);
+  --diamond-light: #dcecff;
+  --diamond-mid: #7195c9;
+  --diamond-glow: rgba(120, 180, 255, 0.5);
+  --diamond-shadow: rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: system-ui, sans-serif;
+}
+
+.diamond-scene {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(
+      circle at center,
+      #18243b 0%,
+      var(--diamond-bg) 68%
+    );
+}
+
+.diamond-particle {
+  position: absolute;
+  width: min(55vw, 320px);
+  aspect-ratio: 1;
+  transform-style: preserve-3d;
+  perspective: 900px;
+  animation: diamond-float 7s ease-in-out infinite;
+  filter: drop-shadow(0 25px 35px var(--diamond-shadow));
+}
+
+.diamond-facet {
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.9),
+      var(--diamond-mid) 45%,
+      rgba(30, 55, 95, 0.9)
+    );
+  transform-origin: center;
+  backface-visibility: hidden;
+  box-shadow: inset 0 0 30px var(--diamond-glow);
+}
+
+.diamond-facet::after {
+  content: "";
+  position: absolute;
+  inset: 8%;
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  opacity: 0.75;
+}
+
+.diamond-facet:nth-child(1) {
+  transform: rotateX(58deg) rotateZ(45deg) translateZ(30px);
+  animation: facet-one 4s ease-in-out infinite;
+}
+
+.diamond-facet:nth-child(2) {
+  transform: rotateX(-58deg) rotateZ(45deg) translateZ(30px);
+  animation: facet-two 4s ease-in-out infinite;
+}
+
+.diamond-facet:nth-child(3) {
+  transform: rotateY(58deg) rotateZ(45deg) translateZ(30px);
+  animation: facet-three 4s ease-in-out infinite;
+}
+
+.diamond-facet:nth-child(4) {
+  transform: rotateY(-58deg) rotateZ(45deg) translateZ(30px);
+  animation: facet-four 4s ease-in-out infinite;
+}
+
+.diamond-content {
+  position: relative;
+  z-index: 2;
+  width: min(88vw, 480px);
+  padding: 2.5rem;
+  text-align: center;
+  color: var(--diamond-light);
+  background: var(--diamond-surface);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 25px 60px var(--diamond-shadow);
+}
+
+.diamond-content h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 7vw, 3.5rem);
+}
+
+.diamond-content p {
+  margin: 0;
+  color: #aebdd3;
+}
+
+@keyframes diamond-float {
+  0%,
+  100% {
+    transform: translateY(0) rotateZ(0deg);
+  }
+
+  50% {
+    transform: translateY(-18px) rotateZ(8deg);
+  }
+}
+
+@keyframes facet-one {
+  0%,
+  100% {
+    transform: rotateX(58deg) rotateZ(45deg) translateZ(30px);
+  }
+
+  50% {
+    transform: rotateX(72deg) rotateZ(45deg) translateZ(42px);
+  }
+}
+
+@keyframes facet-two {
+  0%,
+  100% {
+    transform: rotateX(-58deg) rotateZ(45deg) translateZ(30px);
+  }
+
+  50% {
+    transform: rotateX(-72deg) rotateZ(45deg) translateZ(42px);
+  }
+}
+
+@keyframes facet-three {
+  0%,
+  100% {
+    transform: rotateY(58deg) rotateZ(45deg) translateZ(30px);
+  }
+
+  50% {
+    transform: rotateY(72deg) rotateZ(45deg) translateZ(42px);
+  }
+}
+
+@keyframes facet-four {
+  0%,
+  100% {
+    transform: rotateY(-58deg) rotateZ(45deg) translateZ(30px);
+  }
+
+  50% {
+    transform: rotateY(-72deg) rotateZ(45deg) translateZ(42px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diamond-particle,
+  .diamond-facet {
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --diamond-bg: #edf3fa;
+    --diamond-surface: rgba(255, 255, 255, 0.74);
+    --diamond-light: #17243a;
+    --diamond-mid: #91add0;
+    --diamond-glow: rgba(80, 130, 210, 0.3);
+    --diamond-shadow: rgba(35, 55, 80, 0.18);
+  }
+
+  .diamond-content p {
+    color: #53647b;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a smooth and lightweight Diamond Facet Edge particle effect using pure HTML and vanilla CSS.

Closes #73811

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only Diamond Facet Edge particle effect with animated 3D facets, gradients, glow, and floating motion.

**How does a developer use it?**

Open `demo.html` directly in a browser. The animation is self-contained and requires no JavaScript or external dependencies.

**Why does it fit EaseMotion CSS?**

The effect uses readable HTML and vanilla CSS animations, transforms, gradients, and responsive styling to provide a lightweight animation-first experience.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari (optional)

---

## Notes for Maintainer

The implementation includes dark/light color-scheme support and respects `prefers-reduced-motion` for accessibility.