### PR TITLE
feat: add useCopyToClipboard hook (use-copy-to-clipboard-advk)

### DIFF
--- a/submissions/react/use-copy-to-clipboard-advk/README.md
+++ b/submissions/react/use-copy-to-clipboard-advk/README.md
@@ -1,0 +1,44 @@
+# useCopyToClipboard
+
+A React hook that copies text to the clipboard, with an `execCommand`
+fallback for non-secure contexts, and reports a short-lived `copied` flag
+for driving "Copied!" UI.
+
+## API
+
+```js
+const [copied, copy] = useCopyToClipboard(resetDelay);
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `resetDelay` | `number` | `1500` | Milliseconds before `copied` resets to `false`. |
+
+`copy(text)` returns a promise resolving to a boolean success flag.
+
+## Usage
+
+```jsx
+function CopyButton({ value }) {
+  const [copied, copy] = useCopyToClipboard();
+  return (
+    <button onClick={() => copy(value)}>
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+```
+
+## Why is it useful?
+
+`navigator.clipboard.writeText` requires a secure context and is not
+available in every embedded WebView or over plain HTTP on a local network,
+so a hook that only wraps the async Clipboard API silently breaks in those
+environments. This hook falls back to the older
+select-a-hidden-textarea-and-`execCommand('copy')` technique so the copy
+button keeps working rather than throwing.
+
+Centralizing the reset timer in the hook (with cleanup via `clearTimeout` on
+each call) also avoids a common bug where a component copies twice in quick
+succession and ends up with two competing `setTimeout` calls fighting over
+when `copied` flips back to `false`.

--- a/submissions/react/use-copy-to-clipboard-advk/useCopyToClipboard.jsx
+++ b/submissions/react/use-copy-to-clipboard-advk/useCopyToClipboard.jsx
@@ -1,0 +1,56 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * useCopyToClipboard
+ * Copies text to the clipboard and reports a short-lived "copied" flag.
+ *
+ * Falls back to a hidden textarea + execCommand when the async Clipboard API
+ * is unavailable (non-secure context, older WebViews), rather than failing.
+ */
+export function useCopyToClipboard(resetDelay = 1500) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef(null);
+
+  const copy = useCallback(
+    async (text) => {
+      let ok = false;
+
+      if (navigator.clipboard && window.isSecureContext) {
+        try {
+          await navigator.clipboard.writeText(text);
+          ok = true;
+        } catch {
+          ok = false;
+        }
+      }
+
+      if (!ok) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+          ok = document.execCommand('copy');
+        } catch {
+          ok = false;
+        }
+        document.body.removeChild(textarea);
+      }
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setCopied(ok);
+      if (ok) {
+        timeoutRef.current = setTimeout(() => setCopied(false), resetDelay);
+      }
+      return ok;
+    },
+    [resetDelay]
+  );
+
+  return [copied, copy];
+}
+
+export default useCopyToClipboard;


### PR DESCRIPTION
Closes #74646

React hook that copies text via the async Clipboard API, falling back to a hidden-textarea + execCommand('copy') for non-secure contexts or older WebViews. Returns a resettable `copied` boolean for driving "Copied!" UI, with proper timer cleanup on rapid repeat calls.