### PR TITLE
feat: add ease-metric-counter-ij component (easing count-up cards)

### DIFF
--- a/submissions/examples/ease-metric-counter-ij/README.md
+++ b/submissions/examples/ease-metric-counter-ij/README.md
@@ -1,0 +1,22 @@
+# Metric Counter
+
+An analytics dashboard with easing count-up numbers, filling progress bars, and a staggered sparkline that grows from zero.
+
+## How is it used?
+
+Drop a target value into `data-target` and let the container class drive the motion:
+
+```html
+<section class="metrics played">
+  <article class="metric">
+    <span class="m-value" data-target="184200">0</span>
+    <div class="m-track"><span class="m-bar"></span></div>
+  </article>
+</section>
+```
+
+Removing and re-adding `.played` replays the staggered card reveal, the `width` transition on every `.m-bar`, the `spGrow` sparkline bars, and the JS count-up.
+
+## Why is it useful?
+
+Animated numbers and bars turn dry statistics into a digestible story on dashboards and landing pages. This component shows a tidy pattern — declarative `data-target` values, one state class, and GPU-friendly `transform`/`width` animations — that fits EaseMotion's goal of readable, reusable motion utilities.

--- a/submissions/examples/ease-metric-counter-ij/demo.html
+++ b/submissions/examples/ease-metric-counter-ij/demo.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Metric Counter - EaseMotion Submission</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stage">
+    <header class="dash-head">
+      <h1 class="dash-title">Weekly Analytics</h1>
+      <button class="replay" id="replayBtn">Replay</button>
+    </header>
+
+    <section class="metrics" id="metrics">
+      <article class="metric">
+        <span class="m-label">Page Views</span>
+        <span class="m-value" data-target="184200">0</span>
+        <div class="m-track"><span class="m-bar" data-width="82"></span></div>
+      </article>
+      <article class="metric">
+        <span class="m-label">Sign-ups</span>
+        <span class="m-value" data-target="12480">0</span>
+        <div class="m-track"><span class="m-bar" data-width="64"></span></div>
+      </article>
+      <article class="metric">
+        <span class="m-label">Active Users</span>
+        <span class="m-value" data-target="8934">0</span>
+        <div class="m-track"><span class="m-bar" data-width="47"></span></div>
+      </article>
+      <article class="metric">
+        <span class="m-label">Conversion</span>
+        <span class="m-value" data-target="3.42" data-decimal="2">0</span>
+        <div class="m-track"><span class="m-bar" data-width="58"></span></div>
+      </article>
+    </section>
+
+    <section class="sparkline" aria-hidden="true">
+      <span class="sp-bar s1"></span>
+      <span class="sp-bar s2"></span>
+      <span class="sp-bar s3"></span>
+      <span class="sp-bar s4"></span>
+      <span class="sp-bar s5"></span>
+      <span class="sp-bar s6"></span>
+      <span class="sp-bar s7"></span>
+    </section>
+  </main>
+
+  <script>
+    const metrics = document.getElementById('metrics');
+    const replayBtn = document.getElementById('replayBtn');
+
+    function runCounters() {
+      document.querySelectorAll('.m-value').forEach(el => {
+        const target = parseFloat(el.dataset.target);
+        const decimals = el.dataset.decimal ? Number(el.dataset.decimal) : 0;
+        const duration = 1400;
+        const start = performance.now();
+
+        function frame(now) {
+          const t = Math.min((now - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - t, 3);
+          el.textContent = (target * eased).toLocaleString(undefined, {
+            minimumFractionDigits: decimals,
+            maximumFractionDigits: decimals
+          });
+          if (t < 1) requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+      });
+    }
+
+    function replay() {
+      metrics.classList.remove('played');
+      void metrics.offsetWidth;
+      metrics.classList.add('played');
+      runCounters();
+    }
+
+    replayBtn.addEventListener('click', replay);
+    replay();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-metric-counter-ij/style.css
+++ b/submissions/examples/ease-metric-counter-ij/style.css
@@ -1,0 +1,171 @@
+/* Metric Counter - EaseMotion CSS submission */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: linear-gradient(150deg, #f0f4ff, #e2e9fb);
+  padding: 24px;
+}
+
+.stage {
+  width: 100%;
+  max-width: 640px;
+}
+
+.dash-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.dash-title {
+  font-size: 1.35rem;
+  color: #1e293b;
+  margin: 0;
+}
+
+.replay {
+  cursor: pointer;
+  border: 1px solid #c3cde5;
+  background: #fff;
+  color: #33415c;
+  font-family: inherit;
+  font-weight: 700;
+  padding: 9px 18px;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(30, 41, 59, 0.1);
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.replay:hover {
+  background: #eef2ff;
+}
+
+.replay:active {
+  transform: scale(0.94);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.metric {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: 0 8px 22px rgba(30, 41, 59, 0.06);
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.metrics.played .metric {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.metrics.played .metric:nth-child(2) { transition-delay: 0.1s; }
+.metrics.played .metric:nth-child(3) { transition-delay: 0.2s; }
+.metrics.played .metric:nth-child(4) { transition-delay: 0.3s; }
+
+.m-label {
+  display: block;
+  color: #64748b;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
+}
+
+.m-value {
+  display: block;
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: #0f172a;
+  font-variant-numeric: tabular-nums;
+  margin: 4px 0 12px;
+}
+
+.m-track {
+  height: 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.m-bar {
+  display: block;
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #6366f1, #a855f7);
+}
+
+.metrics.played .m-bar {
+  width: var(--target-width, 50%);
+  transition: width 1.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.metrics.played .metric:nth-child(1) .m-bar { --target-width: 82%; transition-delay: 0.15s; }
+.metrics.played .metric:nth-child(2) .m-bar { --target-width: 64%; transition-delay: 0.25s; }
+.metrics.played .metric:nth-child(3) .m-bar { --target-width: 47%; transition-delay: 0.35s; }
+.metrics.played .metric:nth-child(4) .m-bar { --target-width: 58%; transition-delay: 0.45s; }
+
+.sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 90px;
+  margin-top: 18px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 8px 22px rgba(30, 41, 59, 0.06);
+}
+
+.sp-bar {
+  flex: 1;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, #6366f1, #c4b5fd);
+  height: 0;
+  transform-origin: bottom;
+}
+
+.metrics.played ~ .sparkline .sp-bar {
+  animation: spGrow 1s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.metrics.played ~ .sparkline .s1 { animation-delay: 0.5s; }
+.metrics.played ~ .sparkline .s2 { animation-delay: 0.6s; }
+.metrics.played ~ .sparkline .s3 { animation-delay: 0.7s; }
+.metrics.played ~ .sparkline .s4 { animation-delay: 0.8s; }
+.metrics.played ~ .sparkline .s5 { animation-delay: 0.9s; }
+.metrics.played ~ .sparkline .s6 { animation-delay: 1s; }
+.metrics.played ~ .sparkline .s7 { animation-delay: 1.1s; }
+
+.s1 { --h: 30%; }
+.s2 { --h: 55%; }
+.s3 { --h: 42%; }
+.s4 { --h: 78%; }
+.s5 { --h: 60%; }
+.s6 { --h: 88%; }
+.s7 { --h: 70%; }
+
+@keyframes spGrow {
+  from { height: 0; }
+  to { height: var(--h); }
+}
+
+@media (max-width: 520px) {
+  .metrics { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary

Adds a working analytics dashboard with easing count-up numbers and progress bars under `submissions/examples/ease-metric-counter-ij/`.

### Features
- Count-up numbers with a cubic ease-out
- Progress bars that fill with a spring curve, plus a growing sparkline
- Replay button to re-run the stagger and counters

### Files
- `demo.html` - interactive dashboard
- `style.css` - original EaseMotion CSS with bar fill and sparkline growth
- `README.md` - usage notes

Closes #75537