### PR TITLE
feat: add laser ray trace tabs

### DIFF
--- a/submissions/examples/73565-laser-ray-trace-tab/README.md
+++ b/submissions/examples/73565-laser-ray-trace-tab/README.md
@@ -1,0 +1,41 @@
+# Laser Ray Trace Tabs
+
+A futuristic **CSS-only Tabs & Segmented Control** featuring
+a Laser Ray Trace visual style for the EaseMotion CSS
+component collection.
+
+Implemented for **Issue #73565**.
+
+## ✨ Features
+
+- Laser Ray Trace visual effect
+- CSS-only tab switching
+- Animated laser rays
+- Glowing trace points
+- Animated scanner
+- Spectrum visualization
+- Smooth panel transitions
+- Dark-mode compatible styling
+- Responsive layout
+- Hardware-friendly transforms and opacity animations
+- Reduced-motion support
+- No external JavaScript
+- No third-party dependencies
+
+## 🎨 Style
+
+**Category:** Tabs & Segmented Control
+
+**Style:** Laser Ray Trace
+
+The component uses glowing laser rays, scanning lines,
+trace points, and futuristic interface elements to create
+a high-tech visual treatment.
+
+## 📁 Files
+
+```text
+73565-laser-ray-trace-tab/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/73565-laser-ray-trace-tab/demo.html
+++ b/submissions/examples/73565-laser-ray-trace-tab/demo.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="Laser Ray Trace CSS Tabs"
+  >
+
+  <title>Laser Ray Trace Tabs</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="component" aria-labelledby="page-title">
+
+      <header class="intro">
+        <span class="eyebrow">EASEMOTION CSS // TABS</span>
+
+        <h1 id="page-title">LASER RAY TRACE</h1>
+
+        <p>
+          A CSS-only tab interface with animated laser rays,
+          glowing traces, and smooth hardware-accelerated
+          transitions.
+        </p>
+      </header>
+
+      <section class="tab-card" aria-label="Laser Ray Trace tabs">
+
+        <div class="card-top">
+          <span class="system-status">
+            <i></i>
+            SYSTEM ONLINE
+          </span>
+
+          <span>TRACE_73565</span>
+        </div>
+
+        <div class="tabs">
+
+          <input
+            type="radio"
+            name="laser-tabs"
+            id="tab-overview"
+            checked
+          >
+
+          <input
+            type="radio"
+            name="laser-tabs"
+            id="tab-spectrum"
+          >
+
+          <input
+            type="radio"
+            name="laser-tabs"
+            id="tab-scanner"
+          >
+
+          <input
+            type="radio"
+            name="laser-tabs"
+            id="tab-config"
+          >
+
+          <div class="tab-list" role="tablist">
+
+            <label
+              class="tab"
+              for="tab-overview"
+              role="tab"
+            >
+              <span>01</span>
+              Overview
+            </label>
+
+            <label
+              class="tab"
+              for="tab-spectrum"
+              role="tab"
+            >
+              <span>02</span>
+              Spectrum
+            </label>
+
+            <label
+              class="tab"
+              for="tab-scanner"
+              role="tab"
+            >
+              <span>03</span>
+              Scanner
+            </label>
+
+            <label
+              class="tab"
+              for="tab-config"
+              role="tab"
+            >
+              <span>04</span>
+              Config
+            </label>
+
+          </div>
+
+          <div class="panels">
+
+            <!-- Overview -->
+
+            <article
+              class="panel panel-overview"
+              role="tabpanel"
+            >
+
+              <div class="laser-stage">
+
+                <span class="laser-ray ray-one"></span>
+                <span class="laser-ray ray-two"></span>
+                <span class="laser-ray ray-three"></span>
+                <span class="laser-ray ray-four"></span>
+
+                <span class="laser-node"></span>
+
+                <div class="target">
+                  <span></span>
+                </div>
+
+              </div>
+
+              <div class="panel-content">
+
+                <span class="module">MODULE 01</span>
+
+                <h2>Ray Trace Active</h2>
+
+                <p>
+                  Laser-inspired rays sweep through the
+                  interface while the central trace point
+                  continuously pulses with controlled
+                  CSS animations.
+                </p>
+
+                <div class="stats">
+
+                  <div>
+                    <strong>99.8%</strong>
+                    <span>TRACE</span>
+                  </div>
+
+                  <div>
+                    <strong>12ms</strong>
+                    <span>LATENCY</span>
+                  </div>
+
+                  <div>
+                    <strong>0 JS</strong>
+                    <span>DEPENDENCY</span>
+                  </div>
+
+                </div>
+
+              </div>
+
+            </article>
+
+            <!-- Spectrum -->
+
+            <article
+              class="panel panel-spectrum"
+              role="tabpanel"
+            >
+
+              <div class="panel-content full">
+
+                <span class="module">MODULE 02</span>
+
+                <h2>Laser Spectrum</h2>
+
+                <div class="spectrum">
+
+                  <span style="--level: 35%"></span>
+                  <span style="--level: 62%"></span>
+                  <span style="--level: 48%"></span>
+                  <span style="--level: 82%"></span>
+                  <span style="--level: 70%"></span>
+                  <span style="--level: 94%"></span>
+                  <span style="--level: 58%"></span>
+                  <span style="--level: 76%"></span>
+                  <span style="--level: 42%"></span>
+                  <span style="--level: 88%"></span>
+
+                </div>
+
+                <div class="spectrum-labels">
+                  <span>400</span>
+                  <span>500</span>
+                  <span>600</span>
+                  <span>700</span>
+                  <span>800 NM</span>
+                </div>
+
+              </div>
+
+            </article>
+
+            <!-- Scanner -->
+
+            <article
+              class="panel panel-scanner"
+              role="tabpanel"
+            >
+
+              <div class="panel-content full">
+
+                <span class="module">MODULE 03</span>
+
+                <h2>Ray Scanner</h2>
+
+                <div class="scanner">
+
+                  <div class="scan-line"></div>
+
+                  <div class="scan-grid">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                  </div>
+
+                  <div class="scan-target">
+                    <i></i>
+                  </div>
+
+                </div>
+
+              </div>
+
+            </article>
+
+            <!-- Configuration -->
+
+            <article
+              class="panel panel-config"
+              role="tabpanel"
+            >
+
+              <div class="panel-content full">
+
+                <span class="module">MODULE 04</span>
+
+                <h2>Trace Configuration</h2>
+
+                <div class="config-list">
+
+                  <div>
+                    <span>RAY MODE</span>
+                    <strong>CONTINUOUS</strong>
+                  </div>
+
+                  <div>
+                    <span>TRACE SPEED</span>
+                    <strong>FAST</strong>
+                  </div>
+
+                  <div>
+                    <span>HARDWARE ACCELERATION</span>
+                    <strong>ENABLED</strong>
+                  </div>
+
+                  <div>
+                    <span>TRANSITION</span>
+                    <strong>SMOOTH</strong>
+                  </div>
+
+                </div>
+
+              </div>
+
+            </article>
+
+          </div>
+
+        </div>
+
+        <div class="card-bottom">
+          <span>PURE CSS / VANILLA HTML</span>
+          <span class="ready">● READY</span>
+        </div>
+
+      </section>
+
+      <div class="features">
+
+        <article>
+          <span>01</span>
+          <h3>Laser Trace</h3>
+          <p>
+            Animated rays create a futuristic laser-tracing
+            visual around the active interface.
+          </p>
+        </article>
+
+        <article>
+          <span>02</span>
+          <h3>CSS Only</h3>
+          <p>
+            Native radio controls provide tab switching
+            without external JavaScript.
+          </p>
+        </article>
+
+        <article>
+          <span>03</span>
+          <h3>Responsive</h3>
+          <p>
+            The component adapts to smaller screens while
+            preserving the laser visual effect.
+          </p>
+        </article>
+
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/73565-laser-ray-trace-tab/style.css
+++ b/submissions/examples/73565-laser-ray-trace-tab/style.css
@@ -1,0 +1,1201 @@
+:root {
+  --bg: #05070d;
+  --surface: #0c101a;
+  --surface-light: #111827;
+
+  --text: #f5f8ff;
+  --muted: #8994aa;
+
+  --laser: #00f0ff;
+  --laser-blue: #1687ff;
+  --laser-purple: #8b5cf6;
+  --accent: #ff3bd4;
+
+  --border: #202b41;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+
+  margin: 0;
+
+  color: var(--text);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      rgba(0, 240, 255, 0.08),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 85%,
+      rgba(139, 92, 246, 0.09),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+
+  padding: 60px 16px;
+}
+
+.component {
+  width: min(100%, 1050px);
+
+  margin: auto;
+}
+
+/* =========================
+   INTRO
+========================= */
+
+.intro {
+  max-width: 720px;
+
+  margin: 0 auto 42px;
+
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+
+  margin-bottom: 14px;
+
+  color: var(--laser);
+
+  font-size: 0.68rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.18em;
+}
+
+.intro h1 {
+  margin: 0 0 16px;
+
+  font-size:
+    clamp(2.5rem, 7vw, 5rem);
+
+  line-height: 0.95;
+
+  letter-spacing: -0.05em;
+
+  background:
+    linear-gradient(
+      100deg,
+      var(--laser),
+      #ffffff 48%,
+      var(--accent)
+    );
+
+  -webkit-background-clip: text;
+  background-clip: text;
+
+  color: transparent;
+}
+
+.intro p {
+  margin: 0;
+
+  color: var(--muted);
+
+  font-size: 0.82rem;
+
+  line-height: 1.8;
+}
+
+/* =========================
+   CARD
+========================= */
+
+.tab-card {
+  position: relative;
+
+  overflow: hidden;
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius: 18px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(17, 24, 39, 0.97),
+      rgba(6, 9, 16, 0.98)
+    );
+
+  box-shadow:
+    0 28px 80px
+    rgba(0, 0, 0, 0.42);
+
+  isolation: isolate;
+}
+
+.tab-card::before {
+  position: absolute;
+
+  inset: 0;
+
+  content: "";
+
+  pointer-events: none;
+
+  background:
+    linear-gradient(
+      105deg,
+      transparent 15%,
+      rgba(0, 240, 255, 0.04) 50%,
+      transparent 85%
+    );
+
+  transform:
+    translateX(-100%);
+
+  animation:
+    surfaceTrace 8s ease-in-out infinite;
+}
+
+@keyframes surfaceTrace {
+  0%,
+  55% {
+    transform: translateX(-100%);
+  }
+
+  78%,
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.card-top,
+.card-bottom {
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  gap: 20px;
+
+  padding: 16px 20px;
+
+  color: var(--muted);
+
+  background:
+    rgba(3, 6, 12, 0.75);
+
+  font-size: 0.61rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.08em;
+}
+
+.card-top {
+  border-bottom:
+    1px solid
+    var(--border);
+}
+
+.card-bottom {
+  border-top:
+    1px solid
+    var(--border);
+}
+
+.system-status {
+  display: flex;
+
+  align-items: center;
+
+  gap: 8px;
+}
+
+.system-status i {
+  width: 7px;
+  height: 7px;
+
+  border-radius: 50%;
+
+  background: var(--laser);
+
+  box-shadow:
+    0 0 12px
+    var(--laser);
+
+  animation:
+    statusBlink 1.6s ease-in-out infinite;
+}
+
+@keyframes statusBlink {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.ready {
+  color: var(--laser);
+}
+
+/* =========================
+   RADIO INPUTS
+========================= */
+
+.tabs > input {
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+
+  opacity: 0;
+
+  pointer-events: none;
+}
+
+/* =========================
+   TABS
+========================= */
+
+.tab-list {
+  display: grid;
+
+  grid-template-columns:
+    repeat(4, 1fr);
+
+  background:
+    rgba(5, 8, 15, 0.9);
+
+  border-bottom:
+    1px solid
+    var(--border);
+}
+
+.tab {
+  position: relative;
+
+  display: flex;
+
+  align-items: center;
+
+  justify-content: center;
+
+  gap: 10px;
+
+  min-height: 72px;
+
+  padding: 12px;
+
+  cursor: pointer;
+
+  color: var(--muted);
+
+  border-right:
+    1px solid
+    var(--border);
+
+  font-size: 0.7rem;
+
+  font-weight: 750;
+
+  transition:
+    color 180ms ease,
+    background 180ms ease;
+}
+
+.tab:last-child {
+  border-right: 0;
+}
+
+.tab > span {
+  color: var(--laser);
+
+  font-size: 0.58rem;
+
+  font-weight: 900;
+}
+
+.tab::before {
+  position: absolute;
+
+  left: 50%;
+  bottom: 0;
+
+  width: 0;
+  height: 2px;
+
+  content: "";
+
+  background:
+    linear-gradient(
+      90deg,
+      var(--laser),
+      var(--accent)
+    );
+
+  box-shadow:
+    0 0 14px
+    var(--laser);
+
+  transform:
+    translateX(-50%);
+
+  transition:
+    width 220ms ease;
+}
+
+.tab:hover {
+  color: var(--text);
+
+  background:
+    rgba(0, 240, 255, 0.035);
+}
+
+#tab-overview:checked ~ .tab-list label[for="tab-overview"],
+#tab-spectrum:checked ~ .tab-list label[for="tab-spectrum"],
+#tab-scanner:checked ~ .tab-list label[for="tab-scanner"],
+#tab-config:checked ~ .tab-list label[for="tab-config"] {
+  color: var(--text);
+
+  background:
+    rgba(0, 240, 255, 0.055);
+}
+
+#tab-overview:checked ~ .tab-list label[for="tab-overview"]::before,
+#tab-spectrum:checked ~ .tab-list label[for="tab-spectrum"]::before,
+#tab-scanner:checked ~ .tab-list label[for="tab-scanner"]::before,
+#tab-config:checked ~ .tab-list label[for="tab-config"]::before {
+  width: 72%;
+}
+
+/* =========================
+   PANELS
+========================= */
+
+.panels {
+  min-height: 410px;
+}
+
+.panel {
+  display: none;
+
+  min-height: 410px;
+
+  padding: 46px;
+
+  animation:
+    panelTrace 420ms
+    cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+#tab-overview:checked ~ .panels .panel-overview,
+#tab-spectrum:checked ~ .panels .panel-spectrum,
+#tab-scanner:checked ~ .panels .panel-scanner,
+#tab-config:checked ~ .panels .panel-config {
+  display: flex;
+}
+
+@keyframes panelTrace {
+  from {
+    opacity: 0;
+
+    transform:
+      translateX(20px)
+      scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+
+    transform:
+      translateX(0)
+      scale(1);
+  }
+}
+
+.panel-content {
+  flex: 1;
+}
+
+.panel-content.full {
+  width: 100%;
+}
+
+.module {
+  display: block;
+
+  margin-bottom: 10px;
+
+  color: var(--accent);
+
+  font-size: 0.61rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.14em;
+}
+
+.panel h2 {
+  margin: 0 0 15px;
+
+  font-size:
+    clamp(1.8rem, 4vw, 3rem);
+
+  letter-spacing: -0.04em;
+}
+
+.panel p {
+  max-width: 620px;
+
+  margin: 0;
+
+  color: var(--muted);
+
+  font-size: 0.79rem;
+
+  line-height: 1.8;
+}
+
+/* =========================
+   LASER STAGE
+========================= */
+
+.panel-overview {
+  align-items: center;
+
+  gap: 70px;
+}
+
+.laser-stage {
+  position: relative;
+
+  width: 210px;
+  height: 210px;
+
+  flex-shrink: 0;
+
+  display: grid;
+
+  place-items: center;
+
+  border:
+    1px solid
+    rgba(0, 240, 255, 0.18);
+
+  border-radius: 50%;
+
+  background:
+    radial-gradient(
+      circle,
+      rgba(0, 240, 255, 0.12),
+      transparent 62%
+    );
+
+  overflow: hidden;
+}
+
+.laser-stage::before,
+.laser-stage::after {
+  position: absolute;
+
+  content: "";
+
+  width: 150%;
+
+  height: 1px;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      var(--laser),
+      transparent
+    );
+
+  box-shadow:
+    0 0 12px
+    var(--laser);
+
+  opacity: 0.7;
+
+  transform:
+    rotate(32deg);
+
+  animation:
+    stageRay 2.4s linear infinite;
+}
+
+.laser-stage::after {
+  transform:
+    rotate(-32deg);
+
+  animation-delay: -1.2s;
+}
+
+@keyframes stageRay {
+  from {
+    translate: -60% 0;
+  }
+
+  to {
+    translate: 60% 0;
+  }
+}
+
+.laser-ray {
+  position: absolute;
+
+  left: 50%;
+  top: 50%;
+
+  width: 170px;
+  height: 1px;
+
+  transform-origin: left center;
+
+  background:
+    linear-gradient(
+      90deg,
+      var(--laser),
+      transparent
+    );
+
+  box-shadow:
+    0 0 9px
+    var(--laser);
+
+  opacity: 0.7;
+}
+
+.ray-one {
+  transform:
+    rotate(0deg);
+
+  animation:
+    raySweep 3s linear infinite;
+}
+
+.ray-two {
+  transform:
+    rotate(90deg);
+
+  animation:
+    raySweep 3s linear infinite -0.75s;
+}
+
+.ray-three {
+  transform:
+    rotate(180deg);
+
+  animation:
+    raySweep 3s linear infinite -1.5s;
+}
+
+.ray-four {
+  transform:
+    rotate(270deg);
+
+  animation:
+    raySweep 3s linear infinite -2.25s;
+}
+
+@keyframes raySweep {
+  50% {
+    opacity: 0.15;
+
+    scale: 0.55 1;
+  }
+}
+
+.laser-node {
+  position: absolute;
+
+  width: 30px;
+  height: 30px;
+
+  border-radius: 50%;
+
+  background:
+    var(--laser);
+
+  box-shadow:
+    0 0 12px var(--laser),
+    0 0 35px var(--laser);
+
+  animation:
+    nodePulse 1.5s ease-in-out infinite;
+}
+
+@keyframes nodePulse {
+  50% {
+    scale: 1.35;
+
+    opacity: 0.7;
+  }
+}
+
+.target {
+  position: absolute;
+
+  width: 82px;
+  height: 82px;
+
+  border:
+    1px solid
+    rgba(255, 255, 255, 0.2);
+
+  border-radius: 50%;
+}
+
+.target::before,
+.target::after {
+  position: absolute;
+
+  content: "";
+
+  background: var(--laser);
+}
+
+.target::before {
+  width: 100%;
+  height: 1px;
+
+  left: 0;
+  top: 50%;
+}
+
+.target::after {
+  width: 1px;
+  height: 100%;
+
+  left: 50%;
+  top: 0;
+}
+
+/* =========================
+   STATS
+========================= */
+
+.stats {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 9px;
+
+  margin-top: 28px;
+}
+
+.stats div {
+  padding: 14px;
+
+  border:
+    1px solid
+    var(--border);
+
+  background:
+    rgba(255, 255, 255, 0.02);
+}
+
+.stats strong,
+.stats span {
+  display: block;
+}
+
+.stats strong {
+  margin-bottom: 5px;
+
+  color: var(--laser);
+
+  font-size: 0.95rem;
+}
+
+.stats span {
+  color: var(--muted);
+
+  font-size: 0.5rem;
+
+  letter-spacing: 0.08em;
+}
+
+/* =========================
+   SPECTRUM
+========================= */
+
+.spectrum {
+  height: 230px;
+
+  display: flex;
+
+  align-items: end;
+
+  gap: 10px;
+
+  padding: 20px;
+
+  border:
+    1px solid
+    var(--border);
+
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 43px,
+      rgba(0, 240, 255, 0.045) 44px
+    );
+}
+
+.spectrum span {
+  flex: 1;
+
+  height: var(--level);
+
+  min-width: 8px;
+
+  border-radius:
+    4px 4px 1px 1px;
+
+  background:
+    linear-gradient(
+      to top,
+      var(--laser-blue),
+      var(--laser),
+      #fff
+    );
+
+  box-shadow:
+    0 0 12px
+    rgba(0, 240, 255, 0.35);
+
+  transform-origin: bottom;
+
+  animation:
+    spectrumRise 500ms
+    cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+.spectrum span:nth-child(2) {
+  animation-delay: 50ms;
+}
+
+.spectrum span:nth-child(3) {
+  animation-delay: 100ms;
+}
+
+.spectrum span:nth-child(4) {
+  animation-delay: 150ms;
+}
+
+.spectrum span:nth-child(5) {
+  animation-delay: 200ms;
+}
+
+.spectrum span:nth-child(6) {
+  animation-delay: 250ms;
+}
+
+.spectrum span:nth-child(7) {
+  animation-delay: 300ms;
+}
+
+.spectrum span:nth-child(8) {
+  animation-delay: 350ms;
+}
+
+.spectrum span:nth-child(9) {
+  animation-delay: 400ms;
+}
+
+.spectrum span:nth-child(10) {
+  animation-delay: 450ms;
+}
+
+@keyframes spectrumRise {
+  from {
+    transform: scaleY(0);
+  }
+
+  to {
+    transform: scaleY(1);
+  }
+}
+
+.spectrum-labels {
+  display: flex;
+
+  justify-content: space-between;
+
+  padding: 9px 20px;
+
+  color: var(--muted);
+
+  font-size: 0.53rem;
+}
+
+/* =========================
+   SCANNER
+========================= */
+
+.scanner {
+  position: relative;
+
+  height: 245px;
+
+  overflow: hidden;
+
+  border:
+    1px solid
+    var(--border);
+
+  background:
+    linear-gradient(
+      rgba(0, 240, 255, 0.025) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(0, 240, 255, 0.025) 1px,
+      transparent 1px
+    );
+
+  background-size:
+    35px 35px;
+}
+
+.scan-grid {
+  position: absolute;
+
+  inset: 0;
+
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  grid-template-rows:
+    repeat(2, 1fr);
+}
+
+.scan-grid span {
+  border:
+    1px solid
+    rgba(0, 240, 255, 0.08);
+}
+
+.scan-line {
+  position: absolute;
+
+  z-index: 2;
+
+  left: 0;
+
+  width: 100%;
+
+  height: 2px;
+
+  background:
+    var(--laser);
+
+  box-shadow:
+    0 0 8px var(--laser),
+    0 0 22px var(--laser);
+
+  animation:
+    scanMove 2.5s
+    ease-in-out infinite;
+}
+
+@keyframes scanMove {
+  0%,
+  100% {
+    top: 5%;
+  }
+
+  50% {
+    top: 95%;
+  }
+}
+
+.scan-target {
+  position: absolute;
+
+  left: 50%;
+  top: 50%;
+
+  width: 75px;
+  height: 75px;
+
+  border:
+    1px solid
+    rgba(0, 240, 255, 0.6);
+
+  border-radius: 50%;
+
+  transform:
+    translate(-50%, -50%);
+
+  box-shadow:
+    0 0 25px
+    rgba(0, 240, 255, 0.2);
+}
+
+.scan-target::before,
+.scan-target::after {
+  position: absolute;
+
+  content: "";
+
+  background:
+    var(--laser);
+}
+
+.scan-target::before {
+  left: 50%;
+  top: -12px;
+
+  width: 1px;
+  height: calc(100% + 24px);
+}
+
+.scan-target::after {
+  top: 50%;
+  left: -12px;
+
+  width: calc(100% + 24px);
+  height: 1px;
+}
+
+.scan-target i {
+  position: absolute;
+
+  left: 50%;
+  top: 50%;
+
+  width: 10px;
+  height: 10px;
+
+  border-radius: 50%;
+
+  background:
+    var(--laser);
+
+  box-shadow:
+    0 0 15px
+    var(--laser);
+
+  transform:
+    translate(-50%, -50%);
+}
+
+/* =========================
+   CONFIG
+========================= */
+
+.config-list {
+  display: grid;
+
+  gap: 10px;
+
+  max-width: 720px;
+}
+
+.config-list div {
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  gap: 20px;
+
+  padding: 17px 20px;
+
+  border:
+    1px solid
+    var(--border);
+
+  background:
+    rgba(255, 255, 255, 0.02);
+
+  font-size: 0.64rem;
+}
+
+.config-list span {
+  color: var(--muted);
+}
+
+.config-list strong {
+  color: var(--laser);
+}
+
+/* =========================
+   FEATURES
+========================= */
+
+.features {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 14px;
+
+  margin-top: 24px;
+}
+
+.features article {
+  padding: 22px;
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius: 12px;
+
+  background:
+    rgba(255, 255, 255, 0.015);
+}
+
+.features article > span {
+  display: block;
+
+  margin-bottom: 12px;
+
+  color: var(--accent);
+
+  font-size: 0.58rem;
+
+  font-weight: 900;
+}
+
+.features h3 {
+  margin: 0 0 8px;
+
+  font-size: 0.8rem;
+}
+
+.features p {
+  margin: 0;
+
+  color: var(--muted);
+
+  font-size: 0.68rem;
+
+  line-height: 1.7;
+}
+
+/* =========================
+   RESPONSIVE
+========================= */
+
+@media (max-width: 760px) {
+  .page {
+    padding: 40px 12px;
+  }
+
+  .tab-list {
+    grid-template-columns:
+      repeat(2, 1fr);
+  }
+
+  .tab:nth-child(2) {
+    border-right: 0;
+  }
+
+  .panel {
+    min-height: 470px;
+
+    padding: 30px 22px;
+  }
+
+  .panel-overview {
+    flex-direction: column;
+
+    align-items: flex-start;
+
+    gap: 32px;
+  }
+
+  .laser-stage {
+    width: 170px;
+    height: 170px;
+  }
+
+  .stats,
+  .features {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 460px) {
+  .card-top,
+  .card-bottom {
+    flex-direction: column;
+
+    align-items: flex-start;
+  }
+
+  .tab {
+    min-height: 60px;
+
+    font-size: 0.62rem;
+  }
+
+  .panel {
+    padding: 25px 16px;
+  }
+
+  .spectrum {
+    gap: 6px;
+
+    padding: 12px;
+  }
+
+  .scanner {
+    height: 200px;
+  }
+}
+
+/* =========================
+   REDUCED MOTION
+========================= */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+
+    animation-iteration-count: 1 !important;
+
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
### Description

It is a critical issue to provide a visually distinctive and
reusable tabs component for the EaseMotion CSS collection.

This PR implements the Laser Ray Trace Tabs for #73565.

## Changes

- Added Laser Ray Trace CSS tabs component
- Added CSS-only tab switching
- Added animated laser ray effects
- Added glowing trace node
- Added laser spectrum visualization
- Added animated scanner interface
- Added smooth panel transitions
- Added responsive mobile layout
- Added dark-mode compatible styling
- Added hardware-friendly CSS animations
- Added `prefers-reduced-motion` support
- Added comprehensive README documentation

## Testing

- Tested all four tab states
- Tested CSS-only interaction
- Tested laser ray animations
- Tested spectrum visualization
- Tested scanner animation
- Tested responsive layouts
- Tested mobile layout
- Tested reduced-motion behavior
- Verified no external JavaScript dependency

Closes #73565