### PR TITLE
feat: implement CSS-only radial spotlight hover card #74673

### DIFF
--- a/submissions/examples/spotlight-hover-card/README.md
+++ b/submissions/examples/spotlight-hover-card/README.md
@@ -1,58 +1,121 @@
-```md
-# Spotlight Hover Card
+# CSS-Only Radial Spotlight Hover Card
 
-A modern CSS-only card component featuring a glowing spotlight effect on hover.
+**EaseMotion CSS · Issue [#74673](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/74673)**
 
-## Features
+A `.ease-spotlight-card` component that renders a radial-gradient "spotlight" that smoothly sweeps across a dark-themed card on hover — built **without JavaScript**.
 
-- Pure HTML and CSS
-- Smooth hover animation
-- Glowing spotlight effect
-- Responsive layout
-- No JavaScript required
-- Beginner-friendly implementation
+## Live Demo
 
-## Folder Structure
+Open `demo.html` in any modern browser and hover over the cards.
+
+## How It Works
+
+### 1 — Register animatable custom properties with `@property`
+
+```css
+@property --x {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+
+@property --y {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
 ```
 
-spotlight-hover-card/
-├── demo.html
-├── style.css
-└── README.md
+Registering `--x` and `--y` as `<percentage>` tells the browser their *type*, which unlocks smooth interpolation inside `@keyframes`. Without `@property` the values jump discretely between keyframe stops instead of animating.
 
+### 2 — Spotlight overlay via `::before` + `radial-gradient`
+
+```css
+.ease-spotlight-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+
+  background: radial-gradient(
+    circle 220px at var(--x) var(--y),
+    rgba(255, 255, 255, 0.18),
+    transparent 80%
+  );
+  mix-blend-mode: overlay;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+```
+
+`mix-blend-mode: overlay` softly brightens card content wherever the gradient circle falls, mimicking a real directional light source.
+
+### 3 — Sweep animation on hover
+
+```css
+.ease-spotlight-card:hover::before {
+  opacity: 1;
+  animation: ease-spotlight-sweep 5s ease-in-out infinite alternate;
+}
+
+@keyframes ease-spotlight-sweep {
+  0%   { --x: 10%; --y: 10%; }
+  20%  { --x: 90%; --y:  5%; }
+  40%  { --x: 95%; --y: 90%; }
+  60%  { --x: 50%; --y: 50%; }
+  80%  { --x:  5%; --y: 90%; }
+  100% { --x: 10%; --y: 10%; }
+}
+```
+
+The browser lerps `--x` and `--y` between stops because of the `@property` registration, producing a smooth orbiting-spotlight illusion — no `mousemove` listener needed.
+
+## File Structure
+
+```
+spotlight-hover-card/
+├── demo.html   — Usage example with three cards
+├── style.css   — Component styles + page scaffold
+└── README.md   — This file
 ```
 
 ## Usage
 
-1. Open `demo.html` in your browser.
-2. Hover over any card.
-3. Observe the spotlight glow, lift animation, and enhanced shadow effect.
+Add the class `.ease-spotlight-card` to any dark card container:
 
-## Customization
+```html
+<link rel="stylesheet" href="style.css" />
 
-You can customize:
+<div class="ease-spotlight-card">
+  <h2>Your Title</h2>
+  <p>Your description text.</p>
+</div>
+```
 
-- Card background color
-- Spotlight intensity
-- Border glow
-- Hover elevation
-- Shadow strength
-- Border radius
+## Customisation
 
-## Technologies Used
+| CSS variable / property | What it controls |
+|---|---|
+| `circle 220px` in `radial-gradient` | Spotlight radius |
+| `rgba(255,255,255,0.18)` peak colour | Spotlight brightness |
+| `animation-duration` (default `5s`) | Sweep speed |
+| `--x` / `--y` initial values | Resting spotlight position |
+| `mix-blend-mode` | Blending approach (`screen`, `hard-light`, etc.) |
 
-- HTML5
-- CSS3
-  - Grid Layout
-  - Radial Gradients
-  - Transforms
-  - Transitions
+## Browser Support & Limitations
 
-## Preview
+| Feature | Chrome | Edge | Firefox | Safari |
+|---|---|---|---|---|
+| `@property` | ✅ 85+ | ✅ 85+ | ✅ 128+ | ✅ 16.4+ |
+| `mix-blend-mode` | ✅ | ✅ | ✅ | ✅ |
+| Animatable custom props | ✅ | ✅ | ✅ 128+ | ✅ 16.4+ |
 
-The component displays multiple feature cards that animate upward and reveal a glowing spotlight overlay when hovered.
+### Limitations without JavaScript
+
+- The spotlight **cannot track the real cursor position** without a `mousemove` listener. The CSS-only approximation uses a looping `@keyframes` sweep around the card's edges.
+- In browsers that **don't support `@property`** (IE, old Safari < 16.4, Firefox < 128) the spotlight will not animate; it will remain at `50% 50%` and fade in/out on hover without movement — a graceful degradation.
+- `prefers-reduced-motion` is respected: the sweep animation is disabled and the spotlight sits static at `20% 20%` for users who prefer reduced motion.
 
 ## License
 
-This example is provided for educational and demonstration purposes.
-```
+This example is submitted to EaseMotion CSS under the project's open-source license and is provided for educational and demonstration purposes.

--- a/submissions/examples/spotlight-hover-card/demo.html
+++ b/submissions/examples/spotlight-hover-card/demo.html
@@ -1,42 +1,55 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spotlight Hover Card</title>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Radial Spotlight Hover Card — EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="A CSS-only radial spotlight hover effect on dark-themed cards using @property, radial-gradient, and mix-blend-mode."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <p class="page-eyebrow">EaseMotion CSS · Issue #74673</p>
+    <h1 class="page-title">CSS-Only Radial Spotlight</h1>
+    <p class="page-subtitle">
+      Hover over a card to see the spotlight sweep across it — zero JavaScript.
+    </p>
 
-    <div class="container">
-        <h1>CSS Spotlight Hover Card</h1>
-        <p class="subtitle">
-            Hover over the cards to reveal a glowing spotlight effect.
+    <section class="card-grid" aria-label="Spotlight hover card demo">
+      <div class="ease-spotlight-card" id="spotlight-card-1">
+        <div class="card-icon" aria-hidden="true">⚡</div>
+        <h2>Blazing Performance</h2>
+        <p>
+          GPU-composited animations deliver 60 fps effects with no layout
+          thrash — pure CSS does the heavy lifting.
         </p>
+      </div>
 
-        <div class="card-grid">
-            <div class="spotlight-card">
-                <h2>Modern Design</h2>
-                <p>
-                    Create beautiful interfaces with smooth animations and elegant effects.
-                </p>
-            </div>
+      <div class="ease-spotlight-card" id="spotlight-card-2">
+        <div class="card-icon" aria-hidden="true">🎨</div>
+        <h2>Modern Aesthetics</h2>
+        <p>
+          Radial gradients, <code>mix-blend-mode: overlay</code>, and
+          <code>@property</code> combine to create a premium spotlight feel.
+        </p>
+      </div>
 
-            <div class="spotlight-card">
-                <h2>Pure CSS</h2>
-                <p>
-                    Built entirely with CSS gradients, transitions, and transforms.
-                </p>
-            </div>
-
-            <div class="spotlight-card">
-                <h2>Responsive</h2>
-                <p>
-                    Works seamlessly across desktop, tablet, and mobile devices.
-                </p>
-            </div>
-        </div>
-    </div>
-
-</body>
+      <div class="ease-spotlight-card" id="spotlight-card-3">
+        <div class="card-icon" aria-hidden="true">🔒</div>
+        <h2>Zero Dependencies</h2>
+        <p>
+          No JavaScript, no libraries. A single CSS file is all you need to
+          ship this flagship interaction.
+        </p>
+      </div>
+    </section>
+  </body>
 </html>

--- a/submissions/examples/spotlight-hover-card/style.css
+++ b/submissions/examples/spotlight-hover-card/style.css
@@ -1,98 +1,262 @@
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+/* ============================================================
+   CSS-Only Radial Spotlight Hover Effect  —  EaseMotion CSS
+   Issue #74673 | .ease-spotlight-card component
+   ============================================================ */
+
+/* ---------- Register animatable custom properties ---------- */
+@property --x {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+
+@property --y {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+
+/* ---------- Base reset & fonts ---------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    min-height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background: #0f172a;
-    font-family: Arial, Helvetica, sans-serif;
-    padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem 1.5rem;
+  background: #080d16;
+  font-family:
+    "Inter",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #e2e8f0;
 }
 
-.container {
-    max-width: 1100px;
-    text-align: center;
+/* ---------- Page-level decoration ---------- */
+.page-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #6366f1;
 }
 
-h1 {
-    color: #ffffff;
-    margin-bottom: 0.75rem;
+.page-title {
+  font-size: clamp(1.8rem, 5vw, 3rem);
+  font-weight: 800;
+  text-align: center;
+  background: linear-gradient(135deg, #f8fafc 30%, #94a3b8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
 }
 
-.subtitle {
-    color: #cbd5e1;
-    margin-bottom: 2.5rem;
+.page-subtitle {
+  font-size: 1rem;
+  color: #64748b;
+  text-align: center;
+  max-width: 520px;
 }
 
+/* ---------- Grid ---------- */
 .card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+  gap: 1.5rem;
+  width: min(100%, 960px);
 }
 
-.spotlight-card {
-    position: relative;
-    overflow: hidden;
-    padding: 2rem;
-    border-radius: 18px;
-    background: #1e293b;
-    color: white;
-    border: 1px solid rgba(255,255,255,0.08);
-    transition: transform 0.35s ease,
-                box-shadow 0.35s ease,
-                border-color 0.35s ease;
+/* ============================================================
+   .ease-spotlight-card  —  the core component
+   ============================================================ */
+
+/*
+ * 1. @property lets the browser understand the *type* of --x / --y
+ *    so it can interpolate them inside @keyframes.
+ * 2. ::before is a full-size overlay carrying the radial-gradient.
+ *    On hover it fades in and its custom-property position animates.
+ * 3. mix-blend-mode: overlay means bright areas of the gradient
+ *    brighten card content naturally, just like a real spotlight.
+ */
+.ease-spotlight-card {
+  --x: 50%;
+  --y: 50%;
+
+  position: relative;
+  overflow: hidden;
+  padding: 2rem 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: #0f172a;
+
+  /* Subtle inner glow at rest */
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset,
+    0 8px 32px rgba(0, 0, 0, 0.5);
+
+  transition:
+    transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    border-color 0.35s ease,
+    box-shadow 0.35s ease;
 }
 
-.spotlight-card::before {
-    content: "";
-    position: absolute;
-    inset: -50%;
-    background: radial-gradient(
-        circle,
-        rgba(255,255,255,0.22),
-        transparent 60%
-    );
-    opacity: 0;
-    transition: opacity 0.35s ease;
-    pointer-events: none;
+/* Spotlight overlay layer */
+.ease-spotlight-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+
+  background: radial-gradient(
+    circle 220px at var(--x) var(--y),
+    rgba(255, 255, 255, 0.18),
+    transparent 80%
+  );
+  mix-blend-mode: overlay;
+
+  opacity: 0;
+  transition: opacity 0.4s ease;
 }
 
-.spotlight-card:hover::before {
-    opacity: 1;
+/* Edge-glint border overlay (separate so it doesn't blend) */
+.ease-spotlight-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+
+  background: radial-gradient(
+    circle 220px at var(--x) var(--y),
+    rgba(99, 102, 241, 0.35),
+    transparent 70%
+  );
+
+  opacity: 0;
+  transition: opacity 0.4s ease;
 }
 
-.spotlight-card:hover {
-    transform: translateY(-10px);
-    border-color: rgba(255,255,255,0.25);
-    box-shadow:
-        0 20px 40px rgba(0,0,0,0.4),
-        0 0 30px rgba(255,255,255,0.08);
+/* ---- Hover state ---- */
+.ease-spotlight-card:hover {
+  transform: translateY(-8px) scale(1.02);
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow:
+    0 0 0 1px rgba(99, 102, 241, 0.25) inset,
+    0 24px 56px rgba(0, 0, 0, 0.6),
+    0 0 48px rgba(99, 102, 241, 0.1);
 }
 
-.spotlight-card h2 {
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 1;
+.ease-spotlight-card:hover::before {
+  opacity: 1;
+  /* Sweep animation: smoothly lerps --x / --y around the card */
+  animation: ease-spotlight-sweep 5s ease-in-out infinite alternate;
 }
 
-.spotlight-card p {
-    color: #d1d5db;
-    line-height: 1.6;
-    position: relative;
-    z-index: 1;
+.ease-spotlight-card:hover::after {
+  opacity: 1;
+  animation: ease-spotlight-sweep 5s ease-in-out infinite alternate;
 }
 
-@media (max-width: 768px) {
-    body {
-        padding: 1rem;
-    }
+/* ---- Spotlight sweep keyframes ---- */
+/*
+ * Because @property registers --x and --y as <percentage>,
+ * the browser can interpolate them between keyframe steps —
+ * producing a smooth orbiting-light illusion without JS.
+ */
+@keyframes ease-spotlight-sweep {
+  0% {
+    --x: 10%;
+    --y: 10%;
+  }
+  20% {
+    --x: 90%;
+    --y: 5%;
+  }
+  40% {
+    --x: 95%;
+    --y: 90%;
+  }
+  60% {
+    --x: 50%;
+    --y: 50%;
+  }
+  80% {
+    --x: 5%;
+    --y: 90%;
+  }
+  100% {
+    --x: 10%;
+    --y: 10%;
+  }
+}
 
-    .card-grid {
-        grid-template-columns: 1fr;
-    }
+/* ---- Card content (must sit above ::before / ::after) ---- */
+.ease-spotlight-card .card-icon {
+  position: relative;
+  z-index: 1;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin-bottom: 1.25rem;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.ease-spotlight-card h2 {
+  position: relative;
+  z-index: 1;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin-bottom: 0.65rem;
+  letter-spacing: -0.01em;
+}
+
+.ease-spotlight-card p {
+  position: relative;
+  z-index: 1;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  color: #64748b;
+}
+
+/* ---------- Reduced-motion: disable animation, keep fade ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .ease-spotlight-card {
+    transition: none;
+  }
+
+  .ease-spotlight-card::before,
+  .ease-spotlight-card::after {
+    animation: none !important;
+    /* Park spotlight in top-left corner — still visible but static */
+    --x: 20%;
+    --y: 20%;
+  }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 640px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Pull Request Description

Implements the `.ease-spotlight-card` component from issue #74673 — a CSS-only radial gradient "spotlight" that sweeps across a dark-themed card on hover, using `@property`, `radial-gradient`, and `mix-blend-mode: overlay` with zero JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/spotlight-hover-card/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A `.ease-spotlight-card` component that displays a radial gradient "spotlight" sweeping across a dark card on hover — built entirely in CSS using `@property`, `radial-gradient`, and `mix-blend-mode: overlay`.

**How does a developer use it?**

```html
<link rel="stylesheet" href="style.css" />

<div class="ease-spotlight-card">
  <h2>Your Title</h2>
  <p>Your description text.</p>
</div>
```

**Why does it fit EaseMotion CSS?**

EaseMotion CSS is about expressive, human-readable animations — this component pushes that philosophy to the cutting edge. The spotlight cursor effect is a signature interaction on premium developer landing pages (GitHub Copilot, Vercel, Linear). Traditionally it requires JS `mousemove` listeners. By registering `--x` and `--y` as typed `<percentage>` custom properties via `@property`, the browser can interpolate them inside `@keyframes`, producing a smooth orbiting-light illusion in a single CSS rule — no JavaScript, no dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

- The `@property` rule (Chrome 85+, Edge 85+, Firefox 128+, Safari 16.4+) is required for the animated sweep. Older browsers gracefully degrade — the card still lifts and glows on hover, only the moving spotlight is absent.
- Because CSS cannot track real cursor coordinates without JS, the spotlight follows a looping `@keyframes` sweep path around the card edges — this is documented clearly in the README as a known limitation.
- `prefers-reduced-motion` is respected: the sweep animation is disabled and the spotlight renders statically at `20% 20%`.
- Two overlay layers are used — `::before` with `mix-blend-mode: overlay` for the white brightness hit, and `::after` for an indigo edge-glint — both driven by the same `--x`/`--y` properties.
- Inspired by GitHub Copilot's homepage and Linear's feature cards.