### PR TITLE
feat: add synthwave grid dropdown menu

### DIFF
--- a/submissions/examples/synthwave-grid-dropdown-msm/README.md
+++ b/submissions/examples/synthwave-grid-dropdown-msm/README.md
@@ -1,0 +1,31 @@
+# Synthwave Grid Line Dropdown
+
+## What does this do?
+
+This submission adds a pure HTML and CSS dropdown menu with neon synthwave grid line styling.
+
+## How is it used?
+
+Copy the menu markup from `demo.html` and link the included stylesheet:
+
+```html
+<nav class="synth-dropdown" aria-label="Synthwave navigation">
+  <button class="synth-dropdown-trigger" type="button">Open menu</button>
+  <ul class="synth-dropdown-menu">
+    <li><a href="#">Neon dashboard</a></li>
+  </ul>
+</nav>
+```
+
+The demo is self-contained and works by opening `demo.html` directly in a browser. It uses no JavaScript, external assets, frameworks, or build tooling.
+
+## Why is it useful?
+
+EaseMotion CSS benefits from expressive, accessible UI examples that remain lightweight. This dropdown demonstrates a dark-mode-friendly menu with keyboard-visible focus states, smooth transform transitions, hardware-accelerated motion, and a reduced-motion fallback.
+
+## Accessibility Notes
+
+- Uses semantic navigation, button, list, and link elements.
+- The dropdown appears on hover and focus-within so keyboard users can access it.
+- Links and the trigger include clear `:focus-visible` states.
+- Decorative neon grid layers are hidden from assistive technology.

--- a/submissions/examples/synthwave-grid-dropdown-msm/demo.html
+++ b/submissions/examples/synthwave-grid-dropdown-msm/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Synthwave Grid Line Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="synth-page">
+      <section class="synth-card" aria-labelledby="synth-title">
+        <div class="synth-sun" aria-hidden="true"></div>
+        <div class="synth-grid" aria-hidden="true"></div>
+
+        <p class="synth-kicker">Dropdowns &amp; Menus</p>
+        <h1 id="synth-title">Synthwave Grid Menu</h1>
+        <p class="synth-copy">
+          A neon dropdown pattern with glowing horizon lines, glassy depth, and
+          keyboard-friendly focus behavior.
+        </p>
+
+        <nav class="synth-dropdown" aria-label="Synthwave navigation">
+          <button class="synth-dropdown-trigger" type="button">
+            Open neon menu
+            <span aria-hidden="true">▾</span>
+          </button>
+          <ul class="synth-dropdown-menu">
+            <li><a href="#">Neon dashboard</a></li>
+            <li><a href="#">Grid analytics</a></li>
+            <li><a href="#">Retro reports</a></li>
+            <li><a href="#">Arcade settings</a></li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/synthwave-grid-dropdown-msm/style.css
+++ b/submissions/examples/synthwave-grid-dropdown-msm/style.css
@@ -1,0 +1,281 @@
+:root {
+  --synth-bg: #130822;
+  --synth-panel: rgba(28, 13, 48, 0.78);
+  --synth-ink: #fff7ff;
+  --synth-muted: #c9b8e9;
+  --synth-pink: #ff4fd8;
+  --synth-cyan: #39e9ff;
+  --synth-violet: #8b5cff;
+  --synth-orange: #ff9d4d;
+  --synth-line: rgba(57, 233, 255, 0.42);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--synth-ink);
+  background:
+    radial-gradient(
+      circle at 50% 18%,
+      rgba(255, 79, 216, 0.2),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 84% 20%,
+      rgba(57, 233, 255, 0.16),
+      transparent 22rem
+    ),
+    linear-gradient(180deg, #170724 0%, var(--synth-bg) 54%, #070311 100%);
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+}
+
+.synth-page {
+  display: grid;
+  min-height: 100vh;
+  overflow: hidden;
+  padding: 2rem;
+  place-items: center;
+}
+
+.synth-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 34rem);
+  overflow: visible;
+  padding: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 1.8rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 34%),
+    var(--synth-panel);
+  box-shadow:
+    0 1.8rem 4rem rgba(4, 2, 14, 0.58),
+    inset 0 0 0 0.08rem rgba(255, 255, 255, 0.06),
+    0 0 3rem rgba(139, 92, 255, 0.22);
+  backdrop-filter: blur(1rem);
+}
+
+.synth-card::before {
+  position: absolute;
+  inset: -0.08rem;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    var(--synth-pink),
+    transparent 34%,
+    var(--synth-cyan)
+  );
+  content: "";
+  filter: blur(0.65rem);
+  opacity: 0.48;
+}
+
+.synth-sun {
+  position: absolute;
+  top: 1.2rem;
+  right: 2rem;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      180deg,
+      transparent 0 0.65rem,
+      rgba(19, 8, 34, 0.95) 0.68rem 0.95rem
+    ),
+    linear-gradient(180deg, var(--synth-orange), var(--synth-pink));
+  box-shadow: 0 0 2.2rem rgba(255, 79, 216, 0.58);
+  opacity: 0.84;
+}
+
+.synth-grid {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+  height: 48%;
+  border-radius: 0 0 1.8rem 1.8rem;
+  background:
+    linear-gradient(var(--synth-line) 0.08rem, transparent 0.08rem),
+    linear-gradient(90deg, var(--synth-line) 0.08rem, transparent 0.08rem);
+  background-size:
+    100% 1.05rem,
+    2.4rem 100%;
+  mask-image: linear-gradient(to top, black 0%, transparent 92%);
+  opacity: 0.75;
+  transform: perspective(15rem) rotateX(62deg);
+  transform-origin: bottom;
+}
+
+.synth-kicker {
+  position: relative;
+  margin: 0 0 0.75rem;
+  color: var(--synth-cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.synth-card h1 {
+  position: relative;
+  max-width: 23rem;
+  margin: 0;
+  font-size: clamp(2.25rem, 8vw, 4rem);
+  line-height: 0.9;
+  text-shadow:
+    0 0 1rem rgba(255, 79, 216, 0.52),
+    0 0 2rem rgba(57, 233, 255, 0.18);
+  text-wrap: balance;
+}
+
+.synth-copy {
+  position: relative;
+  max-width: 26rem;
+  margin: 1rem 0 1.7rem;
+  color: var(--synth-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.synth-dropdown {
+  position: relative;
+  width: min(100%, 22rem);
+}
+
+.synth-dropdown-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid rgba(57, 233, 255, 0.46);
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  color: var(--synth-ink);
+  background:
+    linear-gradient(135deg, rgba(255, 79, 216, 0.22), rgba(57, 233, 255, 0.12)),
+    rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 0 1.4rem rgba(57, 233, 255, 0.18),
+    inset 0 0 0.8rem rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  letter-spacing: 0.03em;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.synth-dropdown-trigger span {
+  color: var(--synth-cyan);
+  transition: transform 220ms ease;
+}
+
+.synth-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  left: 0;
+  z-index: 4;
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(255, 79, 216, 0.4);
+  border-radius: 1rem;
+  background:
+    linear-gradient(135deg, rgba(255, 79, 216, 0.16), rgba(57, 233, 255, 0.1)),
+    rgba(17, 6, 32, 0.94);
+  box-shadow:
+    0 1.2rem 2rem rgba(0, 0, 0, 0.34),
+    0 0 2rem rgba(255, 79, 216, 0.18);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, -0.55rem, 0) scale(0.98);
+  transition:
+    opacity 180ms ease,
+    transform 220ms ease;
+}
+
+.synth-dropdown:hover .synth-dropdown-menu,
+.synth-dropdown:focus-within .synth-dropdown-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.synth-dropdown:hover .synth-dropdown-trigger,
+.synth-dropdown:focus-within .synth-dropdown-trigger {
+  border-color: var(--synth-cyan);
+  box-shadow:
+    0 0 1.8rem rgba(57, 233, 255, 0.26),
+    0 0 2.5rem rgba(255, 79, 216, 0.16);
+  transform: translateY(-0.08rem);
+}
+
+.synth-dropdown:hover .synth-dropdown-trigger span,
+.synth-dropdown:focus-within .synth-dropdown-trigger span {
+  transform: rotate(180deg);
+}
+
+.synth-dropdown-menu a {
+  display: block;
+  border-radius: 0.75rem;
+  padding: 0.82rem 0.9rem;
+  color: var(--synth-ink);
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.synth-dropdown-menu a:hover,
+.synth-dropdown-menu a:focus-visible {
+  color: #0a0613;
+  background: linear-gradient(135deg, var(--synth-cyan), var(--synth-pink));
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.synth-dropdown-trigger:focus-visible {
+  outline: 0.2rem solid var(--synth-cyan);
+  outline-offset: 0.22rem;
+}
+
+@media (max-width: 38rem) {
+  .synth-page {
+    padding: 1rem;
+  }
+
+  .synth-card {
+    padding: 1.45rem;
+    border-radius: 1.35rem;
+  }
+
+  .synth-sun {
+    width: 5.5rem;
+    height: 5.5rem;
+    opacity: 0.55;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS dropdown and menu submission for the Synthwave Grid Line style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic nav/button/list markup, hover plus focus-within menu access, visible focus states, and reduced-motion support.

Closes #73683

## Changes Made
- Created `submissions/examples/synthwave-grid-dropdown-msm/`.
- Added a neon synthwave dropdown menu with animated grid-line styling.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/synthwave-grid-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/synthwave-grid-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Dropdown opens on hover and `:focus-within` for keyboard access.
- Uses semantic navigation, button, list, and link elements.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.