### PR TITLE
feat: added CSS-only Rating Stars

### DIFF
--- a/submissions/examples/css-only-rating-stars-cs/README.md
+++ b/submissions/examples/css-only-rating-stars-cs/README.md
@@ -1,0 +1,25 @@
+# CSS-only Rating Stars
+
+A responsive, accessible star-rating component built with semantic HTML and
+pure CSS. It uses radio inputs and CSS sibling selectors, so no JavaScript is
+required.
+
+## Features
+
+- Pure HTML and CSS
+- Five selectable rating levels
+- Native radio-button keyboard interaction
+- Visible `:focus-visible` indicator
+- Responsive layout
+- CSS custom properties for customization
+- Hover and selection feedback
+- `prefers-reduced-motion` support
+- No external dependencies
+
+## Files
+
+```text
+css-rating-stars-cs/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-only-rating-stars-cs/demo.html
+++ b/submissions/examples/css-only-rating-stars-cs/demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Accessible CSS-only star rating component using radio inputs.">
+  <title>CSS-only Rating Stars</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="rating-card" aria-labelledby="rating-title">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1 id="rating-title">Rate your experience</h1>
+      <p class="description">
+        Choose a rating using the keyboard or by selecting a star.
+      </p>
+
+      <form class="rating-form">
+        <fieldset class="rating">
+          <legend class="sr-only">Select a rating from one to five stars</legend>
+
+          <div class="rating-options">
+            <input
+              type="radio"
+              id="rating-1"
+              name="rating"
+              value="1"
+            >
+            <label for="rating-1" aria-label="1 star">
+              <span aria-hidden="true">★</span>
+            </label>
+
+            <input
+              type="radio"
+              id="rating-2"
+              name="rating"
+              value="2"
+            >
+            <label for="rating-2" aria-label="2 stars">
+              <span aria-hidden="true">★</span>
+            </label>
+
+            <input
+              type="radio"
+              id="rating-3"
+              name="rating"
+              value="3"
+            >
+            <label for="rating-3" aria-label="3 stars">
+              <span aria-hidden="true">★</span>
+            </label>
+
+            <input
+              type="radio"
+              id="rating-4"
+              name="rating"
+              value="4"
+            >
+            <label for="rating-4" aria-label="4 stars">
+              <span aria-hidden="true">★</span>
+            </label>
+
+            <input
+              type="radio"
+              id="rating-5"
+              name="rating"
+              value="5"
+            >
+            <label for="rating-5" aria-label="5 stars">
+              <span aria-hidden="true">★</span>
+            </label>
+          </div>
+        </fieldset>
+      </form>
+
+      <p class="rating-hint">
+        <span aria-hidden="true">Keyboard:</span>
+        use Tab and the arrow keys to choose a rating.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-only-rating-stars-cs/style.css
+++ b/submissions/examples/css-only-rating-stars-cs/style.css
@@ -1,0 +1,200 @@
+:root {
+  --rating-bg: #0f172a;
+  --rating-surface: #172033;
+  --rating-border: rgba(255, 255, 255, 0.1);
+  --rating-text: #f8fafc;
+  --rating-muted: #94a3b8;
+  --rating-star: #475569;
+  --rating-star-active: #facc15;
+  --rating-focus: #38bdf8;
+  --rating-radius: 24px;
+  --rating-transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(circle at top, #1e293b 0, var(--rating-bg) 45%);
+  color: var(--rating-text);
+}
+
+button,
+input,
+label {
+  font: inherit;
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.rating-card {
+  width: min(100%, 32rem);
+  padding: clamp(1.75rem, 5vw, 3rem);
+  text-align: center;
+  background: rgba(23, 32, 51, 0.88);
+  border: 1px solid var(--rating-border);
+  border-radius: var(--rating-radius);
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(16px);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--rating-focus);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  line-height: 1.1;
+}
+
+.description {
+  max-width: 28rem;
+  margin: 1rem auto 0;
+  color: var(--rating-muted);
+  line-height: 1.6;
+}
+
+.rating-form {
+  margin-top: 2rem;
+}
+
+.rating {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.rating-options {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(0.2rem, 1.5vw, 0.6rem);
+}
+
+.rating-options input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.rating-options label {
+  position: relative;
+  display: grid;
+  width: clamp(2.8rem, 12vw, 4.25rem);
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--rating-star);
+  cursor: pointer;
+  font-size: clamp(2rem, 10vw, 3.5rem);
+  line-height: 1;
+  transition:
+    color var(--rating-transition),
+    transform var(--rating-transition),
+    background-color var(--rating-transition);
+}
+
+.rating-options label:hover,
+.rating-options label:has(~ input:checked) {
+  color: var(--rating-star-active);
+  transform: translateY(-4px);
+}
+
+.rating-options label:hover {
+  background: rgba(250, 204, 21, 0.06);
+}
+
+.rating-options input:checked + label {
+  color: var(--rating-star-active);
+  transform: translateY(-4px) scale(1.06);
+}
+
+/*
+ * The sibling selector fills every star preceding
+ * the selected radio input.
+ */
+.rating-options input:checked ~ input + label {
+  color: var(--rating-star);
+  transform: none;
+}
+
+/*
+ * Keyboard users receive a clear focus indicator.
+ */
+.rating-options input:focus-visible + label {
+  outline: 3px solid var(--rating-focus);
+  outline-offset: 5px;
+}
+
+.rating-hint {
+  margin: 1.75rem 0 0;
+  color: var(--rating-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .rating-card {
+    padding: 1.5rem 1rem;
+  }
+
+  .rating-options {
+    gap: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rating-options label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #70460

## Summary

Adds a responsive CSS-only star-rating component using native radio inputs
and CSS sibling selectors.

## Changes

- Added `demo.html` with semantic rating controls
- Added `style.css` with the complete visual and interaction styling
- Added `README.md` with usage, customization, accessibility, and implementation details
- Implemented five selectable rating levels
- Added keyboard-friendly native radio controls
- Added visible `:focus-visible` styling
- Added responsive mobile behavior
- Added CSS custom properties for customization
- Added hover and selected-state feedback
- Added `prefers-reduced-motion` support
- Added no JavaScript dependencies

## Accessibility

- Semantic `fieldset` and `legend`
- Properly associated labels and radio inputs
- Accessible star-count labels
- Native keyboard interaction
- Visible keyboard focus indicator
- Decorative star glyphs hidden from assistive technology
- Reduced-motion support

## Submission Checklist

- [x] Files are inside `submissions/examples/css-rating-stars-cs/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Pure HTML/CSS
- [x] Responsive
- [x] Keyboard accessible
- [x] `prefers-reduced-motion` supported
- [x] No core library files modified
- [x] No JavaScript dependency