### PR TITLE
feat: add ease-nomad-tent-pitch-ij demo component

### DIFF
--- a/submissions/examples/ease-nomad-tent-pitch-ij/README.md
+++ b/submissions/examples/ease-nomad-tent-pitch-ij/README.md
@@ -1,0 +1,22 @@
+# Nomad Tent Pitch
+
+A tent that pitches itself: poles hinge upright, the fabric snaps up, and the entrance flaps fold open — plus a flickering campfire.
+
+## How is it used?
+
+The pitch is a sequence of staggered transitions on different elements:
+
+```css
+.tent.up .pole-l { transform: rotate(-38deg); }
+.tent.up .pole-r { transform: rotate(38deg); }
+.tent.up .fabric {
+  transform: scaleY(1); /* starts at scaleY(0), transition-delay 0.35s */
+}
+.tent.up .flap-l { transform: rotate(12deg); /* delay 0.7s */ }
+```
+
+Each part delays its start (`0.35s`, `0.7s`) so the scene unfolds in order, while the poles use a springy overshoot curve to sell the snap of a tent rod.
+
+## Why is it useful?
+
+Staggered transition-delays turn one class toggle into a full sequence — the same technique runs multi-step onboarding reveals, chained accordions, and "assembly" animations. Mixing different easings per step (overshoot for structure, ease for fabric) keeps each material feeling right.

--- a/submissions/examples/ease-nomad-tent-pitch-ij/demo.html
+++ b/submissions/examples/ease-nomad-tent-pitch-ij/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nomad Tent Pitch Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="campsite" aria-label="tent being pitched">
+    <div class="ground" aria-hidden="true"></div>
+    <div class="tent" id="tent" aria-hidden="true">
+      <span class="pole pole-l"></span>
+      <span class="pole pole-r"></span>
+      <span class="fabric"></span>
+      <span class="flap flap-l"></span>
+      <span class="flap flap-r"></span>
+      <span class="guy guy-l"></span>
+      <span class="guy guy-r"></span>
+    </div>
+    <span class="campfire" aria-hidden="true"></span>
+    <button class="pitch-btn" id="pitchBtn" type="button">Pitch Tent</button>
+    <p class="caption">The poles fold up and the fabric snaps into place.</p>
+  </main>
+  <script>
+    const tent = document.getElementById("tent");
+    const btn = document.getElementById("pitchBtn");
+    function pitch() {
+      tent.classList.remove("up");
+      void tent.offsetWidth;
+      tent.classList.add("up");
+    }
+    btn.addEventListener("click", pitch);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-nomad-tent-pitch-ij/style.css
+++ b/submissions/examples/ease-nomad-tent-pitch-ij/style.css
@@ -1,0 +1,192 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a241c;
+  font-family: system-ui, sans-serif;
+}
+
+.campsite {
+  position: relative;
+  width: 340px;
+  height: 300px;
+  background: linear-gradient(180deg, #24343f, #14232b 70%);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.ground {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background: linear-gradient(180deg, #2c3b2e, #1b261d);
+}
+
+.tent {
+  position: absolute;
+  bottom: 64px;
+  left: 50%;
+  margin-left: -80px;
+  width: 160px;
+  height: 130px;
+}
+
+.pole {
+  position: absolute;
+  bottom: 0;
+  width: 4px;
+  height: 120px;
+  background: #8a6b3f;
+  border-radius: 2px;
+  transform-origin: 50% 100%;
+  transition: transform 0.9s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.pole-l {
+  left: 8px;
+  transform: rotate(0deg);
+}
+
+.pole-r {
+  right: 8px;
+  transform: rotate(0deg);
+}
+
+.tent.up .pole-l {
+  transform: rotate(-38deg);
+}
+
+.tent.up .pole-r {
+  transform: rotate(38deg);
+}
+
+.fabric {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 160px;
+  height: 100px;
+  background: linear-gradient(180deg, #e8d5ae, #cfb384);
+  clip-path: polygon(0 100%, 50% 8%, 100% 100%);
+  transform-origin: 50% 100%;
+  transform: scaleY(0);
+  transition: transform 0.7s ease 0.35s;
+  z-index: 2;
+}
+
+.tent.up .fabric {
+  transform: scaleY(1);
+}
+
+.flap {
+  position: absolute;
+  bottom: 0;
+  width: 40px;
+  height: 70px;
+  clip-path: polygon(0 0, 100% 100%, 0 100%);
+  background: #b99a6a;
+  z-index: 3;
+  transform-origin: 100% 0;
+  transition: transform 0.6s ease 0.7s;
+}
+
+.flap-l {
+  left: 62px;
+}
+
+.flap-r {
+  right: 62px;
+  transform: scaleX(-1);
+}
+
+.tent.up .flap-l {
+  transform: rotate(12deg);
+}
+
+.tent.up .flap-r {
+  transform: scaleX(-1) rotate(12deg);
+}
+
+.guy {
+  position: absolute;
+  bottom: 6px;
+  width: 2px;
+  height: 50px;
+  background: #5b6a50;
+  transform-origin: 0 100%;
+  opacity: 0;
+  transition: opacity 0.4s ease 0.5s;
+}
+
+.guy-l {
+  left: 4px;
+  transform: rotate(18deg);
+}
+
+.guy-r {
+  right: 4px;
+  transform: rotate(-18deg);
+}
+
+.tent.up .guy {
+  opacity: 0.8;
+}
+
+.campfire {
+  position: absolute;
+  bottom: 64px;
+  right: 40px;
+  width: 26px;
+  height: 30px;
+  background: radial-gradient(circle at 50% 70%, #ff9d3d, #e05e1e 60%, transparent 75%);
+  animation: fire-flicker 0.9s ease-in-out infinite alternate;
+}
+
+@keyframes fire-flicker {
+  from {
+    transform: scaleY(0.9) scaleX(1);
+  }
+  to {
+    transform: scaleY(1.15) scaleX(0.9);
+  }
+}
+
+.pitch-btn {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #e05e1e;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 4;
+  transition: transform 0.15s ease;
+}
+
+.pitch-btn:hover {
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #9db2a4;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-nomad-tent-pitch-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-nomad-tent-pitch-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.