### PR TITLE
feat: add ease-hydraulic-press-crush-ij demo component

### DIFF
--- a/submissions/examples/ease-hydraulic-press-crush-ij/README.md
+++ b/submissions/examples/ease-hydraulic-press-crush-ij/README.md
@@ -1,0 +1,26 @@
+# Hydraulic Press Crush
+
+A two-post hydraulic press whose ram lowers and flattens an object on the table.
+
+## How is it used?
+
+Two independent transitions coordinate the crush — the arm slides down while the object squashes:
+
+```css
+.press-arm {
+  transition: top 0.8s cubic-bezier(0.65, 0, 0.35, 1);
+}
+.press-arm.down { top: 190px; }
+
+.object {
+  transition: transform 0.45s ease, height 0.45s ease;
+  transform-origin: 50% 100%;
+}
+.object.squashed { height: 30px; transform: translateX(-50%) scale(1.25, 0.9); }
+```
+
+The arm moves on a longer, eased transition while the object compresses on a shorter one, so the squash reads as an impact. The ball of the `::after` ram lands exactly on the object's top edge at `top: 190px`.
+
+## Why is it useful?
+
+Mismatched transition durations — fast on the thing being hit, slower on the thing hitting — is how you fake impact without physics. It's the same technique behind button press feedback, collision states in games, and any compress-and-release interaction.

--- a/submissions/examples/ease-hydraulic-press-crush-ij/demo.html
+++ b/submissions/examples/ease-hydraulic-press-crush-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hydraulic Press Crush Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="press" aria-label="hydraulic press">
+    <div class="press-arm" id="pressArm" aria-hidden="true"></div>
+    <div class="press-post post-l" aria-hidden="true"></div>
+    <div class="press-post post-r" aria-hidden="true"></div>
+    <div class="object" id="object" aria-hidden="true"></div>
+    <div class="table" aria-hidden="true"></div>
+    <button class="crush-btn" id="crushBtn" type="button">Crush</button>
+    <p class="caption">The ram comes down and squashes the object.</p>
+  </main>
+  <script>
+    const arm = document.getElementById("pressArm");
+    const object = document.getElementById("object");
+    const btn = document.getElementById("crushBtn");
+    function crush() {
+      arm.classList.remove("down");
+      object.classList.remove("squashed");
+      void arm.offsetWidth;
+      object.classList.add("squashed");
+      arm.classList.add("down");
+    }
+    btn.addEventListener("click", crush);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hydraulic-press-crush-ij/style.css
+++ b/submissions/examples/ease-hydraulic-press-crush-ij/style.css
@@ -1,0 +1,126 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #101318;
+  font-family: system-ui, sans-serif;
+}
+
+.press {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  background: linear-gradient(180deg, #1b2028, #12151b);
+  border-radius: 14px;
+}
+
+.press-post {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 18px;
+  background: linear-gradient(90deg, #3a4049, #5c6470 50%, #2c3138);
+}
+
+.post-l {
+  left: 18px;
+}
+
+.post-r {
+  right: 18px;
+}
+
+.table {
+  position: absolute;
+  bottom: 34px;
+  left: 14px;
+  width: 272px;
+  height: 14px;
+  background: linear-gradient(180deg, #6a7078, #454a51);
+  border-radius: 3px;
+}
+
+.press-arm {
+  position: absolute;
+  top: 40px;
+  left: 36px;
+  width: 228px;
+  height: 26px;
+  background: linear-gradient(180deg, #7a818c, #565c66);
+  border-radius: 4px;
+  transition: top 0.8s cubic-bezier(0.65, 0, 0.35, 1);
+  z-index: 2;
+}
+
+.press-arm::after {
+  content: "";
+  position: absolute;
+  bottom: -26px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 56px;
+  height: 26px;
+  background: linear-gradient(180deg, #565c66, #3a3f47);
+  border-radius: 0 0 6px 6px;
+}
+
+.press-arm.down {
+  top: 190px;
+}
+
+.object {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
+  height: 88px;
+  background: radial-gradient(circle at 40% 30%, #f2a93b, #c96f1e 65%);
+  border-radius: 8px;
+  transition: transform 0.45s ease, height 0.45s ease;
+  transform-origin: 50% 100%;
+}
+
+.object.squashed {
+  height: 30px;
+  transform: translateX(-50%) scale(1.25, 0.9);
+  background: radial-gradient(circle at 40% 30%, #f2c06b, #d98230 65%);
+}
+
+.crush-btn {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #e0871f;
+  color: #101318;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.crush-btn:hover {
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #9aa3b0;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-hydraulic-press-crush-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-hydraulic-press-crush-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.