### PR TITLE
feat: add Accordion Icon Morph example (accordion-icon-morph-advk)

### DIFF
--- a/submissions/examples/accordion-icon-morph-advk/README.md
+++ b/submissions/examples/accordion-icon-morph-advk/README.md
@@ -1,0 +1,38 @@
+# Accordion Icon Morph
+
+## What does this do?
+
+A `<details>` accordion whose disclosure icon morphs continuously between a
+plus and a minus, rather than swapping between two separate icons. One bar
+stays fixed; the other rotates 90° to lie on top of it, so "plus" and
+"minus" are two rotation states of the same two elements.
+
+## How is it used?
+
+```html
+<details class="aim-item">
+  <summary class="aim-sum">
+    <span class="aim-icon" aria-hidden="true"></span>
+    Question
+  </summary>
+  <div class="aim-panel"><p>Answer.</p></div>
+</details>
+```
+
+The icon is `aria-hidden` because it's purely decorative — the accessible
+open/closed state already comes from `<details>`/`<summary>` semantics, so
+duplicating it in the icon's accessible name would be redundant.
+
+## Why is it useful?
+
+The common alternative — swapping a `+` SVG for a `-` SVG on toggle, or
+toggling `display` between two icon elements — has no intermediate frame:
+the icon just cuts from one shape to the other. Building the plus from two
+independent bars and animating only the vertical one's rotation keeps a
+single continuous transform running for the entire transition, which reads
+as one shape changing rather than one icon being replaced by a different
+one.
+
+Only the rotating bar (`::after`) carries a `transition`; the horizontal bar
+(`::before`) never moves, which keeps the animation cost to a single
+`transform` on one pseudo-element instead of coordinating two moving parts.

--- a/submissions/examples/accordion-icon-morph-advk/demo.html
+++ b/submissions/examples/accordion-icon-morph-advk/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Accordion Icon Morph</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="aim-wrap">
+  <h1 class="aim-h1">Accordion, Plus Morphs to Minus</h1>
+  <p class="aim-lede">The disclosure icon is a single element whose two pseudo-element bars rotate independently: one bar rotates 90deg to vanish into the other, turning a plus into a minus rather than swapping icons.</p>
+
+  <details class="aim-item" open>
+    <summary class="aim-sum">
+      <span class="aim-icon" aria-hidden="true"></span>
+      What is this pattern called?
+    </summary>
+    <div class="aim-panel"><p>A morphing disclosure icon: the same two bars represent both the plus and minus states by rotating rather than being swapped for a different icon.</p></div>
+  </details>
+
+  <details class="aim-item">
+    <summary class="aim-sum">
+      <span class="aim-icon" aria-hidden="true"></span>
+      Why not just swap SVGs?
+    </summary>
+    <div class="aim-panel"><p>Swapping SVGs on toggle is a visible cut with no in-between frame. Rotating one bar of a plus onto the other keeps a continuous, single transform running the whole time.</p></div>
+  </details>
+</main>
+</body>
+</html>

--- a/submissions/examples/accordion-icon-morph-advk/style.css
+++ b/submissions/examples/accordion-icon-morph-advk/style.css
@@ -1,0 +1,87 @@
+/* Accordion Icon Morph
+   The plus is two bars: one fixed (the minus that remains), one that
+   rotates 90deg onto the fixed bar's axis and disappears into it. Only the
+   rotating bar has a transition -- the horizontal bar never moves. */
+
+.aim-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.aim-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.aim-lede { margin: 0 0 2rem; color: #576073; }
+
+.aim-item {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+  margin-bottom: 0.6rem;
+  background: #fbfcfe;
+}
+
+.aim-sum {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.9em 1.1em;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.aim-sum::-webkit-details-marker { display: none; }
+.aim-sum:focus-visible { outline: 2px solid #4c6ef5; outline-offset: -2px; }
+
+.aim-icon {
+  position: relative;
+  flex: none;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.aim-icon::before,
+.aim-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: #4c6ef5;
+  transform: translateY(-50%);
+}
+
+.aim-icon::after {
+  transform: translateY(-50%) rotate(90deg);
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.aim-item[open] .aim-icon::after {
+  transform: translateY(-50%) rotate(0deg);
+}
+
+.aim-panel {
+  padding: 0 1.1em 1.1em;
+  color: #576073;
+  font-size: 0.94rem;
+}
+
+.aim-panel p { margin: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .aim-icon::after { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .aim-item { border-color: CanvasText; }
+  .aim-icon::before, .aim-icon::after { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .aim-wrap { color: #e6e9f2; }
+  .aim-lede { color: #99a1b4; }
+  .aim-item { background: #171b23; border-color: #2a303c; }
+  .aim-panel { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #74821

<details> accordion whose plus/minus icon is built from two bars: one fixed, one that rotates 90deg onto it. The rotating bar's transition is the only animated property, so 'plus' and 'minus' are two states of one continuous transform rather than two icons being swapped.

- prefers-reduced-motion, forced-colors, dark-mode support