### PR TITLE
test: add edge-case coverage for CSS loader timing #74856

### DIFF
--- a/submissions/examples/css-loader-timing-edge-cases-74856/README.md
+++ b/submissions/examples/css-loader-timing-edge-cases-74856/README.md
@@ -1,0 +1,53 @@
+```markdown
+# CSS Loader Timing Edge Cases
+
+## Issue
+
+#74856
+
+## Purpose
+
+This demo provides regression coverage for CSS loader animation timing
+configurations and verifies that the loader remains predictable when timing
+values change.
+
+## Covered Cases
+
+- 0ms duration
+- Very small duration
+- Large duration
+- Missing duration
+- Invalid duration
+- Delay + duration combinations
+- Repeated timing changes
+
+## How to Test
+
+Open `demo.html` directly in a browser.
+
+Use each timing button and observe the loader and status message.
+
+The **Repeated Timing Changes** button rapidly changes the animation timing
+configuration to verify that repeated updates do not leave the loader in an
+unexpected state.
+
+## Expected Behavior
+
+- 0ms timing should not break the page.
+- Very small durations should remain responsive.
+- Large durations should continue running normally.
+- Missing timing values should fall back to browser/CSS defaults.
+- Invalid duration values should not break the animation.
+- Delay and duration should work together.
+- Repeated timing changes should not leave the loader stuck.
+
+## Files
+
+- `demo.html` — Interactive timing test page.
+- `style.css` — Loader animation and styling.
+- `README.md` — Test coverage and expected behavior.
+
+## Browser Compatibility
+
+The demo is designed to run directly in modern browsers without a server.
+```

--- a/submissions/examples/css-loader-timing-edge-cases-74856/demo.html
+++ b/submissions/examples/css-loader-timing-edge-cases-74856/demo.html
@@ -1,0 +1,110 @@
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Loader Timing Edge Cases</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container">
+    <h1>CSS Loader Timing Edge Cases</h1>
+    <p class="intro">
+      Timing regression test for CSS loader animations.
+    </p>
+
+    <section class="controls">
+      <button data-duration="0ms" data-delay="0ms">0ms</button>
+      <button data-duration="10ms" data-delay="0ms">Very Small Duration</button>
+      <button data-duration="10s" data-delay="0ms">Large Duration</button>
+      <button data-duration="" data-delay="">Missing Duration</button>
+      <button data-duration="invalid" data-delay="0ms">Invalid Duration</button>
+      <button data-duration="500ms" data-delay="500ms">Delay + Duration</button>
+      <button id="repeat">Repeated Timing Changes</button>
+    </section>
+
+    <section class="test-area">
+      <div id="loader" class="loader"></div>
+      <p id="status">Timing: default</p>
+    </section>
+
+    <section class="cases">
+      <h2>Covered Cases</h2>
+      <ul>
+        <li>0ms duration</li>
+        <li>Very small duration</li>
+        <li>Large duration</li>
+        <li>Missing duration</li>
+        <li>Invalid duration</li>
+        <li>Delay + duration combinations</li>
+        <li>Repeated timing changes</li>
+      </ul>
+    </section>
+  </main>
+
+  <script>
+    const loader = document.getElementById("loader");
+    const status = document.getElementById("status");
+    const buttons = document.querySelectorAll("[data-duration]");
+
+    function applyTiming(duration, delay) {
+      loader.style.animationDuration = duration;
+      loader.style.animationDelay = delay;
+
+      loader.classList.remove("running");
+      void loader.offsetWidth;
+      loader.classList.add("running");
+
+      status.textContent =
+        `Duration: ${duration || "missing"} | Delay: ${delay || "missing"}`;
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        applyTiming(
+          button.dataset.duration,
+          button.dataset.delay
+        );
+      });
+    });
+
+    document.getElementById("repeat").addEventListener("click", () => {
+      const timings = [
+        ["0ms", "0ms"],
+        ["10ms", "0ms"],
+        ["100ms", "50ms"],
+        ["500ms", "100ms"],
+        ["1s", "0ms"]
+      ];
+
+      let index = 0;
+
+      const interval = setInterval(() => {
+        const [duration, delay] = timings[index];
+
+        loader.style.animationDuration = duration;
+        loader.style.animationDelay = delay;
+
+        loader.classList.remove("running");
+        void loader.offsetWidth;
+        loader.classList.add("running");
+
+        status.textContent =
+          `Repeated change ${index + 1}/${timings.length}: ${duration} + ${delay}`;
+
+        index++;
+
+        if (index === timings.length) {
+          clearInterval(interval);
+        }
+      }, 300);
+    });
+
+    loader.addEventListener("animationend", () => {
+      status.textContent += " | Completed";
+    });
+  </script>
+</body>
+</html>
+```

--- a/submissions/examples/css-loader-timing-edge-cases-74856/style.css
+++ b/submissions/examples/css-loader-timing-edge-cases-74856/style.css
@@ -1,0 +1,96 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  background: #f4f6f8;
+  color: #1f2937;
+}
+
+.container {
+  width: min(900px, 92%);
+  margin: auto;
+  padding: 50px 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+}
+
+.intro {
+  color: #6b7280;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 30px 0;
+}
+
+button {
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 6px;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+.test-area,
+.cases {
+  margin-top: 25px;
+  padding: 30px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.08);
+}
+
+.test-area {
+  text-align: center;
+}
+
+.loader {
+  width: 64px;
+  height: 64px;
+  margin: 20px auto;
+  border: 7px solid #dbe2ea;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation-name: timing-loader;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  animation-duration: 1s;
+  animation-delay: 0s;
+}
+
+.loader.running {
+  animation-play-state: running;
+}
+
+@keyframes timing-loader {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#status {
+  margin-top: 20px;
+  font-weight: 600;
+}
+
+.cases li {
+  margin: 10px 0;
+}
+


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained CSS loader timing test demo for issue #74856. The demo validates edge-case animation timing configurations and checks that the loader remains stable when timing values are changed.

---

## Type of Change

* [ ] ✨ New animation / hover effect
* [ ] 🧩 New component
* [ ] 📝 Documentation improvement
* [ ] 🐛 Bug fix in an existing submission
* [x] Other (CSS loader timing regression tests)

---

## Submission Checklist

* [x] All changes are inside `submissions/`
* [x] Includes `demo.html` — self-contained, opens in browser with no server
* [x] Includes `style.css` — raw CSS for the proposed feature
* [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
* [x] **No changes to `core/`**
* [x] **No changes to `components/`**
* [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds regression coverage for CSS loader animation timing edge cases.

**How does a developer use it?**

```html
<div class="loader"></div>
```

Open `demo.html` directly in a browser and use the timing controls to test different duration and delay configurations.

**Why does it fit EaseMotion CSS?**

The test provides a simple, human-readable way to validate animation timing behavior and helps identify unexpected behavior when CSS animation timing values are changed or configured with edge-case values.

---

## Demo

* [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

* [x] Chrome
* [x] Firefox
* [x] Edge
* [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The demo covers:

* 0ms duration
* Very small duration
* Large duration
* Missing duration
* Invalid duration
* Delay + duration combinations
* Repeated timing changes

No changes were made to `core/` or `components/`.

Closes #74856
