### PR TITLE
feat: add foucault pendulum rating component

### DIFF
--- a/submissions/examples/foucault-pendulum-rating-msm/README.md
+++ b/submissions/examples/foucault-pendulum-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Foucault Pendulum Rating
+
+## What does this do?
+
+This submission creates an accessible pure CSS rating and feedback component inspired by a Foucault pendulum swing.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="foucault-rating-card" aria-labelledby="foucault-rating-title">
+  <fieldset class="foucault-rating-options">
+    <legend id="foucault-rating-title">Rate the motion</legend>
+    <input type="radio" id="rate-5" name="rating" value="5" />
+    <label for="rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a polished rating pattern that remains keyboard-friendly, dependency-free, dark-mode compatible, and suitable for product feedback sections.

--- a/submissions/examples/foucault-pendulum-rating-msm/demo.html
+++ b/submissions/examples/foucault-pendulum-rating-msm/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foucault Pendulum Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="foucault-rating-shell">
+      <form
+        class="foucault-rating-card"
+        aria-labelledby="foucault-rating-title"
+      >
+        <div class="foucault-pendulum" aria-hidden="true">
+          <span class="foucault-wire"></span>
+          <span class="foucault-bob"></span>
+        </div>
+
+        <span class="foucault-rating-kicker">CSS rating component</span>
+        <fieldset class="foucault-rating-options">
+          <legend id="foucault-rating-title">Rate the motion</legend>
+          <p>Choose how smooth this pendulum-inspired interaction feels.</p>
+
+          <div class="foucault-rating-row">
+            <input type="radio" id="rate-1" name="rating" value="1" />
+            <label for="rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input type="radio" id="rate-2" name="rating" value="2" />
+            <label for="rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input type="radio" id="rate-3" name="rating" value="3" checked />
+            <label for="rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input type="radio" id="rate-4" name="rating" value="4" />
+            <label for="rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input type="radio" id="rate-5" name="rating" value="5" />
+            <label for="rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/foucault-pendulum-rating-msm/style.css
+++ b/submissions/examples/foucault-pendulum-rating-msm/style.css
@@ -1,0 +1,253 @@
+:root {
+  --rating-bg: #050812;
+  --rating-card: rgba(10, 17, 34, 0.82);
+  --rating-ink: #f7fbff;
+  --rating-muted: #b9c5d8;
+  --rating-cyan: #56f1ff;
+  --rating-violet: #9b6cff;
+  --rating-lime: #c5ff72;
+  --rating-coral: #ff8a7a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--rating-ink);
+  background: var(--rating-bg);
+  font-family: "Segoe UI", Tahoma, sans-serif;
+}
+
+.foucault-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 24% 20%,
+      rgba(86, 241, 255, 0.24),
+      transparent 21rem
+    ),
+    radial-gradient(
+      circle at 78% 80%,
+      rgba(155, 108, 255, 0.26),
+      transparent 24rem
+    ),
+    linear-gradient(145deg, #040711 0%, #111b35 55%, #050812 100%);
+}
+
+.foucault-rating-card {
+  position: relative;
+  width: min(38rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(86, 241, 255, 0.18),
+      transparent 12rem
+    ),
+    radial-gradient(
+      circle at 90% 20%,
+      rgba(197, 255, 114, 0.16),
+      transparent 11rem
+    ),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.12), transparent 42%),
+    var(--rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.46),
+    inset 0 0 4rem rgba(86, 241, 255, 0.1);
+  backdrop-filter: blur(1.2rem);
+}
+
+.foucault-rating-card::before {
+  position: absolute;
+  inset: auto 10% 2.5rem;
+  height: 4rem;
+  content: "";
+  border-bottom: 2px solid rgba(197, 255, 114, 0.36);
+  border-radius: 50%;
+  filter: drop-shadow(0 0 1rem rgba(197, 255, 114, 0.45));
+  opacity: 0.8;
+  transform: rotateX(64deg);
+}
+
+.foucault-pendulum {
+  position: absolute;
+  top: -0.6rem;
+  right: clamp(1.75rem, 8vw, 4rem);
+  width: 8rem;
+  height: 12rem;
+  transform-origin: 50% 0;
+  animation: rating-swing 5s ease-in-out infinite;
+}
+
+.foucault-wire {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 2px;
+  height: 8.8rem;
+  background: linear-gradient(
+    transparent,
+    rgba(255, 255, 255, 0.7),
+    transparent
+  );
+  box-shadow: 0 0 0.8rem rgba(86, 241, 255, 0.42);
+  transform: translateX(-50%);
+}
+
+.foucault-bob {
+  position: absolute;
+  top: 7.8rem;
+  left: 50%;
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 28%,
+    #ffffff,
+    var(--rating-cyan) 38%,
+    #17376f 74%
+  );
+  box-shadow:
+    0 0 1.2rem rgba(86, 241, 255, 0.86),
+    0 0 3rem rgba(155, 108, 255, 0.5);
+  transform: translateX(-50%);
+}
+
+.foucault-rating-kicker {
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(86, 241, 255, 0.32);
+  border-radius: 999px;
+  color: var(--rating-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.foucault-rating-options {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.foucault-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(86, 241, 255, 0.42),
+    0 0 2.4rem rgba(155, 108, 255, 0.32);
+}
+
+.foucault-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.foucault-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.foucault-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.foucault-rating-row label {
+  display: grid;
+  min-height: 3.4rem;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--rating-muted);
+  cursor: pointer;
+  font-weight: 800;
+  box-shadow: inset 0 0 1.4rem rgba(86, 241, 255, 0.06);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease,
+    color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.foucault-rating-row label:hover,
+.foucault-rating-row input:focus-visible + label {
+  border-color: rgba(86, 241, 255, 0.62);
+  color: var(--rating-ink);
+  transform: translateY(-0.2rem);
+}
+
+.foucault-rating-row input:checked + label {
+  border-color: rgba(197, 255, 114, 0.72);
+  background: linear-gradient(
+    135deg,
+    rgba(86, 241, 255, 0.22),
+    rgba(197, 255, 114, 0.16)
+  );
+  color: #ffffff;
+  box-shadow:
+    0 0 1.5rem rgba(197, 255, 114, 0.28),
+    inset 0 0 1.5rem rgba(86, 241, 255, 0.12);
+}
+
+@keyframes rating-swing {
+  0%,
+  100% {
+    transform: rotate(-11deg);
+  }
+
+  50% {
+    transform: rotate(11deg);
+  }
+}
+
+@media (max-width: 40rem) {
+  .foucault-rating-shell {
+    padding: 1rem;
+  }
+
+  .foucault-rating-card {
+    border-radius: 1.4rem;
+  }
+
+  .foucault-pendulum {
+    opacity: 0.65;
+  }
+
+  .foucault-rating-row {
+    grid-template-columns: repeat(5, minmax(2.5rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .foucault-pendulum {
+    animation: none;
+  }
+
+  .foucault-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Foucault Pendulum Swing style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, pendulum-inspired motion, and reduced-motion support.

Closes #75068

## Changes Made
- Created `submissions/examples/foucault-pendulum-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/foucault-pendulum-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/foucault-pendulum-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.