### PR TITLE
feat: add minimalist outline toast

### DIFF
--- a/submissions/examples/minimalist-outline-toast/README.md
+++ b/submissions/examples/minimalist-outline-toast/README.md
@@ -1,0 +1,33 @@
+# Minimalist Outline Toast
+
+A clean notification toast featuring a minimal outline-based visual
+style with subtle hover transitions.
+
+## Features
+
+- Minimalist outline design
+- Clean and restrained visual appearance
+- Smooth hover transition
+- Subtle elevation effect
+- Lightweight CSS-only implementation
+- Dark mode support
+- Light mode support
+- Responsive layout
+- Accessible notification semantics
+- Keyboard focus styling
+- Reduced-motion support
+- No external dependencies
+
+## Preview
+
+The component uses a transparent-looking dark surface, thin outlines,
+soft shadows, and restrained hover movement to create a minimal toast
+notification.
+
+## Structure
+
+```text
+minimalist-outline-toast/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/minimalist-outline-toast/demo.html
+++ b/submissions/examples/minimalist-outline-toast/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
+  <title>Minimalist Outline Toast</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="demo-area" aria-label="Minimalist outline toast demo">
+
+      <article class="toast" role="status" aria-live="polite">
+        <div class="toast-icon" aria-hidden="true">
+          ✓
+        </div>
+
+        <div class="toast-content">
+          <span class="toast-label">NOTIFICATION</span>
+          <h1>Profile Updated</h1>
+          <p>Your profile information has been saved successfully.</p>
+        </div>
+
+        <button
+          class="toast-close"
+          type="button"
+          aria-label="Close notification"
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </article>
+
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/minimalist-outline-toast/style.css
+++ b/submissions/examples/minimalist-outline-toast/style.css
@@ -1,0 +1,465 @@
+:root {
+  --bg: #0b0d12;
+  --panel: #11141b;
+
+  --text-primary: #f4f6fa;
+  --text-secondary: #9aa2b2;
+  --accent: #91a7ff;
+
+  --outline: rgba(255, 255, 255, 0.16);
+  --outline-hover: rgba(255, 255, 255, 0.32);
+
+  --icon-bg: rgba(255, 255, 255, 0.035);
+  --button-bg: rgba(255, 255, 255, 0.035);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text-primary);
+  background: var(--bg);
+}
+
+/* Main demo */
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 2rem 1rem;
+}
+
+.demo-area {
+  width: min(92vw, 720px);
+  min-height: 360px;
+
+  position: relative;
+
+  display: grid;
+  place-items: center;
+
+  overflow: hidden;
+
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.025),
+      rgba(255, 255, 255, 0.006)
+    );
+
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.035),
+    0 28px 70px rgba(0, 0, 0, 0.28);
+}
+
+/* Minimal ambient decoration */
+
+.demo-area::before {
+  content: "";
+
+  position: absolute;
+
+  width: 260px;
+  height: 260px;
+
+  top: -150px;
+  right: -100px;
+
+  border-radius: 50%;
+
+  background: rgba(100, 120, 220, 0.07);
+
+  filter: blur(80px);
+
+  pointer-events: none;
+}
+
+.demo-area::after {
+  content: "";
+
+  position: absolute;
+
+  width: 220px;
+  height: 220px;
+
+  bottom: -140px;
+  left: -100px;
+
+  border-radius: 50%;
+
+  background: rgba(150, 100, 190, 0.055);
+
+  filter: blur(80px);
+
+  pointer-events: none;
+}
+
+/* Toast */
+
+.toast {
+  width: min(88%, 560px);
+
+  position: relative;
+  z-index: 2;
+
+  display: grid;
+
+  grid-template-columns:
+    auto
+    minmax(0, 1fr)
+    auto;
+
+  align-items: center;
+
+  gap: 1rem;
+
+  padding: 1.15rem 1.2rem;
+
+  border: 1px solid var(--outline);
+  border-radius: 14px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.012)
+    ),
+    var(--panel);
+
+  box-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.28);
+
+  transition:
+    transform 320ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 280ms ease,
+    box-shadow 320ms ease,
+    background 280ms ease;
+
+  animation:
+    toast-in 500ms
+    cubic-bezier(0.16, 1, 0.3, 1)
+    both;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+
+    transform:
+      translateY(12px)
+      scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+
+    transform:
+      translateY(0)
+      scale(1);
+  }
+}
+
+/* Outline interaction */
+
+.toast:hover {
+  transform: translateY(-3px);
+
+  border-color: var(--outline-hover);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.045),
+      rgba(255, 255, 255, 0.015)
+    ),
+    var(--panel);
+
+  box-shadow:
+    0 17px 36px rgba(0, 0, 0, 0.34);
+}
+
+/* Fine outline highlight */
+
+.toast::before {
+  content: "";
+
+  position: absolute;
+
+  inset: -1px;
+
+  border-radius: inherit;
+
+  border: 1px solid transparent;
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.16),
+      transparent 35%,
+      transparent 65%,
+      rgba(255, 255, 255, 0.08)
+    )
+    border-box;
+
+  -webkit-mask:
+    linear-gradient(#000 0 0) padding-box,
+    linear-gradient(#000 0 0);
+
+  -webkit-mask-composite: xor;
+
+  mask-composite: exclude;
+
+  opacity: 0.55;
+
+  pointer-events: none;
+
+  transition: opacity 280ms ease;
+}
+
+.toast:hover::before {
+  opacity: 1;
+}
+
+/* Icon */
+
+.toast-icon {
+  width: 44px;
+  height: 44px;
+
+  display: grid;
+  place-items: center;
+
+  flex-shrink: 0;
+
+  border: 1px solid var(--outline);
+  border-radius: 11px;
+
+  color: var(--text-primary);
+
+  background: var(--icon-bg);
+
+  font-size: 0.95rem;
+  font-weight: 700;
+
+  transition:
+    transform 280ms ease,
+    border-color 280ms ease,
+    background 280ms ease;
+}
+
+.toast:hover .toast-icon {
+  transform: scale(1.04);
+
+  border-color: var(--outline-hover);
+
+  background: rgba(255, 255, 255, 0.055);
+}
+
+/* Content */
+
+.toast-content {
+  min-width: 0;
+}
+
+.toast-label {
+  display: block;
+
+  margin-bottom: 0.25rem;
+
+  color: var(--accent);
+
+  font-size: 0.6rem;
+  font-weight: 700;
+
+  letter-spacing: 0.14em;
+
+  opacity: 0.82;
+}
+
+.toast-content h1 {
+  margin: 0;
+
+  font-size: clamp(1rem, 2vw, 1.12rem);
+  font-weight: 650;
+
+  line-height: 1.35;
+}
+
+.toast-content p {
+  margin: 0.35rem 0 0;
+
+  color: var(--text-secondary);
+
+  font-size: 0.84rem;
+
+  line-height: 1.5;
+}
+
+/* Close button */
+
+.toast-close {
+  width: 34px;
+  height: 34px;
+
+  display: grid;
+  place-items: center;
+
+  border: 1px solid var(--outline);
+  border-radius: 9px;
+
+  color: var(--text-secondary);
+  background: var(--button-bg);
+
+  font-size: 1.2rem;
+  line-height: 1;
+
+  cursor: pointer;
+
+  transition:
+    color 200ms ease,
+    background 200ms ease,
+    border-color 200ms ease,
+    transform 200ms ease;
+}
+
+.toast-close:hover {
+  color: var(--text-primary);
+
+  background: rgba(255, 255, 255, 0.07);
+
+  border-color: var(--outline-hover);
+
+  transform: scale(1.04);
+}
+
+.toast-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+/* Light mode */
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #eef1f6;
+    --panel: #ffffff;
+
+    --text-primary: #191c25;
+    --text-secondary: #697184;
+    --accent: #5266b5;
+
+    --outline: rgba(25, 30, 45, 0.13);
+    --outline-hover: rgba(25, 30, 45, 0.26);
+
+    --icon-bg: rgba(25, 30, 45, 0.025);
+    --button-bg: rgba(25, 30, 45, 0.025);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 20% 20%,
+        rgba(90, 110, 210, 0.08),
+        transparent 35%
+      ),
+      var(--bg);
+  }
+
+  .demo-area {
+    background:
+      linear-gradient(
+        145deg,
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 255, 255, 0.5)
+      );
+
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.9),
+      0 28px 70px rgba(40, 48, 70, 0.1);
+  }
+
+  .toast {
+    box-shadow:
+      0 10px 28px rgba(40, 48, 70, 0.12);
+  }
+
+  .toast:hover {
+    box-shadow:
+      0 17px 36px rgba(40, 48, 70, 0.16);
+  }
+}
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .demo-area {
+    min-height: 330px;
+
+    border-radius: 20px;
+  }
+
+  .toast {
+    grid-template-columns:
+      auto
+      minmax(0, 1fr);
+
+    gap: 0.8rem;
+
+    padding: 1rem;
+  }
+
+  .toast-content {
+    padding-right: 2rem;
+  }
+
+  .toast-close {
+    position: absolute;
+
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .toast-icon {
+    width: 41px;
+    height: 41px;
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue to provide a lightweight and accessible toast
notification with a clean visual treatment.

This PR adds a Minimalist Outline Toast using pure HTML and Vanilla CSS.

## Changes

- Added minimalist outline toast component
- Added subtle hover and elevation transitions
- Added soft outline highlight
- Added responsive layout
- Added light and dark mode support
- Added accessible notification semantics
- Added keyboard focus styling
- Added reduced-motion support
- Added component documentation

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Testing

- Tested desktop layout
- Tested responsive mobile layout
- Tested hover interaction
- Tested keyboard focus state
- Tested light and dark color schemes
- Tested reduced-motion behavior
- No external dependencies used

Closes #73650