### PR TITLE
feat: add ease-jet-engine-spool-ij demo component

### DIFF
--- a/submissions/examples/ease-jet-engine-spool-ij/README.md
+++ b/submissions/examples/ease-jet-engine-spool-ij/README.md
@@ -1,0 +1,24 @@
+# Jet Engine Spool
+
+A turbofan intake whose blades spin, the nacelle vibrates, and a shimmering heat-wave appears as the engine "spools up."
+
+## How is it used?
+
+Blades are rotated bars sharing one `blade-spin` keyframe; the engine class gates their `animation-play-state`:
+
+```css
+.blade {
+  transform-origin: 50% 26px;
+  animation: blade-spin 0.9s linear infinite;
+  animation-play-state: paused;
+}
+.nacelle.running .blade {
+  animation-play-state: running;
+}
+```
+
+Starting the engine adds `.running` to the nacelle — blades turn on, a steps-based shake jitters the housing, and a sibling `.thrust` glow transitions to visible. The `~` sibling selector wires the thrust to the same class without extra JS.
+
+## Why is it useful?
+
+Gating infinite animations with `animation-play-state` and pairing them with a transitioned "effect" layer gives a believable multi-part state change from one toggle. The steps easing is a cheap vibration trick, and the conic-gradient shimmer is reusable for any "energy" surface.

--- a/submissions/examples/ease-jet-engine-spool-ij/demo.html
+++ b/submissions/examples/ease-jet-engine-spool-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jet Engine Spool Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="engine" aria-label="jet engine">
+    <div class="nacelle" aria-hidden="true">
+      <span class="blade b0"></span>
+      <span class="blade b1"></span>
+      <span class="blade b2"></span>
+      <span class="blade b3"></span>
+      <span class="hub"></span>
+    </div>
+    <div class="shimmer" aria-hidden="true"></div>
+    <div class="thrust" aria-hidden="true"></div>
+    <button class="spool-btn" id="spoolBtn" type="button">Start Engine</button>
+    <p class="caption">The fan spools up and thrust shimmers at the intake.</p>
+  </main>
+  <script>
+    const engine = document.querySelector(".nacelle");
+    const thrust = document.querySelector(".thrust");
+    const btn = document.getElementById("spoolBtn");
+    btn.addEventListener("click", () => {
+      const on = engine.classList.toggle("running");
+      thrust.classList.toggle("blowing", on);
+      btn.textContent = on ? "Shut Down" : "Start Engine";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-jet-engine-spool-ij/style.css
+++ b/submissions/examples/ease-jet-engine-spool-ij/style.css
@@ -1,0 +1,187 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0e16;
+  font-family: system-ui, sans-serif;
+}
+
+.engine {
+  position: relative;
+  width: 300px;
+  height: 260px;
+  background: radial-gradient(circle at 50% 40%, #1a2030, #0d111b 70%);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nacelle {
+  position: relative;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, #2a3142 0%, #141a26 60%, #0b0f18 100%);
+  border: 10px solid #262d3d;
+  box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.8);
+}
+
+.nacelle.running {
+  animation: nacelle-shake 0.16s steps(2, jump-none) infinite;
+}
+
+@keyframes nacelle-shake {
+  50% {
+    transform: translate(1px, 1px);
+  }
+}
+
+.blade {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 52px;
+  margin: -26px 0 0 -4px;
+  background: linear-gradient(180deg, #c6cdd8, #6e7684);
+  border-radius: 4px;
+  transform-origin: 50% 26px;
+  animation: blade-spin 0.9s linear infinite;
+  animation-play-state: paused;
+}
+
+.b0 {
+  transform: rotate(0deg);
+}
+
+.b1 {
+  transform: rotate(45deg);
+}
+
+.b2 {
+  transform: rotate(90deg);
+}
+
+.b3 {
+  transform: rotate(135deg);
+}
+
+.nacelle.running .blade {
+  animation-play-state: running;
+}
+
+.nacelle.running .b0 {
+  animation-duration: 0.5s;
+}
+
+.nacelle.running .b1 {
+  animation-duration: 0.5s;
+}
+
+.nacelle.running .b2 {
+  animation-duration: 0.5s;
+}
+
+.nacelle.running .b3 {
+  animation-duration: 0.5s;
+}
+
+@keyframes blade-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.hub {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  margin: -9px 0 0 -9px;
+  border-radius: 50%;
+  background: #394050;
+}
+
+.shimmer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 96px;
+  height: 96px;
+  margin: -48px 0 0 -48px;
+  border-radius: 50%;
+  background: repeating-conic-gradient(from 0deg, rgba(160, 200, 255, 0.14) 0deg 8deg, transparent 8deg 22deg);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: repeating-conic-gradient(from 0deg, rgba(255, 255, 255, 0.1) 0deg 6deg, transparent 6deg 18deg);
+  animation: shimmer-turn 1.2s linear infinite;
+}
+
+@keyframes shimmer-turn {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.nacelle.running ~ .shimmer {
+  opacity: 1;
+}
+
+.thrust {
+  position: absolute;
+  bottom: 30px;
+  width: 170px;
+  height: 30px;
+  background: linear-gradient(90deg, rgba(120, 190, 255, 0.7), rgba(255, 200, 130, 0.5), transparent);
+  border-radius: 40%;
+  filter: blur(6px);
+  opacity: 0;
+  transform: scaleX(0.4);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.thrust.blowing {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.spool-btn {
+  position: absolute;
+  bottom: 16px;
+  padding: 9px 18px;
+  border: none;
+  border-radius: 8px;
+  background: #4a90e2;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.spool-btn:hover {
+  transform: translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  color: #8a94ac;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-jet-engine-spool-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-jet-engine-spool-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.