### PR TITLE
feat: add Masked Input example (masked-input-advk)

### DIFF
--- a/submissions/examples/masked-input-advk/README.md
+++ b/submissions/examples/masked-input-advk/README.md
@@ -1,0 +1,40 @@
+# Masked Input
+
+## What does this do?
+
+A phone-number input that inserts formatting characters — parentheses,
+space, dash — as digits are typed, and shows the mask's shape in the
+placeholder before any input, using `(___) ___-____`.
+
+## How is it used?
+
+```html
+<input
+  type="tel"
+  inputmode="numeric"
+  placeholder="(___) ___-____"
+  oninput="maskApply(this, '(###) ###-####')"
+/>
+```
+
+`maskApply` strips everything but digits from the current value, then
+rebuilds the string against the pattern, inserting a literal character
+whenever the pattern isn't `#`. Stripping first means pasting a
+pre-formatted number (`555-123-4567`) re-masks correctly instead of doubling
+the punctuation.
+
+## Why is it useful?
+
+Masking logic is usually implemented purely in JavaScript with no visual
+cue for the expected format until the user starts typing, so the field's
+structure is discovered by trial and error. Using underscores in the
+placeholder gives the field's shape away up front, and pairing that with
+`font-variant-numeric: tabular-nums` plus matched `letter-spacing` on both
+the placeholder and the typed value keeps each digit landing visually under
+its corresponding blank rather than drifting as proportional-width digits
+shift the line.
+
+`inputmode="numeric"` requests a numeric keyboard on mobile without
+requiring `type="number"`, which would fight with the mask's literal
+characters — `type="tel"` accepts the punctuation the mask inserts while
+still getting the right on-screen keyboard.

--- a/submissions/examples/masked-input-advk/demo.html
+++ b/submissions/examples/masked-input-advk/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Masked Input</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function maskApply(input, pattern) {
+    var digits = input.value.replace(/\D/g, '');
+    var out = '';
+    var di = 0;
+    for (var i = 0; i < pattern.length && di < digits.length; i++) {
+      out += pattern[i] === '#' ? digits[di++] : pattern[i];
+    }
+    input.value = out;
+  }
+</script>
+</head>
+<body>
+<main class="mki-wrap">
+  <h1 class="mki-h1">Masked Input</h1>
+  <p class="mki-lede">A phone-number field that inserts formatting characters as you type, with the mask's literal characters styled distinctly from typed digits so the field's structure stays visible before it's filled.</p>
+
+  <label class="mki-field-label" for="mki-phone">Phone number</label>
+  <input
+    id="mki-phone"
+    class="mki-input"
+    type="tel"
+    inputmode="numeric"
+    placeholder="(___) ___-____"
+    oninput="maskApply(this, '(###) ###-####')"
+    autocomplete="tel"
+  />
+</main>
+</body>
+</html>

--- a/submissions/examples/masked-input-advk/style.css
+++ b/submissions/examples/masked-input-advk/style.css
@@ -1,0 +1,60 @@
+/* Masked Input
+   The placeholder uses underscores in the mask's exact shape so the field's
+   expected structure is visible before any digit is typed, at the same
+   letter-spacing as the value so digits land under the right blank. */
+
+.mki-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.mki-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.mki-lede { margin: 0 0 2rem; color: #576073; }
+
+.mki-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.mki-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.03em;
+  transition: border-color 160ms ease;
+}
+
+.mki-input::placeholder {
+  color: #b7bdcb;
+  letter-spacing: 0.03em;
+}
+
+.mki-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mki-input { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .mki-input { border-color: CanvasText; }
+  .mki-input:focus-visible { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .mki-wrap { color: #e6e9f2; }
+  .mki-lede { color: #99a1b4; }
+  .mki-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .mki-input::placeholder { color: #4a5266; }
+}


### PR DESCRIPTION
Closes #75488

Phone-number field that inserts mask punctuation as digits are typed, stripping non-digits first so pasted pre-formatted numbers re-mask correctly instead of doubling punctuation. Underscore placeholder shows the mask's shape up front; tabular-nums plus matched letter-spacing keeps digits aligned to their blanks.

- inputmode="numeric" for the right mobile keyboard, dark-mode support