### PR TITLE
feat: add pure CSS 3D Retro Arcade Pixel component (#73698)

### DIFF
--- a/submissions/examples/css-3d-retro-arcade-pixel-pure/README.md
+++ b/submissions/examples/css-3d-retro-arcade-pixel-pure/README.md
@@ -1,0 +1,23 @@
+# CSS 3D Effect: Retro Arcade Pixel
+
+A hardware-accelerated, JavaScript-free 3D animation utilizing `transform-style: preserve-3d`. Features stacked `box-shadow` pixel art to create true 3D volumetric voxels from 2D CSS sprites.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript, canvas, or WebGL required for the 3D voxel rendering.
+- **Component Architecture**: 
+  - **The 3D Scene Container**: The `.scene-3d` element establishes the depth perspective (`perspective: 1000px`). The `.voxel-assembly` wrapper applies `transform-style: preserve-3d` and tumbles continuously via a CSS `@keyframes` animation to show off the 3D volume.
+  - **Volumetric Pixel Art Engine**: It is highly inefficient to render 100+ individual HTML elements to build a 3D pixel object (one div per voxel). This component uses a highly performant CSS trick instead:
+    1. We define a single 1x1 base unit element (`.pixel-layer`).
+    2. We draw an entire 2D retro sprite (a Space Invader) using a massive, comma-separated `box-shadow` definition relative to that single unit. This renders the entire flat sprite using only one DOM node.
+    3. To make it true 3D, we duplicate that node 10 times in the HTML.
+    4. In the CSS, we apply `transform: translateZ()` to stack those 10 layers tightly together (4px apart) on the Z-axis.
+  - **Ambient Occlusion Shading**: To enhance the 3D effect, the inner layers (layers 2 through 9) are given a `filter: brightness(0.7)`. This ensures that when the object turns sideways, the "sides" appear darker than the front and back faces, simulating basic 3D ambient occlusion lighting without any complex shaders.
+- **Theming**: Configured via CSS Custom Properties. Supports both light and dark OS themes (`prefers-color-scheme`), automatically swapping the sprite colors from Yellow/Amber to neon Green depending on the system theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by freezing the continuous tumbling animation and locking the voxel object at a static, dramatic isometric angle for motion-sensitive users.
+
+## Usage
+Open `demo.html` in your browser. Watch the continuous tumbling animation and observe the solid, volumetric depth achieved by stacking the 2D `box-shadow` layers.
+
+## Files
+- `demo.html`: The HTML structure defining the 3D scene, the preserve-3d assembly, the floor shadow, and the 10 stacked pixel layers.
+- `style.css`: The styling, the `preserve-3d` mechanics, the massive `box-shadow` mapping defining the Space Invader sprite, the Z-axis stacking logic, and the `brightness()` ambient occlusion filters.

--- a/submissions/examples/css-3d-retro-arcade-pixel-pure/demo.html
+++ b/submissions/examples/css-3d-retro-arcade-pixel-pure/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS 3D Effect: Retro Arcade Pixel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS 3D: Retro Pixel Voxel</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free 3D animation utilizing `transform-style: preserve-3d`. Features stacked `box-shadow` pixel art to create true 3D volumetric voxels from 2D CSS sprites.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The 3D Scene
+              The wrapper establishes the depth perspective.
+            -->
+            <div class="scene-3d">
+                
+                <!-- 
+                  The primary tumbling object. 
+                  It uses preserve-3d to ensure its children maintain their Z-axis stacking.
+                -->
+                <div class="voxel-assembly">
+                    
+                    <!-- 
+                      [TECHNIQUE] Volumetric Pixel Art
+                      We cannot easily draw 3D cubes for every single pixel in CSS 
+                      without destroying DOM performance. 
+                      Instead, we draw a 2D pixel art sprite using a massive `box-shadow` 
+                      on a single 1x1 pixel div. 
+                      Then, we duplicate that div 10 times, pushing each layer 
+                      1px further back on the Z-axis.
+                      This creates a solid, 10px thick 3D voxel object.
+                    -->
+                    <div class="pixel-layer layer-1"></div>
+                    <div class="pixel-layer layer-2"></div>
+                    <div class="pixel-layer layer-3"></div>
+                    <div class="pixel-layer layer-4"></div>
+                    <div class="pixel-layer layer-5"></div>
+                    <div class="pixel-layer layer-6"></div>
+                    <div class="pixel-layer layer-7"></div>
+                    <div class="pixel-layer layer-8"></div>
+                    <div class="pixel-layer layer-9"></div>
+                    <div class="pixel-layer layer-10"></div>
+                    
+                </div>
+                
+                <!-- Floor shadow for grounding -->
+                <div class="floor-shadow"></div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-3d-retro-arcade-pixel-pure/style.css
+++ b/submissions/examples/css-3d-retro-arcade-pixel-pure/style.css
@@ -1,0 +1,252 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #1e1b4b; 
+    --text-primary: #e0e7ff;
+    
+    /* Voxel Colors */
+    --pixel-primary: #fcd34d; /* Yellow */
+    --pixel-secondary: #f59e0b; /* Dark Orange/Yellow */
+    --pixel-black: #171717; /* Outline */
+    
+    /* The unit size of 1 pixel in our sprite */
+    --p-size: 8px;
+    
+    /* The thickness of the 3D extrusion */
+    --voxel-depth: 40px; 
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a; 
+        --text-primary: #f8fafc;
+        
+        --pixel-primary: #34d399; /* Green */
+        --pixel-secondary: #059669; /* Dark Green */
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Press Start 2P', cursive;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 20px 0;
+    line-height: 1.4;
+    color: var(--pixel-primary);
+    text-shadow: 2px 2px 0px var(--pixel-secondary);
+}
+
+.subtitle {
+    font-family: sans-serif;
+    font-size: 1rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: #94a3b8;
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 120px 0;
+    min-height: 500px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] 3D Scene Architecture
+   ========================================= */
+
+.scene-3d {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    perspective: 1000px;
+}
+
+.voxel-assembly {
+    position: absolute;
+    /* Center the sprite (it is 13x13 pixels * 8px = 104px wide) */
+    top: 50%;
+    left: 50%;
+    margin-top: calc(-13 * var(--p-size) / 2);
+    margin-left: calc(-13 * var(--p-size) / 2);
+    
+    width: calc(13 * var(--p-size));
+    height: calc(13 * var(--p-size));
+    
+    /* Crucial: Allows the 2D layers to stack in 3D space */
+    transform-style: preserve-3d;
+    
+    /* Continuous slow tumble to show off the 3D volume */
+    animation: tumble-voxel 8s infinite linear;
+}
+
+@keyframes tumble-voxel {
+    0%   { transform: rotateY(0deg) rotateX(-15deg); }
+    100% { transform: rotateY(360deg) rotateX(-15deg); }
+}
+
+
+/* =========================================
+   [TECHNIQUE] Volumetric Pixel Art (Box Shadow)
+   ========================================= */
+
+/* 
+   We define a single 1x1 base unit. 
+   Then we draw a space invader sprite entirely using box-shadows relative to this origin.
+   This is extremely performant compared to rendering 100+ individual divs.
+*/
+.pixel-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: var(--p-size);
+    height: var(--p-size);
+    
+    /* 
+       A standard 11x8 space invader sprite.
+       c = current color (yellow/green), b = black outline 
+    */
+    background-color: transparent;
+    box-shadow: 
+        /* Row 1 */
+        calc(var(--p-size) * 3) calc(var(--p-size) * 1) 0 var(--pixel-black),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 1) 0 var(--pixel-black),
+        
+        /* Row 2 */
+        calc(var(--p-size) * 4) calc(var(--p-size) * 2) 0 var(--pixel-black),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 2) 0 var(--pixel-black),
+        
+        /* Row 3 */
+        calc(var(--p-size) * 3) calc(var(--p-size) * 3) 0 var(--pixel-black),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 3) 0 var(--pixel-black),
+        
+        /* Row 4 */
+        calc(var(--p-size) * 2) calc(var(--p-size) * 4) 0 var(--pixel-black),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 4) 0 var(--pixel-black),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 4) 0 var(--pixel-black),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 10) calc(var(--p-size) * 4) 0 var(--pixel-black),
+        
+        /* Row 5 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 5) 0 var(--pixel-black),
+        calc(var(--p-size) * 2) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 10) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 5) 0 var(--pixel-black),
+        
+        /* Row 6 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        
+        /* Row 7 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 7) 0 var(--pixel-black),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 7) 0 var(--pixel-black),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        
+        /* Row 8 */
+        calc(var(--p-size) * 4) calc(var(--p-size) * 8) 0 var(--pixel-black),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 8) 0 var(--pixel-black),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 8) 0 var(--pixel-black),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 8) 0 var(--pixel-black);
+}
+
+/* 
+   To make it 3D, we stack 10 identical copies of the sprite, 
+   pushing each one slightly further back on the Z axis. 
+   We space them tightly (4px apart) to create a solid block illusion.
+*/
+.layer-1  { transform: translateZ(20px); }
+.layer-2  { transform: translateZ(16px); }
+.layer-3  { transform: translateZ(12px); }
+.layer-4  { transform: translateZ(8px); }
+.layer-5  { transform: translateZ(4px); }
+.layer-6  { transform: translateZ(0px); }
+.layer-7  { transform: translateZ(-4px); }
+.layer-8  { transform: translateZ(-8px); }
+.layer-9  { transform: translateZ(-12px); }
+.layer-10 { transform: translateZ(-16px); }
+
+/* Give the middle layers a darker shadow color to simulate 3D shading/ambient occlusion */
+.layer-2, .layer-3, .layer-4, .layer-5, .layer-6, .layer-7, .layer-8, .layer-9 {
+    filter: brightness(0.7);
+}
+
+
+/* =========================================
+   Floor Shadow
+   ========================================= */
+
+.floor-shadow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -30px;
+    margin-left: -40px;
+    width: 80px;
+    height: 30px;
+    background: rgba(0,0,0,0.4);
+    border-radius: 50%;
+    filter: blur(8px);
+    
+    /* Keep it grounded while the parent scene provides perspective */
+    transform: translateY(120px) rotateX(70deg);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .voxel-assembly {
+        animation: none !important;
+        transform: rotateY(35deg) rotateX(-15deg) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free 3D animation utilizing `transform-style: preserve-3d`. It features stacked `box-shadow` pixel art to create true 3D volumetric voxels from 2D CSS sprites. Resolves issue #73698.

### Changes Made:
- Added `submissions/examples/css-3d-retro-arcade-pixel-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the 3D scene, the preserve-3d assembly, the floor shadow, and the 10 stacked pixel layers.
- Created `style.css` featuring the UI mechanics:
  - **The 3D Scene Container**: The `.scene-3d` element establishes the depth perspective (`perspective: 1000px`). The `.voxel-assembly` wrapper applies `transform-style: preserve-3d` and tumbles continuously via a CSS `@keyframes` animation to show off the 3D volume.
  - **Volumetric Pixel Art Engine**: It is highly inefficient to render 100+ individual HTML elements to build a 3D pixel object (one div per voxel). This component uses a highly performant CSS trick instead: We define a single 1x1 base unit element. We draw an entire 2D retro sprite (a Space Invader) using a massive, comma-separated `box-shadow` definition relative to that single unit. To make it true 3D, we duplicate that node 10 times in the HTML, and apply `transform: translateZ()` to stack those 10 layers tightly together (4px apart) on the Z-axis.
  - **Ambient Occlusion Shading**: To enhance the 3D effect, the inner layers (layers 2 through 9) are given a `filter: brightness(0.7)`. This ensures that when the object turns sideways, the "sides" appear darker than the front and back faces, simulating basic 3D ambient occlusion lighting.
  - **Theming Supported**: Configured via CSS Custom Properties. Supports both light and dark OS themes (`prefers-color-scheme`), automatically swapping the sprite colors from Yellow/Amber to neon Green depending on the system theme.
- Added `README.md` documenting usage and the technical mechanics of the `preserve-3d` mechanics, the massive `box-shadow` mapping defining the Space Invader sprite, the Z-axis stacking logic, and the `brightness()` ambient occlusion filters.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by freezing the continuous tumbling animation and locking the voxel object at a static, dramatic isometric angle for motion-sensitive users.

Closes #73698
