### PR TITLE
Add CSS animated skill rings component

### DIFF
--- a/submissions/examples/css-animated-skill-rings/README.md
+++ b/submissions/examples/css-animated-skill-rings/README.md
@@ -1,0 +1,29 @@
+# CSS Animated Skill Rings
+
+A pure CSS multi-ring skill proficiency indicator component. Renders nested concentric progress arcs via inline SVG and animates stroke offsets smoothly on page load without external JavaScript libraries.
+
+## How it works
+
+The component combines SVG `<circle>` elements with CSS `stroke-dasharray` and `stroke-dashoffset` variables. Each concentric ring calculates its perimeter based on radius ($2 \times \pi \times r$) and animates its stroke offset down to the target fill percentage using staggered CSS keyframe sequences (`@keyframes ease-outer-fill`, etc.).
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-ring-card-bg`: Card container background color (`#0f172a`)
+- `--ease-ring-card-border`: Card boundary border color (`#1e293b`)
+- `--ease-ring-track-bg`: Unfilled track stroke color (`#1e293b`)
+- `--ease-ring-text`: Primary headline color (`#f8fafc`)
+- `--ease-ring-muted-text`: Subtitle description color (`#94a3b8`)
+- `--ease-ring-accent`: Cyan theme highlight (`#06b6d4`)
+- `--ease-ring-outer-color`: Outer ring fill color (`#06b6d4`)
+- `--ease-ring-middle-color`: Middle ring fill color (`#3b82f6`)
+- `--ease-ring-inner-color`: Inner ring fill color (`#a855f7`)
+- `--ease-ring-duration`: Load fill animation time (`1.6s`)
+
+## Accessibility & Performance
+
+- Includes proper container scoping (`role="region"`, `aria-label`) while keeping structural SVG elements decorative (`aria-hidden="true"`).
+- Full support for `@media (prefers-reduced-motion: reduce)` which disables stroke fill animations and immediately renders final percentage states.

--- a/submissions/examples/css-animated-skill-rings/demo.html
+++ b/submissions/examples/css-animated-skill-rings/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Animated Skill Rings — Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Developer Profile</p>
+    <h1 class="ease-heading">Technical Proficiency</h1>
+    <p class="ease-subtitle">Concentric animated SVG skill rings loading progress states on page display.</p>
+
+    <div class="ease-rings-card">
+      <div 
+        class="ease-skill-rings-wrapper" 
+        role="region" 
+        aria-label="Skill proficiency breakdown"
+      >
+        <svg class="ease-rings-svg" viewBox="0 0 200 200" aria-hidden="true">
+          <!-- Outer Ring: Frontend -->
+          <circle class="ease-ring-bg" cx="100" cy="100" r="85" />
+          <circle class="ease-ring-fill ease-ring-outer" cx="100" cy="100" r="85" />
+
+          <!-- Middle Ring: Backend -->
+          <circle class="ease-ring-bg" cx="100" cy="100" r="65" />
+          <circle class="ease-ring-fill ease-ring-middle" cx="100" cy="100" r="65" />
+
+          <!-- Inner Ring: UI/UX -->
+          <circle class="ease-ring-bg" cx="100" cy="100" r="45" />
+          <circle class="ease-ring-fill ease-ring-inner" cx="100" cy="100" r="45" />
+        </svg>
+
+        <div class="ease-rings-center">
+          <span class="ease-center-val">88%</span>
+          <span class="ease-center-lbl">Avg Score</span>
+        </div>
+      </div>
+
+      <div class="ease-legend">
+        <div class="ease-legend-item">
+          <span class="ease-dot ease-dot-outer"></span>
+          <span class="ease-legend-title">Frontend Architecture</span>
+          <span class="ease-legend-val">90%</span>
+        </div>
+        <div class="ease-legend-item">
+          <span class="ease-dot ease-dot-middle"></span>
+          <span class="ease-legend-title">Backend Systems</span>
+          <span class="ease-legend-val">85%</span>
+        </div>
+        <div class="ease-legend-item">
+          <span class="ease-dot ease-dot-inner"></span>
+          <span class="ease-legend-title">UI & Visual Design</span>
+          <span class="ease-legend-val">70%</span>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-animated-skill-rings/style.css
+++ b/submissions/examples/css-animated-skill-rings/style.css
@@ -1,0 +1,244 @@
+:root {
+  --ease-ring-card-bg: #0f172a;
+  --ease-ring-card-border: #1e293b;
+  --ease-ring-track-bg: #1e293b;
+  --ease-ring-text: #f8fafc;
+  --ease-ring-muted-text: #94a3b8;
+  --ease-ring-accent: #06b6d4;
+
+  /* Ring Colors */
+  --ease-ring-outer-color: #06b6d4;
+  --ease-ring-middle-color: #3b82f6;
+  --ease-ring-inner-color: #a855f7;
+
+  /* Ring Offsets (Circumference: 2 * PI * r) */
+  /* Outer: r=85 => ~534px | 90% => dashoffset 53.4px */
+  --ease-outer-dasharray: 534;
+  --ease-outer-offset: 53.4;
+
+  /* Middle: r=65 => ~408px | 85% => dashoffset 61.2px */
+  --ease-middle-dasharray: 408;
+  --ease-middle-offset: 61.2;
+
+  /* Inner: r=45 => ~283px | 70% => dashoffset 84.9px */
+  --ease-inner-dasharray: 283;
+  --ease-inner-offset: 84.9;
+
+  --ease-ring-duration: 1.6s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #020617;
+  color: var(--ease-ring-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 440px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-ring-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-ring-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+/* Card Wrapper */
+.ease-rings-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  padding: 2.5rem 1.5rem;
+  background: var(--ease-ring-card-bg);
+  border: 1px solid var(--ease-ring-card-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+/* Rings SVG Container */
+.ease-skill-rings-wrapper {
+  position: relative;
+  width: 210px;
+  height: 210px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ease-rings-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+/* Base Ring Tracks */
+.ease-ring-bg {
+  fill: none;
+  stroke: var(--ease-ring-track-bg);
+  stroke-width: 10;
+}
+
+/* Animated Filling Rings */
+.ease-ring-fill {
+  fill: none;
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset var(--ease-ring-duration) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ease-ring-outer {
+  stroke: var(--ease-ring-outer-color);
+  stroke-dasharray: var(--ease-outer-dasharray);
+  stroke-dashoffset: var(--ease-outer-dasharray);
+  animation: ease-outer-fill var(--ease-ring-duration) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ease-ring-middle {
+  stroke: var(--ease-ring-middle-color);
+  stroke-dasharray: var(--ease-middle-dasharray);
+  stroke-dashoffset: var(--ease-middle-dasharray);
+  animation: ease-middle-fill var(--ease-ring-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.2s forwards;
+}
+
+.ease-ring-inner {
+  stroke: var(--ease-ring-inner-color);
+  stroke-dasharray: var(--ease-inner-dasharray);
+  stroke-dashoffset: var(--ease-inner-dasharray);
+  animation: ease-inner-fill var(--ease-ring-duration) cubic-bezier(0.16, 1, 0.3, 1) 0.4s forwards;
+}
+
+/* Center Readout Text */
+.ease-rings-center {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.ease-center-val {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--ease-ring-text);
+}
+
+.ease-center-lbl {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ease-ring-muted-text);
+}
+
+/* Skill Legend */
+.ease-legend {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ease-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.88rem;
+}
+
+.ease-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ease-dot-outer {
+  background: var(--ease-ring-outer-color);
+}
+
+.ease-dot-middle {
+  background: var(--ease-ring-middle-color);
+}
+
+.ease-dot-inner {
+  background: var(--ease-ring-inner-color);
+}
+
+.ease-legend-title {
+  flex: 1;
+  color: var(--ease-ring-text);
+}
+
+.ease-legend-val {
+  font-weight: 600;
+  color: var(--ease-ring-muted-text);
+}
+
+/* Keyframe Animations */
+@keyframes ease-outer-fill {
+  to {
+    stroke-dashoffset: var(--ease-outer-offset);
+  }
+}
+
+@keyframes ease-middle-fill {
+  to {
+    stroke-dashoffset: var(--ease-middle-offset);
+  }
+}
+
+@keyframes ease-inner-fill {
+  to {
+    stroke-dashoffset: var(--ease-inner-offset);
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-rings-card {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-ring-outer {
+    animation: none !important;
+    stroke-dashoffset: var(--ease-outer-offset);
+  }
+  .ease-ring-middle {
+    animation: none !important;
+    stroke-dashoffset: var(--ease-middle-offset);
+  }
+  .ease-ring-inner {
+    animation: none !important;
+    stroke-dashoffset: var(--ease-inner-offset);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #70212

Adds a pure CSS/HTML concentric skill rings component that displays multi-tier proficiency metrics using SVG stroke-dashoffset keyframe animations.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-animated-skill-rings/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A concentric multi-ring skill indicator with customizable CSS properties (`--ease-outer-offset`, `--ease-middle-offset`, etc.) that animates SVG stroke fills on load using staggered keyframes.
**Why does it fit?** Expands EaseMotion CSS showcase components with multi-variable circular progress visuals suitable for portfolio skills and developer dashboards without JavaScript dependencies.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full `prefers-reduced-motion` accessibility support (disabling stroke fill animation sequences) and uses semantic HTML structures paired with SVG graphics.