### PR TITLE
Add ease-dryer-timer-dial component

### DIFF
--- a/submissions/examples/dryer-timer-dial-ij/README.md
+++ b/submissions/examples/dryer-timer-dial-ij/README.md
@@ -1,0 +1,11 @@
+# ease-dryer-timer-dial
+
+A dryer control where the timer dial turns, the temps glow, and the lint light blinks.
+
+## Run
+Open `demo.html` directly in a browser to watch the dial.
+
+## Notes
+- The timer dial turns.
+- Temp options glow.
+- The lint light blinks.

--- a/submissions/examples/dryer-timer-dial-ij/demo.html
+++ b/submissions/examples/dryer-timer-dial-ij/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>ease-dryer-timer-dial</title>
+</head>
+<body>
+<main class="dtd-dryer">
+  <header class="dtd-top">
+    <h1 class="dtd-model">DryMaster</h1>
+    <span class="dtd-state">Running</span>
+  </header>
+  <section class="dtd-dial" aria-label="timer dial">
+    <span class="dtd-notch"></span>
+    <span class="dtd-notch"></span>
+    <span class="dtd-notch"></span>
+    <span class="dtd-notch"></span>
+    <span class="dtd-knob"></span>
+  </section>
+  <section class="dtd-temps" aria-label="heat settings">
+    <button class="dtd-temp">Low</button>
+    <button class="dtd-temp">Med</button>
+    <button class="dtd-temp">High</button>
+  </section>
+  <footer class="dtd-foot">
+    <span class="dtd-lint">Lint full</span>
+    <span class="dtd-left">32 min</span>
+  </footer>
+</main>
+</body>
+</html>

--- a/submissions/examples/dryer-timer-dial-ij/style.css
+++ b/submissions/examples/dryer-timer-dial-ij/style.css
@@ -1,0 +1,22 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;isolation:isolate}
+body{min-height:100vh;display:grid;place-items:center;background:#20242e;font-family:'Tahoma',sans-serif}
+.dtd-dryer{width:294px;border-radius:18px;padding:18px;background:linear-gradient(165deg,#313947,#171c24);color:#edf2f8;box-shadow:0 16px 38px rgba(8,10,16,.6)}
+.dtd-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.dtd-model{font-size:16px;letter-spacing:1px;color:#ffd98f}
+.dtd-state{font-size:11px;color:#8ff0c9;background:#12231c;padding:3px 9px;border-radius:8px}
+.dtd-dial{position:relative;height:112px;margin-bottom:14px;border-radius:50%;background:#14181f}
+.dtd-notch{position:absolute;left:50%;top:12px;width:4px;height:12px;margin-left:-2px;background:#4a5870;border-radius:3px}
+.dtd-notch:nth-child(2){transform:rotate(90deg)}
+.dtd-notch:nth-child(3){transform:rotate(180deg)}
+.dtd-notch:nth-child(4){transform:rotate(270deg)}
+.dtd-knob{position:absolute;left:50%;top:50%;width:54px;height:54px;margin:-27px;border-radius:50%;background:radial-gradient(circle at 35% 30%,#5a6a8a,#222a38);animation:dtd-dial-turn-dryer-timer-dial 4.4s ease-in-out infinite}
+.dtd-temps{display:flex;gap:8px;margin-bottom:14px}
+.dtd-temp{flex:1;font-size:11px;color:#c9d6e6;background:#242c3a;border:none;border-radius:9px;padding:9px 0;animation:dtd-temp-glow-dryer-timer-dial 3s ease-in-out infinite}
+.dtd-temp:nth-child(2){animation-delay:.4s}
+.dtd-temp:nth-child(3){animation-delay:.8s}
+.dtd-foot{display:flex;justify-content:space-between;align-items:center}
+.dtd-lint{font-size:11px;color:#ffb38a;background:#33231d;padding:4px 10px;border-radius:8px;animation:dtd-lint-blink-dryer-timer-dial 2.2s steps(2) infinite}
+.dtd-left{font-size:11px;color:#8ba1c4}
+@keyframes dtd-dial-turn-dryer-timer-dial{0%,100%{transform:rotate(0deg)}50%{transform:rotate(34deg)}}
+@keyframes dtd-temp-glow-dryer-timer-dial{0%,100%{filter:brightness(.75)}50%{filter:brightness(1.3)}}
+@keyframes dtd-lint-blink-dryer-timer-dial{0%,100%{opacity:.35}50%{opacity:1}}


### PR DESCRIPTION
## Component: ease-dryer-timer-dial — dial turns, temps glow, and lint blinks

**Closes #74812**

### What this adds
A dryer control where the timer dial turns, the temps glow, and the lint light blinks.

### Acceptance Criteria covered
- Timer dial turns
- Temp options glow
- Lint filter blinks

### Files
- `submissions/examples/dryer-timer-dial-ij/demo.html`
- `submissions/examples/dryer-timer-dial-ij/style.css`
- `submissions/examples/dryer-timer-dial-ij/README.md`

### How to review
Open `demo.html` directly in a browser. Watch the dial turn, the temps glow, and the lint blink.