### PR TITLE
feat: add basic content spacer utility (#75281)

### DIFF
--- a/submissions/examples/basic-content-spacer/README.md
+++ b/submissions/examples/basic-content-spacer/README.md
@@ -1,0 +1,16 @@
+# Basic Content Spacer
+
+A tiny CSS-only utility for consistent vertical spacing between grouped
+content sections — text blocks, cards, form groups, settings sections.
+
+## Usage
+```html
+<div class="basic-content-spacer"></div>
+```
+
+## Variants
+- `.basic-content-spacer` — default 24px gap
+- `.basic-content-spacer-sm` — 12px gap, for tighter grouping
+- `.basic-content-spacer-lg` — 40px gap, for section breaks
+
+Closes #75281

--- a/submissions/examples/basic-content-spacer/demo.html
+++ b/submissions/examples/basic-content-spacer/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Basic Content Spacer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="demo-wrapper">
+    <section class="demo-block">Section One</section>
+    <div class="basic-content-spacer"></div>
+    <section class="demo-block">Section Two</section>
+    <div class="basic-content-spacer basic-content-spacer-sm"></div>
+    <section class="demo-block">Section Three (tighter gap above)</section>
+  </div>
+</body>
+</html>

--- a/submissions/examples/basic-content-spacer/style.css
+++ b/submissions/examples/basic-content-spacer/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 40px;
+}
+
+.demo-wrapper {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.demo-block {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 20px;
+}
+
+/* Default vertical spacer */
+.basic-content-spacer {
+  display: block;
+  width: 100%;
+  height: 24px;
+}
+
+/* Tighter spacing variant */
+.basic-content-spacer-sm {
+  height: 12px;
+}
+
+/* Optional larger variant for section breaks */
+.basic-content-spacer-lg {
+  height: 40px;
+}


### PR DESCRIPTION
## Description

This adds a minimal, CSS-only spacing utility for creating consistent
vertical rhythm between grouped content blocks — things like stacked text
sections, card lists, form field groups, or settings panels where you'd
otherwise reach for repeated inline margins or one-off `margin-bottom`
overrides.

The utility is just an empty block-level element with a fixed height,
placed between content sections. Because the spacing lives in a dedicated
element rather than being baked into margins on the content itself, it's
easy to reason about, easy to swap out, and doesn't cause margin-collapse
surprises the way stacked `margin-top`/`margin-bottom` rules sometimes do.

Three sizes are included so it covers the common cases without needing
custom values every time:

- **Default (`24px`)** — the standard gap for most section-to-section spacing
- **Small (`12px`)** — tighter spacing, e.g. between related form fields
- **Large (`40px`)** — bigger breaks, e.g. between major page sections

### Why is this useful for EaseMotion CSS?
- **Human-readable** — `basic-content-spacer` says exactly what it does,
  no memorizing a spacing scale or utility shorthand
- **Composable** — works as a standalone block between any two elements,
  regardless of what they are
- **Broadly applicable** — useful in cards, forms, docs pages, dashboards,
  marketing pages — basically anywhere content is stacked vertically
- **Zero dependencies, zero JS** — just a `<div>` and a `height` rule

### Scope
This is intentionally kept small: one class plus two size modifiers. No
JavaScript, no configuration, no dependency on other EaseMotion classes.
It's meant to be a simple building block the maintainer can fold into
`core/utilities.css` under the `ease-*` naming convention (e.g.
`ease-spacer`, `ease-spacer-sm`, `ease-spacer-lg`).