### PR TITLE
feat: add useHover hook (use-hover-advk)

### DIFF
--- a/submissions/react/use-hover-advk/README.md
+++ b/submissions/react/use-hover-advk/README.md
@@ -1,0 +1,35 @@
+# useHover
+
+Reports whether the referenced DOM element is currently hovered, using
+`pointerenter`/`pointerleave` so touch input doesn't get stuck "hovered"
+after a tap.
+
+## API
+
+```js
+const [ref, hovered] = useHover();
+```
+
+## Usage
+
+```jsx
+function Card() {
+  const [ref, hovered] = useHover();
+  return <div ref={ref}>{hovered ? 'Hovering!' : 'Hover me'}</div>;
+}
+```
+
+## Why is it useful?
+
+Versions of this hook built on `mouseenter`/`mouseleave` fire those events
+for touch taps on many mobile browsers (as a compatibility shim for sites
+that only handle mouse events), which leaves `hovered` stuck `true` after a
+tap since no corresponding `mouseleave` follows. `pointerenter`/
+`pointerleave` are pointer-type aware and don't carry that same touch
+compatibility baggage, so tapping a card on mobile doesn't leave it visually
+"stuck" in a hover state.
+
+The hook returns a callback ref rather than a plain `useRef` object so it
+correctly re-attaches its listeners if the underlying DOM node is swapped
+out (e.g. conditional rendering changing the element type) — a plain ref
+would keep listening on the old, now-detached node.

--- a/submissions/react/use-hover-advk/useHover.jsx
+++ b/submissions/react/use-hover-advk/useHover.jsx
@@ -1,0 +1,40 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * useHover
+ * Reports whether the referenced element is currently hovered, via a
+ * callback ref so it re-attaches correctly if the underlying node changes.
+ */
+export function useHover() {
+  const [hovered, setHovered] = useState(false);
+  const nodeRef = useRef(null);
+  const cleanupRef = useRef(null);
+
+  const ref = useCallback((node) => {
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = null;
+    }
+
+    nodeRef.current = node;
+    if (!node) {
+      setHovered(false);
+      return;
+    }
+
+    const onEnter = () => setHovered(true);
+    const onLeave = () => setHovered(false);
+
+    node.addEventListener('pointerenter', onEnter);
+    node.addEventListener('pointerleave', onLeave);
+
+    cleanupRef.current = () => {
+      node.removeEventListener('pointerenter', onEnter);
+      node.removeEventListener('pointerleave', onLeave);
+    };
+  }, []);
+
+  return [ref, hovered];
+}
+
+export default useHover;


### PR DESCRIPTION
Closes #74826

React hook reporting hover state via pointerenter/pointerleave rather than mouseenter/mouseleave, which some mobile browsers fire on tap as a compatibility shim — leaving hover stuck true with no matching leave event. Returns a callback ref so listeners re-attach correctly if the underlying node is swapped.