### PR TITLE
feat: add basic panel footer row demo

### DIFF
--- a/submissions/examples/basic-panel-footer-row-kk/README.md
+++ b/submissions/examples/basic-panel-footer-row-kk/README.md
@@ -1,0 +1,37 @@
+# Basic Panel Footer Row
+
+## What it does
+
+This submission adds a simple CSS-only panel footer row for showing helper text, status details, and a small right-side action at the bottom of cards or panels.
+
+It works well for dashboard cards, settings panels, profile sections, billing summaries, report cards, and compact content blocks.
+
+## How to use it
+
+Add the utility class to a footer row with supporting text and an optional action:
+
+```html
+<div class="basic-panel-footer-row">
+  <span>Last updated today</span>
+  <a href="#">View details</a>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across many frontend layouts. The utility provides a reusable bottom-row pattern for cards and panels without JavaScript or external libraries.
+
+## Included features
+
+- Helper text and right-side action layout
+- Panel/card footer spacing
+- Top divider support
+- Hover and keyboard focus styling for links
+- Responsive stacked layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the panel footer row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-panel-footer-row-kk/demo.html
+++ b/submissions/examples/basic-panel-footer-row-kk/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Panel Footer Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Panel Footer Row</p>
+          <h1>Clean footer rows for cards, panels, and compact actions.</h1>
+          <p class="intro">
+            This CSS-only utility creates a bottom row for helper text,
+            status labels, and small actions inside cards or dashboard panels.
+          </p>
+        </header>
+
+        <section class="preview-panel">
+          <div class="mock-panel">
+            <div class="mock-content">
+              <strong>Project overview</strong>
+              <p>Review files, team updates, and recent activity in one card.</p>
+            </div>
+
+            <div class="basic-panel-footer-row">
+              <span>Last updated today</span>
+              <a href="#">View details</a>
+            </div>
+          </div>
+
+          <div class="mock-panel">
+            <div class="mock-content">
+              <strong>Billing summary</strong>
+              <p>Your current plan and invoice details are ready to view.</p>
+            </div>
+
+            <div class="basic-panel-footer-row">
+              <span>3 invoices available</span>
+              <a href="#">Open</a>
+            </div>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-panel-footer-row"&gt;
+  &lt;span&gt;Last updated today&lt;/span&gt;
+  &lt;a href="#"&gt;View details&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-panel-footer-row-kk/style.css
+++ b/submissions/examples/basic-panel-footer-row-kk/style.css
@@ -1,0 +1,151 @@
+:root {
+  color-scheme: dark;
+  --page: #080e19;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #f9a8d4;
+  --accent-soft: rgba(249, 168, 212, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(249, 168, 212, 0.15), transparent 28%),
+    radial-gradient(circle at 84% 82%, rgba(147, 197, 253, 0.11), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.preview-panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.mock-panel,
+.usage-card {
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.mock-content {
+  padding: 1rem 1.15rem;
+}
+
+.mock-content strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.mock-content p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.basic-panel-footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.15rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-panel-footer-row span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.basic-panel-footer-row a {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.basic-panel-footer-row a:hover,
+.basic-panel-footer-row a:focus-visible {
+  color: #160713;
+  background: var(--accent);
+  outline: none;
+}
+
+.usage-card {
+  padding: 1rem 1.15rem;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-panel-footer-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Panel Footer Row demo inside `submissions/examples/basic-panel-footer-row-kk/`. This submission introduces a compact CSS-only footer row pattern for cards, panels, dashboard summaries, settings sections, and report blocks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only panel footer row for showing helper text, status details, and a small right-side action at the bottom of cards or panels.

**How does a developer use it?**

```html
<div class="basic-panel-footer-row">
  <span>Last updated today</span>
  <a href="#">View details</a>
</div>