### PR TITLE
feat: add pure CSS Glass Effect Diamond Facet Edge component (#73733)

### DIFF
--- a/submissions/examples/css-glass-effect-diamond-facet-edge-pure/README.md
+++ b/submissions/examples/css-glass-effect-diamond-facet-edge-pure/README.md
@@ -1,0 +1,24 @@
+# CSS Glass Effect: Diamond Facet Edge
+
+A hardware-accelerated, JavaScript-free glassmorphism UI element. Features complex `clip-path` polygons and multi-layered gradient borders to simulate the chamfered, reflective edges of cut glass.
+
+## Features
+- Pure CSS and HTML implementation. No SVGs or JavaScript required for the geometric shaping or the glass refractions.
+- **Component Architecture**: 
+  - **Ambient Mesh Background**: True glassmorphism requires a visually complex background to refract. This scene uses a beautiful, slow-moving mesh gradient created by layering four `radial-gradient` backgrounds and animating their `background-position`.
+  - **The Diamond Geometry**: The `.glass-card-diamond` container and its internal elements (the icon and the button) completely reject `border-radius`. Instead, they use complex CSS `clip-path: polygon()` configurations to physically cut the corners off at exact 45-degree angles, creating a geometric "chamfered" look reminiscent of a cut diamond.
+  - **The Reflective Facet Edge**: When you use `clip-path` on an element, it clips off its own `box-shadow` and standard `border`. To create the reflective edge of cut glass:
+    1. A `::before` pseudo-element is placed behind the card, slightly larger (inset: -2px).
+    2. It is given a sharp, diagonal `linear-gradient` that transitions from bright white to transparent.
+    3. It is clipped with the *exact same* polygon shape. 
+    4. *Result*: The slightly larger pseudo-element peeks out from behind the main glass panel, creating what looks like a perfectly shaped, reflective physical border catching the light.
+  - **Shadow Retention Hack**: Because `clip-path` destroys `box-shadow`, depth is restored by applying a CSS `filter: drop-shadow()` to the main wrapper. `drop-shadow` perfectly conforms to the complex geometry of the clipped children.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The mesh background and glass reflections adapt dynamically to the system theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the ambient mesh gradient animation and the subtle pulsing of the reflective facets are disabled.
+
+## Usage
+Open `demo.html` in your browser. Observe the sharp, chamfered edges of the glass panel. Notice how the bright diagonal gradient border creates the illusion of light hitting a physically faceted edge, while the heavy `backdrop-filter` smoothly refracts the animated mesh gradient in the background.
+
+## Files
+- `demo.html`: The HTML structure defining the ambient mesh background and the geometrically faceted glassmorphism container.
+- `style.css`: The styling, the multi-layered `radial-gradient` mesh logic, the complex `clip-path: polygon()` geometry, and the `drop-shadow` hacks required to maintain depth on clipped elements.

--- a/submissions/examples/css-glass-effect-diamond-facet-edge-pure/demo.html
+++ b/submissions/examples/css-glass-effect-diamond-facet-edge-pure/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Glass Effect: Diamond Facet</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+      [TECHNIQUE] The Ambient Background 
+      A complex, colorful mesh gradient background. 
+      Glassmorphism requires a rich background to show off the blur/refraction effect.
+    -->
+    <div class="mesh-background"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Glass: Diamond Facet</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free glassmorphism UI element. Features complex `clip-path` polygons and multi-layered gradient borders to simulate the chamfered, reflective edges of cut glass.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Diamond Facet Glass Card
+              This element combines standard glassmorphism (backdrop-filter) 
+              with advanced geometric shaping (clip-path).
+            -->
+            <div class="glass-card-diamond">
+                
+                <div class="card-icon">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+                    </svg>
+                </div>
+                
+                <h3 class="card-title">Chamfered Edge</h3>
+                <p class="card-text">Instead of a standard `border-radius`, this card uses a complex CSS `clip-path` polygon to physically cut the corners. A secondary gradient pseudo-element sits slightly larger behind it to simulate the reflective, faceted edge of a cut diamond.</p>
+                
+                <button class="glass-button">View Facets</button>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glass-effect-diamond-facet-edge-pure/style.css
+++ b/submissions/examples/css-glass-effect-diamond-facet-edge-pure/style.css
@@ -1,0 +1,324 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Jost:wght@300;400;500&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc; 
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    
+    /* Background Mesh Colors */
+    --mesh-1: #cbd5e1;
+    --mesh-2: #94a3b8;
+    --mesh-3: #e2e8f0;
+    
+    /* Glassmorphism Variables */
+    --glass-bg: rgba(255, 255, 255, 0.5); 
+    --glass-highlight: rgba(255, 255, 255, 0.9);
+    --glass-shadow: rgba(0, 0, 0, 0.1);
+    
+    /* The core diamond geometric value */
+    --chamfer: 30px; 
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617; 
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --mesh-1: #1e1b4b; /* Deep Indigo */
+        --mesh-2: #312e81; /* Indigo */
+        --mesh-3: #0f172a; /* Slate */
+        
+        --glass-bg: rgba(15, 23, 42, 0.6);
+        --glass-highlight: rgba(255, 255, 255, 0.15);
+        --glass-shadow: rgba(0, 0, 0, 0.6);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Jost', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 2.6rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: 0.5px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 80px 0;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Background Mesh Gradient
+   ========================================= */
+
+.mesh-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: var(--bg-base);
+    
+    /* Create a complex, slow-moving ambient gradient */
+    background-image: 
+        radial-gradient(at 0% 0%, var(--mesh-1) 0px, transparent 50%),
+        radial-gradient(at 100% 0%, var(--mesh-2) 0px, transparent 50%),
+        radial-gradient(at 100% 100%, var(--mesh-3) 0px, transparent 50%),
+        radial-gradient(at 0% 100%, var(--mesh-1) 0px, transparent 50%);
+        
+    background-size: 200% 200%;
+    animation: gradient-shift 15s ease infinite alternate;
+    
+    z-index: 0;
+}
+
+@keyframes gradient-shift {
+    0% { background-position: 0% 0%; }
+    50% { background-position: 100% 100%; }
+    100% { background-position: 0% 100%; }
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Diamond Facet Glass Card
+   ========================================= */
+
+/* 
+   We use a wrapper to handle the drop-shadow. 
+   When using `clip-path` on the main element, it clips off its own box-shadow.
+   By placing the drop-shadow on a parent, we retain depth.
+*/
+.glass-card-diamond {
+    position: relative;
+    width: 340px;
+    
+    /* Note: filter: drop-shadow is used instead of box-shadow because it perfectly respects the clip-path shape of the children! */
+    filter: drop-shadow(0 20px 30px var(--glass-shadow));
+    
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.glass-card-diamond:hover {
+    transform: translateY(-8px);
+    filter: drop-shadow(0 30px 40px var(--glass-shadow));
+}
+
+/* 
+   The Outer Facet (The Reflective Border)
+   We use a pseudo-element behind the main content. It's slightly larger 
+   and uses a bright linear-gradient to simulate light catching the cut edge.
+*/
+.glass-card-diamond::before {
+    content: '';
+    position: absolute;
+    /* This negative inset determines the border thickness */
+    top: -2px; left: -2px; right: -2px; bottom: -2px;
+    z-index: -1;
+    
+    /* A sharp diagonal gradient to simulate reflective cut glass */
+    background: linear-gradient(135deg, 
+        var(--glass-highlight) 0%, 
+        rgba(255,255,255,0) 40%, 
+        rgba(255,255,255,0) 60%, 
+        var(--glass-highlight) 100%
+    );
+    
+    /* 
+       The Chamfered Diamond Shape Geometry.
+       Cuts all 4 corners off at exactly `--chamfer` distance.
+    */
+    clip-path: polygon(
+        var(--chamfer) 0%, 
+        calc(100% - var(--chamfer)) 0%, 
+        100% var(--chamfer), 
+        100% calc(100% - var(--chamfer)), 
+        calc(100% - var(--chamfer)) 100%, 
+        var(--chamfer) 100%, 
+        0% calc(100% - var(--chamfer)), 
+        0% var(--chamfer)
+    );
+    
+    /* Subtle pulsing highlight */
+    animation: facet-gleam 4s infinite alternate;
+}
+
+@keyframes facet-gleam {
+    0% { opacity: 0.6; }
+    100% { opacity: 1; }
+}
+
+/* 
+   The Inner Glass Panel 
+   This holds the actual content and applies the blur.
+*/
+.glass-card-diamond::after {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 0;
+    
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    
+    /* Exact same chamfered shape, just 2px smaller (due to not being inset) */
+    clip-path: polygon(
+        var(--chamfer) 0%, 
+        calc(100% - var(--chamfer)) 0%, 
+        100% var(--chamfer), 
+        100% calc(100% - var(--chamfer)), 
+        calc(100% - var(--chamfer)) 100%, 
+        var(--chamfer) 100%, 
+        0% calc(100% - var(--chamfer)), 
+        0% var(--chamfer)
+    );
+}
+
+
+/* =========================================
+   Card Content
+   ========================================= */
+
+/* All content must sit strictly inside the inner glass layer (z-index: 1) */
+.glass-card-diamond > * {
+    position: relative;
+    z-index: 1;
+}
+
+/* We add padding to the wrapper so content respects the chamfered corners */
+.glass-card-diamond {
+    padding: 50px 40px;
+    text-align: center;
+}
+
+.card-icon {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 60px;
+    height: 60px;
+    background: transparent;
+    color: var(--text-primary);
+    margin-bottom: 24px;
+    
+    /* Chamfer the icon container as well for thematic consistency */
+    clip-path: polygon(
+        15px 0%, 
+        calc(100% - 15px) 0%, 
+        100% 15px, 
+        100% calc(100% - 15px), 
+        calc(100% - 15px) 100%, 
+        15px 100%, 
+        0% calc(100% - 15px), 
+        0% 15px
+    );
+    
+    border: 1px solid var(--glass-highlight);
+    background: rgba(255,255,255,0.05);
+}
+
+.card-title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+}
+
+.card-text {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 30px 0;
+}
+
+.glass-button {
+    width: 100%;
+    padding: 16px 0;
+    background: transparent;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    border: none;
+    
+    /* The button gets its own reflective facet */
+    background: linear-gradient(135deg, 
+        rgba(255,255,255,0.1) 0%, 
+        transparent 50%, 
+        rgba(255,255,255,0.1) 100%
+    );
+    border: 1px solid var(--glass-highlight);
+    
+    /* Chamfered button shape */
+    clip-path: polygon(
+        10px 0%, 
+        calc(100% - 10px) 0%, 
+        100% 10px, 
+        100% calc(100% - 10px), 
+        calc(100% - 10px) 100%, 
+        10px 100%, 
+        0% calc(100% - 10px), 
+        0% 10px
+    );
+    
+    transition: all 0.3s ease;
+}
+
+.glass-button:hover {
+    background: var(--text-primary);
+    color: var(--bg-base);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .mesh-background,
+    .glass-card-diamond::before {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free glassmorphism UI element. It features complex `clip-path` polygons and multi-layered gradient borders to simulate the chamfered, reflective edges of cut glass. Resolves issue #73733.

### Changes Made:
- Added `submissions/examples/css-glass-effect-diamond-facet-edge-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the ambient mesh background and the geometrically faceted glassmorphism container.
- Created `style.css` featuring the UI mechanics:
  - **Ambient Mesh Background**: True glassmorphism requires a visually complex background to refract. This scene uses a beautiful, slow-moving mesh gradient created by layering four `radial-gradient` backgrounds and animating their `background-position`.
  - **The Diamond Geometry**: The `.glass-card-diamond` container and its internal elements (the icon and the button) completely reject `border-radius`. Instead, they use complex CSS `clip-path: polygon()` configurations to physically cut the corners off at exact 45-degree angles, creating a geometric "chamfered" look reminiscent of a cut diamond.
  - **The Reflective Facet Edge**: When you use `clip-path` on an element, it clips off its own `box-shadow` and standard `border`. To create the reflective edge of cut glass: A `::before` pseudo-element is placed behind the card, slightly larger (inset: -2px). It is given a sharp, diagonal `linear-gradient` that transitions from bright white to transparent. It is clipped with the *exact same* polygon shape. This pseudo-element peeks out from behind the main glass panel, creating what looks like a perfectly shaped, reflective physical border catching the light.
  - **Shadow Retention Hack**: Because `clip-path` destroys `box-shadow`, depth is restored by applying a CSS `filter: drop-shadow()` to the main wrapper. `drop-shadow` perfectly conforms to the complex geometry of the clipped children.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The mesh background and glass reflections adapt dynamically to the system theme.
- Added `README.md` documenting usage and the technical mechanics of the multi-layered `radial-gradient` mesh logic, the complex `clip-path: polygon()` geometry, and the `drop-shadow` hacks required to maintain depth on clipped elements.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the ambient mesh gradient animation and the subtle pulsing of the reflective facets are disabled.

Closes #73733
