### PR TITLE
feat: add origami paper fold rating component

### DIFF
--- a/submissions/examples/origami-paper-fold-rating-msm/README.md
+++ b/submissions/examples/origami-paper-fold-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Origami Paper Fold Rating
+
+## What does this do?
+
+This submission creates an accessible pure CSS rating and feedback component with an origami paper fold visual style.
+
+## How is it used?
+
+Add the stylesheet and use the demo structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="origami-rating-card" aria-labelledby="origami-rating-title">
+  <fieldset class="origami-rating-options">
+    <legend id="origami-rating-title">Fold your rating</legend>
+    <input type="radio" id="origami-rate-5" name="origami-rating" value="5" />
+    <label for="origami-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a lightweight rating UI that feels dimensional and polished while remaining semantic, keyboard-friendly, responsive, and dependency-free.

--- a/submissions/examples/origami-paper-fold-rating-msm/demo.html
+++ b/submissions/examples/origami-paper-fold-rating-msm/demo.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Origami Paper Fold Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="origami-rating-shell">
+      <form class="origami-rating-card" aria-labelledby="origami-rating-title">
+        <div class="origami-fold-art" aria-hidden="true">
+          <span class="origami-fold origami-fold-one"></span>
+          <span class="origami-fold origami-fold-two"></span>
+          <span class="origami-fold origami-fold-three"></span>
+        </div>
+
+        <span class="origami-rating-kicker">CSS rating component</span>
+        <fieldset class="origami-rating-options">
+          <legend id="origami-rating-title">Fold your rating</legend>
+          <p>Pick a feedback score on a soft folded-paper surface.</p>
+
+          <div class="origami-rating-row">
+            <input
+              type="radio"
+              id="origami-rate-1"
+              name="origami-rating"
+              value="1"
+            />
+            <label for="origami-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="origami-rate-2"
+              name="origami-rating"
+              value="2"
+            />
+            <label for="origami-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="origami-rate-3"
+              name="origami-rating"
+              value="3"
+            />
+            <label for="origami-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="origami-rate-4"
+              name="origami-rating"
+              value="4"
+              checked
+            />
+            <label for="origami-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="origami-rate-5"
+              name="origami-rating"
+              value="5"
+            />
+            <label for="origami-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/origami-paper-fold-rating-msm/style.css
+++ b/submissions/examples/origami-paper-fold-rating-msm/style.css
@@ -1,0 +1,261 @@
+:root {
+  --origami-rating-bg: #071018;
+  --origami-rating-card: rgba(11, 22, 32, 0.84);
+  --origami-rating-ink: #f7fcff;
+  --origami-rating-muted: #bfd0dc;
+  --origami-rating-mint: #86ffd9;
+  --origami-rating-sky: #74c7ff;
+  --origami-rating-coral: #ff997f;
+  --origami-rating-indigo: #7885ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--origami-rating-ink);
+  background: var(--origami-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.origami-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 24%,
+      rgba(134, 255, 217, 0.24),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 80% 18%,
+      rgba(255, 153, 127, 0.2),
+      transparent 22rem
+    ),
+    linear-gradient(145deg, #061019 0%, #102739 55%, #05080d 100%);
+}
+
+.origami-rating-card {
+  position: relative;
+  width: min(39rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 22%,
+      rgba(134, 255, 217, 0.18),
+      transparent 13rem
+    ),
+    radial-gradient(
+      circle at 92% 18%,
+      rgba(255, 153, 127, 0.16),
+      transparent 12rem
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.14), transparent 36%),
+    var(--origami-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.46),
+    inset 0 0 4rem rgba(116, 199, 255, 0.1);
+  backdrop-filter: blur(1.2rem);
+}
+
+.origami-fold-art {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.origami-fold {
+  position: absolute;
+  display: block;
+  filter: drop-shadow(0 1rem 1.2rem rgba(0, 0, 0, 0.22));
+  will-change: transform;
+}
+
+.origami-fold-one {
+  top: -12%;
+  right: -10%;
+  width: 21rem;
+  height: 18rem;
+  background: linear-gradient(
+    145deg,
+    rgba(134, 255, 217, 0.3),
+    rgba(116, 199, 255, 0.04)
+  );
+  clip-path: polygon(0 0, 100% 18%, 54% 100%);
+  animation: origami-rating-float-one 6.2s ease-in-out infinite;
+}
+
+.origami-fold-two {
+  right: 4%;
+  bottom: -14%;
+  width: 19rem;
+  height: 16rem;
+  background: linear-gradient(
+    45deg,
+    rgba(255, 153, 127, 0.24),
+    rgba(120, 133, 255, 0.04)
+  );
+  clip-path: polygon(22% 0, 100% 58%, 0 100%);
+  animation: origami-rating-float-two 7s ease-in-out infinite;
+}
+
+.origami-fold-three {
+  bottom: 10%;
+  left: -8%;
+  width: 15rem;
+  height: 14rem;
+  background: linear-gradient(
+    120deg,
+    rgba(120, 133, 255, 0.24),
+    rgba(134, 255, 217, 0.04)
+  );
+  clip-path: polygon(0 20%, 84% 0, 100% 100%, 18% 72%);
+  animation: origami-rating-float-three 7.6s ease-in-out infinite;
+}
+
+.origami-rating-kicker {
+  position: relative;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(134, 255, 217, 0.34);
+  border-radius: 999px;
+  color: var(--origami-rating-mint);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.origami-rating-options {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.origami-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(134, 255, 217, 0.4),
+    0 0 2.5rem rgba(116, 199, 255, 0.3);
+}
+
+.origami-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--origami-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.origami-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.origami-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.origami-rating-row label {
+  display: grid;
+  min-height: 3.5rem;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 52%),
+    rgba(255, 255, 255, 0.08);
+  color: var(--origami-rating-muted);
+  cursor: pointer;
+  font-weight: 800;
+  box-shadow: inset 0 0 1.3rem rgba(134, 255, 217, 0.06);
+  clip-path: polygon(0 12%, 90% 0, 100% 88%, 10% 100%);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease,
+    color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.origami-rating-row label:hover,
+.origami-rating-row input:focus-visible + label {
+  border-color: rgba(134, 255, 217, 0.6);
+  color: var(--origami-rating-ink);
+  transform: translateY(-0.22rem) rotate(-1deg);
+}
+
+.origami-rating-row input:checked + label {
+  border-color: rgba(255, 153, 127, 0.72);
+  background: linear-gradient(
+    135deg,
+    rgba(134, 255, 217, 0.22),
+    rgba(255, 153, 127, 0.18)
+  );
+  color: #ffffff;
+  box-shadow:
+    0 0 1.4rem rgba(255, 153, 127, 0.28),
+    inset 0 0 1.4rem rgba(116, 199, 255, 0.12);
+}
+
+@keyframes origami-rating-float-one {
+  50% {
+    transform: translate3d(-0.35rem, 0.3rem, 0) rotate(2deg);
+  }
+}
+
+@keyframes origami-rating-float-two {
+  50% {
+    transform: translate3d(0.3rem, -0.35rem, 0) rotate(-2deg);
+  }
+}
+
+@keyframes origami-rating-float-three {
+  50% {
+    transform: translate3d(0.25rem, 0.3rem, 0) rotate(2deg);
+  }
+}
+
+@media (max-width: 40rem) {
+  .origami-rating-shell {
+    padding: 1rem;
+  }
+
+  .origami-rating-card {
+    border-radius: 1.4rem;
+  }
+
+  .origami-rating-row {
+    grid-template-columns: repeat(5, minmax(2.5rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .origami-fold-one,
+  .origami-fold-two,
+  .origami-fold-three {
+    animation: none;
+  }
+
+  .origami-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Origami Paper Fold style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, folded-paper visual styling, and reduced-motion support.

Closes #75067

## Changes Made
- Created `submissions/examples/origami-paper-fold-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/origami-paper-fold-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/origami-paper-fold-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.