### PR TITLE
feat: add ease-ocean-tide-pulse-ij demo component

### DIFF
--- a/submissions/examples/ease-ocean-tide-pulse-ij/README.md
+++ b/submissions/examples/ease-ocean-tide-pulse-ij/README.md
@@ -1,0 +1,27 @@
+# Ocean Tide Pulse
+
+A moonlit coast where stacked wave bands breathe up and down while a tide marker slides to show the water line rising.
+
+## How is it used?
+
+The waves are three overlapping rounded bands scaling vertically on a loop, and the tide marker is a transitioned top value:
+
+```css
+.wave {
+  transform-origin: 50% 100%;
+  animation: wave-pulse 4s ease-in-out infinite;
+}
+@keyframes wave-pulse {
+  50% { transform: scaleY(0.72); }
+}
+.tide-mark {
+  transition: top 1.4s cubic-bezier(0.65, 0, 0.35, 1);
+}
+.tide-mark.high { top: 104px; }
+```
+
+The three bands are offset by `0.5s`/`1s` delays so they lap rather than move in lockstep. High tide just relocates the marker line; the waves keep breathing underneath.
+
+## Why is it useful?
+
+Layered repeating bands with phase offsets create believable fluid motion from flat shapes — a trick that works for water, auroras, smoke, and gradient "breathing" backgrounds. A marker that slides along a keyframe background is a reusable reading-aid pattern for gauges and progress lines.

--- a/submissions/examples/ease-ocean-tide-pulse-ij/demo.html
+++ b/submissions/examples/ease-ocean-tide-pulse-ij/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ocean Tide Pulse Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="coast" aria-label="ocean tide">
+    <div class="moon" aria-hidden="true"></div>
+    <div class="waveband" aria-hidden="true">
+      <span class="wave w1"></span>
+      <span class="wave w2"></span>
+      <span class="wave w3"></span>
+    </div>
+    <div class="tide-mark" id="tideMark" aria-hidden="true"><span class="marker"></span></div>
+    <button class="tide-btn" id="tideBtn" type="button">High Tide</button>
+    <p class="caption">The water line swells with the tide cycle.</p>
+  </main>
+  <script>
+    const mark = document.getElementById("tideMark");
+    const btn = document.getElementById("tideBtn");
+    btn.addEventListener("click", () => {
+      mark.classList.toggle("high");
+      btn.textContent = mark.classList.contains("high") ? "Low Tide" : "High Tide";
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ocean-tide-pulse-ij/style.css
+++ b/submissions/examples/ease-ocean-tide-pulse-ij/style.css
@@ -1,0 +1,146 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b2030;
+  font-family: system-ui, sans-serif;
+}
+
+.coast {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  background: linear-gradient(180deg, #0d2a3d 0%, #12394f 55%, #0a2434 100%);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.moon {
+  position: absolute;
+  top: 26px;
+  right: 40px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #fffbe0, #f4e08a);
+  box-shadow: 0 0 30px rgba(244, 224, 138, 0.55);
+  animation: moon-drift 8s ease-in-out infinite alternate;
+}
+
+@keyframes moon-drift {
+  to {
+    transform: translateX(-10px);
+  }
+}
+
+.waveband {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 40px;
+}
+
+.waveband {
+  top: 150px;
+}
+
+.wave {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 100%;
+  border-radius: 45% 55% 40% 60%;
+  background: linear-gradient(180deg, rgba(70, 160, 200, 0.55), rgba(40, 110, 150, 0.4));
+  transform-origin: 50% 100%;
+  animation: wave-pulse 4s ease-in-out infinite;
+}
+
+.w2 {
+  top: 4px;
+  opacity: 0.6;
+  animation-delay: 0.5s;
+}
+
+.w3 {
+  top: 8px;
+  opacity: 0.35;
+  animation-delay: 1s;
+}
+
+@keyframes wave-pulse {
+  50% {
+    transform: scaleY(0.72);
+  }
+}
+
+.tide-mark {
+  position: absolute;
+  top: 130px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  transition: top 1.4s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.tide-mark.high {
+  top: 104px;
+}
+
+.marker {
+  position: absolute;
+  right: 12px;
+  top: -6px;
+  width: 22px;
+  height: 14px;
+  background: #ffd76e;
+  border-radius: 4px;
+}
+
+.marker::after {
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 4px;
+  width: 8px;
+  height: 6px;
+  background: inherit;
+  border-radius: 3px 0 0 3px;
+}
+
+.tide-btn {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #3fb0d8;
+  color: #0b2030;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.tide-btn:hover {
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #9fcbe0;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-ocean-tide-pulse-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-ocean-tide-pulse-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.