### PR TITLE
feat: add Split-Flap Counter example (split-flap-counter-advk)

### DIFF
--- a/submissions/examples/split-flap-counter-advk/README.md
+++ b/submissions/examples/split-flap-counter-advk/README.md
@@ -1,0 +1,39 @@
+# Split-Flap Counter
+
+## What does this do?
+
+A digit display that flips like a mechanical split-flap (departure board)
+counter: when a digit changes, its card rotates down on the X-axis to
+reveal the new value underneath, instead of just cross-fading or swapping
+text.
+
+## How is it used?
+
+```html
+<span class="sfc-digit">
+  <span class="sfc-current">0</span>
+  <span class="sfc-next">0</span>
+</span>
+<script>sfcSet(digitEl, 7);</script>
+```
+
+`sfcSet` writes the target digit into `.sfc-next` first, retriggers the flip
+animation via a forced reflow (`void el.offsetWidth`), then commits the new
+value into `.sfc-current` once the flip's `animationend` fires — so the
+visible digit only changes at the exact moment the card has rotated past
+90° and would show the back face anyway.
+
+## Why is it useful?
+
+A naive digit-flip effect just cross-fades old and new text, which reads as
+a dissolve rather than a mechanical flip. Stacking `.sfc-next` exactly
+behind `.sfc-current` and rotating only the front card means the new digit
+is genuinely revealed by the old one rotating away, matching how a real
+split-flap display works: the front card's back face is a different colour
+from its front, so the flip has two visually distinct halves rather than
+one card just disappearing.
+
+The forced reflow (`void el.offsetWidth`) between removing and re-adding the
+`sfc-flip` class is necessary because otherwise the browser can coalesce the
+two class changes into one paint and the animation never restarts on a
+second flip of the same digit.

--- a/submissions/examples/split-flap-counter-advk/demo.html
+++ b/submissions/examples/split-flap-counter-advk/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Split-Flap Counter</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function sfcSet(el, digit) {
+    var current = el.querySelector('.sfc-current');
+    var next = el.querySelector('.sfc-next');
+    if (current.textContent === String(digit)) return;
+    next.textContent = digit;
+    el.classList.remove('sfc-flip');
+    void el.offsetWidth;
+    el.classList.add('sfc-flip');
+    el.addEventListener('animationend', function handler() {
+      current.textContent = digit;
+      el.classList.remove('sfc-flip');
+      el.removeEventListener('animationend', handler);
+    });
+  }
+
+  function sfcBump() {
+    var digits = document.querySelectorAll('.sfc-digit');
+    digits.forEach(function (el) {
+      var value = Number(el.querySelector('.sfc-current').textContent);
+      sfcSet(el, (value + 1) % 10);
+    });
+  }
+</script>
+</head>
+<body>
+<main class="sfc-wrap">
+  <h1 class="sfc-h1">Split-Flap Counter</h1>
+  <p class="sfc-lede">Each digit is two stacked halves; changing a digit flips the top half down over the new value while the bottom half updates underneath, mimicking a mechanical departure board.</p>
+
+  <div class="sfc-display">
+    <span class="sfc-digit"><span class="sfc-current">0</span><span class="sfc-next">0</span></span>
+    <span class="sfc-digit"><span class="sfc-current">0</span><span class="sfc-next">0</span></span>
+    <span class="sfc-digit"><span class="sfc-current">0</span><span class="sfc-next">0</span></span>
+  </div>
+
+  <button type="button" class="sfc-btn" onclick="sfcBump()">Flip</button>
+</main>
+</body>
+</html>

--- a/submissions/examples/split-flap-counter-advk/style.css
+++ b/submissions/examples/split-flap-counter-advk/style.css
@@ -1,0 +1,100 @@
+/* Split-Flap Counter
+   .sfc-next is stacked exactly behind .sfc-current and only becomes visible
+   as .sfc-current's card rotates past 90deg on the X-axis, so the flip
+   reveals the new digit instead of just rotating the old one out. */
+
+.sfc-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  text-align: center;
+}
+
+.sfc-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.sfc-lede { margin: 0 0 2rem; color: #576073; text-align: left; }
+
+.sfc-display {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  perspective: 300px;
+  margin-bottom: 1.5rem;
+}
+
+.sfc-digit {
+  position: relative;
+  width: 3rem;
+  height: 4rem;
+  border-radius: 0.4rem;
+  background: #1c2028;
+  overflow: hidden;
+}
+
+.sfc-current,
+.sfc-next {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #fff;
+  backface-visibility: hidden;
+}
+
+.sfc-current {
+  transform-origin: center;
+}
+
+.sfc-digit.sfc-flip .sfc-current {
+  animation: sfc-flip-out 320ms ease-in forwards;
+}
+
+.sfc-digit::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 1;
+}
+
+@keyframes sfc-flip-out {
+  0% { transform: rotateX(0deg); }
+  100% { transform: rotateX(-180deg); }
+}
+
+.sfc-btn {
+  padding: 0.6em 1.4em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+  transition: background 140ms ease;
+}
+
+.sfc-btn:hover { background: #e4e9f4; }
+.sfc-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .sfc-digit.sfc-flip .sfc-current { animation: none; }
+  .sfc-btn { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .sfc-digit { forced-color-adjust: none; background: ButtonText; border: 1px solid CanvasText; }
+  .sfc-current, .sfc-next { color: ButtonFace; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sfc-wrap { color: #e6e9f2; }
+  .sfc-lede { color: #99a1b4; }
+  .sfc-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+  .sfc-btn:hover { background: #262e3d; }
+}


### PR DESCRIPTION
Closes #75487

Digit display that flips mechanically like a departure board: a stacked back layer is revealed as the front card rotates past 90deg on the X-axis, instead of cross-fading old and new text. A forced reflow between animation retriggers keeps repeated flips of the same digit working.

- prefers-reduced-motion and forced-colors support