### PR TITLE
feat: add useLocalStorage hook (use-local-storage-advk)

### DIFF
--- a/submissions/react/use-local-storage-advk/README.md
+++ b/submissions/react/use-local-storage-advk/README.md
@@ -1,0 +1,39 @@
+# useLocalStorage
+
+A `useState`-shaped hook backed by `localStorage`, kept in sync across
+browser tabs via the `storage` event.
+
+## API
+
+```js
+const [value, setValue] = useLocalStorage(key, initialValue);
+```
+
+`setValue` accepts either a new value or an updater function, matching
+`useState`'s setter signature.
+
+## Usage
+
+```jsx
+function ThemeToggle() {
+  const [theme, setTheme] = useLocalStorage('theme', 'light');
+  return (
+    <button onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}>
+      {theme}
+    </button>
+  );
+}
+```
+
+## Why is it useful?
+
+A naive `localStorage` hook reads `localStorage.getItem` once on mount and
+never again, so if the user changes the same key in another tab, the two
+tabs silently disagree. Listening for the `storage` event (which the
+originating tab never receives for its own writes, only other tabs do)
+keeps every open tab converged on the same value without polling.
+
+Every read and write is wrapped in `try`/`catch` because `localStorage` can
+throw in Safari private browsing and when storage quota is exceeded — this
+hook degrades to in-memory React state in that case rather than crashing the
+component tree.

--- a/submissions/react/use-local-storage-advk/useLocalStorage.jsx
+++ b/submissions/react/use-local-storage-advk/useLocalStorage.jsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * useLocalStorage
+ * State backed by localStorage, synced across tabs/windows via the
+ * "storage" event and safe to call during SSR (falls back to initialValue).
+ */
+export function useLocalStorage(key, initialValue) {
+  const read = useCallback(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item === null ? initialValue : JSON.parse(item);
+    } catch {
+      return initialValue;
+    }
+  }, [key, initialValue]);
+
+  const [value, setValue] = useState(read);
+
+  const setStoredValue = useCallback(
+    (next) => {
+      setValue((prev) => {
+        const resolved = typeof next === 'function' ? next(prev) : next;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          // Storage full or unavailable (private browsing): keep React state,
+          // skip persistence rather than throwing.
+        }
+        return resolved;
+      });
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    function onStorage(event) {
+      if (event.key !== key) return;
+      setValue(event.newValue === null ? initialValue : JSON.parse(event.newValue));
+    }
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [key, initialValue]);
+
+  return [value, setStoredValue];
+}
+
+export default useLocalStorage;


### PR DESCRIPTION
Closes #74648

React hook providing useState-shaped state backed by localStorage, kept in sync across browser tabs via the storage event. Reads/writes wrapped in try/catch to degrade to in-memory state under private-browsing/quota errors.