### PR TITLE
feat(submissions): mercury-style skill gauge (thermometer progress indicator)

### DIFF
--- a/submissions/examples/mercury-skill-gauge-clv/README.md
+++ b/submissions/examples/mercury-skill-gauge-clv/README.md
@@ -1,0 +1,29 @@
+# Mercury Skill Gauge
+
+## 1. What does this do?
+
+A thermometer-shaped progress/skill indicator — a "mercury" column rises from a reservoir bulb into a glass tube on hover or focus, slightly overshoots like real liquid settling under momentum, then keeps a subtle surface wobble while active.
+
+## 2. How is it used?
+
+Set the fill amount with a `--fill` custom property on the container, and give it `tabindex="0"` so keyboard users can trigger it via focus, not just mouse hover:
+
+```html
+<div class="mercury-gauge" tabindex="0" style="--fill: 92%;">
+  <div class="mercury-tube">
+    <div class="mercury-fill">
+      <span class="mercury-glint"></span>
+    </div>
+  </div>
+  <div class="mercury-bulb">
+    <span class="mercury-bulb-core"></span>
+  </div>
+  <span class="mercury-label">CSS<br /><strong>92%</strong></span>
+</div>
+```
+
+Swap `--fill` per instance to represent different values (skill levels, load percentages, ratings, etc.) — the tube, bulb, and wobble animation are shared, only the target height changes.
+
+## 3. Why is it useful?
+
+EaseMotion CSS is animation-first and human-readable — this fits both: the metaphor (mercury rising in a thermometer) is instantly understood without a legend or a number needing to load first, and the interaction is built from a couple of readable pieces (`mercury-tube`, `mercury-fill`, `mercury-bulb`) rather than one opaque effect. It's a genuinely different shape of progress indicator from the existing bar/ring/donut style utilities already in the framework, so it fills a visual gap rather than duplicating one. It's also accessible by default: it triggers on `:focus-visible`/`:focus-within` as well as `:hover`, and all motion is disabled under `prefers-reduced-motion: reduce` (the fill still ends at its final state, just without the transition or wobble).

--- a/submissions/examples/mercury-skill-gauge-clv/demo.html
+++ b/submissions/examples/mercury-skill-gauge-clv/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mercury Skill Gauge — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="demo-wrap">
+    <h1 class="demo-title">Mercury Skill Gauge</h1>
+    <p class="demo-sub">Hover (or focus) a gauge to watch the mercury rise and settle, like a real thermometer.</p>
+
+    <div class="gauge-row">
+
+      <div class="mercury-gauge" tabindex="0" style="--fill: 92%;">
+        <div class="mercury-tube">
+          <div class="mercury-fill">
+            <span class="mercury-glint"></span>
+          </div>
+        </div>
+        <div class="mercury-bulb">
+          <span class="mercury-bulb-core"></span>
+        </div>
+        <span class="mercury-label">CSS<br /><strong>92%</strong></span>
+      </div>
+
+      <div class="mercury-gauge" tabindex="0" style="--fill: 68%;">
+        <div class="mercury-tube">
+          <div class="mercury-fill">
+            <span class="mercury-glint"></span>
+          </div>
+        </div>
+        <div class="mercury-bulb">
+          <span class="mercury-bulb-core"></span>
+        </div>
+        <span class="mercury-label">JavaScript<br /><strong>68%</strong></span>
+      </div>
+
+      <div class="mercury-gauge" tabindex="0" style="--fill: 40%;">
+        <div class="mercury-tube">
+          <div class="mercury-fill">
+            <span class="mercury-glint"></span>
+          </div>
+        </div>
+        <div class="mercury-bulb">
+          <span class="mercury-bulb-core"></span>
+        </div>
+        <span class="mercury-label">Rust<br /><strong>40%</strong></span>
+      </div>
+
+    </div>
+
+    <p class="demo-note">Try Tab-ing between gauges too — focus triggers the same rise animation as hover.</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/mercury-skill-gauge-clv/style.css
+++ b/submissions/examples/mercury-skill-gauge-clv/style.css
@@ -1,0 +1,203 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: #e2e8f0;
+  padding: 3rem 1.5rem;
+}
+
+.demo-wrap {
+  max-width: 640px;
+  text-align: center;
+}
+
+.demo-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.demo-sub {
+  margin: 0 0 2.5rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.demo-note {
+  margin-top: 2.5rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.gauge-row {
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ── Gauge ─────────────────────────────────────────────── */
+
+.mercury-gauge {
+  --fill: 50%;
+  --mercury-color: #ff4d4d;
+  --mercury-color-dark: #b91c1c;
+  --tube-bg: rgba(255, 255, 255, 0.06);
+  --tube-border: rgba(255, 255, 255, 0.18);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* ── Tube (the stem the mercury rises through) ────────── */
+
+.mercury-tube {
+  position: relative;
+  width: 22px;
+  height: 160px;
+  border-radius: 999px;
+  background: var(--tube-bg);
+  border: 2px solid var(--tube-border);
+  overflow: hidden;
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.mercury-fill {
+  position: absolute;
+  bottom: -6px; /* dips slightly into the bulb so there's no seam */
+  left: 0;
+  width: 100%;
+  height: 8%; /* resting level before interaction */
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    var(--mercury-color) 0%,
+    var(--mercury-color-dark) 100%
+  );
+  box-shadow: 0 0 10px 1px rgba(255, 77, 77, 0.45);
+  transition: height 900ms cubic-bezier(0.22, 1.6, 0.36, 1);
+}
+
+.mercury-gauge:hover .mercury-fill,
+.mercury-gauge:focus-visible .mercury-fill,
+.mercury-gauge:focus-within .mercury-fill {
+  height: calc(var(--fill) + 8%);
+}
+
+/* Liquid surface wobble — only animates while filled/active */
+.mercury-glint {
+  position: absolute;
+  top: -3px;
+  left: 50%;
+  width: 26px;
+  height: 8px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.55) 0%,
+    transparent 70%
+  );
+  border-radius: 999px;
+  opacity: 0;
+  transform: translate(-50%, 0) scaleX(1);
+}
+
+.mercury-gauge:hover .mercury-glint,
+.mercury-gauge:focus-visible .mercury-glint,
+.mercury-gauge:focus-within .mercury-glint {
+  opacity: 1;
+  animation: mercury-wobble 1.6s ease-in-out 900ms infinite;
+}
+
+@keyframes mercury-wobble {
+  0%,
+  100% {
+    transform: translate(-50%, 0) scaleX(1);
+  }
+  50% {
+    transform: translate(-50%, -1.5px) scaleX(1.18);
+  }
+}
+
+/* ── Bulb (the reservoir at the base) ─────────────────── */
+
+.mercury-bulb {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--tube-bg);
+  border: 2px solid var(--tube-border);
+  margin-top: -4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35);
+  transition: box-shadow 300ms ease;
+}
+
+.mercury-bulb-core {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 30%,
+    #ff8a8a 0%,
+    var(--mercury-color) 45%,
+    var(--mercury-color-dark) 100%
+  );
+  box-shadow: 0 0 8px 1px rgba(255, 77, 77, 0.5);
+  transition: transform 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.mercury-gauge:hover .mercury-bulb-core,
+.mercury-gauge:focus-visible .mercury-bulb-core,
+.mercury-gauge:focus-within .mercury-bulb-core {
+  transform: scale(1.08);
+}
+
+.mercury-gauge:hover .mercury-bulb,
+.mercury-gauge:focus-visible .mercury-bulb,
+.mercury-gauge:focus-within .mercury-bulb {
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35), 0 0 14px 2px rgba(255, 77, 77, 0.35);
+}
+
+/* ── Label ─────────────────────────────────────────────── */
+
+.mercury-label {
+  margin-top: 0.85rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.mercury-label strong {
+  display: inline-block;
+  margin-top: 0.15rem;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+/* ── Reduced motion ────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mercury-fill,
+  .mercury-bulb-core {
+    transition: none;
+  }
+  .mercury-glint {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## What

Adds a new submission: `submissions/examples/mercury-skill-gauge-clv/`

A thermometer-shaped progress/skill gauge. On hover or focus, a "mercury"
column rises from a bulb reservoir into a glass tube, overshoots slightly
like real liquid settling under momentum, then keeps a subtle surface
wobble while active.

## Why

Existing progress indicators in the framework are bar/ring/donut style.
This is a different shape/metaphor entirely — instantly readable without
a legend, and keyboard-accessible by default (:focus-visible /
:focus-within, not just :hover).

## Files

- demo.html — 3 self-contained examples (92% / 68% / 40%)
- style.css — no ease- prefix, no CDN/external deps
- README.md — what / how / why, per submission guidelines

## Checklist

- [x] Correct track: submissions/examples/
- [x] Unique kebab-case name with suffix (no naming collision)
- [x] demo.html opens standalone, no server/build step
- [x] No core/ or components/ files touched
- [x] Respects prefers-reduced-motion
- [x] One self-contained effect, not combined with others