### PR TITLE
feat: add flex wrap navigation component

### DIFF
--- a/submissions/examples/flex-wrap-nav-dg/README.md
+++ b/submissions/examples/flex-wrap-nav-dg/README.md
@@ -1,0 +1,56 @@
+# Flex Wrap Navigation
+
+## What does this do?
+A pure-CSS responsive navigation bar whose links wrap onto multiple lines as the viewport shrinks, then collapse behind an accessible, keyboard-operable toggle button on small screens.
+
+## How is it used?
+```html
+<header class="flexwrap-nav-wrapper">
+  <nav class="flexwrap-nav" aria-label="Primary navigation">
+    <a href="#" class="flexwrap-nav__brand">EaseMotion</a>
+
+    <button
+      class="flexwrap-nav__toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="primary-nav-list"
+      id="nav-toggle"
+    >
+      <span class="flexwrap-nav__toggle-bar"></span>
+      <span class="flexwrap-nav__toggle-bar"></span>
+      <span class="flexwrap-nav__toggle-bar"></span>
+      <span class="sr-only">Toggle navigation menu</span>
+    </button>
+
+    <ul class="flexwrap-nav__list" id="primary-nav-list">
+      <li><a href="#" class="flexwrap-nav__link" aria-current="page">Home</a></li>
+      <li><a href="#" class="flexwrap-nav__link">Docs</a></li>
+      <!-- more links -->
+    </ul>
+  </nav>
+</header>
+```
+
+A small enhancement script toggles the `is-open` class and `aria-expanded`
+attribute on click, and closes the menu on <kbd>Escape</kbd>. All layout and
+wrapping behavior is handled entirely by CSS (`flex-wrap`), so the component
+degrades gracefully with JavaScript disabled — the full link list simply
+stays visible instead of collapsing.
+
+## Why is this useful?
+Wrapping navigation is one of the most common responsive UI needs, and most
+implementations reach for a JS-driven hamburger menu even when a simple
+`flex-wrap` layout would do. This component gives EaseMotion CSS users a
+lightweight, dependency-free pattern that:
+
+- Wraps naturally at medium widths (no collapse needed yet)
+- Collapses cleanly behind a toggle only when space is truly tight
+- Ships with proper ARIA attributes (`aria-expanded`, `aria-controls`,
+  `aria-current`) and full keyboard support out of the box
+
+This fits EaseMotion's philosophy of pure-CSS-first, JS-optional UI
+patterns that developers can drop in without pulling in a framework.
+
+---
+**Track:** `submissions/examples/`
+**Author:** Daksh Garg ([@Daksh-Garg007](https://github.com/Daksh-Garg007))

--- a/submissions/examples/flex-wrap-nav-dg/demo.html
+++ b/submissions/examples/flex-wrap-nav-dg/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flex Wrap Navigation Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header class="flexwrap-nav-wrapper">
+    <nav class="flexwrap-nav" aria-label="Primary navigation">
+      <a href="#" class="flexwrap-nav__brand">EaseMotion</a>
+
+      <button
+        class="flexwrap-nav__toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="primary-nav-list"
+        id="nav-toggle"
+      >
+        <span class="flexwrap-nav__toggle-bar"></span>
+        <span class="flexwrap-nav__toggle-bar"></span>
+        <span class="flexwrap-nav__toggle-bar"></span>
+        <span class="sr-only">Toggle navigation menu</span>
+      </button>
+
+      <ul class="flexwrap-nav__list" id="primary-nav-list">
+        <li><a href="#" class="flexwrap-nav__link" aria-current="page">Home</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Docs</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Components</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Animations</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Playground</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Showcase</a></li>
+        <li><a href="#" class="flexwrap-nav__link">GitHub</a></li>
+        <li><a href="#" class="flexwrap-nav__link">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="demo-content">
+    <h1>Flex Wrap Navigation</h1>
+    <p>
+      Resize the window (or view on a small screen) to see the nav links wrap
+      onto multiple lines. Below a set breakpoint the links collapse behind a
+      toggle button that is fully keyboard operable.
+    </p>
+  </main>
+
+  <script>
+    // Minimal enhancement script: only toggles visibility state and
+    // aria-expanded. No layout logic — wrapping is handled entirely by CSS.
+    const toggle = document.getElementById('nav-toggle');
+    const list = document.getElementById('primary-nav-list');
+
+    toggle.addEventListener('click', () => {
+      const isOpen = list.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    // Close the mobile menu with Escape for keyboard users
+    list.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        list.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.focus();
+      }
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/flex-wrap-nav-dg/style.css
+++ b/submissions/examples/flex-wrap-nav-dg/style.css
@@ -1,0 +1,170 @@
+/* ==========================================================================
+   Flex Wrap Navigation
+   Pure CSS responsive nav that wraps onto multiple lines as space shrinks,
+   then collapses behind a toggle button on small screens.
+   Author: Daksh Garg
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #1a1a2e;
+  background: #fafafa;
+}
+
+/* Visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --------------------------------------------------------------------- */
+/* Nav wrapper                                                            */
+/* --------------------------------------------------------------------- */
+
+.flexwrap-nav-wrapper {
+  background: #ffffff;
+  border-bottom: 1px solid #e5e5ec;
+  padding: 0.75rem 1.5rem;
+}
+
+.flexwrap-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.flexwrap-nav__brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #6c4bff;
+  text-decoration: none;
+  margin-right: auto;
+}
+
+/* --------------------------------------------------------------------- */
+/* Link list — wraps naturally as flex items run out of row space         */
+/* --------------------------------------------------------------------- */
+
+.flexwrap-nav__list {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.5rem 1.25rem;
+  flex: 1 1 100%;
+}
+
+.flexwrap-nav__link {
+  display: inline-block;
+  padding: 0.4rem 0.6rem;
+  color: #1a1a2e;
+  text-decoration: none;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.flexwrap-nav__link:hover,
+.flexwrap-nav__link:focus-visible {
+  background-color: #f1edff;
+  color: #6c4bff;
+  outline: none;
+}
+
+.flexwrap-nav__link[aria-current="page"] {
+  color: #6c4bff;
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------- */
+/* Toggle button — hidden by default, shown only on small screens         */
+/* --------------------------------------------------------------------- */
+
+.flexwrap-nav__toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 40px;
+  height: 36px;
+  padding: 6px;
+  background: transparent;
+  border: 1px solid #e5e5ec;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.flexwrap-nav__toggle:focus-visible {
+  outline: 2px solid #6c4bff;
+  outline-offset: 2px;
+}
+
+.flexwrap-nav__toggle-bar {
+  display: block;
+  height: 2px;
+  width: 100%;
+  background: #1a1a2e;
+  border-radius: 2px;
+}
+
+/* --------------------------------------------------------------------- */
+/* Responsive behavior                                                    */
+/* --------------------------------------------------------------------- */
+
+/* Medium screens: links wrap onto a second row, no collapse yet */
+@media (max-width: 720px) {
+  .flexwrap-nav__list {
+    gap: 0.4rem 0.9rem;
+  }
+}
+
+/* Small screens: collapse the list behind the toggle button */
+@media (max-width: 520px) {
+  .flexwrap-nav__toggle {
+    display: flex;
+  }
+
+  .flexwrap-nav__list {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 0.25rem;
+    padding-top: 0.5rem;
+  }
+
+  .flexwrap-nav__list.is-open {
+    display: flex;
+  }
+
+  .flexwrap-nav__link {
+    width: 100%;
+    padding: 0.6rem 0.5rem;
+  }
+}
+
+/* --------------------------------------------------------------------- */
+/* Demo page content (not part of the component itself)                   */
+/* --------------------------------------------------------------------- */
+
+.demo-content {
+  max-width: 700px;
+  margin: 3rem auto;
+  padding: 0 1.5rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Pull Request Description
Adds a pure-CSS, responsive "Flex Wrap Navigation" component: a nav bar whose links wrap onto multiple lines as the viewport narrows, then collapse behind an accessible toggle button on small screens.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/flex-wrap-nav-dg/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A responsive navigation bar that wraps its links onto multiple lines as space shrinks, and collapses behind a keyboard-accessible toggle button below 520px.

**How does a developer use it?**
```html
<header class="flexwrap-nav-wrapper">
  <nav class="flexwrap-nav" aria-label="Primary navigation">
    <a href="#" class="flexwrap-nav__brand">EaseMotion</a>
    <button class="flexwrap-nav__toggle" aria-expanded="false" aria-controls="primary-nav-list" id="nav-toggle">
      <span class="flexwrap-nav__toggle-bar"></span>
      <span class="flexwrap-nav__toggle-bar"></span>
      <span class="flexwrap-nav__toggle-bar"></span>
      <span class="sr-only">Toggle navigation menu</span>
    </button>
    <ul class="flexwrap-nav__list" id="primary-nav-list">
      <li><a href="#" class="flexwrap-nav__link" aria-current="page">Home</a></li>
      <li><a href="#" class="flexwrap-nav__link">Docs</a></li>
    </ul>
  </nav>
</header>
```

**Why does it fit EaseMotion CSS?**
It's a common responsive UI need that's usually over-engineered with JS-driven hamburger menus. This is pure `flex-wrap`-based CSS with only a tiny JS enhancement for toggling, degrades gracefully with JS disabled, and ships with proper ARIA attributes (`aria-expanded`, `aria-controls`, `aria-current`) and full keyboard support — matching EaseMotion's pure-CSS-first, JS-optional philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Breakpoints are set at 720px (wrap starts) and 520px (collapse behind toggle) — happy to adjust if you'd prefer different thresholds or naming conventions before standardization to `ease-*`.