### PR TITLE
feat: add CSS-only scroll-driven SVG path drawing animation (#74707)

### DIFF
--- a/submissions/examples/scroll-svg-draw/README.md
+++ b/submissions/examples/scroll-svg-draw/README.md
@@ -1,0 +1,46 @@
+# CSS-Only Scroll-Driven SVG Path Drawing
+
+## Overview
+
+A CSS-only effect where an inline SVG illustration's path is progressively drawn onto the screen as the user scrolls the element into the viewport. The animation is powered entirely by the native CSS Scroll-Driven Animations API — no JavaScript, no Intersection Observer, no class toggling.
+
+## Features
+
+- Scroll-driven SVG stroke draw animation
+- `animation-timeline: view()` — ties animation progress directly to scroll position
+- `animation-range: entry 0% entry 80%` — drawing starts on viewport entry and completes before exit
+- `pathLength="1"` normalisation — eliminates the need to measure the exact SVG path length
+- Sticky SVG illustration stays visible across the full scroll range
+- Subtle drop-shadow glow on the stroke for a premium feel
+- Ghost / guide path underneath shows the full shape before it draws
+- `@media (prefers-reduced-motion: no-preference)` wrapper — motion-sensitive users see only the static shape
+- Responsive layout — adapts cleanly to narrow screens
+- Semantic HTML, visible focus styles, and `aria-hidden` on the decorative SVG
+
+## Animation Details
+
+Setting `pathLength="1"` on the SVG `<path>` element normalises the stroke's internal coordinate space so that `stroke-dasharray: 1` always equals the full path length, regardless of the actual geometry. A `@keyframes` rule then animates `stroke-dashoffset` from `1` (fully hidden) to `0` (fully visible). This animation is linked to a view-based scroll timeline via `animation-timeline: view()`, making the draw progress track the element's position inside the viewport with no JavaScript needed.
+
+## Files
+
+- `demo.html` — semantic page structure with inline SVG illustration and explanation callout
+- `style.css` — design system tokens, layout, scroll-driven draw animation, glows, fallback behaviour, responsive rules, and accessibility styling
+- `README.md` — implementation and usage documentation
+
+## Usage
+
+Open `demo.html` in a modern browser that supports CSS Scroll-Driven Animations (Chromium 115+). No JavaScript, package installation, or build step is required.
+
+Browsers that do not support `animation-timeline: view()` will display the final drawn state of the path, keeping the illustration fully visible and the page usable.
+
+## Accessibility
+
+The SVG is marked `aria-hidden="true"` as it is decorative. The animation runs only when the user has not indicated a preference for reduced motion via `@media (prefers-reduced-motion: no-preference)`. All interactive navigation elements include visible focus styling.
+
+## Responsive Behaviour
+
+The SVG scales fluidly with its container and the sticky positioning ensures it remains visible across the full scroll range on any screen size.
+
+## Issue
+
+EaseMotion CSS issue #74707.

--- a/submissions/examples/scroll-svg-draw/demo.html
+++ b/submissions/examples/scroll-svg-draw/demo.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="CSS-only scroll-driven SVG path drawing animation using animation-timeline: view().">
+  <title>Scroll-Driven SVG Draw</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;600;900&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion / Scroll-Driven Animations</p>
+      <h1>Scroll-Driven SVG Draw</h1>
+      <p>Scroll down to watch an inline SVG illustration draw itself onto the screen — powered entirely by CSS with no JavaScript.</p>
+      <a class="scroll-hint" href="#draw-stage">See it draw <span>↓</span></a>
+    </header>
+
+    <section id="draw-stage" class="draw-stage" aria-label="SVG path drawing animation">
+      <div class="draw-stage__label">
+        <p class="eyebrow">animation-timeline: view()</p>
+        <h2>Drawing as you scroll</h2>
+      </div>
+
+      <div class="svg-wrapper">
+        <svg class="illustration" viewBox="0 0 800 520" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <defs>
+            <linearGradient id="grad-stroke" x1="0" y1="0" x2="800" y2="520" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stop-color="#FF007A"/>
+              <stop offset="50%" stop-color="#7928CA"/>
+              <stop offset="100%" stop-color="#4A00E0"/>
+            </linearGradient>
+          </defs>
+
+          <!-- Ghost / unfilled guide path -->
+          <path class="path-ghost"
+                d="M 80,260
+                   C 80,100 260,80 400,160
+                   C 540,240 580,80 680,100
+                   C 760,120 740,260 680,340
+                   C 620,420 540,440 400,360
+                   C 260,280 120,420 80,260 Z"/>
+
+          <!-- Animated drawn path (pathLength="1" normalises the dash math) -->
+          <path class="path-draw"
+                pathLength="1"
+                d="M 80,260
+                   C 80,100 260,80 400,160
+                   C 540,240 580,80 680,100
+                   C 760,120 740,260 680,340
+                   C 620,420 540,440 400,360
+                   C 260,280 120,420 80,260 Z"
+                stroke="url(#grad-stroke)"/>
+        </svg>
+      </div>
+    </section>
+
+    <section class="callout" aria-labelledby="callout-title">
+      <p class="eyebrow">Pure CSS — zero JavaScript</p>
+      <h2 id="callout-title">How it works</h2>
+      <ul class="callout__list">
+        <li><code>pathLength="1"</code> normalises the SVG path so <code>stroke-dasharray: 1</code> always equals the full length.</li>
+        <li><code>stroke-dashoffset: 1 → 0</code> inside <code>@keyframes</code> progressively reveals the stroke.</li>
+        <li><code>animation-timeline: view()</code> ties the keyframe progress to the element's scroll position in the viewport.</li>
+        <li><code>animation-range: entry 0% entry 80%</code> begins drawing on viewport entry and finishes before exit.</li>
+        <li>The entire animation is wrapped in <code>@media (prefers-reduced-motion: no-preference)</code> so motion-sensitive users are unaffected.</li>
+      </ul>
+    </section>
+
+    <footer>EaseMotion CSS · Issue #74707</footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/scroll-svg-draw/style.css
+++ b/submissions/examples/scroll-svg-draw/style.css
@@ -1,0 +1,283 @@
+/* ============================================================
+   Scroll-Driven SVG Draw — EaseMotion CSS · Issue #74707
+   CSS-only SVG path drawing animation using animation-timeline: view()
+   ============================================================ */
+
+/* ── Design tokens ──────────────────────────────────────────── */
+:root {
+  --color-bg:         #06060c;
+  --color-surface:    #0f0f1a;
+  --color-border:     rgba(255, 255, 255, 0.08);
+  --color-text:       #f0f0f8;
+  --color-muted:      #888898;
+  --color-accent-1:   #FF007A;
+  --color-accent-2:   #7928CA;
+  --color-accent-3:   #4A00E0;
+  --font-sans:        'Outfit', system-ui, sans-serif;
+  --radius-lg:        1.25rem;
+}
+
+/* ── Reset / base ───────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+/* ── Layout wrapper ─────────────────────────────────────────── */
+.page {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Shared typography helpers ──────────────────────────────── */
+.eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-accent-1);
+  margin-bottom: 0.75rem;
+}
+
+/* ── Hero ───────────────────────────────────────────────────── */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 2rem;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(121, 40, 202, 0.18) 0%, transparent 70%),
+    var(--color-bg);
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 7vw, 5.5rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  background: linear-gradient(135deg, #fff 30%, #a0a0b8 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1.25rem;
+}
+
+.hero p {
+  max-width: 50ch;
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  font-weight: 300;
+  margin-bottom: 2.5rem;
+}
+
+.scroll-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  border: 1px solid var(--color-border);
+  padding: 0.6rem 1.4rem;
+  border-radius: 100px;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.scroll-hint:hover,
+.scroll-hint:focus-visible {
+  border-color: var(--color-accent-1);
+  color: var(--color-text);
+  outline: none;
+}
+
+.scroll-hint span {
+  display: inline-block;
+  animation: nudge 1.8s ease-in-out infinite;
+}
+
+@keyframes nudge {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(6px); }
+}
+
+/* ── Draw stage ─────────────────────────────────────────────── */
+.draw-stage {
+  /* Tall section so the scroll-timeline has room to breathe */
+  min-height: 200vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8rem 2rem 4rem;
+  gap: 5rem;
+}
+
+.draw-stage__label {
+  text-align: center;
+}
+
+.draw-stage__label h2 {
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+/* ── SVG wrapper (sticky so it stays visible while scrolling) ─ */
+.svg-wrapper {
+  position: sticky;
+  top: 10vh;
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.illustration {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+/* ── Path styles ─────────────────────────────────────────────── */
+.path-ghost {
+  stroke: rgba(255, 255, 255, 0.06);
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.path-draw {
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  filter: drop-shadow(0 0 12px rgba(121, 40, 202, 0.7))
+          drop-shadow(0 0 28px rgba(255, 0, 122, 0.4));
+
+  /*
+    pathLength="1" is set on the element in HTML, so the full path
+    length is normalised to exactly 1. Setting dasharray and dashoffset
+    to 1 hides the stroke completely at the start.
+  */
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+}
+
+/*
+  Wrap the scroll-timeline animation inside prefers-reduced-motion: no-preference
+  so users who prefer reduced motion are never shown the animated effect.
+*/
+@media (prefers-reduced-motion: no-preference) {
+  .path-draw {
+    animation: draw-svg linear forwards;
+
+    /* Link the animation to the element's scroll position in the viewport */
+    animation-timeline: view();
+
+    /*
+      entry 0%  → animation starts the moment .path-draw enters the viewport
+      entry 80% → animation reaches 100% progress while still well within view
+    */
+    animation-range: entry 0% entry 80%;
+  }
+}
+
+@keyframes draw-svg {
+  from { stroke-dashoffset: 1; }
+  to   { stroke-dashoffset: 0; }
+}
+
+/* ── Callout ─────────────────────────────────────────────────── */
+.callout {
+  padding: 6rem 2rem;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.callout h2 {
+  font-size: clamp(1.6rem, 3.5vw, 2.5rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+.callout__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  max-width: 65ch;
+  text-align: left;
+  color: var(--color-muted);
+  font-size: 0.975rem;
+}
+
+.callout__list li {
+  padding-left: 1.4rem;
+  position: relative;
+}
+
+.callout__list li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--color-accent-1);
+}
+
+code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.88em;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  color: var(--color-text);
+}
+
+/* ── Footer ──────────────────────────────────────────────────── */
+footer {
+  text-align: center;
+  padding: 2.5rem 2rem;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .draw-stage {
+    padding: 5rem 1.25rem 3rem;
+    gap: 3rem;
+  }
+
+  .callout {
+    padding: 4rem 1.25rem;
+  }
+}
+
+/* ── Focus styles ─────────────────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--color-accent-1);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
## Pull Request Description

This PR implements a CSS-only SVG path drawing animation on scroll (#74707). It utilizes the modern native CSS Scroll-Driven Animations API (`animation-timeline: view()`) to progressively draw an inline SVG illustration as it enters the viewport. It avoids the need for JavaScript Intersection Observers or class-toggling scripts.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (under `submissions/examples/scroll-svg-draw/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A native, CSS-only scroll-linked animation that draws SVG paths relative to their viewport visibility.

**How does a developer use it?**

Set `pathLength="1"` on your SVG `<path>` and apply the `.path-draw` class:

```html
<svg viewBox="0 0 800 600" fill="none">
  <!-- Ghost guide path -->
  <path class="path-ghost" d="..." />
  
  <!-- Drawn path -->
  <path class="path-draw" pathLength="1" d="..." stroke="url(#gradient)" />
</svg>
```

```css
.path-draw {
  stroke-dasharray: 1;
  stroke-dashoffset: 1;
}

@media (prefers-reduced-motion: no-preference) {
  .path-draw {
    animation: draw-svg linear forwards;
    animation-timeline: view();
    animation-range: entry 0% entry 80%;
  }
}

@keyframes draw-svg {
  to { stroke-dashoffset: 0; }
}
```

**Why does it fit EaseMotion CSS?**

It showcases state-of-the-art native CSS Scroll-Driven Animations, replacing heavy JS-dependent scroll listeners with lightweight, declarative, and highly performant stylesheet animations.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome (Supports Scroll-Driven Animations by default since v115)
- [x] Edge (Supports Scroll-Driven Animations by default since v115)
- [ ] Firefox (Behind flag `layout.css.scroll-driven-animations.enabled`)
- [ ] Safari (Not yet supported; falls back gracefully to a fully visible path state)

---

## Notes for Maintainer

- Used `pathLength="1"` in the HTML to normalize path lengths, avoiding the need for `getTotalLength()` JavaScript calls and ensuring the path math works flawlessly in pure CSS.
- Added a `.path-ghost` background path style to serve as a low-opacity guide line so the shape structure is visible before drawing.
- Properly wrapped in `@media (prefers-reduced-motion: no-preference)` to respect user system accessibility configurations.