### PR TITLE
feat: add pure CSS Media Visualizer Bouncing Spring component (#75082)

### DIFF
--- a/submissions/examples/css-media-visualizer-bouncing-spring-pure/README.md
+++ b/submissions/examples/css-media-visualizer-bouncing-spring-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Media Visualizer: Bouncing Spring
+
+A hardware-accelerated, JavaScript-free audio and media UI element. Features highly elastic, physics-based bouncing animations driven by custom CSS `cubic-bezier` timing functions.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, or JavaScript required for the spring physics or the play/pause state logic.
+- **Component Architecture**: 
+  - **The Magic `cubic-bezier`**: The core of this elastic aesthetic relies on custom timing functions. Standard CSS `ease-in` or `ease-out` functions stay between 0 and 1. However, by supplying a `cubic-bezier()` where the Y-values fall outside of the 0-1 range (e.g., `cubic-bezier(0.68, -0.55, 0.265, 1.55)`), we force the animation to temporarily overshoot its target value before snapping back. This physically simulates an elastic spring.
+  - **The Bouncing Album Art**: The central `.album-art` container utilizes an `@keyframes art-spring` animation. It slowly scales between 0.95 and 1.05. Because it uses the custom spring cubic-bezier, it subtly "pops" outward and squishes inward, making the UI feel alive and physical.
+  - **The Spring Audio Visualizer**: A flex container holds 8 `.spring-dot` elements. They animate using `transform: scaleY()` with `transform-origin: bottom`. The keyframes scale them from 0.2 to 1. Because they also use the overshooting spring cubic-bezier, they snap upward, overshoot their 1.0 scale slightly, and settle back, perfectly mimicking a physical spring snapping. We stagger their `animation-delay` values to simulate chaotic audio frequency dancing.
+  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card (`.media-player-card:has(.play-toggle:not(:checked))`) to instantly apply `animation-play-state: paused` to the album art and the visualizer dots. We also apply a `transform: scaleY(0.1) !important` to squish the dots down to the baseline. Crucially, we ensure the `transition` that handles this squishing *also* uses the spring `cubic-bezier`, so the UI bounces even as it settles into its paused state.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). 
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the overshooting cubic-bezier animations are disabled, and elements are set to static scales.
+
+## Usage
+Open `demo.html` in your browser. Watch the visualizer dots snap elastically and the album art subtly pulse. Click the Play/Pause button to see the magic: the dots will spring back down to a squished state when "paused", driven entirely by CSS state transitions and custom timing curves.
+
+## Files
+- `demo.html`: The HTML structure defining the album art container, the 8 visualizer spring dots, and the hidden checkbox play/pause toggle logic.
+- `style.css`: The styling, the custom overshooting `cubic-bezier` timing functions, the `animation-delay` staggered visualizer mathematics, and the `:has()` selector state interactions.

--- a/submissions/examples/css-media-visualizer-bouncing-spring-pure/demo.html
+++ b/submissions/examples/css-media-visualizer-bouncing-spring-pure/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Media Visualizer: Bouncing Spring</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Bouncing Spring Visualizer</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free audio and media UI element. Features highly elastic, physics-based bouncing animations driven by custom CSS `cubic-bezier` timing functions.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="media-player-card">
+                
+                <div class="card-header">
+                    <div class="album-art">
+                        <div class="playhead"></div>
+                    </div>
+                    <div class="track-info">
+                        <h3 class="track-title">Elasticity</h3>
+                        <p class="track-artist">EaseMotion Bounce</p>
+                    </div>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Spring Visualizer
+                  These elements use a `cubic-bezier` animation that intentionally
+                  overshoots its target value to create a physical "spring" effect.
+                -->
+                <div class="visualizer-container">
+                    <div class="spring-dot dot-1"></div>
+                    <div class="spring-dot dot-2"></div>
+                    <div class="spring-dot dot-3"></div>
+                    <div class="spring-dot dot-4"></div>
+                    <div class="spring-dot dot-5"></div>
+                    <div class="spring-dot dot-6"></div>
+                    <div class="spring-dot dot-7"></div>
+                    <div class="spring-dot dot-8"></div>
+                </div>
+                
+                <div class="media-controls">
+                    <button class="control-btn" aria-label="Previous">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                    </button>
+                    
+                    <!-- Checkbox hack for play/pause toggle -->
+                    <input type="checkbox" id="play-pause" class="play-toggle" checked aria-label="Play/Pause">
+                    <label for="play-pause" class="control-btn play-btn spring-btn">
+                        <svg class="icon-play" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                        <svg class="icon-pause" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+                    </label>
+                    
+                    <button class="control-btn" aria-label="Next">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-media-visualizer-bouncing-spring-pure/style.css
+++ b/submissions/examples/css-media-visualizer-bouncing-spring-pure/style.css
@@ -1,0 +1,311 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;900&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc; 
+    --card-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* Bouncy Accent Colors */
+    --accent: #f43f5e; /* Rose */
+    --accent-light: #fb7185;
+    
+    /* UI Elements */
+    --btn-bg: #f1f5f9;
+    --btn-hover: #e2e8f0;
+    
+    --card-shadow: 0 20px 40px -10px rgba(244, 63, 94, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a; 
+        --card-bg: #1e293b;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --btn-bg: #334155;
+        --btn-hover: #475569;
+        
+        --card-shadow: 0 20px 40px -10px rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Nunito', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.6rem;
+    font-weight: 900;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 500;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0 100px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Media Player Card
+   ========================================= */
+
+.media-player-card {
+    width: 320px;
+    background: var(--card-bg);
+    border-radius: 36px;
+    padding: 40px 30px;
+    box-shadow: var(--card-shadow);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Bouncing Album Art
+   ========================================= */
+
+.album-art {
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #e11d48);
+    margin-bottom: 24px;
+    position: relative;
+    box-shadow: 0 10px 25px rgba(225, 29, 72, 0.3);
+    
+    /* 
+       A subtle, continuous, springy pulse.
+       The cubic-bezier (0.68, -0.55, 0.265, 1.55) is the magic here.
+       The 1.55 means it overshoots 100% scale before settling back down.
+    */
+    animation: art-spring 2s cubic-bezier(0.68, -0.55, 0.265, 1.55) infinite alternate;
+}
+
+@keyframes art-spring {
+    0% { transform: scale(0.95); }
+    100% { transform: scale(1.05); }
+}
+
+.playhead {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 30px;
+    height: 30px;
+    background: var(--card-bg);
+    border-radius: 50%;
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.track-title {
+    font-size: 1.6rem;
+    font-weight: 900;
+    margin: 0 0 6px 0;
+}
+
+.track-artist {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    font-weight: 700;
+    margin: 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Spring Audio Visualizer
+   ========================================= */
+
+.visualizer-container {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 8px;
+    height: 60px;
+    margin-bottom: 40px;
+}
+
+.spring-dot {
+    width: 14px;
+    background: var(--accent);
+    border-radius: 8px;
+    
+    /* 
+       [TECHNIQUE] The Spring Bounce Keyframe
+       Uses transform: scaleY to stretch the dot upwards.
+       The cubic-bezier makes it snap and jiggle.
+    */
+    transform-origin: bottom;
+    animation: dot-spring 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) infinite alternate;
+}
+
+@keyframes dot-spring {
+    0% { 
+        transform: scaleY(0.2); 
+        opacity: 0.6;
+    }
+    100% { 
+        transform: scaleY(1); 
+        opacity: 1;
+    }
+}
+
+/* 
+   Assign staggered delays and varying heights 
+   so they don't all bounce exactly the same way.
+*/
+.dot-1 { animation-delay: -0.4s; height: 30px; }
+.dot-2 { animation-delay: -0.1s; height: 50px; }
+.dot-3 { animation-delay: -0.6s; height: 40px; }
+.dot-4 { animation-delay: -0.3s; height: 60px; }
+.dot-5 { animation-delay: -0.8s; height: 50px; }
+.dot-6 { animation-delay: -0.2s; height: 40px; }
+.dot-7 { animation-delay: -0.5s; height: 50px; }
+.dot-8 { animation-delay: -0.1s; height: 30px; }
+
+
+/* =========================================
+   Media Controls
+   ========================================= */
+
+.media-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+}
+
+.control-btn {
+    background: var(--btn-bg);
+    border: none;
+    color: var(--text-primary);
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* Springy hover transition */
+    transition: transform 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55), background 0.2s;
+}
+
+.control-btn:hover {
+    background: var(--btn-hover);
+    transform: scale(1.15); /* Pop up slightly on hover */
+}
+
+.play-btn {
+    width: 64px;
+    height: 64px;
+    background: var(--accent);
+    color: #ffffff;
+    box-shadow: 0 8px 16px rgba(244, 63, 94, 0.3);
+}
+
+.play-btn:hover {
+    background: var(--accent-light);
+    transform: scale(1.15);
+}
+
+/* Play/Pause Toggle Logic */
+.play-toggle {
+    display: none;
+}
+
+/* Default state (checked = playing) */
+.icon-play { display: none; }
+.icon-pause { display: block; }
+
+/* When paused (unchecked) */
+.play-toggle:not(:checked) ~ .play-btn .icon-play { display: block; }
+.play-toggle:not(:checked) ~ .play-btn .icon-pause { display: none; }
+.play-toggle:not(:checked) ~ .play-btn {
+    background: var(--btn-bg);
+    color: var(--text-primary);
+    box-shadow: none;
+}
+
+
+/* 
+   [TECHNIQUE] The Gravity Drop
+   When the music is paused, we use `:has()` to "drop" the springs.
+*/
+.media-player-card:has(.play-toggle:not(:checked)) .album-art {
+    /* Stop the art pulsing and settle it down */
+    animation-play-state: paused;
+    transform: scale(1) !important;
+    transition: transform 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+.media-player-card:has(.play-toggle:not(:checked)) .spring-dot {
+    /* Stop the dots bouncing and squish them to the bottom */
+    animation-play-state: paused;
+    transform: scaleY(0.1) !important;
+    opacity: 0.3;
+    /* The transition out is also springy */
+    transition: all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .album-art,
+    .spring-dot {
+        animation: none !important;
+        transform: none !important;
+    }
+    .control-btn {
+        transition: background 0.2s !important;
+    }
+    .control-btn:hover {
+        transform: none !important;
+    }
+    .spring-dot {
+        transform: scaleY(0.4) !important; /* Set a static height */
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free audio and media UI element. It features highly elastic, physics-based bouncing animations driven by custom CSS `cubic-bezier` timing functions. Resolves issue #75082.

### Changes Made:
- Added `submissions/examples/css-media-visualizer-bouncing-spring-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the album art container, the 8 visualizer spring dots, and the hidden checkbox play/pause toggle logic.
- Created `style.css` featuring the UI mechanics:
  - **The Magic `cubic-bezier`**: The core of this elastic aesthetic relies on custom timing functions. By supplying a `cubic-bezier()` where the Y-values fall outside of the 0-1 range (e.g., `cubic-bezier(0.68, -0.55, 0.265, 1.55)`), we force the animation to temporarily overshoot its target value before snapping back. This physically simulates an elastic spring.
  - **The Bouncing Album Art**: The central `.album-art` container utilizes an `@keyframes art-spring` animation. It slowly scales between 0.95 and 1.05. Because it uses the custom spring cubic-bezier, it subtly "pops" outward and squishes inward, making the UI feel alive and physical.
  - **The Spring Audio Visualizer**: A flex container holds 8 `.spring-dot` elements. They animate using `transform: scaleY()` with `transform-origin: bottom`. The keyframes scale them from 0.2 to 1. Because they also use the overshooting spring cubic-bezier, they snap upward, overshoot their 1.0 scale slightly, and settle back, perfectly mimicking a physical spring snapping. We stagger their `animation-delay` values to simulate chaotic audio frequency dancing.
  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card to instantly apply `animation-play-state: paused` to the album art and the visualizer dots. We also apply a `transform: scaleY(0.1) !important` to squish the dots down to the baseline. Crucially, we ensure the `transition` that handles this squishing *also* uses the spring `cubic-bezier`, so the UI bounces even as it settles into its paused state.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). 
- Added `README.md` documenting usage and the technical mechanics of the custom overshooting `cubic-bezier` timing functions, the `animation-delay` staggered visualizer mathematics, and the `:has()` selector state interactions.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the overshooting cubic-bezier animations are disabled, and elements are set to static scales.

Closes #75082
