### PR TITLE
feat: add minimalist outline rating component

### DIFF
--- a/submissions/examples/minimalist-outline-rating-msm/README.md
+++ b/submissions/examples/minimalist-outline-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Minimalist Outline Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a minimalist outline visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="outline-rating-card" aria-labelledby="outline-rating-title">
+  <fieldset class="outline-rating-options">
+    <legend id="outline-rating-title">Outline rating</legend>
+    <input type="radio" id="outline-rate-5" name="outline-rating" value="5" />
+    <label for="outline-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a clean, lightweight, dependency-free feedback component with visible focus states, responsive layout, and calm dark-mode contrast.

--- a/submissions/examples/minimalist-outline-rating-msm/demo.html
+++ b/submissions/examples/minimalist-outline-rating-msm/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Minimalist Outline Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="outline-rating-shell">
+      <form class="outline-rating-card" aria-labelledby="outline-rating-title">
+        <span class="outline-rating-frame" aria-hidden="true"></span>
+
+        <span class="outline-rating-kicker">Simple feedback</span>
+        <fieldset class="outline-rating-options">
+          <legend id="outline-rating-title">Outline rating</legend>
+          <p>
+            Pick a score using crisp outline controls with subtle elevation and
+            clear focus states.
+          </p>
+
+          <div class="outline-rating-row">
+            <input
+              type="radio"
+              id="outline-rate-1"
+              name="outline-rating"
+              value="1"
+            />
+            <label for="outline-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="outline-rate-2"
+              name="outline-rating"
+              value="2"
+            />
+            <label for="outline-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="outline-rate-3"
+              name="outline-rating"
+              value="3"
+            />
+            <label for="outline-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="outline-rate-4"
+              name="outline-rating"
+              value="4"
+              checked
+            />
+            <label for="outline-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="outline-rate-5"
+              name="outline-rating"
+              value="5"
+            />
+            <label for="outline-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/minimalist-outline-rating-msm/style.css
+++ b/submissions/examples/minimalist-outline-rating-msm/style.css
@@ -1,0 +1,208 @@
+:root {
+  --outline-rating-bg: #060b10;
+  --outline-rating-card: rgba(8, 15, 21, 0.9);
+  --outline-rating-ink: #f7fbff;
+  --outline-rating-muted: #adbdc9;
+  --outline-rating-line: #7890a3;
+  --outline-rating-cyan: #7de8ff;
+  --outline-rating-lime: #baff9a;
+  --outline-rating-deep: #0f1b24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--outline-rating-ink);
+  background: var(--outline-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.outline-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 20%,
+      rgba(125, 232, 255, 0.14),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(186, 255, 154, 0.12),
+      transparent 23rem
+    ),
+    linear-gradient(145deg, #05090d 0%, #0d202b 55%, #05080c 100%);
+}
+
+.outline-rating-card {
+  position: relative;
+  width: min(38rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(125, 232, 255, 0.24);
+  border-radius: 1.8rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 32%),
+    var(--outline-rating-card);
+  box-shadow:
+    0 2rem 5rem rgba(0, 0, 0, 0.45),
+    inset 0 0 3rem rgba(125, 232, 255, 0.06);
+  backdrop-filter: blur(1rem);
+}
+
+.outline-rating-frame {
+  position: absolute;
+  inset: 1rem;
+  display: block;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.2rem;
+  pointer-events: none;
+}
+
+.outline-rating-frame::before,
+.outline-rating-frame::after {
+  position: absolute;
+  width: 5rem;
+  height: 5rem;
+  border-color: rgba(186, 255, 154, 0.36);
+  content: "";
+}
+
+.outline-rating-frame::before {
+  top: -0.05rem;
+  left: -0.05rem;
+  border-top: 2px solid;
+  border-left: 2px solid;
+  border-radius: 1.2rem 0 0;
+}
+
+.outline-rating-frame::after {
+  right: -0.05rem;
+  bottom: -0.05rem;
+  border-right: 2px solid;
+  border-bottom: 2px solid;
+  border-radius: 0 0 1.2rem;
+}
+
+.outline-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(125, 232, 255, 0.34);
+  border-radius: 999px;
+  color: var(--outline-rating-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.outline-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.outline-rating-options legend {
+  max-width: 11ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.5rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(125, 232, 255, 0.26),
+    0 0 2.4rem rgba(186, 255, 154, 0.14);
+}
+
+.outline-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--outline-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.outline-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.outline-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.outline-rating-row label {
+  display: grid;
+  min-height: 3.55rem;
+  place-items: center;
+  border: 1px solid rgba(120, 144, 163, 0.5);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--outline-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  outline: 1px solid transparent;
+  box-shadow: inset 0 0 1.1rem rgba(125, 232, 255, 0.03);
+  transform: translateZ(0);
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    outline-color 220ms ease,
+    background 220ms ease,
+    color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.outline-rating-row label:hover,
+.outline-rating-row input:focus-visible + label {
+  border-color: rgba(125, 232, 255, 0.72);
+  outline-color: rgba(125, 232, 255, 0.26);
+  color: var(--outline-rating-ink);
+  transform: translate3d(0, -0.22rem, 0);
+}
+
+.outline-rating-row input:checked + label {
+  border-color: rgba(186, 255, 154, 0.76);
+  outline-color: rgba(186, 255, 154, 0.24);
+  background:
+    linear-gradient(145deg, rgba(186, 255, 154, 0.12), transparent 54%),
+    var(--outline-rating-deep);
+  color: #ffffff;
+  box-shadow:
+    0 0 1.2rem rgba(186, 255, 154, 0.14),
+    inset 0 0 1.2rem rgba(125, 232, 255, 0.06);
+}
+
+@media (max-width: 40rem) {
+  .outline-rating-shell {
+    padding: 1rem;
+  }
+
+  .outline-rating-card {
+    border-radius: 1.35rem;
+  }
+
+  .outline-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .outline-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Minimalist Outline style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, crisp outline visuals, and reduced-motion support.

Closes #75059

## Changes Made
- Created `submissions/examples/minimalist-outline-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/minimalist-outline-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/minimalist-outline-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.