### PR TITLE
Add ease-photo-booth-strip component

### DIFF
--- a/submissions/examples/photo-booth-strip-ij/README.md
+++ b/submissions/examples/photo-booth-strip-ij/README.md
@@ -1,0 +1,11 @@
+# ease-photo-booth-strip
+
+A photo booth strip where the flash flickers, the countdown blinks, and the frames fade.
+
+## Run
+Open `demo.html` directly in a browser to watch the booth.
+
+## Notes
+- The flash flickers on capture.
+- The countdown blinks down.
+- Frames fade into the strip.

--- a/submissions/examples/photo-booth-strip-ij/demo.html
+++ b/submissions/examples/photo-booth-strip-ij/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-photo-booth-strip</title>
+</head>
+<body>
+<main class="pbs-booth">
+  <header class="pbs-top">
+    <h1 class="pbs-title">Photo Booth</h1>
+    <span class="pbs-ready">Ready</span>
+  </header>
+  <section class="pbs-lamp" aria-label="studio flash">
+    <span class="pbs-flash"></span>
+  </section>
+  <section class="pbs-count" aria-label="countdown">
+    <strong class="pbs-num">3</strong>
+  </section>
+  <section class="pbs-strip" aria-label="photo strip">
+    <div class="pbs-frame"><span class="pbs-shot pbs-one"></span></div>
+    <div class="pbs-frame"><span class="pbs-shot pbs-two"></span></div>
+    <div class="pbs-frame"><span class="pbs-shot pbs-three"></span></div>
+  </section>
+  <footer class="pbs-foot">
+    <button class="pbs-go">Start</button>
+    <span class="pbs-print">Strip 04</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/photo-booth-strip-ij/style.css
+++ b/submissions/examples/photo-booth-strip-ij/style.css
@@ -1,0 +1,22 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;-webkit-text-size-adjust:100%}
+body{min-height:100vh;display:grid;place-items:center;background:#221c2a;font-family:'Trebuchet MS',sans-serif}
+.pbs-booth{width:288px;border-radius:18px;padding:16px;background:linear-gradient(165deg,#372e46,#1f1a28);color:#f4eefb;box-shadow:0 16px 38px rgba(14,10,20,.65)}
+.pbs-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.pbs-title{font-size:16px;letter-spacing:1px;color:#ffd166}
+.pbs-ready{font-size:11px;color:#7fe0a0;background:#12231b;padding:3px 9px;border-radius:8px}
+.pbs-lamp{height:16px;margin-bottom:10px;border-radius:8px;background:#191420;display:grid;place-items:center}
+.pbs-flash{width:30px;height:10px;border-radius:6px;background:#ffe9a8;animation:pbs-flash-flicker-photo-booth-strip 2.6s steps(2) infinite}
+.pbs-count{text-align:center;margin-bottom:12px}
+.pbs-num{font-size:26px;color:#ff9d7a;animation:pbs-countdown-blink-photo-booth-strip 1.6s steps(2) infinite}
+.pbs-strip{display:flex;flex-direction:column;gap:8px;padding:10px;border-radius:10px;background:#191420}
+.pbs-frame{border-radius:8px;background:#2c2440;padding:4px}
+.pbs-shot{display:block;height:58px;border-radius:6px;animation:pbs-frame-fade-photo-booth-strip 4s ease-in-out infinite}
+.pbs-one{background:linear-gradient(160deg,#5b86c4,#2c3d66)}
+.pbs-two{background:linear-gradient(160deg,#c46b5b,#662f2c);animation-delay:.8s}
+.pbs-three{background:linear-gradient(160deg,#5bc48f,#2c6646);animation-delay:1.6s}
+.pbs-foot{display:flex;justify-content:space-between;align-items:center;margin-top:12px}
+.pbs-go{font-size:12px;color:#0f1a14;background:#7fe0a0;border:none;border-radius:9px;padding:7px 16px}
+.pbs-print{font-size:11px;color:#b9aee0}
+@keyframes pbs-flash-flicker-photo-booth-strip{0%,100%{opacity:1}50%{opacity:.15}}
+@keyframes pbs-countdown-blink-photo-booth-strip{0%,100%{opacity:1}50%{opacity:.3}}
+@keyframes pbs-frame-fade-photo-booth-strip{0%,100%{opacity:.55}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-photo-booth-strip — flash flickers, countdown blinks, and frames fade

**Closes #74804**

### What this adds
A photo booth strip where the flash flickers, the countdown blinks, and the frames fade.

### Acceptance Criteria covered
- Flash flickers on capture
- Countdown blinks down
- Frames fade into strip

### Files
- `submissions/examples/photo-booth-strip-ij/demo.html`
- `submissions/examples/photo-booth-strip-ij/style.css`
- `submissions/examples/photo-booth-strip-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the flash flicker, the countdown blink, and the frames fade.