### PR TITLE
feat: add cyberpunk neon dropdown

### DIFF
--- a/submissions/examples/cyberpunk-neon-dropdown/README.md
+++ b/submissions/examples/cyberpunk-neon-dropdown/README.md
@@ -1,0 +1,26 @@
+# Cyberpunk Neon Dropdown
+
+A futuristic CSS-only dropdown component featuring a cyberpunk neon visual style.
+
+## ✨ Features
+
+- Pure HTML and vanilla CSS
+- No JavaScript
+- Neon cyan and magenta accents
+- Animated scan line
+- Neon glow effects
+- Smooth menu reveal
+- Interactive hover states
+- Keyboard-friendly focus states
+- Light and dark mode support
+- Responsive design
+- Reduced-motion support
+- Hardware-friendly CSS animations
+
+## 📁 Files
+
+```text
+73661-cyberpunk-neon-dropdown/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/cyberpunk-neon-dropdown/demo.html
+++ b/submissions/examples/cyberpunk-neon-dropdown/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Cyberpunk Neon CSS Dropdown - EaseMotion CSS"
+  >
+  <title>Cyberpunk Neon Dropdown</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="demo-card">
+      <div class="scanline" aria-hidden="true"></div>
+
+      <span class="eyebrow">SYSTEM // MENU_07</span>
+
+      <h1>Cyberpunk Neon Dropdown</h1>
+
+      <p class="description">
+        A futuristic CSS-only dropdown featuring neon borders,
+        cyberpunk glow effects, animated scan lines, and smooth transitions.
+      </p>
+
+      <details class="cyber-dropdown">
+        <summary>
+          <span class="trigger-content">
+            <span class="status-dot" aria-hidden="true"></span>
+            <span>ACCESS MENU</span>
+          </span>
+
+          <span class="trigger-code">[01]</span>
+        </summary>
+
+        <div class="dropdown-menu">
+          <a href="#dashboard" class="menu-item">
+            <span class="menu-number">01</span>
+            <span class="menu-content">
+              <strong>Dashboard</strong>
+              <small>System overview</small>
+            </span>
+            <span class="menu-arrow" aria-hidden="true">↗</span>
+          </a>
+
+          <a href="#missions" class="menu-item">
+            <span class="menu-number">02</span>
+            <span class="menu-content">
+              <strong>Missions</strong>
+              <small>Active operations</small>
+            </span>
+            <span class="menu-arrow" aria-hidden="true">↗</span>
+          </a>
+
+          <a href="#network" class="menu-item">
+            <span class="menu-number">03</span>
+            <span class="menu-content">
+              <strong>Network</strong>
+              <small>Connected nodes</small>
+            </span>
+            <span class="menu-arrow" aria-hidden="true">↗</span>
+          </a>
+
+          <a href="#settings" class="menu-item">
+            <span class="menu-number">04</span>
+            <span class="menu-content">
+              <strong>Settings</strong>
+              <small>System configuration</small>
+            </span>
+            <span class="menu-arrow" aria-hidden="true">↗</span>
+          </a>
+        </div>
+
+        <div class="menu-footer">
+          <span>SECURE CONNECTION</span>
+          <span class="connection-status">● ONLINE</span>
+        </div>
+      </details>
+
+      <p class="hint">
+        // SELECT AN OPTION TO CONTINUE
+      </p>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-neon-dropdown/style.css
+++ b/submissions/examples/cyberpunk-neon-dropdown/style.css
@@ -1,0 +1,652 @@
+:root {
+  --bg: #05060a;
+  --panel: #0a0d14;
+  --panel-light: #101521;
+
+  --cyan: #00f6ff;
+  --pink: #ff2bd6;
+  --purple: #8b5cf6;
+  --green: #39ff88;
+
+  --text: #edfaff;
+  --muted: #718091;
+
+  --border: rgba(0, 246, 255, 0.28);
+  --border-strong: rgba(0, 246, 255, 0.7);
+
+  --shadow: rgba(0, 0, 0, 0.65);
+
+  --radius: 4px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  display: grid;
+  place-items: center;
+
+  padding: 24px;
+
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      rgba(0, 246, 255, 0.08),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      rgba(255, 43, 214, 0.08),
+      transparent 30%
+    ),
+    var(--bg);
+
+  font-family:
+    "Courier New",
+    Courier,
+    monospace;
+}
+
+body::before {
+  content: "";
+
+  position: fixed;
+  inset: 0;
+
+  background:
+    linear-gradient(
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px
+    );
+
+  background-size: 32px 32px;
+
+  pointer-events: none;
+}
+
+.page {
+  width: min(100%, 720px);
+}
+
+.demo-card {
+  position: relative;
+
+  padding: clamp(28px, 5vw, 50px);
+
+  border: 1px solid rgba(0, 246, 255, 0.2);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(0, 246, 255, 0.035),
+      rgba(255, 43, 214, 0.025)
+    ),
+    var(--panel);
+
+  box-shadow:
+    0 30px 80px var(--shadow),
+    0 0 60px rgba(0, 246, 255, 0.035);
+
+  overflow: hidden;
+}
+
+.demo-card::before,
+.demo-card::after {
+  content: "";
+
+  position: absolute;
+
+  width: 90px;
+  height: 90px;
+
+  pointer-events: none;
+}
+
+.demo-card::before {
+  top: 0;
+  left: 0;
+
+  border-top: 2px solid var(--cyan);
+  border-left: 2px solid var(--cyan);
+
+  box-shadow:
+    -5px -5px 20px rgba(0, 246, 255, 0.18);
+}
+
+.demo-card::after {
+  right: 0;
+  bottom: 0;
+
+  border-right: 2px solid var(--pink);
+  border-bottom: 2px solid var(--pink);
+
+  box-shadow:
+    5px 5px 20px rgba(255, 43, 214, 0.18);
+}
+
+.scanline {
+  position: absolute;
+  inset: 0;
+
+  height: 1px;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      var(--cyan),
+      transparent
+    );
+
+  opacity: 0.18;
+
+  animation: scan 5s linear infinite;
+
+  pointer-events: none;
+}
+
+.eyebrow {
+  display: inline-block;
+
+  margin-bottom: 12px;
+
+  color: var(--cyan);
+
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+
+  text-shadow:
+    0 0 10px rgba(0, 246, 255, 0.55);
+}
+
+h1 {
+  margin: 0;
+
+  color: var(--text);
+
+  font-size: clamp(1.8rem, 5vw, 2.7rem);
+  line-height: 1.1;
+
+  text-shadow:
+    0 0 22px rgba(0, 246, 255, 0.12);
+}
+
+.description {
+  max-width: 580px;
+
+  margin: 16px 0 30px;
+
+  color: var(--muted);
+
+  font-size: 0.84rem;
+  line-height: 1.8;
+}
+
+.cyber-dropdown {
+  position: relative;
+
+  border: 1px solid var(--border);
+
+  background: rgba(5, 8, 14, 0.94);
+
+  box-shadow:
+    0 16px 40px rgba(0, 0, 0, 0.45),
+    inset 0 0 20px rgba(0, 246, 255, 0.025);
+
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.cyber-dropdown:hover {
+  border-color: var(--border-strong);
+
+  box-shadow:
+    0 18px 45px rgba(0, 0, 0, 0.52),
+    0 0 28px rgba(0, 246, 255, 0.08),
+    inset 0 0 22px rgba(0, 246, 255, 0.035);
+}
+
+.cyber-dropdown[open] {
+  border-color: var(--cyan);
+
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.58),
+    0 0 34px rgba(0, 246, 255, 0.12),
+    0 0 8px rgba(255, 43, 214, 0.1);
+}
+
+.cyber-dropdown summary {
+  position: relative;
+
+  min-height: 66px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 0 20px;
+
+  list-style: none;
+
+  color: var(--text);
+
+  cursor: pointer;
+  user-select: none;
+
+  overflow: hidden;
+}
+
+.cyber-dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.cyber-dropdown summary::before {
+  content: "";
+
+  position: absolute;
+  inset: 0;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      rgba(0, 246, 255, 0.08),
+      transparent
+    );
+
+  transform: translateX(-100%);
+
+  transition: transform 500ms ease;
+
+  pointer-events: none;
+}
+
+.cyber-dropdown summary:hover::before {
+  transform: translateX(100%);
+}
+
+.trigger-content {
+  position: relative;
+  z-index: 1;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+
+  border-radius: 50%;
+
+  background: var(--green);
+
+  box-shadow:
+    0 0 8px var(--green),
+    0 0 18px rgba(57, 255, 136, 0.6);
+
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+.trigger-code {
+  position: relative;
+  z-index: 1;
+
+  color: var(--pink);
+
+  font-size: 0.72rem;
+
+  text-shadow:
+    0 0 10px rgba(255, 43, 214, 0.65);
+
+  transition:
+    color 200ms ease,
+    text-shadow 200ms ease;
+}
+
+.cyber-dropdown[open] .trigger-code {
+  color: var(--cyan);
+
+  text-shadow:
+    0 0 12px rgba(0, 246, 255, 0.7);
+}
+
+.dropdown-menu {
+  padding: 8px 10px 12px;
+
+  border-top: 1px solid rgba(0, 246, 255, 0.12);
+
+  animation: reveal 240ms ease both;
+}
+
+.menu-item {
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  gap: 14px;
+
+  min-height: 68px;
+
+  margin-top: 6px;
+  padding: 10px 12px;
+
+  border: 1px solid transparent;
+
+  color: var(--text);
+  text-decoration: none;
+
+  background: transparent;
+
+  overflow: hidden;
+
+  transition:
+    border-color 200ms ease,
+    background 200ms ease,
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.menu-item::before {
+  content: "";
+
+  position: absolute;
+  inset: 0;
+
+  background:
+    linear-gradient(
+      90deg,
+      rgba(0, 246, 255, 0.09),
+      rgba(255, 43, 214, 0.07),
+      transparent
+    );
+
+  transform: translateX(-105%);
+
+  transition: transform 350ms ease;
+
+  pointer-events: none;
+}
+
+.menu-item:hover,
+.menu-item:focus-visible {
+  border-color: rgba(0, 246, 255, 0.3);
+
+  background: rgba(0, 246, 255, 0.025);
+
+  transform: translateX(4px);
+
+  box-shadow:
+    inset 3px 0 0 var(--cyan),
+    0 0 20px rgba(0, 246, 255, 0.05);
+}
+
+.menu-item:hover::before,
+.menu-item:focus-visible::before {
+  transform: translateX(100%);
+}
+
+.menu-item:focus-visible {
+  outline: 2px solid var(--pink);
+  outline-offset: 2px;
+}
+
+.menu-number {
+  position: relative;
+  z-index: 1;
+
+  width: 36px;
+  height: 36px;
+
+  flex: 0 0 36px;
+
+  display: grid;
+  place-items: center;
+
+  border: 1px solid rgba(255, 43, 214, 0.35);
+
+  color: var(--pink);
+
+  background: rgba(255, 43, 214, 0.035);
+
+  font-size: 0.7rem;
+
+  text-shadow:
+    0 0 8px rgba(255, 43, 214, 0.55);
+
+  transition:
+    border-color 200ms ease,
+    color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.menu-item:hover .menu-number,
+.menu-item:focus-visible .menu-number {
+  border-color: var(--pink);
+
+  box-shadow:
+    0 0 14px rgba(255, 43, 214, 0.18);
+}
+
+.menu-content {
+  position: relative;
+  z-index: 1;
+
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.menu-content strong {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+}
+
+.menu-content small {
+  color: var(--muted);
+
+  font-size: 0.7rem;
+}
+
+.menu-arrow {
+  position: relative;
+  z-index: 1;
+
+  margin-left: auto;
+
+  color: var(--cyan);
+
+  font-size: 1rem;
+
+  opacity: 0.35;
+
+  transform: translateX(-4px);
+
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease,
+    text-shadow 200ms ease;
+}
+
+.menu-item:hover .menu-arrow,
+.menu-item:focus-visible .menu-arrow {
+  opacity: 1;
+
+  transform: translateX(0);
+
+  text-shadow:
+    0 0 10px rgba(0, 246, 255, 0.7);
+}
+
+.menu-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  min-height: 38px;
+
+  padding: 0 14px;
+
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+  color: var(--muted);
+
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+}
+
+.connection-status {
+  color: var(--green);
+
+  text-shadow:
+    0 0 8px rgba(57, 255, 136, 0.5);
+}
+
+.hint {
+  margin: 16px 0 0;
+
+  color: #4d596b;
+
+  font-size: 0.67rem;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+@keyframes scan {
+  0% {
+    top: 0;
+    opacity: 0;
+  }
+
+  10% {
+    opacity: 0.18;
+  }
+
+  90% {
+    opacity: 0.18;
+  }
+
+  100% {
+    top: 100%;
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.65;
+    transform: scale(0.9);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-7px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 14px;
+  }
+
+  .demo-card {
+    padding: 28px 18px;
+  }
+
+  .cyber-dropdown summary {
+    min-height: 60px;
+    padding: 0 15px;
+  }
+
+  .menu-item {
+    min-height: 62px;
+  }
+
+  .menu-footer {
+    font-size: 0.56rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #edf2f7;
+    --panel: #f8fbff;
+    --text: #15202b;
+    --muted: #5d6b79;
+    --border: rgba(0, 130, 150, 0.3);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 15% 20%,
+        rgba(0, 180, 200, 0.1),
+        transparent 28%
+      ),
+      radial-gradient(
+        circle at 85% 80%,
+        rgba(210, 30, 160, 0.08),
+        transparent 30%
+      ),
+      var(--bg);
+  }
+
+  .cyber-dropdown {
+    background: rgba(248, 251, 255, 0.95);
+  }
+
+  .menu-item:hover,
+  .menu-item:focus-visible {
+    background: rgba(0, 180, 200, 0.04);
+  }
+}


### PR DESCRIPTION
### Description

It is a critical issue to provide reusable and visually polished dropdown components for the EaseMotion CSS library.

This PR implements the **Cyberpunk Neon Dropdown** requested in #73661.

## ✨ Features

- Added a pure CSS Cyberpunk Neon dropdown
- Added neon cyan and magenta visual effects
- Added animated scan-line effect
- Added smooth dropdown reveal animation
- Added interactive hover and focus states
- Added neon status indicator
- Added responsive styling
- Added light and dark mode compatibility
- Added `prefers-reduced-motion` support
- No JavaScript or external dependencies

## 📁 Files Added

- `submissions/examples/73661-cyberpunk-neon-dropdown/demo.html`
- `submissions/examples/73661-cyberpunk-neon-dropdown/style.css`
- `submissions/examples/73661-cyberpunk-neon-dropdown/README.md`

## ♿ Accessibility

- Uses native `<details>` and `<summary>`
- Keyboard-friendly interaction
- Visible focus indicators
- Semantic navigation links
- Reduced-motion support

## 🧪 Testing

- Tested dropdown open/close interaction
- Tested hover states
- Tested keyboard focus
- Tested responsive layout
- Tested light/dark appearance
- Verified no JavaScript is required

## 🔗 Issue

Closes #73661