### PR TITLE
feat: add quantum energy shield rating component

### DIFF
--- a/submissions/examples/quantum-energy-shield-rating-msm/README.md
+++ b/submissions/examples/quantum-energy-shield-rating-msm/README.md
@@ -1,0 +1,25 @@
+# Quantum Energy Shield Rating
+
+## What does this do?
+
+This submission adds an accessible pure CSS rating and feedback component with a quantum energy shield visual style.
+
+## How is it used?
+
+Link the stylesheet and use the semantic rating form structure:
+
+```html
+<link rel="stylesheet" href="style.css" />
+
+<form class="quantum-rating-card" aria-labelledby="quantum-rating-title">
+  <fieldset class="quantum-rating-options">
+    <legend id="quantum-rating-title">Shield rating</legend>
+    <input type="radio" id="quantum-rate-5" name="quantum-rating" value="5" />
+    <label for="quantum-rate-5">5</label>
+  </fieldset>
+</form>
+```
+
+## Why is it useful?
+
+It gives EaseMotion users a futuristic, responsive, dependency-free feedback component with clear focus states, shield-like motion, and reduced-motion support.

--- a/submissions/examples/quantum-energy-shield-rating-msm/demo.html
+++ b/submissions/examples/quantum-energy-shield-rating-msm/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quantum Energy Shield Rating</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="quantum-rating-shell">
+      <form class="quantum-rating-card" aria-labelledby="quantum-rating-title">
+        <span class="quantum-rating-shield" aria-hidden="true"></span>
+        <span class="quantum-rating-ring quantum-rating-ring-one"></span>
+        <span class="quantum-rating-ring quantum-rating-ring-two"></span>
+
+        <span class="quantum-rating-kicker">Protected feedback</span>
+        <fieldset class="quantum-rating-options">
+          <legend id="quantum-rating-title">Shield rating</legend>
+          <p>
+            Pick a score inside a glowing shield field with clean keyboard
+            states.
+          </p>
+
+          <div class="quantum-rating-row">
+            <input
+              type="radio"
+              id="quantum-rate-1"
+              name="quantum-rating"
+              value="1"
+            />
+            <label for="quantum-rate-1" aria-label="Rate 1 out of 5">1</label>
+
+            <input
+              type="radio"
+              id="quantum-rate-2"
+              name="quantum-rating"
+              value="2"
+            />
+            <label for="quantum-rate-2" aria-label="Rate 2 out of 5">2</label>
+
+            <input
+              type="radio"
+              id="quantum-rate-3"
+              name="quantum-rating"
+              value="3"
+            />
+            <label for="quantum-rate-3" aria-label="Rate 3 out of 5">3</label>
+
+            <input
+              type="radio"
+              id="quantum-rate-4"
+              name="quantum-rating"
+              value="4"
+              checked
+            />
+            <label for="quantum-rate-4" aria-label="Rate 4 out of 5">4</label>
+
+            <input
+              type="radio"
+              id="quantum-rate-5"
+              name="quantum-rating"
+              value="5"
+            />
+            <label for="quantum-rate-5" aria-label="Rate 5 out of 5">5</label>
+          </div>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/quantum-energy-shield-rating-msm/style.css
+++ b/submissions/examples/quantum-energy-shield-rating-msm/style.css
@@ -1,0 +1,260 @@
+:root {
+  --quantum-rating-bg: #030712;
+  --quantum-rating-card: rgba(8, 15, 32, 0.9);
+  --quantum-rating-ink: #f8fbff;
+  --quantum-rating-muted: #b7c6d8;
+  --quantum-rating-cyan: #5df4ff;
+  --quantum-rating-violet: #9a7cff;
+  --quantum-rating-green: #8dffbf;
+  --quantum-rating-deep: #101a2d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--quantum-rating-ink);
+  background: var(--quantum-rating-bg);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.quantum-rating-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  overflow: hidden;
+  padding: 2rem;
+  background:
+    radial-gradient(
+      circle at 18% 22%,
+      rgba(93, 244, 255, 0.2),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(154, 124, 255, 0.2),
+      transparent 24rem
+    ),
+    linear-gradient(145deg, #030712 0%, #101d3b 55%, #03050d 100%);
+}
+
+.quantum-rating-card {
+  position: relative;
+  width: min(40rem, 100%);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(93, 244, 255, 0.24);
+  border-radius: 2.1rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.13), transparent 34%),
+    radial-gradient(
+      circle at 28% 15%,
+      rgba(141, 255, 191, 0.14),
+      transparent 15rem
+    ),
+    var(--quantum-rating-card);
+  box-shadow:
+    0 2rem 6rem rgba(0, 0, 0, 0.52),
+    inset 0 0 4rem rgba(93, 244, 255, 0.08);
+  backdrop-filter: blur(1.1rem);
+}
+
+.quantum-rating-shield {
+  position: absolute;
+  inset: 1.1rem;
+  display: block;
+  border: 1px solid rgba(93, 244, 255, 0.2);
+  border-radius: 1.5rem;
+  clip-path: polygon(50% 0, 100% 18%, 88% 78%, 50% 100%, 12% 78%, 0 18%);
+  pointer-events: none;
+}
+
+.quantum-rating-shield::before {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      120deg,
+      transparent 28%,
+      rgba(255, 255, 255, 0.14) 38%,
+      transparent 48%
+    ),
+    radial-gradient(circle at 50% 0, rgba(141, 255, 191, 0.12), transparent 65%);
+  animation: quantum-rating-scan 5.8s ease-in-out infinite;
+  content: "";
+  will-change: transform;
+}
+
+.quantum-rating-ring {
+  position: absolute;
+  display: block;
+  border: 1px solid rgba(93, 244, 255, 0.18);
+  border-radius: 50%;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.quantum-rating-ring-one {
+  top: -7rem;
+  right: -5rem;
+  width: 18rem;
+  height: 18rem;
+  animation: quantum-rating-orbit-one 7s ease-in-out infinite;
+}
+
+.quantum-rating-ring-two {
+  bottom: -7rem;
+  left: -6rem;
+  width: 19rem;
+  height: 19rem;
+  border-color: rgba(154, 124, 255, 0.18);
+  animation: quantum-rating-orbit-two 7.6s ease-in-out infinite;
+}
+
+.quantum-rating-kicker {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  margin-bottom: 1rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(93, 244, 255, 0.34);
+  border-radius: 999px;
+  color: var(--quantum-rating-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.quantum-rating-options {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.quantum-rating-options legend {
+  max-width: 10ch;
+  padding: 0;
+  font-size: clamp(2.8rem, 9vw, 5.6rem);
+  font-weight: 800;
+  line-height: 0.92;
+  text-shadow:
+    0 0 1rem rgba(93, 244, 255, 0.42),
+    0 0 2.6rem rgba(154, 124, 255, 0.28);
+}
+
+.quantum-rating-options p {
+  max-width: 28rem;
+  margin: 1rem 0 1.9rem;
+  color: var(--quantum-rating-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.quantum-rating-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  gap: 0.7rem;
+}
+
+.quantum-rating-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.quantum-rating-row label {
+  display: grid;
+  min-height: 3.6rem;
+  place-items: center;
+  border: 1px solid rgba(93, 244, 255, 0.2);
+  border-radius: 1.1rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.12), transparent 52%),
+    var(--quantum-rating-deep);
+  color: var(--quantum-rating-muted);
+  cursor: pointer;
+  font-weight: 900;
+  box-shadow:
+    inset 0 0 1.3rem rgba(93, 244, 255, 0.05),
+    0 0.7rem 1.4rem rgba(0, 0, 0, 0.2);
+  transform: translateZ(0);
+  transition:
+    transform 240ms ease,
+    border-color 240ms ease,
+    background 240ms ease,
+    color 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.quantum-rating-row label:hover,
+.quantum-rating-row input:focus-visible + label {
+  border-color: rgba(93, 244, 255, 0.72);
+  color: var(--quantum-rating-ink);
+  transform: translate3d(0, -0.24rem, 0);
+}
+
+.quantum-rating-row input:checked + label {
+  border-color: rgba(141, 255, 191, 0.76);
+  background:
+    linear-gradient(
+      145deg,
+      rgba(93, 244, 255, 0.22),
+      rgba(154, 124, 255, 0.18)
+    ),
+    var(--quantum-rating-deep);
+  color: #ffffff;
+  box-shadow:
+    0 0 1.5rem rgba(93, 244, 255, 0.22),
+    0 0 2.4rem rgba(141, 255, 191, 0.1),
+    inset 0 0 1.4rem rgba(154, 124, 255, 0.12);
+}
+
+@keyframes quantum-rating-scan {
+  50% {
+    transform: translateY(0.5rem);
+  }
+}
+
+@keyframes quantum-rating-orbit-one {
+  50% {
+    transform: translate3d(-0.38rem, 0.34rem, 0) rotate(3deg);
+  }
+}
+
+@keyframes quantum-rating-orbit-two {
+  50% {
+    transform: translate3d(0.38rem, -0.4rem, 0) rotate(-3deg);
+  }
+}
+
+@media (max-width: 40rem) {
+  .quantum-rating-shell {
+    padding: 1rem;
+  }
+
+  .quantum-rating-card {
+    border-radius: 1.4rem;
+  }
+
+  .quantum-rating-row {
+    grid-template-columns: repeat(5, minmax(2.45rem, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quantum-rating-shield::before,
+  .quantum-rating-ring-one,
+  .quantum-rating-ring-two {
+    animation: none;
+  }
+
+  .quantum-rating-row label {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS rating and feedback submission for the Quantum Energy Shield style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic radio inputs, keyboard-friendly labels, shield-field visuals, and reduced-motion support.

Closes #75058

## Changes Made
- Created `submissions/examples/quantum-energy-shield-rating-msm/`.
- Added an accessible 1-5 rating component with pure HTML/CSS.
- Documented usage, purpose, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/quantum-energy-shield-rating-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/quantum-energy-shield-rating-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic radio controls and visible focus styles for keyboard users.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.