### PR TITLE
feat: add fluid audio visualizer bars display component

### DIFF
--- a/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/README.md
+++ b/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/README.md
@@ -1,0 +1,22 @@
+# Fluid Audio Visualizer Bars Display
+
+An interactive audio frequency spectrum visualizer component featuring neon gradient equalizer bars and track metadata display.
+
+## 1. What does this do?
+This component renders an animated audio spectrum analyzer with 12 fluid frequency bars, track album artwork, artist credentials, and playback timecode status.
+
+## 2. How is it used?
+Link `style.css` and use `.audio-card`:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<div class="audio-card" tabindex="0">
+  <div class="spectrum-bars">
+    <div class="bar" style="--d: 0.1s; --h: 75%"></div>
+  </div>
+</div>
+```
+
+## 3. Why is it useful?
+It provides music streaming applications, podcasts, and audio editing Web apps with a responsive, GPU-accelerated equalizer UI component without external JS dependencies.

--- a/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/demo.html
+++ b/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fluid Audio Visualizer Bars Display - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="audio-container">
+    <header class="audio-header">
+      <span class="badge">GSSoC 2026 Showcase</span>
+      <h1>Fluid Audio Visualizer Bars Display</h1>
+      <p>Dynamic music equalizer visualizer deck with animated frequency spectrum bars, neon peak indicators, and track details.</p>
+    </header>
+
+    <div class="audio-card" tabindex="0">
+      <div class="track-info">
+        <div class="album-art">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
+        </div>
+        <div class="meta">
+          <h3 class="track-title">Cybernetic Resonance</h3>
+          <p class="artist-name">SynthWave Odyssey &bull; Lossless FLAC</p>
+        </div>
+      </div>
+
+      <div class="spectrum-bars">
+        <div class="bar" style="--d: 0.1s; --h: 75%"></div>
+        <div class="bar" style="--d: 0.3s; --h: 40%"></div>
+        <div class="bar" style="--d: 0.2s; --h: 90%"></div>
+        <div class="bar" style="--d: 0.5s; --h: 60%"></div>
+        <div class="bar" style="--d: 0.4s; --h: 100%"></div>
+        <div class="bar" style="--d: 0.15s; --h: 80%"></div>
+        <div class="bar" style="--d: 0.35s; --h: 55%"></div>
+        <div class="bar" style="--d: 0.25s; --h: 95%"></div>
+        <div class="bar" style="--d: 0.45s; --h: 70%"></div>
+        <div class="bar" style="--d: 0.05s; --h: 85%"></div>
+        <div class="bar" style="--d: 0.3s; --h: 45%"></div>
+        <div class="bar" style="--d: 0.2s; --h: 90%"></div>
+      </div>
+
+      <div class="controls-row">
+        <span class="time-stamp">02:45 / 04:12</span>
+        <div class="status-badge">LIVE STEREO</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/style.css
+++ b/submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/style.css
@@ -1,0 +1,169 @@
+:root {
+  --bg-dark: #0a0518;
+  --card-bg: rgba(20, 10, 40, 0.7);
+  --neon-magenta: #ec4899;
+  --neon-purple: #a855f7;
+  --neon-cyan: #06b6d4;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Outfit', sans-serif;
+  background-color: var(--bg-dark);
+  background-image: 
+    radial-gradient(circle at 20% 80%, rgba(236, 72, 153, 0.15), transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(168, 85, 247, 0.15), transparent 50%);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.audio-container {
+  max-width: 750px;
+  width: 100%;
+  text-align: center;
+}
+
+.audio-header {
+  margin-bottom: 3rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.35rem 1rem;
+  background: rgba(236, 72, 153, 0.15);
+  border: 1px solid rgba(236, 72, 153, 0.35);
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  color: var(--neon-magenta);
+  letter-spacing: 1px;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.audio-header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #ffffff, var(--neon-magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.75rem;
+}
+
+.audio-header p {
+  color: var(--text-muted);
+  max-width: 550px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.audio-card {
+  background: var(--card-bg);
+  border: 1px solid rgba(236, 72, 153, 0.25);
+  border-radius: 24px;
+  padding: 2.25rem;
+  backdrop-filter: blur(20px);
+  box-shadow: 
+    0 20px 50px rgba(0, 0, 0, 0.8),
+    0 0 35px rgba(236, 72, 153, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  outline: none;
+  cursor: pointer;
+  transition: all 0.35s ease;
+}
+
+.audio-card:hover,
+.audio-card:focus-visible {
+  border-color: rgba(236, 72, 153, 0.6);
+  box-shadow: 
+    0 25px 60px rgba(0, 0, 0, 0.9),
+    0 0 50px rgba(236, 72, 153, 0.3);
+}
+
+.track-info {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.album-art {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--neon-magenta), var(--neon-purple));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(236, 72, 153, 0.3);
+}
+
+.album-art svg {
+  width: 28px;
+  height: 28px;
+}
+
+.track-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.artist-name {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.spectrum-bars {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.5rem;
+  height: 110px;
+  padding: 1rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.bar {
+  flex: 1;
+  background: linear-gradient(180deg, var(--neon-cyan), var(--neon-magenta));
+  border-radius: 6px;
+  animation: pulseBar 1.2s ease-in-out infinite alternate;
+  animation-delay: var(--d);
+}
+
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.status-badge {
+  padding: 0.25rem 0.75rem;
+  background: rgba(6, 186, 212, 0.15);
+  border: 1px solid rgba(6, 186, 212, 0.3);
+  color: var(--neon-cyan);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@keyframes pulseBar {
+  0% { height: 15%; }
+  100% { height: var(--h); }
+}


### PR DESCRIPTION
# Related Issue
Closes #75923

# Summary
Adds a Fluid Audio Visualizer Bars Display component featuring 12 animated spectrum frequency bars, album art artwork, and track status badges.

# Changes Made
- Created `submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/demo.html`
- Created `submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/style.css`
- Created `submissions/examples/gssoc-2026-fluid-audio-visualizer-bars-display-bb/README.md`

# Testing
- Tested animation smoothness across mobile and desktop.
- Verified visual contrast and layout alignment.

# Impact
Adds a music player spectrum visualizer to EaseMotion-css.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
