### PR TITLE
feat: add origami paper fold mesh gradient

### DIFF
--- a/submissions/examples/origami-paper-fold-mesh-msm/README.md
+++ b/submissions/examples/origami-paper-fold-mesh-msm/README.md
@@ -1,0 +1,27 @@
+# Origami Paper Fold Mesh
+
+## What does this do?
+
+This submission creates a pure CSS mesh-gradient panel inspired by folded origami paper, with layered facets, soft shadows, and accessible contrast.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="origami-shell" aria-labelledby="origami-title">
+  <div class="origami-card">
+    <span class="origami-kicker">CSS mesh gradient</span>
+    <h1 id="origami-title">Origami Paper Fold</h1>
+    <p>
+      Use this as a folded-paper motion surface for product and dashboard UI.
+    </p>
+  </div>
+</section>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a refined dark-mode-compatible background treatment that feels dimensional while staying lightweight, responsive, and dependency-free.

--- a/submissions/examples/origami-paper-fold-mesh-msm/demo.html
+++ b/submissions/examples/origami-paper-fold-mesh-msm/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Origami Paper Fold Mesh</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="origami-shell" aria-labelledby="origami-title">
+      <section class="origami-card" aria-describedby="origami-copy">
+        <div class="origami-folds" aria-hidden="true">
+          <span class="origami-fold origami-fold-a"></span>
+          <span class="origami-fold origami-fold-b"></span>
+          <span class="origami-fold origami-fold-c"></span>
+        </div>
+
+        <span class="origami-kicker">Pure CSS folded surface</span>
+        <h1 id="origami-title">Origami Paper Fold</h1>
+        <p id="origami-copy">
+          A responsive mesh gradient that layers angular folds, glassy shadows,
+          and subtle hover motion to create a crisp paper-sculpted UI section.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/origami-paper-fold-mesh-msm/style.css
+++ b/submissions/examples/origami-paper-fold-mesh-msm/style.css
@@ -1,0 +1,251 @@
+:root {
+  --origami-bg: #071019;
+  --origami-ink: #f6fbff;
+  --origami-muted: #bfd1dc;
+  --origami-panel: rgba(10, 22, 34, 0.8);
+  --origami-mint: #83ffd8;
+  --origami-sky: #63c8ff;
+  --origami-coral: #ff8d7a;
+  --origami-indigo: #6e7bff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--origami-ink);
+  background: var(--origami-bg);
+  font-family: "Gill Sans", "Trebuchet MS", sans-serif;
+}
+
+.origami-shell {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 22%,
+      rgba(131, 255, 216, 0.24),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 86% 18%,
+      rgba(255, 141, 122, 0.22),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 64% 86%,
+      rgba(110, 123, 255, 0.24),
+      transparent 26rem
+    ),
+    linear-gradient(145deg, #06101a 0%, #10263a 54%, #04070d 100%);
+  isolation: isolate;
+}
+
+.origami-shell::before,
+.origami-shell::after {
+  position: absolute;
+  inset: 8%;
+  z-index: -2;
+  content: "";
+  clip-path: polygon(9% 20%, 49% 5%, 92% 24%, 78% 82%, 23% 94%);
+  transform: rotate(-8deg);
+}
+
+.origami-shell::before {
+  background:
+    linear-gradient(128deg, rgba(255, 255, 255, 0.14), transparent 48%),
+    radial-gradient(
+      circle at 24% 30%,
+      rgba(99, 200, 255, 0.22),
+      transparent 20rem
+    );
+  filter: blur(0.1rem);
+  opacity: 0.62;
+}
+
+.origami-shell::after {
+  inset: 15%;
+  z-index: -3;
+  background: rgba(131, 255, 216, 0.16);
+  filter: blur(5rem);
+  opacity: 0.8;
+  transform: rotate(14deg);
+}
+
+.origami-card {
+  position: relative;
+  width: min(44rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4.2rem);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.16), transparent 34%),
+    radial-gradient(
+      circle at 24% 24%,
+      rgba(131, 255, 216, 0.22),
+      transparent 13rem
+    ),
+    radial-gradient(
+      circle at 92% 20%,
+      rgba(255, 141, 122, 0.2),
+      transparent 11rem
+    ),
+    var(--origami-panel);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.48),
+    inset 0 0 4rem rgba(99, 200, 255, 0.1);
+  backdrop-filter: blur(1.2rem);
+  transition:
+    transform 260ms ease,
+    box-shadow 260ms ease;
+}
+
+.origami-card:hover {
+  box-shadow:
+    0 2.4rem 7rem rgba(0, 0, 0, 0.55),
+    inset 0 0 4.5rem rgba(131, 255, 216, 0.13);
+  transform: translateY(-0.28rem);
+}
+
+.origami-folds {
+  position: absolute;
+  inset: 0;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.origami-fold {
+  position: absolute;
+  display: block;
+  filter: drop-shadow(0 1.2rem 1.4rem rgba(0, 0, 0, 0.24));
+  transform-origin: center;
+  will-change: transform;
+}
+
+.origami-fold-a {
+  top: -10%;
+  right: -8%;
+  width: 24rem;
+  height: 22rem;
+  background: linear-gradient(
+    145deg,
+    rgba(131, 255, 216, 0.32),
+    rgba(99, 200, 255, 0.04)
+  );
+  clip-path: polygon(0 0, 100% 14%, 55% 100%);
+  animation: origami-float-a 6s ease-in-out infinite;
+}
+
+.origami-fold-b {
+  right: 10%;
+  bottom: -16%;
+  width: 22rem;
+  height: 18rem;
+  background: linear-gradient(
+    45deg,
+    rgba(255, 141, 122, 0.24),
+    rgba(110, 123, 255, 0.04)
+  );
+  clip-path: polygon(26% 0, 100% 56%, 0 100%);
+  animation: origami-float-b 7s ease-in-out infinite;
+}
+
+.origami-fold-c {
+  bottom: 8%;
+  left: -7%;
+  width: 18rem;
+  height: 16rem;
+  background: linear-gradient(
+    115deg,
+    rgba(110, 123, 255, 0.24),
+    rgba(131, 255, 216, 0.05)
+  );
+  clip-path: polygon(0 18%, 82% 0, 100% 100%, 18% 72%);
+  animation: origami-float-c 8s ease-in-out infinite;
+}
+
+.origami-kicker {
+  position: relative;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(131, 255, 216, 0.34);
+  border-radius: 999px;
+  color: var(--origami-mint);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.origami-card h1 {
+  position: relative;
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(3rem, 10vw, 6.6rem);
+  line-height: 0.9;
+  text-shadow:
+    0 0 1rem rgba(131, 255, 216, 0.42),
+    0 0 3rem rgba(99, 200, 255, 0.32);
+}
+
+.origami-card p {
+  position: relative;
+  max-width: 35rem;
+  margin: 1.25rem 0 0;
+  color: var(--origami-muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+@keyframes origami-float-a {
+  50% {
+    transform: translate3d(-0.45rem, 0.35rem, 0) rotate(2deg);
+  }
+}
+
+@keyframes origami-float-b {
+  50% {
+    transform: translate3d(0.35rem, -0.4rem, 0) rotate(-2deg);
+  }
+}
+
+@keyframes origami-float-c {
+  50% {
+    transform: translate3d(0.3rem, 0.35rem, 0) rotate(2deg);
+  }
+}
+
+@media (max-width: 42rem) {
+  .origami-shell {
+    padding: 1rem;
+  }
+
+  .origami-card {
+    border-radius: 1.4rem;
+  }
+
+  .origami-fold-a,
+  .origami-fold-b,
+  .origami-fold-c {
+    opacity: 0.7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .origami-card,
+  .origami-fold-a,
+  .origami-fold-b,
+  .origami-fold-c {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Origami Paper Fold mesh gradient.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses layered angular folds, soft mesh gradients, hover polish, and reduced-motion-safe animation.

Closes #73838

## Changes Made
- Created `submissions/examples/origami-paper-fold-mesh-msm/`.
- Added a responsive folded-paper mesh gradient demo with semantic HTML.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx prettier --check submissions/examples/origami-paper-fold-mesh-msm/**/*.{html,css,md}` - passed
- `npx stylelint submissions/examples/origami-paper-fold-mesh-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.