### PR TITLE
feat: add basic thumbnail text row demo

### DIFF
--- a/submissions/examples/basic-thumbnail-text-row-kk/README.md
+++ b/submissions/examples/basic-thumbnail-text-row-kk/README.md
@@ -1,0 +1,40 @@
+# Basic Thumbnail Text Row
+
+## What it does
+
+This submission adds a simple CSS-only thumbnail text row for compact media-style list items.
+
+It works well for article previews, project updates, notification lists, activity feeds, product rows, and compact content summaries.
+
+## How to use it
+
+Add the utility class to a row containing a small thumbnail element and text:
+
+```html
+<div class="basic-thumbnail-text-row">
+  <span class="thumb" aria-hidden="true">A</span>
+  <div>
+    <strong>Article preview</strong>
+    <p>Use this row for compact summaries.</p>
+  </div>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many frontend sections. The row can be reused inside cards, dashboards, sidebars, feeds, and content lists without JavaScript or external assets.
+
+## Included features
+
+- Thumbnail and text alignment
+- Small square visual marker
+- Title and supporting copy structure
+- Divider support between rows
+- Responsive spacing
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the thumbnail text row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-thumbnail-text-row-kk/demo.html
+++ b/submissions/examples/basic-thumbnail-text-row-kk/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Thumbnail Text Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Thumbnail Text Row</p>
+          <h1>Compact media rows for lists, cards, and content summaries.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a small thumbnail placeholder with a
+            title and supporting text, creating clean media rows without any
+            external assets.
+          </p>
+        </header>
+
+        <section class="row-panel" aria-label="Thumbnail text row examples">
+          <div class="basic-thumbnail-text-row">
+            <span class="thumb" aria-hidden="true">A</span>
+            <div>
+              <strong>Article preview</strong>
+              <p>Use this row for compact editorial or blog summaries.</p>
+            </div>
+          </div>
+
+          <div class="basic-thumbnail-text-row">
+            <span class="thumb" aria-hidden="true">P</span>
+            <div>
+              <strong>Project update</strong>
+              <p>Pair a visual marker with short supporting information.</p>
+            </div>
+          </div>
+
+          <div class="basic-thumbnail-text-row">
+            <span class="thumb" aria-hidden="true">N</span>
+            <div>
+              <strong>Notification item</strong>
+              <p>Keep activity lists readable and neatly aligned.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-thumbnail-text-row"&gt;
+  &lt;span class="thumb" aria-hidden="true"&gt;A&lt;/span&gt;
+  &lt;div&gt;
+    &lt;strong&gt;Article preview&lt;/strong&gt;
+    &lt;p&gt;Use this row for compact summaries.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-thumbnail-text-row-kk/style.css
+++ b/submissions/examples/basic-thumbnail-text-row-kk/style.css
@@ -1,0 +1,130 @@
+:root {
+  color-scheme: dark;
+  --page: #090d18;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #a2aec4;
+  --accent: #fbbf24;
+  --accent-soft: rgba(251, 191, 36, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(251, 191, 36, 0.18), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(56, 189, 248, 0.12), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.row-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-thumbnail-text-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-thumbnail-text-row + .basic-thumbnail-text-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-thumbnail-text-row .thumb {
+  width: 2.75rem;
+  height: 2.75rem;
+  flex: 0 0 2.75rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(251, 191, 36, 0.34);
+  border-radius: 0.9rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 800;
+}
+
+.basic-thumbnail-text-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.basic-thumbnail-text-row p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-thumbnail-text-row {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Thumbnail Text Row demo inside `submissions/examples/basic-thumbnail-text-row-kk/`. This submission introduces a compact CSS-only media row pattern for article previews, project updates, notification lists, activity feeds, and content summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only thumbnail text row utility for compact media-style list items.

**How does a developer use it?**

```html
<div class="basic-thumbnail-text-row">
  <span class="thumb" aria-hidden="true">A</span>
  <div>
    <strong>Article preview</strong>
    <p>Use this row for compact summaries.</p>
  </div>
</div>