### PR TITLE
feat: add basic file detail row demo

### DIFF
--- a/submissions/examples/basic-file-detail-row-kk/README.md
+++ b/submissions/examples/basic-file-detail-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic File Detail Row
+
+## What it does
+
+This submission adds a simple CSS-only file detail row for upload panels, attachment lists, document cards, and file manager sections.
+
+It aligns a small file marker, filename, metadata, and a right-side action or status.
+
+## How to use it
+
+Add the utility class to a row containing an icon marker, file text, and optional action:
+
+```html
+<div class="basic-file-detail-row">
+  <span class="file-icon" aria-hidden="true">PDF</span>
+  <div class="file-copy">
+    <strong>project-brief.pdf</strong>
+    <p>PDF document · 2.4 MB</p>
+  </div>
+  <span class="file-action">View</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful in many frontend interfaces. The pattern can be reused inside cards, upload forms, dashboards, profile pages, and document lists without JavaScript or external assets.
+
+## Included features
+
+- File marker, filename, metadata, and action layout
+- Compact row spacing
+- Divider support between rows
+- Filename truncation for long file names
+- Responsive spacing for smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the file detail row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-file-detail-row-kk/demo.html
+++ b/submissions/examples/basic-file-detail-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic File Detail Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic File Detail Row</p>
+          <h1>Clean file rows for uploads, attachments, and document lists.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a file icon, filename, metadata, and a
+            small right-side action or status inside compact upload panels.
+          </p>
+        </header>
+
+        <section class="file-panel" aria-label="File detail row examples">
+          <div class="basic-file-detail-row">
+            <span class="file-icon" aria-hidden="true">PDF</span>
+            <div class="file-copy">
+              <strong>project-brief.pdf</strong>
+              <p>PDF document · 2.4 MB</p>
+            </div>
+            <span class="file-action">View</span>
+          </div>
+
+          <div class="basic-file-detail-row">
+            <span class="file-icon" aria-hidden="true">IMG</span>
+            <div class="file-copy">
+              <strong>dashboard-preview.png</strong>
+              <p>Image file · 860 KB</p>
+            </div>
+            <span class="file-action">Ready</span>
+          </div>
+
+          <div class="basic-file-detail-row">
+            <span class="file-icon" aria-hidden="true">CSV</span>
+            <div class="file-copy">
+              <strong>monthly-report.csv</strong>
+              <p>Spreadsheet data · 318 KB</p>
+            </div>
+            <span class="file-action">Open</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-file-detail-row"&gt;
+  &lt;span class="file-icon" aria-hidden="true"&gt;PDF&lt;/span&gt;
+  &lt;div class="file-copy"&gt;
+    &lt;strong&gt;project-brief.pdf&lt;/strong&gt;
+    &lt;p&gt;PDF document · 2.4 MB&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="file-action"&gt;View&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-file-detail-row-kk/style.css
+++ b/submissions/examples/basic-file-detail-row-kk/style.css
@@ -1,0 +1,148 @@
+:root {
+  color-scheme: dark;
+  --page: #080e1a;
+  --card: rgba(14, 21, 35, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f6f8ff;
+  --muted: #9daac1;
+  --accent: #93c5fd;
+  --accent-soft: rgba(147, 197, 253, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 20% 12%, rgba(147, 197, 253, 0.17), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(52, 211, 153, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.file-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-file-detail-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-file-detail-row + .basic-file-detail-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.file-icon {
+  width: 2.8rem;
+  height: 2.8rem;
+  flex: 0 0 2.8rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(147, 197, 253, 0.32);
+  border-radius: 0.85rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.file-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.file-copy strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-copy p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.file-action {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-file-detail-row {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic File Detail Row demo inside `submissions/examples/basic-file-detail-row-kk/`. This submission introduces a compact CSS-only file row pattern for upload panels, attachment lists, document cards, and file manager sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only file detail row utility for showing a file marker, filename, metadata, and a right-side action or status.

**How does a developer use it?**

```html
<div class="basic-file-detail-row">
  <span class="file-icon" aria-hidden="true">PDF</span>
  <div class="file-copy">
    <strong>project-brief.pdf</strong>
    <p>PDF document · 2.4 MB</p>
  </div>
  <span class="file-action">View</span>
</div>