### PR TITLE
feat: add basic stat caption row demo

### DIFF
--- a/submissions/examples/basic-stat-caption-row-kk/README.md
+++ b/submissions/examples/basic-stat-caption-row-kk/README.md
@@ -1,0 +1,37 @@
+# Basic Stat Caption Row
+
+## What it does
+
+This submission adds a simple CSS-only stat caption row for showing a small metric label, value, and helper caption in compact dashboard cards.
+
+It works well for analytics cards, profile summaries, project stats, admin panels, reports, and small overview sections.
+
+## How to use it
+
+Add the utility class to a small stat block:
+
+```html
+<div class="basic-stat-caption-row">
+  <span>Tasks completed</span>
+  <strong>24</strong>
+  <p>Up 8 this week</p>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across dashboard and reporting interfaces. The class provides a reusable structure for compact metric summaries without JavaScript or external libraries.
+
+## Included features
+
+- Metric label, value, and helper caption layout
+- Compact dashboard-card styling
+- Responsive grid demo
+- Clear typography hierarchy
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the stat caption row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-stat-caption-row-kk/demo.html
+++ b/submissions/examples/basic-stat-caption-row-kk/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Stat Caption Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Stat Caption Row</p>
+          <h1>Small metric rows for dashboards, reports, and summaries.</h1>
+          <p class="intro">
+            This CSS-only utility stacks a metric label, value, and helper
+            caption for compact analytics cards and overview panels.
+          </p>
+        </header>
+
+        <section class="stats-panel" aria-label="Stat caption row examples">
+          <div class="basic-stat-caption-row">
+            <span>Tasks completed</span>
+            <strong>24</strong>
+            <p>Up 8 this week</p>
+          </div>
+
+          <div class="basic-stat-caption-row">
+            <span>Open reviews</span>
+            <strong>06</strong>
+            <p>2 waiting for feedback</p>
+          </div>
+
+          <div class="basic-stat-caption-row">
+            <span>Files uploaded</span>
+            <strong>128</strong>
+            <p>Updated today</p>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-stat-caption-row"&gt;
+  &lt;span&gt;Tasks completed&lt;/span&gt;
+  &lt;strong&gt;24&lt;/strong&gt;
+  &lt;p&gt;Up 8 this week&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-stat-caption-row-kk/style.css
+++ b/submissions/examples/basic-stat-caption-row-kk/style.css
@@ -1,0 +1,128 @@
+:root {
+  color-scheme: dark;
+  --page: #090d18;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9aa7bd;
+  --accent: #86efac;
+  --accent-soft: rgba(134, 239, 172, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 80%, rgba(96, 165, 250, 0.12), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.stats-panel {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.85rem;
+}
+
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-stat-caption-row {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--panel);
+}
+
+.basic-stat-caption-row span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.basic-stat-caption-row strong {
+  color: var(--text);
+  font-size: 1.7rem;
+  line-height: 1;
+}
+
+.basic-stat-caption-row p {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.9rem;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .stats-panel {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Stat Caption Row demo inside `submissions/examples/basic-stat-caption-row-kk/`. This submission introduces a compact CSS-only metric row pattern for dashboards, reports, profile summaries, admin panels, and overview sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only stat caption row for showing a small metric label, value, and helper caption in compact dashboard cards.

**How does a developer use it?**

```html
<div class="basic-stat-caption-row">
  <span>Tasks completed</span>
  <strong>24</strong>
  <p>Up 8 this week</p>
</div>