### PR TITLE
feat: add foucault pendulum dropdown menu

### DIFF
--- a/submissions/examples/foucault-pendulum-dropdown-msm/README.md
+++ b/submissions/examples/foucault-pendulum-dropdown-msm/README.md
@@ -1,0 +1,31 @@
+# Foucault Pendulum Swing Dropdown
+
+## What does this do?
+
+This submission adds a pure HTML and CSS dropdown menu with a Foucault pendulum swing-inspired interaction style.
+
+## How is it used?
+
+Copy the menu structure from `demo.html` and include the stylesheet:
+
+```html
+<nav class="pendulum-dropdown" aria-label="Pendulum navigation">
+  <button class="pendulum-trigger" type="button">Open menu</button>
+  <ul class="pendulum-menu">
+    <li><a href="#">Orbit overview</a></li>
+  </ul>
+</nav>
+```
+
+The example is self-contained and works by opening `demo.html` directly in a browser. It requires no JavaScript, CDN, framework, image, or build tooling.
+
+## Why is it useful?
+
+EaseMotion CSS values motion that feels expressive without becoming heavy. This component demonstrates a dropdown menu with accessible hover and keyboard focus behavior, a pendulum-inspired reveal, smooth hardware-friendly transforms, and reduced-motion support.
+
+## Accessibility Notes
+
+- Uses semantic navigation, button, list, and link elements.
+- The dropdown opens on hover and `:focus-within` for keyboard users.
+- The trigger and links include visible `:focus-visible` states.
+- Decorative pendulum and orbit graphics are hidden from assistive technology.

--- a/submissions/examples/foucault-pendulum-dropdown-msm/demo.html
+++ b/submissions/examples/foucault-pendulum-dropdown-msm/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foucault Pendulum Swing Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="pendulum-page">
+      <section class="pendulum-card" aria-labelledby="pendulum-title">
+        <div class="pendulum-orbit" aria-hidden="true">
+          <span class="pendulum-cable"></span>
+          <span class="pendulum-bob"></span>
+        </div>
+
+        <p class="pendulum-kicker">Dropdowns &amp; Menus</p>
+        <h1 id="pendulum-title">Pendulum Swing Menu</h1>
+        <p class="pendulum-copy">
+          A physics-inspired dropdown that swings into view with orbit lines,
+          soft depth, and keyboard-accessible focus behavior.
+        </p>
+
+        <nav class="pendulum-dropdown" aria-label="Pendulum navigation">
+          <button class="pendulum-trigger" type="button">
+            Open orbit menu
+            <span aria-hidden="true">⌄</span>
+          </button>
+          <ul class="pendulum-menu">
+            <li><a href="#">Orbit overview</a></li>
+            <li><a href="#">Swing telemetry</a></li>
+            <li><a href="#">Vector timeline</a></li>
+            <li><a href="#">Stability lab</a></li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/foucault-pendulum-dropdown-msm/style.css
+++ b/submissions/examples/foucault-pendulum-dropdown-msm/style.css
@@ -1,0 +1,316 @@
+:root {
+  --pendulum-bg: #101827;
+  --pendulum-panel: #172337;
+  --pendulum-panel-soft: #20304a;
+  --pendulum-ink: #edf6ff;
+  --pendulum-muted: #a9bbd5;
+  --pendulum-cyan: #4ee7ff;
+  --pendulum-gold: #f7c76c;
+  --pendulum-blue: #5f88ff;
+  --pendulum-shadow: rgba(0, 0, 0, 0.38);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--pendulum-ink);
+  background:
+    radial-gradient(
+      circle at 25% 20%,
+      rgba(78, 231, 255, 0.14),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 76% 28%,
+      rgba(247, 199, 108, 0.12),
+      transparent 22rem
+    ),
+    linear-gradient(135deg, #0a101c 0%, var(--pendulum-bg) 52%, #070b12 100%);
+  font-family: "Lucida Sans", "Segoe UI", sans-serif;
+}
+
+.pendulum-page {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.pendulum-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 34rem);
+  overflow: visible;
+  padding: 2.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.8rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.08), transparent 38%),
+    var(--pendulum-panel);
+  box-shadow:
+    0 1.6rem 3.2rem var(--pendulum-shadow),
+    inset 0 0 0 0.08rem rgba(255, 255, 255, 0.04);
+}
+
+.pendulum-card::before {
+  position: absolute;
+  inset: 1rem;
+  z-index: -1;
+  border: 1px solid rgba(78, 231, 255, 0.12);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(rgba(78, 231, 255, 0.08) 0.08rem, transparent 0.08rem),
+    linear-gradient(
+      90deg,
+      rgba(78, 231, 255, 0.05) 0.08rem,
+      transparent 0.08rem
+    );
+  background-size:
+    100% 3rem,
+    3rem 100%;
+  content: "";
+  opacity: 0.7;
+}
+
+.pendulum-orbit {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.6rem;
+  width: 9rem;
+  height: 9rem;
+  border: 0.08rem solid rgba(78, 231, 255, 0.28);
+  border-radius: 50%;
+  box-shadow:
+    0 0 2rem rgba(78, 231, 255, 0.12),
+    inset 0 0 1.4rem rgba(78, 231, 255, 0.08);
+  opacity: 0.88;
+}
+
+.pendulum-orbit::before,
+.pendulum-orbit::after {
+  position: absolute;
+  inset: 1.35rem;
+  border: 0.08rem solid rgba(247, 199, 108, 0.18);
+  border-radius: 50%;
+  content: "";
+}
+
+.pendulum-orbit::after {
+  inset: 2.75rem;
+  border-color: rgba(95, 136, 255, 0.22);
+}
+
+.pendulum-cable {
+  position: absolute;
+  top: 0.8rem;
+  left: 50%;
+  width: 0.08rem;
+  height: 5.1rem;
+  background: linear-gradient(var(--pendulum-cyan), rgba(78, 231, 255, 0.08));
+  transform-origin: top;
+  animation: pendulum-swing 4.6s ease-in-out infinite;
+}
+
+.pendulum-bob {
+  position: absolute;
+  bottom: -0.35rem;
+  left: 50%;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 30% 25%,
+    #ffffff,
+    var(--pendulum-gold) 42%,
+    #c5782d 100%
+  );
+  box-shadow: 0 0 1.2rem rgba(247, 199, 108, 0.62);
+  transform: translateX(-50%);
+}
+
+.pendulum-kicker {
+  position: relative;
+  margin: 0 0 0.75rem;
+  color: var(--pendulum-cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.pendulum-card h1 {
+  position: relative;
+  max-width: 24rem;
+  margin: 0;
+  font-size: clamp(2.2rem, 8vw, 4rem);
+  line-height: 0.92;
+  text-wrap: balance;
+}
+
+.pendulum-copy {
+  position: relative;
+  max-width: 26rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--pendulum-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.pendulum-dropdown {
+  position: relative;
+  width: min(100%, 22rem);
+}
+
+.pendulum-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid rgba(78, 231, 255, 0.34);
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  color: var(--pendulum-ink);
+  background:
+    linear-gradient(135deg, rgba(78, 231, 255, 0.18), rgba(247, 199, 108, 0.1)),
+    var(--pendulum-panel-soft);
+  box-shadow:
+    0 1rem 2rem rgba(0, 0, 0, 0.2),
+    inset 0 0 1rem rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.pendulum-trigger span {
+  color: var(--pendulum-gold);
+  transition: transform 220ms ease;
+}
+
+.pendulum-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  left: 0;
+  z-index: 4;
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(247, 199, 108, 0.3);
+  border-radius: 1rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(78, 231, 255, 0.14),
+      rgba(247, 199, 108, 0.08)
+    ),
+    rgba(16, 24, 39, 0.96);
+  box-shadow:
+    0 1.3rem 2rem rgba(0, 0, 0, 0.32),
+    0 0 1.8rem rgba(78, 231, 255, 0.12);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, -0.45rem, 0) rotateX(-9deg);
+  transform-origin: top center;
+  transition:
+    opacity 180ms ease,
+    transform 260ms cubic-bezier(0.2, 0.9, 0.25, 1.2);
+}
+
+.pendulum-dropdown:hover .pendulum-menu,
+.pendulum-dropdown:focus-within .pendulum-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) rotateX(0deg);
+}
+
+.pendulum-dropdown:hover .pendulum-trigger,
+.pendulum-dropdown:focus-within .pendulum-trigger {
+  border-color: var(--pendulum-cyan);
+  box-shadow:
+    0 1.2rem 2.2rem rgba(0, 0, 0, 0.26),
+    0 0 1.4rem rgba(78, 231, 255, 0.2);
+  transform: translateY(-0.08rem);
+}
+
+.pendulum-dropdown:hover .pendulum-trigger span,
+.pendulum-dropdown:focus-within .pendulum-trigger span {
+  transform: rotate(180deg);
+}
+
+.pendulum-menu a {
+  display: block;
+  border-radius: 0.75rem;
+  padding: 0.82rem 0.9rem;
+  color: var(--pendulum-ink);
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.pendulum-menu a:hover,
+.pendulum-menu a:focus-visible {
+  color: #101827;
+  background: linear-gradient(
+    135deg,
+    var(--pendulum-cyan),
+    var(--pendulum-gold)
+  );
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.pendulum-trigger:focus-visible {
+  outline: 0.2rem solid var(--pendulum-cyan);
+  outline-offset: 0.24rem;
+}
+
+@keyframes pendulum-swing {
+  0%,
+  100% {
+    transform: translateX(-50%) rotate(-18deg);
+  }
+
+  50% {
+    transform: translateX(-50%) rotate(18deg);
+  }
+}
+
+@media (max-width: 38rem) {
+  .pendulum-page {
+    padding: 1rem;
+  }
+
+  .pendulum-card {
+    padding: 1.45rem;
+    border-radius: 1.35rem;
+  }
+
+  .pendulum-orbit {
+    width: 6rem;
+    height: 6rem;
+    opacity: 0.42;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS dropdown and menu submission for the Foucault Pendulum Swing style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic nav/button/list markup, hover plus focus-within menu access, visible focus states, pendulum-inspired motion, and reduced-motion support.

Closes #73682

## Changes Made
- Created `submissions/examples/foucault-pendulum-dropdown-msm/`.
- Added a dark physics-inspired dropdown menu with orbit graphics and pendulum swing styling.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/foucault-pendulum-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/foucault-pendulum-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Dropdown opens on hover and `:focus-within` for keyboard access.
- Uses semantic navigation, button, list, and link elements.
- Decorative pendulum/orbit elements are hidden from assistive technology.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.