### PR TITLE
feat: add basic dot separator demo

### DIFF
--- a/submissions/examples/basic-dot-separator-kk/README.md
+++ b/submissions/examples/basic-dot-separator-kk/README.md
@@ -1,0 +1,35 @@
+# Basic Dot Separator
+
+## What it does
+
+This submission creates a simple CSS-only dot separator utility for inline metadata, labels, and compact text groups.
+
+## How to use it
+
+Place metadata items inside the shared utility class:
+
+```html
+<p class="basic-dot-separator">
+  <span>Updated today</span>
+  <span>4 min read</span>
+  <span>Frontend</span>
+</p>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in cards, article previews, activity rows, changelog items, and dashboard summaries.
+
+## Included features
+
+- Inline dot separator utility
+- Practical article, activity, and dashboard examples
+- Responsive wrapping behavior
+- Muted metadata styling
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the dot separator utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-dot-separator-kk/demo.html
+++ b/submissions/examples/basic-dot-separator-kk/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Dot Separator</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Basic Dot Separator</p>
+          <h1>Small inline separators for metadata, labels, and compact text groups.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only dot separator utility for
+            keeping inline metadata readable in cards, article previews,
+            activity rows, and dashboard summaries.
+          </p>
+        </header>
+
+        <section class="example-grid">
+          <article class="content-card">
+            <h2>Article Preview</h2>
+            <p class="basic-dot-separator">
+              <span>Updated today</span>
+              <span>4 min read</span>
+              <span>Frontend</span>
+            </p>
+          </article>
+
+          <article class="content-card">
+            <h2>Activity Row</h2>
+            <p class="basic-dot-separator">
+              <span>Kriti</span>
+              <span>2 hours ago</span>
+              <span>Reviewed</span>
+            </p>
+          </article>
+
+          <article class="content-card">
+            <h2>Dashboard Meta</h2>
+            <p class="basic-dot-separator">
+              <span>Active</span>
+              <span>12 tasks</span>
+              <span>High priority</span>
+            </p>
+          </article>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;p class="basic-dot-separator"&gt;
+  &lt;span&gt;Updated today&lt;/span&gt;
+  &lt;span&gt;4 min read&lt;/span&gt;
+  &lt;span&gt;Frontend&lt;/span&gt;
+&lt;/p&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-dot-separator-kk/style.css
+++ b/submissions/examples/basic-dot-separator-kk/style.css
@@ -1,0 +1,123 @@
+:root {
+  color-scheme: dark;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.6);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.example-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.content-card,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.content-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.basic-dot-separator {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.basic-dot-separator span + span::before {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  margin-right: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+  vertical-align: middle;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .example-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+}


### PR DESCRIPTION

PR body:

```md
## Pull Request Description

Adds a self-contained Basic Dot Separator demo inside `submissions/examples/basic-dot-separator-kk/`. This submission introduces a simple CSS-only dot separator utility for inline metadata, labels, and compact text groups.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only inline dot separator utility for metadata rows, labels, compact text groups, and small supporting details.

**How does a developer use it?**

```html
<p class="basic-dot-separator">
  <span>Updated today</span>
  <span>4 min read</span>
  <span>Frontend</span>
</p>