### PR TITLE
feat: add Radio Card Group example (radio-card-group-advk)

### DIFF
--- a/submissions/examples/radio-card-group-advk/README.md
+++ b/submissions/examples/radio-card-group-advk/README.md
@@ -1,0 +1,38 @@
+# Radio Card Group
+
+## What does this do?
+
+A plan/option picker where each choice is a full card — title, description,
+price — rather than a small circle with a text label next to it. The
+entire card is clickable because the `<label>` wraps the whole tile,
+including a visually-hidden `<input type="radio">`.
+
+## How is it used?
+
+```html
+<label class="rcg-card">
+  <input type="radio" name="rcg-plan" value="pro" class="rcg-input" />
+  <span class="rcg-title">Pro</span>
+  <span class="rcg-desc">Everything, plus team seats.</span>
+  <span class="rcg-price">$29/mo</span>
+</label>
+```
+
+Selected/focus styling is applied to `.rcg-card` via `:has(.rcg-input:checked)`
+and `:has(.rcg-input:focus-visible)`, since the radio itself is visually
+hidden and there's no visible circle to style directly.
+
+## Why is it useful?
+
+A plain radio list works but scales poorly once each option needs a
+description or a price — that content either gets cramped next to a tiny
+circle or moved outside the label, which shrinks the click target back down
+to just the circle and its immediate text. Wrapping the input in a `<label>`
+that also contains the description keeps the whole card clickable, and
+`:has()` lets a single selector on the *card* react to the *input's* state
+without a sibling combinator or extra JS-managed classes.
+
+The input is hidden with a `clip`-based visually-hidden technique, not
+`display: none`, which would remove it from the accessibility tree — this
+way the group still behaves like ordinary radio buttons for keyboard and
+screen-reader users, arrow-key navigation included.

--- a/submissions/examples/radio-card-group-advk/demo.html
+++ b/submissions/examples/radio-card-group-advk/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Radio Card Group</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rcg-wrap">
+  <h1 class="rcg-h1">Choose a plan</h1>
+  <p class="rcg-lede">Each option is a full card, not just a small circle, and the whole card is the click target because the label wraps the entire tile.</p>
+
+  <fieldset class="rcg-field">
+    <legend class="rcg-legend">Billing plan</legend>
+    <div class="rcg-grid">
+      <label class="rcg-card">
+        <input type="radio" name="rcg-plan" value="basic" class="rcg-input" />
+        <span class="rcg-title">Basic</span>
+        <span class="rcg-desc">Core features for individuals.</span>
+        <span class="rcg-price">$9/mo</span>
+      </label>
+
+      <label class="rcg-card">
+        <input type="radio" name="rcg-plan" value="pro" class="rcg-input" checked />
+        <span class="rcg-title">Pro</span>
+        <span class="rcg-desc">Everything, plus team seats.</span>
+        <span class="rcg-price">$29/mo</span>
+      </label>
+
+      <label class="rcg-card">
+        <input type="radio" name="rcg-plan" value="enterprise" class="rcg-input" />
+        <span class="rcg-title">Enterprise</span>
+        <span class="rcg-desc">Custom limits and support.</span>
+        <span class="rcg-price">Contact us</span>
+      </label>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/radio-card-group-advk/style.css
+++ b/submissions/examples/radio-card-group-advk/style.css
@@ -1,0 +1,85 @@
+/* Radio Card Group
+   The <input> stays in normal flow but visually hidden -- not display:none --
+   so :focus-visible on it can still style the wrapping label/card via the
+   adjacent-sibling-free ":has()" alternative: a direct child selector on
+   the label itself, since the input is the label's own descendant here. */
+
+.rcg-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.rcg-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.rcg-lede { margin: 0 0 2rem; color: #576073; }
+
+.rcg-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.rcg-legend {
+  font-weight: 600;
+  margin-bottom: 0.9rem;
+}
+
+.rcg-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.rcg-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.1rem;
+  border: 2px solid #dfe3ec;
+  border-radius: 0.7rem;
+  cursor: pointer;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.rcg-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.rcg-title { font-weight: 700; }
+.rcg-desc { font-size: 0.86rem; color: #576073; }
+.rcg-price { margin-top: 0.4rem; font-size: 0.9rem; font-weight: 600; color: #4c6ef5; }
+
+.rcg-card:has(.rcg-input:checked) {
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.18);
+}
+
+.rcg-card:has(.rcg-input:focus-visible) {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.rcg-card:hover { border-color: #b7c0f2; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rcg-card { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .rcg-card { border-color: CanvasText; }
+  .rcg-card:has(.rcg-input:checked) { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rcg-wrap { color: #e6e9f2; }
+  .rcg-lede { color: #99a1b4; }
+  .rcg-card { border-color: #2a303c; }
+  .rcg-desc { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #75489

Plan/option picker where each choice is a full card (title, description, price), not just a circle with adjacent text. The label wraps the whole tile including a visually-hidden radio input, so the entire card is the click target; :has() styles the card from the radio's checked/focus state.

- forced-colors and dark-mode support, keyboard arrow-key navigation preserved