### PR TITLE
feat: add useMediaQuery hook (use-media-query-advk)

### DIFF
--- a/submissions/react/use-media-query-advk/README.md
+++ b/submissions/react/use-media-query-advk/README.md
@@ -1,0 +1,33 @@
+# useMediaQuery
+
+Tracks whether a CSS media query currently matches, re-rendering on change.
+
+## API
+
+```js
+const matches = useMediaQuery('(min-width: 768px)');
+```
+
+## Usage
+
+```jsx
+function Layout() {
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+  return isDesktop ? <SidebarLayout /> : <StackedLayout />;
+}
+```
+
+## Why is it useful?
+
+A common version of this hook initializes state to `false` and only reads
+the real match inside `useEffect`, which means the first client render
+always assumes the query doesn't match — visible as a layout flash on
+desktop viewports that briefly render the mobile layout before the effect
+runs. This hook seeds `useState` with a lazy initializer that calls
+`matchMedia` directly, so the first render already reflects the actual
+viewport.
+
+It also falls back to the deprecated `addListener`/`removeListener` pair for
+Safari versions before 14, which never implemented
+`MediaQueryList.addEventListener`, so the hook doesn't silently stop
+tracking changes on older Safari.

--- a/submissions/react/use-media-query-advk/useMediaQuery.jsx
+++ b/submissions/react/use-media-query-advk/useMediaQuery.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useMediaQuery
+ * Tracks whether a media query currently matches, updating on change.
+ * Reads the initial value synchronously (not in an effect), so the first
+ * render already reflects reality instead of a hard-coded false.
+ */
+export function useMediaQuery(query) {
+  const getMatch = () =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(query).matches
+      : false;
+
+  const [matches, setMatches] = useState(getMatch);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    const mql = window.matchMedia(query);
+    const onChange = (event) => setMatches(event.matches);
+
+    setMatches(mql.matches);
+
+    if (mql.addEventListener) {
+      mql.addEventListener('change', onChange);
+      return () => mql.removeEventListener('change', onChange);
+    }
+
+    // Safari < 14 fallback.
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, [query]);
+
+  return matches;
+}
+
+export default useMediaQuery;


### PR DESCRIPTION
Closes #74822

React hook tracking a media query's match state. Seeds useState with a lazy initializer that calls matchMedia directly, so the first render already reflects the real viewport instead of assuming false and flashing the wrong layout. Falls back to the deprecated addListener/removeListener pair for Safari <14.