### PR TITLE
feat: add basic step status row demo

### DIFF
--- a/submissions/examples/basic-step-status-row-kk/README.md
+++ b/submissions/examples/basic-step-status-row-kk/README.md
@@ -1,0 +1,40 @@
+# Basic Step Status Row
+
+## What it does
+
+This submission adds a simple CSS-only step status row for onboarding cards, setup flows, checklists, and project progress sections.
+
+It aligns a step marker, task title, helper text, and right-side status label in one compact row.
+
+## How to use it
+
+Add the utility class to a row containing a step marker, task copy, and status:
+
+```html
+<div class="basic-step-status-row">
+  <span class="step-marker" aria-hidden="true">1</span>
+  <div class="step-copy">
+    <strong>Create workspace</strong>
+    <p>Set up the main project area.</p>
+  </div>
+  <span class="step-state is-done">Done</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across onboarding panels, setup cards, dashboards, profile completion sections, and checklists without JavaScript or external libraries.
+
+## Included features
+
+- Step marker, title, helper text, and status layout
+- Done, active, and pending status examples
+- Divider support between rows
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the step status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-step-status-row-kk/demo.html
+++ b/submissions/examples/basic-step-status-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Step Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Step Status Row</p>
+          <h1>Compact status rows for onboarding, setup, and checklists.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a step marker, task copy, and a
+            right-side status label for setup cards and progress checklists.
+          </p>
+        </header>
+
+        <section class="steps-panel" aria-label="Step status row examples">
+          <div class="basic-step-status-row">
+            <span class="step-marker" aria-hidden="true">1</span>
+            <div class="step-copy">
+              <strong>Create workspace</strong>
+              <p>Set up the main project area.</p>
+            </div>
+            <span class="step-state is-done">Done</span>
+          </div>
+
+          <div class="basic-step-status-row">
+            <span class="step-marker" aria-hidden="true">2</span>
+            <div class="step-copy">
+              <strong>Invite members</strong>
+              <p>Add collaborators to continue setup.</p>
+            </div>
+            <span class="step-state is-active">Active</span>
+          </div>
+
+          <div class="basic-step-status-row">
+            <span class="step-marker" aria-hidden="true">3</span>
+            <div class="step-copy">
+              <strong>Review settings</strong>
+              <p>Confirm permissions and preferences.</p>
+            </div>
+            <span class="step-state">Pending</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-step-status-row"&gt;
+  &lt;span class="step-marker" aria-hidden="true"&gt;1&lt;/span&gt;
+  &lt;div class="step-copy"&gt;
+    &lt;strong&gt;Create workspace&lt;/strong&gt;
+    &lt;p&gt;Set up the main project area.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="step-state is-done"&gt;Done&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-step-status-row-kk/style.css
+++ b/submissions/examples/basic-step-status-row-kk/style.css
@@ -1,0 +1,161 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #93c5fd;
+  --success: #86efac;
+  --warning: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 84% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.steps-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-step-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-step-status-row + .basic-step-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.step-marker {
+  width: 2.3rem;
+  height: 2.3rem;
+  flex: 0 0 2.3rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(147, 197, 253, 0.34);
+  border-radius: 50%;
+  color: var(--accent);
+  background: rgba(147, 197, 253, 0.12);
+  font-weight: 800;
+}
+
+.step-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.step-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.step-copy p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.step-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.step-state.is-done {
+  color: var(--success);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.step-state.is-active {
+  color: var(--warning);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-step-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .step-state {
+    margin-left: 3.15rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Step Status Row demo inside `submissions/examples/basic-step-status-row-kk/`. This submission introduces a compact CSS-only row pattern for onboarding cards, setup flows, checklists, and project progress sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only step status row for showing a step marker, task title, helper text, and status label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-step-status-row">
  <span class="step-marker" aria-hidden="true">1</span>
  <div class="step-copy">
    <strong>Create workspace</strong>
    <p>Set up the main project area.</p>
  </div>
  <span class="step-state is-done">Done</span>
</div>