### PR TITLE
Add ease-news-ticker-board component

### DIFF
--- a/submissions/examples/news-ticker-board-ij/README.md
+++ b/submissions/examples/news-ticker-board-ij/README.md
@@ -1,0 +1,11 @@
+# ease-news-ticker-board
+
+A news ticker board where the headlines slide, the time blinks, and the flag waves.
+
+## Run
+Open `demo.html` directly in a browser to watch the ticker.
+
+## Notes
+- Headlines slide across.
+- The clock blinks seconds.
+- The live flag waves.

--- a/submissions/examples/news-ticker-board-ij/demo.html
+++ b/submissions/examples/news-ticker-board-ij/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-news-ticker-board</title>
+</head>
+<body>
+<main class="ntb-board">
+  <header class="ntb-top">
+    <h1 class="ntb-station">Channel 9</h1>
+    <span class="ntb-clock">22:41:05</span>
+    <span class="ntb-flag">LIVE</span>
+  </header>
+  <section class="ntb-crawl" aria-label="headline ticker">
+    <p class="ntb-line">Markets rally after strong jobs report</p>
+    <p class="ntb-line">City opens a new waterfront park</p>
+    <p class="ntb-line">Storm warning lifted for coast</p>
+  </section>
+  <footer class="ntb-foot">
+    <span class="ntb-tape">Weather update: sunny tomorrow</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/news-ticker-board-ij/style.css
+++ b/submissions/examples/news-ticker-board-ij/style.css
@@ -1,0 +1,16 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;hanging-punctuation:none}
+body{min-height:100vh;display:grid;place-items:center;background:#141b2c;font-family:'Arial',sans-serif}
+.ntb-board{width:302px;border-radius:14px;padding:16px;background:linear-gradient(170deg,#1e2c48,#0f1726);color:#eef3fb;box-shadow:0 16px 38px rgba(6,10,20,.65)}
+.ntb-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.ntb-station{font-size:15px;letter-spacing:1px;color:#ffd166}
+.ntb-clock{font-size:12px;color:#8fc9ff;animation:ntb-clock-blink-news-ticker-board 2s steps(2) infinite}
+.ntb-flag{font-size:10px;font-weight:700;color:#ff7a7a;background:#331a1a;padding:3px 8px;border-radius:6px;animation:ntb-flag-wave-news-ticker-board 2.4s ease-in-out infinite}
+.ntb-crawl{overflow:hidden;border-radius:10px;background:#0c1420;padding:10px;margin-bottom:12px}
+.ntb-line{font-size:13px;color:#dce7f3;white-space:nowrap;margin-bottom:8px;animation:ntb-headline-slide-news-ticker-board 9s linear infinite}
+.ntb-line:nth-child(2){animation-delay:3s}
+.ntb-line:nth-child(3){animation-delay:6s}
+.ntb-foot{border-radius:10px;background:#0c1420;padding:8px 12px;overflow:hidden}
+.ntb-tape{display:block;font-size:12px;color:#ffd98f;white-space:nowrap;animation:ntb-headline-slide-news-ticker-board 12s linear infinite}
+@keyframes ntb-headline-slide-news-ticker-board{0%{transform:translateX(100%)}100%{transform:translateX(-100%)}}
+@keyframes ntb-clock-blink-news-ticker-board{0%,100%{opacity:1}50%{opacity:.4}}
+@keyframes ntb-flag-wave-news-ticker-board{0%,100%{transform:rotate(0deg)}50%{transform:rotate(6deg)}}


### PR DESCRIPTION
## Component: ease-news-ticker-board — headlines slide, time blinks, and flag waves

**Closes #74806**

### What this adds
A news ticker board where the headlines slide, the time blinks, and the flag waves.

### Acceptance Criteria covered
- Headlines slide across
- Clock blinks seconds
- Live flag waves

### Files
- `submissions/examples/news-ticker-board-ij/demo.html`
- `submissions/examples/news-ticker-board-ij/style.css`
- `submissions/examples/news-ticker-board-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the headlines slide, the time blink, and the flag wave.