### PR TITLE
feat: add basic list item row demo

### DIFF
--- a/submissions/examples/basic-list-item-row-kk/README.md
+++ b/submissions/examples/basic-list-item-row-kk/README.md
@@ -1,0 +1,37 @@
+# Basic List Item Row
+
+## What it does
+
+This submission creates a simple CSS-only list item row utility for settings lists, activity rows, menu items, task lists, and compact content summaries.
+
+## How to use it
+
+Place row content inside the shared utility class:
+
+```html
+<div class="basic-list-item-row">
+  <div>
+    <strong>Account Settings</strong>
+    <p>Manage profile and security options.</p>
+  </div>
+  <span>Open</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many interfaces. It works well in dashboards, profile pages, cards, forms, settings panels, and activity sections.
+
+## Included features
+
+- Basic list item row utility
+- Title, supporting text, and right-side value layout
+- Divider styling between rows
+- Responsive stacked layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained demo that opens directly in a browser
+- `style.css` - raw CSS for the list-row utility
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-list-item-row-kk/demo.html
+++ b/submissions/examples/basic-list-item-row-kk/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic List Item Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="page-card">
+        <header class="page-header">
+          <p class="eyebrow">Basic List Item Row</p>
+          <h1>Clean horizontal rows for settings, activity, tasks, and summaries.</h1>
+          <p class="intro">
+            This demo shows a lightweight CSS-only list row utility for
+            aligning a title, supporting text, and a right-side value or action
+            in compact interface sections.
+          </p>
+        </header>
+
+        <section class="list-panel">
+          <div class="basic-list-item-row">
+            <div>
+              <strong>Account Settings</strong>
+              <p>Manage profile and security options.</p>
+            </div>
+            <span>Open</span>
+          </div>
+
+          <div class="basic-list-item-row">
+            <div>
+              <strong>Notification Rules</strong>
+              <p>Control updates, alerts, and reminders.</p>
+            </div>
+            <span>Active</span>
+          </div>
+
+          <div class="basic-list-item-row">
+            <div>
+              <strong>Recent Activity</strong>
+              <p>Review the latest workspace changes.</p>
+            </div>
+            <span>View</span>
+          </div>
+        </section>
+
+        <div class="usage-panel">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-list-item-row"&gt;
+  &lt;div&gt;
+    &lt;strong&gt;Account Settings&lt;/strong&gt;
+    &lt;p&gt;Manage profile and security options.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span&gt;Open&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-list-item-row-kk/style.css
+++ b/submissions/examples/basic-list-item-row-kk/style.css
@@ -1,0 +1,114 @@
+:root {
+  color-scheme: dark;
+  --panel: rgba(13, 20, 36, 0.92);
+  --panel-soft: rgba(255, 255, 255, 0.03);
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #eef3ff;
+  --muted: rgba(255, 255, 255, 0.62);
+  --body-muted: #a2b1ce;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(143, 167, 255, 0.16), transparent 28%),
+    linear-gradient(180deg, #09111f 0%, #03060c 100%);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.page-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.76rem;
+  color: var(--body-muted);
+}
+
+h1 {
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(1.95rem, 4vw, 2.9rem);
+  line-height: 1.08;
+  max-width: 14ch;
+}
+
+.intro {
+  color: var(--body-muted);
+  line-height: 1.7;
+}
+
+.list-panel,
+.usage-panel {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+}
+
+.basic-list-item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 0;
+}
+
+.basic-list-item-row + .basic-list-item-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-list-item-row p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.basic-list-item-row span {
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #d7e2ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .page-card {
+    padding: 1.4rem;
+  }
+
+  .basic-list-item-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic List Item Row demo inside `submissions/examples/basic-list-item-row-kk/`. This submission introduces a simple CSS-only row utility for settings lists, activity rows, menu items, task lists, and compact content summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only list item row utility for clean horizontal rows with a title, supporting text, and a right-side value or action.

**How does a developer use it?**

```html
<div class="basic-list-item-row">
  <div>
    <strong>Account Settings</strong>
    <p>Manage profile and security options.</p>
  </div>
  <span>Open</span>
</div>