### PR TITLE
feat: add basic alert message row demo

### DIFF
--- a/submissions/examples/basic-alert-message-row-kk/README.md
+++ b/submissions/examples/basic-alert-message-row-kk/README.md
@@ -1,0 +1,39 @@
+# Basic Alert Message Row
+
+## What it does
+
+This submission adds a simple CSS-only alert message row for showing a short feedback message with a small icon marker and optional supporting text.
+
+It works well for form notices, dashboard alerts, warning rows, success messages, account reminders, and inline feedback sections.
+
+## How to use it
+
+Add the utility class to a row containing an icon marker and message copy:
+
+```html
+<div class="basic-alert-message-row is-warning">
+  <span aria-hidden="true">!</span>
+  <div>
+    <strong>Review required</strong>
+    <p>Please check the details before continuing.</p>
+  </div>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across cards, forms, settings panels, dashboards, and content sections. It provides reusable inline feedback styling without JavaScript or external libraries.
+
+## Included features
+
+- Icon marker and message text layout
+- Warning, success, and info examples
+- Rounded alert container styling
+- Compact spacing for inline sections
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the alert message row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-alert-message-row-kk/demo.html
+++ b/submissions/examples/basic-alert-message-row-kk/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Alert Message Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Alert Message Row</p>
+          <h1>Compact feedback rows for alerts, notices, and reminders.</h1>
+          <p class="intro">
+            This CSS-only utility pairs a small icon marker with alert copy,
+            making inline feedback easy to scan inside cards, forms, and panels.
+          </p>
+        </header>
+
+        <section class="alert-panel" aria-label="Alert message row examples">
+          <div class="basic-alert-message-row is-warning">
+            <span aria-hidden="true">!</span>
+            <div>
+              <strong>Review required</strong>
+              <p>Please check the details before continuing.</p>
+            </div>
+          </div>
+
+          <div class="basic-alert-message-row is-success">
+            <span aria-hidden="true">✓</span>
+            <div>
+              <strong>Changes saved</strong>
+              <p>Your latest preferences were updated successfully.</p>
+            </div>
+          </div>
+
+          <div class="basic-alert-message-row is-info">
+            <span aria-hidden="true">i</span>
+            <div>
+              <strong>New update available</strong>
+              <p>Refresh the page to see the newest dashboard data.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-alert-message-row is-warning"&gt;
+  &lt;span aria-hidden="true"&gt;!&lt;/span&gt;
+  &lt;div&gt;
+    &lt;strong&gt;Review required&lt;/strong&gt;
+    &lt;p&gt;Please check the details before continuing.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-alert-message-row-kk/style.css
+++ b/submissions/examples/basic-alert-message-row-kk/style.css
@@ -1,0 +1,155 @@
+:root {
+  color-scheme: dark;
+  --page: #090d16;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --warning: #fbbf24;
+  --success: #86efac;
+  --info: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(251, 191, 36, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--warning);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.alert-panel,
+.usage-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-alert-message-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.95rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.basic-alert-message-row span {
+  width: 1.8rem;
+  height: 1.8rem;
+  flex: 0 0 1.8rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  font-weight: 800;
+}
+
+.basic-alert-message-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.basic-alert-message-row p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.basic-alert-message-row.is-warning {
+  border-color: rgba(251, 191, 36, 0.25);
+  background: rgba(251, 191, 36, 0.09);
+}
+
+.basic-alert-message-row.is-warning span {
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.18);
+}
+
+.basic-alert-message-row.is-success {
+  border-color: rgba(134, 239, 172, 0.24);
+  background: rgba(134, 239, 172, 0.08);
+}
+
+.basic-alert-message-row.is-success span {
+  color: var(--success);
+  background: rgba(134, 239, 172, 0.16);
+}
+
+.basic-alert-message-row.is-info {
+  border-color: rgba(147, 197, 253, 0.25);
+  background: rgba(147, 197, 253, 0.08);
+}
+
+.basic-alert-message-row.is-info span {
+  color: var(--info);
+  background: rgba(147, 197, 253, 0.16);
+}
+
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Alert Message Row demo inside `submissions/examples/basic-alert-message-row-kk/`. This submission introduces a compact CSS-only alert row pattern for form notices, dashboard alerts, warning rows, success messages, account reminders, and inline feedback sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only alert message row for showing a short feedback message with a small icon marker and optional supporting text.

**How does a developer use it?**

```html
<div class="basic-alert-message-row is-warning">
  <span aria-hidden="true">!</span>
  <div>
    <strong>Review required</strong>
    <p>Please check the details before continuing.</p>
  </div>
</div>