### PR TITLE
feat: add Star Rating Hover example (star-rating-hover-advk)

### DIFF
--- a/submissions/examples/star-rating-hover-advk/README.md
+++ b/submissions/examples/star-rating-hover-advk/README.md
@@ -1,0 +1,35 @@
+# Star Rating Hover
+
+## What does this do?
+
+A 5-star rating widget built from radio inputs and labels, with no
+JavaScript. Hovering or focusing a star previews the fill up to that star;
+selecting one keeps the fill after the pointer leaves.
+
+## How is it used?
+
+```html
+<div class="srh-stars">
+  <input type="radio" id="srh-5" name="srh-rating" value="5" />
+  <label for="srh-5" class="srh-star">★<span class="srh-sr">5 stars</span></label>
+  <!-- ...4 down to 1, in that source order -->
+</div>
+```
+
+Stars must be written 5 → 1 in the DOM and displayed reversed with
+`flex-direction: row-reverse`. That ordering is what lets `~` (general
+sibling) and `:hover`/`:checked` select "this star and every star that
+should also light up," since CSS can only combine with later siblings.
+
+## Why is it useful?
+
+Most star ratings reach for JavaScript to track a hovered index and re-render
+fill state. Reordering the markup avoids that: the browser's own sibling
+combinators do the "fill up to here" logic, so the widget keeps working with
+CSS disabled down to plain radio buttons, and there's no hydration mismatch
+between server-rendered and client-rendered fill state.
+
+Each input carries a visually-hidden accessible label (`5 stars`, `4 stars`,
+...) via `.srh-sr`, so screen readers announce a meaningful value rather than
+a bare glyph, and `:focus-visible` gives keyboard users the same preview
+hover users get.

--- a/submissions/examples/star-rating-hover-advk/demo.html
+++ b/submissions/examples/star-rating-hover-advk/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Star Rating Hover</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="srh-wrap">
+  <h1 class="srh-h1">Star Rating</h1>
+  <p class="srh-lede">A radio-based star rating built without JS: hovering or focusing a star fills every star up to it via the general sibling combinator, and the checked radio keeps that fill after the pointer leaves.</p>
+
+  <fieldset class="srh-field">
+    <legend class="srh-legend">Rate this component</legend>
+    <div class="srh-stars">
+      <input type="radio" id="srh-5" name="srh-rating" value="5" />
+      <label for="srh-5" class="srh-star">★<span class="srh-sr">5 stars</span></label>
+
+      <input type="radio" id="srh-4" name="srh-rating" value="4" />
+      <label for="srh-4" class="srh-star">★<span class="srh-sr">4 stars</span></label>
+
+      <input type="radio" id="srh-3" name="srh-rating" value="3" checked />
+      <label for="srh-3" class="srh-star">★<span class="srh-sr">3 stars</span></label>
+
+      <input type="radio" id="srh-2" name="srh-rating" value="2" />
+      <label for="srh-2" class="srh-star">★<span class="srh-sr">2 stars</span></label>
+
+      <input type="radio" id="srh-1" name="srh-rating" value="1" />
+      <label for="srh-1" class="srh-star">★<span class="srh-sr">1 star</span></label>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/star-rating-hover-advk/style.css
+++ b/submissions/examples/star-rating-hover-advk/style.css
@@ -1,0 +1,96 @@
+/* Star Rating Hover
+   Markup is emitted 5 -> 1 and displayed reversed with flex-direction:
+   row-reverse. That lets ~n and general-sibling selectors fill "this star and
+   every star before it" using only CSS the DOM already gives us. */
+
+.srh-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.srh-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.srh-lede { margin: 0 0 2rem; color: #576073; }
+
+.srh-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.srh-legend {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.srh-stars {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+  gap: 0.15rem;
+  width: max-content;
+}
+
+.srh-stars input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.srh-star {
+  font-size: 2rem;
+  line-height: 1;
+  color: #d8dce6;
+  cursor: pointer;
+  transition: color 140ms ease, transform 140ms ease;
+}
+
+.srh-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+/* Fill this label and every label before it (later in source, earlier visually). */
+.srh-stars input:checked ~ label.srh-star,
+.srh-stars input:hover ~ label.srh-star,
+.srh-stars label.srh-star:hover ~ label.srh-star {
+  color: #f2a712;
+}
+
+.srh-star:hover {
+  transform: scale(1.12);
+}
+
+.srh-stars input:focus-visible + label.srh-star {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+  border-radius: 0.2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .srh-star { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .srh-star { forced-color-adjust: none; color: CanvasText; }
+
+  .srh-stars input:checked ~ label.srh-star,
+  .srh-stars input:hover ~ label.srh-star,
+  .srh-stars label.srh-star:hover ~ label.srh-star {
+    color: Highlight;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .srh-wrap { color: #e6e9f2; }
+  .srh-lede { color: #99a1b4; }
+  .srh-star { color: #3a4150; }
+}


### PR DESCRIPTION
Closes #74641

CSS-only 5-star rating built from radio inputs and labels. Hover/focus previews the fill up to that star via the general sibling combinator; the checked radio keeps the fill after the pointer leaves. No JavaScript.

- Visually-hidden per-star accessible labels ("5 stars", ...)
- :focus-visible outline for keyboard users
- prefers-reduced-motion, forced-colors, and dark-mode support