### PR TITLE
feat(scss): Add SCSS color palette scale generator functions #74412

### DIFF
--- a/submissions/scss/color-palette-generator-ag/README.md
+++ b/submissions/scss/color-palette-generator-ag/README.md
@@ -1,0 +1,45 @@
+# Color Palette Scale Generator
+
+## Description
+A utility SCSS function and mixin to automatically generate a standard 10-step color scale (50-900) from a single base color. This is extremely useful for building theme tokens efficiently without having to manually calculate or pick every shade.
+
+## Parameters
+
+### `ease-generate-color-scale($base-color)`
+- `$base-color`: The central color (which becomes the `500` step) from which all other steps (50, 100, 200, 300, 400, 600, 700, 800, 900) are interpolated using `mix()`.
+
+### `ease-color-scale-vars($name, $base-color)`
+- `$name`: The prefix for the generated CSS custom properties (e.g., passing `"primary"` generates `--ease-primary-50` through `--ease-primary-900`).
+- `$base-color`: The central color to generate the scale from.
+
+## Usage
+
+Include the mixin or use the function in your SCSS files to quickly build out your CSS custom properties.
+
+```scss
+// Using the mixin to output CSS variables
+:root {
+  @include ease-color-scale-vars("primary", #3b82f6);
+  @include ease-color-scale-vars("danger", #ef4444);
+}
+
+// Or using the function to get the map directly
+$my-palette: ease-generate-color-scale(#10b981);
+$my-dark-shade: map-get($my-palette, 900);
+```
+
+The resulting CSS for the mixin will look like:
+```css
+:root {
+  --ease-primary-50: #ebf2fe;
+  --ease-primary-100: #d8e6fd;
+  --ease-primary-200: #b0cdfa;
+  --ease-primary-300: #89b3f8;
+  --ease-primary-400: #629af6;
+  --ease-primary-500: #3b82f6;
+  --ease-primary-600: #2f68c5;
+  --ease-primary-700: #234e94;
+  --ease-primary-800: #183462;
+  --ease-primary-900: #0c1a31;
+}
+```

--- a/submissions/scss/color-palette-generator-ag/_color-palette-generator.scss
+++ b/submissions/scss/color-palette-generator-ag/_color-palette-generator.scss
@@ -1,0 +1,26 @@
+// _color-palette-generator.scss
+
+// Function to generate a 10-step color scale (50-900) from a base color
+@function ease-generate-color-scale($base-color) {
+  @return (
+    50: mix(white, $base-color, 90%),
+    100: mix(white, $base-color, 80%),
+    200: mix(white, $base-color, 60%),
+    300: mix(white, $base-color, 40%),
+    400: mix(white, $base-color, 20%),
+    500: $base-color,
+    600: mix(black, $base-color, 20%),
+    700: mix(black, $base-color, 40%),
+    800: mix(black, $base-color, 60%),
+    900: mix(black, $base-color, 80%)
+  );
+}
+
+// Mixin to generate CSS variables for the color scale
+@mixin ease-color-scale-vars($name, $base-color) {
+  $scale: ease-generate-color-scale($base-color);
+  
+  @each $step, $value in $scale {
+    --ease-#{$name}-#{$step}: #{$value};
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces an SCSS utility function and mixin that automatically generate a 10-step color palette scale (50-900) based on a single central color. It calculates lighter variants by mixing the base color with white and darker variants by mixing it with black. This resolves issue #74412.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (describe below)
  - SCSS Utility / Mixin

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server (Not applicable for SCSS track)
- [ ] Includes `style.css` — raw CSS for the proposed feature (Not applicable for SCSS track)
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

*Note: For the SCSS Track, the required files are `_your-mixin.scss` and `README.md`, which have both been provided.*

---

## Feature Description

**What does this add?**

An SCSS mixin and function to automatically generate a complete 10-step color scale (50-900) from a single base color, drastically speeding up theme generation.

**How does a developer use it?**

```scss
// Import the generator and use the mixin in your theme definition
:root {
  @include ease-color-scale-vars("primary", #3b82f6);
  @include ease-color-scale-vars("danger", #ef4444);
}
