### PR TITLE
feat: add glassmorphism blur neumorphic effect

### DIFF
--- a/submissions/examples/glassmorphism-blur-neumorphic-msm/README.md
+++ b/submissions/examples/glassmorphism-blur-neumorphic-msm/README.md
@@ -1,0 +1,29 @@
+# Glassmorphism Blur Neumorphic Effect
+
+## What does this do?
+
+This submission adds a pure HTML and CSS neumorphic panel that blends soft extruded surfaces with glassmorphism blur styling.
+
+## How is it used?
+
+Place the card markup from `demo.html` in a static page and link the included stylesheet:
+
+```html
+<section class="glass-neumo-card">
+  <div class="glass-neumo-preview" aria-hidden="true"></div>
+  <button class="glass-neumo-button" type="button">Tune blur field</button>
+</section>
+```
+
+The component works by opening `demo.html` directly in a browser. It does not need JavaScript, external fonts, frameworks, images, or a build step.
+
+## Why is it useful?
+
+EaseMotion CSS encourages expressive motion and approachable UI primitives. This example shows how frosted-glass depth can be paired with neumorphic shadows, clear content hierarchy, keyboard-visible focus states, and reduced-motion support while staying lightweight.
+
+## Accessibility Notes
+
+- Uses semantic headings, a button, and descriptive text.
+- Decorative glass layers are marked with `aria-hidden="true"`.
+- The primary action has a visible `:focus-visible` state.
+- Animations are disabled for users who prefer reduced motion.

--- a/submissions/examples/glassmorphism-blur-neumorphic-msm/demo.html
+++ b/submissions/examples/glassmorphism-blur-neumorphic-msm/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glassmorphism Blur Neumorphic Effect</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="glass-neumo-page">
+      <section class="glass-neumo-card" aria-labelledby="glass-neumo-title">
+        <div class="glass-neumo-aura aura-one" aria-hidden="true"></div>
+        <div class="glass-neumo-aura aura-two" aria-hidden="true"></div>
+
+        <div class="glass-neumo-preview" aria-hidden="true">
+          <span class="glass-neumo-pane pane-front"></span>
+          <span class="glass-neumo-pane pane-middle"></span>
+          <span class="glass-neumo-pane pane-back"></span>
+        </div>
+
+        <p class="glass-neumo-kicker">Frosted depth</p>
+        <h1 id="glass-neumo-title">Glass Blur Console</h1>
+        <p class="glass-neumo-copy">
+          A tactile control surface that layers soft neumorphic shadows,
+          translucent panes, and gentle blur motion for calm futuristic UI.
+        </p>
+
+        <dl class="glass-neumo-stats" aria-label="Glass blur properties">
+          <div>
+            <dt>Blur</dt>
+            <dd>28px</dd>
+          </div>
+          <div>
+            <dt>Depth</dt>
+            <dd>Soft</dd>
+          </div>
+          <div>
+            <dt>Glow</dt>
+            <dd>Live</dd>
+          </div>
+        </dl>
+
+        <button class="glass-neumo-button" type="button">
+          Tune blur field
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/glassmorphism-blur-neumorphic-msm/style.css
+++ b/submissions/examples/glassmorphism-blur-neumorphic-msm/style.css
@@ -1,0 +1,325 @@
+:root {
+  --glass-neumo-bg: #d7e1ef;
+  --glass-neumo-panel: rgba(236, 243, 252, 0.62);
+  --glass-neumo-ink: #1e2d44;
+  --glass-neumo-muted: #60718e;
+  --glass-neumo-light: rgba(255, 255, 255, 0.86);
+  --glass-neumo-shadow: rgba(137, 153, 181, 0.72);
+  --glass-neumo-cyan: #4bd9ff;
+  --glass-neumo-blue: #5f8dff;
+  --glass-neumo-violet: #a477ff;
+  --glass-neumo-pink: #ff75b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--glass-neumo-ink);
+  background:
+    radial-gradient(
+      circle at 16% 18%,
+      rgba(75, 217, 255, 0.28),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 86% 28%,
+      rgba(164, 119, 255, 0.2),
+      transparent 26rem
+    ),
+    radial-gradient(
+      circle at 50% 100%,
+      rgba(255, 117, 184, 0.13),
+      transparent 30rem
+    ),
+    linear-gradient(135deg, #cbd8e9 0%, var(--glass-neumo-bg) 52%, #f0f5fb 100%);
+  font-family: "Gill Sans", "Segoe UI", sans-serif;
+}
+
+.glass-neumo-page {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.glass-neumo-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 32rem);
+  overflow: hidden;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 2rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.5), rgba(216, 227, 242, 0.3)),
+    var(--glass-neumo-panel);
+  box-shadow:
+    1.25rem 1.25rem 2.35rem var(--glass-neumo-shadow),
+    -1.25rem -1.25rem 2.35rem rgba(255, 255, 255, 0.92),
+    inset 0.08rem 0.08rem 0.2rem rgba(255, 255, 255, 0.78),
+    inset -0.1rem -0.1rem 0.22rem rgba(116, 132, 161, 0.32);
+  backdrop-filter: blur(1.35rem);
+}
+
+.glass-neumo-card::before {
+  position: absolute;
+  inset: 1.1rem;
+  z-index: -1;
+  border: 1px solid rgba(255, 255, 255, 0.36);
+  border-radius: 1.45rem;
+  background:
+    linear-gradient(110deg, rgba(255, 255, 255, 0.34), transparent 42%),
+    rgba(255, 255, 255, 0.08);
+  content: "";
+  pointer-events: none;
+}
+
+.glass-neumo-aura {
+  position: absolute;
+  z-index: -2;
+  border-radius: 999px;
+  filter: blur(0.2rem);
+  opacity: 0.75;
+}
+
+.aura-one {
+  top: -4rem;
+  right: -3rem;
+  width: 12rem;
+  height: 12rem;
+  background: rgba(75, 217, 255, 0.28);
+}
+
+.aura-two {
+  bottom: -4.4rem;
+  left: -3.5rem;
+  width: 13rem;
+  height: 13rem;
+  background: rgba(255, 117, 184, 0.2);
+}
+
+.glass-neumo-preview {
+  position: relative;
+  width: min(100%, 18rem);
+  height: 12rem;
+  margin: 0 auto 1.6rem;
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(
+      circle at 26% 22%,
+      rgba(255, 255, 255, 0.82),
+      transparent 18%
+    ),
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.32),
+      rgba(182, 199, 225, 0.28)
+    );
+  box-shadow:
+    inset 0.55rem 0.55rem 1rem rgba(156, 172, 199, 0.52),
+    inset -0.55rem -0.55rem 1rem rgba(255, 255, 255, 0.86),
+    0 1rem 2rem rgba(99, 116, 151, 0.18);
+}
+
+.glass-neumo-pane {
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.62);
+  border-radius: 1.2rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.58),
+      rgba(255, 255, 255, 0.18)
+    ),
+    rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 1rem 2rem rgba(64, 83, 124, 0.14),
+    inset 0 0.08rem 0.24rem rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(1.15rem);
+}
+
+.pane-back {
+  inset: 1rem 5.1rem 5.6rem 1rem;
+  animation: glass-float 6s ease-in-out infinite;
+}
+
+.pane-middle {
+  inset: 3.8rem 1.1rem 2.9rem 5.2rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(95, 141, 255, 0.28),
+      rgba(255, 255, 255, 0.18)
+    ),
+    rgba(255, 255, 255, 0.18);
+  animation: glass-float 7.5s ease-in-out infinite reverse;
+}
+
+.pane-front {
+  inset: 6.1rem 6.2rem 1.1rem 2.2rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 117, 184, 0.28),
+      rgba(255, 255, 255, 0.2)
+    ),
+    rgba(255, 255, 255, 0.2);
+  animation: glass-float 5.5s ease-in-out infinite;
+}
+
+.glass-neumo-kicker {
+  margin: 0 0 0.65rem;
+  color: var(--glass-neumo-blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.glass-neumo-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3.45rem);
+  line-height: 0.94;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.glass-neumo-copy {
+  max-width: 27rem;
+  margin: 1rem auto 1.55rem;
+  color: var(--glass-neumo-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+  text-align: center;
+}
+
+.glass-neumo-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.85rem;
+  margin: 0 0 1.55rem;
+}
+
+.glass-neumo-stats div {
+  padding: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.24);
+  box-shadow:
+    inset 0.35rem 0.35rem 0.72rem rgba(161, 176, 203, 0.48),
+    inset -0.35rem -0.35rem 0.72rem rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(0.8rem);
+  text-align: center;
+}
+
+.glass-neumo-stats dt,
+.glass-neumo-stats dd {
+  margin: 0;
+}
+
+.glass-neumo-stats dt {
+  color: var(--glass-neumo-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.glass-neumo-stats dd {
+  margin-top: 0.28rem;
+  color: var(--glass-neumo-ink);
+  font-size: 1.15rem;
+  font-weight: 900;
+}
+
+.glass-neumo-button {
+  display: block;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.56);
+  border-radius: 1.25rem;
+  padding: 1rem 1.2rem;
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(255, 255, 255, 0.42),
+      transparent 30%
+    ),
+    linear-gradient(
+      135deg,
+      var(--glass-neumo-cyan),
+      var(--glass-neumo-blue) 45%,
+      var(--glass-neumo-violet)
+    );
+  box-shadow:
+    0 1rem 2rem rgba(95, 141, 255, 0.3),
+    inset 0 0.12rem 0.28rem rgba(255, 255, 255, 0.46);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    filter 220ms ease;
+}
+
+.glass-neumo-button:hover {
+  box-shadow:
+    0 1.25rem 2.4rem rgba(95, 141, 255, 0.38),
+    0 0 2rem rgba(75, 217, 255, 0.24),
+    inset 0 0.12rem 0.28rem rgba(255, 255, 255, 0.5);
+  filter: saturate(1.12);
+  transform: translateY(-0.14rem);
+}
+
+.glass-neumo-button:focus-visible {
+  outline: 0.2rem solid rgba(30, 45, 68, 0.86);
+  outline-offset: 0.24rem;
+}
+
+@keyframes glass-float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+
+  50% {
+    transform: translate3d(0.28rem, -0.34rem, 0) rotate(1.4deg);
+  }
+}
+
+@media (max-width: 38rem) {
+  .glass-neumo-page {
+    padding: 1rem;
+  }
+
+  .glass-neumo-card {
+    padding: 1.45rem;
+    border-radius: 1.55rem;
+  }
+
+  .glass-neumo-preview {
+    height: 10rem;
+  }
+
+  .glass-neumo-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS neumorphic UI submission for the Glassmorphism Blur style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic structure, layered translucent panes, visible focus states, responsive layout, and reduced-motion support.

Closes #73740

## Changes Made
- Created `submissions/examples/glassmorphism-blur-neumorphic-msm/`.
- Added a frosted glass neumorphic control card with animated blur pane motion.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/glassmorphism-blur-neumorphic-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/glassmorphism-blur-neumorphic-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Uses semantic HTML and visible keyboard focus for the button control.
- Decorative blur panes are hidden from assistive technology.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.