### PR TITLE
feat: add useWindowSize hook (use-window-size-advk)

### DIFF
--- a/submissions/react/use-window-size-advk/README.md
+++ b/submissions/react/use-window-size-advk/README.md
@@ -1,0 +1,34 @@
+# useWindowSize
+
+Tracks `window.innerWidth`/`innerHeight`, re-rendering on resize.
+
+## API
+
+```js
+const { width, height } = useWindowSize();
+```
+
+## Usage
+
+```jsx
+function ResponsiveChart() {
+  const { width } = useWindowSize();
+  return <Chart width={Math.min(width - 32, 960)} />;
+}
+```
+
+## Why is it useful?
+
+A version of this hook that initializes state to `{ width: 0, height: 0 }`
+and only reads the real size inside `useEffect` causes anything sized off
+those numbers to render at zero on the first paint and then jump to the
+correct size once the effect runs — visible as a flash for any consumer
+that uses the values directly in layout math (like the chart width above).
+Seeding `useState` with a lazy initializer that reads `window.innerWidth`/
+`innerHeight` directly means the first render already has the real
+dimensions.
+
+The hook deliberately does not debounce or throttle the `resize` listener
+itself — that's a concern of whatever expensive work a consumer does with
+the size, not of tracking the size itself, so debouncing here would force
+every consumer into the same tradeoff even when they don't need it.

--- a/submissions/react/use-window-size-advk/useWindowSize.jsx
+++ b/submissions/react/use-window-size-advk/useWindowSize.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useWindowSize
+ * Tracks the window's inner dimensions, updating on resize. Reads the
+ * initial size synchronously via a lazy useState initializer, avoiding a
+ * 0x0-on-first-render flash that a useEffect-only version produces.
+ */
+export function useWindowSize() {
+  const [size, setSize] = useState(() =>
+    typeof window !== 'undefined'
+      ? { width: window.innerWidth, height: window.innerHeight }
+      : { width: 0, height: 0 }
+  );
+
+  useEffect(() => {
+    function onResize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return size;
+}
+
+export default useWindowSize;


### PR DESCRIPTION
Closes #75492

React hook tracking window.innerWidth/innerHeight. Seeds useState with a lazy initializer reading the real dimensions directly, avoiding the 0x0-on-first-render flash a useEffect-only version produces for anything sized off the values.