### PR TITLE
feat: add gradient shimmer rating component

### DIFF
--- a/submissions/examples/gradient-shimmer-rating-msm/README.md
+++ b/submissions/examples/gradient-shimmer-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Gradient Shimmer Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a gradient shimmer visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="shimmer-rating-card" aria-labelledby="shimmer-rating-title">
+  <fieldset class="shimmer-rating-options">
+    <legend id="shimmer-rating-title">Shimmer score</legend>
+    <input type="radio" id="shimmer-rate-5" name="shimmer-rating" value="5" />
+    <label for="shimmer-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a bright, responsive, dependency-free feedback component with lively shimmer motion, keyboard support, and safe reduced-motion behavior.

--- a/submissions/examples/gradient-shimmer-rating-msm/demo.html
+++ b/submissions/examples/gradient-shimmer-rating-msm/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gradient Shimmer Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="shimmer-rating-shell">
+      <form class="shimmer-rating-card" aria-labelledby="shimmer-rating-title">
+        <span class="shimmer-rating-ribbon" aria-hidden="true"></span>
+        <span class="shimmer-rating-orb shimmer-rating-orb-one"></span>
+        <span class="shimmer-rating-orb shimmer-rating-orb-two"></span>
+
+        <span class="shimmer-rating-kicker">Animated feedback</span>
+        <fieldset class="shimmer-rating-options">
+          <legend id="shimmer-rating-title">Shimmer score</legend>
+          <p>
+            Select a rating with luminous gradients and responsive highlight
+            motion.
+          </p>
+
+          <div class="shimmer-rating-row">
+            <input
+              type="radio"
+              id="shimmer-rate-1"
+              name="shimmer-rating"
+              value="1"
+            />
+            <label for="shimmer-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="shimmer-rate-2"
+              name="shimmer-rating"
+              value="2"
+            />
+            <label for="shimmer-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="shimmer-rate-3"
+              name="shimmer-rating"
+              value="3"
+            />
+            <label for="shimmer-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="shimmer-rate-4"
+              name="shimmer-rating"
+              value="4"
+              checked
+            />
+            <label for="shimmer-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="shimmer-rate-5"
+              name="shimmer-rating"
+              value="5"
+            />
+            <label for="shimmer-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/gradient-shimmer-rating-msm/style.css
+++ b/submissions/examples/gradient-shimmer-rating-msm/style.css
@@ -1,0 +1,268 @@
+:root {
+  --shimmer-rating-bg: #050713;
+  --shimmer-rating-card: rgba(9, 15, 32, 0.9);
+  --shimmer-rating-ink: #f8fbff;
+  --shimmer-rating-muted: #bac7dc;
+  --shimmer-rating-cyan: #68f5ff;
+  --shimmer-rating-pink: #ff7ada;
+  --shimmer-rating-amber: #ffd36e;
+  --shimmer-rating-blue: #7c8cff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--shimmer-rating-ink);
+  background: var(--shimmer-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.shimmer-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 20%,
+      rgba(104, 245, 255, 0.2),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(255, 122, 218, 0.18),
+      transparent 23rem
+    ),
+    linear-gradient(145deg, #050713 0%, #111d3d 54%, #050611 100%);
+}
+
+.shimmer-rating-card {
+  position: relative;
+  width: min(40rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(104, 245, 255, 0.22);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.13), transparent 34%),
+    radial-gradient(
+      circle at 30% 18%,
+      rgba(124, 140, 255, 0.16),
+      transparent 15rem
+    ),
+    var(--shimmer-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.5),
+    inset 0 0 4rem rgba(104, 245, 255, 0.08);
+  backdrop-filter: blur(1.1rem);
+}
+
+.shimmer-rating-card::before {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    120deg,
+    transparent 0 28%,
+    rgba(255, 255, 255, 0.16) 36%,
+    transparent 45% 100%
+  );
+  content: "";
+  opacity: 0.5;
+  pointer-events: none;
+  transform: translateX(-18%);
+}
+
+.shimmer-rating-ribbon {
+  position: absolute;
+  inset: -35% -20%;
+  display: block;
+  background: linear-gradient(
+    115deg,
+    transparent 34%,
+    rgba(104, 245, 255, 0.12) 42%,
+    rgba(255, 122, 218, 0.14) 48%,
+    transparent 58%
+  );
+  animation: shimmer-rating-sweep 5.8s ease-in-out infinite;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.shimmer-rating-orb {
+  position: absolute;
+  display: block;
+  border-radius: 50%;
+  filter: blur(0.25rem);
+  opacity: 0.7;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.shimmer-rating-orb-one {
+  top: -6rem;
+  right: -5rem;
+  width: 16rem;
+  height: 16rem;
+  background: rgba(104, 245, 255, 0.14);
+  animation: shimmer-rating-float-one 7s ease-in-out infinite;
+}
+
+.shimmer-rating-orb-two {
+  bottom: -7rem;
+  left: -5rem;
+  width: 18rem;
+  height: 18rem;
+  background: rgba(255, 122, 218, 0.13);
+  animation: shimmer-rating-float-two 7.6s ease-in-out infinite;
+}
+
+.shimmer-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(104, 245, 255, 0.34);
+  border-radius: 999px;
+  color: var(--shimmer-rating-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.shimmer-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.shimmer-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(104, 245, 255, 0.4),
+    0 0 2.6rem rgba(255, 122, 218, 0.28);
+}
+
+.shimmer-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--shimmer-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.shimmer-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.shimmer-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.shimmer-rating-row label {
+  display: grid;
+  min-height: 3.6rem;
+  place-items: center;
+  border: 1px solid rgba(104, 245, 255, 0.2);
+  border-radius: 1.1rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.12), transparent 52%),
+    rgba(255, 255, 255, 0.07);
+  background-size: 180% 180%;
+  color: var(--shimmer-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow:
+    inset 0 0 1.3rem rgba(104, 245, 255, 0.05),
+    0 0.7rem 1.4rem rgba(0, 0, 0, 0.2);
+  transform: translateZ(0);
+  transition:
+    transform 240ms ease,
+    border-color 240ms ease,
+    background 240ms ease,
+    color 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.shimmer-rating-row label:hover,
+.shimmer-rating-row input:focus-visible + label {
+  border-color: rgba(104, 245, 255, 0.7);
+  color: var(--shimmer-rating-ink);
+  transform: translate3d(0, -0.24rem, 0);
+}
+
+.shimmer-rating-row input:checked + label {
+  border-color: rgba(255, 211, 110, 0.76);
+  background:
+    linear-gradient(
+      115deg,
+      rgba(104, 245, 255, 0.24),
+      rgba(255, 122, 218, 0.2),
+      rgba(255, 211, 110, 0.2)
+    ),
+    rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  box-shadow:
+    0 0 1.6rem rgba(255, 122, 218, 0.24),
+    inset 0 0 1.4rem rgba(104, 245, 255, 0.12);
+}
+
+@keyframes shimmer-rating-sweep {
+  50% {
+    transform: translateX(18%) rotate(1deg);
+  }
+}
+
+@keyframes shimmer-rating-float-one {
+  50% {
+    transform: translate3d(-0.4rem, 0.36rem, 0);
+  }
+}
+
+@keyframes shimmer-rating-float-two {
+  50% {
+    transform: translate3d(0.42rem, -0.4rem, 0);
+  }
+}
+
+@media (max-width: 40rem) {
+  .shimmer-rating-shell {
+    padding: 1rem;
+  }
+
+  .shimmer-rating-card {
+    border-radius: 1.35rem;
+  }
+
+  .shimmer-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer-rating-ribbon,
+  .shimmer-rating-orb-one,
+  .shimmer-rating-orb-two {
+    animation: none;
+  }
+
+  .shimmer-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Gradient Shimmer style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, animated shimmer visuals, and reduced-motion support.

Closes #75060

## Changes Made
- Created `submissions/examples/gradient-shimmer-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/gradient-shimmer-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/gradient-shimmer-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.