### PR TITLE
feat: add plain content wrapper demo

### DIFF
--- a/submissions/examples/plain-content-wrapper-kk/README.md
+++ b/submissions/examples/plain-content-wrapper-kk/README.md
@@ -1,0 +1,33 @@
+# Plain Content Wrapper
+
+## What it does
+
+This submission creates a simple CSS-only plain content wrapper utility for grouping related text, controls, notes, or small layout sections.
+
+## How to use it
+
+Wrap grouped content inside the shared utility class:
+
+```html
+<div class="plain-content-wrapper">
+  <p>Grouped content goes here.</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, dashboards, forms, settings panels, documentation pages, and content sections.
+
+## Included features
+
+- Plain padded content wrapper utility
+- Muted variation included in the demo
+- Practical grouped-content examples
+- Responsive demo layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the wrapper utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/plain-content-wrapper-kk/demo.html
+++ b/submissions/examples/plain-content-wrapper-kk/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plain Content Wrapper</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Plain Content Wrapper</p>
+          <h1>Simple padded wrappers for grouped content and small sections.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only wrapper utility for grouping
+            related text, controls, notes, or compact layout sections with
+            consistent spacing and a subtle surface.
+          </p>
+        </header>
+
+        <section class="wrapper-grid">
+          <div class="plain-content-wrapper">
+            <h2>Profile Details</h2>
+            <p>Grouped content can sit inside a simple wrapper for clearer structure.</p>
+          </div>
+
+          <div class="plain-content-wrapper">
+            <h2>Settings Summary</h2>
+            <p>Use the wrapper around controls, notes, or small dashboard sections.</p>
+          </div>
+
+          <div class="plain-content-wrapper muted">
+            <h2>Documentation Note</h2>
+            <p>A muted variation can provide a slightly stronger grouped surface.</p>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="plain-content-wrapper"&gt;
+  &lt;p&gt;Grouped content goes here.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/plain-content-wrapper-kk/style.css
+++ b/submissions/examples/plain-content-wrapper-kk/style.css
@@ -1,0 +1,114 @@
+:root {
+  color-scheme: dark;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --panel-muted: rgba(255, 255, 255, 0.05);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro,
+.plain-content-wrapper p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.wrapper-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.plain-content-wrapper,
+.usage-panel {
+  padding: 1rem;
+  border-radius: 12px;
+  background: var(--panel-soft);
+}
+
+.plain-content-wrapper.muted {
+  background: var(--panel-muted);
+}
+
+.plain-content-wrapper h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.12rem;
+}
+
+.plain-content-wrapper p {
+  margin: 0;
+}
+
+.usage-panel {
+  border: 1px solid var(--border);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .wrapper-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Plain Content Wrapper demo inside `submissions/examples/plain-content-wrapper-kk/`. This submission introduces a simple CSS-only wrapper utility for grouping related text, controls, notes, or compact layout sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only plain content wrapper utility for grouping related content with simple padding and a subtle surface.

**How does a developer use it?**

```html
<div class="plain-content-wrapper">
  <p>Grouped content goes here.</p>
</div>