### PR TITLE
feat: add scrollbar-style Sass mixin (scrollbar-style-advk)

### DIFF
--- a/submissions/scss/scrollbar-style-advk/README.md
+++ b/submissions/scss/scrollbar-style-advk/README.md
@@ -1,0 +1,37 @@
+# scrollbar-style-advk
+
+A Sass mixin for custom scrollbar styling that writes both the WebKit
+pseudo-element API and the standard `scrollbar-color`/`scrollbar-width`
+properties, since no single API is supported everywhere yet.
+
+## Usage
+
+```scss
+@use 'scrollbar-style' as *;
+
+.sidebar {
+  @include scrollbar-style($thumb: #888, $track: #eee, $size: 8px);
+  overflow-y: auto;
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$thumb` | `#b7bdcb` | Scrollbar thumb colour. |
+| `$track` | `transparent` | Scrollbar track colour. |
+| `$thumb-hover` | `#9aa1b4` | Thumb colour on hover (WebKit only). |
+| `$size` | `10px` | Thumb/track thickness. |
+
+## Why is it useful?
+
+Custom scrollbar styling has two unrelated APIs: WebKit's
+`::-webkit-scrollbar` pseudo-elements (Chrome, Safari, Edge) and the
+standards-track `scrollbar-color`/`scrollbar-width` properties (Firefox,
+and now also Chromium as a second option). A mixin that only writes one of
+the two leaves half of all browsers with the default OS scrollbar, which is
+usually a visible mismatch against a custom track/thumb colour scheme.
+
+`scrollbar-width` only accepts the keywords `auto`, `thin`, or `none` — it
+cannot take a pixel value — so the mixin derives a `thin`/`auto` choice from
+the requested `$size` rather than exposing a parameter that would silently
+do nothing on Firefox.

--- a/submissions/scss/scrollbar-style-advk/_scrollbar-style.scss
+++ b/submissions/scss/scrollbar-style-advk/_scrollbar-style.scss
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// scrollbar-style-advk
+// A cross-engine custom scrollbar mixin: writes both the WebKit pseudo-
+// elements and the standard scrollbar-color/-width properties, since no
+// single API covers Chromium, Firefox, and Safari today.
+// ---------------------------------------------------------------------------
+
+@use 'sass:math';
+
+@mixin scrollbar-style(
+  $thumb: #b7bdcb,
+  $track: transparent,
+  $thumb-hover: #9aa1b4,
+  $size: 10px
+) {
+  // Standard property: Firefox, and Chromium behind a flag historically,
+  // now shipped broadly. Width is keyword-only ("auto" | "thin" | "none").
+  @if $size <= 8px {
+    scrollbar-width: thin;
+  } @else {
+    scrollbar-width: auto;
+  }
+  scrollbar-color: $thumb $track;
+
+  &::-webkit-scrollbar {
+    width: $size;
+    height: $size;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $track;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: $thumb;
+    border-radius: math.div($size, 2);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: $thumb-hover;
+  }
+}
+
+.scrollbar-style-demo {
+  @include scrollbar-style;
+  overflow-y: auto;
+  max-height: 12rem;
+}


### PR DESCRIPTION
Closes #74829

Sass mixin for custom scrollbars. Writes both ::-webkit-scrollbar pseudo-elements (Chromium/Safari) and the standard scrollbar-color/scrollbar-width properties (Firefox, now also Chromium) — a mixin covering only one API leaves the other half of browsers with the default OS scrollbar. scrollbar-width is keyword-only, so it's derived from the requested $size rather than silently ignored.