### PR TITLE
feat: add ease-quicksand-sink-ij demo component

### DIFF
--- a/submissions/examples/ease-quicksand-sink-ij/README.md
+++ b/submissions/examples/ease-quicksand-sink-ij/README.md
@@ -1,0 +1,24 @@
+# Quicksand Sink
+
+A treasure chest slowly swallowed by quicksand, with ripples pulsing outward and bubbles escaping the surface.
+
+## How is it used?
+
+Sinking is a long `bottom` transition combined with a subtle tilt and fade:
+
+```css
+.victim {
+  transition: bottom 2.6s ease-in, opacity 2.6s ease-in, transform 2.6s ease-in;
+}
+.victim.submerged {
+  bottom: 88px;
+  opacity: 0.35;
+  transform: scaleX(1.15) rotate(4deg);
+}
+```
+
+Because the object sits above a rounded sand mound, moving it down inside the sand and fading it reads as submerging. Two half-phase ripple ellipses and two bubbles keep the surface busy with pure `scaleX` and translate loops.
+
+## Why is it useful?
+
+A "sink" transition — moving an element behind/into a surface while fading and compressing it — is the standard way to remove content with direction, like a card collapsing into a list or an item dropping into a tray. The expanding ripple is also a reusable notification/drop marker.

--- a/submissions/examples/ease-quicksand-sink-ij/demo.html
+++ b/submissions/examples/ease-quicksand-sink-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quicksand Sink Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="sinkhole" aria-label="quicksand sink">
+    <div class="sand" aria-hidden="true"></div>
+    <div class="victim" id="victim" aria-hidden="true"></div>
+    <span class="ripple r1" aria-hidden="true"></span>
+    <span class="ripple r2" aria-hidden="true"></span>
+    <span class="bubble bubble1" aria-hidden="true"></span>
+    <span class="bubble bubble2" aria-hidden="true"></span>
+    <button class="sink-btn" id="sinkBtn" type="button">Sink</button>
+    <p class="caption">The object is slowly swallowed by the sand.</p>
+  </main>
+  <script>
+    const victim = document.getElementById("victim");
+    const btn = document.getElementById("sinkBtn");
+    function sink() {
+      victim.classList.remove("submerged");
+      void victim.offsetWidth;
+      victim.classList.add("submerged");
+    }
+    btn.addEventListener("click", sink);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-quicksand-sink-ij/style.css
+++ b/submissions/examples/ease-quicksand-sink-ij/style.css
@@ -1,0 +1,151 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #2b1f17;
+  font-family: system-ui, sans-serif;
+}
+
+.sinkhole {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  background: linear-gradient(180deg, #4a3a26, #2b1f17 75%);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.sand {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 150px;
+  background: radial-gradient(ellipse at 50% 0%, #c9a05c, #a98342 55%, #8a6a33);
+  border-radius: 50% 50% 0 0;
+}
+
+.victim {
+  position: absolute;
+  bottom: 132px;
+  left: 50%;
+  margin-left: -24px;
+  width: 48px;
+  height: 64px;
+  background: radial-gradient(circle at 40% 30%, #e8b95c, #b3782e 70%);
+  border-radius: 8px;
+  transition: bottom 2.6s ease-in, opacity 2.6s ease-in, transform 2.6s ease-in;
+  z-index: 2;
+}
+
+.victim.submerged {
+  bottom: 88px;
+  opacity: 0.35;
+  transform: scaleX(1.15) rotate(4deg);
+}
+
+.ripple {
+  position: absolute;
+  bottom: 130px;
+  left: 50%;
+  width: 60px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid rgba(250, 220, 160, 0.7);
+  opacity: 0;
+}
+
+.ripple.r1 {
+  animation: sand-ripple 2.6s ease-in-out infinite;
+}
+
+.ripple.r2 {
+  animation: sand-ripple 2.6s ease-in-out 1.3s infinite;
+}
+
+@keyframes sand-ripple {
+  0% {
+    transform: translateX(-50%) scaleX(0.4);
+    opacity: 0.8;
+  }
+  70% {
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(-50%) scaleX(1.6);
+    opacity: 0;
+  }
+}
+
+.bubble {
+  position: absolute;
+  bottom: 140px;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(240, 210, 150, 0.5);
+  opacity: 0;
+  animation: sand-bubble 3.2s ease-in infinite;
+}
+
+.bubble1 {
+  margin-left: -16px;
+}
+
+.bubble2 {
+  margin-left: 22px;
+  animation-delay: 1.6s;
+}
+
+@keyframes sand-bubble {
+  0% {
+    opacity: 0;
+    transform: translateY(0) scale(0.4);
+  }
+  25% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-40px) scale(1.2);
+  }
+}
+
+.sink-btn {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 9px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #c9a05c;
+  color: #2b1f17;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  z-index: 3;
+  transition: transform 0.15s ease;
+}
+
+.sink-btn:hover {
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.caption {
+  position: absolute;
+  top: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #c9b392;
+  font-size: 12px;
+}


### PR DESCRIPTION
Adds a working `ease-quicksand-sink-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-quicksand-sink-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.