### PR TITLE
feat: add ease-parachute-drift-ij demo component

### DIFF
--- a/submissions/examples/ease-parachute-drift-ij/README.md
+++ b/submissions/examples/ease-parachute-drift-ij/README.md
@@ -1,0 +1,28 @@
+# Parachute Drift
+
+A parachutist billows open their canopy and drifts down to a landing strip with a gentle sway.
+
+## How is it used?
+
+One long keyframe animates the whole group's descent, while a child canopy runs a fast billow loop:
+
+```css
+.parachute.descending {
+  animation: chute-drift 4.4s ease-in forwards;
+}
+@keyframes chute-drift {
+  0%   { opacity: 0; transform: translateY(0) translateX(0) rotate(0deg); }
+  8%   { opacity: 1; }
+  50%  { transform: translateY(120px) translateX(14px) rotate(4deg); }
+  100% { transform: translateY(300px) translateX(-6px) rotate(-3deg); }
+}
+.canopy {
+  animation: canopy-billow 0.9s ease-in-out infinite alternate;
+}
+```
+
+The parent translates and sways over 4.4s while the canopy keeps a fast, independent scale oscillation — two timelines layered on nested elements. Shroud lines are thin rotated bars spanning canopy to jumper.
+
+## Why is it useful?
+
+Nested independent timelines (a slow trip on the parent, a quick flap on the child) make motion feel alive instead of rigid. This is the core of any object that "carries its own energy" — flags, balloons, birds — and the sway via alternating translateX is a reusable gentle-drift pattern.

--- a/submissions/examples/ease-parachute-drift-ij/demo.html
+++ b/submissions/examples/ease-parachute-drift-ij/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parachute Drift Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="dropzone" aria-label="parachute descent">
+    <div class="parachute" id="chute" aria-hidden="true">
+      <span class="canopy"></span>
+      <span class="line l1"></span>
+      <span class="line l2"></span>
+      <span class="line l3"></span>
+      <span class="line l4"></span>
+      <span class="jumper"></span>
+    </div>
+    <div class="ground-strip" aria-hidden="true"></div>
+    <button class="drop-btn" id="dropBtn" type="button">Release</button>
+    <p class="caption">The canopy billows open and the jumper drifts down.</p>
+  </main>
+  <script>
+    const chute = document.getElementById("chute");
+    const btn = document.getElementById("dropBtn");
+    function drop() {
+      chute.classList.remove("descending");
+      void chute.offsetWidth;
+      chute.classList.add("descending");
+    }
+    btn.addEventListener("click", drop);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-parachute-drift-ij/style.css
+++ b/submissions/examples/ease-parachute-drift-ij/style.css
@@ -1,0 +1,181 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #bfe0ef;
+  font-family: system-ui, sans-serif;
+}
+
+.dropzone {
+  position: relative;
+  width: 300px;
+  height: 340px;
+  background: linear-gradient(180deg, #9fd4ea 0%, #d9eef7 70%, #f4f9fb 100%);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.ground-strip {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: linear-gradient(180deg, #7db25c, #5b8f42);
+}
+
+.parachute {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  margin-left: -70px;
+  width: 140px;
+  height: 240px;
+  opacity: 0;
+}
+
+.parachute.descending {
+  animation: chute-drift 4.4s ease-in forwards;
+}
+
+@keyframes chute-drift {
+  0% {
+    opacity: 0;
+    transform: translateY(0) translateX(0) rotate(0deg);
+  }
+  8% {
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(120px) translateX(14px) rotate(4deg);
+  }
+  100% {
+    transform: translateY(300px) translateX(-6px) rotate(-3deg);
+  }
+}
+
+.canopy {
+  position: absolute;
+  top: 0;
+  left: 14px;
+  width: 112px;
+  height: 74px;
+  background: radial-gradient(circle at 50% 0%, #ff7a59, #e0393c 70%);
+  border-radius: 50% 50% 34% 34%;
+  transform-origin: 50% 0;
+  animation: canopy-billow 0.9s ease-in-out infinite alternate;
+}
+
+@keyframes canopy-billow {
+  to {
+    transform: scaleX(1.08);
+  }
+}
+
+.canopy::after {
+  content: "";
+  position: absolute;
+  top: 34px;
+  left: 20px;
+  width: 72px;
+  height: 12px;
+  background: #ff8d6b;
+  border-radius: 50%;
+}
+
+.line {
+  position: absolute;
+  top: 60px;
+  width: 1px;
+  height: 120px;
+  background: #4b5563;
+  transform-origin: 50% 0;
+}
+
+.l1 {
+  left: 22px;
+  transform: rotate(16deg);
+}
+
+.l2 {
+  left: 60px;
+}
+
+.l3 {
+  left: 80px;
+}
+
+.l4 {
+  left: 108px;
+  transform: rotate(-16deg);
+}
+
+.jumper {
+  position: absolute;
+  top: 176px;
+  left: 56px;
+  width: 28px;
+  height: 52px;
+  background: radial-gradient(circle at 50% 20%, #f7c77d, #d19a4a 60%);
+  border-radius: 12px 12px 8px 8px;
+}
+
+.jumper::before {
+  content: "";
+  position: absolute;
+  top: -22px;
+  left: 4px;
+  width: 20px;
+  height: 24px;
+  border-radius: 50%;
+  background: #2f6a8f;
+}
+
+.jumper::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: -4px;
+  width: 36px;
+  height: 18px;
+  border-radius: 8px;
+  background: #e0393c;
+}
+
+.drop-btn {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #2f6a8f;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.drop-btn:hover {
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #2f5d75;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-parachute-drift-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-parachute-drift-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.