### PR TITLE
feat: add retro arcade pixel tabs

### DIFF
--- a/submissions/examples/73567-retro-arcade-pixel-tab/README.md
+++ b/submissions/examples/73567-retro-arcade-pixel-tab/README.md
@@ -1,0 +1,40 @@
+# Retro Arcade Pixel Tabs
+
+A retro arcade-inspired **CSS-only Tabs & Segmented Control**
+created for the EaseMotion CSS component collection.
+
+Implemented for **Issue #73567**.
+
+## ✨ Features
+
+- Retro arcade pixel styling
+- Neon yellow, cyan, pink, and green accents
+- Pixel-inspired shadows
+- CRT scanline effect
+- Arcade-style flicker animations
+- Smooth tab transitions
+- CSS-only tab switching
+- No JavaScript required
+- Responsive layout
+- Dark-mode friendly design
+- Hardware-friendly CSS transforms
+- `prefers-reduced-motion` support
+- Semantic tab and panel structure
+
+## 🎮 Style
+
+**Category:** Tabs & Segmented Control
+
+**Style:** Retro Arcade Pixel
+
+The component recreates the visual language of classic arcade
+interfaces using pixel shadows, neon borders, scanlines,
+monospace typography, and stepped animations.
+
+## 📁 Files
+
+```text
+73567-retro-arcade-pixel-tab/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/73567-retro-arcade-pixel-tab/demo.html
+++ b/submissions/examples/73567-retro-arcade-pixel-tab/demo.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Retro Arcade Pixel CSS Tabs"
+  >
+  <title>Retro Arcade Pixel Tabs</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="component" aria-labelledby="page-title">
+
+      <header class="intro">
+        <span class="eyebrow">EASEMOTION CSS // TABS</span>
+
+        <h1 id="page-title">RETRO ARCADE</h1>
+
+        <p>
+          A pixel-inspired tab interface with arcade-style
+          transitions, scanlines, and neon game-console visuals.
+        </p>
+      </header>
+
+      <section class="arcade-shell" aria-label="Retro arcade tabs">
+
+        <div class="arcade-top">
+          <span class="pixel-lamp" aria-hidden="true"></span>
+
+          <span class="system-label">
+            PLAYER SELECT
+          </span>
+
+          <span class="score">
+            SCORE: 08420
+          </span>
+        </div>
+
+        <div class="tabs">
+
+          <input
+            type="radio"
+            name="arcade-tabs"
+            id="tab-home"
+            checked
+          >
+
+          <input
+            type="radio"
+            name="arcade-tabs"
+            id="tab-games"
+          >
+
+          <input
+            type="radio"
+            name="arcade-tabs"
+            id="tab-stats"
+          >
+
+          <input
+            type="radio"
+            name="arcade-tabs"
+            id="tab-settings"
+          >
+
+          <div
+            class="tab-list"
+            role="tablist"
+            aria-label="Arcade sections"
+          >
+
+            <label
+              for="tab-home"
+              class="tab"
+              role="tab"
+            >
+              <span class="tab-index">01</span>
+              <span>START</span>
+            </label>
+
+            <label
+              for="tab-games"
+              class="tab"
+              role="tab"
+            >
+              <span class="tab-index">02</span>
+              <span>GAMES</span>
+            </label>
+
+            <label
+              for="tab-stats"
+              class="tab"
+              role="tab"
+            >
+              <span class="tab-index">03</span>
+              <span>STATS</span>
+            </label>
+
+            <label
+              for="tab-settings"
+              class="tab"
+              role="tab"
+            >
+              <span class="tab-index">04</span>
+              <span>OPTIONS</span>
+            </label>
+
+          </div>
+
+          <div class="tab-panels">
+
+            <article
+              class="panel panel-home"
+              role="tabpanel"
+            >
+              <span class="panel-kicker">PLAYER 01</span>
+
+              <h2>
+                READY PLAYER?
+              </h2>
+
+              <p>
+                Insert imagination. Press start. Enter a
+                pixel-powered interface built entirely with CSS.
+              </p>
+
+              <div class="pixel-progress">
+                <span></span>
+              </div>
+
+              <div class="panel-meta">
+                <span>LEVEL 01</span>
+                <span>READY</span>
+              </div>
+            </article>
+
+            <article
+              class="panel panel-games"
+              role="tabpanel"
+            >
+              <span class="panel-kicker">GAME LIBRARY</span>
+
+              <h2>
+                SELECT GAME
+              </h2>
+
+              <div class="game-grid">
+                <div class="game-card">
+                  <strong>PIXEL RUN</strong>
+                  <span>HI 9020</span>
+                </div>
+
+                <div class="game-card">
+                  <strong>NEON WAR</strong>
+                  <span>HI 7610</span>
+                </div>
+
+                <div class="game-card">
+                  <strong>SPACE GRID</strong>
+                  <span>HI 6840</span>
+                </div>
+              </div>
+            </article>
+
+            <article
+              class="panel panel-stats"
+              role="tabpanel"
+            >
+              <span class="panel-kicker">PLAYER DATA</span>
+
+              <h2>
+                HIGH SCORES
+              </h2>
+
+              <div class="score-table">
+                <div>
+                  <span>01</span>
+                  <strong>PLAYER-X</strong>
+                  <b>9840</b>
+                </div>
+
+                <div>
+                  <span>02</span>
+                  <strong>PIXEL-KID</strong>
+                  <b>8420</b>
+                </div>
+
+                <div>
+                  <span>03</span>
+                  <strong>ARCADE-7</strong>
+                  <b>7610</b>
+                </div>
+              </div>
+            </article>
+
+            <article
+              class="panel panel-settings"
+              role="tabpanel"
+            >
+              <span class="panel-kicker">SYSTEM CONFIG</span>
+
+              <h2>
+                OPTIONS
+              </h2>
+
+              <div class="settings-list">
+                <div>
+                  <span>DIFFICULTY</span>
+                  <strong>HARD</strong>
+                </div>
+
+                <div>
+                  <span>SOUND</span>
+                  <strong>ON</strong>
+                </div>
+
+                <div>
+                  <span>PIXEL MODE</span>
+                  <strong>ACTIVE</strong>
+                </div>
+              </div>
+            </article>
+
+          </div>
+        </div>
+
+        <footer class="arcade-footer">
+          <span>INSERT COIN</span>
+
+          <span class="blink">
+            ● PRESS TAB TO PLAY ●
+          </span>
+
+          <span>© 2026</span>
+        </footer>
+
+      </section>
+
+      <div class="feature-grid">
+
+        <article>
+          <span>01</span>
+          <strong>Pixel Motion</strong>
+          <p>
+            Sharp transform-based transitions recreate
+            classic arcade interface movement.
+          </p>
+        </article>
+
+        <article>
+          <span>02</span>
+          <strong>Arcade Visuals</strong>
+          <p>
+            Scanlines, pixel shadows, neon borders, and
+            CRT-inspired details create the retro look.
+          </p>
+        </article>
+
+        <article>
+          <span>03</span>
+          <strong>CSS Only</strong>
+          <p>
+            Tabs are controlled using native radio inputs
+            without external JavaScript.
+          </p>
+        </article>
+
+      </div>
+
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/73567-retro-arcade-pixel-tab/style.css
+++ b/submissions/examples/73567-retro-arcade-pixel-tab/style.css
@@ -1,0 +1,863 @@
+:root {
+  --bg: #08070c;
+  --panel: #11101a;
+  --panel-light: #181523;
+
+  --text: #fff7d6;
+  --muted: #aaa38b;
+
+  --yellow: #ffe600;
+  --pink: #ff3cac;
+  --cyan: #00f5ff;
+  --green: #8cff00;
+
+  --pixel-shadow:
+    4px 4px 0 #000;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+
+  color: var(--text);
+
+  font-family:
+    "Courier New",
+    Courier,
+    monospace;
+
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(255, 60, 172, 0.09),
+      transparent 35%
+    ),
+    radial-gradient(
+      circle at 10% 90%,
+      rgba(0, 245, 255, 0.06),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+
+  padding: 48px 16px;
+}
+
+.component {
+  width: min(100%, 1000px);
+
+  margin: auto;
+}
+
+.intro {
+  max-width: 700px;
+
+  margin: 0 auto 36px;
+
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+
+  margin-bottom: 14px;
+
+  color: var(--cyan);
+
+  font-size: 0.68rem;
+  font-weight: 900;
+
+  letter-spacing: 0.2em;
+}
+
+.intro h1 {
+  margin: 0 0 15px;
+
+  color: var(--yellow);
+
+  font-size: clamp(2.7rem, 8vw, 5.5rem);
+
+  line-height: 0.9;
+
+  letter-spacing: 0.04em;
+
+  text-shadow:
+    4px 4px 0 var(--pink),
+    8px 8px 0 #000;
+
+  animation:
+    titleGlitch 4s steps(1) infinite;
+}
+
+@keyframes titleGlitch {
+  0%,
+  88%,
+  100% {
+    transform: translate(0);
+  }
+
+  89% {
+    transform: translate(-3px, 2px);
+
+    text-shadow:
+      4px 4px 0 var(--cyan),
+      8px 8px 0 #000;
+  }
+
+  90% {
+    transform: translate(3px, -1px);
+  }
+
+  91% {
+    transform: translate(0);
+  }
+}
+
+.intro p {
+  margin: 0 auto;
+
+  max-width: 650px;
+
+  color: var(--muted);
+
+  font-size: 0.78rem;
+
+  line-height: 1.8;
+}
+
+/* =========================
+   ARCADE SHELL
+========================= */
+
+.arcade-shell {
+  position: relative;
+
+  overflow: hidden;
+
+  border:
+    4px solid
+    var(--yellow);
+
+  background:
+    var(--panel);
+
+  box-shadow:
+    8px 8px 0 #000,
+    14px 14px 0 var(--pink);
+
+  isolation: isolate;
+}
+
+.arcade-shell::before {
+  position: absolute;
+
+  inset: 0;
+
+  z-index: 10;
+
+  content: "";
+
+  pointer-events: none;
+
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 4px,
+      rgba(255, 255, 255, 0.025) 5px
+    );
+
+  mix-blend-mode: screen;
+
+  opacity: 0.45;
+}
+
+.arcade-top,
+.arcade-footer {
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  gap: 15px;
+
+  min-height: 54px;
+
+  padding: 12px 18px;
+
+  background:
+    #0d0c13;
+
+  border-bottom:
+    3px solid
+    var(--yellow);
+
+  font-size: 0.62rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.08em;
+}
+
+.arcade-footer {
+  border-top:
+    3px solid
+    var(--yellow);
+
+  border-bottom: 0;
+}
+
+.pixel-lamp {
+  width: 12px;
+  height: 12px;
+
+  flex-shrink: 0;
+
+  background: var(--green);
+
+  box-shadow:
+    0 0 0 3px #000,
+    0 0 18px var(--green);
+
+  animation:
+    lampPulse 1.2s steps(2) infinite;
+}
+
+@keyframes lampPulse {
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.system-label {
+  flex: 1;
+
+  color: var(--cyan);
+}
+
+.score {
+  color: var(--pink);
+}
+
+/* =========================
+   HIDDEN INPUTS
+========================= */
+
+.tabs > input {
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+
+  opacity: 0;
+
+  pointer-events: none;
+}
+
+/* =========================
+   TAB LIST
+========================= */
+
+.tab-list {
+  display: grid;
+
+  grid-template-columns:
+    repeat(4, 1fr);
+
+  border-bottom:
+    3px solid
+    #000;
+
+  background:
+    #0b0a10;
+}
+
+.tab {
+  position: relative;
+
+  display: flex;
+
+  align-items: center;
+
+  justify-content: center;
+
+  gap: 8px;
+
+  min-height: 68px;
+
+  padding: 10px;
+
+  cursor: pointer;
+
+  color: var(--muted);
+
+  border-right:
+    2px solid
+    #000;
+
+  background:
+    #111019;
+
+  font-size: 0.65rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.06em;
+
+  transition:
+    color 120ms steps(2),
+    background 120ms steps(2),
+    transform 120ms steps(2);
+}
+
+.tab:last-child {
+  border-right: 0;
+}
+
+.tab::before {
+  position: absolute;
+
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 4px;
+
+  content: "";
+
+  background:
+    var(--cyan);
+
+  transform: scaleX(0);
+
+  transform-origin: left;
+
+  transition:
+    transform 140ms steps(4);
+}
+
+.tab:hover {
+  color: var(--text);
+
+  background:
+    #1b1826;
+
+  transform:
+    translateY(-2px);
+}
+
+.tab-index {
+  color: var(--pink);
+
+  font-size: 0.55rem;
+}
+
+/* =========================
+   ACTIVE TAB
+========================= */
+
+#tab-home:checked ~ .tab-list label[for="tab-home"],
+#tab-games:checked ~ .tab-list label[for="tab-games"],
+#tab-stats:checked ~ .tab-list label[for="tab-stats"],
+#tab-settings:checked ~ .tab-list label[for="tab-settings"] {
+  color: #08070c;
+
+  background:
+    var(--yellow);
+
+  box-shadow:
+    inset 0 -5px 0 #b8a600;
+}
+
+#tab-home:checked ~ .tab-list label[for="tab-home"]::before,
+#tab-games:checked ~ .tab-list label[for="tab-games"]::before,
+#tab-stats:checked ~ .tab-list label[for="tab-stats"]::before,
+#tab-settings:checked ~ .tab-list label[for="tab-settings"]::before {
+  transform: scaleX(1);
+
+  background:
+    var(--pink);
+}
+
+/* =========================
+   PANELS
+========================= */
+
+.tab-panels {
+  min-height: 365px;
+
+  background:
+    linear-gradient(
+      135deg,
+      #12101a,
+      #0c0b12
+    );
+}
+
+.panel {
+  display: none;
+
+  min-height: 365px;
+
+  padding: 45px;
+
+  animation:
+    pixelReveal 300ms steps(5);
+}
+
+#tab-home:checked ~ .tab-panels .panel-home,
+#tab-games:checked ~ .tab-panels .panel-games,
+#tab-stats:checked ~ .tab-panels .panel-stats,
+#tab-settings:checked ~ .tab-panels .panel-settings {
+  display: block;
+}
+
+@keyframes pixelReveal {
+  0% {
+    opacity: 0;
+
+    transform:
+      translateX(12px)
+      scale(0.98);
+  }
+
+  40% {
+    opacity: 0.45;
+
+    transform:
+      translateX(-4px)
+      scale(1.01);
+  }
+
+  70% {
+    opacity: 0.8;
+
+    transform:
+      translateX(2px);
+  }
+
+  100% {
+    opacity: 1;
+
+    transform:
+      translateX(0)
+      scale(1);
+  }
+}
+
+.panel-kicker {
+  display: block;
+
+  margin-bottom: 12px;
+
+  color: var(--pink);
+
+  font-size: 0.62rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.15em;
+}
+
+.panel h2 {
+  margin: 0 0 20px;
+
+  color: var(--yellow);
+
+  font-size: clamp(1.6rem, 5vw, 2.7rem);
+
+  line-height: 1;
+
+  letter-spacing: 0.04em;
+
+  text-shadow:
+    4px 4px 0 #000;
+}
+
+.panel p {
+  max-width: 600px;
+
+  margin: 0;
+
+  color: var(--muted);
+
+  font-size: 0.76rem;
+
+  line-height: 1.8;
+}
+
+/* =========================
+   PROGRESS
+========================= */
+
+.pixel-progress {
+  width: min(100%, 560px);
+
+  height: 18px;
+
+  margin-top: 32px;
+
+  padding: 3px;
+
+  border:
+    3px solid
+    #000;
+
+  background:
+    #292633;
+}
+
+.pixel-progress span {
+  display: block;
+
+  width: 72%;
+  height: 100%;
+
+  background:
+    repeating-linear-gradient(
+      90deg,
+      var(--cyan) 0 12px,
+      transparent 12px 15px
+    );
+
+  box-shadow:
+    0 0 12px
+    rgba(0, 245, 255, 0.4);
+}
+
+.panel-meta {
+  display: flex;
+
+  justify-content: space-between;
+
+  max-width: 560px;
+
+  margin-top: 12px;
+
+  color: var(--green);
+
+  font-size: 0.58rem;
+
+  font-weight: 900;
+}
+
+/* =========================
+   GAME GRID
+========================= */
+
+.game-grid {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 14px;
+}
+
+.game-card {
+  min-height: 120px;
+
+  display: flex;
+
+  flex-direction: column;
+
+  justify-content: space-between;
+
+  padding: 18px;
+
+  border:
+    3px solid
+    var(--cyan);
+
+  background:
+    #0b0a11;
+
+  box-shadow:
+    5px 5px 0 #000;
+
+  transition:
+    transform 120ms steps(2),
+    background 120ms steps(2);
+}
+
+.game-card:hover {
+  transform:
+    translate(-3px, -3px);
+
+  background:
+    #171525;
+}
+
+.game-card strong {
+  color: var(--yellow);
+
+  font-size: 0.7rem;
+}
+
+.game-card span {
+  color: var(--pink);
+
+  font-size: 0.58rem;
+}
+
+/* =========================
+   SCORE TABLE
+========================= */
+
+.score-table {
+  display: grid;
+
+  gap: 8px;
+
+  max-width: 650px;
+}
+
+.score-table div {
+  display: grid;
+
+  grid-template-columns:
+    45px 1fr auto;
+
+  align-items: center;
+
+  gap: 15px;
+
+  padding: 13px 16px;
+
+  border:
+    2px solid
+    #292633;
+
+  background:
+    #0b0a11;
+
+  font-size: 0.68rem;
+}
+
+.score-table div:first-child {
+  border-color:
+    var(--yellow);
+}
+
+.score-table span {
+  color: var(--pink);
+}
+
+.score-table b {
+  color: var(--cyan);
+}
+
+/* =========================
+   SETTINGS
+========================= */
+
+.settings-list {
+  max-width: 650px;
+
+  display: grid;
+
+  gap: 9px;
+}
+
+.settings-list div {
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  padding: 15px 18px;
+
+  border:
+    2px solid
+    #292633;
+
+  background:
+    #0b0a11;
+
+  font-size: 0.65rem;
+}
+
+.settings-list span {
+  color: var(--muted);
+}
+
+.settings-list strong {
+  color: var(--green);
+}
+
+/* =========================
+   FOOTER
+========================= */
+
+.blink {
+  color: var(--cyan);
+
+  animation:
+    arcadeBlink 1s steps(2) infinite;
+}
+
+@keyframes arcadeBlink {
+  50% {
+    opacity: 0.25;
+  }
+}
+
+/* =========================
+   FEATURE GRID
+========================= */
+
+.feature-grid {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 14px;
+
+  margin-top: 22px;
+}
+
+.feature-grid article {
+  padding: 20px;
+
+  border:
+    2px solid
+    rgba(255, 230, 0, 0.15);
+
+  background:
+    rgba(255, 255, 255, 0.02);
+
+  box-shadow:
+    4px 4px 0 #000;
+}
+
+.feature-grid article > span {
+  display: block;
+
+  margin-bottom: 10px;
+
+  color: var(--pink);
+
+  font-size: 0.6rem;
+
+  font-weight: 900;
+}
+
+.feature-grid strong {
+  display: block;
+
+  margin-bottom: 8px;
+
+  color: var(--yellow);
+
+  font-size: 0.76rem;
+}
+
+.feature-grid p {
+  margin: 0;
+
+  color: var(--muted);
+
+  font-size: 0.68rem;
+
+  line-height: 1.7;
+}
+
+/* =========================
+   RESPONSIVE
+========================= */
+
+@media (max-width: 700px) {
+  .page {
+    padding: 30px 10px;
+  }
+
+  .arcade-shell {
+    box-shadow:
+      5px 5px 0 #000,
+      9px 9px 0 var(--pink);
+  }
+
+  .arcade-top,
+  .arcade-footer {
+    flex-wrap: wrap;
+
+    min-height: auto;
+  }
+
+  .tab-list {
+    grid-template-columns:
+      repeat(2, 1fr);
+  }
+
+  .tab:nth-child(2) {
+    border-right: 0;
+  }
+
+  .panel {
+    min-height: 410px;
+
+    padding: 30px 22px;
+  }
+
+  .game-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .game-card {
+    min-height: 85px;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .tab {
+    min-height: 60px;
+
+    font-size: 0.57rem;
+  }
+
+  .tab-index {
+    display: none;
+  }
+
+  .panel {
+    padding: 25px 17px;
+  }
+}
+
+/* =========================
+   REDUCED MOTION
+========================= */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+
+    animation-iteration-count: 1 !important;
+
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue to provide a distinctive and reusable
tab component for the EaseMotion CSS collection.

This PR implements the Retro Arcade Pixel Tabs for #73567.

## Changes

- Added Retro Arcade Pixel tab component
- Added CSS-only tab switching
- Added arcade-inspired neon styling
- Added CRT scanline effect
- Added pixel-style shadows
- Added stepped transition animations
- Added responsive layout
- Added dark-mode friendly styling
- Added reduced-motion support
- Added documentation

## Testing

- Tested all four tab states
- Tested CSS-only tab switching
- Tested hover and active states
- Tested responsive layout
- Tested scanline effect
- Tested reduced-motion behavior
- Verified no JavaScript dependency

Closes #73567