### PR TITLE
Add ease-drone-flight-hud component

### DIFF
--- a/submissions/examples/drone-flight-hud-ij/README.md
+++ b/submissions/examples/drone-flight-hud-ij/README.md
@@ -1,0 +1,11 @@
+# ease-drone-flight-hud
+
+A drone flight HUD where the altitude slides, the speed ticks, and the battery blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the HUD.
+
+## Notes
+- The altitude ladder slides.
+- The speed tape ticks.
+- The battery blinks low.

--- a/submissions/examples/drone-flight-hud-ij/demo.html
+++ b/submissions/examples/drone-flight-hud-ij/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-drone-flight-hud</title>
+</head>
+<body>
+<main class="dfh-hud">
+  <header class="dfh-top">
+    <h1 class="dfh-model">SkyEye X</h1>
+    <span class="dfh-armed">Armed</span>
+  </header>
+  <section class="dfh-stage" aria-label="flight hud">
+    <div class="dfh-alt" aria-label="altitude ladder">
+      <span class="dfh-altl">80</span>
+      <span class="dfh-altl">60</span>
+      <span class="dfh-altl">40</span>
+      <span class="dfh-altl">20</span>
+      <span class="dfh-altl">0</span>
+    </div>
+    <div class="dfh-tape" aria-label="speed tape">
+      <span class="dfh-tapel">30</span>
+      <span class="dfh-tapel">35</span>
+      <span class="dfh-tapel">40</span>
+      <span class="dfh-tapel">45</span>
+    </div>
+    <strong class="dfh-speed">38 km/h</strong>
+    <span class="dfh-horizon"></span>
+  </section>
+  <footer class="dfh-foot">
+    <span class="dfh-batt">Battery 32%</span>
+    <span class="dfh-home">Home 540 m</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/drone-flight-hud-ij/style.css
+++ b/submissions/examples/drone-flight-hud-ij/style.css
@@ -1,0 +1,19 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;overscroll-behavior:contain}
+body{min-height:100vh;display:grid;place-items:center;background:#0d1512;font-family:'Courier New',monospace}
+.dfh-hud{width:300px;border-radius:16px;padding:16px;background:linear-gradient(175deg,#12231c,#0a1410);color:#b7f2d4;box-shadow:0 16px 38px rgba(5,12,9,.65)}
+.dfh-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.dfh-model{font-size:16px;letter-spacing:2px;color:#8ff0c9}
+.dfh-armed{font-size:11px;color:#ff7a7a;background:#331a1a;padding:3px 9px;border-radius:8px;animation:dfh-battery-blink-drone-flight-hud 2s steps(2) infinite}
+.dfh-stage{position:relative;height:158px;border-radius:12px;background:#0c1a13;border:2px solid #24503a;overflow:hidden}
+.dfh-alt{position:absolute;left:0;top:0;bottom:0;width:40px;display:flex;flex-direction:column;justify-content:center;gap:10px;background:#0f2118;animation:dfh-altitude-slide-drone-flight-hud 4.5s ease-in-out infinite}
+.dfh-altl{text-align:center;font-size:11px;color:#7fe0a0}
+.dfh-tape{position:absolute;right:0;top:0;bottom:0;width:42px;display:flex;flex-direction:column;justify-content:center;gap:14px;background:#0f2118}
+.dfh-tapel{text-align:center;font-size:11px;color:#ffd166;animation:dfh-speed-tick-drone-flight-hud 1.2s steps(2) infinite}
+.dfh-speed{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font-size:22px;color:#b7f2d4}
+.dfh-horizon{position:absolute;left:42px;right:42px;top:50%;height:2px;background:#3dd6c9;opacity:.5}
+.dfh-foot{display:flex;justify-content:space-between;align-items:center;margin-top:10px}
+.dfh-batt{font-size:11px;color:#ff9d7a;animation:dfh-battery-blink-drone-flight-hud 2.4s steps(2) infinite}
+.dfh-home{font-size:11px;color:#9fc9b2}
+@keyframes dfh-altitude-slide-drone-flight-hud{0%,100%{transform:translateY(0)}50%{transform:translateY(-18px)}}
+@keyframes dfh-speed-tick-drone-flight-hud{0%,100%{opacity:.4}50%{opacity:1}}
+@keyframes dfh-battery-blink-drone-flight-hud{0%,100%{opacity:1}50%{opacity:.35}}


### PR DESCRIPTION
## Component: ease-drone-flight-hud — altitude slides, speed ticks, and battery blinks

**Closes #74803**

### What this adds
A drone flight HUD where the altitude slides, the speed ticks, and the battery blinks.

### Acceptance Criteria covered
- Altitude ladder slides
- Speed tape ticks
- Battery blinks low

### Files
- `submissions/examples/drone-flight-hud-ij/demo.html`
- `submissions/examples/drone-flight-hud-ij/style.css`
- `submissions/examples/drone-flight-hud-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the altitude slide, the speed tick, and the battery blink.