### PR TITLE
feat: add ease-cassette-tape-load-ij demo component

### DIFF
--- a/submissions/examples/ease-cassette-tape-load-ij/README.md
+++ b/submissions/examples/ease-cassette-tape-load-ij/README.md
@@ -1,0 +1,22 @@
+# Cassette Tape Load
+
+A cassette deck where the tape slides into the well with a springy settle and the reels start spinning.
+
+## How is it used?
+
+Toggling `.loaded` on the cassette moves it into the deck and flips the reels to `running`:
+
+```css
+.cassette {
+  top: 62px;
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), top 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.cassette.loaded { top: 82px; }
+.cassette.loaded .reel { animation-play-state: running; }
+```
+
+`animation-play-state` lets one toggle pause or play the reel spin without restarting the timeline — the counter-rotating reels use `animation-direction: reverse` on the second reel.
+
+## Why is it useful?
+
+This is a tidy pairing of a transitioned entry motion with an independently-gated infinite animation. The play/pause pattern via a class switch is the same mechanism behind audio players, weather widgets and any "widget starts animating when visible" behavior, all without touching the animation timeline itself.

--- a/submissions/examples/ease-cassette-tape-load-ij/demo.html
+++ b/submissions/examples/ease-cassette-tape-load-ij/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cassette Tape Load Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="deck" aria-label="cassette deck">
+    <div class="cassette" id="cassette" aria-hidden="true">
+      <span class="reel rl"></span>
+      <span class="reel rr"></span>
+      <span class="window-label">EaseMotion 90</span>
+    </div>
+    <div class="well" aria-hidden="true"></div>
+    <button class="eject-btn" id="ejectBtn" type="button">Load Cassette</button>
+    <p class="hint">The tape glides in and the reels begin to spin.</p>
+  </main>
+  <script>
+    const cassette = document.getElementById("cassette");
+    const btn = document.getElementById("ejectBtn");
+    btn.addEventListener("click", () => {
+      cassette.classList.toggle("loaded");
+      btn.textContent = cassette.classList.contains("loaded") ? "Eject Cassette" : "Load Cassette";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-cassette-tape-load-ij/style.css
+++ b/submissions/examples/ease-cassette-tape-load-ij/style.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #12151c;
+  font-family: system-ui, sans-serif;
+}
+
+.deck {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  background: linear-gradient(180deg, #2b303b, #191d26);
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.5);
+}
+
+.well {
+  position: absolute;
+  top: 30px;
+  width: 200px;
+  height: 46px;
+  background: #0b0e14;
+  border-radius: 6px;
+  border: 1px solid #000;
+}
+
+.cassette {
+  position: absolute;
+  top: 62px;
+  width: 170px;
+  height: 106px;
+  background: linear-gradient(180deg, #3d4453, #2a303c);
+  border-radius: 8px;
+  border: 1px solid #14181f;
+  transform: translateY(0);
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), top 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 2;
+}
+
+.cassette.loaded {
+  top: 82px;
+}
+
+.reel {
+  position: absolute;
+  top: 24px;
+  width: 38px;
+  height: 38px;
+  border: 5px solid #c9a24b;
+  border-radius: 50%;
+  background: #171b22;
+  animation: reel-spin 2.4s linear infinite;
+  animation-play-state: paused;
+}
+
+.rl {
+  left: 22px;
+}
+
+.rr {
+  right: 22px;
+  animation-direction: reverse;
+}
+
+.cassette.loaded .reel {
+  animation-play-state: running;
+}
+
+@keyframes reel-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.window-label {
+  position: absolute;
+  top: 78px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #8d95a6;
+  font-size: 9px;
+  letter-spacing: 1px;
+}
+
+.eject-btn {
+  position: absolute;
+  bottom: 18px;
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #c9a24b;
+  color: #14181f;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.eject-btn:hover {
+  background: #ddb85f;
+  transform: translateY(-2px);
+}
+
+.hint {
+  position: absolute;
+  bottom: -34px;
+  color: #8d95a6;
+  font-size: 12px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Adds a working `ease-cassette-tape-load-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-cassette-tape-load-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.