### PR TITLE
feat: add ease-anvil-drop-forge-ij demo component

### DIFF
--- a/submissions/examples/ease-anvil-drop-forge-ij/README.md
+++ b/submissions/examples/ease-anvil-drop-forge-ij/README.md
@@ -1,0 +1,23 @@
+# Anvil Drop Forge
+
+A blacksmith hammer that swings down and strikes an anvil, popping a spark flash at the point of impact.
+
+## How is it used?
+
+The hammer is a rotated bar whose `transform-origin` sits at the top pivot. Clicking the button toggles `.swing`:
+
+```html
+<div class="hammer" id="hammer"></div>
+```
+
+```css
+.hammer.swing {
+  animation: hammer-hit 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+```
+
+The demo re-triggers the animation by removing the class, forcing a reflow with `offsetWidth`, then re-adding it. The `.spark-ring` runs a parallel `spark-pop` keyframe that scales up and fades out exactly when the hammer reaches the anvil.
+
+## Why is it useful?
+
+A single springy overshoot curve sells the weight of a striking tool. The same `transform-origin` + rotate trick powers any lever or seesaw motion, and the coincident flash gives the impact a satisfying cause-and-effect — a compact pattern for physical-feeling UI moments.

--- a/submissions/examples/ease-anvil-drop-forge-ij/demo.html
+++ b/submissions/examples/ease-anvil-drop-forge-ij/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anvil Drop Forge Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="forge">
+    <div class="hammer" id="hammer" aria-hidden="true"></div>
+    <div class="anvil" id="anvil" aria-hidden="true">
+      <span class="anvil-horn"></span>
+      <span class="anvil-body"></span>
+      <span class="anvil-base"></span>
+      <span class="spark-ring" id="sparkRing"></span>
+    </div>
+    <button class="strike-btn" id="strikeBtn" type="button">Strike Forge</button>
+    <p class="hint">A dropped hammer pounds the anvil with a spark flash.</p>
+  </main>
+  <script>
+    const forge = document.getElementById("hammer");
+    const spark = document.getElementById("sparkRing");
+    const btn = document.getElementById("strikeBtn");
+    function strike() {
+      forge.classList.remove("swing");
+      spark.classList.remove("flash");
+      void forge.offsetWidth;
+      void spark.offsetWidth;
+      forge.classList.add("swing");
+      spark.classList.add("flash");
+    }
+    btn.addEventListener("click", strike);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-anvil-drop-forge-ij/style.css
+++ b/submissions/examples/ease-anvil-drop-forge-ij/style.css
@@ -1,0 +1,176 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1c1512;
+  font-family: system-ui, sans-serif;
+}
+
+.forge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.hammer {
+  position: relative;
+  width: 12px;
+  height: 110px;
+  background: linear-gradient(90deg, #7a4a2b, #a9713c 40%, #7a4a2b);
+  border-radius: 4px;
+  transform-origin: 50% 0;
+  transform: rotate(38deg);
+}
+
+.hammer::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: -12px;
+  width: 36px;
+  height: 12px;
+  background: #33312e;
+  border-radius: 4px;
+}
+
+.hammer::after {
+  content: "";
+  position: absolute;
+  top: -7px;
+  left: 10px;
+  width: 46px;
+  height: 26px;
+  background: linear-gradient(180deg, #9aa0a8, #5c6168);
+  border-radius: 6px;
+}
+
+.hammer.swing {
+  animation: hammer-hit 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes hammer-hit {
+  0% {
+    transform: rotate(38deg);
+  }
+  55% {
+    transform: rotate(4deg);
+  }
+  70% {
+    transform: rotate(6deg);
+  }
+  100% {
+    transform: rotate(38deg);
+  }
+}
+
+.anvil {
+  position: relative;
+  width: 120px;
+  height: 84px;
+}
+
+.anvil-horn {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 62px;
+  height: 30px;
+  background: linear-gradient(180deg, #7d8289, #4a4e54);
+  border-radius: 20px 6px 6px 6px;
+}
+
+.anvil-body {
+  position: absolute;
+  top: 18px;
+  left: 28px;
+  width: 68px;
+  height: 34px;
+  background: #565b62;
+  border-radius: 4px;
+}
+
+.anvil-base {
+  position: absolute;
+  top: 46px;
+  left: 20px;
+  width: 84px;
+  height: 26px;
+  background: linear-gradient(180deg, #6a6f76, #43474d);
+  border-radius: 4px 4px 10px 10px;
+}
+
+.spark-ring {
+  position: absolute;
+  top: -8px;
+  left: 44px;
+  width: 34px;
+  height: 18px;
+  opacity: 0;
+}
+
+.spark-ring::before,
+.spark-ring::after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 15px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #ffc43d;
+}
+
+.spark-ring::after {
+  left: 5px;
+  top: 0;
+}
+
+.spark-ring.flash {
+  animation: spark-pop 0.5s ease-out both;
+}
+
+@keyframes spark-pop {
+  0% {
+    opacity: 1;
+    transform: scale(0.4);
+  }
+  70% {
+    opacity: 0.9;
+    transform: scale(1.6);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(2.2);
+  }
+}
+
+.strike-btn {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #ff7a3d;
+  color: #1c1512;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.strike-btn:hover {
+  background: #ff935f;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #d8b59a;
+  font-size: 13px;
+  opacity: 0.75;
+}


### PR DESCRIPTION
Adds a working `ease-anvil-drop-forge-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-anvil-drop-forge-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.