### PR TITLE
feat: add Animated Checklist example (animated-checklist-advk)

### DIFF
--- a/submissions/examples/animated-checklist-advk/README.md
+++ b/submissions/examples/animated-checklist-advk/README.md
@@ -1,0 +1,41 @@
+# Animated Checklist
+
+## What does this do?
+
+A checklist where checking an item draws an SVG checkmark stroke and strikes
+through the label. State comes entirely from `:checked` plus the general
+sibling combinator, so it degrades to a plain, working checkbox list with
+CSS disabled.
+
+## How is it used?
+
+```html
+<li class="ack-item">
+  <input type="checkbox" id="ack-1" class="ack-input" />
+  <label for="ack-1" class="ack-label">
+    <svg class="ack-check" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 12.5 9.5 18 20 6" />
+    </svg>
+    <span>Draft the proposal</span>
+  </label>
+</li>
+```
+
+The checkbox must come before the label in source order — `~` only selects
+later siblings, which is also why the checkbox itself is visually hidden
+rather than `display: none` (removing it from the accessibility tree would
+break keyboard and screen-reader use).
+
+## Why is it useful?
+
+The draw-on animation depends on `stroke-dasharray`/`stroke-dashoffset`
+matching the exact path length, which is normally computed in JavaScript via
+`getTotalLength()` so it works for arbitrary paths. This checkmark uses one
+fixed, hand-measured path, so the same trick works with a static
+`dasharray` value and no script at all — appropriate here because the icon
+never changes shape, only state.
+
+Driving both the stroke animation and the strikethrough from `:checked`
+means there is a single source of truth for "done": no risk of the visual
+state and the underlying form value drifting apart, which is a common bug
+in checkbox lists reimplemented with a JS-managed `done` class.

--- a/submissions/examples/animated-checklist-advk/demo.html
+++ b/submissions/examples/animated-checklist-advk/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Animated Checklist</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ack-wrap">
+  <h1 class="ack-h1">Checklist</h1>
+  <p class="ack-lede">Checking an item draws its checkmark with a stroke-dashoffset animation and strikes through the label, all triggered by :checked so the list works with JS disabled.</p>
+
+  <ul class="ack-list">
+    <li class="ack-item">
+      <input type="checkbox" id="ack-1" class="ack-input" />
+      <label for="ack-1" class="ack-label">
+        <svg class="ack-check" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 12.5 9.5 18 20 6" />
+        </svg>
+        <span>Draft the proposal</span>
+      </label>
+    </li>
+    <li class="ack-item">
+      <input type="checkbox" id="ack-2" class="ack-input" checked />
+      <label for="ack-2" class="ack-label">
+        <svg class="ack-check" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 12.5 9.5 18 20 6" />
+        </svg>
+        <span>Review with the team</span>
+      </label>
+    </li>
+    <li class="ack-item">
+      <input type="checkbox" id="ack-3" class="ack-input" />
+      <label for="ack-3" class="ack-label">
+        <svg class="ack-check" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 12.5 9.5 18 20 6" />
+        </svg>
+        <span>Send for approval</span>
+      </label>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/animated-checklist-advk/style.css
+++ b/submissions/examples/animated-checklist-advk/style.css
@@ -1,0 +1,107 @@
+/* Animated Checklist
+   The check path's stroke-dasharray equals its own measured length, so
+   dashoffset can travel from that length (fully hidden) to 0 (fully drawn)
+   purely in CSS -- no JS length calculation needed for this fixed path. */
+
+.ack-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ack-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ack-lede { margin: 0 0 2rem; color: #576073; }
+
+.ack-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ack-item {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+  background: #fbfcfe;
+}
+
+.ack-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.ack-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85em 1em;
+  cursor: pointer;
+}
+
+.ack-check {
+  flex: none;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  border: 2px solid #b7bdcb;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.ack-check path {
+  fill: none;
+  stroke: #fff;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset 260ms ease 60ms;
+}
+
+.ack-label span {
+  transition: color 200ms ease;
+}
+
+.ack-input:checked ~ .ack-label .ack-check {
+  border-color: #34a853;
+  background: #34a853;
+}
+
+.ack-input:checked ~ .ack-label .ack-check path {
+  stroke-dashoffset: 0;
+}
+
+.ack-input:checked ~ .ack-label span {
+  color: #8b93a3;
+  text-decoration: line-through;
+}
+
+.ack-input:focus-visible ~ .ack-label {
+  outline: 2px solid #4c6ef5;
+  outline-offset: -2px;
+  border-radius: 0.6rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ack-check, .ack-check path, .ack-label span { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ack-check { border-color: CanvasText; }
+  .ack-input:checked ~ .ack-label .ack-check { background: Highlight; border-color: Highlight; }
+  .ack-check path { stroke: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ack-wrap { color: #e6e9f2; }
+  .ack-lede { color: #99a1b4; }
+  .ack-item { background: #171b23; border-color: #2a303c; }
+  .ack-check { border-color: #3a4150; }
+}


### PR DESCRIPTION
Closes #74645

Checklist where checking an item draws an SVG checkmark via stroke-dashoffset and strikes through the label, all via :checked + general sibling combinator. Degrades to a plain working checkbox list with CSS disabled.

- prefers-reduced-motion, forced-colors, and dark-mode support