### PR TITLE
feat: add velvet smooth transition rating component

### DIFF
--- a/submissions/examples/velvet-smooth-transition-rating-msm/README.md
+++ b/submissions/examples/velvet-smooth-transition-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Velvet Smooth Transition Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a velvet smooth transition visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="velvet-rating-card" aria-labelledby="velvet-rating-title">
+  <fieldset class="velvet-rating-options">
+    <legend id="velvet-rating-title">Smooth rating</legend>
+    <input type="radio" id="velvet-rate-5" name="velvet-rating" value="5" />
+    <label for="velvet-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a soft, refined feedback pattern that stays dependency-free, keyboard-friendly, responsive, and polished for dark themed interfaces.

--- a/submissions/examples/velvet-smooth-transition-rating-msm/demo.html
+++ b/submissions/examples/velvet-smooth-transition-rating-msm/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Velvet Smooth Transition Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="velvet-rating-shell">
+      <form class="velvet-rating-card" aria-labelledby="velvet-rating-title">
+        <span class="velvet-rating-glow velvet-rating-glow-one"></span>
+        <span class="velvet-rating-glow velvet-rating-glow-two"></span>
+
+        <span class="velvet-rating-kicker">Soft feedback</span>
+        <fieldset class="velvet-rating-options">
+          <legend id="velvet-rating-title">Smooth rating</legend>
+          <p>
+            Select a score with slow, tactile transitions and soft velvet depth.
+          </p>
+
+          <div class="velvet-rating-row">
+            <input
+              type="radio"
+              id="velvet-rate-1"
+              name="velvet-rating"
+              value="1"
+            />
+            <label for="velvet-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="velvet-rate-2"
+              name="velvet-rating"
+              value="2"
+            />
+            <label for="velvet-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="velvet-rate-3"
+              name="velvet-rating"
+              value="3"
+            />
+            <label for="velvet-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="velvet-rate-4"
+              name="velvet-rating"
+              value="4"
+              checked
+            />
+            <label for="velvet-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="velvet-rate-5"
+              name="velvet-rating"
+              value="5"
+            />
+            <label for="velvet-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/velvet-smooth-transition-rating-msm/style.css
+++ b/submissions/examples/velvet-smooth-transition-rating-msm/style.css
@@ -1,0 +1,245 @@
+:root {
+  --velvet-rating-bg: #08050c;
+  --velvet-rating-card: rgba(19, 9, 25, 0.9);
+  --velvet-rating-ink: #fff9fb;
+  --velvet-rating-muted: #d7c2cf;
+  --velvet-rating-plum: #5b224f;
+  --velvet-rating-rose: #ff7cab;
+  --velvet-rating-peach: #ffc4a6;
+  --velvet-rating-lilac: #c6a4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--velvet-rating-ink);
+  background: var(--velvet-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.velvet-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 22%,
+      rgba(255, 124, 171, 0.2),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 78% 18%,
+      rgba(198, 164, 255, 0.2),
+      transparent 24rem
+    ),
+    linear-gradient(145deg, #08040c 0%, #241227 52%, #07040a 100%);
+}
+
+.velvet-rating-card {
+  position: relative;
+  width: min(39rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 196, 166, 0.2);
+  border-radius: 2.2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 34%),
+    radial-gradient(
+      circle at 30% 15%,
+      rgba(255, 124, 171, 0.16),
+      transparent 14rem
+    ),
+    var(--velvet-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.52),
+    inset 0 0 4rem rgba(255, 124, 171, 0.08);
+  backdrop-filter: blur(1.2rem);
+}
+
+.velvet-rating-card::before {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0.035) 0 0.08rem,
+      transparent 0.08rem 0.55rem
+    ),
+    radial-gradient(
+      circle at 70% 20%,
+      rgba(255, 196, 166, 0.1),
+      transparent 14rem
+    );
+  content: "";
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.velvet-rating-glow {
+  position: absolute;
+  display: block;
+  border-radius: 999px;
+  filter: blur(0.25rem);
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+
+.velvet-rating-glow-one {
+  top: -6rem;
+  right: -5rem;
+  width: 17rem;
+  height: 17rem;
+  background: rgba(255, 124, 171, 0.16);
+  animation: velvet-rating-drift-one 7s ease-in-out infinite;
+}
+
+.velvet-rating-glow-two {
+  bottom: -7rem;
+  left: -5rem;
+  width: 18rem;
+  height: 18rem;
+  background: rgba(198, 164, 255, 0.14);
+  animation: velvet-rating-drift-two 8s ease-in-out infinite;
+}
+
+.velvet-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(255, 196, 166, 0.32);
+  border-radius: 999px;
+  color: var(--velvet-rating-peach);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.velvet-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.velvet-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(255, 124, 171, 0.42),
+    0 0 2.6rem rgba(198, 164, 255, 0.28);
+}
+
+.velvet-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--velvet-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.velvet-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.velvet-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.velvet-rating-row label {
+  display: grid;
+  min-height: 3.6rem;
+  place-items: center;
+  border: 1px solid rgba(255, 196, 166, 0.18);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.11), transparent 55%),
+    rgba(255, 255, 255, 0.07);
+  color: var(--velvet-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow:
+    inset 0 0 1.4rem rgba(255, 124, 171, 0.06),
+    0 0.6rem 1.4rem rgba(0, 0, 0, 0.18);
+  transition:
+    transform 420ms cubic-bezier(0.2, 0.9, 0.25, 1),
+    border-color 420ms ease,
+    background 420ms ease,
+    color 420ms ease,
+    box-shadow 420ms ease;
+}
+
+.velvet-rating-row label:hover,
+.velvet-rating-row input:focus-visible + label {
+  border-color: rgba(255, 196, 166, 0.64);
+  color: var(--velvet-rating-ink);
+  transform: translateY(-0.22rem) scale(1.04);
+}
+
+.velvet-rating-row input:checked + label {
+  border-color: rgba(255, 124, 171, 0.72);
+  background: linear-gradient(
+    145deg,
+    rgba(255, 124, 171, 0.26),
+    rgba(198, 164, 255, 0.18)
+  );
+  color: #ffffff;
+  box-shadow:
+    0 0 1.6rem rgba(255, 124, 171, 0.26),
+    inset 0 0 1.4rem rgba(255, 196, 166, 0.12);
+}
+
+@keyframes velvet-rating-drift-one {
+  50% {
+    opacity: 0.76;
+    transform: translate3d(-0.5rem, 0.45rem, 0) scale(1.05);
+  }
+}
+
+@keyframes velvet-rating-drift-two {
+  50% {
+    opacity: 0.72;
+    transform: translate3d(0.45rem, -0.5rem, 0) scale(1.04);
+  }
+}
+
+@media (max-width: 40rem) {
+  .velvet-rating-shell {
+    padding: 1rem;
+  }
+
+  .velvet-rating-card {
+    border-radius: 1.5rem;
+  }
+
+  .velvet-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .velvet-rating-glow-one,
+  .velvet-rating-glow-two {
+    animation: none;
+  }
+
+  .velvet-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Velvet Smooth Transition style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, soft tactile transitions, and reduced-motion support.

Closes #75063

## Changes Made
- Created `submissions/examples/velvet-smooth-transition-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/velvet-smooth-transition-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/velvet-smooth-transition-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.