### PR TITLE
feat: add 3D glassmorphism tilt & flip card (#75298)

### DIFF
--- a/submissions/examples/3d-glassmorphism-tilt-flip-card/README.md
+++ b/submissions/examples/3d-glassmorphism-tilt-flip-card/README.md
@@ -1,0 +1,15 @@
+# 3D Glassmorphism Tilt & Flip Card
+
+An interactive 3D perspective flip card with a frosted glassmorphism texture,
+smooth 180° rotation, hardware-accelerated CSS transforms, and backface
+depth visibility.
+
+## Usage
+Open `demo.html` — hover the card to trigger the flip.
+
+## Why it fits EaseMotion CSS
+- Pure CSS, zero JavaScript
+- 60fps hover-driven transform (no keyframes needed)
+- Reusable `.card-scene` / `.ease-3d-card` / `.card-face` structure
+
+Closes #75298

--- a/submissions/examples/3d-glassmorphism-tilt-flip-card/demo.html
+++ b/submissions/examples/3d-glassmorphism-tilt-flip-card/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3D Glassmorphism Tilt & Flip Card</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="card-scene">
+    <div class="ease-3d-card">
+      <div class="card-face card-face-front">
+        <span class="card-badge">Pro Feature</span>
+        <h2>EaseMotion Pro</h2>
+        <p>Hover to flip and reveal analytics.</p>
+      </div>
+      <div class="card-face card-face-back">
+        <h2>Card Analytics</h2>
+        <p>Frosted glass, 3D depth, zero JS.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/3d-glassmorphism-tilt-flip-card/style.css
+++ b/submissions/examples/3d-glassmorphism-tilt-flip-card/style.css
@@ -1,0 +1,59 @@
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #1e1b4b, #4c1d95);
+  font-family: system-ui, sans-serif;
+}
+
+.card-scene {
+  perspective: 1000px;
+  width: 100%;
+  max-width: 360px;
+  height: 480px;
+}
+
+.ease-3d-card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
+  cursor: pointer;
+}
+
+.card-scene:hover .ease-3d-card {
+  transform: rotateY(180deg) translateY(-8px);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 32px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+.card-face-back {
+  transform: rotateY(180deg);
+}
+
+.card-badge {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  margin-bottom: 12px;
+}


### PR DESCRIPTION
## Description

This component adds a reusable "tilt & flip" card pattern to EaseMotion CSS's
submission library. It combines two visual techniques that are common in
modern UI design but usually implemented separately:

1. **Glassmorphism** — a frosted, translucent surface built with
   `backdrop-filter: blur()` and a semi-transparent background, so the card
   picks up color/light from whatever sits behind it.
2. **3D flip on hover** — using `perspective` on the parent scene and
   `transform-style: preserve-3d` on the card, the component rotates 180°
   on the Y-axis to reveal a "back" face, with `backface-visibility: hidden`
   ensuring only one face is visible at a time.

The motion uses a spring-like `cubic-bezier(0.34, 1.56, 0.64, 1)` easing
curve so the flip has a slight overshoot/bounce rather than a flat linear
rotation, and a small `translateY(-8px)` lift is layered on top of the
rotation to add depth.

**No JavaScript is required** — everything is driven by the `:hover`
pseudo-class and CSS transforms, so it runs on the compositor thread and
stays smooth at 60fps even on lower-end devices.

### Intended use cases
- Pricing tiers (front = price, back = feature list)
- Team/profile cards (front = photo, back = bio/socials)
- Feature highlight cards (front = icon + title, back = description)

### Structure
- `.card-scene` — sets the 3D perspective and card dimensions
- `.ease-3d-card` — the rotating element (`preserve-3d` + transition)
- `.card-face` / `.card-face-front` / `.card-face-back` — the two glass
  panels, with the back pre-rotated 180° so it lines up after the flip