### PR TITLE
feat: add skip-link Sass mixin (skip-link-advk)

### DIFF
--- a/submissions/scss/skip-link-advk/README.md
+++ b/submissions/scss/skip-link-advk/README.md
@@ -1,0 +1,44 @@
+# skip-link-advk
+
+A "skip to main content" link mixin: hidden off-screen until it receives
+keyboard focus, then pinned above the page so the first Tab stop on any
+page lets keyboard users bypass repeated navigation.
+
+## Usage
+
+```scss
+@use 'skip-link' as *;
+
+.skip-link {
+  @include skip-link;
+}
+```
+
+```html
+<a href="#main" class="skip-link">Skip to content</a>
+<nav>...</nav>
+<main id="main">...</main>
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$bg` | `#1c2028` | Background colour when focused. |
+| `$color` | `#fff` | Text colour when focused. |
+| `$z` | `999` | z-index, high enough to sit above sticky headers. |
+
+## Why is it useful?
+
+Skip links are frequently implemented with `display: none`, which removes
+them from the accessibility tree entirely and defeats their purpose — a
+keyboard user tabbing from the top of the page never reaches them. This
+mixin instead moves the link off-screen with `top: -3rem` while it stays
+focusable, and animates it into view on `:focus-visible`, so it's silent for
+mouse/touch users but appears immediately for anyone tabbing through the
+page.
+
+Using `:focus-visible` rather than `:focus` keeps it from flashing into view
+on a mouse click that happens to land on the link's hit area, and the
+`forced-colors` branch swaps the hand-picked colours for system `ButtonFace`/
+`ButtonText` so the link stays legible in Windows High Contrast mode instead
+of rendering with author colours the user has explicitly overridden
+elsewhere.

--- a/submissions/scss/skip-link-advk/_skip-link.scss
+++ b/submissions/scss/skip-link-advk/_skip-link.scss
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// skip-link-advk
+// A "skip to content" link mixin: visually hidden until keyboard focus,
+// then pinned to the top of the viewport above everything else.
+// ---------------------------------------------------------------------------
+
+@mixin skip-link(
+  $bg: #1c2028,
+  $color: #fff,
+  $z: 999
+) {
+  position: absolute;
+  top: -3rem;
+  left: 0.5rem;
+  z-index: $z;
+  padding: 0.6em 1.1em;
+  background: $bg;
+  color: $color;
+  border-radius: 0 0 0.4rem 0.4rem;
+  text-decoration: none;
+  font-weight: 600;
+  transition: top 160ms ease;
+
+  &:focus-visible {
+    top: 0;
+    outline: 2px solid #fff;
+    outline-offset: -4px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  @media (forced-colors: active) {
+    background: ButtonFace;
+    color: ButtonText;
+    border: 1px solid ButtonText;
+  }
+}
+
+.skip-link-demo {
+  @include skip-link;
+}


### PR DESCRIPTION
Closes #74652

Sass mixin for a "skip to content" link. Off-screen until keyboard focus via :focus-visible (not display:none, which would remove it from the accessibility tree), pinned above the page once focused. Uses system ButtonFace/ButtonText under forced-colors.