### PR TITLE
feat: add diamond facet edge mesh gradient

### DIFF
--- a/submissions/examples/diamond-facet-edge-mesh-msm/README.md
+++ b/submissions/examples/diamond-facet-edge-mesh-msm/README.md
@@ -1,0 +1,25 @@
+# Diamond Facet Edge Mesh
+
+## What does this do?
+
+This submission creates a pure CSS mesh-gradient showcase with sharp diamond facets, luminous edges, and smooth hover depth.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<section class="diamond-shell" aria-labelledby="diamond-title">
+  <div class="diamond-card">
+    <span class="diamond-kicker">CSS mesh gradient</span>
+    <h1 id="diamond-title">Diamond Facet Edge</h1>
+    <p>Use this as a crystalline accent panel for polished landing pages.</p>
+  </div>
+</section>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a crisp, premium-looking gradient surface that works in dark UI themes without JavaScript, external assets, or heavy rendering.

--- a/submissions/examples/diamond-facet-edge-mesh-msm/demo.html
+++ b/submissions/examples/diamond-facet-edge-mesh-msm/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diamond Facet Edge Mesh</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="diamond-shell" aria-labelledby="diamond-title">
+      <section class="diamond-card" aria-describedby="diamond-copy">
+        <div class="diamond-gem" aria-hidden="true">
+          <span class="diamond-facet diamond-facet-a"></span>
+          <span class="diamond-facet diamond-facet-b"></span>
+          <span class="diamond-facet diamond-facet-c"></span>
+          <span class="diamond-facet diamond-facet-d"></span>
+        </div>
+
+        <span class="diamond-kicker">Pure CSS crystalline mesh</span>
+        <h1 id="diamond-title">Diamond Facet Edge</h1>
+        <p id="diamond-copy">
+          A lightweight gradient composition with beveled polygon facets,
+          glowing edge lines, and responsive contrast for high-impact hero
+          panels.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/diamond-facet-edge-mesh-msm/style.css
+++ b/submissions/examples/diamond-facet-edge-mesh-msm/style.css
@@ -1,0 +1,239 @@
+:root {
+  --diamond-bg: #040712;
+  --diamond-ink: #f7fbff;
+  --diamond-muted: #c2cce0;
+  --diamond-panel: rgba(8, 14, 30, 0.82);
+  --diamond-ice: #8df3ff;
+  --diamond-blue: #5f8cff;
+  --diamond-pink: #ff6edb;
+  --diamond-gold: #ffd37a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--diamond-ink);
+  background: var(--diamond-bg);
+  font-family: Optima, "Segoe UI", sans-serif;
+}
+
+.diamond-shell {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(141, 243, 255, 0.26),
+      transparent 23rem
+    ),
+    radial-gradient(
+      circle at 82% 28%,
+      rgba(255, 110, 219, 0.22),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 58% 86%,
+      rgba(255, 211, 122, 0.16),
+      transparent 26rem
+    ),
+    linear-gradient(145deg, #030511 0%, #121b3b 54%, #050713 100%);
+  isolation: isolate;
+}
+
+.diamond-shell::before {
+  position: absolute;
+  inset: 8%;
+  z-index: -2;
+  content: "";
+  background-image:
+    linear-gradient(60deg, rgba(141, 243, 255, 0.15) 1px, transparent 1px),
+    linear-gradient(120deg, rgba(255, 110, 219, 0.12) 1px, transparent 1px);
+  background-size: 4rem 4rem;
+  mask-image: radial-gradient(circle, #000 0 38%, transparent 72%);
+  transform: rotate(8deg);
+}
+
+.diamond-shell::after {
+  position: absolute;
+  inset: auto 15% 10%;
+  z-index: -3;
+  height: 18rem;
+  content: "";
+  background: radial-gradient(
+    ellipse at center,
+    rgba(141, 243, 255, 0.28),
+    transparent 62%
+  );
+  filter: blur(3.5rem);
+  opacity: 0.85;
+}
+
+.diamond-card {
+  position: relative;
+  width: min(45rem, 100%);
+  min-height: 34rem;
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4.4rem);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.16), transparent 36%),
+    radial-gradient(
+      circle at 18% 28%,
+      rgba(141, 243, 255, 0.2),
+      transparent 14rem
+    ),
+    radial-gradient(
+      circle at 92% 16%,
+      rgba(255, 110, 219, 0.18),
+      transparent 12rem
+    ),
+    var(--diamond-panel);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.5),
+    inset 0 0 4rem rgba(95, 140, 255, 0.12);
+  backdrop-filter: blur(1.2rem);
+  transition:
+    transform 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.diamond-card:hover {
+  box-shadow:
+    0 2.5rem 7rem rgba(0, 0, 0, 0.56),
+    inset 0 0 4.6rem rgba(141, 243, 255, 0.14);
+  transform: translateY(-0.25rem) scale(1.005);
+}
+
+.diamond-gem {
+  position: absolute;
+  top: clamp(1.25rem, 5vw, 3.4rem);
+  right: clamp(1.25rem, 7vw, 4.8rem);
+  width: min(18rem, 48vw);
+  aspect-ratio: 1;
+  filter: drop-shadow(0 0 1.4rem rgba(141, 243, 255, 0.42));
+  transform: rotate(45deg);
+  transform-origin: center;
+  animation: diamond-hover 5.8s ease-in-out infinite;
+}
+
+.diamond-gem::before {
+  position: absolute;
+  inset: 10%;
+  content: "";
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.34), transparent 34%),
+    radial-gradient(
+      circle at 38% 30%,
+      rgba(141, 243, 255, 0.38),
+      transparent 44%
+    ),
+    rgba(95, 140, 255, 0.12);
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+}
+
+.diamond-facet {
+  position: absolute;
+  inset: 10%;
+  display: block;
+  mix-blend-mode: screen;
+}
+
+.diamond-facet-a {
+  background: rgba(141, 243, 255, 0.25);
+  clip-path: polygon(50% 0, 100% 50%, 50% 50%);
+}
+
+.diamond-facet-b {
+  background: rgba(255, 110, 219, 0.22);
+  clip-path: polygon(50% 50%, 100% 50%, 50% 100%);
+}
+
+.diamond-facet-c {
+  background: rgba(255, 211, 122, 0.18);
+  clip-path: polygon(0 50%, 50% 50%, 50% 100%);
+}
+
+.diamond-facet-d {
+  background: rgba(255, 255, 255, 0.2);
+  clip-path: polygon(50% 0, 50% 50%, 0 50%);
+}
+
+.diamond-kicker {
+  position: relative;
+  display: inline-flex;
+  margin-top: 10rem;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(141, 243, 255, 0.36);
+  border-radius: 999px;
+  color: var(--diamond-ice);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.diamond-card h1 {
+  position: relative;
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(3rem, 10vw, 6.6rem);
+  line-height: 0.9;
+  text-shadow:
+    0 0 1rem rgba(141, 243, 255, 0.46),
+    0 0 3rem rgba(255, 110, 219, 0.3);
+}
+
+.diamond-card p {
+  position: relative;
+  max-width: 35rem;
+  margin: 1.25rem 0 0;
+  color: var(--diamond-muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.7;
+}
+
+@keyframes diamond-hover {
+  50% {
+    transform: translate3d(0, -0.45rem, 0) rotate(45deg) scale(1.02);
+  }
+}
+
+@media (max-width: 42rem) {
+  .diamond-shell {
+    padding: 1rem;
+  }
+
+  .diamond-card {
+    min-height: 36rem;
+    border-radius: 1.4rem;
+  }
+
+  .diamond-gem {
+    right: 50%;
+    width: 14rem;
+    transform: translateX(50%) rotate(45deg);
+  }
+
+  .diamond-kicker {
+    margin-top: 13rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diamond-card,
+  .diamond-gem {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS submission for the Diamond Facet Edge mesh gradient.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses crystalline polygon facets, luminous edge glow, hover depth, and reduced-motion-safe animation.

Closes #73837

## Changes Made
- Created `submissions/examples/diamond-facet-edge-mesh-msm/`.
- Added a responsive diamond-facet mesh gradient demo with semantic HTML.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/diamond-facet-edge-mesh-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/diamond-facet-edge-mesh-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.