### PR TITLE
feat: add neumorphic soft shadow variation (#73741)

### DIFF
--- a/submissions/examples/neumorphic-soft-shadow-73741/README.md
+++ b/submissions/examples/neumorphic-soft-shadow-73741/README.md
@@ -1,0 +1,24 @@
+# CSS Neumorphic Effect: Neumorphic Soft Shadow Variation
+
+Pure CSS neumorphic UI featuring dynamic dual box-shadow elevation depth levels, haptic tactile push states, and inset shadow profiles.
+
+## 1. What does this do?
+Adjusts neumorphic soft shadow elevation levels (Low, Medium, High, Inset) with smooth dual `box-shadow` blur radiuses and haptic vertical displacement without JavaScript.
+
+## 2. How is it used?
+Include `style.css` and use radio triggers to adjust soft shadow elevation:
+
+```html
+<input type="radio" name="shadow-level" id="shadow-mid" class="shadow-radio" checked>
+
+<div class="shadow-stage">
+  <div class="shadow-plate">
+    <div class="plate-content">MEDIUM ELEVATION</div>
+  </div>
+</div>
+
+<label for="shadow-mid" class="neumorphic-btn">Medium</label>
+```
+
+## 3. Why is it useful?
+Offers a clean design system reference for neumorphic shadow depth hierarchy, card elevations, button states, and haptic feedback with full dark mode compatibility and reduced motion accessibility.

--- a/submissions/examples/neumorphic-soft-shadow-73741/demo.html
+++ b/submissions/examples/neumorphic-soft-shadow-73741/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Neumorphic Soft Shadow - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="demo-wrapper">
+    <header class="demo-header">
+      <span class="demo-badge">Neumorphism Effect</span>
+      <h1>Neumorphic Soft Shadow</h1>
+      <p>Interactive Neumorphic UI featuring multi-level soft shadow depth elevations, inset pressed states, and light source transitions.</p>
+    </header>
+
+    <section class="neumorphic-card" aria-label="Soft Shadow Showcase">
+      <!-- Pure CSS State Radio Controls -->
+      <input type="radio" name="shadow-level" id="shadow-low" class="shadow-radio">
+      <input type="radio" name="shadow-level" id="shadow-mid" class="shadow-radio" checked>
+      <input type="radio" name="shadow-level" id="shadow-high" class="shadow-radio">
+      <input type="radio" name="shadow-level" id="shadow-inset" class="shadow-radio">
+
+      <!-- Soft Shadow Display Plate Stage -->
+      <div class="shadow-stage">
+        <div class="shadow-plate">
+          <div class="plate-content">
+            <div class="plate-icon-wrapper">
+              <svg class="plate-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+              </svg>
+            </div>
+            
+            <div class="shadow-meta">
+              <span class="shadow-title title-low">SOFT LOW SHADOW</span>
+              <span class="shadow-title title-mid">SOFT MEDIUM ELEVATION</span>
+              <span class="shadow-title title-high">SOFT HIGH SHADOW</span>
+              <span class="shadow-title title-inset">INSET PRESSED DEPTH</span>
+              
+              <span class="shadow-blur-label label-low">Blur: 10px | Offset: 5px</span>
+              <span class="shadow-blur-label label-mid">Blur: 20px | Offset: 10px</span>
+              <span class="shadow-blur-label label-high">Blur: 35px | Offset: 18px</span>
+              <span class="shadow-blur-label label-inset">Inner Blur: 14px | Inset</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Controls Panel -->
+      <div class="controls-panel" aria-label="Select Soft Shadow Level">
+        <span class="controls-title">Shadow Elevation</span>
+        <div class="btn-group">
+          <label for="shadow-low" class="neumorphic-btn btn-low" tabindex="0" title="Low Shadow">Low</label>
+          <label for="shadow-mid" class="neumorphic-btn btn-mid" tabindex="0" title="Medium Shadow">Medium</label>
+          <label for="shadow-high" class="neumorphic-btn btn-high" tabindex="0" title="High Shadow">High</label>
+          <label for="shadow-inset" class="neumorphic-btn btn-inset" tabindex="0" title="Inset Shadow">Inset</label>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/neumorphic-soft-shadow-73741/style.css
+++ b/submissions/examples/neumorphic-soft-shadow-73741/style.css
@@ -1,0 +1,279 @@
+/* CSS Neumorphic Effect: Neumorphic Soft Shadow Variation #73741 */
+:root {
+  --bg-color: #e0e5ec;
+  --text-main: #2d3748;
+  --text-muted: #718096;
+  --shadow-light: #ffffff;
+  --shadow-dark: #a3b1c6;
+  --accent-color: #3b82f6;
+  --accent-glow: rgba(59, 130, 246, 0.3);
+  --font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #181e2a;
+    --text-main: #f1f5f9;
+    --text-muted: #94a3b8;
+    --shadow-light: #222a3a;
+    --shadow-dark: #0e121a;
+    --accent-color: #60a5fa;
+    --accent-glow: rgba(96, 165, 250, 0.3);
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-family);
+  background-color: var(--bg-color);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+  transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+.demo-wrapper {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.35rem 0.85rem;
+  border-radius: 50px;
+  background: var(--bg-color);
+  color: var(--accent-color);
+  box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
+  margin-bottom: 0.75rem;
+}
+
+.demo-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.demo-header p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Neumorphic Card Outer */
+.neumorphic-card {
+  width: 100%;
+  background: var(--bg-color);
+  padding: 2.5rem 2rem;
+  border-radius: 28px;
+  box-shadow: 12px 12px 24px var(--shadow-dark), -12px -12px 24px var(--shadow-light);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.2rem;
+}
+
+.shadow-radio {
+  display: none;
+}
+
+/* Shadow Display Stage */
+.shadow-stage {
+  position: relative;
+  width: 100%;
+  height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.shadow-plate {
+  width: 200px;
+  height: 180px;
+  border-radius: 24px;
+  background: var(--bg-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: box-shadow 0.5s ease, transform 0.5s ease;
+  will-change: box-shadow, transform;
+  transform: translate3d(0, 0, 0);
+  box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light);
+}
+
+.plate-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+  padding: 1rem;
+}
+
+.plate-icon-wrapper {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: var(--bg-color);
+  box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--accent-color);
+}
+
+.plate-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.shadow-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.shadow-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-main);
+  display: none;
+}
+
+.shadow-blur-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  display: none;
+}
+
+/* Pure CSS Radio Trigger Elevations */
+#shadow-low:checked ~ .shadow-stage .shadow-plate {
+  box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light);
+  transform: translateY(2px);
+}
+#shadow-low:checked ~ .shadow-stage .title-low,
+#shadow-low:checked ~ .shadow-stage .label-low {
+  display: block;
+}
+
+#shadow-mid:checked ~ .shadow-stage .shadow-plate {
+  box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light);
+  transform: translateY(0);
+}
+#shadow-mid:checked ~ .shadow-stage .title-mid,
+#shadow-mid:checked ~ .shadow-stage .label-mid {
+  display: block;
+}
+
+#shadow-high:checked ~ .shadow-stage .shadow-plate {
+  box-shadow: 18px 18px 35px var(--shadow-dark), -18px -18px 35px var(--shadow-light);
+  transform: translateY(-4px);
+}
+#shadow-high:checked ~ .shadow-stage .title-high,
+#shadow-high:checked ~ .shadow-stage .label-high {
+  display: block;
+}
+
+#shadow-inset:checked ~ .shadow-stage .shadow-plate {
+  box-shadow: inset 7px 7px 14px var(--shadow-dark), inset -7px -7px 14px var(--shadow-light);
+  transform: translateY(0);
+}
+#shadow-inset:checked ~ .shadow-stage .title-inset,
+#shadow-inset:checked ~ .shadow-stage .label-inset {
+  display: block;
+}
+
+#shadow-inset:checked ~ .shadow-stage .plate-icon-wrapper {
+  box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
+}
+
+/* Control Buttons */
+.controls-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.controls-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.6rem;
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.neumorphic-btn {
+  flex: 1;
+  min-width: 70px;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-main);
+  background: var(--bg-color);
+  border-radius: 16px;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light);
+  transition: all 0.3s ease;
+}
+
+.neumorphic-btn:hover {
+  color: var(--accent-color);
+  transform: translateY(-2px);
+}
+
+.neumorphic-btn:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 4px;
+}
+
+#shadow-low:checked ~ .controls-panel .btn-low,
+#shadow-mid:checked ~ .controls-panel .btn-mid,
+#shadow-high:checked ~ .controls-panel .btn-high,
+#shadow-inset:checked ~ .controls-panel .btn-inset {
+  box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light);
+  color: var(--accent-color);
+  transform: translateY(0);
+}
+
+/* Accessibility & Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .shadow-plate,
+  .neumorphic-btn {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Adds a pure CSS Neumorphic Soft Shadow variation featuring adjustable elevation depth levels, haptic tactile push profiles, and inset shadow transitions.

## Changes
- Added submissions/examples/neumorphic-soft-shadow-73741/demo.html`n- Added submissions/examples/neumorphic-soft-shadow-73741/style.css`n- Added submissions/examples/neumorphic-soft-shadow-73741/README.md`n
## Verification
Tested shadow elevation states in browser: low, mid, high, and inset shadow profiles transition smoothly, light/dark mode themes function cleanly.

## Accessibility
Provides visible focus outlines and supports prefers-reduced-motion settings.

## Issue
Closes #73741