### PR TITLE
feat: add pure CSS Micro-interaction Laser Ray Trace component (#73854)

### DIFF
--- a/submissions/examples/css-micro-interaction-laser-ray-trace-pure/README.md
+++ b/submissions/examples/css-micro-interaction-laser-ray-trace-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Micro-interactions: Laser Ray Trace
+
+A collection of hardware-accelerated, JavaScript-free micro-interactions focused on glowing laser beams tracing the perimeter of UI elements. 
+
+## Features
+- Pure CSS and HTML implementation. No Canvas, WebGL, SVG line-drawing, or JavaScript required for the physics.
+- **Component Architecture**: 
+  - **Perimeter Scan Button**: An interactive button that deploys a laser tracking effect on hover. It uses four absolute-positioned `.laser-track` divs representing the four borders. Initially, they are translated off-screen (e.g., `transform: translateX(-100%)`). On `:hover`, they transition back to `0`. By using staggered `transition-delay` values (`0s`, `0.2s`, `0.4s`, `0.6s`), the laser appears to seamlessly draw a continuous box around the button.
+  - **Conic Laser Card**: A highly performant, infinite laser border. This is achieved by placing a pseudo-element *behind* the main card content (`z-index: 1`), giving it a sharp `conic-gradient` (transparent to solid red), and animating its rotation with `transform: rotate()`. A second pseudo-element with a `blur` filter provides the glowing laser bloom. The solid `.card-content` sits on top (`z-index: 5`), masking the center and leaving only the spinning edges visible.
+  - **Laser Underline Link**: A classic minimal interaction. It uses an `::after` pseudo-element for the underline. On `:hover`, it scales from `0` to `1` on the X-axis. By dynamically changing the `transform-origin` between `right` (initial state) and `left` (hover state), the laser appears to strike from left to right, and then retract from right to left when the mouse leaves.
+- **Theming**: Configured via CSS Custom Properties. The color palette focuses on intense, high-energy neon colors: a stark Laser Red (`#ff0055`) set against a deep space black background.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by disabling the spinning loader and complex transition traces for users who prefer less motion.
+
+## Usage
+Open `demo.html` in your browser to view the gallery of micro-interactions. Hover over the button and the link to trigger the laser drawing effects, and observe the continuous rotation of the conic laser card.
+
+## Files
+- `demo.html`: The HTML structure defining the layout grid and the markup for each of the 3 laser micro-interactions.
+- `style.css`: The styling, the `conic-gradient` geometry, the `transform-origin` manipulation, and the staggered transition delays.

--- a/submissions/examples/css-micro-interaction-laser-ray-trace-pure/demo.html
+++ b/submissions/examples/css-micro-interaction-laser-ray-trace-pure/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Micro-interactions: Laser Ray Trace</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1>Laser Ray Trace</h1>
+            <p>Pure CSS hardware-accelerated laser outline micro-interactions.</p>
+        </header>
+
+        <main class="grid">
+            
+            <!-- Laser Trace Button -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Perimeter Scan Button</h2>
+                    <p>Hover to activate the laser perimeter trace.</p>
+                    
+                    <div class="component-box dark-box">
+                        <button class="btn btn-laser">
+                            <span>INITIALIZE SCAN</span>
+                            <div class="laser-track top"></div>
+                            <div class="laser-track right"></div>
+                            <div class="laser-track bottom"></div>
+                            <div class="laser-track left"></div>
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Conic Laser Card -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Conic Laser Card</h2>
+                    <p>Uses a spinning conic gradient for an infinite laser border.</p>
+                    
+                    <div class="component-box dark-box">
+                        <div class="laser-card">
+                            <div class="card-content">
+                                <h3>SECURE DATA</h3>
+                                <p>Encrypted packet.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Laser Underline Link -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Laser Strike Underline</h2>
+                    <p>Hover for a fast, glowing underline strike.</p>
+                    
+                    <div class="component-box dark-box">
+                        <a href="#" class="laser-link">VIEW TRANSMISSION</a>
+                    </div>
+                </div>
+            </section>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-micro-interaction-laser-ray-trace-pure/style.css
+++ b/submissions/examples/css-micro-interaction-laser-ray-trace-pure/style.css
@@ -1,0 +1,287 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;700&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #06060a;
+    --text-primary: #e2e8f0;
+    --text-secondary: #94a3b8;
+    
+    /* Laser Colors */
+    --laser-color: #ff0055;
+    --laser-glow: rgba(255, 0, 85, 0.6);
+    --laser-width: 2px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Rajdhani', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 100%;
+    max-width: 1000px;
+    padding: 40px 20px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 60px;
+}
+
+.header h1 {
+    font-size: 2.5rem;
+    margin: 0 0 10px 0;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: var(--laser-color);
+    text-shadow: 0 0 15px var(--laser-glow);
+}
+
+.header p {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    letter-spacing: 1px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px;
+}
+
+.demo-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.demo-content h2 {
+    font-size: 1.2rem;
+    margin: 0 0 5px 0;
+    letter-spacing: 1px;
+}
+
+.demo-content p {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0 0 20px 0;
+}
+
+.component-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+    background: #0d0d12;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Perimeter Scan Button
+   Uses 4 absolute positioned divs representing the 4 borders.
+   On hover, they scale from 0 to 1 in sequence using transition-delay.
+   ========================================= */
+.btn-laser {
+    position: relative;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 1.1rem;
+    font-weight: 700;
+    padding: 16px 32px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.btn-laser span {
+    position: relative;
+    z-index: 10;
+}
+
+.laser-track {
+    position: absolute;
+    background: var(--laser-color);
+    box-shadow: 0 0 10px var(--laser-color), 0 0 20px var(--laser-color);
+    transition: transform 0.2s linear;
+}
+
+.laser-track.top {
+    top: 0; left: 0;
+    width: 100%; height: var(--laser-width);
+    transform: translateX(-100%);
+}
+
+.laser-track.right {
+    top: 0; right: 0;
+    width: var(--laser-width); height: 100%;
+    transform: translateY(-100%);
+}
+
+.laser-track.bottom {
+    bottom: 0; right: 0;
+    width: 100%; height: var(--laser-width);
+    transform: translateX(100%);
+}
+
+.laser-track.left {
+    bottom: 0; left: 0;
+    width: var(--laser-width); height: 100%;
+    transform: translateY(100%);
+}
+
+/* Sequential animation on hover */
+.btn-laser:hover .top { transform: translateX(0); transition-delay: 0s; }
+.btn-laser:hover .right { transform: translateY(0); transition-delay: 0.2s; }
+.btn-laser:hover .bottom { transform: translateX(0); transition-delay: 0.4s; }
+.btn-laser:hover .left { transform: translateY(0); transition-delay: 0.6s; }
+
+.btn-laser:hover {
+    color: var(--laser-color);
+    background: rgba(255, 0, 85, 0.05);
+    /* Delay the background color change until the laser completes its trace */
+    transition-delay: 0.8s;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Conic Laser Card
+   Uses a spinning conic gradient pseudo-element placed behind
+   a solid inner card to create an infinite tracing laser.
+   ========================================= */
+.laser-card {
+    position: relative;
+    width: 250px;
+    height: 120px;
+    border-radius: 8px;
+    padding: var(--laser-width); /* Space for the laser border */
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* The spinning laser beam */
+.laser-card::before {
+    content: '';
+    position: absolute;
+    top: -50%; left: -50%;
+    width: 200%; height: 200%;
+    /* A sharp slice of color in an otherwise transparent gradient */
+    background: conic-gradient(
+        from 0deg,
+        transparent 70%,
+        var(--laser-color) 100%
+    );
+    animation: laser-spin 2.5s linear infinite;
+    z-index: 1;
+}
+
+/* Optional: Add a glow to the spinning laser */
+.laser-card::after {
+    content: '';
+    position: absolute;
+    top: -50%; left: -50%;
+    width: 200%; height: 200%;
+    background: conic-gradient(
+        from 0deg,
+        transparent 70%,
+        var(--laser-color) 100%
+    );
+    filter: blur(10px);
+    animation: laser-spin 2.5s linear infinite;
+    z-index: 2;
+}
+
+.card-content {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: #0d0d12;
+    border-radius: 6px;
+    z-index: 5; /* Sit above the spinning gradient */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.card-content h3 {
+    margin: 0 0 5px 0;
+    font-size: 1.3rem;
+    letter-spacing: 2px;
+}
+.card-content p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+@keyframes laser-spin {
+    100% { transform: rotate(360deg); }
+}
+
+
+/* =========================================
+   [TECHNIQUE 3] Laser Underline Link
+   Uses ::after with transform-origin to create a fast, glowing
+   strike across the text.
+   ========================================= */
+.laser-link {
+    position: relative;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 1.2rem;
+    font-weight: 700;
+    letter-spacing: 2px;
+    padding-bottom: 5px;
+    transition: color 0.3s ease;
+}
+
+.laser-link::after {
+    content: '';
+    position: absolute;
+    bottom: 0; left: 0;
+    width: 100%; height: var(--laser-width);
+    background: var(--laser-color);
+    box-shadow: 0 0 10px var(--laser-color);
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.4s cubic-bezier(0.86, 0, 0.07, 1);
+}
+
+.laser-link:hover {
+    color: var(--laser-color);
+    text-shadow: 0 0 10px var(--laser-glow);
+}
+
+.laser-link:hover::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .btn-laser:hover .laser-track,
+    .laser-card::before, .laser-card::after,
+    .laser-link::after {
+        animation: none;
+        transition: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a collection of hardware-accelerated, JavaScript-free micro-interactions focused on glowing laser beams tracing the perimeter of UI elements. Resolves issue #73854.

### Changes Made:
- Added `submissions/examples/css-micro-interaction-laser-ray-trace-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the layout grid and the markup for each of the 3 laser micro-interactions (Perimeter Scan Button, Conic Laser Card, Laser Strike Underline).
- Created `style.css` featuring the UI mechanics:
  - **Perimeter Scan Button**: An interactive button that deploys a laser tracking effect on hover. It uses four absolute-positioned `.laser-track` divs representing the four borders. Initially, they are translated off-screen (e.g., `transform: translateX(-100%)`). On `:hover`, they transition back to `0`. By using staggered `transition-delay` values (`0s`, `0.2s`, `0.4s`, `0.6s`), the laser appears to seamlessly draw a continuous box around the button.
  - **Conic Laser Card**: A highly performant, infinite laser border. This is achieved by placing a pseudo-element *behind* the main card content (`z-index: 1`), giving it a sharp `conic-gradient` (transparent to solid red), and animating its rotation with `transform: rotate()`. A second pseudo-element with a `blur` filter provides the glowing laser bloom. The solid `.card-content` sits on top (`z-index: 5`), masking the center and leaving only the spinning edges visible.
  - **Laser Underline Link**: A classic minimal interaction. It uses an `::after` pseudo-element for the underline. On `:hover`, it scales from `0` to `1` on the X-axis. By dynamically changing the `transform-origin` between `right` (initial state) and `left` (hover state), the laser appears to strike from left to right, and then retract from right to left when the mouse leaves.
  - **Theming Supported**: Configured via CSS Custom Properties. The color palette focuses on intense, high-energy neon colors: a stark Laser Red (`#ff0055`) set against a deep space black background.
- Added `README.md` documenting usage and the technical mechanics of the `conic-gradient` geometry, the `transform-origin` manipulation, and the staggered transition delays.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by disabling the spinning loader and complex transition traces for users who prefer less motion.

Closes #73854
