### PR TITLE
Add CSS GitHub stats card component

### DIFF
--- a/submissions/examples/css-github-stats-card/README.md
+++ b/submissions/examples/css-github-stats-card/README.md
@@ -1,0 +1,26 @@
+# CSS GitHub Stats Card
+
+A pure CSS GitHub-style contribution stats card complete with a heat-map activity grid, streak badge counter, metrics header, and intensity legend. Built with responsive layout techniques and load-in pop keyframe animations. No JavaScript required.
+
+## How it works
+
+The contribution grid is rendered using CSS flexbox column arrays (`.ease-grid-matrix` and `.ease-grid-col`). Each activity square (`.ease-cell`) assigns dark mode color variables (`--ease-gh-level-0` through `--ease-gh-level-4`) based on activity volume, with CSS `@keyframes ease-cell-pop` driving the load-in sequence.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-gh-bg`: Inset grid matrix background color (`#0d1117`)
+- `--ease-gh-card-bg`: Card surface background color (`#161b22`)
+- `--ease-gh-border`: Boundary line color (`#30363d`)
+- `--ease-gh-text`: Primary headline color (`#f0f6fc`)
+- `--ease-gh-muted-text`: Subtitle and handle text color (`#8b949e`)
+- `--ease-gh-accent`: Primary blue accent color (`#2f81f7`)
+- `--ease-gh-level-0` to `--ease-gh-level-4`: GitHub dark-theme contribution heat scale colors
+
+## Accessibility & Performance
+
+- Complete accessibility structure using `role="region"`, explicit `aria-label` declarations, and cell `title` attributes for screen readers.
+- Full support for `@media (prefers-reduced-motion: reduce)` which bypasses grid entrance keyframes and hover scaling effects.

--- a/submissions/examples/css-github-stats-card/demo.html
+++ b/submissions/examples/css-github-stats-card/demo.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS GitHub Stats Card — Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Developer Metrics</p>
+    <h1 class="ease-heading">GitHub Activity Card</h1>
+    <p class="ease-subtitle">Pure CSS GitHub-style contribution grid and streak stats card with load-in animations.</p>
+
+    <div class="ease-github-card" role="region" aria-label="GitHub contribution statistics and activity grid">
+      <!-- Profile & Primary Metrics Header -->
+      <div class="ease-github-header">
+        <div class="ease-user-info">
+          <div class="ease-avatar">
+            <span>GH</span>
+          </div>
+          <div class="ease-user-details">
+            <h2 class="ease-user-name">SAPTARSHI-coder</h2>
+            <p class="ease-user-handle">@SAPTARSHI-coder • 1,428 contributions in 2026</p>
+          </div>
+        </div>
+        <div class="ease-streak-badge">
+          <span class="ease-streak-fire">🔥</span>
+          <span class="ease-streak-count">42 Day Streak</span>
+        </div>
+      </div>
+
+      <!-- Contribution Grid Representation -->
+      <div class="ease-grid-container" aria-label="Contribution activity matrix">
+        <div class="ease-grid-days" aria-hidden="true">
+          <span>Mon</span>
+          <span>Wed</span>
+          <span>Fri</span>
+        </div>
+
+        <div class="ease-grid-matrix" role="img" aria-label="Contribution grid showing activity intensity">
+          <!-- Column 1 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-0" title="0 contributions"></span>
+            <span class="ease-cell level-1" title="2 contributions"></span>
+            <span class="ease-cell level-2" title="5 contributions"></span>
+            <span class="ease-cell level-0" title="0 contributions"></span>
+            <span class="ease-cell level-3" title="8 contributions"></span>
+            <span class="ease-cell level-1" title="1 contribution"></span>
+            <span class="ease-cell level-4" title="14 contributions"></span>
+          </div>
+
+          <!-- Column 2 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-2" title="4 contributions"></span>
+            <span class="ease-cell level-3" title="9 contributions"></span>
+            <span class="ease-cell level-1" title="3 contributions"></span>
+            <span class="ease-cell level-4" title="12 contributions"></span>
+            <span class="ease-cell level-2" title="6 contributions"></span>
+            <span class="ease-cell level-0" title="0 contributions"></span>
+            <span class="ease-cell level-1" title="2 contributions"></span>
+          </div>
+
+          <!-- Column 3 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-1" title="1 contribution"></span>
+            <span class="ease-cell level-4" title="15 contributions"></span>
+            <span class="ease-cell level-2" title="5 contributions"></span>
+            <span class="ease-cell level-3" title="8 contributions"></span>
+            <span class="ease-cell level-4" title="11 contributions"></span>
+            <span class="ease-cell level-3" title="7 contributions"></span>
+            <span class="ease-cell level-2" title="4 contributions"></span>
+          </div>
+
+          <!-- Column 4 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-3" title="7 contributions"></span>
+            <span class="ease-cell level-1" title="2 contributions"></span>
+            <span class="ease-cell level-0" title="0 contributions"></span>
+            <span class="ease-cell level-2" title="6 contributions"></span>
+            <span class="ease-cell level-4" title="16 contributions"></span>
+            <span class="ease-cell level-2" title="4 contributions"></span>
+            <span class="ease-cell level-3" title="9 contributions"></span>
+          </div>
+
+          <!-- Column 5 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-4" title="18 contributions"></span>
+            <span class="ease-cell level-2" title="5 contributions"></span>
+            <span class="ease-cell level-3" title="10 contributions"></span>
+            <span class="ease-cell level-1" title="3 contributions"></span>
+            <span class="ease-cell level-0" title="0 contributions"></span>
+            <span class="ease-cell level-2" title="4 contributions"></span>
+            <span class="ease-cell level-4" title="13 contributions"></span>
+          </div>
+
+          <!-- Column 6 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-2" title="4 contributions"></span>
+            <span class="ease-cell level-4" title="12 contributions"></span>
+            <span class="ease-cell level-1" title="2 contributions"></span>
+            <span class="ease-cell level-3" title="8 contributions"></span>
+            <span class="ease-cell level-4" title="14 contributions"></span>
+            <span class="ease-cell level-1" title="1 contribution"></span>
+            <span class="ease-cell level-3" title="7 contributions"></span>
+          </div>
+
+          <!-- Column 7 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-1" title="2 contributions"></span>
+            <span class="ease-cell level-3" title="9 contributions"></span>
+            <span class="ease-cell level-4" title="15 contributions"></span>
+            <span class="ease-cell level-2" title="6 contributions"></span>
+            <span class="ease-cell level-3" title="10 contributions"></span>
+            <span class="ease-cell level-4" title="12 contributions"></span>
+            <span class="ease-cell level-2" title="5 contributions"></span>
+          </div>
+
+          <!-- Column 8 -->
+          <div class="ease-grid-col">
+            <span class="ease-cell level-3" title="8 contributions"></span>
+            <span class="ease-cell level-2" title="4 contributions"></span>
+            <span class="ease-cell level-4" title="16 contributions"></span>
+            <span class="ease-cell level-1" title="1 contribution"></span>
+            <span class="ease-cell level-2" title="5 contributions"></span>
+            <span class="ease-cell level-3" title="9 contributions"></span>
+            <span class="ease-cell level-4" title="14 contributions"></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer Legend & Stats summary -->
+      <div class="ease-github-footer">
+        <div class="ease-footer-stats">
+          <span class="ease-stat-item"><strong>98%</strong> Commit Ratio</span>
+          <span class="ease-stat-item"><strong>312</strong> Pull Requests</span>
+        </div>
+
+        <div class="ease-grid-legend" aria-label="Contribution level scale">
+          <span class="ease-legend-text">Less</span>
+          <span class="ease-cell level-0"></span>
+          <span class="ease-cell level-1"></span>
+          <span class="ease-cell level-2"></span>
+          <span class="ease-cell level-3"></span>
+          <span class="ease-cell level-4"></span>
+          <span class="ease-legend-text">More</span>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-github-stats-card/style.css
+++ b/submissions/examples/css-github-stats-card/style.css
@@ -1,0 +1,259 @@
+:root {
+  --ease-gh-bg: #0d1117;
+  --ease-gh-card-bg: #161b22;
+  --ease-gh-border: #30363d;
+  --ease-gh-text: #f0f6fc;
+  --ease-gh-muted-text: #8b949e;
+  --ease-gh-accent: #2f81f7;
+  
+  /* GitHub Contribution Level Colors */
+  --ease-gh-level-0: #161b22;
+  --ease-gh-level-1: #0e4429;
+  --ease-gh-level-2: #006d32;
+  --ease-gh-level-3: #26a641;
+  --ease-gh-level-4: #39d353;
+
+  --ease-gh-radius: 12px;
+  --ease-gh-duration: 0.8s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #010409;
+  color: var(--ease-gh-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-gh-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-gh-muted-text);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+/* Card Wrapper */
+.ease-github-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: var(--ease-gh-card-bg);
+  border: 1px solid var(--ease-gh-border);
+  border-radius: var(--ease-gh-radius);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+/* Header & Avatar */
+.ease-github-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ease-user-info {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.ease-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2f81f7, #238636);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #fff;
+  flex-shrink: 0;
+  box-shadow: 0 0 10px rgba(47, 129, 247, 0.3);
+}
+
+.ease-user-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.ease-user-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ease-gh-text);
+}
+
+.ease-user-handle {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--ease-gh-muted-text);
+}
+
+.ease-streak-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(247, 129, 47, 0.12);
+  border: 1px solid rgba(247, 129, 47, 0.3);
+  padding: 0.3rem 0.65rem;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #f7812f;
+}
+
+/* Contribution Grid Container */
+.ease-grid-container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--ease-gh-bg);
+  padding: 1rem;
+  border: 1px solid var(--ease-gh-border);
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.ease-grid-days {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 96px;
+  font-size: 0.68rem;
+  color: var(--ease-gh-muted-text);
+}
+
+.ease-grid-matrix {
+  display: flex;
+  gap: 5px;
+  flex: 1;
+}
+
+.ease-grid-col {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+/* Individual Grid Cells & Levels */
+.ease-cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+  outline: 1px solid rgba(27, 31, 36, 0.15);
+  transition: transform 0.15s ease, filter 0.15s ease;
+  animation: ease-cell-pop var(--ease-gh-duration) cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+}
+
+.ease-cell:hover {
+  transform: scale(1.3);
+  z-index: 2;
+  filter: brightness(1.2);
+}
+
+.level-0 { background-color: var(--ease-gh-level-0); border: 1px solid var(--ease-gh-border); }
+.level-1 { background-color: var(--ease-gh-level-1); }
+.level-2 { background-color: var(--ease-gh-level-2); }
+.level-3 { background-color: var(--ease-gh-level-3); }
+.level-4 { background-color: var(--ease-gh-level-4); box-shadow: 0 0 6px rgba(57, 211, 83, 0.4); }
+
+/* Footer & Legend */
+.ease-github-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.78rem;
+  color: var(--ease-gh-muted-text);
+  flex-wrap: wrap;
+}
+
+.ease-footer-stats {
+  display: flex;
+  gap: 1rem;
+}
+
+.ease-stat-item strong {
+  color: var(--ease-gh-text);
+}
+
+.ease-grid-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ease-legend-text {
+  font-size: 0.7rem;
+  margin: 0 2px;
+}
+
+.ease-grid-legend .ease-cell {
+  animation: none !important;
+  opacity: 1 !important;
+}
+
+/* Animation Keyframes */
+@keyframes ease-cell-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.3);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-github-card {
+    padding: 1.1rem;
+  }
+  .ease-github-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cell {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .ease-cell:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #70209

Adds a pure CSS/HTML GitHub-style contribution stats card component featuring an activity heat-map matrix, streak counter badge, and contribution level scale.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-github-stats-card/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A GitHub stats card component with customizable CSS color level variables (`--ease-gh-level-0` through `--ease-gh-level-4`), hover scale states, and entrance animations for contribution grids.
**Why does it fit?** Expands EaseMotion CSS showcase components with developer-focused portfolio stats and dashboard widgets built entirely with lightweight CSS.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full screen reader accessibility (`role="region"`, `aria-label`, and `title` tooltips on grid cells) and `prefers-reduced-motion` fallbacks (disabling cell pop entrance keyframe animations).