### PR TITLE
feat: add particle burst neumorphic effect

### DIFF
--- a/submissions/examples/particle-burst-neumorphic-msm/README.md
+++ b/submissions/examples/particle-burst-neumorphic-msm/README.md
@@ -1,0 +1,31 @@
+# Particle Burst Neumorphic Effect
+
+## What does this do?
+
+This submission adds a pure HTML and CSS neumorphic interface card with a particle-burst interaction style.
+
+## How is it used?
+
+Add the card markup from `demo.html` and include `style.css` in any static HTML page:
+
+```html
+<section class="particle-neumo-card">
+  <div class="particle-neumo-orb" aria-hidden="true"></div>
+  <button class="particle-neumo-action" type="button">
+    Launch particle burst
+  </button>
+</section>
+```
+
+The component is self-contained and does not require JavaScript, a build step, external fonts, or CDN assets.
+
+## Why is it useful?
+
+EaseMotion CSS focuses on expressive motion that still feels lightweight and readable. This component demonstrates how a soft neumorphic surface can feel more energetic through GPU-friendly transforms, layered radial gradients, clear focus states, and reduced-motion support.
+
+## Accessibility Notes
+
+- The demo uses semantic landmarks, headings, buttons, and list content.
+- Decorative particles are hidden with `aria-hidden="true"`.
+- Interactive controls include visible hover and keyboard focus states.
+- Motion-heavy effects are disabled for users who prefer reduced motion.

--- a/submissions/examples/particle-burst-neumorphic-msm/demo.html
+++ b/submissions/examples/particle-burst-neumorphic-msm/demo.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Particle Burst Neumorphic Effect</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="particle-neumo-page">
+      <section
+        class="particle-neumo-card"
+        aria-labelledby="particle-neumo-title"
+      >
+        <div class="particle-neumo-glow" aria-hidden="true"></div>
+        <div class="particle-neumo-orb" aria-hidden="true">
+          <span class="particle particle-one"></span>
+          <span class="particle particle-two"></span>
+          <span class="particle particle-three"></span>
+          <span class="particle particle-four"></span>
+          <span class="particle particle-five"></span>
+          <span class="particle particle-six"></span>
+        </div>
+
+        <p class="particle-neumo-kicker">Neumorphic UI</p>
+        <h1 id="particle-neumo-title">Particle Burst Control</h1>
+        <p class="particle-neumo-copy">
+          A soft tactile panel with animated particle energy, deep inset
+          shadows, and responsive feedback for expressive interface moments.
+        </p>
+
+        <div class="particle-neumo-metrics" aria-label="Particle burst metrics">
+          <div>
+            <span class="metric-value">96%</span>
+            <span class="metric-label">Glow Sync</span>
+          </div>
+          <div>
+            <span class="metric-value">42ms</span>
+            <span class="metric-label">Pulse Lag</span>
+          </div>
+          <div>
+            <span class="metric-value">8x</span>
+            <span class="metric-label">Burst Arc</span>
+          </div>
+        </div>
+
+        <button class="particle-neumo-action" type="button">
+          Launch particle burst
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/particle-burst-neumorphic-msm/style.css
+++ b/submissions/examples/particle-burst-neumorphic-msm/style.css
@@ -1,0 +1,371 @@
+:root {
+  --particle-neumo-bg: #dbe4f3;
+  --particle-neumo-ink: #213047;
+  --particle-neumo-muted: #697895;
+  --particle-neumo-panel: #e8eef8;
+  --particle-neumo-highlight: #ffffff;
+  --particle-neumo-shadow: #aab8cf;
+  --particle-neumo-blue: #4f8cff;
+  --particle-neumo-cyan: #2ad4ff;
+  --particle-neumo-pink: #ff69c8;
+  --particle-neumo-amber: #ffbc58;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--particle-neumo-ink);
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(79, 140, 255, 0.2),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 82% 28%,
+      rgba(255, 105, 200, 0.14),
+      transparent 24rem
+    ),
+    linear-gradient(
+      135deg,
+      #d4deec 0%,
+      var(--particle-neumo-bg) 48%,
+      #edf2fa 100%
+    );
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.particle-neumo-page {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.particle-neumo-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 31rem);
+  overflow: hidden;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.62);
+  border-radius: 2.2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.42),
+      rgba(204, 216, 235, 0.34)
+    ),
+    var(--particle-neumo-panel);
+  box-shadow:
+    1.2rem 1.2rem 2.4rem rgba(149, 164, 190, 0.82),
+    -1.2rem -1.2rem 2.4rem rgba(255, 255, 255, 0.9),
+    inset 0.08rem 0.08rem 0.2rem rgba(255, 255, 255, 0.8),
+    inset -0.08rem -0.08rem 0.22rem rgba(150, 164, 190, 0.38);
+}
+
+.particle-neumo-card::before,
+.particle-neumo-card::after {
+  position: absolute;
+  z-index: -1;
+  border-radius: 999px;
+  content: "";
+  filter: blur(0.2rem);
+}
+
+.particle-neumo-card::before {
+  top: -6rem;
+  right: -5rem;
+  width: 14rem;
+  height: 14rem;
+  background: rgba(42, 212, 255, 0.22);
+}
+
+.particle-neumo-card::after {
+  bottom: -5.5rem;
+  left: -4rem;
+  width: 12rem;
+  height: 12rem;
+  background: rgba(255, 105, 200, 0.16);
+}
+
+.particle-neumo-glow {
+  position: absolute;
+  inset: 1.4rem;
+  z-index: -1;
+  border-radius: 1.7rem;
+  background:
+    radial-gradient(circle at 50% 8%, rgba(79, 140, 255, 0.2), transparent 36%),
+    radial-gradient(
+      circle at 50% 100%,
+      rgba(255, 188, 88, 0.14),
+      transparent 38%
+    );
+  box-shadow: inset 0 0 2rem rgba(79, 140, 255, 0.1);
+  opacity: 0.9;
+}
+
+.particle-neumo-orb {
+  position: relative;
+  display: grid;
+  width: 9rem;
+  height: 9rem;
+  margin: 0 auto 1.75rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 28%, #ffffff 0 9%, transparent 10%),
+    radial-gradient(
+      circle at 50% 50%,
+      rgba(42, 212, 255, 0.78),
+      rgba(79, 140, 255, 0.42) 38%,
+      transparent 62%
+    ),
+    linear-gradient(145deg, #f8fbff, #c8d6e9);
+  box-shadow:
+    0.72rem 0.72rem 1.4rem rgba(143, 158, 183, 0.72),
+    -0.72rem -0.72rem 1.4rem rgba(255, 255, 255, 0.94),
+    inset 0.35rem 0.35rem 0.8rem rgba(255, 255, 255, 0.78),
+    inset -0.45rem -0.45rem 0.9rem rgba(114, 132, 165, 0.42);
+  place-items: center;
+}
+
+.particle-neumo-orb::before,
+.particle-neumo-orb::after {
+  position: absolute;
+  inset: 1rem;
+  border: 0.08rem solid rgba(79, 140, 255, 0.42);
+  border-radius: 50%;
+  content: "";
+}
+
+.particle-neumo-orb::before {
+  animation: particle-spin 9s linear infinite;
+  box-shadow: 0 -0.35rem 0 var(--particle-neumo-cyan);
+}
+
+.particle-neumo-orb::after {
+  inset: 2.05rem;
+  animation: particle-spin 6s linear infinite reverse;
+  border-color: rgba(255, 105, 200, 0.42);
+  box-shadow: 0 0.32rem 0 var(--particle-neumo-pink);
+}
+
+.particle {
+  position: absolute;
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 999px;
+  background: var(--particle-neumo-blue);
+  box-shadow: 0 0 1rem currentcolor;
+  animation: particle-burst 2.8s ease-in-out infinite;
+}
+
+.particle-one {
+  top: 1rem;
+  left: 4.2rem;
+  color: var(--particle-neumo-cyan);
+  animation-delay: -0.2s;
+}
+
+.particle-two {
+  top: 2.3rem;
+  right: 1.3rem;
+  color: var(--particle-neumo-pink);
+  animation-delay: -0.65s;
+}
+
+.particle-three {
+  right: 1.6rem;
+  bottom: 2.1rem;
+  color: var(--particle-neumo-amber);
+  animation-delay: -1.1s;
+}
+
+.particle-four {
+  bottom: 1rem;
+  left: 4rem;
+  color: var(--particle-neumo-cyan);
+  animation-delay: -1.55s;
+}
+
+.particle-five {
+  bottom: 2.3rem;
+  left: 1.2rem;
+  color: var(--particle-neumo-pink);
+  animation-delay: -2s;
+}
+
+.particle-six {
+  top: 2.4rem;
+  left: 1.4rem;
+  color: var(--particle-neumo-amber);
+  animation-delay: -2.45s;
+}
+
+.particle-neumo-kicker {
+  margin: 0 0 0.65rem;
+  color: var(--particle-neumo-blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.particle-neumo-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3.25rem);
+  line-height: 0.94;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.particle-neumo-copy {
+  max-width: 27rem;
+  margin: 1rem auto 1.6rem;
+  color: var(--particle-neumo-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+  text-align: center;
+}
+
+.particle-neumo-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.particle-neumo-metrics div {
+  padding: 0.9rem 0.65rem;
+  border-radius: 1.1rem;
+  background: rgba(232, 238, 248, 0.72);
+  box-shadow:
+    inset 0.32rem 0.32rem 0.7rem rgba(171, 184, 207, 0.74),
+    inset -0.32rem -0.32rem 0.7rem rgba(255, 255, 255, 0.82);
+  text-align: center;
+}
+
+.metric-value,
+.metric-label {
+  display: block;
+}
+
+.metric-value {
+  color: var(--particle-neumo-ink);
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.metric-label {
+  margin-top: 0.25rem;
+  color: var(--particle-neumo-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.particle-neumo-action {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-radius: 1.3rem;
+  padding: 1rem 1.15rem;
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(255, 255, 255, 0.42),
+      transparent 30%
+    ),
+    linear-gradient(
+      135deg,
+      var(--particle-neumo-blue),
+      #7b5cff 55%,
+      var(--particle-neumo-pink)
+    );
+  box-shadow:
+    0 1rem 1.9rem rgba(79, 140, 255, 0.32),
+    inset 0 0.12rem 0.28rem rgba(255, 255, 255, 0.42);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    filter 220ms ease;
+}
+
+.particle-neumo-action:hover {
+  box-shadow:
+    0 1.3rem 2.4rem rgba(79, 140, 255, 0.4),
+    0 0 2.2rem rgba(255, 105, 200, 0.28),
+    inset 0 0.12rem 0.28rem rgba(255, 255, 255, 0.5);
+  filter: saturate(1.14);
+  transform: translateY(-0.16rem);
+}
+
+.particle-neumo-action:focus-visible {
+  outline: 0.2rem solid rgba(33, 48, 71, 0.84);
+  outline-offset: 0.22rem;
+}
+
+.particle-neumo-card:hover .particle {
+  animation-duration: 1.7s;
+}
+
+@keyframes particle-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes particle-burst {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.7) translate3d(0, 0, 0);
+  }
+
+  48% {
+    opacity: 1;
+    transform: scale(1.22) translate3d(0.2rem, -0.25rem, 0);
+  }
+
+  72% {
+    opacity: 0.8;
+    transform: scale(0.9) translate3d(-0.12rem, 0.16rem, 0);
+  }
+}
+
+@media (max-width: 38rem) {
+  .particle-neumo-page {
+    padding: 1rem;
+  }
+
+  .particle-neumo-card {
+    padding: 1.45rem;
+    border-radius: 1.6rem;
+  }
+
+  .particle-neumo-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS neumorphic UI submission for the Particle Burst style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic structure, decorative particles, focus-visible states, responsive layout, and reduced-motion support.

Closes #73751

## Changes Made
- Created `submissions/examples/particle-burst-neumorphic-msm/`.
- Added a tactile neumorphic control card with particle burst motion and inset surface styling.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/particle-burst-neumorphic-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/particle-burst-neumorphic-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic HTML and visible keyboard focus for the button control.
- Decorative particle elements are hidden from assistive technology.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.