### PR TITLE
feat: add CSS mobile phone frame

### DIFF
--- a/submissions/examples/css-mobile-phone-frame/README.md
+++ b/submissions/examples/css-mobile-phone-frame/README.md
@@ -1,0 +1,37 @@
+# CSS Mobile Phone Frame
+
+A responsive smartphone frame mockup built entirely with semantic
+HTML and vanilla CSS.
+
+The component is designed for showcasing mobile applications,
+UI screenshots, landing pages and responsive interface concepts
+without requiring JavaScript or external UI libraries.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- No external dependencies
+- Responsive smartphone dimensions
+- Realistic phone hardware frame
+- Dynamic Island-style camera area
+- Physical side buttons
+- Mobile screen UI
+- Status bar
+- Bottom navigation
+- Home indicator
+- Animated visual element
+- Hover interaction
+- Keyboard focus support
+- Dark mode support
+- Reduced-motion support
+- Hardware-friendly transforms
+- Responsive desktop/mobile layout
+
+## 📁 Structure
+
+```text
+css-mobile-phone-frame/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-mobile-phone-frame/demo.html
+++ b/submissions/examples/css-mobile-phone-frame/demo.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="Responsive CSS-only mobile phone frame mockup."
+  >
+
+  <title>CSS Mobile Phone Frame</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="phone-demo">
+
+    <section
+      class="phone"
+      aria-label="Mobile phone frame demonstration"
+      tabindex="0"
+    >
+
+      <!-- Physical phone frame -->
+      <div class="phone__hardware">
+
+        <!-- Dynamic Island / camera area -->
+        <div
+          class="phone__island"
+          aria-hidden="true"
+        >
+          <span class="phone__camera"></span>
+          <span class="phone__sensor"></span>
+        </div>
+
+        <!-- Side button -->
+        <span
+          class="phone__side-button phone__side-button--power"
+          aria-hidden="true"
+        ></span>
+
+        <!-- Volume buttons -->
+        <span
+          class="phone__side-button phone__side-button--volume-up"
+          aria-hidden="true"
+        ></span>
+
+        <span
+          class="phone__side-button phone__side-button--volume-down"
+          aria-hidden="true"
+        ></span>
+
+        <!-- Screen -->
+        <div class="phone__screen">
+
+          <div class="screen">
+
+            <header class="screen__status-bar">
+              <span>9:41</span>
+
+              <div
+                class="screen__status-icons"
+                aria-hidden="true"
+              >
+                <span class="status-icon status-icon--signal"></span>
+                <span class="status-icon status-icon--wifi"></span>
+                <span class="status-icon status-icon--battery"></span>
+              </div>
+            </header>
+
+            <section class="screen__content">
+
+              <div class="screen__badge">
+                CSS ONLY
+              </div>
+
+              <h1>
+                Build without
+                <span>JavaScript.</span>
+              </h1>
+
+              <p>
+                A responsive smartphone frame designed entirely
+                with semantic HTML and vanilla CSS.
+              </p>
+
+              <a
+                class="screen__button"
+                href="#features"
+              >
+                Explore
+                <span aria-hidden="true">→</span>
+              </a>
+
+              <div
+                class="screen__visual"
+                aria-hidden="true"
+              >
+                <span class="visual-ring visual-ring--one"></span>
+                <span class="visual-ring visual-ring--two"></span>
+                <span class="visual-core"></span>
+              </div>
+
+            </section>
+
+            <nav
+              class="screen__navigation"
+              aria-label="Phone preview navigation"
+            >
+              <a
+                class="screen__nav-item screen__nav-item--active"
+                href="#home"
+                aria-label="Home"
+              >
+                <span></span>
+              </a>
+
+              <a
+                class="screen__nav-item"
+                href="#search"
+                aria-label="Search"
+              >
+                <span></span>
+              </a>
+
+              <a
+                class="screen__nav-item"
+                href="#profile"
+                aria-label="Profile"
+              >
+                <span></span>
+              </a>
+            </nav>
+
+            <div
+              class="screen__home-indicator"
+              aria-hidden="true"
+            ></div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    </section>
+
+    <section
+      class="phone-demo__info"
+      id="features"
+    >
+      <p class="phone-demo__eyebrow">
+        PURE CSS COMPONENT
+      </p>
+
+      <h2>
+        Mobile Phone Frame
+      </h2>
+
+      <p>
+        Responsive smartphone mockup with a realistic hardware
+        frame, screen interface and accessible interactions.
+      </p>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-mobile-phone-frame/style.css
+++ b/submissions/examples/css-mobile-phone-frame/style.css
@@ -1,0 +1,1001 @@
+/* ==========================================================
+   CSS Mobile Phone Frame
+   Pure HTML + Vanilla CSS
+   ========================================================== */
+
+
+/* ----------------------------------------------------------
+   Design tokens
+   ---------------------------------------------------------- */
+
+   :root {
+    color-scheme: light dark;
+  
+    --page-background: #eef2f7;
+    --text-primary: #111827;
+    --text-secondary: #667085;
+  
+    --phone-body: #171a21;
+    --phone-edge: #303541;
+    --phone-frame-highlight: rgb(255 255 255 / 0.14);
+  
+    --screen-background: #0d1117;
+  
+    --accent: #7c3aed;
+    --accent-secondary: #2563eb;
+  
+    --white: #ffffff;
+  
+    --phone-width: min(82vw, 21rem);
+    --phone-height: calc(var(--phone-width) * 2.04);
+  
+    --phone-radius: calc(var(--phone-width) * 0.16);
+    --screen-radius: calc(var(--phone-width) * 0.13);
+  
+    --spring-ease: cubic-bezier(
+      0.34,
+      1.56,
+      0.64,
+      1
+    );
+  
+    --phone-shadow:
+      0 45px 90px rgb(15 23 42 / 0.22),
+      0 15px 35px rgb(15 23 42 / 0.12);
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Reset
+     ---------------------------------------------------------- */
+  
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  html {
+    min-height: 100%;
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    min-height: 100vh;
+    margin: 0;
+  
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--text-primary);
+    background: var(--page-background);
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Main layout
+     ---------------------------------------------------------- */
+  
+  .phone-demo {
+    min-height: 100vh;
+  
+    display: grid;
+    place-items: center;
+  
+    gap: clamp(2rem, 6vw, 4rem);
+  
+    padding:
+      clamp(2rem, 5vw, 5rem)
+      1.25rem;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Phone
+     ---------------------------------------------------------- */
+  
+  .phone {
+    position: relative;
+  
+    width: var(--phone-width);
+    height: var(--phone-height);
+  
+    outline: none;
+  
+    transform:
+      translate3d(0, 0, 0)
+      rotateX(0deg);
+  
+    transition:
+      transform 750ms var(--spring-ease),
+      filter 500ms ease;
+  }
+  
+  
+  /* Interactive lift */
+  
+  .phone:hover,
+  .phone:focus-visible {
+    transform:
+      translate3d(0, -0.65rem, 0)
+      rotateX(1deg);
+  }
+  
+  
+  /* Keyboard focus */
+  
+  .phone:focus-visible {
+    filter:
+      drop-shadow(
+        0 0 0.75rem
+        rgb(124 58 237 / 0.45)
+      );
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Hardware shell
+     ---------------------------------------------------------- */
+  
+  .phone__hardware {
+    position: relative;
+  
+    width: 100%;
+    height: 100%;
+  
+    padding: 3.2%;
+  
+    border:
+      1px solid
+      rgb(255 255 255 / 0.18);
+  
+    border-radius: var(--phone-radius);
+  
+    background:
+      linear-gradient(
+        145deg,
+        #343945 0%,
+        #171a21 22%,
+        #0d0f14 70%,
+        #252a34 100%
+      );
+  
+    box-shadow: var(--phone-shadow);
+  
+    isolation: isolate;
+  
+    overflow: hidden;
+  }
+  
+  
+  /* Metallic edge */
+  
+  .phone__hardware::before {
+    content: "";
+  
+    position: absolute;
+    inset: 0;
+  
+    border-radius: inherit;
+  
+    padding: 1px;
+  
+    background:
+      linear-gradient(
+        135deg,
+        rgb(255 255 255 / 0.3),
+        transparent 25%,
+        transparent 70%,
+        rgb(255 255 255 / 0.12)
+      );
+
+  
+    -webkit-mask-composite: xor;
+  
+    mask-composite: exclude;
+  
+    pointer-events: none;
+  }
+  
+  
+  /* Bottom reflection */
+  
+  .phone__hardware::after {
+    content: "";
+  
+    position: absolute;
+  
+    left: 10%;
+    right: 10%;
+    bottom: -20%;
+  
+    height: 40%;
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        ellipse,
+        rgb(124 58 237 / 0.16),
+        transparent 70%
+      );
+  
+    filter: blur(1.2rem);
+  
+    pointer-events: none;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Screen
+     ---------------------------------------------------------- */
+  
+  .phone__screen {
+    position: relative;
+  
+    width: 100%;
+    height: 100%;
+  
+    overflow: hidden;
+  
+    border-radius: var(--screen-radius);
+  
+    background: var(--screen-background);
+  
+    box-shadow:
+      inset 0 0 0 1px
+      rgb(255 255 255 / 0.08),
+      inset 0 0 35px
+      rgb(0 0 0 / 0.5);
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Screen content
+     ---------------------------------------------------------- */
+  
+  .screen {
+    position: relative;
+  
+    width: 100%;
+    height: 100%;
+  
+    overflow: hidden;
+  
+    background:
+      radial-gradient(
+        circle at 80% 15%,
+        rgb(124 58 237 / 0.28),
+        transparent 32%
+      ),
+      radial-gradient(
+        circle at 15% 70%,
+        rgb(37 99 235 / 0.2),
+        transparent 35%
+      ),
+      linear-gradient(
+        150deg,
+        #111827,
+        #080b11 70%
+      );
+  
+    color: var(--white);
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Status bar
+     ---------------------------------------------------------- */
+  
+  .screen__status-bar {
+    position: relative;
+    z-index: 5;
+  
+    height: 9%;
+  
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  
+    padding:
+      0 8%;
+  
+    font-size: clamp(0.55rem, 2vw, 0.7rem);
+    font-weight: 700;
+  }
+  
+  
+  .screen__status-icons {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  
+  
+  /* Signal */
+  
+  .status-icon--signal {
+    width: 0.65rem;
+    height: 0.55rem;
+  
+    background:
+      linear-gradient(
+        to top,
+        currentColor 20%,
+        transparent 20%
+      );
+  
+    clip-path: polygon(
+      0 100%,
+      0 70%,
+      20% 70%,
+      20% 50%,
+      40% 50%,
+      40% 30%,
+      60% 30%,
+      60% 10%,
+      80% 10%,
+      80% 0,
+      100% 0,
+      100% 100%
+    );
+  }
+  
+  
+  /* Wi-Fi */
+  
+  .status-icon--wifi {
+    width: 0.8rem;
+    height: 0.55rem;
+  
+    border:
+      2px solid currentColor;
+  
+    border-top-color: transparent;
+    border-left-color: transparent;
+  
+    border-radius: 50%;
+  
+    transform:
+      rotate(45deg)
+      scale(0.7);
+  }
+  
+  
+  /* Battery */
+  
+  .status-icon--battery {
+    position: relative;
+  
+    width: 1rem;
+    height: 0.45rem;
+  
+    border:
+      1px solid currentColor;
+  
+    border-radius: 0.12rem;
+  }
+  
+  .status-icon--battery::before {
+    content: "";
+  
+    position: absolute;
+    inset: 0.08rem;
+  
+    width: 70%;
+  
+    border-radius: 0.06rem;
+  
+    background: currentColor;
+  }
+  
+  .status-icon--battery::after {
+    content: "";
+  
+    position: absolute;
+  
+    top: 50%;
+    right: -0.2rem;
+  
+    width: 0.12rem;
+    height: 0.2rem;
+  
+    transform: translateY(-50%);
+  
+    border-radius: 0 0.1rem 0.1rem 0;
+  
+    background: currentColor;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Dynamic Island
+     ---------------------------------------------------------- */
+  
+  .phone__island {
+    position: absolute;
+    z-index: 20;
+  
+    top: 4%;
+  
+    left: 50%;
+  
+    width: 30%;
+    height: 4.5%;
+  
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  
+    gap: 0.35rem;
+  
+    padding: 0 5%;
+  
+    transform: translateX(-50%);
+  
+    border-radius: 999px;
+  
+    background:
+      linear-gradient(
+        180deg,
+        #050609,
+        #15171c
+      );
+  
+    box-shadow:
+      inset 0 1px 1px
+      rgb(255 255 255 / 0.08),
+      0 3px 8px
+      rgb(0 0 0 / 0.4);
+  }
+  
+  
+  /* Camera */
+  
+  .phone__camera {
+    width: 20%;
+    aspect-ratio: 1;
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        circle at 35% 30%,
+        #5b6575,
+        #111827 55%,
+        #030406 75%
+      );
+  
+    box-shadow:
+      inset 0 0 0 1px
+      rgb(255 255 255 / 0.1);
+  }
+  
+  
+  /* Sensor */
+  
+  .phone__sensor {
+    width: 12%;
+    aspect-ratio: 1;
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        circle,
+        #293241,
+        #080a0e 70%
+      );
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Physical side buttons
+     ---------------------------------------------------------- */
+  
+  .phone__side-button {
+    position: absolute;
+    z-index: -1;
+  
+    width: 1.5%;
+  
+    border-radius: 0 0.3rem 0.3rem 0;
+  
+    background:
+      linear-gradient(
+        90deg,
+        #171a21,
+        #454a56
+      );
+  
+    box-shadow:
+      1px 0 2px rgb(0 0 0 / 0.4);
+  }
+  
+  
+  .phone__side-button--power {
+    right: -1.3%;
+  
+    top: 27%;
+  
+    height: 11%;
+  }
+  
+  
+  .phone__side-button--volume-up {
+    left: -1.3%;
+  
+    top: 25%;
+  
+    height: 7%;
+  }
+  
+  
+  .phone__side-button--volume-down {
+    left: -1.3%;
+  
+    top: 34%;
+  
+    height: 7%;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Main screen content
+     ---------------------------------------------------------- */
+  
+  .screen__content {
+    position: relative;
+    z-index: 2;
+  
+    height: 73%;
+  
+    display: flex;
+    flex-direction: column;
+  
+    padding:
+      8%
+      9%;
+  }
+  
+  
+  /* Badge */
+  
+  .screen__badge {
+    align-self: flex-start;
+  
+    padding:
+      0.35rem
+      0.65rem;
+  
+    border:
+      1px solid
+      rgb(255 255 255 / 0.12);
+  
+    border-radius: 999px;
+  
+    background:
+      rgb(255 255 255 / 0.05);
+  
+    color:
+      rgb(255 255 255 / 0.7);
+  
+    font-size: 0.48rem;
+    font-weight: 800;
+    letter-spacing: 0.13em;
+  
+    backdrop-filter: blur(8px);
+  }
+  
+  
+  /* Heading */
+  
+  .screen h1 {
+    max-width: 90%;
+  
+    margin:
+      1.3rem 0 0.7rem;
+  
+    font-size:
+      clamp(1.45rem, 7vw, 2rem);
+  
+    line-height: 1.08;
+  
+    letter-spacing: -0.045em;
+  }
+  
+  
+  .screen h1 span {
+    display: block;
+  
+    background:
+      linear-gradient(
+        100deg,
+        #a78bfa,
+        #60a5fa
+      );
+  
+    -webkit-background-clip: text;
+    background-clip: text;
+  
+    color: transparent;
+  }
+  
+  
+  /* Description */
+  
+  .screen__content p {
+    max-width: 92%;
+  
+    margin: 0;
+  
+    color:
+      rgb(255 255 255 / 0.58);
+  
+    font-size:
+      clamp(0.6rem, 2.3vw, 0.78rem);
+  
+    line-height: 1.6;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     CTA
+     ---------------------------------------------------------- */
+  
+  .screen__button {
+    align-self: flex-start;
+  
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  
+    margin-top: 1rem;
+  
+    padding:
+      0.6rem
+      0.8rem;
+  
+    border-radius: 0.65rem;
+  
+    background:
+      linear-gradient(
+        135deg,
+        var(--accent),
+        var(--accent-secondary)
+      );
+  
+    color: var(--white);
+  
+    font-size: 0.6rem;
+    font-weight: 750;
+  
+    text-decoration: none;
+  
+    box-shadow:
+      0 8px 20px
+      rgb(124 58 237 / 0.22);
+  
+    transition:
+      transform 450ms var(--spring-ease),
+      box-shadow 300ms ease;
+  }
+  
+  
+  .screen__button:hover,
+  .screen__button:focus-visible {
+    transform:
+      translateY(-0.18rem)
+      scale(1.03);
+  
+    box-shadow:
+      0 12px 25px
+      rgb(124 58 237 / 0.32);
+  }
+  
+  
+  .screen__button:focus-visible {
+    outline:
+      2px solid
+      rgb(255 255 255 / 0.8);
+  
+    outline-offset: 3px;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Decorative visual
+     ---------------------------------------------------------- */
+  
+  .screen__visual {
+    position: absolute;
+  
+    right: -12%;
+    bottom: -2%;
+  
+    width: 65%;
+    aspect-ratio: 1;
+  }
+  
+  
+  .visual-ring,
+  .visual-core {
+    position: absolute;
+  
+    inset: 0;
+  
+    border-radius: 50%;
+  }
+  
+  
+  .visual-ring {
+    border:
+      1px solid
+      rgb(167 139 250 / 0.2);
+  
+    animation:
+      pulse-ring 5s ease-in-out infinite;
+  }
+  
+  
+  .visual-ring--two {
+    inset: 15%;
+  
+    border-color:
+      rgb(96 165 250 / 0.22);
+  
+    animation-delay: -1.5s;
+  }
+  
+  
+  .visual-core {
+    inset: 31%;
+  
+    background:
+      radial-gradient(
+        circle at 35% 30%,
+        #c4b5fd,
+        #7c3aed 35%,
+        #1d4ed8 70%,
+        transparent 72%
+      );
+  
+    box-shadow:
+      0 0 35px
+      rgb(124 58 237 / 0.3);
+  
+    animation:
+      core-float 4s ease-in-out infinite;
+  }
+  
+  
+  @keyframes pulse-ring {
+    0%,
+    100% {
+      transform: scale(0.92);
+      opacity: 0.35;
+    }
+  
+    50% {
+      transform: scale(1.04);
+      opacity: 0.8;
+    }
+  }
+  
+  
+  @keyframes core-float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+  
+    50% {
+      transform: translateY(-0.45rem);
+    }
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Bottom navigation
+     ---------------------------------------------------------- */
+  
+  .screen__navigation {
+    position: absolute;
+  
+    left: 8%;
+    right: 8%;
+    bottom: 6%;
+  
+    z-index: 4;
+  
+    display: flex;
+    justify-content: center;
+  
+    gap: 1.2rem;
+  }
+  
+  
+  .screen__nav-item {
+    width: 1.5rem;
+    height: 1.5rem;
+  
+    display: grid;
+    place-items: center;
+  
+    border-radius: 50%;
+  
+    background:
+      rgb(255 255 255 / 0.045);
+  
+    transition:
+      transform 400ms var(--spring-ease),
+      background-color 250ms ease;
+  }
+  
+  
+  .screen__nav-item span {
+    width: 0.35rem;
+    height: 0.35rem;
+  
+    border-radius: 50%;
+  
+    background:
+      rgb(255 255 255 / 0.4);
+  }
+  
+  
+  .screen__nav-item:hover,
+  .screen__nav-item:focus-visible,
+  .screen__nav-item--active {
+    transform:
+      translateY(-0.15rem)
+      scale(1.08);
+  
+    background:
+      rgb(124 58 237 / 0.22);
+  }
+  
+  
+  .screen__nav-item--active span {
+    background: #a78bfa;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Home indicator
+     ---------------------------------------------------------- */
+  
+  .screen__home-indicator {
+    position: absolute;
+  
+    z-index: 10;
+  
+    left: 50%;
+    bottom: 2.3%;
+  
+    width: 30%;
+    height: 0.8%;
+  
+    transform: translateX(-50%);
+  
+    border-radius: 999px;
+  
+    background:
+      rgb(255 255 255 / 0.8);
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Information
+     ---------------------------------------------------------- */
+  
+  .phone-demo__info {
+    width: min(100%, 30rem);
+  
+    text-align: center;
+  }
+  
+  
+  .phone-demo__eyebrow {
+    margin: 0 0 0.5rem;
+  
+    color: var(--accent);
+  
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+  }
+  
+  
+  .phone-demo__info h2 {
+    margin: 0 0 0.6rem;
+  
+    font-size:
+      clamp(1.5rem, 5vw, 2.2rem);
+  
+    letter-spacing: -0.04em;
+  }
+  
+  
+  .phone-demo__info > p:last-child {
+    margin: 0;
+  
+    color: var(--text-secondary);
+  
+    line-height: 1.7;
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Dark mode
+     ---------------------------------------------------------- */
+  
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --page-background: #070a0f;
+      --text-primary: #f8fafc;
+      --text-secondary: #94a3b8;
+    }
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Reduced motion
+     ---------------------------------------------------------- */
+  
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  
+    .phone:hover,
+    .phone:focus-visible {
+      transform: none;
+    }
+  }
+  
+  
+  /* ----------------------------------------------------------
+     Responsive adjustments
+     ---------------------------------------------------------- */
+  
+  @media (max-width: 480px) {
+    :root {
+      --phone-width: min(86vw, 20rem);
+    }
+  
+    .phone-demo {
+      padding-top: 2rem;
+    }
+  }
+  
+  
+  @media (min-width: 900px) {
+    .phone-demo {
+      grid-template-columns:
+        minmax(18rem, 22rem)
+        minmax(16rem, 30rem);
+  
+      align-items: center;
+  
+      column-gap: clamp(3rem, 8vw, 8rem);
+    }
+  
+    .phone-demo__info {
+      text-align: left;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Mobile Phone Frame requested in #70178.

### ✨ Features

- Added responsive smartphone frame
- Pure HTML and vanilla CSS
- No JavaScript or external dependencies
- Added realistic phone hardware styling
- Added Dynamic Island-style camera area
- Added physical side buttons
- Added responsive mobile screen UI
- Added status bar and navigation
- Added CSS-only animated visual
- Added hover and focus interactions
- Added dark mode support
- Added reduced-motion accessibility support

### ♿ Accessibility

- Semantic HTML
- Keyboard accessible interactions
- Visible focus states
- Descriptive ARIA labels
- Decorative elements marked with `aria-hidden`
- `prefers-reduced-motion` support

### ⚡ Performance

The implementation uses CSS transforms and opacity for the main
interactive and animated elements and does not require JavaScript.

### 📱 Responsive

Tested for both mobile and desktop layouts with fluid CSS sizing.

### 🧪 Testing

- Tested direct browser rendering
- Tested responsive layout
- Tested keyboard navigation
- Tested focus states
- Tested dark mode
- Tested reduced-motion behavior

Closes #70178