### PR TITLE
feat: add ease-eclipse-moon-overlay-ij demo component

### DIFF
--- a/submissions/examples/ease-eclipse-moon-overlay-ij/README.md
+++ b/submissions/examples/ease-eclipse-moon-overlay-ij/README.md
@@ -1,0 +1,21 @@
+# Eclipse Moon Overlay
+
+A sun with a glowing corona that is slowly swallowed by a dark moon, dimming the whole scene.
+
+## How is it used?
+
+The moon sits off-screen and glides over the sun via a transition:
+
+```css
+.moon {
+  transform: translateX(220px);
+  transition: transform 1.4s cubic-bezier(0.65, 0, 0.35, 1);
+}
+.moon.covering { transform: translateX(0); }
+```
+
+Toggling `.covering` slides the moon into place. A parent `.dark` state can additionally swap the scene's background gradient, so the whole sky darkens in sync with the same click. The `z-index` keeps the moon over the sun while the button and caption stay clickable.
+
+## Why is it useful?
+
+This is an overlay/interruption pattern: an element translated in from off-canvas, layered over content, then removed. The same translate-with-z-index choreography drives modals, tour spotlights, and "peek" panels, and pairing it with a timed color shift shows how to coordinate multiple elements on a single state toggle.

--- a/submissions/examples/ease-eclipse-moon-overlay-ij/demo.html
+++ b/submissions/examples/ease-eclipse-moon-overlay-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eclipse Moon Overlay Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="sky-eclipse" aria-label="solar eclipse">
+    <div class="sun" aria-hidden="true"></div>
+    <div class="moon" id="moon" aria-hidden="true"></div>
+    <div class="corona" aria-hidden="true"></div>
+    <button class="eclipse-btn" id="eclipseBtn" type="button">Toggle Eclipse</button>
+    <p class="caption">The moon slides over the sun, dimming the sky.</p>
+  </main>
+  <script>
+    const moon = document.getElementById("moon");
+    const btn = document.getElementById("eclipseBtn");
+    btn.addEventListener("click", () => {
+      moon.classList.toggle("covering");
+      btn.textContent = moon.classList.contains("covering") ? "Release Eclipse" : "Toggle Eclipse";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-eclipse-moon-overlay-ij/style.css
+++ b/submissions/examples/ease-eclipse-moon-overlay-ij/style.css
@@ -1,0 +1,109 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0d0d16;
+  font-family: system-ui, sans-serif;
+}
+
+.sky-eclipse {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #1c2340 0%, #101426 55%, #0a0b14 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 26px;
+  overflow: hidden;
+  transition: background 1.2s ease;
+}
+
+.sky-eclipse.dark {
+  background: radial-gradient(circle, #080910 0%, #05060b 60%, #020204 100%);
+}
+
+.sun {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 120px;
+  height: 120px;
+  margin: -60px 0 0 -60px;
+  background: radial-gradient(circle, #fff7d6 0%, #ffd75e 45%, #ff9d2e 75%, rgba(255, 157, 46, 0) 100%);
+  border-radius: 50%;
+}
+
+.corona {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 200px;
+  height: 200px;
+  margin: -100px 0 0 -100px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 220, 140, 0.35) 30%, rgba(255, 200, 100, 0) 62%);
+  opacity: 0.6;
+  animation: corona-pulse 3.5s ease-in-out infinite;
+}
+
+@keyframes corona-pulse {
+  50% {
+    transform: scale(1.08);
+    opacity: 0.9;
+  }
+}
+
+.moon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 118px;
+  height: 118px;
+  margin: -59px 0 0 -59px;
+  background: radial-gradient(circle at 38% 34%, #3a3f4d, #171a22 70%);
+  border-radius: 50%;
+  transform: translateX(220px);
+  transition: transform 1.4s cubic-bezier(0.65, 0, 0.35, 1);
+  z-index: 2;
+}
+
+.moon.covering {
+  transform: translateX(0);
+}
+
+.eclipse-btn {
+  position: absolute;
+  bottom: 22px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 20px;
+  background: #ffd75e;
+  color: #0d0d16;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.eclipse-btn:hover {
+  transform: translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 22px;
+  color: #9aa3c4;
+  font-size: 12px;
+  z-index: 3;
+}


### PR DESCRIPTION
Adds a working `ease-eclipse-moon-overlay-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-eclipse-moon-overlay-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.