### PR TITLE
feat: add pure CSS Glass Effect 3D Perspective Tilt component (#73715)

### DIFF
--- a/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/README.md
+++ b/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/README.md
@@ -1,0 +1,23 @@
+# CSS Glass Effect: 3D Perspective Tilt
+
+A hardware-accelerated, JavaScript-free glassmorphism UI element. Features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors and a 3x3 hover grid.
+
+## Features
+- Pure CSS and HTML implementation. Absolutely no JavaScript required for the interactive 3D mouse tracking.
+- **Component Architecture**: 
+  - **The Hover Grid Hack**: JavaScript is typically required to track mouse position to tilt an element in 3D space. To achieve this in pure CSS, we use a classic technique: 
+    1. The parent container establishes the 3D space using `perspective: 1000px`.
+    2. Inside the container, we place 9 invisible `div` elements arranged in a 3x3 grid using absolute positioning. These elements sit on top of everything (`z-index: 10`) to catch mouse hover events.
+    3. The actual glass card (`.glass-card-3d`) sits underneath this invisible grid.
+    4. We use the CSS general sibling combinator (`~`). When you hover over the "top-left" invisible div, CSS applies `transform: rotateX(12deg) rotateY(-12deg)` to the sibling glass card.
+  - **Dynamic Specular Glare**: Real glass reflects light dynamically as it moves. Inside the glass card, an oversized `.specular-glare` element is created using a white `radial-gradient`. Using the same sibling combinator trick, we move this glare in the *opposite* direction of the tilt, perfectly simulating light passing across the surface of the glass as it turns.
+  - **3D Parallax Content**: The internal content (`.card-content-3d`) uses `transform: translateZ(40px)`. Because the parent glass card has `transform-style: preserve-3d`, the content physically pops out of the glass surface. As the card tilts, the content experiences true parallax.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The animated mesh background and UI colors adapt dynamically to the system theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the invisible hover grid is disabled, the ambient mesh animation is stopped, and the card is given a subtle, static, fixed 3D tilt.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse around the glass card to see it tilt dynamically towards your cursor. Notice how the internal content pops out in 3D parallax, and observe the specular glare sweeping across the glass surface.
+
+## Files
+- `demo.html`: The HTML structure defining the ambient mesh background, the 9-cell invisible hover grid, and the foreground glassmorphism container.
+- `style.css`: The styling, the complex sibling selector logic (`~`) governing the 3D transforms, the specular glare translation, and the `transform-style: preserve-3d` parallax setup.

--- a/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/demo.html
+++ b/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Glass Effect: 3D Perspective Tilt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- Ambient background to show off the glass refraction -->
+    <div class="mesh-background"></div>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Glass: 3D Tilt</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free glassmorphism UI element. Features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors and a 3x3 hover grid.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The 3D Perspective Container
+              This is the bounding box that establishes the 3D space (`perspective`)
+              and holds both the hover grid and the actual card.
+            -->
+            <div class="tilt-container">
+                
+                <!-- 
+                  [TECHNIQUE] The Hover Grid
+                  A 3x3 grid of invisible elements that sit on top of the card.
+                  When you hover over one of these grid cells, it uses the CSS general
+                  sibling combinator (~) to apply a specific rotateX/rotateY transform 
+                  to the `.glass-card-3d` underneath.
+                -->
+                <div class="hover-zone top-left"></div>
+                <div class="hover-zone top-center"></div>
+                <div class="hover-zone top-right"></div>
+                
+                <div class="hover-zone mid-left"></div>
+                <div class="hover-zone center"></div>
+                <div class="hover-zone mid-right"></div>
+                
+                <div class="hover-zone bottom-left"></div>
+                <div class="hover-zone bottom-center"></div>
+                <div class="hover-zone bottom-right"></div>
+                
+                
+                <!-- 
+                  [TECHNIQUE] The Glass Card
+                  The element that actually tilts. Must have `transform-style: preserve-3d`
+                  if it contains 3D children.
+                -->
+                <div class="glass-card-3d">
+                    
+                    <!-- 
+                       Content is translated in Z space (`translateZ`) to pop out 
+                       when the card tilts, enhancing the 3D parallax effect.
+                    -->
+                    <div class="card-content-3d">
+                        <div class="card-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M2 12l10-8 10 8-10 8z"></path>
+                                <path d="M2 12l10 8 10-8"></path>
+                            </svg>
+                        </div>
+                        
+                        <h3 class="card-title">Interactive Tilt</h3>
+                        <p class="card-text">Move your mouse around this card. The physical tilt and the intense specular highlight are powered entirely by a 3x3 invisible HTML grid and CSS sibling selectors.</p>
+                        
+                        <button class="glass-button">View Source</button>
+                    </div>
+                    
+                    <!-- A dynamic specular highlight that moves opposite to the tilt -->
+                    <div class="specular-glare"></div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/style.css
+++ b/submissions/examples/css-glass-effect-3d-perspective-tilt-pure/style.css
@@ -1,0 +1,304 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;500;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #fafafa; 
+    --text-primary: #171717;
+    --text-secondary: #52525b;
+    
+    /* Background Mesh Colors */
+    --mesh-1: #38bdf8;
+    --mesh-2: #818cf8;
+    --mesh-3: #c084fc;
+    
+    /* Glassmorphism Variables */
+    --glass-bg: rgba(255, 255, 255, 0.4); 
+    --glass-border: rgba(255, 255, 255, 0.6);
+    --glass-shadow: rgba(0, 0, 0, 0.1);
+    
+    /* 3D Tilt Configuration */
+    --tilt-deg: 12deg;
+    --perspective: 1000px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #09090b; 
+        --text-primary: #f8fafc;
+        --text-secondary: #a1a1aa;
+        
+        --mesh-1: #0284c7;
+        --mesh-2: #4338ca;
+        --mesh-3: #7e22ce;
+        
+        --glass-bg: rgba(24, 24, 27, 0.5);
+        --glass-border: rgba(255, 255, 255, 0.15);
+        --glass-shadow: rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Inter', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -1px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 100px 0;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Background Mesh
+   ========================================= */
+
+.mesh-background {
+    position: absolute;
+    top: 50%; left: 50%;
+    width: 150vw; height: 150vh;
+    transform: translate(-50%, -50%);
+    background-color: var(--bg-base);
+    
+    background-image: 
+        radial-gradient(circle at 10% 20%, var(--mesh-1) 0%, transparent 40%),
+        radial-gradient(circle at 80% 30%, var(--mesh-2) 0%, transparent 40%),
+        radial-gradient(circle at 50% 80%, var(--mesh-3) 0%, transparent 40%);
+        
+    filter: blur(60px);
+    opacity: 0.5;
+    z-index: 0;
+    pointer-events: none;
+    
+    animation: rotate-mesh 20s infinite linear;
+}
+
+@keyframes rotate-mesh {
+    0% { transform: translate(-50%, -50%) rotate(0deg); }
+    100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+
+/* =========================================
+   [TECHNIQUE] The 3D Perspective Tilt System
+   ========================================= */
+
+.tilt-container {
+    position: relative;
+    width: 320px;
+    height: 420px;
+    /* Establish the 3D space */
+    perspective: var(--perspective);
+}
+
+/* 
+   The Hover Grid
+   We divide the container into a 3x3 grid (9 invisible divs).
+   They sit on top of the card (z-index: 10) to catch mouse events.
+*/
+.hover-zone {
+    position: absolute;
+    width: 33.33%;
+    height: 33.33%;
+    z-index: 10;
+    /* border: 1px solid red; /* Uncomment to see the grid */
+}
+
+/* Position the 9 zones */
+.top-left { top: 0; left: 0; }
+.top-center { top: 0; left: 33.33%; }
+.top-right { top: 0; left: 66.66%; }
+.mid-left { top: 33.33%; left: 0; }
+.center { top: 33.33%; left: 33.33%; }
+.mid-right { top: 33.33%; left: 66.66%; }
+.bottom-left { top: 66.66%; left: 0; }
+.bottom-center { top: 66.66%; left: 33.33%; }
+.bottom-right { top: 66.66%; left: 66.66%; }
+
+/* 
+   The Target Glass Card 
+*/
+.glass-card-3d {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    box-shadow: 0 20px 40px var(--glass-shadow);
+    
+    /* Crucial for 3D children */
+    transform-style: preserve-3d;
+    
+    /* Smoothly animate back to resting state when not hovered */
+    transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+    
+    overflow: hidden;
+}
+
+/* 
+   [TECHNIQUE] The Sibling Selectors for Tilt Logic
+   When a specific hover zone is hovered, we apply a specific rotateX/Y 
+   to the sibling `.glass-card-3d`.
+*/
+.hover-zone.top-left:hover ~ .glass-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(calc(var(--tilt-deg) * -1)); }
+.hover-zone.top-center:hover ~ .glass-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(0deg); }
+.hover-zone.top-right:hover ~ .glass-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(var(--tilt-deg)); }
+
+.hover-zone.mid-left:hover ~ .glass-card-3d { transform: rotateX(0deg) rotateY(calc(var(--tilt-deg) * -1)); }
+/* Center hover means flat */
+.hover-zone.center:hover ~ .glass-card-3d { transform: rotateX(0deg) rotateY(0deg); }
+.hover-zone.mid-right:hover ~ .glass-card-3d { transform: rotateX(0deg) rotateY(var(--tilt-deg)); }
+
+.hover-zone.bottom-left:hover ~ .glass-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(calc(var(--tilt-deg) * -1)); }
+.hover-zone.bottom-center:hover ~ .glass-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(0deg); }
+.hover-zone.bottom-right:hover ~ .glass-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(var(--tilt-deg)); }
+
+
+/* 
+   [TECHNIQUE] The Specular Highlight
+   A gradient layer that moves in the *opposite* direction of the tilt 
+   to simulate light moving across the glass surface.
+*/
+.specular-glare {
+    position: absolute;
+    top: -50%; left: -50%;
+    width: 200%; height: 200%;
+    background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.4) 0%, transparent 60%);
+    pointer-events: none;
+    z-index: 1;
+    
+    /* Default position */
+    transform: translate(0, 0);
+    transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Move glare based on hover zones */
+.hover-zone.top-left:hover ~ .glass-card-3d .specular-glare { transform: translate(15%, 15%); }
+.hover-zone.top-center:hover ~ .glass-card-3d .specular-glare { transform: translate(0, 15%); }
+.hover-zone.top-right:hover ~ .glass-card-3d .specular-glare { transform: translate(-15%, 15%); }
+.hover-zone.mid-left:hover ~ .glass-card-3d .specular-glare { transform: translate(15%, 0); }
+.hover-zone.center:hover ~ .glass-card-3d .specular-glare { transform: translate(0, 0); }
+.hover-zone.mid-right:hover ~ .glass-card-3d .specular-glare { transform: translate(-15%, 0); }
+.hover-zone.bottom-left:hover ~ .glass-card-3d .specular-glare { transform: translate(15%, -15%); }
+.hover-zone.bottom-center:hover ~ .glass-card-3d .specular-glare { transform: translate(0, -15%); }
+.hover-zone.bottom-right:hover ~ .glass-card-3d .specular-glare { transform: translate(-15%, -15%); }
+
+
+/* =========================================
+   Card Content (3D Parallax)
+   ========================================= */
+
+.card-content-3d {
+    position: relative;
+    width: 100%; height: 100%;
+    padding: 40px 30px;
+    box-sizing: border-box;
+    text-align: center;
+    z-index: 2;
+    
+    /* [TECHNIQUE] Push content forward in 3D space so it floats above the glass */
+    transform: translateZ(40px);
+}
+
+.card-icon {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border);
+    margin-bottom: 24px;
+    color: var(--text-primary);
+}
+
+.card-title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+}
+
+.card-text {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 30px 0;
+}
+
+.glass-button {
+    width: 100%;
+    padding: 14px 0;
+    border-radius: 12px;
+    border: 1px solid var(--glass-border);
+    background: rgba(255,255,255,0.1);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 1rem;
+    cursor: pointer;
+    
+    transition: all 0.3s ease;
+}
+
+.glass-button:hover {
+    background: var(--text-primary);
+    color: var(--bg-base);
+}
+
+
+/* Accessibility - Disable interactive tilt for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .mesh-background { animation: none !important; }
+    
+    .hover-zone { display: none !important; /* Disable the grid */ }
+    
+    .glass-card-3d {
+        /* Apply a static tilt instead of interactive */
+        transform: rotateX(5deg) rotateY(10deg) !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free glassmorphism UI element. It features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors and a 3x3 hover grid. Resolves issue #73715.

### Changes Made:
- Added `submissions/examples/css-glass-effect-3d-perspective-tilt-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the ambient mesh background, the 9-cell invisible hover grid, and the foreground glassmorphism container.
- Created `style.css` featuring the UI mechanics:
  - **The Hover Grid Hack**: JavaScript is typically required to track mouse position to tilt an element in 3D space. To achieve this in pure CSS, we use a classic technique. The parent container establishes the 3D space using `perspective: 1000px`. Inside the container, we place 9 invisible `div` elements arranged in a 3x3 grid using absolute positioning. These elements sit on top of everything to catch mouse hover events. The actual glass card sits underneath this invisible grid. We use the CSS general sibling combinator (`~`). When you hover over the "top-left" invisible div, CSS applies `transform: rotateX(12deg) rotateY(-12deg)` to the sibling glass card.
  - **Dynamic Specular Glare**: Real glass reflects light dynamically as it moves. Inside the glass card, an oversized `.specular-glare` element is created using a white `radial-gradient`. Using the same sibling combinator trick, we move this glare in the *opposite* direction of the tilt, perfectly simulating light passing across the surface of the glass as it turns.
  - **3D Parallax Content**: The internal content uses `transform: translateZ(40px)`. Because the parent glass card has `transform-style: preserve-3d`, the content physically pops out of the glass surface. As the card tilts, the content experiences true parallax.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The animated mesh background and UI colors adapt dynamically to the system theme.
- Added `README.md` documenting usage and the technical mechanics of the complex sibling selector logic (`~`) governing the 3D transforms, the specular glare translation, and the `transform-style: preserve-3d` parallax setup.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the invisible hover grid is disabled, the ambient mesh animation is stopped, and the card is given a subtle, static, fixed 3D tilt.

Closes #73715
