### PR TITLE
feat: add ease-constellation-connect-ij demo component

### DIFF
--- a/submissions/examples/ease-constellation-connect-ij/README.md
+++ b/submissions/examples/ease-constellation-connect-ij/README.md
@@ -1,0 +1,24 @@
+# Constellation Connect
+
+A night-sky panel where five stars twinkle and connecting lines draw themselves between them, forming a constellation.
+
+## How is it used?
+
+Each `.line` is a 2px gradient bar anchored at its left end, then grown with a scaleX transition:
+
+```css
+.line {
+  transform-origin: 0 50%;
+  animation: line-draw 1.4s ease-out both;
+}
+@keyframes line-draw {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+```
+
+The lines are rotated to their target angles with `transform: rotate(...)`, and staggered `animation-delay` makes them draw in sequence after the stars have twinkled on. Stars twinkle with a shared opacity/scale keyframe offset by their own delays.
+
+## Why is it useful?
+
+Line-drawing via `scaleX` from a `transform-origin` is a reusable entrance for SVG-like connectors, dividers, and timelines. Pairing it with staggered delays creates a natural "system coming online" sequence — a pattern that fits loading states, onboarding diagrams, and data-junction visualizations.

--- a/submissions/examples/ease-constellation-connect-ij/demo.html
+++ b/submissions/examples/ease-constellation-connect-ij/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Constellation Connect Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="sky" aria-label="constellation">
+    <span class="star s1" id="s1"></span>
+    <span class="star s2" id="s2"></span>
+    <span class="star s3" id="s3"></span>
+    <span class="star s4" id="s4"></span>
+    <span class="star s5" id="s5"></span>
+    <span class="line l1" aria-hidden="true"></span>
+    <span class="line l2" aria-hidden="true"></span>
+    <span class="line l3" aria-hidden="true"></span>
+    <span class="line l4" aria-hidden="true"></span>
+    <p class="label">Orion's Bow</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-constellation-connect-ij/style.css
+++ b/submissions/examples/ease-constellation-connect-ij/style.css
@@ -1,0 +1,136 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #060a18;
+  font-family: system-ui, sans-serif;
+}
+
+.sky {
+  position: relative;
+  width: 340px;
+  height: 240px;
+  background: radial-gradient(ellipse at 50% 40%, #101a3a, #060a18 70%);
+  border-radius: 16px;
+  border: 1px solid #223057;
+}
+
+.star {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #dbe7ff;
+  box-shadow: 0 0 10px #dbe7ff;
+  animation: star-twinkle 2.4s ease-in-out infinite;
+}
+
+.star::before {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  background: radial-gradient(circle, rgba(219, 231, 255, 0.4), transparent 70%);
+}
+
+.s1 {
+  top: 52px;
+  left: 66px;
+}
+
+.s2 {
+  top: 34px;
+  left: 170px;
+  animation-delay: 0.3s;
+}
+
+.s3 {
+  top: 90px;
+  left: 238px;
+  animation-delay: 0.6s;
+}
+
+.s4 {
+  top: 160px;
+  left: 190px;
+  animation-delay: 0.9s;
+}
+
+.s5 {
+  top: 178px;
+  left: 96px;
+  animation-delay: 1.2s;
+}
+
+@keyframes star-twinkle {
+  50% {
+    opacity: 0.45;
+    transform: scale(0.8);
+  }
+}
+
+.line {
+  position: absolute;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(150, 185, 255, 0.9), rgba(150, 185, 255, 0.1));
+  transform-origin: 0 50%;
+  animation: line-draw 1.4s ease-out both;
+}
+
+.l1 {
+  top: 76px;
+  left: 68px;
+  width: 104px;
+  transform: rotate(-10deg);
+  animation-delay: 0.4s;
+}
+
+.l2 {
+  top: 56px;
+  left: 172px;
+  width: 70px;
+  transform: rotate(37deg);
+  animation-delay: 0.8s;
+}
+
+.l3 {
+  top: 106px;
+  left: 240px;
+  width: 94px;
+  transform: rotate(131deg);
+  animation-delay: 1.2s;
+}
+
+.l4 {
+  top: 172px;
+  left: 100px;
+  width: 92px;
+  transform: rotate(-27deg);
+  animation-delay: 1.6s;
+}
+
+@keyframes line-draw {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.label {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #7d93c9;
+  font-size: 11px;
+  letter-spacing: 3px;
+}


### PR DESCRIPTION
Adds a working `ease-constellation-connect-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-constellation-connect-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.