### PR TITLE
feat: add ease-skeleton-content-card-ij demo component

### DIFF
--- a/submissions/examples/ease-skeleton-content-card-ij/README.md
+++ b/submissions/examples/ease-skeleton-content-card-ij/README.md
@@ -1,0 +1,30 @@
+# Skeleton Content Card
+
+A profile card that shows shimmering placeholder blocks while content loads, then fades them out when marked `.loaded`.
+
+## How is it used?
+
+Give every loading block the `.skel` class; toggling `.loaded` on the card fades the blocks away:
+
+```html
+<div class="card" id="card">
+  <div class="skel banner"></div>
+  <div class="skel line short"></div>
+  <div class="skel line"></div>
+</div>
+```
+
+```css
+.skel::after {
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+.card.loaded .skel {
+  animation: fadeOut 0.4s ease forwards;
+}
+```
+
+The `.skel::after` pseudo-element carries a skewed white gradient that sweeps across via `translateX`.
+
+## Why is it useful?
+
+Skeleton screens are the standard way to signal loading without a spinner. This component isolates the shimmer in a single reusable `.skel` class backed by one `::after` pseudo-element, so any block in a card becomes a loading placeholder — plus a smooth fade-out transition into real content. A compact, realistic EaseMotion example.

--- a/submissions/examples/ease-skeleton-content-card-ij/demo.html
+++ b/submissions/examples/ease-skeleton-content-card-ij/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skeleton Card - EaseMotion Submission</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="stage">
+    <h1 class="page-title">Profile preview</h1>
+
+    <div class="card" id="card">
+      <div class="skel banner"></div>
+      <div class="card-body">
+        <div class="skel avatar"></div>
+        <div class="skel line short"></div>
+        <div class="skel line"></div>
+        <div class="skel line"></div>
+        <div class="skel line half"></div>
+        <div class="card-actions">
+          <button class="follow-btn" id="followBtn">Follow</button>
+          <button class="msg-btn" id="msgBtn">Message</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="hint">The shimmer sweeps across the placeholders while content is still loading.</p>
+  </main>
+
+  <script>
+    const card = document.getElementById('card');
+    const followBtn = document.getElementById('followBtn');
+
+    followBtn.addEventListener('click', () => {
+      card.classList.toggle('loaded');
+      followBtn.textContent = card.classList.contains('loaded') ? 'Following' : 'Follow';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-skeleton-content-card-ij/style.css
+++ b/submissions/examples/ease-skeleton-content-card-ij/style.css
@@ -1,0 +1,149 @@
+/* Skeleton Card - EaseMotion CSS submission */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: linear-gradient(160deg, #f1f5f9, #e2e8f0);
+  padding: 24px;
+}
+
+.stage {
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+}
+
+.page-title {
+  color: #334155;
+  font-size: 1.25rem;
+  margin: 0 0 22px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 22px 50px rgba(15, 23, 42, 0.1);
+}
+
+.skel {
+  position: relative;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(105deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.65) 48%,
+    transparent 66%);
+  transform: translateX(-100%);
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  100% { transform: translateX(100%); }
+}
+
+.banner {
+  height: 130px;
+}
+
+.card-body {
+  position: relative;
+  padding: 54px 24px 24px;
+}
+
+.avatar {
+  position: absolute;
+  top: -38px;
+  left: 24px;
+  width: 78px;
+  height: 78px;
+  border-radius: 50%;
+  border: 4px solid #fff;
+}
+
+.line {
+  height: 14px;
+  border-radius: 999px;
+  margin-bottom: 12px;
+}
+
+.line.short {
+  width: 38%;
+  height: 18px;
+  margin-bottom: 18px;
+}
+
+.line.half {
+  width: 56%;
+}
+
+.card-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.follow-btn,
+.msg-btn {
+  flex: 1;
+  cursor: pointer;
+  border: 0;
+  font-family: inherit;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 11px 0;
+  border-radius: 10px;
+  transition: opacity 0.25s ease, background 0.25s ease, transform 0.15s ease;
+}
+
+.follow-btn {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+}
+
+.msg-btn {
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.follow-btn:hover,
+.msg-btn:hover {
+  filter: brightness(1.05);
+}
+
+.follow-btn:active,
+.msg-btn:active {
+  transform: scale(0.96);
+}
+
+.card.loaded .skel {
+  background: #f8fafc;
+  animation: fadeOut 0.4s ease forwards;
+}
+
+.card.loaded .skel::after {
+  display: none;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
+}
+
+.hint {
+  margin-top: 20px;
+  color: #64748b;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Adds a working `ease-skeleton-content-card-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-skeleton-content-card-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.