### PR TITLE
feat: add pure CSS Media Visualizer Origami Paper Fold component (#75094)

### DIFF
--- a/submissions/examples/css-media-visualizer-origami-paper-fold-pure/README.md
+++ b/submissions/examples/css-media-visualizer-origami-paper-fold-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Media Visualizer: Origami Paper Fold
+
+A hardware-accelerated, JavaScript-free audio and media UI element. Features 3D CSS transforms and `clip-path` geometry to create a tactile, folding paper aesthetic.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, SVG manipulation, or JavaScript required for the folding geometry or the play/pause state logic.
+- **Component Architecture**: 
+  - **The 3D Stage**: The parent `.origami-media-card` is given a `perspective: 1200px` property. This creates a 3D stage for the child elements to rotate within, allowing for realistic depth when elements fold towards or away from the viewer. The containers inside use `transform-style: preserve-3d` to pass this perspective down.
+  - **The Folding Art**: The `.origami-art-container` uses a base `.origami-base` element styled as a diamond using `clip-path: polygon()`. On top of it sit two flaps (`.fold-top` and `.fold-bottom`), which are halves of the diamond. These flaps use `@keyframes` to animate their `rotateX()` property, anchoring their `transform-origin` to their respective center edges. This simulates paper flaps opening and closing continuously.
+  - **The Geometric Visualizer**: Instead of traditional rectangular bars that scale vertically, this visualizer uses `.origami-peak` elements shaped into sharp triangles via `clip-path`. They animate their audio frequencies by using `rotateX()` anchored at the `bottom`. As they fold downwards, their background color darkens, simulating a shadow falling on the folded paper.
+  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card (`.origami-media-card:has(.play-toggle:not(:checked))`) to instantly apply `animation-play-state: paused` to all folding elements. We then apply `transform: rotateX(179deg)` to the art flaps and `rotateX(85deg)` to the visualizer triangles. This forces the entire UI to "fold flat" into its paused state, driven smoothly by a CSS `transition`.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). 
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all 3D rotations are disabled, presenting a static, semi-folded accessible player UI.
+
+## Usage
+Open `demo.html` in your browser. Watch the origami flaps open and close, and the geometric visualizer triangles fold up and down. Click the Play/Pause button to see the magic: the entire UI will smoothly fold itself completely flat into a resting state when "paused", driven entirely by CSS state transitions.
+
+## Files
+- `demo.html`: The HTML structure defining the 3D containers, the `clip-path` geometry elements, and the hidden checkbox play/pause toggle logic.
+- `style.css`: The styling, the `perspective` setups, the `rotateX` keyframes, the `clip-path: polygon()` shapes, and the `:has()` selector state interactions for the flat-fold resting state.

--- a/submissions/examples/css-media-visualizer-origami-paper-fold-pure/demo.html
+++ b/submissions/examples/css-media-visualizer-origami-paper-fold-pure/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Media Visualizer: Origami Paper Fold</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Origami Fold Visualizer</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free audio and media UI element. Features 3D CSS transforms and `clip-path` geometry to create a tactile, folding paper aesthetic.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="origami-media-card">
+                
+                <div class="card-header">
+                    
+                    <!-- 
+                      [TECHNIQUE] The Origami Art
+                      The album art uses clip-path and 3D rotation to simulate
+                      a geometric paper fold opening and closing.
+                    -->
+                    <div class="origami-art-container">
+                        <div class="origami-base"></div>
+                        <div class="origami-fold fold-top"></div>
+                        <div class="origami-fold fold-bottom"></div>
+                    </div>
+                    
+                    <div class="track-info">
+                        <h3 class="track-title">Geometric Beats</h3>
+                        <p class="track-artist">EaseMotion Paper</p>
+                    </div>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Origami Visualizer
+                  Instead of standard bars, we use triangular polygons that fold 
+                  downwards (rotateX) to simulate audio frequencies.
+                -->
+                <div class="visualizer-container">
+                    <div class="origami-peak peak-1"></div>
+                    <div class="origami-peak peak-2"></div>
+                    <div class="origami-peak peak-3"></div>
+                    <div class="origami-peak peak-4"></div>
+                    <div class="origami-peak peak-5"></div>
+                    <div class="origami-peak peak-6"></div>
+                    <div class="origami-peak peak-7"></div>
+                    <div class="origami-peak peak-8"></div>
+                </div>
+                
+                <div class="media-controls">
+                    <button class="control-btn" aria-label="Previous">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                    </button>
+                    
+                    <!-- Checkbox hack for play/pause toggle -->
+                    <input type="checkbox" id="play-pause" class="play-toggle" checked aria-label="Play/Pause">
+                    <label for="play-pause" class="control-btn play-btn">
+                        <svg class="icon-play" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                        <svg class="icon-pause" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+                    </label>
+                    
+                    <button class="control-btn" aria-label="Next">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-media-visualizer-origami-paper-fold-pure/style.css
+++ b/submissions/examples/css-media-visualizer-origami-paper-fold-pure/style.css
@@ -1,0 +1,355 @@
+@import url('https://fonts.googleapis.com/css2?family=Jost:wght@300;400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f0f0f0; 
+    --card-bg: #fafafa;
+    --text-primary: #333333;
+    --text-secondary: #777777;
+    
+    /* Origami Paper Colors */
+    --paper-front: #e0f2fe; /* Light sky blue */
+    --paper-back: #0284c7;  /* Deep sky blue for the fold shadow */
+    --paper-accent: #0ea5e9;
+    
+    /* UI Elements */
+    --btn-bg: #ffffff;
+    --btn-hover: #f1f5f9;
+    
+    --card-shadow: 0 15px 35px -5px rgba(2, 132, 199, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #121212; 
+        --card-bg: #1e1e1e;
+        --text-primary: #e0e0e0;
+        --text-secondary: #999999;
+        
+        --paper-front: #0284c7; 
+        --paper-back: #082f49;
+        --paper-accent: #38bdf8;
+        
+        --btn-bg: #2d2d2d;
+        --btn-hover: #3d3d3d;
+        
+        --card-shadow: 0 15px 35px -5px rgba(0, 0, 0, 0.5);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Jost', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0 100px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Media Player Card
+   ========================================= */
+
+.origami-media-card {
+    width: 320px;
+    background: var(--card-bg);
+    /* Sharp corners fit the geometric paper theme */
+    border-radius: 4px; 
+    padding: 40px 30px;
+    box-shadow: var(--card-shadow);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    
+    /* Setup 3D perspective for child folds */
+    perspective: 1200px;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 40px;
+    width: 100%;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Origami Art Fold
+   ========================================= */
+
+.origami-art-container {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    margin-bottom: 32px;
+    /* Required for 3D child positioning */
+    transform-style: preserve-3d;
+}
+
+/* The diamond base shape */
+.origami-base {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: var(--paper-front);
+    /* Use clip-path to create a diamond/rhombus */
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+/* 
+   The folding flaps.
+   We split the diamond into top and bottom halves using clip-path,
+   then rotate them on the X-axis to simulate folding paper.
+*/
+.origami-fold {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: var(--paper-back);
+    transform-origin: center center;
+    backface-visibility: hidden;
+}
+
+.fold-top {
+    clip-path: polygon(50% 0%, 100% 50%, 0% 50%);
+    transform-origin: bottom center;
+    animation: fold-flap-top 4s cubic-bezier(0.25, 1, 0.5, 1) infinite alternate;
+}
+
+.fold-bottom {
+    clip-path: polygon(100% 50%, 50% 100%, 0% 50%);
+    transform-origin: top center;
+    animation: fold-flap-bottom 4s cubic-bezier(0.25, 1, 0.5, 1) infinite alternate;
+}
+
+@keyframes fold-flap-top {
+    0%, 20% { transform: rotateX(170deg); }
+    80%, 100% { transform: rotateX(0deg); }
+}
+
+@keyframes fold-flap-bottom {
+    0%, 20% { transform: rotateX(-170deg); }
+    80%, 100% { transform: rotateX(0deg); }
+}
+
+.track-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    letter-spacing: 1px;
+}
+
+.track-artist {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    font-weight: 400;
+    margin: 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Origami Visualizer
+   ========================================= */
+
+.visualizer-container {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end; /* Align to bottom */
+    gap: 2px;
+    height: 50px;
+    margin-bottom: 40px;
+    transform-style: preserve-3d;
+}
+
+.origami-peak {
+    width: 24px; /* Wider to allow for a noticeable triangle */
+    height: 100%;
+    background: var(--paper-accent);
+    
+    /* 
+       [TECHNIQUE] Geometric Clip Path 
+       Instead of rectangular bars, the visualizer uses sharp triangles.
+    */
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    
+    /* 
+       [TECHNIQUE] The Folding EQ
+       Instead of scaleY(), we use rotateX() anchored at the bottom
+       to make the triangles "fold" flat against the surface.
+    */
+    transform-origin: bottom;
+    animation: fold-eq 0.5s cubic-bezier(0.25, 1, 0.5, 1) infinite alternate;
+}
+
+@keyframes fold-eq {
+    0% { 
+        transform: rotateX(80deg); /* Folded almost flat */
+        background: var(--paper-back); /* Show shadow color when folded */
+    }
+    100% { 
+        transform: rotateX(0deg); /* Standing straight up */
+        background: var(--paper-accent); 
+    }
+}
+
+/* Stagger the folds */
+.peak-1 { animation-delay: -0.4s; height: 60%; }
+.peak-2 { animation-delay: -0.1s; height: 100%; }
+.peak-3 { animation-delay: -0.6s; height: 80%; }
+.peak-4 { animation-delay: -0.3s; height: 70%; }
+.peak-5 { animation-delay: -0.8s; height: 90%; }
+.peak-6 { animation-delay: -0.2s; height: 60%; }
+.peak-7 { animation-delay: -0.5s; height: 80%; }
+.peak-8 { animation-delay: -0.1s; height: 100%; }
+
+
+/* =========================================
+   Media Controls
+   ========================================= */
+
+.media-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+}
+
+.control-btn {
+    background: var(--btn-bg);
+    border: 1px solid rgba(0,0,0,0.05);
+    color: var(--text-primary);
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    /* Sharp corners for paper aesthetic */
+    border-radius: 4px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.control-btn:hover {
+    background: var(--btn-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(0,0,0,0.08);
+}
+
+.play-btn {
+    width: 64px;
+    height: 64px;
+    background: var(--paper-accent);
+    color: #ffffff;
+    border: none;
+    box-shadow: 0 8px 16px rgba(14, 165, 233, 0.3);
+}
+
+.play-btn:hover {
+    background: var(--paper-front);
+    color: var(--paper-accent);
+    transform: translateY(-2px);
+    box-shadow: 0 12px 20px rgba(14, 165, 233, 0.4);
+}
+
+/* Play/Pause Toggle Logic */
+.play-toggle {
+    display: none;
+}
+
+/* Default state (checked = playing) */
+.icon-play { display: none; }
+.icon-pause { display: block; }
+
+/* When paused (unchecked) */
+.play-toggle:not(:checked) ~ .play-btn .icon-play { display: block; }
+.play-toggle:not(:checked) ~ .play-btn .icon-pause { display: none; }
+.play-toggle:not(:checked) ~ .play-btn {
+    background: var(--btn-bg);
+    color: var(--text-primary);
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+
+/* 
+   [TECHNIQUE] The Paused Fold State
+   When the music is paused, we use `:has()` to fold everything flat.
+*/
+.origami-media-card:has(.play-toggle:not(:checked)) .fold-top {
+    animation-play-state: paused;
+    transform: rotateX(179deg) !important; /* Fold completely shut */
+    transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.origami-media-card:has(.play-toggle:not(:checked)) .fold-bottom {
+    animation-play-state: paused;
+    transform: rotateX(-179deg) !important; /* Fold completely shut */
+    transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.origami-media-card:has(.play-toggle:not(:checked)) .origami-peak {
+    animation-play-state: paused;
+    transform: rotateX(85deg) !important; /* Fold triangles flat to the ground */
+    background: var(--paper-back);
+    transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1), background 0.4s;
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .fold-top,
+    .fold-bottom,
+    .origami-peak {
+        animation: none !important;
+    }
+    
+    .fold-top,
+    .fold-bottom {
+        transform: rotateX(0deg) !important; /* Keep art open */
+    }
+    
+    .origami-peak {
+        transform: rotateX(30deg) !important; /* Static semi-folded state */
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a hardware-accelerated, JavaScript-free audio and media UI element. It features 3D CSS transforms and `clip-path` geometry to create a tactile, folding paper aesthetic. Resolves issue #75094.

### Changes Made:
- Added `submissions/examples/css-media-visualizer-origami-paper-fold-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the 3D containers, the `clip-path` geometry elements, and the hidden checkbox play/pause toggle logic.
- Created `style.css` featuring the UI mechanics:
  - **The 3D Stage**: The parent `.origami-media-card` is given a `perspective: 1200px` property. This creates a 3D stage for the child elements to rotate within, allowing for realistic depth when elements fold towards or away from the viewer. The containers inside use `transform-style: preserve-3d` to pass this perspective down.
  - **The Folding Art**: The `.origami-art-container` uses a base `.origami-base` element styled as a diamond using `clip-path: polygon()`. On top of it sit two flaps (`.fold-top` and `.fold-bottom`), which are halves of the diamond. These flaps use `@keyframes` to animate their `rotateX()` property, anchoring their `transform-origin` to their respective center edges. This simulates paper flaps opening and closing continuously.
  - **The Geometric Visualizer**: Instead of traditional rectangular bars that scale vertically, this visualizer uses `.origami-peak` elements shaped into sharp triangles via `clip-path`. They animate their audio frequencies by using `rotateX()` anchored at the `bottom`. As they fold downwards, their background color darkens, simulating a shadow falling on the folded paper.
  - **The `:has()` Selector State Logic**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card to instantly apply `animation-play-state: paused` to all folding elements. We then apply `transform: rotateX(179deg)` to the art flaps and `rotateX(85deg)` to the visualizer triangles. This forces the entire UI to "fold flat" into its paused state, driven smoothly by a CSS `transition`.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`). 
- Added `README.md` documenting usage and the technical mechanics of the `perspective` setups, the `rotateX` keyframes, the `clip-path: polygon()` shapes, and the `:has()` selector state interactions for the flat-fold resting state.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all 3D rotations are disabled, presenting a static, semi-folded accessible player UI.

Closes #75094
