### PR TITLE
feat: add CSS Copy Confirmation Tick component

### DIFF
--- a/submissions/examples/copy-confirmation-tick-70050-sb/README.md
+++ b/submissions/examples/copy-confirmation-tick-70050-sb/README.md
@@ -1,0 +1,45 @@
+# Copy Confirmation Tick
+
+## What does this do?
+
+A copy button that shows an animated tick (checkmark) the instant it is activated, giving the user immediate visual confirmation that the value was "copied".
+
+## How is it used?
+
+Wrap a value in a `.copy-card`, then add a `.copy-tick` control made of a hidden checkbox and a styled `<label>` button. Toggling the checkbox drives the confirmation animation &mdash; no JavaScript required.
+
+```html
+<span class="copy-tick">
+  <input
+    class="copy-tick__input"
+    type="checkbox"
+    id="copy-x"
+    aria-label="Copy the value"
+  />
+  <label class="copy-tick__button" for="copy-x">
+    <svg class="copy-tick__icon" viewBox="0 0 24 24" ...>
+      <!-- copy glyph -->
+    </svg>
+    <svg class="copy-tick__tick" viewBox="0 0 24 24" ...>
+      <path class="copy-tick__tick-path" d="M5 12.5l4.5 4.5L19 7"></path>
+    </svg>
+    <span class="copy-tick__text">
+      <span class="copy-tick__text--idle">Copy</span>
+      <span class="copy-tick__text--done">Copied!</span>
+    </span>
+  </label>
+</span>
+```
+
+- The copy glyph fades out and the tick draws in (SVG `stroke-dashoffset` animation) when `:checked`.
+- The label swaps "Copy" &rarr; "Copied!" and the button turns success-green with a soft glow.
+
+## Why does it fit EaseMotion CSS?
+
+It is an animation-first, human-readable UI pattern built with zero JavaScript. The confirmation motion &mdash; an SVG checkmark drawing in, a spring-scale entrance, and a color/glow shift &mdash; is exactly the kind of ready-to-use micro-interaction EaseMotion curates. It is responsive, accessible (keyboard-operable via the native checkbox, with an `aria-label` and a visible focus ring), and self-contained, so it fits the framework's "open it in a browser and it works" philosophy.
+
+## Accessibility &amp; notes
+
+- The real checkbox is visually hidden but remains in the tab order, so `Tab` focuses the button and `Space`/`Enter` toggles it &mdash; the confirmation animation is fully keyboard-operable.
+- Each control carries an `aria-label` describing what it copies; the decorative icons are `aria-hidden`.
+- The demo simulates the "copied" confirmation state purely in CSS. In production, a single line of JavaScript wires the toggle to the Clipboard API (`navigator.clipboard.writeText(value)`) to perform the actual copy; the CSS animation/confirmation UI shown here is the part EaseMotion standardizes.

--- a/submissions/examples/copy-confirmation-tick-70050-sb/demo.html
+++ b/submissions/examples/copy-confirmation-tick-70050-sb/demo.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy Confirmation Tick — EaseMotion CSS Submission</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <p class="demo-shell__eyebrow">EaseMotion CSS Submission</p>
+      <h1 class="demo-shell__title">Copy Confirmation Tick</h1>
+      <p class="demo-shell__lede">
+        A copy button that shows an animated tick the moment it is activated.
+        Pure CSS &mdash; the confirmation state is driven by a hidden checkbox
+        toggle, so it works with the mouse and the keyboard (Tab to focus, Space
+        to copy).
+      </p>
+
+      <ul class="copy-list">
+        <li class="copy-card">
+          <span class="copy-card__label">
+            <span class="copy-card__hint">API endpoint</span>
+            <span class="copy-card__value"
+              >https://api.easemotion.dev/v1/animate</span
+            >
+          </span>
+          <span class="copy-tick">
+            <input
+              class="copy-tick__input"
+              type="checkbox"
+              id="copy-api"
+              aria-label="Copy the API endpoint to the clipboard"
+            />
+            <label class="copy-tick__button" for="copy-api">
+              <svg
+                class="copy-tick__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <rect x="9" y="9" width="11" height="11" rx="2" ry="2"></rect>
+                <path
+                  d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                ></path>
+              </svg>
+              <svg
+                class="copy-tick__tick"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  class="copy-tick__tick-path"
+                  d="M5 12.5l4.5 4.5L19 7"
+                ></path>
+              </svg>
+              <span class="copy-tick__text">
+                <span class="copy-tick__text--idle">Copy</span>
+                <span class="copy-tick__text--done">Copied!</span>
+              </span>
+            </label>
+          </span>
+        </li>
+
+        <li class="copy-card">
+          <span class="copy-card__label">
+            <span class="copy-card__hint">Install command</span>
+            <span class="copy-card__value">npm install easemotion-css</span>
+          </span>
+          <span class="copy-tick">
+            <input
+              class="copy-tick__input"
+              type="checkbox"
+              id="copy-install"
+              aria-label="Copy the install command to the clipboard"
+            />
+            <label class="copy-tick__button" for="copy-install">
+              <svg
+                class="copy-tick__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <rect x="9" y="9" width="11" height="11" rx="2" ry="2"></rect>
+                <path
+                  d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                ></path>
+              </svg>
+              <svg
+                class="copy-tick__tick"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  class="copy-tick__tick-path"
+                  d="M5 12.5l4.5 4.5L19 7"
+                ></path>
+              </svg>
+              <span class="copy-tick__text">
+                <span class="copy-tick__text--idle">Copy</span>
+                <span class="copy-tick__text--done">Copied!</span>
+              </span>
+            </label>
+          </span>
+        </li>
+
+        <li class="copy-card">
+          <span class="copy-card__label">
+            <span class="copy-card__hint">Brand color</span>
+            <span class="copy-card__value">#6366F1</span>
+          </span>
+          <span class="copy-tick">
+            <input
+              class="copy-tick__input"
+              type="checkbox"
+              id="copy-color"
+              aria-label="Copy the brand color hex value to the clipboard"
+            />
+            <label class="copy-tick__button" for="copy-color">
+              <svg
+                class="copy-tick__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <rect x="9" y="9" width="11" height="11" rx="2" ry="2"></rect>
+                <path
+                  d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                ></path>
+              </svg>
+              <svg
+                class="copy-tick__tick"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  class="copy-tick__tick-path"
+                  d="M5 12.5l4.5 4.5L19 7"
+                ></path>
+              </svg>
+              <span class="copy-tick__text">
+                <span class="copy-tick__text--idle">Copy</span>
+                <span class="copy-tick__text--done">Copied!</span>
+              </span>
+            </label>
+          </span>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/copy-confirmation-tick-70050-sb/style.css
+++ b/submissions/examples/copy-confirmation-tick-70050-sb/style.css
@@ -1,0 +1,276 @@
+/* ===========================================================
+   Copy Confirmation Tick — pure-CSS copy button with an
+   animated tick (checkmark) that draws in on activation.
+   The "copied" state is driven by a hidden checkbox toggle
+   (no JavaScript), so the confirmation animation is fully
+   reproducible from the keyboard as well as the mouse.
+   =========================================================== */
+
+:root {
+  --ct-bg: #0f172a;
+  --ct-surface: #1e293b;
+  --ct-surface-2: #334155;
+  --ct-text: #f1f5f9;
+  --ct-muted: #94a3b8;
+  --ct-accent: #6366f1;
+  --ct-accent-strong: #818cf8;
+  --ct-success: #22c55e;
+  --ct-success-glow: rgba(34, 197, 94, 0.35);
+  --ct-radius: 12px;
+  --ct-shadow: 0 10px 30px rgba(2, 6, 23, 0.45);
+  --ct-transition: 220ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 3rem);
+  font-family:
+    "Inter",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: var(--ct-text);
+  background:
+    radial-gradient(
+      1200px 600px at 10% -10%,
+      rgba(99, 102, 241, 0.25),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 110% 10%,
+      rgba(34, 197, 94, 0.18),
+      transparent 55%
+    ),
+    var(--ct-bg);
+}
+
+.demo-shell {
+  width: min(720px, 100%);
+}
+
+.demo-shell__eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ct-accent-strong);
+}
+
+.demo-shell__title {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.6rem, 4vw, 2.25rem);
+  line-height: 1.1;
+}
+
+.demo-shell__lede {
+  margin: 0 0 2rem;
+  color: var(--ct-muted);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.copy-list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.copy-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: var(--ct-surface);
+  border: 1px solid var(--ct-surface-2);
+  border-radius: var(--ct-radius);
+  box-shadow: var(--ct-shadow);
+}
+
+.copy-card__label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.copy-card__hint {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ct-muted);
+  margin-bottom: 0.2rem;
+}
+
+.copy-card__value {
+  display: block;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.95rem;
+  color: var(--ct-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---------- the copy-tick control ---------- */
+
+.copy-tick {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+/* visually hidden but keyboard-focusable checkbox */
+.copy-tick__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.copy-tick__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 116px;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--ct-surface-2);
+  background: var(--ct-surface-2);
+  color: var(--ct-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background var(--ct-transition),
+    border-color var(--ct-transition),
+    color var(--ct-transition),
+    box-shadow var(--ct-transition);
+}
+
+.copy-tick__input:focus-visible + .copy-tick__button {
+  outline: 3px solid var(--ct-accent-strong);
+  outline-offset: 2px;
+}
+
+.copy-tick__input:not(:checked) + .copy-tick__button:hover {
+  background: var(--ct-accent);
+  border-color: var(--ct-accent);
+}
+
+/* ---- icons (copy glyph + animated tick) ---- */
+
+.copy-tick__icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.copy-tick__tick {
+  position: absolute;
+  top: 50%;
+  left: 1rem;
+  width: 18px;
+  height: 18px;
+  margin-top: -9px;
+  opacity: 0;
+  transform: scale(0.6);
+  transition:
+    opacity 180ms ease 120ms,
+    transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1) 120ms;
+}
+
+.copy-tick__tick-path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset 360ms cubic-bezier(0.65, 0, 0.35, 1) 160ms;
+}
+
+/* ---- the "copied" state, driven by :checked ---- */
+
+.copy-tick__input:checked + .copy-tick__button {
+  background: var(--ct-success);
+  border-color: var(--ct-success);
+  color: #052e16;
+  box-shadow: 0 0 0 4px var(--ct-success-glow);
+}
+
+.copy-tick__input:checked + .copy-tick__button .copy-tick__icon {
+  opacity: 0;
+  transform: scale(0.6);
+}
+
+.copy-tick__input:checked + .copy-tick__button .copy-tick__tick {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.copy-tick__input:checked + .copy-tick__button .copy-tick__tick-path {
+  stroke-dashoffset: 0;
+}
+
+/* swap the label text via two stacked spans */
+.copy-tick__text {
+  position: relative;
+  display: inline-block;
+  min-width: 48px;
+  text-align: left;
+}
+
+.copy-tick__text--idle,
+.copy-tick__text--done {
+  display: inline-block;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.copy-tick__text--done {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.copy-tick__input:checked + .copy-tick__button .copy-tick__text--idle {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.copy-tick__input:checked + .copy-tick__button .copy-tick__text--done {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---- responsive: collapse on very narrow cards ---- */
+@media (max-width: 420px) {
+  .copy-card {
+    flex-wrap: wrap;
+  }
+
+  .copy-tick__button {
+    min-width: 0;
+    padding: 0.55rem 0.75rem;
+  }
+
+  .copy-tick__text {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
## Summary

A pure-CSS **Copy Confirmation Tick** component: a copy button that shows an animated tick (checkmark) the instant it is activated, giving immediate visual confirmation that a value was "copied". The confirmation state is driven by a hidden checkbox toggle — no JavaScript — so the animation is fully reproducible from the mouse and the keyboard.

## Issue

Closes #70050

## Root Cause

This is a curated-submission feature request (not a bug). The EaseMotion contribution model asks for a self-contained `demo.html` + `style.css` + `README.md` under `submissions/examples/`. The challenge it addresses: implementing a "copy → animated confirmation tick" pattern **without JavaScript**, while remaining responsive and accessible. The solution uses the classic checkbox-toggle pattern — a visually-hidden but focusable `<input type="checkbox">` paired with a styled `<label>` — so the `:checked` state drives the entire confirmation animation.

## Changes Made

- `style.css` — design tokens, card layout, and the `.copy-tick` control. The confirmation motion is built from three coordinated CSS transitions: (1) the copy glyph fades+scales out, (2) an SVG checkmark **draws in** via `stroke-dashoffset` with a spring-scale entrance, and (3) the label swaps "Copy" → "Copied!" and the button turns success-green with a soft glow.
- `demo.html` — three responsive copy cards (an API endpoint, an npm install command, and a brand hex color), each with its own keyboard-operable copy-tick control. Self-contained: no server, CDN, or external framework.
- `README.md` — what it does, how to use it (HTML class usage), why it fits EaseMotion, and accessibility/production notes.

## Files Changed

- `submissions/examples/copy-confirmation-tick-70050-sb/style.css`
- `submissions/examples/copy-confirmation-tick-70050-sb/demo.html`
- `submissions/examples/copy-confirmation-tick-70050-sb/README.md`

## Testing

- Unit tests (repo `vitest` suite): **PASS** — 61/61 tests pass (engine/tabs/modal/smoke/reveal). My change adds files only under `submissions/`, so no existing test is affected.
- Lint (stylelint): **N/A** — `.stylelintignore` excludes `submissions/`, so submission CSS is not stylelint-checked by CI (confirmed it does not run on these files).
- HTMLHint (`.github/workflows/htmlhint.config.json`): **PASS** — 0 errors.
- Prettier (`--check`): **PASS** — all 3 files use Prettier code style.
- Build: **N/A** — no core/`easemotion.min.css` touched, so `npm run build` is not required.

## E2E Verification

Served `demo.html` via a local HTTP server and verified the full user flow in a real browser + a JSDOM assertion harness:

1. **Initial render** — 3 copy cards render, each showing the "Copy" label and the copy glyph; all checkboxes unchecked.
2. **Happy path** — clicked the first copy button → the copy glyph swaps to the tick SVG, the label swaps "Copy" → **"Copied!"**, and the button turns success-green with a glow (confirmed in browser state + screenshot). The other two buttons remain in their idle state (independent per-card state).
3. **Keyboard accessibility** — verified via JSDOM that every control is a native `type="checkbox"` (keyboard-focusable, `Space`/`Enter` toggles), each carries an `aria-label`, and toggling changes `checked` as expected.
4. **Reset** — toggling back unchecks the box and returns the label/glyph to the idle state.
5. **Responsive** — CSS contains a `@media (max-width: 420px)` rule that collapses the card/button on narrow viewports.
6. **Validator conformance** — `<!DOCTYPE html>` first, `<html>/<head>/<body>` present, `<title>` present, all IDs unique (`copy-api`, `copy-install`, `copy-color`), double-quoted attributes — matching the htmlhint config and the submission-validator's quality checks.

## Edge Cases Tested

- Narrow viewport (≤420px): card wraps and button collapses to a smaller width.
- Independent state: activating one card does not affect the others.
- Reset: unchecking returns the button to the idle "Copy" state (the demo is a toggle, so users can re-trigger the animation).
- Decorative icons are `aria-hidden="true"` so screen readers only announce the `aria-label`.

## Screenshots / Evidence

E2E run captured browser screenshots of the idle state and the activated "Copied!" state (tick drawn in, success-green button). JSDOM assertions logged: `checkboxes found: 3`, `all unchecked initially: true`, `after toggle #0 checked: true | others unchecked: true`, `reset #0 -> unchecked: true`, `ids unique: true`.

## Risk / Impact

No impact on existing functionality — only 3 new files are added under `submissions/examples/`. No `core/`, `components/`, `easemotion.min.css`, or any existing file is modified, per the strict submission-first pipeline.

## Checklist

- [x] Issue reproduced/understood
- [x] Root cause / approach identified
- [x] Submission implemented (pure CSS, no JS)
- [x] Tests run (repo suite 61/61 pass)
- [x] Existing tests passed
- [x] E2E verified (browser + JSDOM)
- [x] Final diff reviewed (only 3 new files under submissions/)
- [x] No unrelated changes

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/examples/copy-confirmation-tick-70050-sb/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server/CDN
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
