### PR TITLE
feat: add glass-panel Sass mixin (glass-panel-advk)

### DIFF
--- a/submissions/scss/glass-panel-advk/README.md
+++ b/submissions/scss/glass-panel-advk/README.md
@@ -1,0 +1,46 @@
+# glass-panel-advk
+
+A frosted-glass panel mixin that only turns translucent where
+`backdrop-filter` is actually supported, and forces an opaque, high-contrast
+surface under `forced-colors`.
+
+## Usage
+
+```scss
+@use 'glass-panel' as *;
+
+.modal-surface {
+  @include glass-panel;
+}
+
+.modal-surface--dark {
+  @include glass-panel(
+    $tint: rgba(20, 22, 28, 0.55),
+    $opaque-fallback: #14161c,
+    $border: rgba(255, 255, 255, 0.12)
+  );
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$tint` | `rgba(255, 255, 255, 0.55)` | Translucent background used when blur is supported. |
+| `$opaque-fallback` | `#f4f5f8` | Solid background used everywhere else. |
+| `$blur` | `14px` | Blur radius. |
+| `$border` | `rgba(255, 255, 255, 0.4)` | Panel border colour. |
+
+## Why is it useful?
+
+A glass panel authored as `background: rgba(...)` plus `backdrop-filter`
+directly is only translucent by intent — in a browser without
+`backdrop-filter` support, the same rgba background renders as a low-opacity
+wash with whatever is behind it showing through unblurred, which frequently
+fails contrast for the text sitting on top. This mixin sets an opaque
+`$opaque-fallback` background unconditionally and only swaps in the
+translucent tint inside an `@supports` block that tests for real blur
+support, so contrast is never accidentally inherited from unsupported
+translucency.
+
+It also forces the opaque path under `forced-colors: active`, where blur
+effects are typically suppressed by the user agent anyway and a translucent
+background over system colours can produce unreadable text.

--- a/submissions/scss/glass-panel-advk/_glass-panel.scss
+++ b/submissions/scss/glass-panel-advk/_glass-panel.scss
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// glass-panel-advk
+// A frosted-glass surface mixin with an opaque fallback for browsers/contexts
+// without backdrop-filter support (older Firefox, forced-colors mode),
+// rather than a see-through panel with unreadable contrast.
+// ---------------------------------------------------------------------------
+
+@mixin glass-panel(
+  $tint: rgba(255, 255, 255, 0.55),
+  $opaque-fallback: #f4f5f8,
+  $blur: 14px,
+  $border: rgba(255, 255, 255, 0.4)
+) {
+  background: $opaque-fallback;
+  border: 1px solid $border;
+
+  @supports (backdrop-filter: blur($blur)) or (-webkit-backdrop-filter: blur($blur)) {
+    background: $tint;
+    backdrop-filter: blur($blur);
+    -webkit-backdrop-filter: blur($blur);
+  }
+
+  @media (forced-colors: active) {
+    background: Canvas;
+    border-color: CanvasText;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+.glass-panel-demo {
+  @include glass-panel;
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.glass-panel-demo--dark {
+  @include glass-panel(
+    $tint: rgba(20, 22, 28, 0.55),
+    $opaque-fallback: #14161c,
+    $border: rgba(255, 255, 255, 0.12)
+  );
+}


### PR DESCRIPTION
Closes #74651

Sass mixin for frosted-glass panels. Sets an opaque background unconditionally; only swaps in the translucent tint inside @supports(backdrop-filter), avoiding low-contrast translucent fallbacks on engines without blur support. Forces the opaque path under forced-colors.