### PR TITLE
feat: add diamond facet edge rating component

### DIFF
--- a/submissions/examples/diamond-facet-edge-rating-msm/README.md
+++ b/submissions/examples/diamond-facet-edge-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Diamond Facet Edge Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a diamond facet edge visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="diamond-rating-card" aria-labelledby="diamond-rating-title">
+  <fieldset class="diamond-rating-options">
+    <legend id="diamond-rating-title">Rate the shine</legend>
+    <input type="radio" id="diamond-rate-5" name="diamond-rating" value="5" />
+    <label for="diamond-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a polished, dependency-free rating UI that is responsive, keyboard-friendly, dark-mode compatible, and visually distinct for premium feedback flows.

--- a/submissions/examples/diamond-facet-edge-rating-msm/demo.html
+++ b/submissions/examples/diamond-facet-edge-rating-msm/demo.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diamond Facet Edge Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="diamond-rating-shell">
+      <form class="diamond-rating-card" aria-labelledby="diamond-rating-title">
+        <div class="diamond-rating-prism" aria-hidden="true">
+          <span class="diamond-rating-facet diamond-rating-facet-one"></span>
+          <span class="diamond-rating-facet diamond-rating-facet-two"></span>
+          <span class="diamond-rating-facet diamond-rating-facet-three"></span>
+        </div>
+
+        <span class="diamond-rating-kicker">Premium feedback</span>
+        <fieldset class="diamond-rating-options">
+          <legend id="diamond-rating-title">Rate the shine</legend>
+          <p>
+            Choose a score on a crisp gem-cut surface with animated reflective
+            edges.
+          </p>
+
+          <div class="diamond-rating-row">
+            <input
+              type="radio"
+              id="diamond-rate-1"
+              name="diamond-rating"
+              value="1"
+            />
+            <label for="diamond-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="diamond-rate-2"
+              name="diamond-rating"
+              value="2"
+            />
+            <label for="diamond-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="diamond-rate-3"
+              name="diamond-rating"
+              value="3"
+            />
+            <label for="diamond-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="diamond-rate-4"
+              name="diamond-rating"
+              value="4"
+              checked
+            />
+            <label for="diamond-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="diamond-rate-5"
+              name="diamond-rating"
+              value="5"
+            />
+            <label for="diamond-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/diamond-facet-edge-rating-msm/style.css
+++ b/submissions/examples/diamond-facet-edge-rating-msm/style.css
@@ -1,0 +1,279 @@
+:root {
+  --diamond-rating-bg: #060a12;
+  --diamond-rating-card: rgba(9, 17, 31, 0.86);
+  --diamond-rating-ink: #f8fbff;
+  --diamond-rating-muted: #b6c7d9;
+  --diamond-rating-ice: #9ee7ff;
+  --diamond-rating-cyan: #55f0ff;
+  --diamond-rating-violet: #b99cff;
+  --diamond-rating-rose: #ff8ac4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--diamond-rating-ink);
+  background: var(--diamond-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.diamond-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(85, 240, 255, 0.22),
+      transparent 20rem
+    ),
+    radial-gradient(
+      circle at 84% 20%,
+      rgba(185, 156, 255, 0.22),
+      transparent 22rem
+    ),
+    linear-gradient(145deg, #030712 0%, #0c1d34 54%, #03050b 100%);
+}
+
+.diamond-rating-card {
+  position: relative;
+  width: min(40rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(158, 231, 255, 0.28);
+  border-radius: 1.8rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.16), transparent 30%),
+    linear-gradient(225deg, rgba(85, 240, 255, 0.12), transparent 32%),
+    var(--diamond-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.48),
+    inset 0 0 4rem rgba(85, 240, 255, 0.1);
+  backdrop-filter: blur(1.1rem);
+}
+
+.diamond-rating-card::before {
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.2rem;
+  background:
+    linear-gradient(
+      125deg,
+      transparent 0 27%,
+      rgba(255, 255, 255, 0.08) 28% 29%,
+      transparent 30%
+    ),
+    linear-gradient(
+      35deg,
+      transparent 0 58%,
+      rgba(158, 231, 255, 0.12) 59% 60%,
+      transparent 61%
+    );
+  clip-path: polygon(8% 0, 92% 0, 100% 16%, 86% 100%, 14% 100%, 0 16%);
+  content: "";
+  pointer-events: none;
+}
+
+.diamond-rating-prism {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.diamond-rating-facet {
+  position: absolute;
+  display: block;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  filter: drop-shadow(0 1rem 1.4rem rgba(0, 0, 0, 0.24));
+  will-change: transform;
+}
+
+.diamond-rating-facet-one {
+  top: -16%;
+  right: -8%;
+  width: 22rem;
+  height: 18rem;
+  background: linear-gradient(
+    145deg,
+    rgba(85, 240, 255, 0.28),
+    rgba(255, 255, 255, 0.03)
+  );
+  clip-path: polygon(50% 0, 100% 42%, 76% 100%, 24% 100%, 0 42%);
+  animation: diamond-rating-glint-one 6s ease-in-out infinite;
+}
+
+.diamond-rating-facet-two {
+  right: 3%;
+  bottom: -15%;
+  width: 19rem;
+  height: 17rem;
+  background: linear-gradient(
+    45deg,
+    rgba(185, 156, 255, 0.28),
+    rgba(255, 138, 196, 0.04)
+  );
+  clip-path: polygon(50% 0, 100% 35%, 82% 100%, 18% 100%, 0 35%);
+  animation: diamond-rating-glint-two 7s ease-in-out infinite;
+}
+
+.diamond-rating-facet-three {
+  bottom: 12%;
+  left: -10%;
+  width: 16rem;
+  height: 15rem;
+  background: linear-gradient(
+    120deg,
+    rgba(255, 138, 196, 0.2),
+    rgba(85, 240, 255, 0.04)
+  );
+  clip-path: polygon(50% 0, 100% 45%, 72% 100%, 28% 100%, 0 45%);
+  animation: diamond-rating-glint-three 7.4s ease-in-out infinite;
+}
+
+.diamond-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(85, 240, 255, 0.45);
+  border-radius: 999px;
+  color: var(--diamond-rating-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.diamond-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.diamond-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.7rem, 9vw, 5.5rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(85, 240, 255, 0.45),
+    0 0 2.6rem rgba(185, 156, 255, 0.32);
+}
+
+.diamond-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--diamond-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.diamond-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.diamond-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.diamond-rating-row label {
+  display: grid;
+  min-height: 3.6rem;
+  place-items: center;
+  border: 1px solid rgba(158, 231, 255, 0.24);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.14), transparent 52%),
+    rgba(255, 255, 255, 0.07);
+  color: var(--diamond-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  clip-path: polygon(50% 0, 100% 32%, 86% 100%, 14% 100%, 0 32%);
+  box-shadow:
+    inset 0 0 1.2rem rgba(85, 240, 255, 0.07),
+    0 0.6rem 1.3rem rgba(0, 0, 0, 0.18);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease,
+    color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.diamond-rating-row label:hover,
+.diamond-rating-row input:focus-visible + label {
+  border-color: rgba(85, 240, 255, 0.72);
+  color: var(--diamond-rating-ink);
+  transform: translateY(-0.24rem) scale(1.03);
+}
+
+.diamond-rating-row input:checked + label {
+  border-color: rgba(255, 138, 196, 0.78);
+  background: linear-gradient(
+    145deg,
+    rgba(85, 240, 255, 0.24),
+    rgba(255, 138, 196, 0.22)
+  );
+  color: #ffffff;
+  box-shadow:
+    0 0 1.5rem rgba(255, 138, 196, 0.3),
+    inset 0 0 1.4rem rgba(158, 231, 255, 0.14);
+}
+
+@keyframes diamond-rating-glint-one {
+  50% {
+    transform: translate3d(-0.4rem, 0.28rem, 0) rotate(2deg);
+  }
+}
+
+@keyframes diamond-rating-glint-two {
+  50% {
+    transform: translate3d(0.32rem, -0.36rem, 0) rotate(-2deg);
+  }
+}
+
+@keyframes diamond-rating-glint-three {
+  50% {
+    transform: translate3d(0.28rem, 0.32rem, 0) rotate(2deg);
+  }
+}
+
+@media (max-width: 40rem) {
+  .diamond-rating-shell {
+    padding: 1rem;
+  }
+
+  .diamond-rating-card {
+    border-radius: 1.3rem;
+  }
+
+  .diamond-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diamond-rating-facet-one,
+  .diamond-rating-facet-two,
+  .diamond-rating-facet-three {
+    animation: none;
+  }
+
+  .diamond-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Diamond Facet Edge style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, gem-cut visual styling, and reduced-motion support.

Closes #75065

## Changes Made
- Created `submissions/examples/diamond-facet-edge-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/diamond-facet-edge-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/diamond-facet-edge-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.