### PR TITLE
feat: add clamp-lines Sass mixin (clamp-lines-advk)

### DIFF
--- a/submissions/scss/clamp-lines-advk/README.md
+++ b/submissions/scss/clamp-lines-advk/README.md
@@ -1,0 +1,37 @@
+# clamp-lines-advk
+
+A Sass mixin for multi-line text truncation with a real fallback for
+engines that don't support `-webkit-line-clamp`.
+
+## Usage
+
+```scss
+@use 'clamp-lines' as *;
+
+.card-summary {
+  @include clamp-lines(3);
+}
+
+.card-summary--tight {
+  @include clamp-lines(2, 1.35);
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$lines` | `3` | Number of lines to show before truncating. |
+| `$line-height` | `1.5` | Unitless line-height, also used to size the fallback box. |
+
+## Why is it useful?
+
+Most line-clamp snippets are just the three `-webkit-line-clamp`
+declarations, which do nothing in an engine that doesn't recognize them —
+the text overflows its container uncapped instead of truncating. This mixin
+wraps the vendor declarations in `@supports` and, outside that block, sets a
+`max-height` computed from `$lines * $line-height` with `overflow: hidden`,
+so unsupported engines still get a hard-capped box rather than a layout
+break. Text isn't ellipsized in the fallback path, but it can no longer spill
+past the card.
+
+Using `math.div()` instead of `/` keeps the module deprecation-free under
+Dart Sass, where `/` as division is removed.

--- a/submissions/scss/clamp-lines-advk/_clamp-lines.scss
+++ b/submissions/scss/clamp-lines-advk/_clamp-lines.scss
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------------
+// clamp-lines-advk
+// A line-clamp mixin with a real fallback: browsers without
+// -webkit-line-clamp support get a fixed-height, overflow:hidden box instead
+// of unclamped text spilling past the card boundary.
+// ---------------------------------------------------------------------------
+
+@use 'sass:math';
+
+/// Truncate text to a fixed number of lines, ellipsizing the overflow.
+///
+/// @param {Number} $lines        Number of lines to show.
+/// @param {Number} $line-height  Unitless line-height, used to size the fallback.
+@mixin clamp-lines($lines: 3, $line-height: 1.5) {
+  @if $lines < 1 {
+    @error 'clamp-lines: $lines must be >= 1, got #{$lines}';
+  }
+
+  line-height: $line-height;
+
+  // Fallback for engines without -webkit-line-clamp: hard-cap the box
+  // height so text can't overflow into whatever sits below it.
+  max-height: #{math.div($lines, 1) * $line-height}em;
+  overflow: hidden;
+
+  @supports (-webkit-line-clamp: $lines) {
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    -webkit-box-orient: vertical;
+    max-height: none;
+  }
+}
+
+.clamp-lines-demo {
+  @include clamp-lines(3);
+}
+
+.clamp-lines-demo--tight {
+  @include clamp-lines(2, 1.35);
+}


### PR DESCRIPTION
Closes #74650

Sass mixin for multi-line text truncation. Wraps -webkit-line-clamp in @supports and sets a max-height (computed from $lines * $line-height) with overflow:hidden as a real fallback, so unsupported engines get a capped box instead of unclamped overflow. Uses math.div() (Dart Sass deprecation-free).