### PR TITLE
feat: add Tag Input Chips example (tag-input-chips-advk)

### DIFF
--- a/submissions/examples/tag-input-chips-advk/README.md
+++ b/submissions/examples/tag-input-chips-advk/README.md
@@ -1,0 +1,35 @@
+# Tag Input Chips
+
+## What does this do?
+
+A tag/chip input: typing a value and pressing Enter or comma turns it into a
+removable chip; Backspace on an empty field removes the last chip. The text
+input lives inside the same flex container as the chips, so it reflows
+naturally as chips are added.
+
+## How is it used?
+
+```html
+<div class="tic-list" id="tic-list">
+  <input id="tic-input" class="tic-input" type="text" onkeydown="tagKeydown(event, tic-list)" />
+</div>
+```
+
+`tagAdd` inserts each new chip with `insertBefore(chip, inputEl)`, keeping
+the input pinned as the last flex item so new chips always append before the
+active cursor position, matching how the field visually reads left to
+right.
+
+## Why is it useful?
+
+Tag inputs are usually built with the text field as a fixed-width box
+separate from the chip list, which either wastes space when empty or
+truncates the typed value when the list is full. Making the input a `flex: 1`
+item inside the same flex row as the chips means it always claims whatever
+horizontal space is left and — thanks to `flex-wrap: wrap` and a
+`min-width` floor — drops to its own line once the chips crowd it out
+instead of shrinking to an unusable sliver.
+
+Each chip's remove button carries an `aria-label` naming the specific tag
+("Remove React"), rather than a bare "×", so screen reader users removing
+tags by keyboard know which one they're about to delete.

--- a/submissions/examples/tag-input-chips-advk/demo.html
+++ b/submissions/examples/tag-input-chips-advk/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Tag Input Chips</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function tagAdd(inputEl, listEl) {
+    var value = inputEl.value.trim();
+    if (!value) return;
+    var chip = document.createElement('span');
+    chip.className = 'tic-chip';
+    var label = document.createElement('span');
+    label.textContent = value;
+    var remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'tic-remove';
+    remove.setAttribute('aria-label', 'Remove ' + value);
+    remove.textContent = '×';
+    remove.onclick = function () { chip.remove(); inputEl.focus(); };
+    chip.appendChild(label);
+    chip.appendChild(remove);
+    listEl.insertBefore(chip, inputEl);
+    inputEl.value = '';
+  }
+
+  function tagKeydown(event, listEl) {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      tagAdd(event.target, listEl);
+    } else if (event.key === 'Backspace' && !event.target.value) {
+      var chips = listEl.querySelectorAll('.tic-chip');
+      var last = chips[chips.length - 1];
+      if (last) last.remove();
+    }
+  }
+</script>
+</head>
+<body>
+<main class="tic-wrap">
+  <h1 class="tic-h1">Tag Input</h1>
+  <p class="tic-lede">Type a value and press Enter or comma to add a chip; Backspace on an empty field removes the last one. The field grows to fill remaining row space via flex.</p>
+
+  <label class="tic-field-label" for="tic-input">Skills</label>
+  <div class="tic-list" id="tic-list">
+    <input
+      id="tic-input"
+      class="tic-input"
+      type="text"
+      placeholder="Add a skill..."
+      onkeydown="tagKeydown(event, document.getElementById('tic-list'))"
+    />
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/tag-input-chips-advk/style.css
+++ b/submissions/examples/tag-input-chips-advk/style.css
@@ -1,0 +1,95 @@
+/* Tag Input Chips
+   The bare <input> is one flex item among the chips, with flex:1 and a
+   min-width floor -- so it wraps onto its own line once the chips crowd it
+   out rather than shrinking to an unusable sliver. */
+
+.tic-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.tic-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.tic-lede { margin: 0 0 2rem; color: #576073; }
+
+.tic-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.tic-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #fff;
+  transition: border-color 160ms ease;
+}
+
+.tic-list:focus-within {
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.tic-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25em 0.4em 0.25em 0.7em;
+  border-radius: 999px;
+  background: #e8ecf9;
+  color: #35408c;
+  font-size: 0.88rem;
+  animation: tic-pop 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tic-remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.1em 0.3em;
+  border-radius: 999px;
+}
+
+.tic-remove:hover { background: rgba(53, 64, 140, 0.15); }
+.tic-remove:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 1px; }
+
+.tic-input {
+  flex: 1;
+  min-width: 8rem;
+  border: none;
+  outline: none;
+  font: inherit;
+  padding: 0.3em 0.2em;
+}
+
+@keyframes tic-pop {
+  from { transform: scale(0.6); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tic-list, .tic-chip { transition: none; animation: none; }
+}
+
+@media (forced-colors: active) {
+  .tic-list { border-color: CanvasText; }
+  .tic-chip { forced-color-adjust: none; background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tic-wrap { color: #e6e9f2; }
+  .tic-lede { color: #99a1b4; }
+  .tic-list { background: #171b23; border-color: #2a303c; }
+  .tic-chip { background: #262e4a; color: #b7c0f2; }
+  .tic-input { background: transparent; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #74819

Tag/chip input where the text field is a flex:1 item inside the same flex row as the chips, with a min-width floor — so it always claims remaining space and wraps to its own line once chips crowd it out, instead of shrinking to an unusable sliver. Enter/comma adds a chip, Backspace on an empty field removes the last one.

- Per-chip aria-label on remove buttons ("Remove React", not bare "×")