### PR TITLE
feat: add ease-kaleidoscope-rotate-ij demo component

### DIFF
--- a/submissions/examples/ease-kaleidoscope-rotate-ij/README.md
+++ b/submissions/examples/ease-kaleidoscope-rotate-ij/README.md
@@ -1,0 +1,22 @@
+# Kaleidoscope Rotate
+
+Eight mirror petals around a glowing core that spin together like a kaleidoscope wheel.
+
+## How is it used?
+
+Each petal is a CSS triangle (`border-style: solid` with a colored bottom border) rotated to its own angle. The wheel then runs one shared turn keyframe:
+
+```css
+.wheel.spinning {
+  animation: wheel-turn 6s linear infinite;
+}
+@keyframes wheel-turn {
+  to { transform: rotate(360deg); }
+}
+```
+
+Color is set per-petal with a `--c` custom property consumed by the triangle border, so adding a petal is one element plus one rule. The core pulses with its own scale/brightness keyframe on top of the wheel's rotation.
+
+## Why is it useful?
+
+This shows two layers of motion at once — the whole group rotating while a child pulses — which is the standard pattern for any orbital system (spinners, dashboards' orbiting badges, sun/planet widgets). CSS triangles via borders remain a dependency-free way to build arrowheads, speech markers, and gauge pointers.

--- a/submissions/examples/ease-kaleidoscope-rotate-ij/demo.html
+++ b/submissions/examples/ease-kaleidoscope-rotate-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kaleidoscope Rotate Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="scope" aria-label="kaleidoscope">
+    <div class="wheel" aria-hidden="true">
+      <span class="petal p1"></span>
+      <span class="petal p2"></span>
+      <span class="petal p3"></span>
+      <span class="petal p4"></span>
+      <span class="petal p5"></span>
+      <span class="petal p6"></span>
+      <span class="petal p7"></span>
+      <span class="petal p8"></span>
+      <span class="core"></span>
+    </div>
+    <button class="spin-btn" id="spinBtn" type="button">Spin</button>
+    <p class="caption">Mirrored petals rotate around a bright core.</p>
+  </main>
+  <script>
+    const wheel = document.querySelector(".wheel");
+    const btn = document.getElementById("spinBtn");
+    btn.addEventListener("click", () => {
+      wheel.classList.toggle("spinning");
+      btn.textContent = wheel.classList.contains("spinning") ? "Stop" : "Spin";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-kaleidoscope-rotate-ij/style.css
+++ b/submissions/examples/ease-kaleidoscope-rotate-ij/style.css
@@ -1,0 +1,144 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #100c1c;
+  font-family: system-ui, sans-serif;
+}
+
+.scope {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, #1c1440, #0c0818 75%);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wheel {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.wheel.spinning {
+  animation: wheel-turn 6s linear infinite;
+}
+
+@keyframes wheel-turn {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.petal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 22px 86px 22px;
+  border-color: transparent transparent var(--c, #d4517e) transparent;
+  transform-origin: 50% 0;
+  opacity: 0.9;
+}
+
+.p1 {
+  --c: #d4517e;
+  transform: rotate(0deg) translateY(-20px);
+}
+
+.p2 {
+  --c: #7e6ef2;
+  transform: rotate(45deg) translateY(-20px);
+}
+
+.p3 {
+  --c: #37c1d0;
+  transform: rotate(90deg) translateY(-20px);
+}
+
+.p4 {
+  --c: #f2b33d;
+  transform: rotate(135deg) translateY(-20px);
+}
+
+.p5 {
+  --c: #d4517e;
+  transform: rotate(180deg) translateY(-20px);
+}
+
+.p6 {
+  --c: #7e6ef2;
+  transform: rotate(225deg) translateY(-20px);
+}
+
+.p7 {
+  --c: #37c1d0;
+  transform: rotate(270deg) translateY(-20px);
+}
+
+.p8 {
+  --c: #f2b33d;
+  transform: rotate(315deg) translateY(-20px);
+}
+
+.petal:nth-child(even) {
+  transform: rotate(calc(attr(data-r))) translateY(-20px) scale(0.8);
+}
+
+.core {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff8dc, #ffd76e 60%, #f29b2f);
+  animation: core-glow 2s ease-in-out infinite;
+  z-index: 2;
+}
+
+@keyframes core-glow {
+  50% {
+    transform: scale(1.12);
+    filter: brightness(1.2);
+  }
+}
+
+.spin-btn {
+  position: absolute;
+  bottom: 20px;
+  padding: 9px 20px;
+  border: none;
+  border-radius: 20px;
+  background: #7e6ef2;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.spin-btn:hover {
+  transform: translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 18px;
+  color: #b7a8e8;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-kaleidoscope-rotate-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-kaleidoscope-rotate-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.