### PR TITLE
feat: add pure CSS Mesh Gradient 3D Perspective Tilt component (#73820)

### DIFF
--- a/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/README.md
+++ b/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/README.md
@@ -1,0 +1,24 @@
+# CSS Mesh Gradient: 3D Perspective Tilt
+
+A hardware-accelerated, JavaScript-free gradient mesh. Features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors, making the mesh feel like a physical, touchable surface.
+
+## Features
+- Pure CSS and HTML implementation. Absolutely no JavaScript required for the interactive 3D mouse tracking or the fluid gradient mesh.
+- **Component Architecture**: 
+  - **The Vibrant Mesh Gradient**: The background of the card (`.mesh-card-3d`) is created by layering four distinct `radial-gradient` definitions, each anchored to a different corner of the element. A `@keyframes` animation slowly shifts the `background-position` of this complex background, causing the colors to fluidly mix and swirl over time.
+  - **The Hover Grid Hack (3D Interactivity)**: JavaScript is typically required to track mouse position to tilt an element in 3D space. To achieve this physically reactive surface in pure CSS, we use a classic technique: 
+    1. The parent container establishes the 3D space using `perspective: 1200px`.
+    2. Inside the container, we place 9 invisible `div` elements arranged in a 3x3 grid using absolute positioning. These elements sit on top of everything (`z-index: 10`) to catch mouse hover events.
+    3. The actual mesh card sits underneath this invisible grid.
+    4. We use the CSS general sibling combinator (`~`). When you hover over the "top-left" invisible div, CSS applies `transform: rotateX(15deg) rotateY(-15deg)` to the sibling mesh card.
+  - **Dynamic Specular Glare (Lighting Physics)**: To make the gradient feel like a physical, glossy material, an oversized `.specular-glare` element is created using a white `radial-gradient`. Using the same sibling combinator trick, we move this glare in the *opposite* direction of the tilt. A `mix-blend-mode: overlay` is applied so the highlight interacts beautifully with the vibrant underlying mesh colors.
+  - **3D Parallax Content**: The internal content uses `transform: translateZ(50px)`. Because the parent mesh card has `transform-style: preserve-3d`, the content physically pops out of the gradient surface. As the card tilts, the content experiences true parallax.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The mesh uses a slightly deeper, more intense set of neon colors in dark mode.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the invisible hover grid is disabled, the ambient mesh animation is stopped, and the card is given a subtle, static, fixed 3D tilt.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse around the vibrant gradient surface to see it physically react and tilt dynamically towards your cursor. Notice how the internal content pops out in 3D parallax, and observe the specular lighting sweeping across the gradient mesh.
+
+## Files
+- `demo.html`: The HTML structure defining the 9-cell invisible hover grid and the foreground mesh container.
+- `style.css`: The styling, the complex multi-stop `radial-gradient` mesh definitions, the sibling selector logic (`~`) governing the 3D transforms, the specular glare translation, and the `transform-style: preserve-3d` parallax setup.

--- a/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/demo.html
+++ b/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/demo.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Mesh Gradient: 3D Perspective Tilt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Pure CSS Mesh: 3D Tilt</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free gradient mesh. Features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors, making the mesh feel like a physical, touchable surface.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The 3D Perspective Container
+              Establishes the 3D space (`perspective`) for the interactive tilt.
+            -->
+            <div class="tilt-container">
+                
+                <!-- 
+                  [TECHNIQUE] The Hover Grid
+                  A 3x3 grid of invisible elements that catch mouse hovers.
+                  Uses the `~` sibling selector to apply rotation to the mesh card below.
+                -->
+                <div class="hover-zone top-left"></div>
+                <div class="hover-zone top-center"></div>
+                <div class="hover-zone top-right"></div>
+                
+                <div class="hover-zone mid-left"></div>
+                <div class="hover-zone center"></div>
+                <div class="hover-zone mid-right"></div>
+                
+                <div class="hover-zone bottom-left"></div>
+                <div class="hover-zone bottom-center"></div>
+                <div class="hover-zone bottom-right"></div>
+                
+                
+                <!-- 
+                  [TECHNIQUE] The Mesh Card
+                  The element that contains the complex gradient and actually tilts.
+                -->
+                <div class="mesh-card-3d">
+                    
+                    <!-- 
+                       Content is translated in Z space (`translateZ`) to pop out 
+                       when the card tilts, creating a beautiful parallax over the mesh.
+                    -->
+                    <div class="card-content-3d">
+                        <div class="card-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M12 2l9 4.9V17L12 22l-9-4.9V7z"/>
+                                <path d="M12 22V12"/>
+                                <path d="M12 12L2.8 7.1"/>
+                                <path d="M12 12l9.2-4.9"/>
+                            </svg>
+                        </div>
+                        
+                        <h3 class="card-title">Physical Gradients</h3>
+                        <p class="card-text">Move your mouse around this surface. The vibrant multi-stop radial gradient mesh physically reacts to your cursor in 3D space, powered entirely by a 3x3 invisible HTML grid.</p>
+                        
+                        <button class="mesh-button">Interact</button>
+                    </div>
+                    
+                    <!-- A dynamic specular highlight that moves opposite to the tilt to simulate light reflection on the gradient surface -->
+                    <div class="specular-glare"></div>
+                    
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/style.css
+++ b/submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/style.css
@@ -1,0 +1,311 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f1f5f9; 
+    --text-primary: #1e293b;
+    --text-secondary: #475569;
+    
+    /* Mesh Gradient Colors */
+    --mesh-color-1: #3b82f6; /* Blue */
+    --mesh-color-2: #8b5cf6; /* Purple */
+    --mesh-color-3: #ec4899; /* Pink */
+    --mesh-color-4: #f43f5e; /* Rose */
+    
+    /* Structural Elements */
+    --card-shadow: rgba(0, 0, 0, 0.15);
+    --button-bg: rgba(255,255,255,0.2);
+    --button-hover: rgba(255,255,255,0.3);
+    
+    /* 3D Tilt Configuration */
+    --tilt-deg: 15deg;
+    --perspective: 1200px;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #020617; 
+        --text-primary: #f8fafc;
+        --text-secondary: #cbd5e1;
+        
+        /* Deeper, more intense neon colors for dark mode */
+        --mesh-color-1: #2563eb; 
+        --mesh-color-2: #7c3aed; 
+        --mesh-color-3: #db2777; 
+        --mesh-color-4: #e11d48; 
+        
+        --card-shadow: rgba(0, 0, 0, 0.5);
+        --button-bg: rgba(0,0,0,0.2);
+        --button-hover: rgba(0,0,0,0.4);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -1px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 100px 0;
+    min-height: 400px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The 3D Perspective Tilt System
+   ========================================= */
+
+.tilt-container {
+    position: relative;
+    width: 340px;
+    height: 460px;
+    /* Establish the 3D space */
+    perspective: var(--perspective);
+}
+
+/* 
+   The Hover Grid
+   We divide the container into a 3x3 grid (9 invisible divs).
+   They sit on top of the card (z-index: 10) to catch mouse events.
+*/
+.hover-zone {
+    position: absolute;
+    width: 33.33%;
+    height: 33.33%;
+    z-index: 10;
+    /* border: 1px solid rgba(255,0,0,0.3); /* Uncomment to visualize the grid */
+}
+
+/* Position the 9 zones */
+.top-left { top: 0; left: 0; }
+.top-center { top: 0; left: 33.33%; }
+.top-right { top: 0; left: 66.66%; }
+.mid-left { top: 33.33%; left: 0; }
+.center { top: 33.33%; left: 33.33%; }
+.mid-right { top: 33.33%; left: 66.66%; }
+.bottom-left { top: 66.66%; left: 0; }
+.bottom-center { top: 66.66%; left: 33.33%; }
+.bottom-right { top: 66.66%; left: 66.66%; }
+
+
+/* =========================================
+   [TECHNIQUE] The Mesh Gradient Surface
+   ========================================= */
+
+.mesh-card-3d {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    
+    border-radius: 24px;
+    box-shadow: 0 30px 60px var(--card-shadow);
+    
+    /* Crucial for 3D children (the parallax content) */
+    transform-style: preserve-3d;
+    
+    /* Smoothly animate back to resting state when not hovered */
+    transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+    
+    overflow: hidden;
+    
+    /* 
+       The Complex Mesh Gradient
+       Created by layering multiple radial gradients with different anchor points.
+       To make the colors pop, we use a white text scheme internally.
+    */
+    background-color: var(--mesh-color-1);
+    background-image: 
+        radial-gradient(at 0% 0%, var(--mesh-color-2) 0px, transparent 60%),
+        radial-gradient(at 100% 0%, var(--mesh-color-3) 0px, transparent 60%),
+        radial-gradient(at 100% 100%, var(--mesh-color-4) 0px, transparent 60%),
+        radial-gradient(at 0% 100%, var(--mesh-color-2) 0px, transparent 60%);
+    background-size: 150% 150%;
+    
+    /* We force light text inside the mesh card regardless of system theme */
+    color: #ffffff;
+    
+    /* Animate the mesh background independently of the tilt */
+    animation: mesh-shift 15s ease infinite alternate;
+}
+
+@keyframes mesh-shift {
+    0% { background-position: 0% 0%; }
+    50% { background-position: 100% 100%; }
+    100% { background-position: 0% 100%; }
+}
+
+/* 
+   [TECHNIQUE] Sibling Selectors for Tilt Logic
+   Hovering a specific zone applies a specific rotateX/Y to the sibling `.mesh-card-3d`.
+*/
+.hover-zone.top-left:hover ~ .mesh-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(calc(var(--tilt-deg) * -1)); }
+.hover-zone.top-center:hover ~ .mesh-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(0deg); }
+.hover-zone.top-right:hover ~ .mesh-card-3d { transform: rotateX(var(--tilt-deg)) rotateY(var(--tilt-deg)); }
+
+.hover-zone.mid-left:hover ~ .mesh-card-3d { transform: rotateX(0deg) rotateY(calc(var(--tilt-deg) * -1)); }
+.hover-zone.center:hover ~ .mesh-card-3d { transform: rotateX(0deg) rotateY(0deg); }
+.hover-zone.mid-right:hover ~ .mesh-card-3d { transform: rotateX(0deg) rotateY(var(--tilt-deg)); }
+
+.hover-zone.bottom-left:hover ~ .mesh-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(calc(var(--tilt-deg) * -1)); }
+.hover-zone.bottom-center:hover ~ .mesh-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(0deg); }
+.hover-zone.bottom-right:hover ~ .mesh-card-3d { transform: rotateX(calc(var(--tilt-deg) * -1)) rotateY(var(--tilt-deg)); }
+
+
+/* 
+   [TECHNIQUE] The Specular Highlight
+   Simulates physical lighting on the mesh surface.
+   It moves in the *opposite* direction of the tilt.
+*/
+.specular-glare {
+    position: absolute;
+    top: -50%; left: -50%;
+    width: 200%; height: 200%;
+    background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.4) 0%, transparent 60%);
+    pointer-events: none;
+    z-index: 1;
+    
+    /* Blend mode makes the highlight interact beautifully with the vibrant mesh colors */
+    mix-blend-mode: overlay;
+    
+    transform: translate(0, 0);
+    transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* Move glare based on hover zones */
+.hover-zone.top-left:hover ~ .mesh-card-3d .specular-glare { transform: translate(20%, 20%); }
+.hover-zone.top-center:hover ~ .mesh-card-3d .specular-glare { transform: translate(0, 20%); }
+.hover-zone.top-right:hover ~ .mesh-card-3d .specular-glare { transform: translate(-20%, 20%); }
+.hover-zone.mid-left:hover ~ .mesh-card-3d .specular-glare { transform: translate(20%, 0); }
+.hover-zone.center:hover ~ .mesh-card-3d .specular-glare { transform: translate(0, 0); }
+.hover-zone.mid-right:hover ~ .mesh-card-3d .specular-glare { transform: translate(-20%, 0); }
+.hover-zone.bottom-left:hover ~ .mesh-card-3d .specular-glare { transform: translate(20%, -20%); }
+.hover-zone.bottom-center:hover ~ .mesh-card-3d .specular-glare { transform: translate(0, -20%); }
+.hover-zone.bottom-right:hover ~ .mesh-card-3d .specular-glare { transform: translate(-20%, -20%); }
+
+
+/* =========================================
+   Card Content (3D Parallax)
+   ========================================= */
+
+.card-content-3d {
+    position: relative;
+    width: 100%; height: 100%;
+    padding: 50px 30px;
+    box-sizing: border-box;
+    text-align: center;
+    z-index: 2;
+    
+    /* [TECHNIQUE] Push content forward in 3D space so it floats above the mesh surface */
+    transform: translateZ(50px);
+}
+
+.card-icon {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    margin-bottom: 24px;
+    color: #ffffff;
+    
+    /* Additional subtle animation on the inner icon */
+    animation: icon-float 3s ease-in-out infinite alternate;
+}
+
+@keyframes icon-float {
+    0% { transform: translateY(0); }
+    100% { transform: translateY(-5px); }
+}
+
+.card-title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin: 0 0 12px 0;
+}
+
+.card-text {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.9);
+    margin: 0 0 40px 0;
+}
+
+.mesh-button {
+    width: 100%;
+    padding: 16px 0;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: var(--button-bg);
+    color: #ffffff;
+    font-family: inherit;
+    font-weight: 700;
+    font-size: 1rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    cursor: pointer;
+    
+    transition: all 0.3s ease;
+}
+
+.mesh-button:hover {
+    background: var(--button-hover);
+    transform: translateY(-2px);
+}
+
+
+/* Accessibility - Disable interactive tilt and mesh shift for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .mesh-card-3d { 
+        animation: none !important; 
+        /* Static slight tilt */
+        transform: rotateX(5deg) rotateY(-10deg) !important;
+    }
+    
+    .card-icon { animation: none !important; }
+    
+    .hover-zone { display: none !important; /* Disable the interactive grid */ }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free gradient mesh. It features a fully interactive 3D perspective tilt effect achieved purely through CSS sibling selectors, making the mesh feel like a physical, touchable surface. Resolves issue #73820.

### Changes Made:
- Added `submissions/examples/css-mesh-gradient-3d-perspective-tilt-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the 9-cell invisible hover grid and the foreground mesh container.
- Created `style.css` featuring the UI mechanics:
  - **The Vibrant Mesh Gradient**: The background of the card is created by layering four distinct `radial-gradient` definitions, each anchored to a different corner of the element. A `@keyframes` animation slowly shifts the `background-position` of this complex background, causing the colors to fluidly mix and swirl over time.
  - **The Hover Grid Hack (3D Interactivity)**: JavaScript is typically required to track mouse position to tilt an element in 3D space. To achieve this physically reactive surface in pure CSS, we use a classic technique. The parent container establishes the 3D space using `perspective: 1200px`. Inside the container, we place 9 invisible `div` elements arranged in a 3x3 grid using absolute positioning. These elements sit on top of everything to catch mouse hover events. The actual mesh card sits underneath this invisible grid. We use the CSS general sibling combinator (`~`). When you hover over the "top-left" invisible div, CSS applies `transform: rotateX(15deg) rotateY(-15deg)` to the sibling mesh card.
  - **Dynamic Specular Glare (Lighting Physics)**: To make the gradient feel like a physical, glossy material, an oversized `.specular-glare` element is created using a white `radial-gradient`. Using the same sibling combinator trick, we move this glare in the *opposite* direction of the tilt. A `mix-blend-mode: overlay` is applied so the highlight interacts beautifully with the vibrant underlying mesh colors.
  - **3D Parallax Content**: The internal content uses `transform: translateZ(50px)`. Because the parent mesh card has `transform-style: preserve-3d`, the content physically pops out of the gradient surface. As the card tilts, the content experiences true parallax.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The mesh uses a slightly deeper, more intense set of neon colors in dark mode.
- Added `README.md` documenting usage and the technical mechanics of the complex multi-stop `radial-gradient` mesh definitions, the sibling selector logic (`~`) governing the 3D transforms, the specular glare translation, and the `transform-style: preserve-3d` parallax setup.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the invisible hover grid is disabled, the ambient mesh animation is stopped, and the card is given a subtle, static, fixed 3D tilt.

Closes #73820
