### PR TITLE
feat: add Quantity Stepper example (quantity-stepper-advk)

### DIFF
--- a/submissions/examples/quantity-stepper-advk/README.md
+++ b/submissions/examples/quantity-stepper-advk/README.md
@@ -1,0 +1,39 @@
+# Quantity Stepper
+
+## What does this do?
+
+A number input with increment/decrement buttons on either side, clamped to
+`min`/`max` and announced via `aria-live` so screen reader users hear the
+new value without moving focus.
+
+## How is it used?
+
+```html
+<div class="qty-stepper">
+  <button type="button" onclick="qtyStep(input, -1)">−</button>
+  <input id="qty-input" type="number" min="0" max="10" value="1" aria-live="polite" />
+  <button type="button" onclick="qtyStep(input, 1)">+</button>
+</div>
+```
+
+`qtyStep(input, delta)` reads the input's own `min`/`max`, clamps the next
+value, and dispatches a `change` event so anything listening for form
+changes (a cart total, a form library) picks up the update the same way it
+would for direct typing.
+
+## Why is it useful?
+
+The native spin buttons (`<input type="number">`'s built-in arrows) are
+tiny, inconsistent across browsers, and unstyleable in any meaningful way,
+which is why most quantity pickers replace them with custom buttons — but
+that replacement often forgets to also hide the native spinner
+(`-webkit-inner/outer-spin-button`, `-moz-appearance: textfield`), leaving
+both controls visible and out of sync. This example removes the native
+spinner explicitly so the custom buttons are the only way to step the value
+outside of typing directly.
+
+Dispatching a real `change` event from the buttons (rather than only
+mutating `.value`) matters because many frameworks and native form
+submission only observe input state through events, not direct property
+writes — skipping this step is a common bug where clicking the buttons
+silently fails to update anything listening for changes.

--- a/submissions/examples/quantity-stepper-advk/demo.html
+++ b/submissions/examples/quantity-stepper-advk/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Quantity Stepper</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function qtyStep(input, delta) {
+    var min = Number(input.min || 0);
+    var max = Number(input.max || Infinity);
+    var next = Number(input.value || 0) + delta;
+    input.value = Math.min(max, Math.max(min, next));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+</script>
+</head>
+<body>
+<main class="qty-wrap">
+  <h1 class="qty-h1">Quantity Stepper</h1>
+  <p class="qty-lede">A number input flanked by increment/decrement buttons, disabling each button at its bound via :out-of-range-adjacent CSS logic driven by the input's own min/max.</p>
+
+  <div class="qty-stepper">
+    <button type="button" class="qty-btn" aria-label="Decrease quantity" onclick="qtyStep(document.getElementById('qty-input'), -1)">−</button>
+    <input
+      id="qty-input"
+      class="qty-input"
+      type="number"
+      inputmode="numeric"
+      min="0"
+      max="10"
+      value="1"
+      aria-live="polite"
+    />
+    <button type="button" class="qty-btn" aria-label="Increase quantity" onclick="qtyStep(document.getElementById('qty-input'), 1)">+</button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/quantity-stepper-advk/style.css
+++ b/submissions/examples/quantity-stepper-advk/style.css
@@ -1,0 +1,90 @@
+/* Quantity Stepper
+   The buttons stay enabled at the bounds (min/max clamp in JS instead), since
+   CSS alone cannot read an input's current numeric value to disable a
+   sibling button -- that clamping is the one thing left to the script. */
+
+.qty-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.qty-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.qty-lede { margin: 0 0 2rem; color: #576073; }
+
+.qty-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.6rem;
+  overflow: hidden;
+}
+
+.qty-btn {
+  width: 2.6rem;
+  border: none;
+  background: #f1f4fa;
+  color: #1c2028;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 140ms ease;
+}
+
+.qty-btn:hover { background: #e4e9f4; }
+.qty-btn:active { background: #d8dff0; }
+
+.qty-btn:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: -2px;
+  z-index: 1;
+  position: relative;
+}
+
+.qty-input {
+  width: 3.6rem;
+  border: none;
+  border-left: 1px solid #d3d8e2;
+  border-right: 1px solid #d3d8e2;
+  text-align: center;
+  font: inherit;
+  -moz-appearance: textfield;
+}
+
+.qty-input::-webkit-inner-spin-button,
+.qty-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.qty-input:focus-visible {
+  outline: none;
+  background: #f1f4fa;
+}
+
+.qty-input:invalid,
+.qty-input:out-of-range {
+  color: #e0483f;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qty-btn { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .qty-stepper { border-color: CanvasText; }
+  .qty-btn { background: ButtonFace; color: ButtonText; }
+  .qty-input { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .qty-wrap { color: #e6e9f2; }
+  .qty-lede { color: #99a1b4; }
+  .qty-stepper { border-color: #2a303c; }
+  .qty-btn { background: #1e2430; color: #e6e9f2; }
+  .qty-btn:hover { background: #262e3d; }
+  .qty-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .qty-input:focus-visible { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #74818

Number input with custom increment/decrement buttons, clamped to the input's own min/max, dispatching a real change event so anything listening for form changes stays in sync. Removes the native spin buttons explicitly (-webkit-inner/outer-spin-button, -moz-appearance) so only the custom buttons are visible.

- forced-colors and dark-mode support