### PR TITLE
feat: add AnimatedNumber component (animated-number-advk)

### DIFF
--- a/submissions/react/animated-number-advk/AnimatedNumber.jsx
+++ b/submissions/react/animated-number-advk/AnimatedNumber.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * AnimatedNumber
+ * Tweens its displayed value toward `value` using requestAnimationFrame,
+ * easing on the delta rather than on elapsed time so a value change mid-tween
+ * restarts smoothly from the current on-screen number instead of jumping.
+ */
+export function AnimatedNumber({
+  value,
+  duration = 500,
+  format = (n) => Math.round(n).toLocaleString(),
+  className,
+}) {
+  const [display, setDisplay] = useState(value);
+  const frameRef = useRef(null);
+  const fromRef = useRef(value);
+  const startRef = useRef(null);
+  const prefersReducedMotion = useRef(
+    typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  );
+
+  useEffect(() => {
+    if (prefersReducedMotion.current) {
+      setDisplay(value);
+      return;
+    }
+
+    fromRef.current = display;
+    startRef.current = null;
+    const from = fromRef.current;
+    const delta = value - from;
+
+    function tick(timestamp) {
+      if (startRef.current === null) startRef.current = timestamp;
+      const elapsed = timestamp - startRef.current;
+      const progress = Math.min(1, elapsed / duration);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplay(from + delta * eased);
+      if (progress < 1) {
+        frameRef.current = requestAnimationFrame(tick);
+      }
+    }
+
+    frameRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, duration]);
+
+  return <span className={className}>{format(display)}</span>;
+}
+
+export default AnimatedNumber;

--- a/submissions/react/animated-number-advk/README.md
+++ b/submissions/react/animated-number-advk/README.md
@@ -1,0 +1,31 @@
+# AnimatedNumber
+
+A `<span>` that tweens its displayed number toward a target `value` using
+`requestAnimationFrame`, honoring `prefers-reduced-motion`.
+
+## API
+
+```jsx
+<AnimatedNumber value={1234} duration={500} format={(n) => n.toFixed(0)} />
+```
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `value` | `number` | — | Target value to animate toward. |
+| `duration` | `number` | `500` | Tween duration in ms. |
+| `format` | `(n: number) => string` | `toLocaleString` rounded | Formats the interpolated value each frame. |
+| `className` | `string` | — | Passed to the rendered `<span>`. |
+
+## Why is it useful?
+
+Counter animations are often built by lerping from the *previous target* to
+the *new target* over a fixed duration from scratch. If the value changes
+again before the previous tween finishes — a live dashboard number ticking
+up twice in quick succession — that approach jumps to the stale target
+first, then restarts, producing a visible stutter. This component instead
+starts every new tween from `display`, the number currently on screen, so
+rapid updates blend into one continuous motion.
+
+It also checks `prefers-reduced-motion` once and skips the
+`requestAnimationFrame` loop entirely for users who've opted out, setting
+the value directly instead of animating past it.


### PR DESCRIPTION
Closes #74649

React component that tweens its displayed number toward a target value via requestAnimationFrame. Each new tween starts from the currently displayed value rather than the previous target, so rapid updates blend smoothly instead of stuttering. Skips animation entirely under prefers-reduced-motion.