### PR TITLE
feat: add pure CSS Bento Card Retro Arcade Pixel component (#75113)

### DIFF
--- a/submissions/examples/css-bento-card-retro-arcade-pixel-pure/README.md
+++ b/submissions/examples/css-bento-card-retro-arcade-pixel-pure/README.md
@@ -1,0 +1,21 @@
+# CSS Bento Grid: Retro Arcade Pixel
+
+A hardware-accelerated, JavaScript-free bento grid layout. Features 8-bit styling, pixelated corners via CSS `clip-path` and `box-shadow`, CRT scanlines, and retro hover animations.
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, images, or JavaScript required for the pixel art or the CRT monitor effects.
+- **Component Architecture**: 
+  - **The Bento Grid**: Built using modern CSS Grid (`display: grid; grid-template-columns: repeat(4, 1fr)`). The layout is fully responsive, gracefully degrading to a 2-column, and eventually 1-column layout on smaller screens.
+  - **The Pixel Corners**: True 8-bit aesthetic requires blocky corners, not smooth `border-radius`. We achieve this without images by using a precise CSS `clip-path: polygon()` on the outer `.pixel-card` to cut out the 4x4 pixel corners. Then, we use multiple `inset box-shadow` values on a `::before` pseudo-element to redraw the thick internal pixel border perfectly conforming to the cut shape.
+  - **Pure CSS Pixel Art Sprites**: The alien invader, ghost, and coin icons are not images or SVGs. They are single `<div>` elements (e.g. `.sprite-invader`) sized to `4px` or `6px`. We use massive, multi-layered `box-shadow` declarations to "draw" the pixels of the sprite on a grid relative to that single div.
+  - **Stepped Animation**: Smooth transitions ruin 8-bit aesthetics. All animations (`hover`, `transform`, sprite changes) use `transition-timing-function: steps(x)`. This forces the animations to snap frame-by-frame, authentically replicating low framerate retro games.
+  - **The CRT Overlay**: A fixed, `pointer-events: none` overlay covers the entire screen. It uses a repeating `linear-gradient` (`background-size: 100% 4px`) alternating between transparent and semi-transparent black. This perfectly simulates the horizontal scanlines of an old CRT arcade cabinet monitor.
+- **Theming**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), featuring classic arcade neon colors (Red, Green, Yellow, Blue).
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the blinking cursors and stepped hover animations are disabled.
+
+## Usage
+Open `demo.html` in your browser. Notice the CRT scanlines overlaying the screen. Hover over the various cards to see the pixel art sprites animate using pure CSS box-shadows. The "Start" button simulates a physical arcade push-button when clicked.
+
+## Files
+- `demo.html`: The HTML structure defining the CSS Grid layout and the pixel art containers. Includes standard Google Fonts for the 8-bit typography.
+- `style.css`: The styling, the CSS Grid layout mathematics, the complex `box-shadow` pixel art generators, the `clip-path` corners, and the `steps()` timing functions.

--- a/submissions/examples/css-bento-card-retro-arcade-pixel-pure/demo.html
+++ b/submissions/examples/css-bento-card-retro-arcade-pixel-pure/demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Bento Grid: Retro Arcade Pixel</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Using a pixel/monospace font -->
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="layout-container">
+        
+        <header class="section-header">
+            <h1 class="title title-glitch" data-text="ARCADE BENTO">ARCADE BENTO</h1>
+            <p class="subtitle">A hardware-accelerated, JavaScript-free bento grid layout. Features 8-bit styling, pixelated corners via CSS `box-shadow`, CRT scanlines, and retro hover animations.</p>
+        </header>
+
+        <div class="demo-area">
+            
+            <!-- 
+              [TECHNIQUE] The Bento Grid Container
+              Uses CSS Grid to create a responsive, asymmetric layout.
+            -->
+            <div class="bento-grid">
+                
+                <!-- 
+                  [TECHNIQUE] The Pixel Cards
+                  The pixelated corners are achieved using the box-shadow property
+                  rather than border-radius.
+                -->
+                
+                <div class="pixel-card card-large">
+                    <div class="card-inner">
+                        <div class="card-icon pixel-icon icon-red">
+                            <!-- Simple pure CSS pixel art sprite -->
+                            <div class="sprite-invader"></div>
+                        </div>
+                        <h3 class="card-title">INSERT COIN</h3>
+                        <p class="card-desc">Welcome to the pure CSS arcade. Zero JavaScript required to render these 8-bit aesthetics and layout engines.</p>
+                        <div class="blinking-cursor">_</div>
+                    </div>
+                </div>
+                
+                <div class="pixel-card card-medium-1">
+                    <div class="card-inner align-center">
+                        <h3 class="card-stat text-yellow">1UP</h3>
+                        <p class="card-desc">EXTRA LIFE</p>
+                    </div>
+                </div>
+                
+                <div class="pixel-card card-medium-2">
+                    <div class="card-inner">
+                        <h3 class="card-title text-green">SCORE</h3>
+                        <p class="card-desc">CSS Grid layout perfectly mapped to Cartesian coordinates.</p>
+                    </div>
+                </div>
+                
+                <div class="pixel-card card-small-1">
+                    <div class="card-inner align-center">
+                        <div class="card-icon pixel-icon icon-blue">
+                            <div class="sprite-ghost"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="pixel-card card-small-2">
+                    <div class="card-inner align-center">
+                        <div class="card-icon pixel-icon icon-orange">
+                            <div class="sprite-coin"></div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="pixel-card card-wide">
+                    <div class="card-inner flex-row">
+                        <div class="text-block">
+                            <h3 class="card-title">STAGE 1-1</h3>
+                            <p class="card-desc">Ready Player One. Hover over elements to trigger the 8-bit interaction states.</p>
+                        </div>
+                        <button class="pixel-btn">START</button>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </div>
+        
+    </div>
+    
+    <!-- 
+      [TECHNIQUE] CRT Scanlines Overlay
+      A fixed pseudo-element covering the screen with a repeating linear-gradient
+      to simulate an old CRT monitor.
+    -->
+    <div class="crt-overlay"></div>
+
+</body>
+</html>

--- a/submissions/examples/css-bento-card-retro-arcade-pixel-pure/style.css
+++ b/submissions/examples/css-bento-card-retro-arcade-pixel-pure/style.css
@@ -1,0 +1,351 @@
+/* =========================================
+   Theming via Custom Properties
+   ========================================= */
+:root {
+    --bg-base: #111111; 
+    --card-bg: #222222;
+    --text-primary: #ffffff;
+    --text-secondary: #aaaaaa;
+    
+    /* Arcade Palette */
+    --arcade-red: #ff003c;
+    --arcade-blue: #00e5ff;
+    --arcade-green: #39ff14;
+    --arcade-yellow: #ffff00;
+    --arcade-orange: #ff7700;
+    
+    /* Pixel Grid setup */
+    --pixel-size: 4px;
+    --pixel-border: #ffffff;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg-base: #e0e0e0; 
+        --card-bg: #ffffff;
+        --text-primary: #000000;
+        --text-secondary: #555555;
+        --pixel-border: #000000;
+        
+        --arcade-red: #d1002c;
+        --arcade-blue: #0096cc;
+        --arcade-green: #00aa00;
+        --arcade-yellow: #cc9900;
+    }
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    font-family: 'VT323', monospace; /* Pixel text */
+    color: var(--text-primary);
+    -webkit-font-smoothing: none; /* Crucial for crisp pixels */
+    min-height: 100vh;
+}
+
+.layout-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 60px 20px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 60px;
+    text-align: center;
+}
+
+.title {
+    font-family: 'Press Start 2P', cursive;
+    font-size: 2.2rem;
+    color: var(--arcade-yellow);
+    margin: 0 0 24px 0;
+    text-shadow: 4px 4px 0 var(--arcade-red);
+}
+
+.subtitle {
+    font-size: 1.4rem;
+    margin: 0 auto;
+    max-width: 650px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+}
+
+.demo-area {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0 100px 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Bento Grid Layout
+   ========================================= */
+
+.bento-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(180px, auto);
+    gap: 24px; /* Slightly larger gap to accommodate the pixel borders */
+    width: 100%;
+    max-width: 900px;
+}
+
+
+/* =========================================
+   [TECHNIQUE] The Pixel Card
+   ========================================= */
+
+.pixel-card {
+    position: relative;
+    background: var(--card-bg);
+    /* 
+       We do NOT use border-radius.
+       Instead, we use a solid box-shadow that draws steps
+       to simulate a low-res pixelated corner.
+    */
+    border: var(--pixel-size) solid var(--pixel-border);
+    /* Remove corners via clip path for the outer shape */
+    clip-path: polygon(
+        var(--pixel-size) 0, 
+        calc(100% - var(--pixel-size)) 0, 
+        100% var(--pixel-size), 
+        100% calc(100% - var(--pixel-size)), 
+        calc(100% - var(--pixel-size)) 100%, 
+        var(--pixel-size) 100%, 
+        0 calc(100% - var(--pixel-size)), 
+        0 var(--pixel-size)
+    );
+    
+    transition: transform 0.1s steps(3); /* Chunky step animation */
+    cursor: pointer;
+}
+
+.pixel-card::before {
+    /* Create the internal pixel border using box-shadow inside the clip-path */
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    box-shadow: 
+        inset var(--pixel-size) 0 0 0 var(--pixel-border),
+        inset calc(var(--pixel-size)*-1) 0 0 0 var(--pixel-border),
+        inset 0 var(--pixel-size) 0 0 var(--pixel-border),
+        inset 0 calc(var(--pixel-size)*-1) 0 0 var(--pixel-border);
+    pointer-events: none;
+    z-index: 5;
+}
+
+.pixel-card:hover {
+    /* Snap move up instead of smooth */
+    transform: translateY(-8px);
+    background: var(--bg-base);
+}
+
+.card-inner {
+    position: relative;
+    height: 100%;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    z-index: 1;
+}
+
+
+/* Specific Grid Areas */
+.card-large { grid-column: span 2; grid-row: span 2; }
+.card-medium-1 { grid-column: span 2; grid-row: span 1; }
+.card-medium-2 { grid-column: span 2; grid-row: span 1; }
+.card-small-1 { grid-column: span 1; grid-row: span 1; }
+.card-small-2 { grid-column: span 1; grid-row: span 1; }
+.card-wide { grid-column: span 4; grid-row: span 1; }
+
+.card-large .card-icon { margin-bottom: auto; }
+.card-large .card-title { font-size: 2.2rem; }
+
+
+/* Text Utilities */
+.card-title {
+    font-family: 'Press Start 2P', cursive;
+    font-size: 1.2rem;
+    margin: 0 0 16px 0;
+    line-height: 1.4;
+}
+
+.card-desc {
+    font-size: 1.4rem;
+    color: var(--text-secondary);
+    line-height: 1.2;
+    margin: 0;
+}
+
+.align-center {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.card-stat {
+    font-family: 'Press Start 2P', cursive;
+    font-size: 2rem;
+    margin: 0 0 16px 0;
+    animation: blink 1s step-end infinite;
+}
+
+.text-red { color: var(--arcade-red); }
+.text-green { color: var(--arcade-green); }
+.text-yellow { color: var(--arcade-yellow); }
+.text-blue { color: var(--arcade-blue); }
+
+.flex-row {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+.text-block { max-width: 60%; }
+
+.blinking-cursor {
+    font-size: 2rem;
+    animation: blink 1s step-end infinite;
+    margin-top: 10px;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+
+/* =========================================
+   [TECHNIQUE] Pixel Art Sprites via Box-Shadow
+   ========================================= */
+   
+.pixel-icon {
+    width: 64px;
+    height: 64px;
+    background: var(--card-bg);
+    border: var(--pixel-size) solid var(--pixel-border);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.icon-red { border-color: var(--arcade-red); }
+.icon-blue { border-color: var(--arcade-blue); }
+.icon-orange { border-color: var(--arcade-orange); }
+
+/* 
+   We draw an alien invader purely using box-shadows on a 4x4px div.
+*/
+.sprite-invader {
+    width: 4px;
+    height: 4px;
+    background: transparent;
+    box-shadow: 
+        12px 0 0 0 var(--arcade-red), -12px 0 0 0 var(--arcade-red),
+        8px 4px 0 0 var(--arcade-red), -8px 4px 0 0 var(--arcade-red),
+        8px 8px 0 0 var(--arcade-red), 4px 8px 0 0 var(--arcade-red), 0 8px 0 0 var(--arcade-red), -4px 8px 0 0 var(--arcade-red), -8px 8px 0 0 var(--arcade-red),
+        16px 12px 0 0 var(--arcade-red), 12px 12px 0 0 var(--arcade-red), 4px 12px 0 0 var(--arcade-red), 0 12px 0 0 var(--arcade-red), -4px 12px 0 0 var(--arcade-red), -12px 12px 0 0 var(--arcade-red), -16px 12px 0 0 var(--arcade-red),
+        16px 16px 0 0 var(--arcade-red), 0 16px 0 0 var(--arcade-red), -16px 16px 0 0 var(--arcade-red),
+        8px 20px 0 0 var(--arcade-red), -8px 20px 0 0 var(--arcade-red);
+    transform: translateY(-10px);
+}
+
+.pixel-card:hover .sprite-invader {
+    /* Animate arms */
+    box-shadow: 
+        8px 0 0 0 var(--arcade-red), -8px 0 0 0 var(--arcade-red),
+        12px 4px 0 0 var(--arcade-red), -12px 4px 0 0 var(--arcade-red),
+        8px 8px 0 0 var(--arcade-red), 4px 8px 0 0 var(--arcade-red), 0 8px 0 0 var(--arcade-red), -4px 8px 0 0 var(--arcade-red), -8px 8px 0 0 var(--arcade-red),
+        16px 12px 0 0 var(--arcade-red), 12px 12px 0 0 var(--arcade-red), 4px 12px 0 0 var(--arcade-red), 0 12px 0 0 var(--arcade-red), -4px 12px 0 0 var(--arcade-red), -12px 12px 0 0 var(--arcade-red), -16px 12px 0 0 var(--arcade-red),
+        16px 16px 0 0 var(--arcade-red), 0 16px 0 0 var(--arcade-red), -16px 16px 0 0 var(--arcade-red),
+        12px 20px 0 0 var(--arcade-red), -12px 20px 0 0 var(--arcade-red);
+}
+
+.sprite-ghost {
+    width: 6px; height: 6px; background: var(--arcade-blue);
+    box-shadow: 6px 0 var(--arcade-blue), -6px 0 var(--arcade-blue), 0 -6px var(--arcade-blue), 0 6px var(--arcade-blue), -6px 6px var(--arcade-blue), 6px 6px var(--arcade-blue);
+    transform: translateY(-3px);
+}
+.pixel-card:hover .sprite-ghost { transform: translateY(-6px); }
+
+.sprite-coin {
+    width: 8px; height: 12px; background: var(--arcade-yellow);
+    box-shadow: 8px 0 var(--arcade-yellow), -8px 0 var(--arcade-yellow);
+}
+.pixel-card:hover .sprite-coin { transform: scaleX(0.2); }
+
+
+/* =========================================
+   [TECHNIQUE] Pixel Button
+   ========================================= */
+
+.pixel-btn {
+    font-family: 'Press Start 2P', cursive;
+    background: var(--arcade-green);
+    color: #000;
+    border: var(--pixel-size) solid var(--pixel-border);
+    padding: 16px 24px;
+    font-size: 1rem;
+    cursor: pointer;
+    box-shadow: 4px 4px 0 var(--pixel-border);
+    text-transform: uppercase;
+    transition: transform 0.1s steps(2), box-shadow 0.1s steps(2);
+}
+
+.pixel-btn:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--pixel-border);
+}
+
+.pixel-btn:active {
+    transform: translate(4px, 4px);
+    box-shadow: 0 0 0 var(--pixel-border);
+    background: var(--arcade-yellow);
+}
+
+
+/* =========================================
+   [TECHNIQUE] CRT Overlay
+   ========================================= */
+
+.crt-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    pointer-events: none;
+    z-index: 100;
+    /* Repeating linear gradient for scanlines */
+    background: linear-gradient(
+        to bottom,
+        rgba(255,255,255,0),
+        rgba(255,255,255,0) 50%,
+        rgba(0,0,0,0.1) 50%,
+        rgba(0,0,0,0.1)
+    );
+    background-size: 100% 4px; /* 4px scanlines */
+}
+
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .bento-grid { grid-template-columns: repeat(2, 1fr); }
+    .card-large, .card-wide { grid-column: span 2; }
+    .flex-row { flex-direction: column; align-items: flex-start; gap: 24px; }
+    .text-block { max-width: 100%; }
+}
+
+@media (max-width: 480px) {
+    .bento-grid { grid-template-columns: 1fr; }
+    .pixel-card { grid-column: span 1 !important; }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .pixel-card, .pixel-btn, .blinking-cursor, .sprite-invader {
+        transition: none !important;
+        animation: none !important;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free bento grid layout. It features 8-bit styling, pixelated corners via CSS `clip-path` and `box-shadow`, CRT scanlines, and retro hover animations. Resolves issue #75113.

### Changes Made:
- Added `submissions/examples/css-bento-card-retro-arcade-pixel-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the CSS Grid layout and the pixel art containers. Includes standard Google Fonts for the 8-bit typography.
- Created `style.css` featuring the UI mechanics:
  - **The Bento Grid**: Built using modern CSS Grid (`display: grid; grid-template-columns: repeat(4, 1fr)`). The layout is fully responsive, gracefully degrading to a 2-column, and eventually 1-column layout on smaller screens.
  - **The Pixel Corners**: True 8-bit aesthetic requires blocky corners, not smooth `border-radius`. We achieve this without images by using a precise CSS `clip-path: polygon()` on the outer `.pixel-card` to cut out the 4x4 pixel corners. Then, we use multiple `inset box-shadow` values on a `::before` pseudo-element to redraw the thick internal pixel border perfectly conforming to the cut shape.
  - **Pure CSS Pixel Art Sprites**: The alien invader, ghost, and coin icons are not images or SVGs. They are single `<div>` elements (e.g. `.sprite-invader`) sized to `4px` or `6px`. We use massive, multi-layered `box-shadow` declarations to "draw" the pixels of the sprite on a grid relative to that single div.
  - **Stepped Animation**: Smooth transitions ruin 8-bit aesthetics. All animations (`hover`, `transform`, sprite changes) use `transition-timing-function: steps(x)`. This forces the animations to snap frame-by-frame, authentically replicating low framerate retro games.
  - **The CRT Overlay**: A fixed, `pointer-events: none` overlay covers the entire screen. It uses a repeating `linear-gradient` (`background-size: 100% 4px`) alternating between transparent and semi-transparent black. This perfectly simulates the horizontal scanlines of an old CRT arcade cabinet monitor.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully responsive to OS-level dark mode (`prefers-color-scheme`), featuring classic arcade neon colors (Red, Green, Yellow, Blue).
- Added `README.md` documenting usage and the technical mechanics of the complex `box-shadow` pixel art generators, the `clip-path` corners, and the `steps()` timing functions.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. For motion-sensitive users, the blinking cursors and stepped hover animations are disabled.

Closes #75113
