### PR TITLE
feat: add 3D Toggle Switch example (toggle-switch-3d-advk)

### DIFF
--- a/submissions/examples/toggle-switch-3d-advk/README.md
+++ b/submissions/examples/toggle-switch-3d-advk/README.md
@@ -1,0 +1,34 @@
+# 3D Toggle Switch
+
+## What does this do?
+
+A checkbox-driven toggle switch whose thumb both slides and rotates
+(`rotateY(360deg)`) as it flips, giving the motion a physical, coin-flick
+feel instead of a flat slide. State comes from a real checkbox, so it works
+as a form control with no JavaScript.
+
+## How is it used?
+
+```html
+<input type="checkbox" id="t3d-1" class="t3d-input" />
+<label for="t3d-1" class="t3d-switch">
+  <span class="t3d-thumb"></span>
+  <span class="t3d-sr">Enable notifications</span>
+</label>
+```
+
+The wrapper needs `perspective` set on an ancestor (here `.t3d-wrap`) for the
+`rotateY` to read as 3D rather than a flat horizontal squash.
+
+## Why is it useful?
+
+Toggle switches are usually just a translate on the thumb, which is fine but
+reads as flat motion no matter how the surrounding UI feels. Pairing the
+translate with a full `rotateY(360deg)` on the same duration and easing
+curve makes both finish together, so the thumb appears to spin exactly once
+while crossing the track — a small detail that differentiates the switch
+from a generic slider without adding any interaction complexity.
+
+Because the checkbox itself remains an unstyled, accessible input (visually
+hidden but not `display: none`), the switch keeps native keyboard toggling
+via Space, form participation, and `:focus-visible` styling for free.

--- a/submissions/examples/toggle-switch-3d-advk/demo.html
+++ b/submissions/examples/toggle-switch-3d-advk/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3D Toggle Switch</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="t3d-wrap">
+  <h1 class="t3d-h1">3D Toggle Switch</h1>
+  <p class="t3d-lede">A checkbox-driven switch whose thumb rotates on a Y-axis as it slides, so the flip reads as a physical flick rather than a flat slide.</p>
+
+  <div class="t3d-row">
+    <input type="checkbox" id="t3d-1" class="t3d-input" />
+    <label for="t3d-1" class="t3d-switch">
+      <span class="t3d-thumb"></span>
+      <span class="t3d-sr">Enable notifications</span>
+    </label>
+    <span class="t3d-text">Enable notifications</span>
+  </div>
+
+  <div class="t3d-row">
+    <input type="checkbox" id="t3d-2" class="t3d-input" checked />
+    <label for="t3d-2" class="t3d-switch">
+      <span class="t3d-thumb"></span>
+      <span class="t3d-sr">Auto-save drafts</span>
+    </label>
+    <span class="t3d-text">Auto-save drafts</span>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/toggle-switch-3d-advk/style.css
+++ b/submissions/examples/toggle-switch-3d-advk/style.css
@@ -1,0 +1,98 @@
+/* 3D Toggle Switch
+   The thumb's rotateY passes through 90deg at the midpoint of the slide, so
+   it appears edge-on halfway across -- timed on the same duration as the
+   translate so rotation and position finish together. */
+
+.t3d-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  perspective: 400px;
+}
+
+.t3d-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.t3d-lede { margin: 0 0 2rem; color: #576073; }
+
+.t3d-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.6rem 0;
+}
+
+.t3d-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.t3d-switch {
+  position: relative;
+  display: inline-block;
+  width: 3.2rem;
+  height: 1.8rem;
+  flex: none;
+  border-radius: 999px;
+  background: #cdd2df;
+  cursor: pointer;
+  transform-style: preserve-3d;
+  transition: background 200ms ease;
+}
+
+.t3d-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.t3d-thumb {
+  position: absolute;
+  top: 0.18rem;
+  left: 0.18rem;
+  width: 1.44rem;
+  height: 1.44rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: center;
+}
+
+.t3d-input:checked + .t3d-switch {
+  background: #34a853;
+}
+
+.t3d-input:checked + .t3d-switch .t3d-thumb {
+  transform: translateX(1.4rem) rotateY(360deg);
+}
+
+.t3d-input:focus-visible + .t3d-switch {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.t3d-text {
+  font-size: 0.95rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t3d-thumb, .t3d-switch { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .t3d-switch { forced-color-adjust: none; border: 1px solid CanvasText; background: Canvas; }
+  .t3d-input:checked + .t3d-switch { background: Highlight; }
+  .t3d-thumb { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .t3d-wrap { color: #e6e9f2; }
+  .t3d-lede { color: #99a1b4; }
+  .t3d-switch { background: #3a4150; }
+}


### PR DESCRIPTION
Closes #74817

Checkbox-driven toggle switch whose thumb both slides and rotates a full 360deg on a Y-axis as it flips, timed with the translate so both finish together — reads as a physical flick rather than a flat slide. Real checkbox underneath, so it's a working form control with no JS.

- Keyboard toggling via Space (native checkbox)
- prefers-reduced-motion, forced-colors, dark-mode support