### PR TITLE
feat: add cyberpunk neon toast

### DIFF
--- a/submissions/examples/cyberpunk-neon-toast/README.md
+++ b/submissions/examples/cyberpunk-neon-toast/README.md
@@ -1,0 +1,60 @@
+# Cyberpunk Neon Toast
+
+A smooth, accessible, and performant pure CSS toast notification featuring a Cyberpunk Neon design.
+
+## Features
+
+- Cyberpunk neon visual style
+- Cyan and magenta glow effects
+- Neon border and accent lighting
+- Cyberpunk grid background
+- Subtle scanline effect
+- Animated hover elevation
+- Neon icon treatment
+- Responsive layout
+- Dark-mode compatible
+- Hardware-accelerated transforms
+- Accessible toast semantics
+- Keyboard-accessible close button
+- Reduced-motion support
+- No JavaScript
+- No external dependencies
+
+## Files
+
+- `demo.html` - Toast notification markup
+- `style.css` - Complete component styling
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+No JavaScript, framework, build tool, or external dependency is required.
+
+## Accessibility
+
+The component includes:
+
+- `role="status"`
+- `aria-live="polite"`
+- `aria-atomic="true"`
+- Accessible close button
+- Visible keyboard focus state
+- `prefers-reduced-motion` support
+
+## Design
+
+The Cyberpunk Neon appearance is created using:
+
+- Cyan and magenta neon colors
+- CSS box-shadow glow effects
+- Gradient accent lighting
+- Cyberpunk grid patterns
+- Subtle scanlines
+- Monospace system labels
+- Neon corner details
+
+## Technologies
+
+- HTML5
+- Vanilla CSS

--- a/submissions/examples/cyberpunk-neon-toast/demo.html
+++ b/submissions/examples/cyberpunk-neon-toast/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="Cyberpunk Neon CSS Toast Notification"
+  >
+
+  <title>Cyberpunk Neon Toast</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section
+      class="toast"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div class="toast-accent" aria-hidden="true"></div>
+
+      <div class="toast-icon" aria-hidden="true">
+        <span>✓</span>
+      </div>
+
+      <div class="toast-content">
+        <span class="toast-code">SYS://NOTIFY_73636</span>
+
+        <h1>System Update Complete</h1>
+
+        <p>
+          Your cyber interface has been synchronized successfully.
+        </p>
+      </div>
+
+      <button
+        class="toast-close"
+        type="button"
+        aria-label="Close notification"
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-neon-toast/style.css
+++ b/submissions/examples/cyberpunk-neon-toast/style.css
@@ -1,0 +1,521 @@
+:root {
+  --bg: #070912;
+  --surface: #0c1020;
+
+  --cyan: #00f6ff;
+  --pink: #ff2bd6;
+  --purple: #8b5cf6;
+
+  --text: #f3f7ff;
+  --muted: #8994ad;
+
+  --border: rgba(0, 246, 255, 0.55);
+
+  --cyan-glow:
+    0 0 6px rgba(0, 246, 255, 0.8),
+    0 0 18px rgba(0, 246, 255, 0.4);
+
+  --pink-glow:
+    0 0 6px rgba(255, 43, 214, 0.75),
+    0 0 18px rgba(255, 43, 214, 0.35);
+
+  --radius: 5px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+
+  font-family:
+    "Segoe UI",
+    Inter,
+    system-ui,
+    sans-serif;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(139, 92, 246, 0.12),
+      transparent 32%
+    ),
+    radial-gradient(
+      circle at 80% 75%,
+      rgba(255, 43, 214, 0.08),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  position: relative;
+
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 24px;
+
+  overflow: hidden;
+}
+
+/* Cyberpunk background grid */
+
+.page::before {
+  content: "";
+
+  position: absolute;
+  inset: 0;
+
+  background-image:
+    linear-gradient(
+      rgba(0, 246, 255, 0.035) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(0, 246, 255, 0.035) 1px,
+      transparent 1px
+    );
+
+  background-size: 32px 32px;
+
+  mask-image:
+    linear-gradient(
+      to bottom,
+      transparent,
+      black 20%,
+      black 80%,
+      transparent
+    );
+
+  pointer-events: none;
+}
+
+/* Toast */
+
+.toast {
+  position: relative;
+
+  isolation: isolate;
+
+  display: flex;
+  align-items: center;
+  gap: 18px;
+
+  width: min(650px, 100%);
+  min-height: 120px;
+
+  padding: 22px 24px;
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(14, 19, 38, 0.98),
+      rgba(7, 10, 21, 0.98)
+    );
+
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+
+  box-shadow:
+    0 0 0 1px rgba(255, 43, 214, 0.12),
+    0 0 22px rgba(0, 246, 255, 0.18),
+    0 16px 45px rgba(0, 0, 0, 0.5);
+
+  transform: translate3d(0, 0, 0);
+
+  transition:
+    transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 260ms ease,
+    border-color 260ms ease;
+
+  will-change: transform;
+}
+
+.toast::before {
+  content: "";
+
+  position: absolute;
+  inset: 0;
+
+  border-radius: inherit;
+
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 4px,
+      rgba(0, 246, 255, 0.025) 5px
+    );
+
+  pointer-events: none;
+}
+
+.toast::after {
+  content: "";
+
+  position: absolute;
+
+  top: -1px;
+  left: 14%;
+
+  width: 36%;
+  height: 1px;
+
+  background: var(--cyan);
+
+  box-shadow: var(--cyan-glow);
+
+  pointer-events: none;
+}
+
+.toast:hover {
+  transform: translate3d(0, -5px, 0);
+
+  border-color: var(--cyan);
+
+  box-shadow:
+    0 0 0 1px rgba(255, 43, 214, 0.22),
+    0 0 12px rgba(0, 246, 255, 0.35),
+    0 0 30px rgba(0, 246, 255, 0.18),
+    0 20px 50px rgba(0, 0, 0, 0.55);
+}
+
+/* Accent edge */
+
+.toast-accent {
+  position: absolute;
+
+  left: -1px;
+  top: 15%;
+
+  width: 3px;
+  height: 70%;
+
+  background: linear-gradient(
+    to bottom,
+    var(--cyan),
+    var(--purple),
+    var(--pink)
+  );
+
+  box-shadow:
+    var(--cyan-glow),
+    var(--pink-glow);
+
+  border-radius: 0 3px 3px 0;
+}
+
+/* Icon */
+
+.toast-icon {
+  position: relative;
+
+  flex: 0 0 54px;
+
+  width: 54px;
+  height: 54px;
+
+  display: grid;
+  place-items: center;
+
+  border: 1px solid rgba(0, 246, 255, 0.65);
+
+  border-radius: 3px;
+
+  color: var(--cyan);
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(0, 246, 255, 0.08),
+      rgba(255, 43, 214, 0.06)
+    );
+
+  box-shadow:
+    inset 0 0 12px rgba(0, 246, 255, 0.08),
+    var(--cyan-glow);
+
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.toast-icon::before,
+.toast-icon::after {
+  content: "";
+
+  position: absolute;
+
+  width: 7px;
+  height: 7px;
+
+  border-color: var(--pink);
+
+  border-style: solid;
+}
+
+.toast-icon::before {
+  top: -1px;
+  left: -1px;
+
+  border-width: 1px 0 0 1px;
+}
+
+.toast-icon::after {
+  right: -1px;
+  bottom: -1px;
+
+  border-width: 0 1px 1px 0;
+}
+
+.toast:hover .toast-icon {
+  transform: translate3d(0, -2px, 0);
+
+  box-shadow:
+    inset 0 0 15px rgba(0, 246, 255, 0.12),
+    0 0 8px rgba(0, 246, 255, 0.8),
+    0 0 25px rgba(0, 246, 255, 0.35);
+}
+
+.toast-icon span {
+  font-size: 22px;
+  font-weight: 800;
+
+  text-shadow: var(--cyan-glow);
+}
+
+/* Content */
+
+.toast-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.toast-code {
+  display: block;
+
+  margin-bottom: 6px;
+
+  color: var(--pink);
+
+  font-family:
+    "Courier New",
+    monospace;
+
+  font-size: 9px;
+  font-weight: 700;
+
+  letter-spacing: 1.8px;
+
+  text-shadow: var(--pink-glow);
+}
+
+.toast h1 {
+  margin-bottom: 6px;
+
+  font-family:
+    "Courier New",
+    monospace;
+
+  font-size: clamp(18px, 3vw, 24px);
+  line-height: 1.15;
+
+  font-weight: 800;
+  letter-spacing: 0.5px;
+
+  text-shadow:
+    0 0 5px rgba(243, 247, 255, 0.25);
+}
+
+.toast p {
+  color: var(--muted);
+
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* Close button */
+
+.toast-close {
+  position: relative;
+
+  flex: 0 0 auto;
+
+  width: 38px;
+  height: 38px;
+
+  display: grid;
+  place-items: center;
+
+  border: 1px solid rgba(255, 43, 214, 0.5);
+  border-radius: 3px;
+
+  background: rgba(255, 43, 214, 0.035);
+
+  color: var(--pink);
+
+  font: inherit;
+  font-size: 22px;
+  line-height: 1;
+
+  cursor: pointer;
+
+  box-shadow:
+    0 0 7px rgba(255, 43, 214, 0.2);
+
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.toast-close::before,
+.toast-close::after {
+  content: "";
+
+  position: absolute;
+
+  width: 5px;
+  height: 5px;
+
+  border-color: var(--cyan);
+  border-style: solid;
+}
+
+.toast-close::before {
+  top: -1px;
+  right: -1px;
+
+  border-width: 1px 1px 0 0;
+}
+
+.toast-close::after {
+  bottom: -1px;
+  left: -1px;
+
+  border-width: 0 0 1px 1px;
+}
+
+.toast-close:hover {
+  color: var(--cyan);
+
+  border-color: var(--cyan);
+
+  transform: translate3d(0, -1px, 0);
+
+  box-shadow: var(--cyan-glow);
+}
+
+.toast-close:active {
+  transform: translate3d(0, 0, 0);
+
+  box-shadow:
+    0 0 5px rgba(0, 246, 255, 0.45);
+}
+
+.toast-close:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 4px;
+}
+
+/* Small cyberpunk status line */
+
+.toast-content::after {
+  content: "● ONLINE";
+
+  display: block;
+
+  margin-top: 7px;
+
+  color: var(--cyan);
+
+  font-family:
+    "Courier New",
+    monospace;
+
+  font-size: 8px;
+  font-weight: 700;
+
+  letter-spacing: 1.5px;
+
+  text-shadow: var(--cyan-glow);
+}
+
+/* Responsive */
+
+@media (max-width: 520px) {
+  .page {
+    padding: 18px;
+  }
+
+  .toast {
+    gap: 13px;
+
+    min-height: 104px;
+
+    padding: 18px;
+
+    border-radius: 4px;
+  }
+
+  .toast-icon {
+    flex-basis: 44px;
+
+    width: 44px;
+    height: 44px;
+  }
+
+  .toast-icon span {
+    font-size: 18px;
+  }
+
+  .toast h1 {
+    font-size: 17px;
+  }
+
+  .toast p {
+    font-size: 11px;
+  }
+
+  .toast-close {
+    width: 33px;
+    height: 33px;
+
+    font-size: 19px;
+  }
+
+  .toast:hover {
+    transform: translate3d(0, -2px, 0);
+  }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+  .toast,
+  .toast-icon,
+  .toast-close {
+    transition: none;
+  }
+
+  .toast:hover,
+  .toast:hover .toast-icon,
+  .toast-close:hover,
+  .toast-close:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue to provide a polished, accessible, and reusable Cyberpunk Neon toast component for the EaseMotion CSS collection.

This PR implements the Cyberpunk Neon Toast variation requested in #73636 using pure HTML and Vanilla CSS.

## Changes

- Added Cyberpunk Neon toast notification
- Added cyan and magenta neon glow effects
- Added cyberpunk grid background
- Added subtle scanline visual effect
- Added neon accent edge and corner details
- Added smooth hover elevation
- Added responsive layout
- Added hardware-accelerated transforms
- Added accessible toast semantics
- Added keyboard-accessible close button
- Added `prefers-reduced-motion` support
- Added component documentation

## Files Added

- `submissions/examples/cyberpunk-neon-toast/demo.html`
- `submissions/examples/cyberpunk-neon-toast/style.css`
- `submissions/examples/cyberpunk-neon-toast/README.md`

## Testing

- Tested in a modern browser
- Verified responsive behavior
- Verified hover and focus interactions
- Verified neon glow effects
- Verified reduced-motion behavior
- No external JavaScript or dependencies used

## Issue

Closes #73636