### PR TITLE
feat: add metallic sheen rating component

### DIFF
--- a/submissions/examples/metallic-sheen-rating-msm/README.md
+++ b/submissions/examples/metallic-sheen-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Metallic Sheen Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a metallic sheen visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="metallic-rating-card" aria-labelledby="metallic-rating-title">
+  <fieldset class="metallic-rating-options">
+    <legend id="metallic-rating-title">Polish the rating</legend>
+    <input type="radio" id="metallic-rate-5" name="metallic-rating" value="5" />
+    <label for="metallic-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a sleek, responsive, dependency-free feedback UI with strong keyboard support and a premium dark-mode look.

--- a/submissions/examples/metallic-sheen-rating-msm/demo.html
+++ b/submissions/examples/metallic-sheen-rating-msm/demo.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Metallic Sheen Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="metallic-rating-shell">
+      <form
+        class="metallic-rating-card"
+        aria-labelledby="metallic-rating-title"
+      >
+        <span class="metallic-rating-sweep" aria-hidden="true"></span>
+        <span class="metallic-rating-rivet metallic-rating-rivet-one"></span>
+        <span class="metallic-rating-rivet metallic-rating-rivet-two"></span>
+
+        <span class="metallic-rating-kicker">Brushed feedback</span>
+        <fieldset class="metallic-rating-options">
+          <legend id="metallic-rating-title">Polish the rating</legend>
+          <p>
+            Choose a score on a brushed metal panel with reflective hover
+            states.
+          </p>
+
+          <div class="metallic-rating-row">
+            <input
+              type="radio"
+              id="metallic-rate-1"
+              name="metallic-rating"
+              value="1"
+            />
+            <label for="metallic-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="metallic-rate-2"
+              name="metallic-rating"
+              value="2"
+            />
+            <label for="metallic-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="metallic-rate-3"
+              name="metallic-rating"
+              value="3"
+            />
+            <label for="metallic-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="metallic-rate-4"
+              name="metallic-rating"
+              value="4"
+              checked
+            />
+            <label for="metallic-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="metallic-rate-5"
+              name="metallic-rating"
+              value="5"
+            />
+            <label for="metallic-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/metallic-sheen-rating-msm/style.css
+++ b/submissions/examples/metallic-sheen-rating-msm/style.css
@@ -1,0 +1,245 @@
+:root {
+  --metallic-rating-bg: #06080c;
+  --metallic-rating-card: rgba(18, 22, 28, 0.9);
+  --metallic-rating-ink: #f8fbff;
+  --metallic-rating-muted: #bec7d0;
+  --metallic-rating-steel: #d8e2ec;
+  --metallic-rating-blue: #7dd3fc;
+  --metallic-rating-gold: #ffd580;
+  --metallic-rating-graphite: #1d2630;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--metallic-rating-ink);
+  background: var(--metallic-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.metallic-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 22%,
+      rgba(125, 211, 252, 0.2),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(255, 213, 128, 0.18),
+      transparent 22rem
+    ),
+    linear-gradient(145deg, #030508 0%, #14202b 52%, #05070b 100%);
+}
+
+.metallic-rating-card {
+  position: relative;
+  width: min(40rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(216, 226, 236, 0.24);
+  border-radius: 1.6rem;
+  background:
+    repeating-linear-gradient(
+      105deg,
+      rgba(255, 255, 255, 0.06) 0 0.08rem,
+      rgba(255, 255, 255, 0.01) 0.08rem 0.5rem
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.16), transparent 34%),
+    var(--metallic-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.5),
+    inset 0 0 4rem rgba(125, 211, 252, 0.08);
+  backdrop-filter: blur(1rem);
+}
+
+.metallic-rating-card::before {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 0 32%,
+    rgba(255, 255, 255, 0.18) 39%,
+    transparent 47% 100%
+  );
+  content: "";
+  opacity: 0.52;
+  pointer-events: none;
+  transform: translateX(-16%);
+}
+
+.metallic-rating-sweep {
+  position: absolute;
+  inset: -35% -10%;
+  display: block;
+  background: linear-gradient(
+    115deg,
+    transparent 34%,
+    rgba(255, 255, 255, 0.14) 44%,
+    transparent 54%
+  );
+  animation: metallic-rating-sheen 5.8s ease-in-out infinite;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.metallic-rating-rivet {
+  position: absolute;
+  display: block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 28%, #ffffff, #7b8792 52%, #151b22);
+  box-shadow: 0 0 1rem rgba(125, 211, 252, 0.16);
+}
+
+.metallic-rating-rivet-one {
+  top: 1.25rem;
+  left: 1.25rem;
+}
+
+.metallic-rating-rivet-two {
+  right: 1.25rem;
+  bottom: 1.25rem;
+}
+
+.metallic-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(255, 213, 128, 0.34);
+  border-radius: 999px;
+  color: var(--metallic-rating-gold);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.metallic-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.metallic-rating-options legend {
+  max-width: 11ch;
+  padding: 0;
+  font-size: clamp(2.7rem, 9vw, 5.4rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(125, 211, 252, 0.34),
+    0 0 2.5rem rgba(255, 213, 128, 0.18);
+}
+
+.metallic-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--metallic-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.metallic-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.metallic-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.metallic-rating-row label {
+  display: grid;
+  min-height: 3.55rem;
+  place-items: center;
+  border: 1px solid rgba(216, 226, 236, 0.22);
+  border-radius: 0.95rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.16), transparent 48%),
+    linear-gradient(315deg, rgba(125, 211, 252, 0.08), transparent 56%),
+    var(--metallic-rating-graphite);
+  color: var(--metallic-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow:
+    inset 0 0 1.2rem rgba(255, 255, 255, 0.05),
+    0 0.7rem 1.3rem rgba(0, 0, 0, 0.2);
+  transition:
+    transform 240ms ease,
+    border-color 240ms ease,
+    background 240ms ease,
+    color 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.metallic-rating-row label:hover,
+.metallic-rating-row input:focus-visible + label {
+  border-color: rgba(125, 211, 252, 0.68);
+  color: var(--metallic-rating-ink);
+  transform: translateY(-0.24rem);
+}
+
+.metallic-rating-row input:checked + label {
+  border-color: rgba(255, 213, 128, 0.76);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.2), transparent 46%),
+    linear-gradient(
+      315deg,
+      rgba(255, 213, 128, 0.2),
+      rgba(125, 211, 252, 0.14)
+    ),
+    #25313d;
+  color: #ffffff;
+  box-shadow:
+    0 0 1.5rem rgba(255, 213, 128, 0.24),
+    inset 0 0 1.4rem rgba(255, 255, 255, 0.1);
+}
+
+@keyframes metallic-rating-sheen {
+  50% {
+    transform: translateX(18%) rotate(1deg);
+  }
+}
+
+@media (max-width: 40rem) {
+  .metallic-rating-shell {
+    padding: 1rem;
+  }
+
+  .metallic-rating-card {
+    border-radius: 1.25rem;
+  }
+
+  .metallic-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .metallic-rating-sweep {
+    animation: none;
+  }
+
+  .metallic-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Metallic Sheen style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, brushed-metal visuals, and reduced-motion support.

Closes #75062

## Changes Made
- Created `submissions/examples/metallic-sheen-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/metallic-sheen-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/metallic-sheen-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.