### PR TITLE
feat: add pure CSS Media Visualizer Minimalist Outline component (#75088)

### DIFF
--- a/submissions/examples/css-media-visualizer-minimalist-outline-pure/README.md
+++ b/submissions/examples/css-media-visualizer-minimalist-outline-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Media Visualizer: Minimalist Outline
+
+A hardware-accelerated, JavaScript-free audio and media UI element. Features a stark, clean aesthetic relying entirely on 1px borders, negative space, and monochromatic contrast.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, or JavaScript required for the visualizer animation or the play/pause state logic.
+- **Component Architecture**: 
+  - **The Minimalist Aesthetic**: The entire component eschews shadows, gradients, and solid backgrounds. Instead, it defines a single `--outline-color` and `--outline-width` (1px). Every element, from the card container to the buttons and the visualizer bars, is styled primarily by its border, creating a blueprint-like or wireframe appearance.
+  - **The Rotating Art**: The album art is abstracted down to a simple, empty `.outline-art` circle with a single `.outline-dot` placed on its edge. It rotates smoothly using an infinite `@keyframes slow-spin` animation, serving as a minimalist playhead indicator.
+  - **The Transparent Visualizer**: The audio visualizer is built using `.outline-bar` elements. Because they have `background: transparent`, they are defined solely by their 1px borders. They animate using `transform: scaleY()` with `transform-origin: bottom`. 
+  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card (`.outline-media-card:has(.play-toggle:not(:checked))`) to instantly apply `animation-play-state: paused` to the rotating art. Additionally, the visualizer bars are flattened to a tiny `scaleY(0.05)`, resting quietly on the baseline border when the music stops.
+  - **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The contrast simply inverts, keeping the stark minimalist aesthetic intact regardless of the user's system theme.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all scaling and spinning animations are completely disabled, presenting a static, highly readable player UI.
+
+## Usage
+Open `demo.html` in your browser. Watch the transparent, outlined visualizer bars scale rhythmically and the minimalist circular playhead rotate. Click the Play/Pause button to see the visualizer bars instantly flatten to the baseline when "paused", driven entirely by CSS state transitions.
+
+## Files
+- `demo.html`: The HTML structure defining the outlined containers, the abstracted album art, the 10 transparent visualizer tracks, and the hidden checkbox play/pause toggle logic.
+- `style.css`: The styling, the strict 1px border aesthetic, the `transform: scaleY()` keyframes, and the `:has()` selector state interactions for flattening the visualizer.

--- a/submissions/examples/css-media-visualizer-minimalist-outline-pure/demo.html
+++ b/submissions/examples/css-media-visualizer-minimalist-outline-pure/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Media Visualizer: Minimalist Outline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Minimalist Outline Visualizer</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free audio and media UI element. Features a stark, clean aesthetic relying entirely on 1px borders and empty space.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="outline-media-card">
+                
+                <div class="card-header">
+                    <div class="outline-art-container">
+                        <!-- 
+                          [TECHNIQUE] The Minimalist Art
+                          An empty circle that rotates slowly.
+                        -->
+                        <div class="outline-art">
+                            <div class="outline-dot"></div>
+                        </div>
+                    </div>
+                    <div class="track-info">
+                        <h3 class="track-title">Negative Space</h3>
+                        <p class="track-artist">EaseMotion Minimum</p>
+                    </div>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Outline Visualizer
+                  These bars are transparent with a solid 1px border.
+                  They scale up and down to simulate audio frequencies.
+                -->
+                <div class="visualizer-container">
+                    <div class="outline-bar bar-1"></div>
+                    <div class="outline-bar bar-2"></div>
+                    <div class="outline-bar bar-3"></div>
+                    <div class="outline-bar bar-4"></div>
+                    <div class="outline-bar bar-5"></div>
+                    <div class="outline-bar bar-6"></div>
+                    <div class="outline-bar bar-7"></div>
+                    <div class="outline-bar bar-8"></div>
+                    <div class="outline-bar bar-9"></div>
+                    <div class="outline-bar bar-10"></div>
+                </div>
+                
+                <div class="media-controls">
+                    <button class="control-btn" aria-label="Previous">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                    </button>
+                    
+                    <!-- Checkbox hack for play/pause toggle -->
+                    <input type="checkbox" id="play-pause" class="play-toggle" checked aria-label="Play/Pause">
+                    <label for="play-pause" class="control-btn play-btn">
+                        <svg class="icon-play" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                        <svg class="icon-pause" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+                    </label>
+                    
+                    <button class="control-btn" aria-label="Next">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-media-visualizer-minimalist-outline-pure/style.css
+++ b/submissions/examples/css-media-visualizer-minimalist-outline-pure/style.css
@@ -1,0 +1,296 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f8fafc; 
+    --card-bg: transparent; /* Minimalist design often uses transparency */
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    
+    /* The core styling element: The Outline */
+    --outline-color: #0f172a;
+    --outline-width: 1px;
+    
+    --hover-bg: rgba(15, 23, 42, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a; 
+        --card-bg: transparent;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --outline-color: #f8fafc;
+        --hover-bg: rgba(248, 250, 252, 0.1);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Space Grotesk', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.6rem;
+    font-weight: 300;
+    margin: 0 0 16px 0;
+    letter-spacing: -1px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 400;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0 100px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Minimalist Outline Card
+   ========================================= */
+
+.outline-media-card {
+    width: 340px;
+    background: var(--card-bg);
+    /* 
+       The core aesthetic: No shadows, no gradients.
+       Just a stark 1px solid border and empty space.
+    */
+    border: var(--outline-width) solid var(--outline-color);
+    border-radius: 2px; /* Very sharp corners for minimalism */
+    padding: 40px 30px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 40px;
+    width: 100%;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Minimalist Album Art
+   ========================================= */
+
+.outline-art-container {
+    margin-bottom: 32px;
+}
+
+.outline-art {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    /* Empty space surrounded by the outline */
+    border: var(--outline-width) solid var(--outline-color);
+    position: relative;
+    
+    /* Smooth, constant rotation */
+    animation: slow-spin 8s linear infinite;
+}
+
+.outline-dot {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--outline-color);
+}
+
+@keyframes slow-spin {
+    100% { transform: rotate(360deg); }
+}
+
+.track-title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0 0 6px 0;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.track-artist {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-weight: 300;
+    margin: 0;
+    letter-spacing: 1px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Outline Visualizer
+   ========================================= */
+
+.visualizer-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    height: 60px;
+    margin-bottom: 40px;
+    /* A stark baseline */
+    border-bottom: var(--outline-width) solid var(--outline-color);
+    padding-bottom: 4px;
+}
+
+.outline-bar {
+    width: 12px;
+    height: 100%;
+    
+    /* 
+       The bars are completely transparent, 
+       defined only by their outline.
+    */
+    background: transparent;
+    border: var(--outline-width) solid var(--outline-color);
+    
+    /* Scale Y from the bottom to simulate frequencies */
+    transform-origin: bottom;
+    animation: outline-eq 0.6s ease infinite alternate;
+}
+
+@keyframes outline-eq {
+    0% { transform: scaleY(0.1); }
+    100% { transform: scaleY(1); }
+}
+
+/* Stagger the bars */
+.bar-1 { animation-delay: -0.4s; }
+.bar-2 { animation-delay: -0.1s; }
+.bar-3 { animation-delay: -0.6s; }
+.bar-4 { animation-delay: -0.3s; }
+.bar-5 { animation-delay: -0.8s; }
+.bar-6 { animation-delay: -0.2s; }
+.bar-7 { animation-delay: -0.5s; }
+.bar-8 { animation-delay: -0.1s; }
+.bar-9 { animation-delay: -0.7s; }
+.bar-10 { animation-delay: -0.3s; }
+
+
+/* =========================================
+   Media Controls
+   ========================================= */
+
+.media-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+}
+
+.control-btn {
+    background: transparent;
+    /* Strict outline styling for buttons */
+    border: var(--outline-width) solid var(--outline-color);
+    color: var(--outline-color);
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    border-radius: 2px; /* Sharp corners */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: all 0.2s ease;
+}
+
+.control-btn:hover {
+    background: var(--hover-bg);
+}
+
+.play-btn {
+    width: 64px;
+    height: 64px;
+    /* Invert the play button for contrast while remaining minimalist */
+    background: var(--outline-color);
+    color: var(--bg-base);
+}
+
+.play-btn:hover {
+    background: var(--text-secondary);
+    border-color: var(--text-secondary);
+}
+
+/* Play/Pause Toggle Logic */
+.play-toggle {
+    display: none;
+}
+
+/* Default state (checked = playing) */
+.icon-play { display: none; }
+.icon-pause { display: block; }
+
+/* When paused (unchecked) */
+.play-toggle:not(:checked) ~ .play-btn .icon-play { display: block; }
+.play-toggle:not(:checked) ~ .play-btn .icon-pause { display: none; }
+.play-toggle:not(:checked) ~ .play-btn {
+    background: transparent;
+    color: var(--outline-color);
+}
+.play-toggle:not(:checked) ~ .play-btn:hover {
+    background: var(--hover-bg);
+}
+
+
+/* 
+   [TECHNIQUE] The Static State
+   When paused, we stop the animations and flatten the visualizer.
+*/
+.outline-media-card:has(.play-toggle:not(:checked)) .outline-art {
+    animation-play-state: paused;
+}
+
+.outline-media-card:has(.play-toggle:not(:checked)) .outline-bar {
+    animation-play-state: paused;
+    transform: scaleY(0.05) !important;
+    transition: transform 0.4s ease;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .outline-art,
+    .outline-bar {
+        animation: none !important;
+    }
+    .outline-bar {
+        transform: scaleY(0.2) !important; /* Static height */
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a hardware-accelerated, JavaScript-free audio and media UI element. It features a stark, clean aesthetic relying entirely on 1px borders, negative space, and monochromatic contrast. Resolves issue #75088.

### Changes Made:
- Added `submissions/examples/css-media-visualizer-minimalist-outline-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the outlined containers, the abstracted album art, the 10 transparent visualizer tracks, and the hidden checkbox play/pause toggle logic.
- Created `style.css` featuring the UI mechanics:
  - **The Minimalist Aesthetic**: The entire component eschews shadows, gradients, and solid backgrounds. Instead, it defines a single `--outline-color` and `--outline-width` (1px). Every element, from the card container to the buttons and the visualizer bars, is styled primarily by its border, creating a blueprint-like or wireframe appearance.
  - **The Rotating Art**: The album art is abstracted down to a simple, empty `.outline-art` circle with a single `.outline-dot` placed on its edge. It rotates smoothly using an infinite `@keyframes slow-spin` animation, serving as a minimalist playhead indicator.
  - **The Transparent Visualizer**: The audio visualizer is built using `.outline-bar` elements. Because they have `background: transparent`, they are defined solely by their 1px borders. They animate using `transform: scaleY()` with `transform-origin: bottom`. 
  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card to instantly apply `animation-play-state: paused` to the rotating art. Additionally, the visualizer bars are flattened to a tiny `scaleY(0.05)`, resting quietly on the baseline border when the music stops.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). The contrast simply inverts, keeping the stark minimalist aesthetic intact regardless of the user's system theme.
- Added `README.md` documenting usage and the technical mechanics of the strict 1px border aesthetic, the `transform: scaleY()` keyframes, and the `:has()` selector state interactions for flattening the visualizer.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all scaling and spinning animations are completely disabled, presenting a static, highly readable player UI.

Closes #75088
