### PR TITLE
feat: add liquid wave fill variation (#73746)

### DIFF
--- a/submissions/examples/liquid-wave-fill-73746/README.md
+++ b/submissions/examples/liquid-wave-fill-73746/README.md
@@ -1,0 +1,29 @@
+# CSS Neumorphic Effect: Liquid Wave Fill Variation
+
+Pure CSS neumorphic UI featuring an interactive liquid wave fill animation with soft haptic shadows, fluid wave crests, and dynamic level triggers.
+
+## 1. What does this do?
+Creates a soft neumorphic vessel container with rotating CSS wave crest pseudo-elements and rising bubble keyframe animations that dynamically fill to selected capacity levels (25%, 50%, 75%, 100%) without JavaScript.
+
+## 2. How is it used?
+Include `style.css` and use radio input triggers paired with liquid vessel markup:
+
+```html
+<input type="radio" name="wave-fill-level" id="level-50" class="fill-radio" checked>
+
+<div class="liquid-vessel-container">
+  <div class="neumorphic-vessel">
+    <div class="fluid-mask">
+      <div class="liquid-layer">
+        <div class="wave-crest wave-primary"></div>
+        <div class="wave-crest wave-secondary"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<label for="level-50" class="neumorphic-btn">50%</label>
+```
+
+## 3. Why is it useful?
+Provides an engaging, hardware-accelerated fluid status/battery/progress indicator for modern web dashboards and mobile-inspired interfaces, supporting light/dark color schemes and accessible reduced-motion preferences.

--- a/submissions/examples/liquid-wave-fill-73746/demo.html
+++ b/submissions/examples/liquid-wave-fill-73746/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Neumorphic Liquid Wave Fill - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <span class="demo-badge">Neumorphism Effect</span>
+      <h1>Liquid Wave Fill</h1>
+      <p>Interactive Neumorphic UI featuring pure CSS fluid wave filling, haptic shadow depth, and dynamic level triggers.</p>
+    </header>
+
+    <section class="neumorphic-card" aria-label="Liquid Wave Fill Showcase">
+      <!-- Pure CSS State Controls -->
+      <input type="radio" name="wave-fill-level" id="level-25" class="fill-radio">
+      <input type="radio" name="wave-fill-level" id="level-50" class="fill-radio" checked>
+      <input type="radio" name="wave-fill-level" id="level-75" class="fill-radio">
+      <input type="radio" name="wave-fill-level" id="level-100" class="fill-radio">
+
+      <div class="liquid-vessel-container">
+        <!-- Neumorphic Soft Inset Vessel Outer -->
+        <div class="neumorphic-vessel">
+          <!-- Fluid Wave Fill Mask -->
+          <div class="fluid-mask">
+            <div class="liquid-layer">
+              <div class="wave-crest wave-primary"></div>
+              <div class="wave-crest wave-secondary"></div>
+              <div class="liquid-bubbles">
+                <span class="bubble b1"></span>
+                <span class="bubble b2"></span>
+                <span class="bubble b3"></span>
+                <span class="bubble b4"></span>
+              </div>
+            </div>
+          </div>
+          <!-- Percentage Readout Overlay -->
+          <div class="liquid-readout">
+            <span class="percentage-val val-25">25%</span>
+            <span class="percentage-val val-50">50%</span>
+            <span class="percentage-val val-75">75%</span>
+            <span class="percentage-val val-100">100%</span>
+            <span class="readout-label">Capacity</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Neumorphic Control Buttons -->
+      <div class="controls-panel" aria-label="Fill Level Selectors">
+        <span class="controls-title">Select Liquid Level</span>
+        <div class="btn-group">
+          <label for="level-25" class="neumorphic-btn btn-25" tabindex="0" title="Set fill to 25%">25%</label>
+          <label for="level-50" class="neumorphic-btn btn-50" tabindex="0" title="Set fill to 50%">50%</label>
+          <label for="level-75" class="neumorphic-btn btn-75" tabindex="0" title="Set fill to 75%">75%</label>
+          <label for="level-100" class="neumorphic-btn btn-100" tabindex="0" title="Set fill to 100%">100%</label>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/liquid-wave-fill-73746/style.css
+++ b/submissions/examples/liquid-wave-fill-73746/style.css
@@ -1,0 +1,328 @@
+/* CSS Neumorphic Effect: Liquid Wave Fill Variation #73746 */
+:root {
+  --bg-color: #e0e5ec;
+  --text-main: #2d3748;
+  --text-muted: #718096;
+  --shadow-light: #ffffff;
+  --shadow-dark: #a3b1c6;
+  --primary-glow: #3182ce;
+  --liquid-start: #3182ce;
+  --liquid-end: #00b4d8;
+  --vessel-bg: #e0e5ec;
+  --font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #1a202c;
+    --text-main: #e2e8f0;
+    --text-muted: #a0aec0;
+    --shadow-light: #242c3d;
+    --shadow-dark: #10141d;
+    --primary-glow: #63b3ed;
+    --liquid-start: #0077b6;
+    --liquid-end: #90e0ef;
+    --vessel-bg: #1a202c;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-family);
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+  transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+.demo-wrapper {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.35rem 0.85rem;
+  border-radius: 50px;
+  background: var(--bg-color);
+  color: var(--primary-glow);
+  box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
+  margin-bottom: 0.75rem;
+}
+
+.demo-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.demo-header p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Neumorphic Card Outer */
+.neumorphic-card {
+  width: 100%;
+  background: var(--bg-color);
+  padding: 2.5rem 2rem;
+  border-radius: 28px;
+  box-shadow: 12px 12px 24px var(--shadow-dark), -12px -12px 24px var(--shadow-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.fill-radio {
+  display: none;
+}
+
+/* Vessel Container */
+.liquid-vessel-container {
+  position: relative;
+  width: 180px;
+  height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.neumorphic-vessel {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 40px;
+  background: var(--vessel-bg);
+  box-shadow: inset 8px 8px 16px var(--shadow-dark), inset -8px -8px 16px var(--shadow-light);
+  padding: 12px;
+  overflow: hidden;
+}
+
+/* Fluid Mask */
+.fluid-mask {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 30px;
+  overflow: hidden;
+  background: transparent;
+  transform: translate3d(0, 0, 0);
+}
+
+/* Liquid Layer */
+.liquid-layer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 50%;
+  background: linear-gradient(180deg, var(--liquid-end) 0%, var(--liquid-start) 100%);
+  transition: height 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: height;
+  border-radius: 0 0 28px 28px;
+}
+
+/* Wave Crest Animation */
+.wave-crest {
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, -90%) rotate(0deg);
+  border-radius: 43%;
+  will-change: transform;
+}
+
+.wave-primary {
+  background: var(--vessel-bg);
+  opacity: 0.95;
+  animation: waveRotate 8s linear infinite;
+}
+
+.wave-secondary {
+  background: rgba(255, 255, 255, 0.35);
+  opacity: 0.6;
+  border-radius: 40%;
+  animation: waveRotate 5s linear infinite reverse;
+}
+
+@keyframes waveRotate {
+  0% {
+    transform: translate(-50%, -90%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -90%) rotate(360deg);
+  }
+}
+
+/* Floating Liquid Bubbles */
+.liquid-bubbles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.bubble {
+  position: absolute;
+  bottom: 0;
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  animation: bubbleRise 3s ease-in infinite;
+  will-change: transform, opacity;
+}
+
+.b1 { left: 20%; width: 8px; height: 8px; animation-delay: 0.2s; animation-duration: 2.8s; }
+.b2 { left: 45%; width: 12px; height: 12px; animation-delay: 1.1s; animation-duration: 3.4s; }
+.b3 { left: 70%; width: 6px; height: 6px; animation-delay: 0.7s; animation-duration: 2.5s; }
+.b4 { left: 85%; width: 10px; height: 10px; animation-delay: 1.8s; animation-duration: 3.1s; }
+
+@keyframes bubbleRise {
+  0% {
+    transform: translateY(0) scale(0.5);
+    opacity: 0;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    transform: translateY(-160px) scale(1.2);
+    opacity: 0;
+  }
+}
+
+/* Percentage Readout Overlay */
+.liquid-readout {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.percentage-val {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--text-main);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: none;
+}
+
+.readout-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+/* Pure CSS Radio Trigger States */
+#level-25:checked ~ .liquid-vessel-container .liquid-layer { height: 25%; }
+#level-50:checked ~ .liquid-vessel-container .liquid-layer { height: 50%; }
+#level-75:checked ~ .liquid-vessel-container .liquid-layer { height: 75%; }
+#level-100:checked ~ .liquid-vessel-container .liquid-layer { height: 100%; }
+
+#level-25:checked ~ .liquid-vessel-container .val-25 { display: block; }
+#level-50:checked ~ .liquid-vessel-container .val-50 { display: block; }
+#level-75:checked ~ .liquid-vessel-container .val-75 { display: block; }
+#level-100:checked ~ .liquid-vessel-container .val-100 { display: block; }
+
+/* Control Buttons */
+.controls-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.controls-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.75rem;
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.neumorphic-btn {
+  flex: 1;
+  min-width: 70px;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-main);
+  background: var(--bg-color);
+  border-radius: 16px;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light);
+  transition: all 0.3s ease;
+}
+
+.neumorphic-btn:hover {
+  color: var(--primary-glow);
+  transform: translateY(-2px);
+}
+
+.neumorphic-btn:focus-visible {
+  outline: 2px solid var(--primary-glow);
+  outline-offset: 4px;
+}
+
+/* Active Button Highlight */
+#level-25:checked ~ .controls-panel .btn-25,
+#level-50:checked ~ .controls-panel .btn-50,
+#level-75:checked ~ .controls-panel .btn-75,
+#level-100:checked ~ .controls-panel .btn-100 {
+  box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light);
+  color: var(--primary-glow);
+  transform: translateY(0);
+}
+
+/* Accessibility & Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .wave-primary,
+  .wave-secondary,
+  .bubble,
+  .liquid-layer,
+  .neumorphic-btn {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Neumorphic Liquid Wave Fill variation featuring rotating fluid wave crests, rising bubble particle keyframes, extruded soft haptic shadows, and interactive level controls.

## Changes
- Added submissions/examples/liquid-wave-fill-73746/demo.html`n- Added submissions/examples/liquid-wave-fill-73746/style.css`n- Added submissions/examples/liquid-wave-fill-73746/README.md`n
## Verification
Tested locally in browser: wave animations rotate smoothly, fill levels change seamlessly via CSS triggers, light/dark mode color variables switch correctly.

## Accessibility
Supports keyboard focus navigation and respects prefers-reduced-motion settings.

## Issue
Closes #73746