### PR TITLE
feat: add holographic flicker variation (#73744)

### DIFF
--- a/submissions/examples/holographic-flicker-73744/README.md
+++ b/submissions/examples/holographic-flicker-73744/README.md
@@ -1,0 +1,26 @@
+# CSS Neumorphic Effect: Holographic Flicker Variation
+
+Pure CSS neumorphic UI featuring holographic scanlines, iridescent sheen sweeps, micro-glitch opacity flicker keyframes, and HUD display triggers.
+
+## 1. What does this do?
+Renders a sci-fi holographic HUD display inside an inset neumorphic window with pure CSS flickering, sheen sweeps, and mode selectors (Stable, Flicker, Glitch) without JavaScript.
+
+## 2. How is it used?
+Link `style.css` and use radio input triggers paired with holographic container elements:
+
+```html
+<input type="radio" name="holo-mode" id="holo-flicker" class="holo-radio" checked>
+
+<div class="holo-emitter-window">
+  <div class="holo-scanlines"></div>
+  <div class="holo-projection">
+    <div class="holo-sheen"></div>
+    <div class="hud-content">CYBER_ID</div>
+  </div>
+</div>
+
+<label for="holo-flicker" class="neumorphic-btn">Flicker</label>
+```
+
+## 3. Why is it useful?
+Delivers high-impact sci-fi and cyberpunk UI elements for gaming dashboards, profile cards, and web applications with full dark mode compatibility and reduced motion accessibility.

--- a/submissions/examples/holographic-flicker-73744/demo.html
+++ b/submissions/examples/holographic-flicker-73744/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Neumorphic Holographic Flicker - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <span class="demo-badge">Neumorphism Effect</span>
+      <h1>Holographic Flicker</h1>
+      <p>Interactive Neumorphic UI featuring pure CSS holographic projection sheen, glitch flicker keyframes, and scanline HUD triggers.</p>
+    </header>
+
+    <section class="neumorphic-card" aria-label="Holographic Flicker Showcase">
+      <!-- Pure CSS State Controls -->
+      <input type="radio" name="holo-mode" id="holo-stable" class="holo-radio" checked>
+      <input type="radio" name="holo-mode" id="holo-flicker" class="holo-radio">
+      <input type="radio" name="holo-mode" id="holo-glitch" class="holo-radio">
+
+      <!-- Holographic Display Emitter Window -->
+      <div class="holo-emitter-window">
+        <div class="holo-scanlines" aria-hidden="true"></div>
+        <div class="holo-projection">
+          <div class="holo-sheen"></div>
+          
+          <!-- Holographic HUD Content -->
+          <div class="hud-content">
+            <div class="hud-avatar">
+              <svg class="hud-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <circle cx="12" cy="8" r="5"></circle>
+                <path d="M20 21a8 8 0 0 0-16 0"></path>
+              </svg>
+            </div>
+            
+            <div class="hud-meta">
+              <span class="hud-title">CYBER_ID // 8094</span>
+              <span class="hud-status">STATUS: ONLINE</span>
+            </div>
+
+            <div class="hud-bars">
+              <span class="hud-bar b1"></span>
+              <span class="hud-bar b2"></span>
+              <span class="hud-bar b3"></span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Control Panel -->
+      <div class="controls-panel" aria-label="Holographic Projection Modes">
+        <span class="controls-title">Projection Mode</span>
+        <div class="btn-group">
+          <label for="holo-stable" class="neumorphic-btn btn-stable" tabindex="0" title="Stable Hologram">Stable</label>
+          <label for="holo-flicker" class="neumorphic-btn btn-flicker" tabindex="0" title="Low Power Flicker">Flicker</label>
+          <label for="holo-glitch" class="neumorphic-btn btn-glitch" tabindex="0" title="Cyber Glitch Burst">Glitch</label>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/holographic-flicker-73744/style.css
+++ b/submissions/examples/holographic-flicker-73744/style.css
@@ -1,0 +1,335 @@
+/* CSS Neumorphic Effect: Holographic Flicker Variation #73744 */
+:root {
+  --bg-color: #e5e9f0;
+  --text-main: #1e293b;
+  --text-muted: #64748b;
+  --shadow-light: #ffffff;
+  --shadow-dark: #b6c1d2;
+  --holo-cyan: #00f2fe;
+  --holo-blue: #4facfe;
+  --holo-pink: #f43f5e;
+  --holo-glow: rgba(0, 242, 254, 0.4);
+  --font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Space Mono', monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #0d1117;
+    --text-main: #f1f5f9;
+    --text-muted: #94a3b8;
+    --shadow-light: #161b22;
+    --shadow-dark: #010409;
+    --holo-cyan: #38bdf8;
+    --holo-blue: #818cf8;
+    --holo-pink: #fb7185;
+    --holo-glow: rgba(56, 189, 248, 0.4);
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-family);
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+  transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+.demo-wrapper {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.35rem 0.85rem;
+  border-radius: 50px;
+  background: var(--bg-color);
+  color: var(--holo-cyan);
+  box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
+  margin-bottom: 0.75rem;
+}
+
+.demo-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.demo-header p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Neumorphic Card Outer */
+.neumorphic-card {
+  width: 100%;
+  background: var(--bg-color);
+  padding: 2.5rem 2rem;
+  border-radius: 28px;
+  box-shadow: 12px 12px 24px var(--shadow-dark), -12px -12px 24px var(--shadow-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.holo-radio {
+  display: none;
+}
+
+/* Holographic Projection Emitter Window */
+.holo-emitter-window {
+  position: relative;
+  width: 100%;
+  height: 220px;
+  border-radius: 20px;
+  background: var(--bg-color);
+  box-shadow: inset 8px 8px 16px var(--shadow-dark), inset -8px -8px 16px var(--shadow-light);
+  padding: 1rem;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.holo-scanlines {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.15),
+    rgba(0, 0, 0, 0.15) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  pointer-events: none;
+  z-index: 8;
+  opacity: 0.6;
+}
+
+.holo-projection {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(0, 242, 254, 0.12) 0%, rgba(79, 172, 254, 0.08) 100%);
+  border: 1px solid rgba(0, 242, 254, 0.3);
+  box-shadow: 0 0 20px var(--holo-glow);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  will-change: transform, opacity, filter;
+  transform: translate3d(0, 0, 0);
+}
+
+.holo-sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 20%,
+    rgba(0, 242, 254, 0.25) 45%,
+    rgba(244, 63, 94, 0.2) 55%,
+    transparent 80%
+  );
+  animation: holoSheenSweep 4s linear infinite;
+  will-change: transform;
+}
+
+@keyframes holoSheenSweep {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+/* HUD Overlay Content */
+.hud-content {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--holo-cyan);
+  text-shadow: 0 0 8px var(--holo-glow);
+}
+
+.hud-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px dashed var(--holo-cyan);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: avatarRotate 12s linear infinite;
+}
+
+@keyframes avatarRotate {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.hud-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--holo-cyan);
+}
+
+.hud-meta {
+  text-align: center;
+  font-family: var(--font-mono);
+}
+
+.hud-title {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.hud-status {
+  display: block;
+  font-size: 0.7rem;
+  opacity: 0.85;
+}
+
+.hud-bars {
+  display: flex;
+  gap: 4px;
+}
+
+.hud-bar {
+  width: 24px;
+  height: 4px;
+  background: var(--holo-cyan);
+  border-radius: 2px;
+  opacity: 0.7;
+}
+
+/* Mode Animations */
+#holo-stable:checked ~ .holo-emitter-window .holo-projection {
+  animation: holoStableGlow 3s ease-in-out infinite alternate;
+}
+
+@keyframes holoStableGlow {
+  0% { opacity: 0.95; filter: drop-shadow(0 0 6px var(--holo-glow)); }
+  100% { opacity: 1; filter: drop-shadow(0 0 14px var(--holo-glow)); }
+}
+
+#holo-flicker:checked ~ .holo-emitter-window .holo-projection {
+  animation: holoFlickerPulse 1.2s steps(2, start) infinite;
+}
+
+@keyframes holoFlickerPulse {
+  0%, 100% { opacity: 0.95; filter: contrast(1); }
+  25% { opacity: 0.45; filter: contrast(1.4) hue-rotate(15deg); }
+  50% { opacity: 0.85; }
+  75% { opacity: 0.3; filter: contrast(0.8); }
+}
+
+#holo-glitch:checked ~ .holo-emitter-window .holo-projection {
+  animation: holoGlitchShift 0.8s ease-in-out infinite;
+}
+
+@keyframes holoGlitchShift {
+  0% { transform: translate(0, 0); filter: none; }
+  20% { transform: translate(-3px, 2px) skewX(2deg); filter: drop-shadow(-2px 0 var(--holo-pink)); }
+  40% { transform: translate(3px, -1px); filter: drop-shadow(2px 0 var(--holo-cyan)); }
+  60% { transform: translate(-2px, -2px); filter: none; }
+  80% { transform: translate(2px, 1px) skewX(-2deg); filter: drop-shadow(-2px 0 var(--holo-blue)); }
+  100% { transform: translate(0, 0); filter: none; }
+}
+
+/* Controls Panel */
+.controls-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.controls-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.75rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.neumorphic-btn {
+  flex: 1;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-main);
+  background: var(--bg-color);
+  border-radius: 16px;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light);
+  transition: all 0.3s ease;
+}
+
+.neumorphic-btn:hover {
+  color: var(--holo-cyan);
+  transform: translateY(-2px);
+}
+
+.neumorphic-btn:focus-visible {
+  outline: 2px solid var(--holo-cyan);
+  outline-offset: 4px;
+}
+
+#holo-stable:checked ~ .controls-panel .btn-stable,
+#holo-flicker:checked ~ .controls-panel .btn-flicker,
+#holo-glitch:checked ~ .controls-panel .btn-glitch {
+  box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light);
+  color: var(--holo-cyan);
+  transform: translateY(0);
+}
+
+/* Accessibility & Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .holo-projection,
+  .holo-sheen,
+  .hud-avatar,
+  .neumorphic-btn {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Neumorphic Holographic Flicker variation featuring scanlines, iridescent sheen sweeps, micro-glitch opacity flicker keyframes, and HUD display triggers.

## Changes
- Added submissions/examples/holographic-flicker-73744/demo.html`n- Added submissions/examples/holographic-flicker-73744/style.css`n- Added submissions/examples/holographic-flicker-73744/README.md`n
## Verification
Tested holographic projection in browser: flicker modes and sheen sweeps transition smoothly, light/dark mode themes function correctly.

## Accessibility
Provides clear focus rings and supports prefers-reduced-motion settings.

## Issue
Closes #73744