### PR TITLE
feat: add Floating Label Input example (floating-label-input-advk)

### DIFF
--- a/submissions/examples/floating-label-input-advk/README.md
+++ b/submissions/examples/floating-label-input-advk/README.md
@@ -1,0 +1,36 @@
+# Floating Label Input
+
+## What does this do?
+
+A form field whose label sits inside the input at rest and floats above it
+once the field has focus or a value — driven entirely by
+`:placeholder-shown`, with no JavaScript class toggling.
+
+## How is it used?
+
+```html
+<div class="fli-field">
+  <input class="fli-input" id="name" type="text" placeholder=" " />
+  <label class="fli-label" for="name">Full name</label>
+</div>
+```
+
+`placeholder=" "` (a literal single space, not empty) is required: an empty
+placeholder still counts as "no placeholder" in some engines, and
+`:placeholder-shown` only matches when a placeholder is present and the
+value is empty.
+
+## Why is it useful?
+
+Floating labels are commonly implemented by listening for `focus`/`blur`/
+`input` events and toggling a `has-value` class, which has to be
+re-synchronised whenever the field is filled programmatically (autofill,
+form reset, framework state binding) rather than by direct typing. Because
+`:placeholder-shown` reflects the DOM value directly, autofill and
+programmatic value changes float the label correctly without any extra
+event wiring.
+
+The label keeps `pointer-events: none` so clicks pass through to the input
+even while it overlaps the text, and the floated state is shared between
+`:not(:placeholder-shown)` and `:focus` so the label commits to its position
+the instant focus lands, rather than waiting for a keystroke.

--- a/submissions/examples/floating-label-input-advk/demo.html
+++ b/submissions/examples/floating-label-input-advk/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Floating Label Input</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="fli-wrap">
+  <h1 class="fli-h1">Floating Label</h1>
+  <p class="fli-lede">The label floats above the field once it has focus or content, detected with :placeholder-shown so no JS class toggling is needed.</p>
+
+  <form class="fli-form">
+    <div class="fli-field">
+      <input class="fli-input" id="fli-name" type="text" placeholder=" " autocomplete="name" />
+      <label class="fli-label" for="fli-name">Full name</label>
+    </div>
+
+    <div class="fli-field">
+      <input class="fli-input" id="fli-email" type="email" placeholder=" " autocomplete="email" />
+      <label class="fli-label" for="fli-email">Email address</label>
+    </div>
+
+    <div class="fli-field">
+      <textarea class="fli-input fli-textarea" id="fli-msg" placeholder=" " rows="3"></textarea>
+      <label class="fli-label" for="fli-msg">Message</label>
+    </div>
+  </form>
+</main>
+</body>
+</html>

--- a/submissions/examples/floating-label-input-advk/style.css
+++ b/submissions/examples/floating-label-input-advk/style.css
@@ -1,0 +1,80 @@
+/* Floating Label Input
+   placeholder=" " (a single space) keeps :placeholder-shown truthy only when
+   the field is genuinely empty and unfocused, which is what drives the label
+   position -- no JS "has-value" class required. */
+
+.fli-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.fli-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.fli-lede { margin: 0 0 2rem; color: #576073; }
+
+.fli-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.fli-field {
+  position: relative;
+}
+
+.fli-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1.25em 0.8em 0.5em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  background: #fff;
+  transition: border-color 160ms ease;
+}
+
+.fli-textarea {
+  resize: vertical;
+  min-height: 4.5rem;
+}
+
+.fli-label {
+  position: absolute;
+  left: 0.85em;
+  top: 0.85em;
+  color: #6b7386;
+  pointer-events: none;
+  transform-origin: left top;
+  transition: transform 160ms ease, color 160ms ease, top 160ms ease;
+}
+
+.fli-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.fli-input:not(:placeholder-shown) ~ .fli-label,
+.fli-input:focus ~ .fli-label {
+  top: 0.45em;
+  transform: scale(0.78);
+  color: #4c6ef5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fli-input, .fli-label { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .fli-input { border-color: CanvasText; }
+  .fli-input:focus-visible { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fli-wrap { color: #e6e9f2; }
+  .fli-lede { color: #99a1b4; }
+  .fli-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .fli-label { color: #8891a3; }
+}


### PR DESCRIPTION
Closes #74644

Form fields whose label floats above the input on focus/content, driven by :placeholder-shown (placeholder=" " — a literal space) so autofill and programmatic value changes float the label correctly without JS.

- pointer-events: none on the label so clicks pass through
- forced-colors and dark-mode support