### PR TITLE
✨ feat(examples): add Basic Icon Circle Placeholder (#75271)

### DIFF
--- a/submissions/examples/basic-icon-circle-placeholder/README.md
+++ b/submissions/examples/basic-icon-circle-placeholder/README.md
@@ -1,0 +1,9 @@
+# Basic Icon Circle Placeholder (#75271)
+
+A lightweight, reusable CSS-only circular placeholder utility for initials, icons, or UI markers.
+
+## Features
+- **Versatile:** Displays single letters, icons, or symbols centered inside a circular shape.
+- **Pure CSS:** Zero JavaScript dependencies; styled strictly using flexbox and standard CSS properties.
+- **Performance:** Lightweight, non-blocking CSS layout optimization.
+- **Accessibility:** High contrast text-to-background ratio and scalable font-size integration.

--- a/submissions/examples/basic-icon-circle-placeholder/demo.html
+++ b/submissions/examples/basic-icon-circle-placeholder/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Basic Icon Circle Placeholder #75271 Demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 16px;
+      min-height: 100vh;
+      background-color: #0f172a;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <span class="basic-icon-circle">K</span>
+  <span class="basic-icon-circle" style="--circle-bg: #10b981; --circle-border: #34d399;">A</span>
+  <span class="basic-icon-circle" style="--circle-bg: #8b5cf6; --circle-border: #a78bfa;">?</span>
+
+</body>
+</html>

--- a/submissions/examples/basic-icon-circle-placeholder/style.css
+++ b/submissions/examples/basic-icon-circle-placeholder/style.css
@@ -1,0 +1,30 @@
+:root {
+  --circle-bg: #2563eb;
+  --circle-text: #ffffff;
+  --circle-border: #3b82f6;
+  --circle-size: 40px;
+}
+
+.basic-icon-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--circle-size);
+  height: var(--circle-size);
+  border-radius: 50%;
+  background-color: var(--circle-bg);
+  color: var(--circle-text);
+  border: 1px solid var(--circle-border);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+  user-select: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.basic-icon-circle:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
## Description
Creates a reusable Basic Icon Circle Placeholder component inside `submissions/examples/basic-icon-circle-placeholder/` to meet directory validation criteria.

## Changes Made
- Added `submissions/examples/basic-icon-circle-placeholder/demo.html`
- Added `submissions/examples/basic-icon-circle-placeholder/style.css`
- Added `submissions/examples/basic-icon-circle-placeholder/README.md`

Fixes #75271