### PR TITLE
feat: add Before/After Reveal example (before-after-reveal-advk)

### DIFF
--- a/submissions/examples/before-after-reveal-advk/README.md
+++ b/submissions/examples/before-after-reveal-advk/README.md
@@ -1,0 +1,39 @@
+# Before/After Reveal
+
+## What does this do?
+
+A before/after comparison slider: dragging a handle reveals more or less of
+the "after" layer over the "before" layer beneath it, using a range input to
+drive a `clip-path: inset()` custom property.
+
+## How is it used?
+
+```html
+<div class="bar-compare">
+  <div class="bar-layer bar-before">Before</div>
+  <div class="bar-layer bar-after" style="--bar-pos: 50%">After</div>
+  <input type="range" class="bar-range" min="0" max="100" value="50"
+    oninput="this.previousElementSibling.style.setProperty('--bar-pos', this.value + '%')" />
+  <div class="bar-handle" style="left: 50%"></div>
+</div>
+```
+
+The range input is stretched transparent (`opacity: 0`) over the entire
+compare area so it captures drag/click input anywhere in the frame, not just
+along a thin visible track; a separate `.bar-handle` element supplies the
+visible dividing line and thumb.
+
+## Why is it useful?
+
+Building a draggable before/after divider by hand means implementing
+pointer capture, drag bounds clamping, and touch support from scratch. Using
+a native `<input type="range">` for the interaction gets all of that free —
+keyboard arrow-key stepping, touch dragging, and click-to-jump — while its
+native visuals are hidden entirely so the custom `.bar-handle` can be styled
+independently without fighting the browser's thumb/track rendering across
+engines.
+
+Driving the clip with a CSS custom property (`--bar-pos`) rather than
+directly setting `clip-path` from JS on every input event keeps the actual
+clip-path expression declared once in CSS, so changing the reveal direction
+or transition timing later doesn't require touching the script.

--- a/submissions/examples/before-after-reveal-advk/demo.html
+++ b/submissions/examples/before-after-reveal-advk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Before/After Reveal</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="bar-wrap">
+  <h1 class="bar-h1">Before / After</h1>
+  <p class="bar-lede">A range input drives a clip-path inset on the "after" layer, so dragging the handle reveals more or less of it over the "before" layer beneath — no image-specific JS.</p>
+
+  <div class="bar-compare">
+    <div class="bar-layer bar-before">Before</div>
+    <div class="bar-layer bar-after" style="--bar-pos: 50%">After</div>
+    <input
+      type="range"
+      class="bar-range"
+      min="0"
+      max="100"
+      value="50"
+      aria-label="Reveal amount"
+      oninput="this.previousElementSibling.style.setProperty('--bar-pos', this.value + '%')"
+    />
+    <div class="bar-handle" style="left: 50%"></div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/before-after-reveal-advk/style.css
+++ b/submissions/examples/before-after-reveal-advk/style.css
@@ -1,0 +1,87 @@
+/* Before/After Reveal
+   The range input is stretched transparent over the whole compare area so
+   it captures drag input everywhere, while a separate .bar-handle (driven
+   by the same --bar-pos custom property via inline style) provides the
+   visible line -- the native thumb stays invisible throughout. */
+
+.bar-wrap {
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.bar-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.bar-lede { margin: 0 0 2rem; color: #576073; }
+
+.bar-compare {
+  position: relative;
+  height: 12rem;
+  border-radius: 0.7rem;
+  overflow: hidden;
+  user-select: none;
+}
+
+.bar-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: #fff;
+}
+
+.bar-before { background: #4c6ef5; }
+
+.bar-after {
+  background: #a855f7;
+  clip-path: inset(0 calc(100% - var(--bar-pos, 50%)) 0 0);
+}
+
+.bar-range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  appearance: none;
+}
+
+.bar-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.bar-handle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  transform: translate(-50%, -50%);
+}
+
+.bar-range:focus-visible ~ .bar-handle {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .bar-before, .bar-after { forced-color-adjust: none; }
+  .bar-handle { background: CanvasText; }
+}


### PR DESCRIPTION
Closes #75490

Before/after comparison slider. A transparent range input stretched over the whole frame captures drag/click input anywhere (not just a thin track) and drives a clip-path inset via a CSS custom property; a separate handle element supplies the visible divider line.

- Native keyboard stepping and touch dragging come from the range input for free