### PR TITLE
feat: add ease-range-slider-ij demo component

### DIFF
--- a/submissions/examples/ease-range-slider-ij/README.md
+++ b/submissions/examples/ease-range-slider-ij/README.md
@@ -1,0 +1,30 @@
+# Range Slider
+
+A custom-styled brightness slider whose fill track, glowing orb, and preview panel all respond live to the thumb position.
+
+## How is it used?
+
+Reset the native range's chrome and style the fill from a custom property:
+
+```html
+<input type="range" id="brightness" class="range" min="0" max="100" value="70">
+```
+
+```css
+.range {
+  -webkit-appearance: none;
+  appearance: none;
+  background: linear-gradient(90deg, #8b5cf6 var(--fill, 70%), #334155 var(--fill, 70%));
+}
+.range::-webkit-slider-thumb { /* custom thumb */ }
+```
+
+```js
+slider.style.setProperty('--fill', pct + '%');
+```
+
+The `input` event sets `--fill` for the track and, in the demo, recomputes the orb's HSL gradient, glow, and panel tint.
+
+## Why is it useful?
+
+Native range inputs are notoriously plain, and a styled slider instantly lifts a settings panel. This component shows the cross-browser recipe — `appearance: none`, `::-webkit-slider-thumb` and `::-moz-range-thumb` — plus a live data binding that demonstrates how animation and state can feed off the same property, keeping the example both simple and expressive.

--- a/submissions/examples/ease-range-slider-ij/demo.html
+++ b/submissions/examples/ease-range-slider-ij/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Range Slider - EaseMotion Submission</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stage">
+    <h1 class="page-title">Adjust brightness</h1>
+
+    <div class="slider-row">
+      <input type="range" id="brightness" class="range" min="0" max="100" value="70"
+             aria-label="Brightness">
+      <output class="value" id="value" for="brightness">70</output>
+    </div>
+
+    <div class="preview" id="preview">
+      <div class="preview-panel" id="previewPanel">
+        <h2>Preview</h2>
+        <p>The glowing orb below tracks your slider.</p>
+      </div>
+      <div class="orb-wrap">
+        <div class="orb" id="orb"></div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const slider = document.getElementById('brightness');
+    const value = document.getElementById('value');
+    const orb = document.getElementById('orb');
+    const panel = document.getElementById('previewPanel');
+
+    function paint() {
+      const v = Number(slider.value);
+      value.textContent = v;
+
+      const hue = 200 - v * 1.4;
+      const light = 18 + v * 0.62;
+      orb.style.background = 'radial-gradient(circle at 35% 30%, hsl(' + hue + ' 90% 70%), hsl(' + hue + ' 85% ' + light + '%))';
+      orb.style.boxShadow = '0 0 ' + (20 + v) + 'px hsl(' + hue + ' 90% 55%)';
+      panel.style.background = 'linear-gradient(160deg, hsl(' + hue + ' 40% ' + (30 - v * 0.1) + '%), #0f172a)';
+
+      const pct = ((v - slider.min) / (slider.max - slider.min)) * 100;
+      slider.style.setProperty('--fill', pct + '%');
+    }
+
+    slider.addEventListener('input', paint);
+    paint();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-range-slider-ij/style.css
+++ b/submissions/examples/ease-range-slider-ij/style.css
@@ -1,0 +1,150 @@
+/* Range Slider - EaseMotion CSS submission */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+  padding: 24px;
+}
+
+.stage {
+  width: 100%;
+  max-width: 560px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 20px;
+  padding: 34px 30px;
+  animation: rise 0.5s ease both;
+}
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(22px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.page-title {
+  margin: 0 0 30px;
+  color: #e2e8f0;
+  font-size: 1.3rem;
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.range {
+  -webkit-appearance: none;
+  appearance: none;
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  outline: none;
+  background: linear-gradient(90deg, #8b5cf6 var(--fill, 70%), #334155 var(--fill, 70%));
+  transition: background 0.08s linear;
+}
+
+.range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #8b5cf6;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.5);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.range::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 6px 18px rgba(139, 92, 246, 0.7);
+}
+
+.range::-webkit-slider-thumb:active {
+  transform: scale(0.92);
+}
+
+.range::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #8b5cf6;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.5);
+}
+
+.range::-moz-range-track {
+  height: 8px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.range:focus-visible {
+  box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.25);
+}
+
+.value {
+  min-width: 52px;
+  text-align: center;
+  font-family: inherit;
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.12);
+  border-radius: 10px;
+  padding: 8px 6px;
+}
+
+.preview {
+  margin-top: 30px;
+  display: grid;
+  grid-template-columns: 1fr 180px;
+  gap: 18px;
+  align-items: center;
+}
+
+.preview-panel {
+  background: linear-gradient(160deg, #1e40af, #0f172a);
+  border-radius: 14px;
+  padding: 22px;
+  transition: background 0.25s ease;
+}
+
+.preview-panel h2 {
+  margin: 0 0 8px;
+  color: #f8fafc;
+  font-size: 1.02rem;
+}
+
+.preview-panel p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.orb-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.orb {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, hsl(205 90% 70%), hsl(205 85% 61%));
+  box-shadow: 0 0 90px hsl(205 90% 55%);
+  transition: background 0.12s linear, box-shadow 0.12s linear;
+}


### PR DESCRIPTION
Adds a working `ease-range-slider-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-range-slider-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.

Closes #75687