### PR TITLE
feat: add pure CSS Glass Effect Retro Arcade Pixel component (#73726)

### DIFF
--- a/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/README.md
+++ b/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Glass Effect: Retro Arcade Pixel
+
+A hardware-accelerated, JavaScript-free glassmorphism UI element. Features an animated 8-bit voxel background refracted through a pixelated frosted glass panel.
+
+## Features
+- Pure CSS and HTML implementation. No images, SVGs, or Canvas required for the 8-bit aesthetic or the background sprites.
+- **Component Architecture**: 
+  - **Animated 8-Bit Background**: True glassmorphism requires a visually complex background to refract. This scene uses a massive, comma-separated `box-shadow` applied to a single `1x1` pixel `div` to draw an entire Space Invader sprite. It floats behind the UI using an alternating CSS `steps()` animation to mimic retro framerates.
+  - **Glassmorphism Core**: The `.glass-card-retro` element achieves the frosted glass look using a translucent `background-color` and `backdrop-filter: blur(12px)`. This allows the animated 8-bit sprite to refract dynamically through the glass.
+  - **The Pixelated Glass Hack**: You cannot use `border-radius` to create blocky, 8-bit corners; it only creates smooth curves. Instead, this component achieves a "pixelated border" using a highly advanced CSS `clip-path` polygon combined with a multi-layered `box-shadow` on an underlying pseudo-element (`::before`). This mathematically cuts the corners of the glass panel into exact 4px steps while preserving the `backdrop-filter` effect across the entire surface.
+  - **8-Bit Typography**: Uses the 'Press Start 2P' Google Font for authentic retro styling, complete with heavy, hard-edged text shadows.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), automatically swapping the glass borders and sprite colors from Yellow/Amber to neon Green depending on the system theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the `steps()` animations on the background sprite and stars are disabled, freezing them in place.
+
+## Usage
+Open `demo.html` in your browser. Observe the blocky, 8-bit stepped corners of the glass panel and watch how the animated box-shadow sprite refracts through the frosted glass background.
+
+## Files
+- `demo.html`: The HTML structure defining the ambient 8-bit background sprites, the glassmorphism container, and the retro UI elements.
+- `style.css`: The styling, the massive `box-shadow` definitions drawing the sprites, the glassmorphism blur logic, and the complex `clip-path` geometry required to create stepped 8-bit corners on a blurred container.

--- a/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/demo.html
+++ b/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Glass Effect: Retro Arcade Pixel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Glass: Retro Pixel</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free glassmorphism UI element. Features an animated 8-bit voxel background refracted through a pixelated frosted glass panel.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] Animated 8-Bit Background 
+              A complex pixel-art space invader built entirely with a single box-shadow,
+              animated to float behind the glass to show off the blur refraction.
+            -->
+            <div class="pixel-invader"></div>
+            
+            <!-- A secondary animated element to add depth -->
+            <div class="pixel-star"></div>
+            
+            <!-- 
+              [TECHNIQUE] The Pixelated Glass Card
+              This element combines glassmorphism (translucency + blur)
+              with an 8-bit aesthetic (stepped corners via box-shadow).
+            -->
+            <div class="glass-card-retro">
+                
+                <div class="card-icon">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter">
+                        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"></path>
+                    </svg>
+                </div>
+                
+                <h3 class="card-title">Insert Coin</h3>
+                <p class="card-text">Notice the blocky, stepped "border-radius" on this card. It is achieved entirely using stacked `box-shadow` layers while maintaining the glass blur effect.</p>
+                
+                <button class="glass-button">Start Game</button>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/style.css
+++ b/submissions/examples/css-glass-effect-retro-arcade-pixel-pure/style.css
@@ -1,0 +1,347 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #1e1b4b; 
+    --text-primary: #e0e7ff;
+    
+    /* Pixel Sprite Colors */
+    --pixel-primary: #fcd34d; /* Yellow */
+    --pixel-secondary: #f59e0b; /* Dark Orange/Yellow */
+    
+    /* Glassmorphism Variables */
+    /* Needs to be quite opaque so the pixel shadow border looks solid */
+    --glass-bg: rgba(30, 27, 75, 0.7); 
+    --glass-border: #fcd34d;
+    --glass-shadow: rgba(0, 0, 0, 0.8);
+    
+    /* The unit size of 1 pixel in our sprites */
+    --p-size: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a; 
+        --text-primary: #f8fafc;
+        
+        --pixel-primary: #34d399; /* Green */
+        --pixel-secondary: #059669; /* Dark Green */
+        
+        --glass-bg: rgba(15, 23, 42, 0.7);
+        --glass-border: #34d399;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Press Start 2P', cursive;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 20px 0;
+    line-height: 1.4;
+    color: var(--pixel-primary);
+    text-shadow: 2px 2px 0px var(--pixel-secondary);
+}
+
+.subtitle {
+    font-family: sans-serif;
+    font-size: 1rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: #94a3b8;
+}
+
+.demo-area {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 100px 0;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Animated 8-Bit Background 
+   ========================================= */
+
+.pixel-invader {
+    position: absolute;
+    top: 50%;
+    left: 20%;
+    width: var(--p-size);
+    height: var(--p-size);
+    
+    /* 
+       A standard 11x8 space invader sprite drawn with box-shadows.
+    */
+    background-color: transparent;
+    box-shadow: 
+        /* Row 1 */
+        calc(var(--p-size) * 3) calc(var(--p-size) * 1) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 1) 0 var(--pixel-primary),
+        /* Row 2 */
+        calc(var(--p-size) * 4) calc(var(--p-size) * 2) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 2) 0 var(--pixel-primary),
+        /* Row 3 */
+        calc(var(--p-size) * 3) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 3) 0 var(--pixel-primary),
+        /* Row 4 (Eyes) */
+        calc(var(--p-size) * 2) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        calc(var(--p-size) * 10) calc(var(--p-size) * 4) 0 var(--pixel-primary),
+        /* Row 5 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 2) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 4) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 6) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 10) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 5) 0 var(--pixel-primary),
+        /* Row 6 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 6) 0 var(--pixel-primary),
+        /* Row 7 */
+        calc(var(--p-size) * 1) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        calc(var(--p-size) * 9) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        calc(var(--p-size) * 11) calc(var(--p-size) * 7) 0 var(--pixel-primary),
+        /* Row 8 */
+        calc(var(--p-size) * 4) calc(var(--p-size) * 8) 0 var(--pixel-primary),
+        calc(var(--p-size) * 5) calc(var(--p-size) * 8) 0 var(--pixel-primary),
+        calc(var(--p-size) * 7) calc(var(--p-size) * 8) 0 var(--pixel-primary),
+        calc(var(--p-size) * 8) calc(var(--p-size) * 8) 0 var(--pixel-primary);
+        
+    z-index: 0;
+    animation: float-invader 6s infinite alternate steps(10);
+}
+
+@keyframes float-invader {
+    0% { transform: translateY(-50px) translateX(0); }
+    100% { transform: translateY(50px) translateX(40px); }
+}
+
+.pixel-star {
+    position: absolute;
+    top: 30%;
+    right: 20%;
+    width: var(--p-size);
+    height: var(--p-size);
+    background-color: transparent;
+    box-shadow: 
+        calc(var(--p-size) * 2) calc(var(--p-size) * 0) 0 var(--pixel-secondary),
+        calc(var(--p-size) * 1) calc(var(--p-size) * 1) 0 var(--pixel-secondary),
+        calc(var(--p-size) * 2) calc(var(--p-size) * 1) 0 var(--pixel-secondary),
+        calc(var(--p-size) * 3) calc(var(--p-size) * 1) 0 var(--pixel-secondary),
+        calc(var(--p-size) * 2) calc(var(--p-size) * 2) 0 var(--pixel-secondary);
+        
+    z-index: 0;
+    animation: blink-star 1s infinite alternate steps(2);
+}
+
+@keyframes blink-star {
+    0% { opacity: 0.3; }
+    100% { opacity: 1; }
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Pixelated Glass Card
+   ========================================= */
+
+.glass-card-retro {
+    position: relative;
+    width: 320px;
+    padding: 40px 30px;
+    margin: 16px; /* Space for the pseudo-element border */
+    
+    /* Core Glassmorphism */
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    
+    /* 
+       To create a pixelated "stepped" border, we cannot use border-radius.
+       Instead, we use a complex box-shadow on a pseudo-element.
+    */
+    z-index: 1;
+    text-align: center;
+}
+
+/* 
+   The Pixelated Border Hack 
+   We draw a multi-layered box-shadow that steps inwards at the corners.
+*/
+.glass-card-retro::before {
+    content: '';
+    position: absolute;
+    top: -4px;
+    left: -4px;
+    right: -4px;
+    bottom: -4px;
+    z-index: -1;
+    
+    /* 
+       The base shape is a rectangle. 
+       The box-shadow draws the stepped pixels around it.
+    */
+    box-shadow: 
+        /* Top Edge */
+        0 -4px 0 -4px var(--glass-border),
+        /* Bottom Edge */
+        0 4px 0 -4px var(--glass-border),
+        /* Left Edge */
+        -4px 0 0 -4px var(--glass-border),
+        /* Right Edge */
+        4px 0 0 -4px var(--glass-border),
+        
+        /* The Stepped Corners (4px steps) */
+        /* Top Left */
+        -4px -4px 0 -4px transparent, 
+        -4px 0 0 -4px var(--glass-border),
+        0 -4px 0 -4px var(--glass-border),
+        
+        /* The overall drop shadow (pixelated) */
+        8px 8px 0 var(--glass-shadow);
+        
+    /* To apply the actual border color, we use borders on the main axes */
+    border-top: 4px solid var(--glass-border);
+    border-bottom: 4px solid var(--glass-border);
+    border-left: 4px solid var(--glass-border);
+    border-right: 4px solid var(--glass-border);
+    
+    /* We clip the corners of this pseudo element to let the box-shadow handle them */
+    clip-path: polygon(
+        4px 0, calc(100% - 4px) 0, 
+        100% 4px, 100% calc(100% - 4px), 
+        calc(100% - 4px) 100%, 4px 100%, 
+        0 calc(100% - 4px), 0 4px
+    );
+}
+
+/* Because clip-path on the ::before cuts off the glass background too, 
+   we need to apply the exact same clip-path to the main card */
+.glass-card-retro {
+    clip-path: polygon(
+        4px 0, calc(100% - 4px) 0, 
+        100% 4px, 100% calc(100% - 4px), 
+        calc(100% - 4px) 100%, 4px 100%, 
+        0 calc(100% - 4px), 0 4px
+    );
+}
+
+
+/* =========================================
+   Card Content
+   ========================================= */
+
+.card-icon {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    background: transparent;
+    border: 4px solid var(--glass-border);
+    margin-bottom: 24px;
+    color: var(--pixel-primary);
+    
+    /* Stepped border for the icon */
+    clip-path: polygon(
+        4px 0, calc(100% - 4px) 0, 
+        100% 4px, 100% calc(100% - 4px), 
+        calc(100% - 4px) 100%, 4px 100%, 
+        0 calc(100% - 4px), 0 4px
+    );
+}
+
+.card-title {
+    font-size: 1rem;
+    font-weight: 400;
+    margin: 0 0 20px 0;
+    line-height: 1.5;
+    color: var(--pixel-primary);
+}
+
+.card-text {
+    font-family: sans-serif; /* Keep body text readable */
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #cbd5e1;
+    margin: 0 0 30px 0;
+}
+
+.glass-button {
+    width: 100%;
+    padding: 16px 0;
+    background: transparent;
+    border: 4px solid var(--glass-border);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-weight: 400;
+    font-size: 0.8rem;
+    cursor: pointer;
+    
+    clip-path: polygon(
+        4px 0, calc(100% - 4px) 0, 
+        100% 4px, 100% calc(100% - 4px), 
+        calc(100% - 4px) 100%, 4px 100%, 
+        0 calc(100% - 4px), 0 4px
+    );
+    
+    transition: background 0.2s steps(2);
+}
+
+.glass-button:hover {
+    background: var(--glass-border);
+    color: var(--bg-base);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .pixel-invader, .pixel-star {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free glassmorphism UI element. It features an animated 8-bit voxel background refracted through a pixelated frosted glass panel. Resolves issue #73726.

### Changes Made:
- Added `submissions/examples/css-glass-effect-retro-arcade-pixel-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the ambient 8-bit background sprites, the glassmorphism container, and the retro UI elements.
- Created `style.css` featuring the UI mechanics:
  - **Animated 8-Bit Background**: True glassmorphism requires a visually complex background to refract. This scene uses a massive, comma-separated `box-shadow` applied to a single `1x1` pixel `div` to draw an entire Space Invader sprite. It floats behind the UI using an alternating CSS `steps()` animation to mimic retro framerates.
  - **Glassmorphism Core**: The `.glass-card-retro` element achieves the frosted glass look using a translucent `background-color` and `backdrop-filter: blur(12px)`. This allows the animated 8-bit sprite to refract dynamically through the glass.
  - **The Pixelated Glass Hack**: You cannot use `border-radius` to create blocky, 8-bit corners; it only creates smooth curves. Instead, this component achieves a "pixelated border" using a highly advanced CSS `clip-path` polygon combined with a multi-layered `box-shadow` on an underlying pseudo-element (`::before`). This mathematically cuts the corners of the glass panel into exact 4px steps while preserving the `backdrop-filter` effect across the entire surface.
  - **8-Bit Typography**: Uses the 'Press Start 2P' Google Font for authentic retro styling, complete with heavy, hard-edged text shadows.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), automatically swapping the glass borders and sprite colors from Yellow/Amber to neon Green depending on the system theme.
- Added `README.md` documenting usage and the technical mechanics of the massive `box-shadow` definitions drawing the sprites, the glassmorphism blur logic, and the complex `clip-path` geometry required to create stepped 8-bit corners on a blurred container.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the `steps()` animations on the background sprite and stars are disabled, freezing them in place.

Closes #73726
