### PR TITLE
feat: add button-reset Sass mixin (button-reset-advk)

### DIFF
--- a/submissions/scss/button-reset-advk/README.md
+++ b/submissions/scss/button-reset-advk/README.md
@@ -1,0 +1,36 @@
+# button-reset-advk
+
+A Sass mixin that strips a `<button>`'s user-agent chrome down to an
+unstyled interactive base, while deliberately leaving the default
+`:focus-visible` outline intact.
+
+## Usage
+
+```scss
+@use 'button-reset' as *;
+
+.icon-button {
+  @include button-reset;
+  padding: 0.5rem;
+  border-radius: 999px;
+
+  &:hover { background: rgba(0, 0, 0, 0.06); }
+}
+```
+
+## Why is it useful?
+
+The typical button-reset snippet also zeroes out `outline: none`, on the
+assumption that the author will always remember to add back a visible focus
+style. In practice that follow-up step gets skipped often enough that
+"reset a button" and "remove keyboard focus visibility" end up correlated
+bugs across a codebase. This mixin resets everything else — appearance,
+border, margin, padding, background, font inheritance, text alignment,
+cursor — but leaves the browser's own `:focus-visible` ring in place, so a
+button styled with this mixin and nothing else is still keyboard-navigable
+without an extra rule.
+
+`font: inherit` and `color: inherit` matter specifically for buttons nested
+inside styled text (a link-styled button inside a paragraph, for example) —
+without them the button reverts to the platform's default button font,
+which usually doesn't match the surrounding copy.

--- a/submissions/scss/button-reset-advk/_button-reset.scss
+++ b/submissions/scss/button-reset-advk/_button-reset.scss
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// button-reset-advk
+// Strips a <button>'s user-agent styling down to an unstyled interactive
+// element while deliberately keeping the properties that preserve
+// accessibility (cursor, focus-visible outline) rather than the common
+// reset that also strips those.
+// ---------------------------------------------------------------------------
+
+@mixin button-reset {
+  appearance: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
+
+  // Deliberately NOT removed: default :focus-visible outline. A reset that
+  // also clears this needs the caller to remember to add a replacement, and
+  // that step gets skipped often enough to be a real accessibility bug.
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.button-reset-demo {
+  @include button-reset;
+}


### PR DESCRIPTION
Closes #75495

Sass mixin resetting button user-agent chrome (appearance, border, margin, padding, background, font/color inheritance) while deliberately leaving the default :focus-visible outline in place, since resets that also strip it rely on a follow-up rule that's often skipped, breaking keyboard focus visibility.