### PR TITLE
feat: add full-screen overlay menu

### DIFF
--- a/submissions/examples/fullscreen-overlay-menu-v2/README.md
+++ b/submissions/examples/fullscreen-overlay-menu-v2/README.md
@@ -1,0 +1,31 @@
+# Full-screen Overlay Menu
+
+A modern full-screen navigation overlay built with pure HTML and
+vanilla CSS.
+
+Part of the EaseMotion CSS component collection.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Full-screen overlay navigation
+- Circular reveal animation
+- Staggered navigation-link animations
+- Animated hamburger → close icon
+- Responsive design
+- Keyboard focus states
+- `prefers-reduced-motion` support
+- High-contrast mode support
+- CSS-only interaction
+- GPU-friendly transforms and opacity
+- Modern responsive typography
+- Semantic navigation structure
+
+## 📁 Structure
+
+```text
+fullscreen-overlay-menu/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/fullscreen-overlay-menu-v2/demo.html
+++ b/submissions/examples/fullscreen-overlay-menu-v2/demo.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <meta
+    name="description"
+    content="Pure CSS full-screen overlay menu with staggered link animations."
+  >
+
+  <title>Full-screen Overlay Menu | EaseMotion CSS</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <header class="site-header">
+      <a class="brand" href="#home" aria-label="EaseMotion home">
+        <span class="brand-mark" aria-hidden="true">E</span>
+        <span>EaseMotion</span>
+      </a>
+
+      <!-- CSS-only menu trigger -->
+      <input
+        class="menu-toggle"
+        type="checkbox"
+        id="menu-toggle"
+        aria-hidden="true"
+      >
+
+      <label
+        class="menu-button"
+        for="menu-toggle"
+        aria-label="Toggle navigation menu"
+      >
+        <span class="menu-icon" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+
+        <span class="menu-label">
+          <span class="open-label">Menu</span>
+          <span class="close-label">Close</span>
+        </span>
+      </label>
+
+      <!-- Full-screen overlay -->
+      <div class="overlay">
+
+        <div class="overlay-background" aria-hidden="true">
+          <span class="background-circle circle-one"></span>
+          <span class="background-circle circle-two"></span>
+          <span class="background-grid"></span>
+        </div>
+
+        <div class="overlay-content">
+
+          <div class="overlay-intro">
+            <span class="eyebrow">Navigation</span>
+
+            <h1>
+              Move with
+              <span>intention.</span>
+            </h1>
+
+            <p>
+              Explore a collection of smooth, expressive and
+              accessible CSS motion patterns.
+            </p>
+          </div>
+
+          <nav
+            class="overlay-navigation"
+            aria-label="Main navigation"
+          >
+            <a class="nav-link" href="#home">
+              <span class="nav-number">01</span>
+              <span class="nav-text">Home</span>
+              <span class="nav-arrow" aria-hidden="true">↗</span>
+            </a>
+
+            <a class="nav-link" href="#components">
+              <span class="nav-number">02</span>
+              <span class="nav-text">Components</span>
+              <span class="nav-arrow" aria-hidden="true">↗</span>
+            </a>
+
+            <a class="nav-link" href="#animations">
+              <span class="nav-number">03</span>
+              <span class="nav-text">Animations</span>
+              <span class="nav-arrow" aria-hidden="true">↗</span>
+            </a>
+
+            <a class="nav-link" href="#about">
+              <span class="nav-number">04</span>
+              <span class="nav-text">About</span>
+              <span class="nav-arrow" aria-hidden="true">↗</span>
+            </a>
+          </nav>
+
+          <footer class="overlay-footer">
+            <span>Pure CSS</span>
+            <span aria-hidden="true">•</span>
+            <span>No JavaScript</span>
+            <span aria-hidden="true">•</span>
+            <span>Responsive</span>
+          </footer>
+
+        </div>
+      </div>
+    </header>
+
+    <!-- Demo content -->
+    <section class="hero" id="home">
+      <div class="hero-content">
+
+        <span class="hero-tag">CSS INTERACTION</span>
+
+        <h2>
+          Full-screen
+          <span>Overlay Menu</span>
+        </h2>
+
+        <p>
+          A modern navigation overlay built entirely with
+          semantic HTML and vanilla CSS.
+        </p>
+
+        <label class="hero-action" for="menu-toggle">
+          Explore Menu
+          <span aria-hidden="true">→</span>
+        </label>
+
+      </div>
+
+      <div class="hero-decoration" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+    </section>
+
+    <section class="demo-section" id="components">
+      <span>02</span>
+      <h2>Components</h2>
+    </section>
+
+    <section class="demo-section" id="animations">
+      <span>03</span>
+      <h2>Animations</h2>
+    </section>
+
+    <section class="demo-section" id="about">
+      <span>04</span>
+      <h2>About</h2>
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fullscreen-overlay-menu-v2/style.css
+++ b/submissions/examples/fullscreen-overlay-menu-v2/style.css
@@ -1,0 +1,1074 @@
+/* =========================================================
+   EaseMotion CSS
+   Full-screen Overlay Menu
+   Pure HTML + CSS
+   ========================================================= */
+
+
+/* -----------------------------
+   Design Tokens
+   ----------------------------- */
+
+   :root {
+    --color-bg: #0a0a0c;
+    --color-surface: #111116;
+    --color-text: #f5f5f7;
+    --color-muted: #96969f;
+    --color-border: rgba(255, 255, 255, 0.12);
+  
+    --color-accent: #a8ff78;
+    --color-accent-soft: rgba(168, 255, 120, 0.12);
+  
+    --overlay-bg: rgba(8, 8, 10, 0.97);
+  
+    --font-display:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    --font-body:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  
+    --ease-smooth: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  
+    --header-height: 88px;
+  }
+  
+  
+  /* -----------------------------
+     Reset
+     ----------------------------- */
+  
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  html {
+    scroll-behavior: smooth;
+  }
+  
+  body {
+    margin: 0;
+    min-width: 320px;
+  
+    background: var(--color-bg);
+    color: var(--color-text);
+  
+    font-family: var(--font-body);
+    line-height: 1.5;
+  
+    overflow-x: hidden;
+  }
+  
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  
+  button,
+  label {
+    -webkit-tap-highlight-color: transparent;
+  }
+  
+  
+  /* -----------------------------
+     Page
+     ----------------------------- */
+  
+  .page {
+    min-height: 100vh;
+    background:
+      radial-gradient(
+        circle at 80% 20%,
+        rgba(168, 255, 120, 0.06),
+        transparent 30%
+      ),
+      var(--color-bg);
+  }
+  
+  
+  /* -----------------------------
+     Header
+     ----------------------------- */
+  
+  .site-header {
+    position: fixed;
+    inset: 0 0 auto;
+  
+    z-index: 100;
+  
+    height: var(--header-height);
+  
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  
+    padding-inline: clamp(1.25rem, 5vw, 5rem);
+  
+    isolation: isolate;
+  }
+  
+  
+  /* -----------------------------
+     Brand
+     ----------------------------- */
+  
+  .brand {
+    position: relative;
+    z-index: 110;
+  
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+  
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  
+    transition:
+      opacity 300ms ease,
+      transform 300ms var(--ease-smooth);
+  }
+  
+  .brand:hover {
+    transform: translateY(-2px);
+  }
+  
+  .brand-mark {
+    width: 34px;
+    height: 34px;
+  
+    display: grid;
+    place-items: center;
+  
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+  
+    color: var(--color-bg);
+    background: var(--color-accent);
+  
+    font-weight: 900;
+  }
+  
+  
+  /* -----------------------------
+     Menu Toggle
+     ----------------------------- */
+  
+  .menu-toggle {
+    position: absolute;
+  
+    width: 1px;
+    height: 1px;
+  
+    opacity: 0;
+    pointer-events: none;
+  }
+  
+  
+  /* -----------------------------
+     Menu Button
+     ----------------------------- */
+  
+  .menu-button {
+    position: relative;
+    z-index: 110;
+  
+    width: 108px;
+    height: 46px;
+  
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+  
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+  
+    background: rgba(255, 255, 255, 0.04);
+  
+    color: var(--color-text);
+  
+    cursor: pointer;
+  
+    user-select: none;
+  
+    transition:
+      background 300ms ease,
+      border-color 300ms ease,
+      transform 300ms var(--ease-bounce);
+  }
+  
+  .menu-button:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.25);
+    transform: scale(1.03);
+  }
+  
+  .menu-button:active {
+    transform: scale(0.96);
+  }
+  
+  
+  /* -----------------------------
+     Hamburger
+     ----------------------------- */
+  
+  .menu-icon {
+    width: 18px;
+    height: 14px;
+  
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  
+  .menu-icon span {
+    display: block;
+  
+    width: 100%;
+    height: 1.5px;
+  
+    border-radius: 999px;
+  
+    background: currentColor;
+  
+    transform-origin: center;
+  
+    transition:
+      transform 500ms var(--ease-smooth),
+      opacity 300ms ease;
+  }
+  
+  
+  /* -----------------------------
+     Menu Labels
+     ----------------------------- */
+  
+  .menu-label {
+    position: relative;
+  
+    width: 38px;
+    height: 20px;
+  
+    overflow: hidden;
+  
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  
+  .open-label,
+  .close-label {
+    position: absolute;
+    inset: 0;
+  
+    display: grid;
+    place-items: center;
+  
+    transition:
+      transform 500ms var(--ease-smooth),
+      opacity 300ms ease;
+  }
+  
+  .close-label {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  
+  
+  /* -----------------------------
+     Full-screen Overlay
+     ----------------------------- */
+  
+  .overlay {
+    position: fixed;
+    inset: 0;
+  
+    z-index: 90;
+  
+    min-height: 100svh;
+  
+    display: flex;
+    align-items: center;
+  
+    overflow: hidden;
+  
+    background: var(--overlay-bg);
+  
+    visibility: hidden;
+    pointer-events: none;
+  
+    clip-path: circle(0% at calc(100% - 4rem) 2.75rem);
+  
+    transition:
+      clip-path 900ms var(--ease-smooth),
+      visibility 0s linear 900ms;
+  }
+  
+  
+  /* Open state */
+  
+  .menu-toggle:checked ~ .overlay {
+    visibility: visible;
+    pointer-events: auto;
+  
+    clip-path: circle(
+      150% at calc(100% - 4rem) 2.75rem
+    );
+  
+    transition:
+      clip-path 900ms var(--ease-smooth),
+      visibility 0s linear;
+  }
+  
+  
+  /* -----------------------------
+     Overlay Background
+     ----------------------------- */
+  
+  .overlay-background {
+    position: absolute;
+    inset: 0;
+  
+    pointer-events: none;
+    overflow: hidden;
+  }
+  
+  .background-circle {
+    position: absolute;
+  
+    border-radius: 50%;
+  
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  
+    animation: slowFloat 10s ease-in-out infinite alternate;
+  }
+  
+  .circle-one {
+    width: 55vw;
+    height: 55vw;
+  
+    right: -20vw;
+    top: -20vw;
+  }
+  
+  .circle-two {
+    width: 35vw;
+    height: 35vw;
+  
+    left: -15vw;
+    bottom: -15vw;
+  
+    animation-delay: -3s;
+  }
+  
+  .background-grid {
+    position: absolute;
+    inset: 0;
+  
+    opacity: 0.25;
+  
+    background-image:
+      linear-gradient(
+        rgba(255, 255, 255, 0.04) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.04) 1px,
+        transparent 1px
+      );
+  
+    background-size: 70px 70px;
+  
+    mask-image:
+      linear-gradient(
+        to bottom,
+        black,
+        transparent 90%
+      );
+  }
+  
+  
+  /* -----------------------------
+     Overlay Content
+     ----------------------------- */
+  
+  .overlay-content {
+    position: relative;
+    z-index: 2;
+  
+    width: min(1200px, 100%);
+  
+    margin-inline: auto;
+  
+    padding:
+      calc(var(--header-height) + 3rem)
+      clamp(1.25rem, 7vw, 7rem)
+      3rem;
+  
+    display: grid;
+  
+    grid-template-columns:
+      minmax(220px, 0.8fr)
+      minmax(320px, 1.2fr);
+  
+    gap: clamp(3rem, 8vw, 9rem);
+  
+    align-items: center;
+  }
+  
+  
+  /* -----------------------------
+     Intro
+     ----------------------------- */
+  
+  .overlay-intro {
+    max-width: 460px;
+  }
+  
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+  
+    margin-bottom: 1.25rem;
+  
+    color: var(--color-accent);
+  
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  
+    opacity: 0;
+    transform: translateY(25px);
+  }
+  
+  .eyebrow::before {
+    content: "";
+  
+    width: 24px;
+    height: 1px;
+  
+    background: currentColor;
+  }
+  
+  .overlay-intro h1 {
+    margin: 0;
+  
+    font-family: var(--font-display);
+  
+    font-size: clamp(3rem, 6vw, 6rem);
+  
+    line-height: 0.95;
+    letter-spacing: -0.065em;
+  
+    font-weight: 800;
+  
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  
+  .overlay-intro h1 span {
+    display: block;
+    color: var(--color-accent);
+  }
+  
+  .overlay-intro p {
+    max-width: 400px;
+  
+    margin: 1.75rem 0 0;
+  
+    color: var(--color-muted);
+  
+    font-size: clamp(0.9rem, 1.5vw, 1.05rem);
+  
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  
+  
+  /* -----------------------------
+     Navigation
+     ----------------------------- */
+  
+  .overlay-navigation {
+    width: 100%;
+  }
+  
+  .nav-link {
+    position: relative;
+  
+    min-height: 82px;
+  
+    display: grid;
+  
+    grid-template-columns: 55px 1fr 35px;
+  
+    align-items: center;
+  
+    border-bottom: 1px solid var(--color-border);
+  
+    overflow: hidden;
+  
+    opacity: 0;
+    transform: translateY(50px);
+  
+    transition:
+      color 300ms ease,
+      padding 400ms var(--ease-smooth);
+  }
+  
+  .nav-link::before {
+    content: "";
+  
+    position: absolute;
+    inset: auto 0 0;
+  
+    height: 100%;
+  
+    background: var(--color-accent-soft);
+  
+    transform: translateY(100%);
+  
+    transition: transform 500ms var(--ease-smooth);
+  
+    z-index: -1;
+  }
+  
+  .nav-link:hover,
+  .nav-link:focus-visible {
+    color: var(--color-accent);
+  
+    padding-inline: 1rem;
+  }
+  
+  .nav-link:hover::before,
+  .nav-link:focus-visible::before {
+    transform: translateY(0);
+  }
+  
+  .nav-link:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 4px;
+  }
+  
+  .nav-number {
+    color: var(--color-muted);
+  
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+  
+  .nav-text {
+    font-size: clamp(1.8rem, 4vw, 3.5rem);
+  
+    line-height: 1;
+  
+    font-weight: 700;
+  
+    letter-spacing: -0.045em;
+  }
+  
+  .nav-arrow {
+    font-size: 1.4rem;
+  
+    transform: translate(-5px, 5px);
+  
+    transition:
+      transform 400ms var(--ease-bounce);
+  }
+  
+  .nav-link:hover .nav-arrow,
+  .nav-link:focus-visible .nav-arrow {
+    transform: translate(0, 0);
+  }
+  
+  
+  /* -----------------------------
+     Footer
+     ----------------------------- */
+  
+  .overlay-footer {
+    grid-column: 1 / -1;
+  
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+  
+    color: var(--color-muted);
+  
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  
+  
+  /* =========================================================
+     OPEN ANIMATION SEQUENCE
+     ========================================================= */
+  
+  .menu-toggle:checked ~ .overlay
+  .overlay-intro .eyebrow {
+    animation:
+      revealItem 700ms var(--ease-smooth) 250ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .overlay-intro h1 {
+    animation:
+      revealItem 800ms var(--ease-smooth) 320ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .overlay-intro p {
+    animation:
+      revealItem 700ms var(--ease-smooth) 430ms forwards;
+  }
+  
+  
+  /* Navigation stagger */
+  
+  .menu-toggle:checked ~ .overlay
+  .nav-link:nth-child(1) {
+    animation:
+      revealItem 700ms var(--ease-smooth) 420ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .nav-link:nth-child(2) {
+    animation:
+      revealItem 700ms var(--ease-smooth) 500ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .nav-link:nth-child(3) {
+    animation:
+      revealItem 700ms var(--ease-smooth) 580ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .nav-link:nth-child(4) {
+    animation:
+      revealItem 700ms var(--ease-smooth) 660ms forwards;
+  }
+  
+  .menu-toggle:checked ~ .overlay
+  .overlay-footer {
+    animation:
+      revealItem 600ms var(--ease-smooth) 780ms forwards;
+  }
+  
+  
+  /* -----------------------------
+     Toggle → Hamburger Animation
+     ----------------------------- */
+  
+  .menu-toggle:checked ~ .menu-button .menu-icon span:nth-child(1) {
+    transform: translateY(6.25px) rotate(45deg);
+  }
+  
+  .menu-toggle:checked ~ .menu-button .menu-icon span:nth-child(2) {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+  
+  .menu-toggle:checked ~ .menu-button .menu-icon span:nth-child(3) {
+    transform: translateY(-6.25px) rotate(-45deg);
+  }
+  
+  .menu-toggle:checked ~ .menu-button .open-label {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  
+  .menu-toggle:checked ~ .menu-button .close-label {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  
+  
+  /* -----------------------------
+     Hero
+     ----------------------------- */
+  
+  .hero {
+    min-height: 100svh;
+  
+    display: grid;
+    place-items: center;
+  
+    position: relative;
+  
+    padding:
+      calc(var(--header-height) + 3rem)
+      1.5rem
+      4rem;
+  }
+  
+  .hero-content {
+    width: min(900px, 100%);
+    text-align: center;
+  }
+  
+  .hero-tag {
+    display: inline-block;
+  
+    margin-bottom: 1.5rem;
+  
+    color: var(--color-accent);
+  
+    font-size: 0.7rem;
+    font-weight: 800;
+  
+    letter-spacing: 0.15em;
+  }
+  
+  .hero h2 {
+    margin: 0;
+  
+    font-size: clamp(3.2rem, 9vw, 8rem);
+  
+    line-height: 0.9;
+  
+    letter-spacing: -0.07em;
+  }
+  
+  .hero h2 span {
+    display: block;
+    color: var(--color-muted);
+  }
+  
+  .hero p {
+    width: min(520px, 100%);
+  
+    margin: 2rem auto;
+  
+    color: var(--color-muted);
+  }
+  
+  .hero-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 1rem;
+  
+    padding: 0.9rem 1.2rem;
+  
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+  
+    cursor: pointer;
+  
+    font-size: 0.8rem;
+    font-weight: 700;
+  
+    transition:
+      background 300ms ease,
+      color 300ms ease,
+      transform 300ms var(--ease-bounce);
+  }
+  
+  .hero-action:hover {
+    color: var(--color-bg);
+    background: var(--color-accent);
+  
+    transform: translateY(-3px);
+  }
+  
+  .hero-action span {
+    transition: transform 300ms var(--ease-bounce);
+  }
+  
+  .hero-action:hover span {
+    transform: translateX(4px);
+  }
+  
+  
+  /* -----------------------------
+     Decorative Hero Element
+     ----------------------------- */
+  
+  .hero-decoration {
+    position: absolute;
+  
+    right: 8%;
+    bottom: 10%;
+  
+    display: flex;
+    gap: 5px;
+  
+    transform: rotate(-25deg);
+  }
+  
+  .hero-decoration span {
+    display: block;
+  
+    width: 2px;
+    height: 80px;
+  
+    background: var(--color-border);
+  }
+  
+  .hero-decoration span:nth-child(2) {
+    height: 120px;
+  }
+  
+  .hero-decoration span:nth-child(3) {
+    height: 55px;
+  }
+  
+  
+  /* -----------------------------
+     Demo Sections
+     ----------------------------- */
+  
+  .demo-section {
+    min-height: 70vh;
+  
+    display: grid;
+    place-content: center;
+  
+    padding: 5rem 1.5rem;
+  
+    border-top: 1px solid var(--color-border);
+  }
+  
+  .demo-section span {
+    margin-bottom: 1rem;
+  
+    color: var(--color-accent);
+  
+    font-size: 0.75rem;
+    font-weight: 800;
+  }
+  
+  .demo-section h2 {
+    margin: 0;
+  
+    font-size: clamp(3rem, 8vw, 7rem);
+  
+    letter-spacing: -0.06em;
+  }
+  
+  
+  /* =========================================================
+     KEYFRAMES
+     ========================================================= */
+  
+  @keyframes revealItem {
+    from {
+      opacity: 0;
+      transform: translateY(40px);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes slowFloat {
+    from {
+      transform: translate3d(0, 0, 0) rotate(0deg);
+    }
+  
+    to {
+      transform: translate3d(20px, -20px, 0) rotate(5deg);
+    }
+  }
+  
+  
+  /* =========================================================
+     RESPONSIVE
+     ========================================================= */
+  
+  @media (max-width: 800px) {
+  
+    :root {
+      --header-height: 76px;
+    }
+  
+    .site-header {
+      padding-inline: 1rem;
+    }
+  
+    .menu-button {
+      width: 96px;
+      height: 42px;
+    }
+  
+    .overlay {
+      align-items: flex-start;
+  
+      overflow-y: auto;
+  
+      clip-path: circle(
+        0% at calc(100% - 3rem) 2.4rem
+      );
+    }
+  
+    .menu-toggle:checked ~ .overlay {
+      clip-path: circle(
+        160% at calc(100% - 3rem) 2.4rem
+      );
+    }
+  
+    .overlay-content {
+      min-height: 100svh;
+  
+      grid-template-columns: 1fr;
+  
+      gap: 2.5rem;
+  
+      padding:
+        calc(var(--header-height) + 3rem)
+        1.25rem
+        2rem;
+    }
+  
+    .overlay-intro {
+      max-width: 600px;
+    }
+  
+    .overlay-intro h1 {
+      font-size: clamp(3rem, 14vw, 5rem);
+    }
+  
+    .nav-link {
+      min-height: 70px;
+  
+      grid-template-columns: 40px 1fr 25px;
+    }
+  
+    .nav-text {
+      font-size: clamp(1.7rem, 8vw, 3rem);
+    }
+  
+    .overlay-footer {
+      grid-column: auto;
+  
+      flex-wrap: wrap;
+    }
+  
+    .background-circle {
+      opacity: 0.5;
+    }
+  }
+  
+  
+  /* Small phones */
+  
+  @media (max-width: 480px) {
+  
+    .brand > span:last-child {
+      display: none;
+    }
+  
+    .menu-button {
+      width: 92px;
+    }
+  
+    .overlay-content {
+      gap: 2rem;
+    }
+  
+    .overlay-intro p {
+      margin-top: 1.25rem;
+    }
+  
+    .nav-link {
+      min-height: 64px;
+    }
+  
+    .nav-number {
+      font-size: 0.62rem;
+    }
+  
+    .nav-arrow {
+      font-size: 1rem;
+    }
+  
+    .overlay-footer {
+      font-size: 0.58rem;
+    }
+  }
+  
+  
+  /* =========================================================
+     ACCESSIBILITY
+     ========================================================= */
+  
+  @media (prefers-reduced-motion: reduce) {
+  
+    html {
+      scroll-behavior: auto;
+    }
+  
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  
+    .overlay {
+      clip-path: none;
+  
+      opacity: 0;
+      transition: opacity 200ms ease;
+    }
+  
+    .menu-toggle:checked ~ .overlay {
+      opacity: 1;
+    }
+  }
+  
+  
+  /* Keyboard focus */
+  
+  .menu-button:focus-within {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 4px;
+  }
+  
+  
+  /* High contrast support */
+  
+  @media (forced-colors: active) {
+  
+    .menu-button,
+    .nav-link {
+      border: 1px solid CanvasText;
+    }
+  
+    .menu-icon span {
+      background: CanvasText;
+    }
+  
+    .nav-link:focus-visible,
+    .menu-button:focus-within {
+      outline: 2px solid Highlight;
+    }
+  }


### PR DESCRIPTION
## Description

Implemented the CSS Full-screen Overlay Menu requested in #70196.

### ✨ Features

- Pure HTML + Vanilla CSS
- CSS-only menu toggle
- Full-screen circular reveal
- Staggered navigation link animations
- Animated hamburger/close icon
- Responsive desktop and mobile layouts
- Keyboard focus states
- `prefers-reduced-motion` support
- High-contrast mode support
- No external dependencies

### 📁 Files Added

- `submissions/examples/fullscreen-overlay-menu/demo.html`
- `submissions/examples/fullscreen-overlay-menu/style.css`
- `submissions/examples/fullscreen-overlay-menu/README.md`

### 🧪 Testing

- Tested desktop layout
- Tested mobile layout
- Tested menu open/close
- Tested keyboard focus
- Tested reduced-motion behavior
- Ran `git diff --check`

Closes #70196