### PR TITLE
feat: add CSS-only mountains landscape

### DIFF
--- a/submissions/examples/css-only-mountains/README.md
+++ b/submissions/examples/css-only-mountains/README.md
@@ -1,0 +1,30 @@
+# CSS-only Mountains
+
+A responsive mountain landscape created entirely with HTML and modern
+Vanilla CSS.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- No external dependencies
+- Responsive layout
+- Layered mountain silhouettes
+- CSS-generated moon and stars
+- Atmospheric mist
+- Snow-cap details
+- Subtle hover interactions
+- CSS animations
+- Dark-mode friendly
+- `prefers-reduced-motion` support
+- High-contrast mode support
+- Mobile optimized
+- Hardware-friendly transform animations
+
+## 📁 Structure
+
+```text
+css-only-mountains/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/css-only-mountains/demo.html
+++ b/submissions/examples/css-only-mountains/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="Responsive CSS-only mountain landscape created using pure HTML and CSS."
+  >
+
+  <title>CSS Only Mountains</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="mountain-demo">
+
+    <section
+      class="mountain-scene"
+      aria-label="Decorative CSS mountain landscape"
+    >
+
+      <!-- Atmospheric background -->
+      <div class="sky" aria-hidden="true"></div>
+
+      <!-- Moon -->
+      <div class="moon" aria-hidden="true"></div>
+
+      <!-- Stars -->
+      <div class="stars stars-one" aria-hidden="true"></div>
+      <div class="stars stars-two" aria-hidden="true"></div>
+      <div class="stars stars-three" aria-hidden="true"></div>
+
+      <!-- Distant mountain range -->
+      <div class="mountains mountains-back" aria-hidden="true">
+        <span class="peak peak-1"></span>
+        <span class="peak peak-2"></span>
+        <span class="peak peak-3"></span>
+        <span class="peak peak-4"></span>
+        <span class="peak peak-5"></span>
+      </div>
+
+      <!-- Middle mountain range -->
+      <div class="mountains mountains-middle" aria-hidden="true">
+        <span class="peak peak-1"></span>
+        <span class="peak peak-2"></span>
+        <span class="peak peak-3"></span>
+        <span class="peak peak-4"></span>
+      </div>
+
+      <!-- Foreground mountains -->
+      <div class="mountains mountains-front" aria-hidden="true">
+        <span class="peak peak-1"></span>
+        <span class="peak peak-2"></span>
+        <span class="peak peak-3"></span>
+      </div>
+
+      <!-- Snow caps -->
+      <div class="snow-caps" aria-hidden="true">
+        <span class="snow snow-1"></span>
+        <span class="snow snow-2"></span>
+        <span class="snow snow-3"></span>
+      </div>
+
+      <!-- Mist -->
+      <div class="mist mist-one" aria-hidden="true"></div>
+      <div class="mist mist-two" aria-hidden="true"></div>
+
+      <!-- Foreground ground -->
+      <div class="ground" aria-hidden="true"></div>
+
+      <!-- Content -->
+      <div class="scene-content">
+        <span class="eyebrow">PURE CSS LANDSCAPE</span>
+
+        <h1>Beyond the Peaks</h1>
+
+        <p>
+          A responsive mountain landscape crafted entirely with
+          HTML and modern CSS.
+        </p>
+
+        <div class="scene-meta">
+          <span>CSS Only</span>
+          <span>Responsive</span>
+          <span>No JavaScript</span>
+        </div>
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-only-mountains/style.css
+++ b/submissions/examples/css-only-mountains/style.css
@@ -1,0 +1,723 @@
+/* =========================================================
+   CSS ONLY MOUNTAINS
+   EaseMotion CSS
+   Pure HTML + Vanilla CSS
+   ========================================================= */
+
+   :root {
+    --scene-height: min(720px, 100svh);
+  
+    --sky-top: #07111f;
+    --sky-middle: #142b49;
+    --sky-bottom: #385b72;
+  
+    --moon-color: #f8f1d4;
+    --moon-glow: rgba(248, 241, 212, 0.22);
+  
+    --mountain-back: #263b50;
+    --mountain-middle: #1c3044;
+    --mountain-front: #102235;
+  
+    --snow: rgba(235, 243, 247, 0.9);
+  
+    --ground: #081522;
+  
+    --text-primary: #f7fafc;
+    --text-secondary: rgba(247, 250, 252, 0.72);
+  
+    --accent: #a9d7e8;
+  
+    --transition:
+      transform 700ms cubic-bezier(0.22, 1, 0.36, 1),
+      opacity 500ms ease;
+  }
+  
+  /* =========================================================
+     RESET
+     ========================================================= */
+  
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  html {
+    color-scheme: dark;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+  
+    background: #07111f;
+  
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    color: var(--text-primary);
+  }
+  
+  /* =========================================================
+     MAIN
+     ========================================================= */
+  
+  .mountain-demo {
+    min-height: 100svh;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  
+  /* =========================================================
+     SCENE
+     ========================================================= */
+  
+  .mountain-scene {
+    position: relative;
+  
+    width: 100%;
+    min-height: var(--scene-height);
+  
+    overflow: hidden;
+    isolation: isolate;
+  
+    background:
+      linear-gradient(
+        to bottom,
+        var(--sky-top) 0%,
+        var(--sky-middle) 48%,
+        var(--sky-bottom) 100%
+      );
+  }
+  
+  /* =========================================================
+     ATMOSPHERIC SKY
+     ========================================================= */
+  
+  .sky {
+    position: absolute;
+    inset: 0;
+  
+    z-index: -5;
+  
+    background:
+      radial-gradient(
+        ellipse at 50% 100%,
+        rgba(172, 208, 222, 0.18),
+        transparent 48%
+      ),
+      linear-gradient(
+        to bottom,
+        transparent 55%,
+        rgba(116, 170, 188, 0.12)
+      );
+  
+    pointer-events: none;
+  }
+  
+  /* =========================================================
+     MOON
+     ========================================================= */
+  
+  .moon {
+    position: absolute;
+  
+    top: 13%;
+    right: clamp(8%, 14vw, 18%);
+  
+    width: clamp(64px, 9vw, 110px);
+    aspect-ratio: 1;
+  
+    border-radius: 50%;
+  
+    background: var(--moon-color);
+  
+    box-shadow:
+      0 0 35px var(--moon-glow),
+      0 0 90px rgba(248, 241, 212, 0.12);
+  
+    animation: moonFloat 8s ease-in-out infinite;
+  
+    z-index: -3;
+  }
+  
+  @keyframes moonFloat {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+  
+    50% {
+      transform: translateY(-8px);
+    }
+  }
+  
+  /* =========================================================
+     STARS
+     ========================================================= */
+  
+  .stars {
+    position: absolute;
+    inset: 0;
+  
+    z-index: -4;
+  
+    pointer-events: none;
+  
+    opacity: 0.75;
+  }
+  
+  .stars-one {
+    background-image:
+      radial-gradient(circle at 10% 20%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 27% 11%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 42% 25%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 63% 15%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 82% 28%, #fff 1px, transparent 1.5px);
+  }
+  
+  .stars-two {
+    opacity: 0.45;
+  
+    background-image:
+      radial-gradient(circle at 18% 34%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 35% 18%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 55% 31%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 72% 12%, #fff 1px, transparent 1.5px),
+      radial-gradient(circle at 91% 23%, #fff 1px, transparent 1.5px);
+  }
+  
+  /* =========================================================
+     MOUNTAIN SYSTEM
+     ========================================================= */
+  
+  .mountains {
+    position: absolute;
+  
+    left: -5%;
+    right: -5%;
+    bottom: 0;
+  
+    height: 65%;
+  
+    display: flex;
+    align-items: flex-end;
+  
+    pointer-events: none;
+  }
+  
+  .peak {
+    position: relative;
+  
+    display: block;
+  
+    width: 28%;
+    height: 100%;
+  
+    clip-path: polygon(
+      0 100%,
+      50% 8%,
+      100% 100%
+    );
+  
+    flex-shrink: 0;
+  }
+  
+  /* =========================================================
+     BACK RANGE
+     ========================================================= */
+  
+  .mountains-back {
+    z-index: -2;
+  
+    height: 53%;
+  
+    filter: blur(0.3px);
+  }
+  
+  .mountains-back .peak {
+    background:
+      linear-gradient(
+        125deg,
+        #30495e 0 42%,
+        #22384b 43% 100%
+      );
+  }
+  
+  .mountains-back .peak:nth-child(1) {
+    transform: translateX(-8%);
+  }
+  
+  .mountains-back .peak:nth-child(2) {
+    transform: translateX(-3%) scale(1.15);
+  }
+  
+  .mountains-back .peak:nth-child(3) {
+    transform: translateX(-5%) scale(0.95);
+  }
+  
+  .mountains-back .peak:nth-child(4) {
+    transform: translateX(-10%) scale(1.2);
+  }
+  
+  .mountains-back .peak:nth-child(5) {
+    transform: translateX(-15%) scale(0.9);
+  }
+  
+  /* =========================================================
+     MIDDLE RANGE
+     ========================================================= */
+  
+  .mountains-middle {
+    z-index: -1;
+  
+    height: 65%;
+  }
+  
+  .mountains-middle .peak {
+    background:
+      linear-gradient(
+        115deg,
+        #243b4e 0 47%,
+        #172c40 48% 100%
+      );
+  }
+  
+  .mountains-middle .peak:nth-child(1) {
+    transform: translateX(-14%) scale(1.1);
+  }
+  
+  .mountains-middle .peak:nth-child(2) {
+    transform: translateX(-10%) scale(1.35);
+  }
+  
+  .mountains-middle .peak:nth-child(3) {
+    transform: translateX(-17%) scale(1.05);
+  }
+  
+  .mountains-middle .peak:nth-child(4) {
+    transform: translateX(-22%) scale(1.3);
+  }
+  
+  /* =========================================================
+     FOREGROUND RANGE
+     ========================================================= */
+  
+  .mountains-front {
+    z-index: 1;
+  
+    height: 72%;
+  
+    transform: translateY(5%);
+  }
+  
+  .mountains-front .peak {
+    width: 38%;
+  
+    background:
+      linear-gradient(
+        120deg,
+        #182e42 0 48%,
+        #0d1f31 49% 100%
+      );
+  
+    transition: var(--transition);
+  }
+  
+  .mountains-front .peak:nth-child(1) {
+    transform: translateX(-20%) scale(1.15);
+  }
+  
+  .mountains-front .peak:nth-child(2) {
+    transform: translateX(-18%) scale(1.3);
+  }
+  
+  .mountains-front .peak:nth-child(3) {
+    transform: translateX(-25%) scale(1.2);
+  }
+  
+  /* =========================================================
+     SNOW CAPS
+     ========================================================= */
+  
+  .snow-caps {
+    position: absolute;
+  
+    inset: 0;
+  
+    z-index: 2;
+  
+    pointer-events: none;
+  }
+  
+  .snow {
+    position: absolute;
+  
+    display: block;
+  
+    width: 0;
+    height: 0;
+  
+    border-left: clamp(30px, 4vw, 60px) solid transparent;
+    border-right: clamp(30px, 4vw, 60px) solid transparent;
+  
+    border-bottom: clamp(42px, 5vw, 75px) solid var(--snow);
+  
+    filter:
+      drop-shadow(
+        0 3px 4px rgba(0, 0, 0, 0.12)
+      );
+  
+    opacity: 0.72;
+  }
+  
+  .snow-1 {
+    left: 21%;
+    bottom: 43%;
+  
+    transform: rotate(1deg) scale(0.7);
+  }
+  
+  .snow-2 {
+    left: 49%;
+    bottom: 47%;
+  
+    transform: rotate(-2deg) scale(0.9);
+  }
+  
+  .snow-3 {
+    left: 77%;
+    bottom: 40%;
+  
+    transform: rotate(2deg) scale(0.65);
+  }
+  
+  /* =========================================================
+     MIST
+     ========================================================= */
+  
+  .mist {
+    position: absolute;
+  
+    left: -10%;
+  
+    width: 120%;
+    height: 90px;
+  
+    border-radius: 50%;
+  
+    background:
+      radial-gradient(
+        ellipse,
+        rgba(220, 239, 243, 0.16),
+        transparent 68%
+      );
+  
+    filter: blur(10px);
+  
+    pointer-events: none;
+  
+    z-index: 3;
+  }
+  
+  .mist-one {
+    bottom: 30%;
+  
+    animation:
+      mistMoveOne 12s ease-in-out infinite alternate;
+  }
+  
+  .mist-two {
+    bottom: 24%;
+  
+    opacity: 0.5;
+  
+    animation:
+      mistMoveTwo 16s ease-in-out infinite alternate;
+  }
+  
+  @keyframes mistMoveOne {
+    from {
+      transform: translateX(-4%);
+    }
+  
+    to {
+      transform: translateX(4%);
+    }
+  }
+  
+  @keyframes mistMoveTwo {
+    from {
+      transform: translateX(5%);
+    }
+  
+    to {
+      transform: translateX(-5%);
+    }
+  }
+  
+  /* =========================================================
+     GROUND
+     ========================================================= */
+  
+  .ground {
+    position: absolute;
+  
+    left: -5%;
+    right: -5%;
+    bottom: -5%;
+  
+    height: 25%;
+  
+    z-index: 4;
+  
+    border-radius: 50% 50% 0 0 / 25% 25% 0 0;
+  
+    background:
+      linear-gradient(
+        to bottom,
+        rgba(8, 21, 34, 0.94),
+        var(--ground)
+      );
+  
+    box-shadow:
+      0 -20px 70px rgba(4, 15, 27, 0.35);
+  }
+  
+  /* =========================================================
+     CONTENT
+     ========================================================= */
+  
+  .scene-content {
+    position: absolute;
+  
+    z-index: 5;
+  
+    top: 50%;
+    left: 50%;
+  
+    width: min(90%, 760px);
+  
+    transform: translate(-50%, -50%);
+  
+    text-align: center;
+  
+    pointer-events: none;
+  }
+  
+  .eyebrow {
+    display: inline-block;
+  
+    margin-bottom: 1rem;
+  
+    padding: 0.4rem 0.75rem;
+  
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 999px;
+  
+    background: rgba(255, 255, 255, 0.06);
+  
+    backdrop-filter: blur(8px);
+  
+    color: var(--accent);
+  
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+  }
+  
+  .scene-content h1 {
+    margin: 0;
+  
+    font-size: clamp(2.5rem, 7vw, 6.5rem);
+  
+    line-height: 0.95;
+  
+    letter-spacing: -0.055em;
+  
+    text-shadow:
+      0 4px 30px rgba(0, 0, 0, 0.35);
+  }
+  
+  .scene-content p {
+    max-width: 540px;
+  
+    margin: 1.4rem auto 0;
+  
+    color: var(--text-secondary);
+  
+    font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  
+    line-height: 1.7;
+  }
+  
+  .scene-meta {
+    display: flex;
+  
+    justify-content: center;
+    flex-wrap: wrap;
+  
+    gap: 0.6rem;
+  
+    margin-top: 1.5rem;
+  }
+  
+  .scene-meta span {
+    padding: 0.45rem 0.75rem;
+  
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  
+    border-radius: 999px;
+  
+    background: rgba(255, 255, 255, 0.05);
+  
+    color: rgba(255, 255, 255, 0.7);
+  
+    font-size: 0.72rem;
+  
+    backdrop-filter: blur(8px);
+  }
+  
+  /* =========================================================
+     HOVER INTERACTION
+     ========================================================= */
+  
+  .mountain-scene:hover .mountains-front .peak:nth-child(1) {
+    transform:
+      translateX(-20%)
+      translateY(-5px)
+      scale(1.15);
+  }
+  
+  .mountain-scene:hover .mountains-front .peak:nth-child(2) {
+    transform:
+      translateX(-18%)
+      translateY(-8px)
+      scale(1.3);
+  }
+  
+  .mountain-scene:hover .mountains-front .peak:nth-child(3) {
+    transform:
+      translateX(-25%)
+      translateY(-5px)
+      scale(1.2);
+  }
+  
+  .mountain-scene:hover .moon {
+    box-shadow:
+      0 0 45px rgba(248, 241, 212, 0.28),
+      0 0 120px rgba(248, 241, 212, 0.14);
+  }
+  
+  /* =========================================================
+     RESPONSIVE
+     ========================================================= */
+  
+  @media (max-width: 700px) {
+    :root {
+      --scene-height: 100svh;
+    }
+  
+    .moon {
+      top: 10%;
+      right: 12%;
+    }
+  
+    .mountains-back {
+      height: 48%;
+    }
+  
+    .mountains-middle {
+      height: 58%;
+    }
+  
+    .mountains-front {
+      height: 64%;
+    }
+  
+    .snow-1 {
+      left: 17%;
+      bottom: 38%;
+    }
+  
+    .snow-2 {
+      left: 47%;
+      bottom: 41%;
+    }
+  
+    .snow-3 {
+      left: 75%;
+      bottom: 36%;
+    }
+  
+    .ground {
+      height: 27%;
+    }
+  
+    .scene-content {
+      top: 42%;
+    }
+  }
+  
+  @media (max-width: 420px) {
+    .scene-content h1 {
+      font-size: clamp(2.4rem, 13vw, 4rem);
+    }
+  
+    .scene-content p {
+      font-size: 0.9rem;
+    }
+  
+    .scene-meta {
+      gap: 0.35rem;
+    }
+  
+    .scene-meta span {
+      font-size: 0.65rem;
+    }
+  
+    .mountains-front {
+      height: 59%;
+    }
+  }
+  
+  /* =========================================================
+     REDUCED MOTION
+     ========================================================= */
+  
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+  
+  /* =========================================================
+     HIGH CONTRAST / PRINT SAFETY
+     ========================================================= */
+  
+  @media (forced-colors: active) {
+    .mountain-scene {
+      background: Canvas;
+    }
+  
+    .scene-content {
+      color: CanvasText;
+    }
+  
+    .scene-meta span,
+    .eyebrow {
+      border: 1px solid CanvasText;
+    }
+  }


### PR DESCRIPTION
## Description

Closes #70191

Added a responsive CSS-only mountain landscape to
`submissions/examples/css-only-mountains/`.

## Features

- Pure HTML + Vanilla CSS
- Layered mountain silhouettes
- CSS-generated moon and stars
- Snow-cap details
- Atmospheric mist
- Responsive design
- CSS animations
- Hover interaction
- Reduced-motion support
- High-contrast support
- No JavaScript
- No external dependencies

## Files Added

- `demo.html`
- `style.css`
- `README.md`

## Testing

- [x] Desktop tested
- [x] Tablet tested
- [x] Mobile tested
- [x] Reduced motion tested
- [x] No JavaScript used
- [x] No external assets used
- [x] Responsive behavior verified