### PR TITLE
feat: add Password Strength Meter example (password-strength-meter-advk)

### DIFF
--- a/submissions/examples/password-strength-meter-advk/README.md
+++ b/submissions/examples/password-strength-meter-advk/README.md
@@ -1,0 +1,36 @@
+# Password Strength Meter
+
+## What does this do?
+
+A password strength indicator built on a native `<meter>` element. A small
+script computes an integer score (0-4) and writes it to `data-score`; every
+colour and width comes from CSS reacting to that attribute.
+
+## How is it used?
+
+```html
+<meter id="psm-meter" class="psm-meter" data-score="0" min="0" max="4" value="0"></meter>
+<script>
+  meter.setAttribute('data-score', String(score));
+  meter.value = score;
+</script>
+```
+
+The script's only job is producing a number. All presentation — bar colour
+per level, transitions, dark mode, forced-colors — lives in `style.css`
+keyed off `[data-score="N"]`.
+
+## Why is it useful?
+
+Strength meters are usually built by setting inline `style.width` and
+`style.background` from JavaScript, which means every visual change requires
+touching the script and duplicates state between JS and CSS. Routing the
+score through a single data attribute keeps JS and CSS cleanly separated:
+designers can restyle every level without reading the script, and the score
+computation can be swapped (e.g. for a zxcvbn-style estimator) without
+touching a single style rule.
+
+Using `<meter>` instead of a `<div>` bar also means the value participates in
+the accessibility tree with correct min/max semantics for free, and the
+visible text label is wired through `aria-live="polite"` so assistive tech
+announces strength changes as the user types.

--- a/submissions/examples/password-strength-meter-advk/demo.html
+++ b/submissions/examples/password-strength-meter-advk/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Password Strength Meter</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function psmScore(value) {
+    var score = 0;
+    if (value.length >= 8) score++;
+    if (/[a-z]/.test(value) && /[A-Z]/.test(value)) score++;
+    if (/\d/.test(value)) score++;
+    if (/[^A-Za-z0-9]/.test(value)) score++;
+    return value.length ? Math.max(1, score) : 0;
+  }
+
+  function psmUpdate(input) {
+    var score = psmScore(input.value);
+    var meter = document.getElementById('psm-meter');
+    var label = document.getElementById('psm-label');
+    var labels = ['Empty', 'Weak', 'Fair', 'Good', 'Strong'];
+    meter.setAttribute('data-score', String(score));
+    meter.value = score;
+    label.textContent = labels[score];
+  }
+</script>
+</head>
+<body>
+<main class="psm-wrap">
+  <h1 class="psm-h1">Password Strength</h1>
+  <p class="psm-lede">A four-segment strength meter driven by a native &lt;meter&gt; element, styled per fill level with data-score so colour comes from CSS attribute selectors, not inline styles set by script.</p>
+
+  <label class="psm-field-label" for="psm-input">New password</label>
+  <input
+    id="psm-input"
+    class="psm-input"
+    type="password"
+    autocomplete="new-password"
+    oninput="psmUpdate(this)"
+    placeholder="Enter a password"
+  />
+
+  <meter
+    id="psm-meter"
+    class="psm-meter"
+    data-score="0"
+    min="0"
+    max="4"
+    value="0"
+    aria-label="Password strength"
+  ></meter>
+  <p class="psm-status" id="psm-label" aria-live="polite">Empty</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/password-strength-meter-advk/style.css
+++ b/submissions/examples/password-strength-meter-advk/style.css
@@ -1,0 +1,84 @@
+/* Password Strength Meter
+   Colour is chosen entirely by the data-score attribute the script sets, so
+   the JS only ever writes one integer and CSS owns all presentation. */
+
+.psm-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.psm-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.psm-lede { margin: 0 0 2rem; color: #576073; }
+
+.psm-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.psm-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  margin-bottom: 0.6rem;
+  transition: border-color 160ms ease;
+}
+
+.psm-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.25);
+}
+
+.psm-meter {
+  width: 100%;
+  height: 0.55rem;
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #e4e7ef;
+  transition: filter 200ms ease;
+}
+
+.psm-meter::-webkit-meter-bar { background: #e4e7ef; border: none; }
+.psm-meter::-webkit-meter-optimum-value { background: #d8dce6; transition: width 220ms ease; }
+
+.psm-meter[data-score="1"]::-webkit-meter-optimum-value { background: #e0483f; }
+.psm-meter[data-score="2"]::-webkit-meter-optimum-value { background: #e0a53f; }
+.psm-meter[data-score="3"]::-webkit-meter-optimum-value { background: #d7c22f; }
+.psm-meter[data-score="4"]::-webkit-meter-optimum-value { background: #34a853; }
+
+.psm-meter[data-score="1"] { color: #e0483f; }
+.psm-meter[data-score="2"] { color: #e0a53f; }
+.psm-meter[data-score="3"] { color: #d7c22f; }
+.psm-meter[data-score="4"] { color: #34a853; }
+
+.psm-status {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #576073;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .psm-input, .psm-meter, .psm-meter::-webkit-meter-optimum-value { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .psm-meter { forced-color-adjust: none; background: Canvas; border: 1px solid CanvasText; }
+  .psm-meter::-webkit-meter-optimum-value { background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .psm-wrap { color: #e6e9f2; }
+  .psm-lede, .psm-status { color: #99a1b4; }
+  .psm-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .psm-meter, .psm-meter::-webkit-meter-bar { background: #2a303c; }
+}


### PR DESCRIPTION
Closes #74643

Native <meter>-based password strength indicator. The script's only job is computing an integer score written to `data-score`; every colour and transition lives in CSS keyed off that attribute.

- Live-announced status text via aria-live="polite"
- prefers-reduced-motion, forced-colors, and dark-mode support