### PR TITLE
feat: add frosted glass / glassmorphism card

### DIFF
--- a/submissions/examples/frosted-glass-card/README.md
+++ b/submissions/examples/frosted-glass-card/README.md
@@ -1,0 +1,109 @@
+# Frosted Glass Card
+
+`.ease-glass-card` — a semi-transparent card using a real
+`backdrop-filter: blur()`, so whatever's actually behind it in the page
+shows through, softened, rather than a fake pre-blurred background image
+standing in for the effect. Pure CSS.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Three cards (default, dark, tinted) over a colorful backdrop |
+| `style.css` | The component, its variants, and the demo backdrop |
+| `README.md` | This file |
+
+## Usage
+
+```html
+<article class="ease-glass-card">
+  <span class="ease-glass-card__badge">New</span>
+  <h2 class="ease-glass-card__title">Cloud sync</h2>
+  <p class="ease-glass-card__text">Every change saves instantly across all your devices.</p>
+  <a href="#" class="ease-glass-card__link">Learn more &rarr;</a>
+</article>
+```
+
+**Glassmorphism needs something to blur.** This component makes no
+assumptions about what's behind it — the demo ships an animated
+gradient backdrop specifically so the effect is visible at all, but in a
+real page `.ease-glass-card` would just as happily sit over a photo, a
+video, or any other content. Put it over a plain flat background and the
+blur has nothing to do; it'll just look like a slightly translucent box.
+
+## The core declarations
+
+```css
+.ease-glass-card {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px); /* Safari still needs the prefix */
+  box-shadow:
+    0 20px 40px -20px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+```
+
+The `inset` shadow is doing real work here, not just extra polish — a
+1px inner highlight along the top edge is what makes a flat translucent
+box start reading as a physical pane of glass catching light, rather than
+just a semi-transparent rectangle.
+
+## CSS custom properties
+
+| Property | Default | Controls |
+|---|---|---|
+| `--gc-glass-bg` | `rgba(255,255,255,0.12)` | The glass tint itself |
+| `--gc-glass-border` | `rgba(255,255,255,0.35)` | Edge highlight |
+| `--gc-glass-blur` | `14px` | Backdrop blur radius |
+| `--gc-duration` / `--gc-ease` | `240ms` / custom curve | Hover transition |
+
+## Variants
+
+- `.ease-glass-card-dark` — a darker glass tint, for use over lighter
+  backdrops where white-tinted glass would wash out.
+- `.ease-glass-card-tinted` — mixes a color (violet, by default) into the
+  glass itself while staying translucent, rather than just changing the
+  border/badge accent.
+
+Both are two-line overrides on the same base component — no duplicated
+structure.
+
+## Accessibility
+
+- `:focus-within` puts a visible outline on the whole card when its
+  internal link is focused, not just a default browser outline on the
+  link alone — easier to see against a busy, blurred backdrop.
+- Text colors (`--gc-text`, `--gc-text-muted`) are chosen for contrast
+  against the specific backdrop this demo ships; a project reusing this
+  component over a different backdrop should re-check contrast, since
+  glass-over-arbitrary-content is inherently a contrast risk no fixed
+  color choice can fully solve on its own.
+- Respects `prefers-reduced-motion: reduce`: the backdrop's ambient drift
+  animation stops, and the hover lift transition collapses to `1ms`.
+
+## Fallback for unsupported browsers
+
+```css
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ease-glass-card {
+    background: rgba(20, 22, 28, 0.72);
+  }
+}
+```
+
+Where `backdrop-filter` isn't supported at all, the card falls back to a
+solid-looking dark translucent panel instead of a fully see-through box
+with illegible text over a busy backdrop.
+
+## Responsive behavior
+
+The card grid drops from three columns to two at `760px` and to one at
+`520px`.
+
+## Browser support
+
+`backdrop-filter` needs the `-webkit-` prefix on Safari (included above)
+and is otherwise supported in all current evergreen browsers. The
+`@supports` fallback covers anything older.

--- a/submissions/examples/frosted-glass-card/demo.html
+++ b/submissions/examples/frosted-glass-card/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Frosted Glass Card — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="backdrop" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Frosted glass card</h1>
+    <p class="hero-sub">A semi-transparent card with a real <code>backdrop-filter: blur()</code>, so whatever sits behind it actually shows through, softened. Pure CSS.</p>
+  </header>
+
+  <main class="showcase">
+
+    <div class="card-grid">
+
+      <article class="ease-glass-card">
+        <span class="ease-glass-card__badge">New</span>
+        <h2 class="ease-glass-card__title">Cloud sync</h2>
+        <p class="ease-glass-card__text">Every change saves instantly across all your devices, no manual sync required.</p>
+        <a href="#" class="ease-glass-card__link">Learn more &rarr;</a>
+      </article>
+
+      <article class="ease-glass-card ease-glass-card-dark">
+        <span class="ease-glass-card__badge">Beta</span>
+        <h2 class="ease-glass-card__title">Live collaboration</h2>
+        <p class="ease-glass-card__text">See teammates' cursors and edits in real time, no page refresh needed.</p>
+        <a href="#" class="ease-glass-card__link">Learn more &rarr;</a>
+      </article>
+
+      <article class="ease-glass-card ease-glass-card-tinted">
+        <span class="ease-glass-card__badge">Popular</span>
+        <h2 class="ease-glass-card__title">Smart search</h2>
+        <p class="ease-glass-card__text">Find anything across every workspace in under 100ms, typo-tolerant by default.</p>
+        <a href="#" class="ease-glass-card__link">Learn more &rarr;</a>
+      </article>
+
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/frosted-glass-card</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/frosted-glass-card/style.css
+++ b/submissions/examples/frosted-glass-card/style.css
@@ -1,0 +1,295 @@
+/* =========================================================================
+   Frosted Glass Card — EaseMotion CSS
+   .ease-glass-card: a semi-transparent card using a real
+   backdrop-filter: blur(), so whatever actually sits behind it in the
+   page shows through, softened — not a fake blurred-background-image
+   trick. Requires a colorful backdrop behind it to be visible at all,
+   which is why the demo ships one; the card itself makes no assumptions
+   about what that backdrop is. Pure CSS.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --gc-text: #ffffff;
+  --gc-text-muted: rgba(255, 255, 255, 0.75);
+
+  --gc-glass-bg: rgba(255, 255, 255, 0.12);
+  --gc-glass-border: rgba(255, 255, 255, 0.35);
+  --gc-glass-blur: 14px;
+
+  --gc-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --gc-font-body: "Inter", "Segoe UI", sans-serif;
+  --gc-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  --gc-duration: 240ms;
+  --gc-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--gc-text);
+  font-family: var(--gc-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Colorful, moving backdrop so the blur has something worth blurring.
+   Not part of the component — a real page would have its own photo,
+   gradient hero, or video behind the cards instead. */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 15% 20%, #ff6b6b 0%, transparent 45%),
+    radial-gradient(circle at 85% 15%, #4de8ff 0%, transparent 45%),
+    radial-gradient(circle at 30% 85%, #a78bfa 0%, transparent 50%),
+    radial-gradient(circle at 80% 80%, #ffd166 0%, transparent 45%),
+    #0e1116;
+  animation: gc-drift 16s ease-in-out infinite;
+}
+
+@keyframes gc-drift {
+  0%, 100% { background-position: 0% 0%, 0% 0%, 0% 0%, 0% 0%, 0% 0%; }
+  50% { background-position: 6% 4%, -5% 6%, 4% -5%, -6% -4%, 0% 0%; }
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 88px 24px 40px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--gc-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--gc-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--gc-text-muted);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.hero-sub code {
+  font-family: var(--gc-font-mono);
+  font-size: 13px;
+  color: var(--gc-text);
+  background: rgba(0, 0, 0, 0.25);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 20px 24px 100px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+
+/* -------------------------------------------------------------------------
+   4. THE COMPONENT — .ease-glass-card
+   ------------------------------------------------------------------------- */
+
+.ease-glass-card {
+  position: relative;
+  padding: 26px 24px 24px;
+  border-radius: 18px;
+
+  background: var(--gc-glass-bg);
+  border: 1px solid var(--gc-glass-border);
+  backdrop-filter: blur(var(--gc-glass-blur));
+  -webkit-backdrop-filter: blur(var(--gc-glass-blur));
+
+  box-shadow:
+    0 20px 40px -20px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+
+  transition: transform var(--gc-duration) var(--gc-ease),
+    box-shadow var(--gc-duration) var(--gc-ease),
+    background var(--gc-duration) var(--gc-ease);
+}
+
+.ease-glass-card:hover {
+  transform: translateY(-4px);
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 28px 52px -20px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.ease-glass-card__badge {
+  display: inline-block;
+  font-family: var(--gc-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #0e1116;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 3px 9px;
+  border-radius: 999px;
+  margin-bottom: 14px;
+}
+
+.ease-glass-card__title {
+  font-family: var(--gc-font-display);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.ease-glass-card__text {
+  font-size: 13.5px;
+  color: var(--gc-text-muted);
+  margin: 0 0 16px;
+}
+
+.ease-glass-card__link {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gc-text);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+  padding-bottom: 1px;
+}
+
+.ease-glass-card__link:hover {
+  border-bottom-color: var(--gc-text);
+}
+
+.ease-glass-card:focus-within {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+
+/* -------------------------------------------------------------------------
+   5. Variants
+   ------------------------------------------------------------------------- */
+
+/* Darker glass — reads better over light backdrops */
+.ease-glass-card-dark {
+  --gc-glass-bg: rgba(0, 0, 0, 0.28);
+  --gc-glass-border: rgba(255, 255, 255, 0.18);
+}
+
+.ease-glass-card-dark:hover {
+  background: rgba(0, 0, 0, 0.34);
+}
+
+/* A color tint mixed into the glass itself, still translucent */
+.ease-glass-card-tinted {
+  --gc-glass-bg: rgba(167, 139, 250, 0.22);
+  --gc-glass-border: rgba(210, 190, 255, 0.4);
+}
+
+.ease-glass-card-tinted:hover {
+  background: rgba(167, 139, 250, 0.28);
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--gc-text-muted);
+  font-family: var(--gc-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 760px) {
+  .card-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero {
+    padding: 68px 20px 32px;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Fallback for browsers without backdrop-filter support
+   ------------------------------------------------------------------------- */
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ease-glass-card {
+    background: rgba(20, 22, 28, 0.72);
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop {
+    animation: none;
+  }
+
+  .ease-glass-card {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #71741

## Pull Request Description
Adds `.ease-glass-card` — a frosted-glass card using a real `backdrop-filter: blur()` (with `-webkit-` prefix for Safari) over a semi-transparent background, with dark and tinted variants. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/frosted-glass-card/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

**What does this add?**
A frosted-glass card component using a real `backdrop-filter: blur()`, so content behind it visibly shows through, softened — not a fake pre-blurred background standing in for the effect.

**How does a developer use it?**
```html
<article class="ease-glass-card">
  <h2 class="ease-glass-card__title">Title</h2>
  <p class="ease-glass-card__text">Body text.</p>
</article>
```
Add `.ease-glass-card-dark` or `.ease-glass-card-tinted` for variants, or override `--gc-glass-bg`/`--gc-glass-blur` directly. Needs something visually busy behind it (photo, gradient, video) to actually read as glass — ships an animated gradient backdrop in the demo for exactly that reason.

**Why does it fit EaseMotion CSS?**
Matches the issue's requirements directly (semi-transparent background, `backdrop-filter: blur(10px)`-equivalent, subtle border, box-shadow), plus an `@supports` fallback for browsers without `backdrop-filter` and variants built as clean token overrides.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Included a `@supports not (backdrop-filter...)` fallback so browsers without support get a solid dark panel instead of a fully see-through box with illegible text. Flagged in the README that text contrast over glass is inherently backdrop-dependent — a project reusing this over a different backdrop than the demo's should re-check contrast rather than assume the shipped colors are universally safe.