### PR TITLE
feat: add pure CSS Media Visualizer Foucault Pendulum Swing component(#75095)

### DIFF
--- a/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/README.md
+++ b/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Media Visualizer: Foucault Pendulum Swing
+
+A hardware-accelerated, JavaScript-free audio and media UI element. Features physics-based swinging animations driven by `transform-origin` anchoring and `ease-in-out` timing functions.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, physics engines, or JavaScript required for the swinging geometry or the play/pause state logic.
+- **Component Architecture**: 
+  - **The Physics Engine**: True pendulum physics dictate that a swing is fastest at the bottom and slows down to a stop at the peaks before reversing. We simulate this perfectly in pure CSS by using `ease-in-out` timing functions on our animations.
+  - **The Swinging Art**: The `.pendulum-art` container is anchored to a pivot point at the top using `transform-origin: top center;`. An `@keyframes swing-art` animation applies a slow, gentle `rotate()` back and forth. A pseudo-element line draws the connecting rod.
+  - **The Pendulum Array Visualizer**: The audio visualizer eschews traditional vertical scaling. Instead, it uses 8 `.pendulum-line` elements of varying heights, hanging from a top rod. Each line has a `.pendulum-bob` weight at the bottom. They use a much faster `@keyframes swing-viz` animation.
+  - **The Chaos**: By aggressively staggering the `animation-delay` values of the visualizer pendulums, we simulate chaotic, overlapping waves of movement that perfectly represent active audio frequencies.
+  - **The `:has()` Selector Gravity Settle**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card (`.pendulum-media-card:has(.play-toggle:not(:checked))`) to instantly apply `animation-play-state: paused` to all swinging elements. Crucially, we apply `transform: rotate(0deg) !important` to force everything to hang straight down. We pair this with a long CSS `transition` (1.5s), allowing "gravity" to slowly and realistically settle the pendulums to a complete stop when the music pauses.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), featuring a sophisticated brass/gold and dark wood color palette.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all swinging animations are disabled, and the pendulums hang straight down in a static, accessible player UI.
+
+## Usage
+Open `demo.html` in your browser. Watch the slow, rhythmic swing of the album art and the chaotic wave of the pendulum visualizer array. Click the Play/Pause button to see the magic: the entire UI will slowly settle down to a straight, hanging stop when "paused", driven entirely by CSS state transitions acting as gravity.
+
+## Files
+- `demo.html`: The HTML structure defining the pivot points, the swinging art container, the 8 visualizer pendulums, and the hidden checkbox play/pause toggle logic.
+- `style.css`: The styling, the `transform-origin: top center` anchoring, the `rotate()` keyframes, and the `:has()` selector state interactions for the gravity settle effect.

--- a/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/demo.html
+++ b/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Media Visualizer: Foucault Pendulum Swing</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Foucault Pendulum Visualizer</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free audio and media UI element. Features physics-based swinging animations driven by `transform-origin` anchoring and `ease-in-out` timing functions.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <div class="pendulum-media-card">
+                
+                <div class="card-header">
+                    <!-- 
+                      [TECHNIQUE] The Swinging Art
+                      The album art hangs from the top edge and swings gently
+                      like a grandfather clock pendulum.
+                    -->
+                    <div class="art-pivot">
+                        <div class="pendulum-art">
+                            <div class="art-bob"></div>
+                        </div>
+                    </div>
+                    
+                    <div class="track-info">
+                        <h3 class="track-title">Rhythmic Swing</h3>
+                        <p class="track-artist">EaseMotion Physics</p>
+                    </div>
+                </div>
+                
+                <!-- 
+                  [TECHNIQUE] The Pendulum Array Visualizer
+                  These lines hang from a pivot point and swing back and forth.
+                  Staggered animation delays create a chaotic wave effect.
+                -->
+                <div class="visualizer-container">
+                    <div class="pendulum-line line-1"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-2"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-3"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-4"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-5"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-6"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-7"><div class="pendulum-bob"></div></div>
+                    <div class="pendulum-line line-8"><div class="pendulum-bob"></div></div>
+                </div>
+                
+                <div class="media-controls">
+                    <button class="control-btn" aria-label="Previous">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="19 20 9 12 19 4 19 20"></polygon><line x1="5" y1="19" x2="5" y2="5"></line></svg>
+                    </button>
+                    
+                    <!-- Checkbox hack for play/pause toggle -->
+                    <input type="checkbox" id="play-pause" class="play-toggle" checked aria-label="Play/Pause">
+                    <label for="play-pause" class="control-btn play-btn">
+                        <svg class="icon-play" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+                        <svg class="icon-pause" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+                    </label>
+                    
+                    <button class="control-btn" aria-label="Next">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"></polygon><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                    </button>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/style.css
+++ b/submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/style.css
@@ -1,0 +1,344 @@
+@import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;600;700&family=Work+Sans:wght@300;400;600&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #f4f1ea; 
+    --card-bg: #ffffff;
+    --text-primary: #2c2925;
+    --text-secondary: #8c8375;
+    
+    /* Pendulum Colors */
+    --pendulum-rod: #d4af37; /* Gold/Brass */
+    --pendulum-bob: #b8860b; /* Dark Goldenrod */
+    --pendulum-accent: #8b0000; /* Dark Red */
+    
+    /* UI Elements */
+    --btn-bg: #fdfbf7;
+    --btn-hover: #f0ead6;
+    
+    --card-shadow: 0 25px 50px -12px rgba(184, 134, 11, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #1a1816; 
+        --card-bg: #262422;
+        --text-primary: #f4f1ea;
+        --text-secondary: #a39c93;
+        
+        --pendulum-rod: #c5a059; 
+        --pendulum-bob: #daa520;
+        
+        --btn-bg: #33302d;
+        --btn-hover: #45413c;
+        
+        --card-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Work Sans', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 80px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Crimson Pro', serif;
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    font-size: 1.05rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 600px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 0 120px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Media Player Card
+   ========================================= */
+
+.pendulum-media-card {
+    width: 320px;
+    background: var(--card-bg);
+    border-radius: 12px;
+    padding: 40px 30px;
+    box-shadow: var(--card-shadow);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 50px;
+    width: 100%;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Swinging Art Pendulum
+   ========================================= */
+
+/* The pivot point at the top */
+.art-pivot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--pendulum-bob);
+    position: relative;
+    margin-bottom: 120px; /* Space for the swinging art */
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
+}
+
+/* The art container acts as the rigid rod */
+.pendulum-art {
+    position: absolute;
+    top: 6px; /* Align to center of pivot */
+    left: 50%;
+    width: 120px;
+    /* Move left edge to center to act as a straight hanging rod */
+    margin-left: -60px;
+    height: 140px;
+    
+    /* 
+       [TECHNIQUE] Pendulum Physics
+       Anchor the transform to the top center.
+       Use ease-in-out to simulate gravity slowing the swing at the peaks.
+    */
+    transform-origin: top center;
+    animation: swing-art 3s ease-in-out infinite alternate;
+}
+
+/* Draw a line connecting the pivot to the art */
+.pendulum-art::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 2px;
+    height: 100%;
+    background: var(--pendulum-rod);
+    margin-left: -1px;
+    z-index: 0;
+}
+
+.art-bob {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background: var(--pendulum-accent);
+    z-index: 1;
+    box-shadow: inset -10px -10px 20px rgba(0,0,0,0.3), 0 10px 20px rgba(139, 0, 0, 0.4);
+}
+
+@keyframes swing-art {
+    0% { transform: rotate(-15deg); }
+    100% { transform: rotate(15deg); }
+}
+
+.track-title {
+    font-family: 'Crimson Pro', serif;
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin: 0 0 6px 0;
+}
+
+.track-artist {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Pendulum Array Visualizer
+   ========================================= */
+
+.visualizer-container {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start; /* Hang from top */
+    gap: 12px;
+    width: 100%;
+    height: 60px;
+    margin-bottom: 40px;
+    /* Add a rod across the top that they all hang from */
+    border-top: 4px solid var(--pendulum-rod);
+    border-radius: 2px;
+}
+
+/* The hanging string */
+.pendulum-line {
+    width: 2px;
+    background: var(--text-secondary);
+    position: relative;
+    
+    /* Anchor to the top rod */
+    transform-origin: top center;
+    animation: swing-viz 0.8s ease-in-out infinite alternate;
+}
+
+/* The weight at the bottom */
+.pendulum-bob {
+    position: absolute;
+    bottom: -6px;
+    left: -5px; /* Center the 12px bob on the 2px line */
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--pendulum-bob);
+    box-shadow: 0 4px 8px rgba(184, 134, 11, 0.3);
+}
+
+/* 
+   Unlike the slow art, the visualizer swings rapidly and widely 
+*/
+@keyframes swing-viz {
+    0% { transform: rotate(-45deg); }
+    100% { transform: rotate(45deg); }
+}
+
+/* Stagger the swings and alter lengths */
+.line-1 { animation-delay: -0.4s; height: 30px; }
+.line-2 { animation-delay: -0.1s; height: 50px; }
+.line-3 { animation-delay: -0.6s; height: 40px; }
+.line-4 { animation-delay: -0.3s; height: 60px; }
+.line-5 { animation-delay: -0.8s; height: 45px; }
+.line-6 { animation-delay: -0.2s; height: 55px; }
+.line-7 { animation-delay: -0.5s; height: 35px; }
+.line-8 { animation-delay: -0.1s; height: 45px; }
+
+
+/* =========================================
+   Media Controls
+   ========================================= */
+
+.media-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+    width: 100%;
+}
+
+.control-btn {
+    background: var(--btn-bg);
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: all 0.3s ease;
+}
+
+.control-btn:hover {
+    background: var(--btn-hover);
+    color: var(--text-primary);
+}
+
+.play-btn {
+    width: 64px;
+    height: 64px;
+    background: var(--pendulum-bob);
+    color: #ffffff;
+    box-shadow: 0 10px 20px rgba(184, 134, 11, 0.2);
+}
+
+.play-btn:hover {
+    background: var(--pendulum-rod);
+    box-shadow: 0 12px 25px rgba(184, 134, 11, 0.3);
+    transform: translateY(-2px);
+}
+
+/* Play/Pause Toggle Logic */
+.play-toggle {
+    display: none;
+}
+
+/* Default state (checked = playing) */
+.icon-play { display: none; }
+.icon-pause { display: block; }
+
+/* When paused (unchecked) */
+.play-toggle:not(:checked) ~ .play-btn .icon-play { display: block; }
+.play-toggle:not(:checked) ~ .play-btn .icon-pause { display: none; }
+.play-toggle:not(:checked) ~ .play-btn {
+    background: var(--btn-bg);
+    color: var(--text-primary);
+    box-shadow: none;
+}
+.play-toggle:not(:checked) ~ .play-btn:hover {
+    background: var(--btn-hover);
+}
+
+
+/* 
+   [TECHNIQUE] The Gravity Settle State
+   When paused, we use `:has()` to let gravity pull the pendulums straight down.
+*/
+.pendulum-media-card:has(.play-toggle:not(:checked)) .pendulum-art {
+    animation-play-state: paused;
+    transform: rotate(0deg) !important; /* Hang straight down */
+    /* Long transition to let it slowly settle */
+    transition: transform 1.5s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.pendulum-media-card:has(.play-toggle:not(:checked)) .pendulum-line {
+    animation-play-state: paused;
+    transform: rotate(0deg) !important; /* Hang straight down */
+    transition: transform 1s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .pendulum-art,
+    .pendulum-line {
+        animation: none !important;
+        transform: rotate(0deg) !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a hardware-accelerated, JavaScript-free audio and media UI element. It features physics-based swinging animations driven by `transform-origin` anchoring and `ease-in-out` timing functions. Resolves issue #75095.

### Changes Made:
- Added `submissions/examples/css-media-visualizer-foucault-pendulum-swing-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the pivot points, the swinging art container, the 8 visualizer pendulums, and the hidden checkbox play/pause toggle logic.
- Created `style.css` featuring the UI mechanics:
  - **The Physics Engine**: True pendulum physics dictate that a swing is fastest at the bottom and slows down to a stop at the peaks before reversing. We simulate this perfectly in pure CSS by using `ease-in-out` timing functions on our animations.
  - **The Swinging Art**: The `.pendulum-art` container is anchored to a pivot point at the top using `transform-origin: top center;`. An `@keyframes swing-art` animation applies a slow, gentle `rotate()` back and forth. A pseudo-element line draws the connecting rod.
  - **The Pendulum Array Visualizer**: The audio visualizer eschews traditional vertical scaling. Instead, it uses 8 `.pendulum-line` elements of varying heights, hanging from a top rod. Each line has a `.pendulum-bob` weight at the bottom. They use a much faster `@keyframes swing-viz` animation.
  - **The `:has()` Selector Gravity Settle**: The play/pause button is a hidden `<input type="checkbox">` styled using the CSS checkbox hack. When the user "pauses" the music, we use the modern CSS `:has()` selector on the parent card to instantly apply `animation-play-state: paused` to all swinging elements. Crucially, we apply `transform: rotate(0deg) !important` to force everything to hang straight down. We pair this with a long CSS `transition` (1.5s), allowing "gravity" to slowly and realistically settle the pendulums to a complete stop when the music pauses.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), featuring a sophisticated brass/gold and dark wood color palette.
- Added `README.md` documenting usage and the technical mechanics of the `transform-origin: top center` anchoring, the `rotate()` keyframes, and the `:has()` selector state interactions for the gravity settle effect.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, all swinging animations are disabled, and the pendulums hang straight down in a static, accessible player UI.

Closes #75095
