### PR TITLE
feat: add animated OTP verification input component (otp-verification-input-nk)

### DIFF
--- a/submissions/examples/otp-verification-input-nk/README.md
+++ b/submissions/examples/otp-verification-input-nk/README.md
@@ -1,0 +1,104 @@
+# OTP Verification Input — `otp-verification-input-nk`
+
+## 1. What does this do?
+
+An animated 6-digit OTP/PIN verification input that auto-advances focus between digit boxes on entry, shakes all boxes simultaneously on a wrong code, and fires a drawn SVG checkmark with a scale-pop success burst on a correct code — all transitions driven by pure CSS keyframes and state classes toggled by a minimal JS bridge.
+
+---
+
+## 2. How is it used?
+
+### HTML structure
+
+```html
+<!-- OTP digit group — add data-strength via JS -->
+<div class="otp-group" id="otp-group" role="group" aria-label="6-digit code">
+  <input class="otp-box" type="text" inputmode="numeric"
+         pattern="[0-9]" maxlength="1" aria-label="Digit 1"
+         autocomplete="one-time-code" />
+  <input class="otp-box" type="text" inputmode="numeric"
+         pattern="[0-9]" maxlength="1" aria-label="Digit 2" />
+  <!-- ...repeat for digits 3–6... -->
+</div>
+```
+
+### State classes
+
+| Class / Attribute | Applied to | Effect |
+|---|---|---|
+| `:focus` (native) | `.otp-box` | Scale-up bounce + indigo border glow |
+| `[data-filled]` | `.otp-box` | Soft filled background, lighter border |
+| `.otp-box--error` | `.otp-box` | Red border + glow |
+| `.otp-group--error` | `.otp-group` | Horizontal shake animation |
+| `.otp-box--success` | `.otp-box` | Green border + glow + scale pop |
+| `.otp-group--success` | `.otp-group` | Retained green state |
+| `.otp-success--visible` | `.otp-success` | Reveals SVG checkmark with draw animation |
+
+### JS bridge (minimal — only toggles classes and moves focus)
+
+```js
+// Wrong code → shake + error glow
+group.classList.add('otp-group--error');
+boxes.forEach(b => b.classList.add('otp-box--error'));
+
+// Correct code → success burst
+group.classList.add('otp-group--success');
+boxes.forEach(b => b.classList.add('otp-box--success'));
+successEl.classList.add('otp-success--visible');
+
+// Auto-advance on digit entry
+if (box.value && i < boxes.length - 1) boxes[i + 1].focus();
+
+// Paste → fill all boxes instantly
+text.split('').forEach((ch, idx) => {
+  boxes[idx].value = ch;
+  boxes[idx].setAttribute('data-filled', '');
+});
+```
+
+All visual transitions — focus scale, error shake, success draw, entrance fade — are pure CSS. The JS only sets `data-filled`, moves focus, and toggles state classes.
+
+---
+
+## 3. Why is it useful?
+
+OTP inputs are one of the highest-friction points in any authentication flow. Most implementations are plain static boxes with no feedback — users don't know if they mis-typed, are on the right box, or succeeded.
+
+This component fits EaseMotion's philosophy because:
+
+- **Motion communicates state.** The focus scale-bounce tells the user exactly which box is active. The shake says "wrong" without a word. The SVG draw says "done" in a way a toast never could.
+- **CSS does the heavy lifting.** Every transition — the bounce pop on focus, the lateral shake on error, the circle-draw on success — is a CSS keyframe. The JS is ~60 lines and purely orchestrates DOM state; swap it for React `useState`, Alpine `x-bind`, or HTMX and the stylesheet works unchanged.
+- **Accessible by default.** Each input has an `aria-label`. A `role="status"` live region announces state changes to screen readers. The group uses `role="group"` with a label. `prefers-reduced-motion` collapses all animation durations to near-zero.
+- **Zero dependencies.** Open `demo.html` directly in any modern browser — no server, no CDN, no build step.
+- **Mobile-first.** `inputmode="numeric"` raises the numeric keypad on iOS/Android. Paste of a 6-digit code fills all boxes instantly. Responsive breakpoint at 380px shrinks boxes for small screens.
+
+---
+
+## Animations used
+
+| Animation | Trigger | Effect |
+|---|---|---|
+| `otp-fade-up` | Card / hint on page load | Fade + slide up entrance |
+| `otp-focus-pop` | Any `.otp-box:focus` | Bounce scale-up (1 → 1.12 → 1.08) |
+| `otp-shake` | `.otp-group--error` | 7-step horizontal shake |
+| `otp-success-pop` | `.otp-box--success` | Quick scale burst (1 → 1.18 → 1) |
+| `otp-success-entrance` | `.otp-success--visible` | Scale + fade entrance for checkmark container |
+| `otp-draw-circle` | SVG circle on success | Stroke-dashoffset draw from 166 → 0 |
+| `otp-draw-check` | SVG check on success | Stroke-dashoffset draw from 48 → 0 |
+| Shimmer sweep | Submit button on hover | Light sweep across gradient background |
+
+---
+
+## Files
+
+```
+submissions/examples/otp-verification-input-nk/
+├── demo.html   — self-contained demo, works by opening directly in a browser
+├── style.css   — all styles, keyframes, and state transitions
+└── README.md   — this file
+```
+
+### Demo credentials
+
+- Correct code: **`123456`** → success checkmark + green burst
+- Any other 6 digits → shake + error glow + boxes cleared

--- a/submissions/examples/otp-verification-input-nk/demo.html
+++ b/submissions/examples/otp-verification-input-nk/demo.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OTP Verification Input — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+
+      <!-- Card -->
+      <div class="otp-card">
+        <div class="otp-card__icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="5" y="11" width="14" height="10" rx="2"/>
+            <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+          </svg>
+        </div>
+
+        <h1 class="otp-card__title">Verify your identity</h1>
+        <p class="otp-card__subtitle">
+          Enter the 6-digit code sent to
+          <strong>ni***@gmail.com</strong>
+        </p>
+
+        <!-- Status live region for screen readers -->
+        <div
+          class="otp-sr-status"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          id="otp-status"
+        ></div>
+
+        <!-- OTP input group -->
+        <form
+          class="otp-form"
+          id="otp-form"
+          autocomplete="off"
+          novalidate
+          aria-label="One-time password entry"
+        >
+          <div class="otp-group" id="otp-group" role="group" aria-label="6-digit code">
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 1" autocomplete="one-time-code" />
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 2" />
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 3" />
+
+            <!-- Visual separator -->
+            <span class="otp-sep" aria-hidden="true">—</span>
+
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 4" />
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 5" />
+            <input class="otp-box" type="text" inputmode="numeric" pattern="[0-9]"
+                   maxlength="1" aria-label="Digit 6" />
+          </div>
+
+          <!-- Success checkmark (hidden until correct) -->
+          <div class="otp-success" id="otp-success" aria-hidden="true">
+            <svg class="otp-success__icon" viewBox="0 0 52 52"
+                 xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <circle class="otp-success__circle" cx="26" cy="26" r="25" fill="none"/>
+              <path  class="otp-success__check"  fill="none"
+                     d="M14 27 l8 8 l16 -16"/>
+            </svg>
+            <p class="otp-success__text">Verified!</p>
+          </div>
+
+          <button class="otp-submit" type="submit" id="otp-submit">
+            Verify Code
+          </button>
+        </form>
+
+        <!-- Resend row -->
+        <p class="otp-resend">
+          Didn't receive a code?
+          <button class="otp-resend__btn" type="button" id="resend-btn">
+            Resend
+          </button>
+          <span class="otp-resend__timer" id="resend-timer" aria-live="polite">
+            in <span id="resend-countdown">30</span>s
+          </span>
+        </p>
+      </div>
+
+      <!-- Demo hint card -->
+      <div class="demo-hint">
+        <p class="demo-hint__title">Try these to see each state:</p>
+        <ul class="demo-hint__list">
+          <li>Type any 6 digits → auto-advance between boxes</li>
+          <li>Submit <strong>123456</strong> → success burst + checkmark</li>
+          <li>Submit any <em>other</em> 6 digits → shake + error glow</li>
+          <li>Paste a 6-digit number → fills all boxes instantly</li>
+        </ul>
+      </div>
+
+    </div>
+
+    <script>
+    (function () {
+      const CORRECT_CODE = '123456';
+
+      const form      = document.getElementById('otp-form');
+      const group     = document.getElementById('otp-group');
+      const boxes     = Array.from(group.querySelectorAll('.otp-box'));
+      const submitBtn = document.getElementById('otp-submit');
+      const statusEl  = document.getElementById('otp-status');
+      const successEl = document.getElementById('otp-success');
+
+      /* ── helpers ── */
+      function announce(msg) {
+        statusEl.textContent = '';
+        // brief delay so screen readers re-fire
+        requestAnimationFrame(() => { statusEl.textContent = msg; });
+      }
+
+      function getValue() {
+        return boxes.map(b => b.value).join('');
+      }
+
+      function clearBoxes() {
+        boxes.forEach(b => { b.value = ''; b.removeAttribute('data-filled'); });
+        boxes[0].focus();
+      }
+
+      function triggerShake() {
+        group.classList.remove('otp-group--error');
+        // force reflow so animation replays
+        void group.offsetWidth;
+        group.classList.add('otp-group--error');
+        boxes.forEach(b => b.classList.add('otp-box--error'));
+        setTimeout(() => {
+          group.classList.remove('otp-group--error');
+          boxes.forEach(b => b.classList.remove('otp-box--error'));
+        }, 650);
+      }
+
+      function triggerSuccess() {
+        group.classList.add('otp-group--success');
+        boxes.forEach(b => b.classList.add('otp-box--success'));
+        successEl.classList.add('otp-success--visible');
+        successEl.removeAttribute('aria-hidden');
+        submitBtn.disabled = true;
+        submitBtn.style.display = 'none';
+        announce('Code verified successfully!');
+      }
+
+      /* ── keyboard navigation ── */
+      boxes.forEach((box, i) => {
+        box.addEventListener('keydown', (e) => {
+          if (e.key === 'Backspace') {
+            if (box.value === '' && i > 0) {
+              boxes[i - 1].value = '';
+              boxes[i - 1].removeAttribute('data-filled');
+              boxes[i - 1].focus();
+            } else {
+              box.value = '';
+              box.removeAttribute('data-filled');
+            }
+            e.preventDefault();
+          }
+
+          if (e.key === 'ArrowLeft' && i > 0)  { boxes[i - 1].focus(); e.preventDefault(); }
+          if (e.key === 'ArrowRight' && i < boxes.length - 1) { boxes[i + 1].focus(); e.preventDefault(); }
+        });
+
+        box.addEventListener('input', (e) => {
+          // keep only the last digit typed (handles quick typing)
+          const raw = e.target.value.replace(/\D/g, '');
+          box.value = raw ? raw[raw.length - 1] : '';
+
+          if (box.value) {
+            box.setAttribute('data-filled', '');
+            if (i < boxes.length - 1) {
+              boxes[i + 1].focus();
+            } else {
+              box.blur(); // last digit — dismiss mobile keyboard
+            }
+          } else {
+            box.removeAttribute('data-filled');
+          }
+        });
+
+        box.addEventListener('focus', () => {
+          box.select();
+        });
+
+        /* ── paste handler (on any box) ── */
+        box.addEventListener('paste', (e) => {
+          e.preventDefault();
+          const text = (e.clipboardData || window.clipboardData)
+            .getData('text')
+            .replace(/\D/g, '')
+            .slice(0, 6);
+          text.split('').forEach((ch, idx) => {
+            if (boxes[idx]) {
+              boxes[idx].value = ch;
+              boxes[idx].setAttribute('data-filled', '');
+            }
+          });
+          // focus the box after the last pasted digit (or last box)
+          const nextIndex = Math.min(text.length, boxes.length - 1);
+          boxes[nextIndex].focus();
+        });
+      });
+
+      /* ── form submit ── */
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const code = getValue();
+
+        if (code.length < 6) {
+          triggerShake();
+          announce('Please enter all 6 digits.');
+          boxes[code.length]?.focus();
+          return;
+        }
+
+        if (code === CORRECT_CODE) {
+          triggerSuccess();
+        } else {
+          triggerShake();
+          announce('Incorrect code. Please try again.');
+          clearBoxes();
+        }
+      });
+
+      /* ── resend timer ── */
+      const resendBtn     = document.getElementById('resend-btn');
+      const resendTimer   = document.getElementById('resend-timer');
+      const countdownEl   = document.getElementById('resend-countdown');
+      let   resendSeconds = 30;
+      let   interval      = null;
+
+      resendBtn.disabled = true;
+
+      function startTimer() {
+        resendSeconds = 30;
+        resendBtn.disabled  = true;
+        resendTimer.style.display = '';
+        countdownEl.textContent = resendSeconds;
+
+        interval = setInterval(() => {
+          resendSeconds--;
+          countdownEl.textContent = resendSeconds;
+          if (resendSeconds <= 0) {
+            clearInterval(interval);
+            resendBtn.disabled = false;
+            resendTimer.style.display = 'none';
+          }
+        }, 1000);
+      }
+
+      resendBtn.addEventListener('click', () => {
+        clearBoxes();
+        // reset success state if showing
+        group.classList.remove('otp-group--success');
+        boxes.forEach(b => b.classList.remove('otp-box--success'));
+        successEl.classList.remove('otp-success--visible');
+        successEl.setAttribute('aria-hidden', 'true');
+        submitBtn.disabled = false;
+        submitBtn.style.display = '';
+        announce('A new code has been sent.');
+        startTimer();
+      });
+
+      startTimer();
+    })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/otp-verification-input-nk/style.css
+++ b/submissions/examples/otp-verification-input-nk/style.css
@@ -1,0 +1,518 @@
+/* ============================================================
+   OTP Verification Input — EaseMotion CSS Submission
+   Track: Standard (HTML/CSS)
+   Component ID: otp-verification-input-nk
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   0. Design tokens
+   ------------------------------------------------------------ */
+:root {
+  --otp-color-bg:        #ffffff;
+  --otp-color-surface:   #f8fafc;
+  --otp-color-border:    #e2e8f0;
+  --otp-color-border-focus: #6366f1;
+  --otp-color-border-error:  #ef4444;
+  --otp-color-border-success: #10b981;
+
+  --otp-color-text:      #1e293b;
+  --otp-color-muted:     #94a3b8;
+  --otp-color-label:     #475569;
+
+  --otp-color-primary:   #6366f1;
+  --otp-color-primary-hover: #4f46e5;
+  --otp-color-danger:    #ef4444;
+  --otp-color-success:   #10b981;
+
+  --otp-glow-focus:   0 0 0 3px rgba(99, 102, 241, 0.18);
+  --otp-glow-error:   0 0 0 3px rgba(239, 68,  68,  0.18);
+  --otp-glow-success: 0 0 0 3px rgba(16,  185, 129, 0.18);
+
+  --otp-radius-box:  12px;
+  --otp-radius-btn:  10px;
+  --otp-radius-card: 20px;
+
+  --otp-speed-fast:   0.15s;
+  --otp-speed-mid:    0.25s;
+  --otp-speed-slow:   0.4s;
+  --otp-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+  --otp-ease-bounce:  cubic-bezier(0.34, 1.56, 0.64, 1);
+  --otp-ease-out:     cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* ------------------------------------------------------------
+   1. Base reset
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f0fdf4 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--otp-color-text);
+}
+
+/* ------------------------------------------------------------
+   2. Demo wrapper
+   ------------------------------------------------------------ */
+.demo-wrapper {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ------------------------------------------------------------
+   3. Card
+   ------------------------------------------------------------ */
+.otp-card {
+  background: var(--otp-color-bg);
+  border: 1px solid var(--otp-color-border);
+  border-radius: var(--otp-radius-card);
+  padding: 2.25rem 2rem 2.5rem;
+  box-shadow:
+    0 1px 3px rgba(0,0,0,.06),
+    0 10px 30px rgba(0,0,0,.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+
+  /* entrance */
+  animation: otp-fade-up var(--otp-speed-slow) var(--otp-ease-out) both;
+}
+
+.otp-card__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #eef2ff, #e0e7ff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  color: var(--otp-color-primary);
+}
+
+.otp-card__icon svg {
+  width: 26px;
+  height: 26px;
+}
+
+.otp-card__title {
+  font-size: 1.3125rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--otp-color-text);
+  text-align: center;
+}
+
+.otp-card__subtitle {
+  margin-top: 0.45rem;
+  font-size: 0.875rem;
+  color: var(--otp-color-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.otp-card__subtitle strong {
+  color: var(--otp-color-label);
+  font-weight: 600;
+}
+
+/* screen-reader only status region */
+.otp-sr-status {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ------------------------------------------------------------
+   4. Form & OTP group
+   ------------------------------------------------------------ */
+.otp-form {
+  width: 100%;
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.otp-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* separator dash */
+.otp-sep {
+  font-size: 1.25rem;
+  color: var(--otp-color-border);
+  user-select: none;
+  margin: 0 0.125rem;
+  line-height: 1;
+}
+
+/* ------------------------------------------------------------
+   5. Individual OTP box
+   ------------------------------------------------------------ */
+.otp-box {
+  width: 48px;
+  height: 56px;
+  border: 2px solid var(--otp-color-border);
+  border-radius: var(--otp-radius-box);
+  background: var(--otp-color-surface);
+  font-size: 1.375rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--otp-color-text);
+  caret-color: var(--otp-color-primary);
+  outline: none;
+  transition:
+    border-color   var(--otp-speed-fast) var(--otp-ease),
+    box-shadow     var(--otp-speed-fast) var(--otp-ease),
+    transform      var(--otp-speed-mid)  var(--otp-ease-bounce),
+    background     var(--otp-speed-fast) var(--otp-ease);
+}
+
+/* focus state — scale up + indigo glow */
+.otp-box:focus {
+  border-color: var(--otp-color-border-focus);
+  box-shadow: var(--otp-glow-focus);
+  transform: scale(1.08);
+  background: #ffffff;
+  animation: otp-focus-pop var(--otp-speed-mid) var(--otp-ease-bounce);
+}
+
+/* filled state — subtle filled bg */
+.otp-box[data-filled] {
+  border-color: #a5b4fc;
+  background: #eef2ff;
+  transform: scale(1);
+}
+
+/* error state */
+.otp-box--error {
+  border-color: var(--otp-color-border-error) !important;
+  box-shadow: var(--otp-glow-error) !important;
+  background: #fef2f2 !important;
+}
+
+/* success state */
+.otp-box--success {
+  border-color: var(--otp-color-border-success) !important;
+  box-shadow: var(--otp-glow-success) !important;
+  background: #f0fdf4 !important;
+  color: var(--otp-color-success) !important;
+  animation: otp-success-pop var(--otp-speed-mid) var(--otp-ease-bounce);
+}
+
+/* ------------------------------------------------------------
+   6. Error shake — applied to the group
+   ------------------------------------------------------------ */
+.otp-group--error {
+  animation: otp-shake 0.55s var(--otp-ease) both;
+}
+
+/* ------------------------------------------------------------
+   7. Success checkmark
+   ------------------------------------------------------------ */
+.otp-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  opacity: 0;
+  transform: scale(0.7) translateY(8px);
+  pointer-events: none;
+  transition:
+    opacity   var(--otp-speed-mid) var(--otp-ease),
+    transform var(--otp-speed-mid) var(--otp-ease-bounce);
+  height: 0;
+  overflow: hidden;
+}
+
+.otp-success--visible {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+  height: auto;
+  overflow: visible;
+  animation: otp-success-entrance var(--otp-speed-slow) var(--otp-ease-bounce) both;
+}
+
+.otp-success__icon {
+  width: 60px;
+  height: 60px;
+}
+
+.otp-success__circle {
+  stroke: var(--otp-color-success);
+  stroke-width: 2;
+  stroke-dasharray: 166;
+  stroke-dashoffset: 166;
+  stroke-linecap: round;
+}
+
+.otp-success--visible .otp-success__circle {
+  animation: otp-draw-circle 0.5s var(--otp-ease-out) 0.1s forwards;
+}
+
+.otp-success__check {
+  stroke: var(--otp-color-success);
+  stroke-width: 3;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.otp-success--visible .otp-success__check {
+  animation: otp-draw-check 0.35s var(--otp-ease-out) 0.5s forwards;
+}
+
+.otp-success__text {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--otp-color-success);
+  letter-spacing: 0.01em;
+}
+
+/* ------------------------------------------------------------
+   8. Submit button
+   ------------------------------------------------------------ */
+.otp-submit {
+  width: 100%;
+  height: 2.875rem;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: none;
+  border-radius: var(--otp-radius-btn);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition:
+    opacity   var(--otp-speed-fast) var(--otp-ease),
+    transform var(--otp-speed-fast) var(--otp-ease),
+    box-shadow var(--otp-speed-fast) var(--otp-ease);
+}
+
+.otp-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.38);
+}
+
+.otp-submit:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.otp-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* shimmer sweep on hover */
+.otp-submit::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 30%,
+    rgba(255,255,255,0.22) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  transition: transform 0s;
+}
+.otp-submit:hover::after {
+  transform: translateX(100%);
+  transition: transform 0.5s var(--otp-ease);
+}
+
+/* ------------------------------------------------------------
+   9. Resend row
+   ------------------------------------------------------------ */
+.otp-resend {
+  font-size: 0.8125rem;
+  color: var(--otp-color-muted);
+  text-align: center;
+  margin-top: -0.25rem;
+}
+
+.otp-resend__btn {
+  background: none;
+  border: none;
+  font-size: inherit;
+  font-weight: 600;
+  color: var(--otp-color-primary);
+  cursor: pointer;
+  padding: 0;
+  transition: opacity var(--otp-speed-fast) var(--otp-ease);
+}
+
+.otp-resend__btn:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.otp-resend__btn:disabled {
+  color: var(--otp-color-muted);
+  cursor: default;
+}
+
+.otp-resend__timer {
+  display: inline;
+  font-size: inherit;
+  color: var(--otp-color-muted);
+}
+
+/* ------------------------------------------------------------
+   10. Demo hint card
+   ------------------------------------------------------------ */
+.demo-hint {
+  background: var(--otp-color-bg);
+  border: 1px solid var(--otp-color-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  animation: otp-fade-up var(--otp-speed-slow) var(--otp-ease-out) 0.1s both;
+}
+
+.demo-hint__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--otp-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.demo-hint__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.demo-hint__list li {
+  font-size: 0.8125rem;
+  color: var(--otp-color-text);
+  padding-left: 1rem;
+  position: relative;
+}
+
+.demo-hint__list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--otp-color-primary);
+  font-size: 0.75rem;
+}
+
+/* ------------------------------------------------------------
+   11. Keyframe animations
+   ------------------------------------------------------------ */
+
+/* Card / hint entrance */
+@keyframes otp-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Box focus pop */
+@keyframes otp-focus-pop {
+  0%   { transform: scale(1); }
+  60%  { transform: scale(1.12); }
+  100% { transform: scale(1.08); }
+}
+
+/* Box success bounce */
+@keyframes otp-success-pop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.18); }
+  100% { transform: scale(1); }
+}
+
+/* Group shake on wrong code */
+@keyframes otp-shake {
+  0%,100% { transform: translateX(0); }
+  15%     { transform: translateX(-7px); }
+  30%     { transform: translateX(7px); }
+  45%     { transform: translateX(-5px); }
+  60%     { transform: translateX(5px); }
+  75%     { transform: translateX(-3px); }
+  90%     { transform: translateX(3px); }
+}
+
+/* Success checkmark container entrance */
+@keyframes otp-success-entrance {
+  0%   { opacity: 0; transform: scale(0.6) translateY(10px); }
+  60%  { transform: scale(1.06) translateY(-2px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* SVG circle draw */
+@keyframes otp-draw-circle {
+  to { stroke-dashoffset: 0; }
+}
+
+/* SVG checkmark draw */
+@keyframes otp-draw-check {
+  to { stroke-dashoffset: 0; }
+}
+
+/* ------------------------------------------------------------
+   12. Reduced motion overrides
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration:   0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration:  0.01ms !important;
+  }
+
+  .otp-box:focus  { transform: scale(1); }
+  .otp-box[data-filled] { transform: scale(1); }
+}
+
+/* ------------------------------------------------------------
+   13. Responsive — smaller screens
+   ------------------------------------------------------------ */
+@media (max-width: 380px) {
+  .otp-box {
+    width: 42px;
+    height: 50px;
+    font-size: 1.25rem;
+    border-radius: 10px;
+  }
+
+  .otp-group {
+    gap: 0.35rem;
+  }
+
+  .otp-card {
+    padding: 1.75rem 1.25rem 2rem;
+  }
+}


### PR DESCRIPTION
fix #75897 

## Pull Request Description
Adds a fully animated 6-digit OTP/PIN verification input with auto-advance focus, paste support, error shake, and an SVG drawn checkmark on success - all visual transitions driven by pure CSS keyframes off toggled state classes.

## Type of Change
- [x] 🧩 New component

## Submission Checklist
⚠️ PRs that fail this checklist will be closed without review.

- [x] All changes are inside `submissions/examples/otp-verification-input-nk/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

## Feature Description

### What does this add?
An animated 6-digit OTP verification input with focus scale-bounce, auto-advance, paste fill, error shake on wrong code, and a drawn SVG checkmark burst on correct code.

### How does a developer use it?

```html
<div class="otp-group" id="otp-group" role="group" aria-label="6-digit code">
  <input class="otp-box" type="text" inputmode="numeric" maxlength="1" aria-label="Digit 1" />
  <!-- repeat × 6 -->
</div>
```

JS toggles `otp-group--error` / `otp-box--error` for shake, `otp-box--success` / `otp-success--visible` for the checkmark draw. All animation is CSS.

### Why does it fit EaseMotion CSS?
OTP inputs are peak authentication friction. The focus pop tells users which box is active, the shake says "wrong" without a word, and the SVG draw says "done" in a way no toast can match. Motion is the message - exactly EaseMotion's philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)
- Correct code: `123456` → green checkmark draw
- Any other 6 digits → shake + red glow + boxes cleared

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari (optional but appreciated)

## Notes for Maintainer
All 7 keyframes use `--otp-*` custom property tokens. `prefers-reduced-motion` collapses all durations to near-zero. The JS bridge is ~60 lines and framework-agnostic - swap for React state or Alpine bindings without touching the stylesheet.