### PR TITLE
feat: add usePrevious hook (use-previous-advk)

### DIFF
--- a/submissions/react/use-previous-advk/README.md
+++ b/submissions/react/use-previous-advk/README.md
@@ -1,0 +1,36 @@
+# usePrevious
+
+Returns the value a component held on its previous render.
+
+## API
+
+```js
+const previous = usePrevious(value);
+```
+
+## Usage
+
+```jsx
+function PriceTag({ price }) {
+  const previousPrice = usePrevious(price);
+  const direction = previousPrice === undefined || price === previousPrice
+    ? null
+    : price > previousPrice ? 'up' : 'down';
+  return <span className={direction && `price-${direction}`}>{price}</span>;
+}
+```
+
+## Why is it useful?
+
+A common but broken version of this hook writes `ref.current = value`
+directly in the render body instead of inside a `useEffect`. Refs mutated
+during render are updated *before* the return statement executes, so
+`ref.current` already equals the new `value` by the time it's read — the
+hook silently always returns the current value, not the previous one, and
+the bug only surfaces when someone diffs `previous` against `value` and
+gets `false` for a genuine change.
+
+Writing the ref inside a bodyless `useEffect(() => { ref.current = value; })`
+(no dependency array — it runs after every render) defers the update until
+after the browser has painted the current render, so the value read during
+render is always the one from one render prior.

--- a/submissions/react/use-previous-advk/usePrevious.jsx
+++ b/submissions/react/use-previous-advk/usePrevious.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * usePrevious
+ * Returns the value a hook/component held on the previous render (or
+ * undefined on the first). Updates the ref in an effect, so the value
+ * returned during the *current* render is always one render behind, never
+ * the value just written.
+ */
+export function usePrevious(value) {
+  const ref = useRef(undefined);
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+}
+
+export default usePrevious;


### PR DESCRIPTION
Closes #75493

React hook returning the value from the previous render. Writes the ref inside a bodyless useEffect rather than during render — a common but broken version mutates the ref directly in the render body, which updates it before the return statement runs and makes the hook always return the current value instead of the prior one.