### PR TITLE
feat: add subtle elevate rating component

### DIFF
--- a/submissions/examples/subtle-elevate-rating-msm/README.md
+++ b/submissions/examples/subtle-elevate-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Subtle Elevate Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a subtle elevate visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="elevate-rating-card" aria-labelledby="elevate-rating-title">
+  <fieldset class="elevate-rating-options">
+    <legend id="elevate-rating-title">Lift your rating</legend>
+    <input type="radio" id="elevate-rate-5" name="elevate-rating" value="5" />
+    <label for="elevate-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a calm, responsive, dependency-free feedback control with polished elevation states, keyboard support, and dark-mode-friendly contrast.

--- a/submissions/examples/subtle-elevate-rating-msm/demo.html
+++ b/submissions/examples/subtle-elevate-rating-msm/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subtle Elevate Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="elevate-rating-shell">
+      <form class="elevate-rating-card" aria-labelledby="elevate-rating-title">
+        <span class="elevate-rating-orb elevate-rating-orb-one"></span>
+        <span class="elevate-rating-orb elevate-rating-orb-two"></span>
+
+        <span class="elevate-rating-kicker">Quiet confidence</span>
+        <fieldset class="elevate-rating-options">
+          <legend id="elevate-rating-title">Lift your rating</legend>
+          <p>
+            Select a score with a gentle rise, soft shadows, and calm motion.
+          </p>
+
+          <div class="elevate-rating-row">
+            <input
+              type="radio"
+              id="elevate-rate-1"
+              name="elevate-rating"
+              value="1"
+            />
+            <label for="elevate-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="elevate-rate-2"
+              name="elevate-rating"
+              value="2"
+            />
+            <label for="elevate-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="elevate-rate-3"
+              name="elevate-rating"
+              value="3"
+            />
+            <label for="elevate-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="elevate-rate-4"
+              name="elevate-rating"
+              value="4"
+              checked
+            />
+            <label for="elevate-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="elevate-rate-5"
+              name="elevate-rating"
+              value="5"
+            />
+            <label for="elevate-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/subtle-elevate-rating-msm/style.css
+++ b/submissions/examples/subtle-elevate-rating-msm/style.css
@@ -1,0 +1,245 @@
+:root {
+  --elevate-rating-bg: #071015;
+  --elevate-rating-card: rgba(11, 25, 31, 0.9);
+  --elevate-rating-ink: #f7fffb;
+  --elevate-rating-muted: #bad0c9;
+  --elevate-rating-mint: #8fffe0;
+  --elevate-rating-teal: #46d4c5;
+  --elevate-rating-sand: #ffe0a3;
+  --elevate-rating-deep: #10242b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--elevate-rating-ink);
+  background: var(--elevate-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.elevate-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(143, 255, 224, 0.18),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 82% 24%,
+      rgba(255, 224, 163, 0.14),
+      transparent 23rem
+    ),
+    linear-gradient(145deg, #061015 0%, #12313a 54%, #05090d 100%);
+}
+
+.elevate-rating-card {
+  position: relative;
+  width: min(39rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(143, 255, 224, 0.18);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 32%),
+    radial-gradient(
+      circle at 25% 14%,
+      rgba(143, 255, 224, 0.14),
+      transparent 15rem
+    ),
+    var(--elevate-rating-card);
+  box-shadow:
+    0 2rem 5rem rgba(0, 0, 0, 0.45),
+    inset 0 0 4rem rgba(70, 212, 197, 0.08);
+  backdrop-filter: blur(1.1rem);
+}
+
+.elevate-rating-card::before {
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.4rem;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.08),
+    transparent 48%
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.elevate-rating-orb {
+  position: absolute;
+  display: block;
+  border-radius: 50%;
+  filter: blur(0.15rem);
+  opacity: 0.7;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.elevate-rating-orb-one {
+  top: -5rem;
+  right: -4rem;
+  width: 15rem;
+  height: 15rem;
+  background: rgba(143, 255, 224, 0.14);
+  animation: elevate-rating-float-one 7s ease-in-out infinite;
+}
+
+.elevate-rating-orb-two {
+  bottom: -6rem;
+  left: -5rem;
+  width: 17rem;
+  height: 17rem;
+  background: rgba(255, 224, 163, 0.12);
+  animation: elevate-rating-float-two 7.6s ease-in-out infinite;
+}
+
+.elevate-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(143, 255, 224, 0.32);
+  border-radius: 999px;
+  color: var(--elevate-rating-mint);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.elevate-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.elevate-rating-options legend {
+  max-width: 11ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(143, 255, 224, 0.36),
+    0 0 2.4rem rgba(70, 212, 197, 0.22);
+}
+
+.elevate-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--elevate-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.elevate-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.72rem;
+}
+
+.elevate-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.elevate-rating-row label {
+  display: grid;
+  min-height: 3.6rem;
+  place-items: center;
+  border: 1px solid rgba(143, 255, 224, 0.18);
+  border-radius: 1.15rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.1), transparent 52%),
+    var(--elevate-rating-deep);
+  color: var(--elevate-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow:
+    0 0.45rem 0.9rem rgba(0, 0, 0, 0.16),
+    inset 0 0 1.2rem rgba(143, 255, 224, 0.04);
+  transform: translateZ(0);
+  transition:
+    transform 260ms ease,
+    border-color 260ms ease,
+    background 260ms ease,
+    color 260ms ease,
+    box-shadow 260ms ease;
+}
+
+.elevate-rating-row label:hover,
+.elevate-rating-row input:focus-visible + label {
+  border-color: rgba(143, 255, 224, 0.62);
+  color: var(--elevate-rating-ink);
+  transform: translate3d(0, -0.28rem, 0);
+  box-shadow:
+    0 1rem 1.8rem rgba(0, 0, 0, 0.24),
+    inset 0 0 1.3rem rgba(143, 255, 224, 0.08);
+}
+
+.elevate-rating-row input:checked + label {
+  border-color: rgba(255, 224, 163, 0.72);
+  background: linear-gradient(
+    145deg,
+    rgba(143, 255, 224, 0.2),
+    rgba(255, 224, 163, 0.16)
+  );
+  color: #ffffff;
+  box-shadow:
+    0 1rem 2rem rgba(0, 0, 0, 0.28),
+    0 0 1.4rem rgba(255, 224, 163, 0.18),
+    inset 0 0 1.3rem rgba(143, 255, 224, 0.12);
+  transform: translate3d(0, -0.36rem, 0);
+}
+
+@keyframes elevate-rating-float-one {
+  50% {
+    transform: translate3d(-0.4rem, 0.35rem, 0);
+  }
+}
+
+@keyframes elevate-rating-float-two {
+  50% {
+    transform: translate3d(0.42rem, -0.38rem, 0);
+  }
+}
+
+@media (max-width: 40rem) {
+  .elevate-rating-shell {
+    padding: 1rem;
+  }
+
+  .elevate-rating-card {
+    border-radius: 1.4rem;
+  }
+
+  .elevate-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .elevate-rating-orb-one,
+  .elevate-rating-orb-two {
+    animation: none;
+  }
+
+  .elevate-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Subtle Elevate style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, gentle elevation states, and reduced-motion support.

Closes #75061

## Changes Made
- Created `submissions/examples/subtle-elevate-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/subtle-elevate-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/subtle-elevate-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.