### PR TITLE
feat: added error stack trace

### DIFF
--- a/submissions/examples/error-stack-trace-cs/README.md
+++ b/submissions/examples/error-stack-trace-cs/README.md
@@ -1,0 +1,27 @@
+# CSS Error Stack Trace
+
+A responsive, CSS-only error stack trace component with collapsible stack frames, source-code context, keyboard navigation, and reduced-motion support.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Native `<details>` / `<summary>` frame expansion
+- Collapsible stack frames
+- Error location and frame metadata
+- Source-code context with highlighted error line
+- Keyboard-accessible controls
+- Visible `:focus-visible` states
+- Responsive desktop and mobile layouts
+- `prefers-reduced-motion` support
+- CSS custom properties for customization
+- Semantic document structure
+- Dark developer-tool inspired interface
+
+## Files
+
+```text
+css-error-stack-trace-cs/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/error-stack-trace-cs/demo.html
+++ b/submissions/examples/error-stack-trace-cs/demo.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="CSS-only expandable error stack trace component."
+  >
+  <title>CSS Error Stack Trace</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to stack trace</a>
+
+  <main id="main-content" class="page-shell">
+    <section class="trace-card" aria-labelledby="trace-title">
+      <header class="trace-header">
+        <div class="error-icon" aria-hidden="true">!</div>
+
+        <div class="error-heading">
+          <p class="error-label">Runtime Error</p>
+          <h1 id="trace-title">TypeError: Cannot read properties of undefined</h1>
+          <p class="error-location">
+            src/components/dashboard.js:48:17
+          </p>
+        </div>
+
+        <span class="status-badge">ERROR</span>
+      </header>
+
+      <div class="trace-summary">
+        <span class="summary-count">5 frames</span>
+        <span>Click a frame to inspect its details</span>
+      </div>
+
+      <div class="stack-list">
+        <details class="stack-frame" open>
+          <summary>
+            <span class="frame-index">01</span>
+            <span class="frame-method">renderDashboard</span>
+            <span class="frame-source">dashboard.js:48</span>
+            <span class="summary-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <div class="frame-details">
+            <div class="code-block" aria-label="Source code">
+              <span class="line-number">46</span>
+              <code>const dashboard = state.user;</code>
+
+              <span class="line-number">47</span>
+              <code>const metrics = dashboard.metrics;</code>
+
+              <span class="line-number error-line">48</span>
+              <code>return metrics.revenue.total;</code>
+            </div>
+
+            <p class="frame-note">
+              <strong>Location:</strong> src/components/dashboard.js:48:17
+            </p>
+          </div>
+        </details>
+
+        <details class="stack-frame">
+          <summary>
+            <span class="frame-index">02</span>
+            <span class="frame-method">updateDashboard</span>
+            <span class="frame-source">dashboard.js:72</span>
+            <span class="summary-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <div class="frame-details">
+            <div class="code-block">
+              <span class="line-number">70</span>
+              <code>function updateDashboard(state) {</code>
+              <span class="line-number">71</span>
+              <code>  const view = renderDashboard(state);</code>
+              <span class="line-number">72</span>
+              <code>  dashboardRoot.replaceChildren(view);</code>
+            </div>
+
+            <p class="frame-note">
+              <strong>Location:</strong> src/components/dashboard.js:72:9
+            </p>
+          </div>
+        </details>
+
+        <details class="stack-frame">
+          <summary>
+            <span class="frame-index">03</span>
+            <span class="frame-method">handleRefresh</span>
+            <span class="frame-source">refresh.js:31</span>
+            <span class="summary-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <div class="frame-details">
+            <div class="code-block">
+              <span class="line-number">29</span>
+              <code>async function handleRefresh() {</code>
+              <span class="line-number">30</span>
+              <code>  const state = await loadDashboard();</code>
+              <span class="line-number">31</span>
+              <code>  updateDashboard(state);</code>
+            </div>
+
+            <p class="frame-note">
+              <strong>Location:</strong> src/services/refresh.js:31:3
+            </p>
+          </div>
+        </details>
+
+        <details class="stack-frame">
+          <summary>
+            <span class="frame-index">04</span>
+            <span class="frame-method">asyncTask</span>
+            <span class="frame-source">scheduler.js:18</span>
+            <span class="summary-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <div class="frame-details">
+            <div class="code-block">
+              <span class="line-number">16</span>
+              <code>const runTask = async () =&gt; {</code>
+              <span class="line-number">17</span>
+              <code>  const result = await task();</code>
+              <span class="line-number">18</span>
+              <code>  return result;</code>
+            </div>
+
+            <p class="frame-note">
+              <strong>Location:</strong> src/core/scheduler.js:18:10
+            </p>
+          </div>
+        </details>
+
+        <details class="stack-frame">
+          <summary>
+            <span class="frame-index">05</span>
+            <span class="frame-method">processRequest</span>
+            <span class="frame-source">router.js:104</span>
+            <span class="summary-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <div class="frame-details">
+            <div class="code-block">
+              <span class="line-number">102</span>
+              <code>const request = createRequest(event);</code>
+              <span class="line-number">103</span>
+              <code>const result = await process(request);</code>
+              <span class="line-number">104</span>
+              <code>return result;</code>
+            </div>
+
+            <p class="frame-note">
+              <strong>Location:</strong> src/router.js:104:5
+            </p>
+          </div>
+        </details>
+      </div>
+
+      <footer class="trace-footer">
+        <span>CSS-only component</span>
+        <span aria-hidden="true">•</span>
+        <span>Keyboard accessible</span>
+        <span aria-hidden="true">•</span>
+        <span>Reduced-motion ready</span>
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/error-stack-trace-cs/style.css
+++ b/submissions/examples/error-stack-trace-cs/style.css
@@ -1,0 +1,376 @@
+:root {
+  --trace-bg: #080b12;
+  --trace-surface: #10151f;
+  --trace-surface-hover: #151c28;
+  --trace-border: #273141;
+  --trace-border-active: #3a4658;
+  --trace-text: #e7ebf2;
+  --trace-muted: #8d98a8;
+  --trace-dim: #606b7b;
+  --trace-error: #ff5c6c;
+  --trace-error-soft: rgba(255, 92, 108, 0.12);
+  --trace-code: #0b0f17;
+  --trace-radius: 14px;
+  --trace-transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+  scroll-behavior: smooth;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(255, 92, 108, 0.08), transparent 34rem),
+    var(--trace-bg);
+  color: var(--trace-text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+button,
+summary {
+  font: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 10;
+  padding: 0.65rem 0.9rem;
+  border-radius: 8px;
+  background: var(--trace-text);
+  color: var(--trace-bg);
+  text-decoration: none;
+  transform: translateY(-160%);
+  transition: transform var(--trace-transition);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 3rem 1.25rem;
+}
+
+.trace-card {
+  width: min(100%, 900px);
+  overflow: hidden;
+  border: 1px solid var(--trace-border);
+  border-radius: var(--trace-radius);
+  background: rgba(16, 21, 31, 0.96);
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.015);
+}
+
+.trace-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--trace-border);
+}
+
+.error-icon {
+  display: grid;
+  flex: 0 0 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border: 1px solid rgba(255, 92, 108, 0.35);
+  border-radius: 50%;
+  background: var(--trace-error-soft);
+  color: var(--trace-error);
+  font-weight: 800;
+}
+
+.error-heading {
+  min-width: 0;
+  flex: 1;
+}
+
+.error-label {
+  margin: 0 0 0.25rem;
+  color: var(--trace-error);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.error-heading h1 {
+  margin: 0;
+  color: var(--trace-text);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.error-location {
+  margin: 0.45rem 0 0;
+  color: var(--trace-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.status-badge {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid rgba(255, 92, 108, 0.3);
+  border-radius: 999px;
+  background: var(--trace-error-soft);
+  color: var(--trace-error);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.trace-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.5rem;
+  color: var(--trace-muted);
+  font-size: 0.78rem;
+  border-bottom: 1px solid var(--trace-border);
+}
+
+.summary-count {
+  color: var(--trace-text);
+  font-weight: 700;
+}
+
+.stack-list {
+  padding: 0.75rem;
+}
+
+.stack-frame {
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  transition:
+    background var(--trace-transition),
+    border-color var(--trace-transition),
+    transform var(--trace-transition);
+}
+
+.stack-frame + .stack-frame {
+  margin-top: 0.35rem;
+}
+
+.stack-frame:hover {
+  border-color: var(--trace-border);
+  background: var(--trace-surface-hover);
+}
+
+.stack-frame[open] {
+  border-color: var(--trace-border-active);
+  background: var(--trace-surface-hover);
+}
+
+.stack-frame summary {
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr) auto 1rem;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0.7rem 0.85rem;
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+}
+
+.stack-frame summary::-webkit-details-marker {
+  display: none;
+}
+
+.stack-frame summary:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--trace-error);
+  border-radius: 8px;
+}
+
+.frame-index {
+  color: var(--trace-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.frame-method {
+  min-width: 0;
+  color: var(--trace-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.frame-source {
+  color: var(--trace-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.summary-arrow {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 1.5px solid var(--trace-muted);
+  border-bottom: 1.5px solid var(--trace-muted);
+  transform: rotate(-45deg);
+  transition: transform var(--trace-transition);
+}
+
+.stack-frame[open] .summary-arrow {
+  transform: rotate(45deg);
+}
+
+.frame-details {
+  padding: 0 0.85rem 1rem 4.05rem;
+  animation: trace-expand 180ms ease-out;
+}
+
+.code-block {
+  display: grid;
+  grid-template-columns: 2.75rem minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--trace-border);
+  border-radius: 8px;
+  background: var(--trace-code);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.code-block > * {
+  min-width: 0;
+  padding: 0.45rem 0.65rem;
+}
+
+.line-number {
+  color: var(--trace-dim);
+  text-align: right;
+  user-select: none;
+  border-right: 1px solid var(--trace-border);
+}
+
+.code-block code {
+  overflow-x: auto;
+  color: #b8c1cf;
+  white-space: pre;
+}
+
+.error-line {
+  background: var(--trace-error-soft);
+  color: var(--trace-error);
+}
+
+.frame-note {
+  margin: 0.75rem 0 0;
+  color: var(--trace-muted);
+  font-size: 0.72rem;
+}
+
+.frame-note strong {
+  color: var(--trace-text);
+}
+
+.trace-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--trace-border);
+  color: var(--trace-dim);
+  font-size: 0.7rem;
+}
+
+@keyframes trace-expand {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    padding: 1rem 0.75rem;
+  }
+
+  .trace-header {
+    padding: 1.15rem;
+  }
+
+  .trace-summary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.75rem 1.15rem;
+  }
+
+  .status-badge {
+    display: none;
+  }
+
+  .stack-list {
+    padding: 0.5rem;
+  }
+
+  .stack-frame summary {
+    grid-template-columns: 2rem minmax(0, 1fr) 0.75rem;
+    gap: 0.55rem;
+    padding-inline: 0.65rem;
+  }
+
+  .frame-source {
+    display: none;
+  }
+
+  .frame-details {
+    padding: 0 0.65rem 0.8rem 3.2rem;
+  }
+
+  .code-block {
+    font-size: 0.68rem;
+  }
+
+  .trace-footer {
+    padding: 0.85rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
Closes #70705

## Summary

Adds a responsive CSS-only error stack trace component with collapsible stack frames and source-code context.

The component uses native HTML disclosure controls and CSS motion to provide an interactive developer-tool style interface without JavaScript.

## Changes

- Added collapsible error stack frames using native `<details>` and `<summary>`
- Added error heading and source location metadata
- Added highlighted source-code error line
- Added keyboard-accessible frame controls
- Added visible `:focus-visible` styling
- Added responsive desktop and mobile layouts
- Added CSS custom properties for customization
- Added `prefers-reduced-motion` support
- Added semantic HTML structure
- Added skip-link support
- Added documentation and usage instructions

## Accessibility

- [x] Semantic HTML
- [x] Native keyboard-accessible disclosure controls
- [x] Visible focus states
- [x] Decorative icons marked with `aria-hidden`
- [x] Responsive layout
- [x] Reduced-motion support
- [x] No JavaScript required

## Files Added

```text
submissions/examples/css-error-stack-trace-cs/
├── demo.html
├── style.css
└── README.md