### PR TITLE
Add ease-gamepad-controller-view component

### DIFF
--- a/submissions/examples/gamepad-controller-view-ij/README.md
+++ b/submissions/examples/gamepad-controller-view-ij/README.md
@@ -1,0 +1,11 @@
+# ease-gamepad-controller-view
+
+A gamepad controller where the D-pad pulses, the face buttons glow, and the sticks drift.
+
+## Run
+Open `demo.html` directly in a browser to watch the controller.
+
+## Notes
+- The D-pad pulses in turns.
+- Face buttons glow on press.
+- The sticks drift slightly.

--- a/submissions/examples/gamepad-controller-view-ij/demo.html
+++ b/submissions/examples/gamepad-controller-view-ij/demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-gamepad-controller-view</title>
+</head>
+<body>
+<main class="gcv-pad">
+  <header class="gcv-top">
+    <h1 class="gcv-name">Titan Pro</h1>
+    <span class="gcv-state">Connected</span>
+  </header>
+  <section class="gcv-body" aria-label="controller face">
+    <div class="gcv-dpad" aria-label="d pad">
+      <span class="gcv-dp gcv-dp-up"></span>
+      <span class="gcv-dp gcv-dp-left"></span>
+      <span class="gcv-dp gcv-dp-right"></span>
+      <span class="gcv-dp gcv-dp-down"></span>
+    </div>
+    <span class="gcv-stick gcv-stick-l"></span>
+    <span class="gcv-stick gcv-stick-r"></span>
+    <div class="gcv-btns" aria-label="face buttons">
+      <span class="gcv-btn gcv-btn-a">A</span>
+      <span class="gcv-btn gcv-btn-b">B</span>
+      <span class="gcv-btn gcv-btn-x">X</span>
+      <span class="gcv-btn gcv-btn-y">Y</span>
+    </div>
+  </section>
+  <footer class="gcv-foot">
+    <span class="gcv-batt">Battery 78%</span>
+    <span class="gcv-home">Home</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/gamepad-controller-view-ij/style.css
+++ b/submissions/examples/gamepad-controller-view-ij/style.css
@@ -1,0 +1,28 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;font-optical-sizing:auto}
+body{min-height:100vh;display:grid;place-items:center;background:#1d2030;font-family:'Tahoma',sans-serif}
+.gcv-pad{width:296px;border-radius:26px;padding:20px;background:linear-gradient(150deg,#33364d,#1c1e2c);color:#f0f1fa;box-shadow:0 18px 42px rgba(10,12,24,.65)}
+.gcv-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}
+.gcv-name{font-size:16px;letter-spacing:1px;color:#ffd98f}
+.gcv-state{font-size:11px;color:#7fe0a0;background:#12231b;padding:3px 9px;border-radius:8px}
+.gcv-body{position:relative;height:156px;border-radius:18px;background:#151726;border:2px solid #2e3148;padding:16px}
+.gcv-dpad{position:absolute;left:26px;top:44px;width:56px;height:56px}
+.gcv-dp{position:absolute;background:#3a3e5a;border-radius:4px}
+.gcv-dp-up{left:20px;top:0;width:16px;height:18px;animation:gcv-dpad-pulse-gamepad-controller-view 2.6s ease-in-out infinite}
+.gcv-dp-left{left:0;top:19px;width:18px;height:16px;animation:gcv-dpad-pulse-gamepad-controller-view 2.6s ease-in-out infinite;animation-delay:.4s}
+.gcv-dp-right{right:0;top:19px;width:18px;height:16px;animation:gcv-dpad-pulse-gamepad-controller-view 2.6s ease-in-out infinite;animation-delay:.8s}
+.gcv-dp-down{left:20px;bottom:0;width:16px;height:18px;animation:gcv-dpad-pulse-gamepad-controller-view 2.6s ease-in-out infinite;animation-delay:1.2s}
+.gcv-stick{position:absolute;top:30px;width:44px;height:44px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#5a5e82,#262a42);border:4px solid #2b2e48;animation:gcv-stick-drift-gamepad-controller-view 4s ease-in-out infinite}
+.gcv-stick-l{left:118px}
+.gcv-stick-r{right:26px;animation-delay:.8s}
+.gcv-btns{position:absolute;right:30px;bottom:20px;width:74px;height:58px}
+.gcv-btn{position:absolute;display:grid;place-items:center;width:24px;height:24px;border-radius:50%;font-size:11px;font-weight:700;background:#2c2f48;animation:gcv-button-glow-gamepad-controller-view 3s ease-in-out infinite}
+.gcv-btn-a{right:0;top:32px;color:#7fe0a0}
+.gcv-btn-b{right:28px;top:0;color:#ff9d7a}
+.gcv-btn-x{left:0;top:4px;color:#8fc9ff}
+.gcv-btn-y{left:26px;top:0;color:#ffd166}
+.gcv-foot{display:flex;justify-content:space-between;align-items:center;margin-top:14px}
+.gcv-batt{font-size:11px;color:#8ba1c4}
+.gcv-home{font-size:11px;color:#cfc8e8;background:#2c2f48;border-radius:8px;padding:5px 14px}
+@keyframes gcv-dpad-pulse-gamepad-controller-view{0%,100%{filter:brightness(.7)}50%{filter:brightness(1.35)}}
+@keyframes gcv-button-glow-gamepad-controller-view{0%,100%{box-shadow:0 0 0 rgba(255,209,102,0)}50%{box-shadow:0 0 10px rgba(255,209,102,.55)}}
+@keyframes gcv-stick-drift-gamepad-controller-view{0%,100%{transform:translate(0,0)}50%{transform:translate(5px,-4px)}}


### PR DESCRIPTION
## Component: ease-gamepad-controller-view — pad pulses, buttons glow, and sticks drift

**Closes #74801**

### What this adds
A gamepad controller where the D-pad pulses, the face buttons glow, and the sticks drift.

### Acceptance Criteria covered
- D-pad pulses in turns
- Face buttons glow
- Sticks drift slightly

### Files
- `submissions/examples/gamepad-controller-view-ij/demo.html`
- `submissions/examples/gamepad-controller-view-ij/style.css`
- `submissions/examples/gamepad-controller-view-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the pad pulse, the buttons glow, and the sticks drift.