### PR TITLE
feat: add text-gradient Sass mixin (text-gradient-advk)

### DIFF
--- a/submissions/scss/text-gradient-advk/README.md
+++ b/submissions/scss/text-gradient-advk/README.md
@@ -1,0 +1,36 @@
+# text-gradient-advk
+
+A Sass mixin for gradient-filled text, with a solid-colour fallback so
+unsupported engines show readable text instead of invisible
+transparent-on-transparent content.
+
+## Usage
+
+```scss
+@use 'text-gradient' as *;
+
+.hero-title {
+  @include text-gradient($gradient: linear-gradient(90deg, #f59e0b, #ef4444));
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$gradient` | `linear-gradient(90deg, #4c6ef5, #a855f7)` | Gradient painted through the text. |
+| `$fallback` | `#4c6ef5` | Solid colour used where clip-to-text isn't supported. |
+
+## Why is it useful?
+
+The standard gradient-text recipe sets `color: transparent` and clips a
+background gradient to the glyph shapes — but `color: transparent` is
+unconditional in most copies of the snippet, so an engine without
+`background-clip: text` support renders genuinely invisible text: transparent
+color, no clipped background to show through. This mixin sets an opaque
+`$fallback` color first and only overrides it to `transparent` inside an
+`@supports` block gated on real clip-to-text support, so the unsupported
+path degrades to solid-colour text rather than disappearing.
+
+It also forces solid `CanvasText` under `forced-colors: active`, where
+gradient fills are typically stripped by the user agent anyway and a leftover
+`transparent` color would otherwise make the text vanish against a
+high-contrast background.

--- a/submissions/scss/text-gradient-advk/_text-gradient.scss
+++ b/submissions/scss/text-gradient-advk/_text-gradient.scss
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// text-gradient-advk
+// Gradient text with a solid-colour fallback for engines without
+// background-clip: text support, instead of invisible (transparent-on-
+// transparent) text.
+// ---------------------------------------------------------------------------
+
+@mixin text-gradient(
+  $gradient: linear-gradient(90deg, #4c6ef5, #a855f7),
+  $fallback: #4c6ef5
+) {
+  color: $fallback;
+
+  @supports (background-clip: text) or (-webkit-background-clip: text) {
+    background: $gradient;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+
+  @media (forced-colors: active) {
+    background: none;
+    -webkit-text-fill-color: CanvasText;
+    color: CanvasText;
+  }
+}
+
+.text-gradient-demo {
+  @include text-gradient;
+  font-weight: 700;
+}


### PR DESCRIPTION
Closes #74830

Sass mixin for gradient-filled text. Sets an opaque $fallback color unconditionally and only switches to transparent inside @supports(background-clip:text), so engines without clip-to-text support render readable solid-colour text instead of genuinely invisible transparent-on-transparent content. Forces solid CanvasText under forced-colors.