### PR TITLE
feat: add neumorphic soft shadow toast

### DIFF
--- a/submissions/examples/73638-neumorphic-soft-shadow-toast/README.md
+++ b/submissions/examples/73638-neumorphic-soft-shadow-toast/README.md
@@ -1,0 +1,59 @@
+# Neumorphic Soft Shadow Toast
+
+A smooth, accessible, and performant pure CSS toast notification featuring a Neumorphic Soft Shadow design.
+
+## Features
+
+- Neumorphic raised surface
+- Soft dual-direction shadows
+- Inset icon treatment
+- Subtle hover elevation
+- Pressed close-button interaction
+- Smooth CSS transitions
+- Dark mode support
+- Responsive layout
+- Hardware-accelerated transforms
+- Accessible toast semantics
+- Keyboard-accessible close button
+- Reduced-motion support
+- No JavaScript
+- No external dependencies
+
+## Files
+
+- `demo.html` - Toast notification markup
+- `style.css` - Complete component styling
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+No JavaScript, framework, build tool, or external dependency is required.
+
+## Accessibility
+
+The component includes:
+
+- `role="status"`
+- `aria-live="polite"`
+- `aria-atomic="true"`
+- Accessible close button
+- Visible keyboard focus state
+- `prefers-reduced-motion` support
+
+## Design
+
+The Neumorphic Soft Shadow effect uses:
+
+- Raised outer shadows
+- Inset inner shadows
+- Soft highlight overlays
+- Consistent rounded surfaces
+- Subtle hover elevation
+
+The component automatically adapts its shadow system for light and dark color schemes.
+
+## Technologies
+
+- HTML5
+- Vanilla CSS

--- a/submissions/examples/73638-neumorphic-soft-shadow-toast/demo.html
+++ b/submissions/examples/73638-neumorphic-soft-shadow-toast/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="Neumorphic Soft Shadow CSS Toast Notification"
+  >
+
+  <title>Neumorphic Soft Shadow Toast</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section
+      class="toast"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div class="toast-icon" aria-hidden="true">
+        <span>✓</span>
+      </div>
+
+      <div class="toast-content">
+        <span class="toast-label">SYSTEM NOTIFICATION</span>
+
+        <h1>Changes Saved</h1>
+
+        <p>
+          Your preferences have been updated successfully.
+        </p>
+      </div>
+
+      <button
+        class="toast-close"
+        type="button"
+        aria-label="Close notification"
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/73638-neumorphic-soft-shadow-toast/style.css
+++ b/submissions/examples/73638-neumorphic-soft-shadow-toast/style.css
@@ -1,0 +1,344 @@
+:root {
+  --page-bg: #e4e9f0;
+  --toast-bg: #e4e9f0;
+
+  --text-primary: #303746;
+  --text-secondary: #697386;
+  --accent: #4f7cff;
+
+  --light-shadow: rgba(255, 255, 255, 0.9);
+  --dark-shadow: rgba(163, 174, 193, 0.65);
+
+  --toast-radius: 22px;
+
+  --shadow-raised:
+    12px 12px 24px var(--dark-shadow),
+    -12px -12px 24px var(--light-shadow);
+
+  --shadow-pressed:
+    inset 7px 7px 14px var(--dark-shadow),
+    inset -7px -7px 14px var(--light-shadow);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text-primary);
+  background: var(--page-bg);
+}
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 24px;
+}
+
+/* Toast */
+
+.toast {
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  gap: 18px;
+
+  width: min(620px, 100%);
+  min-height: 116px;
+
+  padding: 22px 23px;
+
+  background: var(--toast-bg);
+
+  border-radius: var(--toast-radius);
+
+  box-shadow: var(--shadow-raised);
+
+  transform: translate3d(0, 0, 0);
+
+  transition:
+    transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 260ms ease;
+
+  will-change: transform;
+}
+
+.toast:hover {
+  transform: translate3d(0, -4px, 0);
+
+  box-shadow:
+    15px 15px 30px var(--dark-shadow),
+    -15px -15px 30px var(--light-shadow);
+}
+
+/* Soft highlight */
+
+.toast::before {
+  content: "";
+
+  position: absolute;
+
+  inset: 1px;
+
+  border-radius: calc(var(--toast-radius) - 1px);
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.18),
+      transparent 42%,
+      rgba(163, 174, 193, 0.08)
+    );
+
+  pointer-events: none;
+}
+
+/* Icon */
+
+.toast-icon {
+  position: relative;
+
+  flex: 0 0 54px;
+
+  width: 54px;
+  height: 54px;
+
+  display: grid;
+  place-items: center;
+
+  border-radius: 17px;
+
+  background: var(--toast-bg);
+
+  box-shadow: var(--shadow-pressed);
+
+  color: var(--accent);
+
+  font-size: 21px;
+  font-weight: 800;
+
+  transition:
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.toast:hover .toast-icon {
+  transform: translate3d(0, -1px, 0);
+
+  box-shadow:
+    inset 5px 5px 11px var(--dark-shadow),
+    inset -5px -5px 11px var(--light-shadow);
+}
+
+.toast-icon span {
+  display: grid;
+  place-items: center;
+
+  width: 28px;
+  height: 28px;
+
+  border-radius: 50%;
+
+  background: var(--toast-bg);
+
+  box-shadow:
+    3px 3px 7px var(--dark-shadow),
+    -3px -3px 7px var(--light-shadow);
+}
+
+/* Content */
+
+.toast-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.toast-label {
+  display: inline-block;
+
+  margin-bottom: 5px;
+
+  color: var(--accent);
+
+  font-size: 9px;
+  font-weight: 800;
+
+  letter-spacing: 1.8px;
+}
+
+.toast h1 {
+  margin-bottom: 5px;
+
+  font-size: clamp(19px, 3vw, 25px);
+  line-height: 1.15;
+
+  font-weight: 750;
+  letter-spacing: -0.35px;
+}
+
+.toast p {
+  color: var(--text-secondary);
+
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* Close button */
+
+.toast-close {
+  flex: 0 0 auto;
+
+  width: 38px;
+  height: 38px;
+
+  display: grid;
+  place-items: center;
+
+  border: 0;
+  border-radius: 12px;
+
+  background: var(--toast-bg);
+
+  color: var(--text-secondary);
+
+  font: inherit;
+  font-size: 23px;
+  line-height: 1;
+
+  cursor: pointer;
+
+  box-shadow:
+    5px 5px 10px var(--dark-shadow),
+    -5px -5px 10px var(--light-shadow);
+
+  transition:
+    color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.toast-close:hover {
+  color: var(--text-primary);
+
+  transform: translate3d(0, -1px, 0);
+
+  box-shadow:
+    3px 3px 7px var(--dark-shadow),
+    -3px -3px 7px var(--light-shadow);
+}
+
+.toast-close:active {
+  transform: translate3d(0, 0, 0);
+
+  box-shadow: var(--shadow-pressed);
+}
+
+.toast-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+/* Dark mode */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #20242c;
+    --toast-bg: #20242c;
+
+    --text-primary: #edf1f8;
+    --text-secondary: #9ca6b8;
+    --accent: #7ea2ff;
+
+    --light-shadow: rgba(54, 61, 73, 0.9);
+    --dark-shadow: rgba(12, 14, 18, 0.8);
+  }
+}
+
+/* Responsive */
+
+@media (max-width: 520px) {
+  .page {
+    padding: 18px;
+  }
+
+  .toast {
+    gap: 13px;
+
+    min-height: 100px;
+
+    padding: 18px;
+
+    border-radius: 18px;
+  }
+
+  .toast-icon {
+    flex-basis: 44px;
+
+    width: 44px;
+    height: 44px;
+
+    border-radius: 14px;
+
+    font-size: 18px;
+  }
+
+  .toast-icon span {
+    width: 24px;
+    height: 24px;
+  }
+
+  .toast h1 {
+    font-size: 18px;
+  }
+
+  .toast p {
+    font-size: 12px;
+  }
+
+  .toast-close {
+    width: 33px;
+    height: 33px;
+
+    border-radius: 10px;
+
+    font-size: 20px;
+  }
+
+  .toast:hover {
+    transform: translate3d(0, -2px, 0);
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .toast-icon,
+  .toast-close {
+    transition: none;
+  }
+
+  .toast:hover,
+  .toast:hover .toast-icon,
+  .toast-close:hover,
+  .toast-close:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Description

It is a critical issue to provide a polished, accessible, and reusable Neumorphic Soft Shadow toast component for the EaseMotion CSS collection.

This PR implements the Neumorphic Soft Shadow Toast variation requested in #73638 using pure HTML and Vanilla CSS.

## Changes

- Added Neumorphic Soft Shadow toast notification
- Added soft dual-direction raised shadows
- Added inset neumorphic icon styling
- Added pressed close-button interaction
- Added smooth hover elevation
- Added dark mode support
- Added responsive layout
- Added hardware-accelerated transforms
- Added accessible toast semantics
- Added keyboard-accessible close button
- Added `prefers-reduced-motion` support
- Added component documentation

## Files Added

- `submissions/examples/73638-neumorphic-soft-shadow-toast/demo.html`
- `submissions/examples/73638-neumorphic-soft-shadow-toast/style.css`
- `submissions/examples/73638-neumorphic-soft-shadow-toast/README.md`

## Testing

- Tested in a modern browser
- Verified light and dark color schemes
- Verified responsive behavior
- Verified hover and pressed interactions
- Verified keyboard focus state
- Verified reduced-motion behavior
- No external JavaScript or dependencies used

## Issue

Closes #73638