### PR TITLE
feat: add aspect-ratio-fallback Sass mixin (aspect-ratio-fallback-advk)

### DIFF
--- a/submissions/scss/aspect-ratio-fallback-advk/README.md
+++ b/submissions/scss/aspect-ratio-fallback-advk/README.md
@@ -1,0 +1,41 @@
+# aspect-ratio-fallback-advk
+
+A Sass mixin that sets the native `aspect-ratio` property and provides the
+classic padding-top intrinsic-ratio fallback for engines that predate it.
+
+## Usage
+
+```scss
+@use 'aspect-ratio-fallback' as *;
+
+.video-frame {
+  @include aspect-ratio-fallback(16, 9);
+}
+```
+
+```html
+<div class="video-frame">
+  <iframe src="..."></iframe>
+</div>
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$width` | `16` | Ratio width component. |
+| `$height` | `9` | Ratio height component. |
+
+In the fallback path, the mixin's element needs exactly one child (the
+media/content) — the fallback absolutely positions `:first-child` to fill
+the ratio box created by the `::before` spacer.
+
+## Why is it useful?
+
+`aspect-ratio` is broadly supported now, but a component library aiming for
+older browser support (or embedded WebViews pinned to older engines) can't
+assume it's always present — without a fallback, those boxes collapse to
+zero height in a browser that ignores the property, since nothing else sets
+a height. The `@supports not (aspect-ratio: 1 / 1)` block reintroduces the
+padding-top trick (`padding-top` percentages resolve against the
+*containing block's width*, which is what makes it usable as a
+width-derived height) only where it's actually needed, so modern browsers
+get the simpler, layout-cheaper native property and nothing extra.

--- a/submissions/scss/aspect-ratio-fallback-advk/_aspect-ratio-fallback.scss
+++ b/submissions/scss/aspect-ratio-fallback-advk/_aspect-ratio-fallback.scss
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// aspect-ratio-fallback-advk
+// Sets the native aspect-ratio property and, inside @supports(not(...)),
+// falls back to the padding-top intrinsic-ratio hack for engines that
+// predate it, so the box never collapses to zero height.
+// ---------------------------------------------------------------------------
+
+@use 'sass:math';
+
+@mixin aspect-ratio-fallback($width: 16, $height: 9) {
+  aspect-ratio: #{$width} / #{$height};
+
+  @supports not (aspect-ratio: 1 / 1) {
+    position: relative;
+
+    &::before {
+      content: "";
+      display: block;
+      padding-top: math.div($height, $width) * 100%;
+    }
+
+    > :first-child {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
+.aspect-ratio-fallback-demo {
+  @include aspect-ratio-fallback(16, 9);
+}


### PR DESCRIPTION
Closes #74832

Sass mixin that sets the native aspect-ratio property and reintroduces the padding-top intrinsic-ratio trick inside @supports not(aspect-ratio: 1/1), so a box never collapses to zero height on an engine that doesn't recognize aspect-ratio. Modern browsers get the plain native property with no extra markup requirement.