### PR TITLE
Add Cyberpunk Foucault Pendulum Swing UI

### DIFF
--- a/submissions/examples/cyberpunk-foucault-pendulum-ak/README.md
+++ b/submissions/examples/cyberpunk-foucault-pendulum-ak/README.md
@@ -1,0 +1,17 @@
+# Cyberpunk Foucault Pendulum Swing UI
+
+1. What does this do?
+Creates a hardware-accelerated, pure CSS 3D Foucault Pendulum that simulates both a realistic gravity swing and Earth's rotational precession, wrapped in a neon cyberpunk aesthetic.
+
+2. How is it used?
+```html
+<div class="cyberpunk-floor-grid-ak"></div>
+<div class="cyberpunk-foucault-precession-ak">
+  <div class="cyberpunk-pendulum-arm-ak">
+    <div class="cyberpunk-pendulum-bob-ak"></div>
+  </div>
+</div>
+```
+
+3. Why is it useful?
+It demonstrates the raw power of CSS 3D transforms (`rotateY` for precession + `rotateZ` for swing) working together to create complex, realistic physical simulations without JavaScript. The dark mode cyberpunk aesthetic fits beautifully as a futuristic loader, dashboard idle screen, or ambient background element while remaining fully accessible (respecting `prefers-reduced-motion`).

--- a/submissions/examples/cyberpunk-foucault-pendulum-ak/demo.html
+++ b/submissions/examples/cyberpunk-foucault-pendulum-ak/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Foucault Pendulum Swing</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <!-- Optional floor grid for 3D perspective enhancement -->
+  <div class="cyberpunk-floor-grid-ak"></div>
+  
+  <div class="cyberpunk-foucault-precession-ak">
+    <div class="cyberpunk-pendulum-arm-ak">
+      <div class="cyberpunk-pendulum-bob-ak"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/cyberpunk-foucault-pendulum-ak/style.css
+++ b/submissions/examples/cyberpunk-foucault-pendulum-ak/style.css
@@ -1,0 +1,120 @@
+/* style.css */
+body {
+  background-color: #0b0c10;
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start; /* Hang from top */
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
+  perspective: 1000px;
+}
+
+/* The Foucault Precession Container */
+.cyberpunk-foucault-precession-ak {
+  position: relative;
+  width: 0;
+  height: 0;
+  transform-style: preserve-3d;
+  animation: precession-ak 15s linear infinite;
+  margin-top: 10vh;
+}
+
+/* The Pendulum Swing */
+.cyberpunk-pendulum-arm-ak {
+  position: absolute;
+  top: 0;
+  left: -2px;
+  width: 4px;
+  height: 50vh;
+  background: linear-gradient(to bottom, rgba(255,0,85,0), #ff0055);
+  box-shadow: 0 0 10px rgba(255,0,85,0.8);
+  transform-origin: top center;
+  animation: swing-ak 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite alternate;
+  transform-style: preserve-3d;
+}
+
+/* The Anchor Point */
+.cyberpunk-foucault-precession-ak::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: -15px;
+  width: 30px;
+  height: 15px;
+  background: #111;
+  border: 1px solid #00f0ff;
+  border-radius: 4px;
+  box-shadow: 0 0 15px rgba(0, 240, 255, 0.4);
+}
+
+/* The Bob (Cyberpunk Core) */
+.cyberpunk-pendulum-bob-ak {
+  position: absolute;
+  bottom: -25px;
+  left: -23px;
+  width: 50px;
+  height: 50px;
+  background: #0a0a0f;
+  border: 2px solid #00f0ff;
+  border-radius: 50%;
+  box-shadow: 
+    0 0 20px rgba(0, 240, 255, 0.6),
+    inset 0 0 15px rgba(0, 240, 255, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.cyberpunk-pendulum-bob-ak::after {
+  content: '';
+  width: 20px;
+  height: 20px;
+  background: #ff0055;
+  border-radius: 50%;
+  box-shadow: 0 0 15px #ff0055;
+  animation: pulse-ak 1.5s ease-in-out infinite alternate;
+}
+
+/* Floor Grid to emphasize 3D space */
+.cyberpunk-floor-grid-ak {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 40vh;
+  background: 
+    linear-gradient(transparent 90%, rgba(0,240,255,0.15) 100%),
+    linear-gradient(90deg, transparent 95%, rgba(0,240,255,0.15) 100%);
+  background-size: 50px 50px;
+  transform: rotateX(75deg);
+  transform-origin: bottom;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Animations */
+@keyframes precession-ak {
+  0% { transform: rotateY(0deg); }
+  100% { transform: rotateY(360deg); }
+}
+
+@keyframes swing-ak {
+  0% { transform: rotateZ(35deg); }
+  100% { transform: rotateZ(-35deg); }
+}
+
+@keyframes pulse-ak {
+  0% { transform: scale(0.8); opacity: 0.7; }
+  100% { transform: scale(1.2); opacity: 1; }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .cyberpunk-foucault-precession-ak,
+  .cyberpunk-pendulum-arm-ak,
+  .cyberpunk-pendulum-bob-ak::after {
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
fixes #75154 

## Pull Request Description

This PR introduces a pure CSS Cyberpunk & Sci-Fi component that simulates a Foucault Pendulum. It combines `preserve-3d`, `rotateZ` for gravity swinging, and `rotateY` for Earth's rotational precession, delivering a highly realistic physics simulation wrapped in a neon cyberpunk aesthetic without any JavaScript.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Creates a hardware-accelerated, pure CSS 3D Foucault Pendulum that simulates both a realistic gravity swing and Earth's rotational precession, wrapped in a neon cyberpunk aesthetic.

**How does a developer use it?**

```html
<div class="cyberpunk-floor-grid-ak"></div>
<div class="cyberpunk-foucault-precession-ak">
  <div class="cyberpunk-pendulum-arm-ak">
    <div class="cyberpunk-pendulum-bob-ak"></div>
  </div>
</div>
