### PR TITLE
feat: add pure CSS Bento Card Laser Ray Trace component (#75111)

### DIFF
--- a/submissions/examples/css-bento-card-laser-ray-trace-pure/README.md
+++ b/submissions/examples/css-bento-card-laser-ray-trace-pure/README.md
@@ -1,0 +1,22 @@
+# CSS Bento Grid: Laser Ray Trace
+
+A hardware-accelerated, JavaScript-free bento grid layout. Features continuous, glowing laser lines tracing the borders of the cards, powered entirely by CSS `conic-gradient` masking.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, SVG tracing algorithms, or JavaScript required for the glowing animated borders.
+- **Component Architecture**: 
+  - **The Bento Grid**: Built using modern CSS Grid (`display: grid; grid-template-columns: repeat(4, 1fr)`). The layout is fully responsive, gracefully degrading to a 2-column, and eventually 1-column layout on smaller screens.
+  - **The Outer Laser Container**: Each card requires two containers. The outer container (`.laser-card`) has `overflow: hidden`.
+  - **The Spinning Gradient**: Attached to the outer container are two `::before` and `::after` pseudo-elements. They are oversized (`width: 200%; height: 200%`) and feature a `conic-gradient` that transitions from transparent to a bright cyan laser color. They continuously rotate via an `@keyframes rotate-laser` animation.
+  - **The Volumetric Light Bleed (Bloom)**: The `::after` pseudo-element is a duplicate of the spinning gradient, but it receives a CSS `filter: blur(15px)`. This creates a soft, glowing halo behind the sharp laser line, simulating neon bloom or volumetric light bleed.
+  - **The Inner Mask**: The actual card content sits inside the `.laser-inner` container. This inner container is placed exactly `2px` inside the outer container (`top: 2px; left: 2px; etc.`) and is given a solid background color. This effectively "masks" the spinning gradients, only allowing them to be visible through the `2px` border gap around the edge.
+  - **Staggered Chaos**: To prevent the grid from looking too uniform, the animation speeds and `animation-delay` values are slightly altered depending on the grid placement area of the card, making the lasers trace asynchronously across the dashboard.
+- **Theming**: Configured via CSS Custom Properties. Best viewed in a dark theme, utilizing a cybernetic `Space Grotesk` font and cyan neon colors.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the rotating animations and glowing blur filters are disabled, and the border is replaced with a static, semi-transparent solid color.
+
+## Usage
+Open `demo.html` in your browser. Observe the continuous laser tracing effects mapping around the borders of the bento grid cards. Hover over any card to see the laser intensity and bloom effect increase.
+
+## Files
+- `demo.html`: The HTML structure defining the CSS Grid layout and the nested outer/inner containers required for the gradient masking technique.
+- `style.css`: The styling, the CSS Grid layout mathematics, the `conic-gradient` pseudo-elements, the `blur()` filter bloom, and the responsive media queries.

--- a/submissions/examples/css-bento-card-laser-ray-trace-pure/demo.html
+++ b/submissions/examples/css-bento-card-laser-ray-trace-pure/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Bento Grid: Laser Ray Trace</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title">Laser Trace Bento Grid</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free bento grid layout. Features continuous, glowing laser lines tracing the borders of the cards, powered entirely by CSS `conic-gradient` masking.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Bento Grid Container
+              Uses CSS Grid to create a responsive, asymmetric layout.
+            -->
+            <div class="bento-grid">
+                
+                <!-- 
+                  [TECHNIQUE] The Laser Trace Cards
+                  Each card requires an outer container (with overflow:hidden and the rotating gradient)
+                  and an inner container (the actual card background) to mask the center.
+                -->
+                
+                <div class="laser-card card-large">
+                    <div class="laser-inner">
+                        <div class="card-icon glow-icon">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"></polygon></svg>
+                        </div>
+                        <h3 class="card-title">Cybernetic Edge</h3>
+                        <p class="card-desc">Zero Canvas. Zero WebGL. The glowing edges are created by rotating a conic gradient behind a solid inner container.</p>
+                    </div>
+                </div>
+                
+                <div class="laser-card card-medium-1">
+                    <div class="laser-inner align-center">
+                        <h3 class="card-stat">0ms</h3>
+                        <p class="card-desc">JS Overhead</p>
+                    </div>
+                </div>
+                
+                <div class="laser-card card-medium-2">
+                    <div class="laser-inner">
+                        <h3 class="card-title">Neon Bloom</h3>
+                        <p class="card-desc">`filter: blur()` applied to pseudo-elements generates the volumetric light bleed.</p>
+                    </div>
+                </div>
+                
+                <div class="laser-card card-small-1">
+                    <div class="laser-inner align-center">
+                        <div class="card-icon mini-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="laser-card card-small-2">
+                    <div class="laser-inner align-center">
+                        <div class="card-icon mini-icon">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="laser-card card-wide">
+                    <div class="laser-inner flex-row">
+                        <div class="text-block">
+                            <h3 class="card-title">System Active</h3>
+                            <p class="card-desc">Grid coordinates mapped. Tracing sequence engaged. Performance optimized.</p>
+                        </div>
+                        <div class="status-indicator">
+                            <div class="pulse-dot"></div>
+                            <span>Online</span>
+                        </div>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-bento-card-laser-ray-trace-pure/style.css
+++ b/submissions/examples/css-bento-card-laser-ray-trace-pure/style.css
@@ -1,0 +1,377 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;500;700&display=swap');
+
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #050505; 
+    --card-bg: #0a0a0a;
+    --card-border: #1a1a1a;
+    --text-primary: #f8f9fa;
+    --text-secondary: #8b8b8b;
+    
+    /* Cyber/Laser Colors */
+    --laser-color: #00ffcc; /* Cyan/Teal glow */
+    --laser-dim: rgba(0, 255, 204, 0.1);
+    
+    /* Layout */
+    --border-width: 2px;
+    --border-radius: 16px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'Space Grotesk', sans-serif;
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    
+    /* Cyber grid background */
+    background-image: 
+        linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 30px 30px;
+}
+
+.layout-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    letter-spacing: -1px;
+    text-transform: uppercase;
+    text-shadow: 0 0 20px rgba(0, 255, 204, 0.3);
+}
+
+.subtitle {
+    font-size: 1.1rem;
+    font-weight: 300;
+    margin: 0 auto;
+    max-width: 650px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0 100px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Bento Grid Layout
+   ========================================= */
+
+.bento-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(160px, auto);
+    gap: 20px;
+    width: 100%;
+    max-width: 900px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Laser Trace Card Effect
+   ========================================= */
+
+/* The outer container that holds the glowing gradient */
+.laser-card {
+    position: relative;
+    border-radius: var(--border-radius);
+    background: var(--card-border); /* Fallback border color */
+    overflow: hidden;
+    z-index: 1;
+}
+
+/* 
+   The spinning laser light.
+   It's a conic gradient centered in the card that spins continuously.
+*/
+.laser-card::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: conic-gradient(
+        transparent, 
+        transparent 60%, 
+        var(--laser-color) 100%
+    );
+    animation: rotate-laser 4s linear infinite;
+    z-index: -2;
+    opacity: 0.5;
+    transition: opacity 0.3s ease;
+}
+
+/* 
+   The bloom/glow effect.
+   A duplicate of the spinning light, but blurred heavily.
+*/
+.laser-card::after {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: conic-gradient(
+        transparent, 
+        transparent 70%, 
+        var(--laser-color) 100%
+    );
+    animation: rotate-laser 4s linear infinite;
+    z-index: -1;
+    filter: blur(15px);
+    opacity: 0.3;
+    transition: opacity 0.3s ease;
+}
+
+@keyframes rotate-laser {
+    100% { transform: rotate(1turn); }
+}
+
+/* Hover effects intensify the laser */
+.laser-card:hover::before {
+    opacity: 1;
+}
+.laser-card:hover::after {
+    opacity: 0.8;
+}
+
+/* 
+   The inner container.
+   This sits on top of the spinning gradient, leaving a 2px gap 
+   (the border) where the gradient is visible.
+*/
+.laser-inner {
+    position: absolute;
+    top: var(--border-width);
+    left: var(--border-width);
+    right: var(--border-width);
+    bottom: var(--border-width);
+    background: var(--card-bg);
+    border-radius: calc(var(--border-radius) - var(--border-width));
+    padding: 30px;
+    z-index: 2;
+    
+    display: flex;
+    flex-direction: column;
+}
+
+
+/* Specific Grid Areas */
+
+.card-large {
+    grid-column: span 2;
+    grid-row: span 2;
+}
+/* Adjust rotation speed for different sized cards to keep tracing consistent */
+.card-large::before, .card-large::after {
+    animation-duration: 6s; 
+}
+.card-large .card-title { font-size: 1.8rem; }
+.card-large .card-icon { margin-bottom: auto; }
+
+.card-medium-1 {
+    grid-column: span 2;
+    grid-row: span 1;
+}
+.card-medium-1::before, .card-medium-1::after {
+    animation-duration: 5s;
+    /* Stagger rotation starting points */
+    animation-delay: -1s;
+}
+
+.card-medium-2 {
+    grid-column: span 2;
+    grid-row: span 1;
+}
+.card-medium-2::before, .card-medium-2::after {
+    animation-duration: 4.5s;
+    animation-delay: -2s;
+}
+
+.card-small-1 {
+    grid-column: span 1;
+    grid-row: span 1;
+}
+
+.card-small-2 {
+    grid-column: span 1;
+    grid-row: span 1;
+}
+
+.card-wide {
+    grid-column: span 4;
+    grid-row: span 1;
+}
+.card-wide::before, .card-wide::after {
+    animation-duration: 7s;
+}
+
+
+/* Content Formatting */
+
+.card-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    background: var(--laser-dim);
+    border: 1px solid rgba(0, 255, 204, 0.2);
+    color: var(--laser-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.glow-icon svg {
+    filter: drop-shadow(0 0 8px var(--laser-color));
+}
+
+.mini-icon {
+    margin-bottom: 0;
+}
+
+.card-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    letter-spacing: 0.5px;
+}
+
+.card-desc {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0;
+}
+
+.align-center {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.card-stat {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--laser-color);
+    margin: 0 0 4px 0;
+    text-shadow: 0 0 15px rgba(0, 255, 204, 0.4);
+}
+
+.flex-row {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.text-block {
+    max-width: 60%;
+}
+
+
+/* Status Indicator */
+.status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: rgba(0, 255, 204, 0.05);
+    border: 1px solid rgba(0, 255, 204, 0.2);
+    border-radius: 20px;
+    color: var(--laser-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.pulse-dot {
+    width: 8px;
+    height: 8px;
+    background: var(--laser-color);
+    border-radius: 50%;
+    box-shadow: 0 0 8px var(--laser-color);
+    animation: pulse 2s infinite alternate;
+}
+
+@keyframes pulse {
+    0% { opacity: 0.4; }
+    100% { opacity: 1; box-shadow: 0 0 12px var(--laser-color); }
+}
+
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .bento-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .card-large {
+        grid-column: span 2;
+    }
+    
+    .card-wide {
+        grid-column: span 2;
+    }
+    
+    .flex-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 20px;
+    }
+    .text-block {
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    .bento-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .laser-card {
+        grid-column: span 1 !important;
+    }
+}
+
+
+/* Accessibility - Disable animations for motion-sensitive users */
+@media (prefers-reduced-motion: reduce) {
+    .laser-card::before,
+    .laser-card::after {
+        animation: none !important;
+        /* Replace spinning gradient with a solid static border */
+        background: var(--laser-color) !important;
+        opacity: 0.3 !important;
+        filter: none !important;
+    }
+    
+    .laser-card:hover::before,
+    .laser-card:hover::after {
+        opacity: 0.5 !important;
+    }
+    
+    .pulse-dot {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free bento grid layout. It features continuous, glowing laser lines tracing the borders of the cards, powered entirely by CSS `conic-gradient` masking. Resolves issue #75111.

### Changes Made:
- Added `submissions/examples/css-bento-card-laser-ray-trace-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the CSS Grid layout and the nested outer/inner containers required for the gradient masking technique.
- Created `style.css` featuring the UI mechanics:
  - **The Bento Grid**: Built using modern CSS Grid (`display: grid; grid-template-columns: repeat(4, 1fr)`). The layout is fully responsive, gracefully degrading to a 2-column, and eventually 1-column layout on smaller screens.
  - **The Outer Laser Container**: Each card requires two containers. The outer container (`.laser-card`) has `overflow: hidden`.
  - **The Spinning Gradient**: Attached to the outer container are two `::before` and `::after` pseudo-elements. They are oversized (`width: 200%; height: 200%`) and feature a `conic-gradient` that transitions from transparent to a bright cyan laser color. They continuously rotate via an `@keyframes rotate-laser` animation.
  - **The Volumetric Light Bleed (Bloom)**: The `::after` pseudo-element is a duplicate of the spinning gradient, but it receives a CSS `filter: blur(15px)`. This creates a soft, glowing halo behind the sharp laser line, simulating neon bloom or volumetric light bleed.
  - **The Inner Mask**: The actual card content sits inside the `.laser-inner` container. This inner container is placed exactly `2px` inside the outer container (`top: 2px; left: 2px; etc.`) and is given a solid background color. This effectively "masks" the spinning gradients, only allowing them to be visible through the `2px` border gap around the edge.
  - **Staggered Chaos**: To prevent the grid from looking too uniform, the animation speeds and `animation-delay` values are slightly altered depending on the grid placement area of the card, making the lasers trace asynchronously across the dashboard.
  - **Theming Supported**: Configured via CSS Custom Properties. Best viewed in a dark theme, utilizing a cybernetic font and cyan neon colors.
- Added `README.md` documenting usage and the technical mechanics of the CSS Grid layout mathematics, the `conic-gradient` pseudo-elements, the `blur()` filter bloom, and the responsive media queries.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the rotating animations and glowing blur filters are disabled, and the border is replaced with a static, semi-transparent solid color.

Closes #75111
