### PR TITLE
feat: add basic action link row demo

### DIFF
--- a/submissions/examples/basic-action-link-row-kk/README.md
+++ b/submissions/examples/basic-action-link-row-kk/README.md
@@ -1,0 +1,40 @@
+# Basic Action Link Row
+
+## What it does
+
+This submission adds a simple CSS-only action link row for pairing short section text with a right-aligned action link.
+
+It works well for card headers, settings panels, dashboard summaries, profile sections, quick links, and compact navigation rows.
+
+## How to use it
+
+Add the utility class to a row with text content and a link:
+
+```html
+<div class="basic-action-link-row">
+  <div>
+    <strong>Recent invoices</strong>
+    <p>Review the latest billing activity.</p>
+  </div>
+  <a href="#">View all</a>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and easy to reuse across multiple UI sections. The class name clearly explains the purpose of the component, and the pattern can be combined with cards, lists, dashboards, and content sections.
+
+## Included features
+
+- Compact text and action layout
+- Right-aligned pill-style action link
+- Divider support between rows
+- Hover and keyboard focus styling
+- Responsive stacked layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the action link row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-action-link-row-kk/demo.html
+++ b/submissions/examples/basic-action-link-row-kk/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Action Link Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Action Link Row</p>
+          <h1>Pair short section text with a clear right-side action.</h1>
+          <p class="intro">
+            This CSS-only utility creates compact rows for card headers,
+            dashboard summaries, settings sections, and quick navigation links.
+          </p>
+        </header>
+
+        <section class="preview-panel" aria-label="Action link row examples">
+          <div class="basic-action-link-row">
+            <div>
+              <strong>Recent invoices</strong>
+              <p>Review the latest billing activity.</p>
+            </div>
+            <a href="#">View all</a>
+          </div>
+
+          <div class="basic-action-link-row">
+            <div>
+              <strong>Team members</strong>
+              <p>Manage access for your workspace.</p>
+            </div>
+            <a href="#">Manage</a>
+          </div>
+
+          <div class="basic-action-link-row">
+            <div>
+              <strong>Saved reports</strong>
+              <p>Open your frequently used summaries.</p>
+            </div>
+            <a href="#">Open</a>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-action-link-row"&gt;
+  &lt;div&gt;
+    &lt;strong&gt;Recent invoices&lt;/strong&gt;
+    &lt;p&gt;Review the latest billing activity.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;a href="#"&gt;View all&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-action-link-row-kk/style.css
+++ b/submissions/examples/basic-action-link-row-kk/style.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: dark;
+  --page: #08101d;
+  --card: rgba(14, 22, 38, 0.92);
+  --surface: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f4f7ff;
+  --muted: #9facbf;
+  --accent: #7dd3fc;
+  --accent-soft: rgba(125, 211, 252, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 10%, rgba(125, 211, 252, 0.18), transparent 28%),
+    radial-gradient(circle at 88% 86%, rgba(74, 222, 128, 0.12), transparent 24%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.35);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 14ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.preview-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+}
+
+.basic-action-link-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 0;
+}
+
+.basic-action-link-row + .basic-action-link-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-action-link-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.basic-action-link-row p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.basic-action-link-row a {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.basic-action-link-row a:hover,
+.basic-action-link-row a:focus-visible {
+  color: #06111f;
+  background: var(--accent);
+  outline: none;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-action-link-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Action Link Row demo inside `submissions/examples/basic-action-link-row-kk/`. This submission introduces a compact CSS-only row pattern for pairing short section text with a right-aligned action link.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only action link row component for card headers, settings panels, dashboard summaries, profile sections, quick links, and compact navigation rows.

**How does a developer use it?**

```html
<div class="basic-action-link-row">
  <div>
    <strong>Recent invoices</strong>
    <p>Review the latest billing activity.</p>
  </div>
  <a href="#">View all</a>
</div>