### PR TITLE
feat: add scroll-margin Sass mixin (scroll-margin-advk)

### DIFF
--- a/submissions/scss/scroll-margin-advk/README.md
+++ b/submissions/scss/scroll-margin-advk/README.md
@@ -1,0 +1,37 @@
+# scroll-margin-advk
+
+A Sass mixin that sets `scroll-margin-top` on anchor targets, so jumping to
+an in-page anchor doesn't leave the target heading hidden behind a
+fixed/sticky header. Also sets `scroll-behavior: smooth` at the root,
+disabled under `prefers-reduced-motion`.
+
+## Usage
+
+```scss
+@use 'scroll-margin' as *;
+
+h2[id] {
+  @include scroll-margin-for-header($header-height: 3.5rem, $gap: 0.75rem);
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$header-height` | `4rem` | Height of the fixed/sticky header covering the top of the viewport. |
+| `$gap` | `1rem` | Extra breathing room below the header. |
+
+## Why is it useful?
+
+`id`-based in-page navigation (`<a href="#section-2">`) scrolls the target
+element flush to the top of the viewport by default, which puts it directly
+under a fixed or sticky header — a longstanding annoyance usually patched
+with a JS scroll-offset hack that recalculates on every click.
+`scroll-margin-top` solves this natively: it's respected by both anchor
+navigation and `Element.scrollIntoView()`, and by keeping the header height
+as a single Sass parameter, every target element (headings, form fields, TOC
+anchors) derives its offset from one source instead of duplicating a magic
+pixel number.
+
+`scroll-behavior: smooth` is gated behind
+`prefers-reduced-motion: reduce` reverting it to `auto`, since smooth
+scrolling is itself a motion effect some users have explicitly opted out of.

--- a/submissions/scss/scroll-margin-advk/_scroll-margin.scss
+++ b/submissions/scss/scroll-margin-advk/_scroll-margin.scss
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------
+// scroll-margin-advk
+// Sets scroll-margin-top on anchor targets so a fixed/sticky header doesn't
+// cover the target heading after an in-page jump -- the header's height is
+// the one number this mixin needs, kept in one place.
+// ---------------------------------------------------------------------------
+
+@mixin scroll-margin-for-header($header-height: 4rem, $gap: 1rem) {
+  scroll-margin-top: calc(#{$header-height} + #{$gap});
+}
+
+:root {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    scroll-behavior: auto;
+  }
+}
+
+.scroll-margin-demo {
+  @include scroll-margin-for-header;
+}


### PR DESCRIPTION
Closes #75496

Sass mixin setting scroll-margin-top on anchor targets from a single header-height parameter, so in-page anchor navigation and scrollIntoView() don't land a heading under a fixed/sticky header. Also sets scroll-behavior: smooth at the root, reverted to auto under prefers-reduced-motion.