### PR TITLE
feat: add fractal-breadcrumb component

### DIFF
--- a/submissions/examples/fractal-breadcrumb/README.md
+++ b/submissions/examples/fractal-breadcrumb/README.md
@@ -1,0 +1,46 @@
+# Fractal Breadcrumb
+
+A visually expressive breadcrumb navigation component that represents nested navigation as a growing branching path.
+
+Instead of displaying a conventional:
+
+Home → Products → Category → Item
+
+breadcrumb, Fractal Breadcrumb treats each navigation level as a node in a small visual hierarchy.
+
+## Features
+
+- Branching breadcrumb visual
+- Current-location highlighting
+- Hover-based node interaction
+- Lightweight CSS animations
+- Responsive mobile layout
+- Dependency-free implementation
+- Semantic breadcrumb navigation
+- Works with arbitrary navigation depth
+- Dark interface friendly
+
+## Why?
+
+Traditional breadcrumbs are useful, but visually repetitive.
+
+Most breadcrumb implementations rely on simple separators such as:
+
+`/`
+`>`
+`→`
+
+Fractal Breadcrumb explores a different visual metaphor:
+
+navigation as a growing tree.
+
+Each visited level becomes another node in the structure.
+
+## Structure
+
+```text
+Home
+ └── Products
+      └── Electronics
+           └── Audio
+                └── Headphones

--- a/submissions/examples/fractal-breadcrumb/demo.html
+++ b/submissions/examples/fractal-breadcrumb/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  />
+
+  <title>Fractal Breadcrumb</title>
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="demo-card">
+
+      <div class="eyebrow">
+        NAVIGATION SYSTEM
+      </div>
+
+      <h1>Fractal Breadcrumb</h1>
+
+      <p class="description">
+        A branching breadcrumb trail that visualizes
+        your position inside a nested navigation structure.
+      </p>
+
+      <nav
+        class="fractal-breadcrumb"
+        aria-label="Breadcrumb"
+      >
+
+        <a href="#" class="crumb">
+          <span class="node"></span>
+          <span class="label">Home</span>
+        </a>
+
+        <span class="branch"></span>
+
+        <a href="#" class="crumb">
+          <span class="node"></span>
+          <span class="label">Products</span>
+        </a>
+
+        <span class="branch"></span>
+
+        <a href="#" class="crumb">
+          <span class="node"></span>
+          <span class="label">Electronics</span>
+        </a>
+
+        <span class="branch"></span>
+
+        <a href="#" class="crumb">
+          <span class="node"></span>
+          <span class="label">Audio</span>
+        </a>
+
+        <span class="branch"></span>
+
+        <a
+          href="#"
+          class="crumb current"
+          aria-current="page"
+        >
+          <span class="node"></span>
+          <span class="label">Headphones</span>
+        </a>
+
+      </nav>
+
+      <div class="path-info">
+
+        <span class="path-dot"></span>
+
+        <span>
+          Current location:
+          <strong>Headphones</strong>
+        </span>
+
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/fractal-breadcrumb/style.css
+++ b/submissions/examples/fractal-breadcrumb/style.css
@@ -1,0 +1,238 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #080a0f;
+  --card: #10131a;
+  --border: #242936;
+  --text: #f4f6fb;
+  --muted: #858c9d;
+  --line: #343b4b;
+  --accent: #9eff6e;
+}
+
+body {
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  background:
+    radial-gradient(
+      circle at 50% 10%,
+      rgba(158, 255, 110, 0.08),
+      transparent 35%
+    ),
+    var(--bg);
+
+  color: var(--text);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 20px;
+}
+
+.demo-card {
+  width: min(850px, 100%);
+  padding: 42px;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: rgba(16, 19, 26, 0.92);
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.35);
+}
+
+.eyebrow {
+  margin-bottom: 12px;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+h1 {
+  font-size: clamp(32px, 5vw, 52px);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.description {
+  max-width: 580px;
+  margin-top: 18px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.fractal-breadcrumb {
+  margin-top: 48px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.crumb {
+  position: relative;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+
+  padding: 9px 12px;
+
+  border-radius: 999px;
+
+  color: var(--muted);
+  text-decoration: none;
+
+  border: 1px solid transparent;
+
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.crumb:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.035);
+  transform: translateY(-2px);
+}
+
+.node {
+  width: 9px;
+  height: 9px;
+
+  border-radius: 50%;
+
+  background: var(--line);
+
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.crumb:hover .node {
+  background: var(--accent);
+
+  transform: scale(1.35);
+
+  box-shadow:
+    0 0 0 5px rgba(158, 255, 110, 0.08),
+    0 0 18px rgba(158, 255, 110, 0.35);
+}
+
+.crumb.current {
+  color: var(--text);
+  border-color: rgba(158, 255, 110, 0.25);
+  background: rgba(158, 255, 110, 0.06);
+}
+
+.crumb.current .node {
+  background: var(--accent);
+
+  box-shadow:
+    0 0 0 5px rgba(158, 255, 110, 0.08),
+    0 0 20px rgba(158, 255, 110, 0.45);
+}
+
+.branch {
+  position: relative;
+
+  width: 32px;
+  height: 1px;
+
+  background: var(--line);
+}
+
+.branch::after {
+  content: "";
+
+  position: absolute;
+
+  right: 0;
+  top: 50%;
+
+  width: 5px;
+  height: 5px;
+
+  border-right: 1px solid var(--line);
+  border-top: 1px solid var(--line);
+
+  transform:
+    translateY(-50%)
+    rotate(45deg);
+}
+
+.path-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  margin-top: 42px;
+  padding-top: 20px;
+
+  border-top: 1px solid var(--border);
+
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.path-info strong {
+  color: var(--text);
+}
+
+.path-dot {
+  width: 7px;
+  height: 7px;
+
+  border-radius: 50%;
+
+  background: var(--accent);
+
+  box-shadow:
+    0 0 14px rgba(158, 255, 110, 0.6);
+}
+
+@media (max-width: 650px) {
+  .demo-card {
+    padding: 28px 22px;
+  }
+
+  .fractal-breadcrumb {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .branch {
+    width: 1px;
+    height: 22px;
+    margin-left: 16px;
+  }
+
+  .branch::after {
+    right: auto;
+    left: 50%;
+    top: auto;
+    bottom: 0;
+
+    transform:
+      translateX(-50%)
+      rotate(135deg);
+  }
+}


### PR DESCRIPTION
## Description

closes #76096 

This PR adds a new Fractal Breadcrumb navigation component.

Instead of using conventional breadcrumb separators, the component represents navigation levels as connected nodes, creating a small branching visual hierarchy.

## What Changed

- Added Fractal Breadcrumb demo
- Added responsive navigation structure
- Added interactive breadcrumb nodes
- Added current-location state
- Added responsive vertical layout for smaller screens
- Added accessible breadcrumb navigation markup
- Added component documentation

## Component Behavior

Desktop navigation is represented as a connected horizontal path.

Example:

Home ─ Products ─ Electronics ─ Audio ─ Headphones

On smaller screens, the same structure becomes a vertical path.

## Accessibility

- Uses semantic `<nav>` element
- Uses accessible anchor elements
- Uses `aria-label="Breadcrumb"`
- Uses `aria-current="page"` for the active location
- Visual effects do not replace navigation text

## Files Added

- demo.html
- style.css
- README.md

## Testing

- Tested desktop layout
- Tested mobile layout
- Tested hover states
- Tested active breadcrumb state
- Verified responsive wrapping
- Verified that navigation remains readable without animations

## Checklist

- [x] Component is dependency-free
- [x] Responsive behavior implemented
- [x] Accessibility considered
- [x] Hover interactions implemented
- [x] Active state implemented
- [x] README added
- [x] No unnecessary JavaScript added