### PR TITLE
feat: add origami paper fold dropdown menu

### DIFF
--- a/submissions/examples/origami-paper-dropdown-msm/README.md
+++ b/submissions/examples/origami-paper-dropdown-msm/README.md
@@ -1,0 +1,31 @@
+# Origami Paper Fold Dropdown
+
+## What does this do?
+
+This submission adds a pure HTML and CSS dropdown menu with an origami paper fold reveal style.
+
+## How is it used?
+
+Copy the menu markup from `demo.html` and link the stylesheet:
+
+```html
+<nav class="origami-dropdown" aria-label="Origami navigation">
+  <button class="origami-trigger" type="button">Open menu</button>
+  <ul class="origami-menu">
+    <li><a href="#">Folded dashboard</a></li>
+  </ul>
+</nav>
+```
+
+The demo is self-contained and works by opening `demo.html` directly in a browser. It requires no JavaScript, CDN, remote image, framework, or build tool.
+
+## Why is it useful?
+
+EaseMotion CSS benefits from small, expressive UI patterns that can be understood quickly. This dropdown demonstrates a paper-fold inspired reveal using transform origins, layered shadows, accessible focus behavior, and reduced-motion support while staying lightweight.
+
+## Accessibility Notes
+
+- Uses semantic navigation, button, list, and link elements.
+- The menu opens on hover and `:focus-within` for keyboard access.
+- The trigger and menu links include visible focus states.
+- Decorative fold marks are hidden from assistive technology.

--- a/submissions/examples/origami-paper-dropdown-msm/demo.html
+++ b/submissions/examples/origami-paper-dropdown-msm/demo.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Origami Paper Fold Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="origami-page">
+      <section class="origami-card" aria-labelledby="origami-title">
+        <div class="origami-fold-art" aria-hidden="true">
+          <span class="fold fold-one"></span>
+          <span class="fold fold-two"></span>
+          <span class="fold fold-three"></span>
+        </div>
+
+        <p class="origami-kicker">Dropdowns &amp; Menus</p>
+        <h1 id="origami-title">Origami Fold Menu</h1>
+        <p class="origami-copy">
+          A crisp paper-inspired dropdown that unfolds with layered panels,
+          tactile shadows, and keyboard-accessible interaction states.
+        </p>
+
+        <nav class="origami-dropdown" aria-label="Origami navigation">
+          <button class="origami-trigger" type="button">
+            Open paper menu
+            <span aria-hidden="true">⌄</span>
+          </button>
+          <ul class="origami-menu">
+            <li><a href="#">Folded dashboard</a></li>
+            <li><a href="#">Paper analytics</a></li>
+            <li><a href="#">Crease timeline</a></li>
+            <li><a href="#">Layout settings</a></li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/origami-paper-dropdown-msm/style.css
+++ b/submissions/examples/origami-paper-dropdown-msm/style.css
@@ -1,0 +1,321 @@
+:root {
+  --origami-bg: #f5efe5;
+  --origami-paper: #fffaf1;
+  --origami-crease: #e6d8c5;
+  --origami-ink: #2f261d;
+  --origami-muted: #766958;
+  --origami-coral: #ef735f;
+  --origami-blue: #4c8bcf;
+  --origami-gold: #e0a84a;
+  --origami-shadow: rgba(96, 74, 48, 0.24);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--origami-ink);
+  background:
+    radial-gradient(
+      circle at 16% 18%,
+      rgba(239, 115, 95, 0.18),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 84% 28%,
+      rgba(76, 139, 207, 0.18),
+      transparent 22rem
+    ),
+    linear-gradient(135deg, #eadfcf 0%, var(--origami-bg) 52%, #fffaf3 100%);
+  font-family: Georgia, "Segoe UI", serif;
+}
+
+.origami-page {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.origami-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 34rem);
+  overflow: visible;
+  padding: 2.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 1.35rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.68), transparent 32%),
+    var(--origami-paper);
+  box-shadow:
+    0 1.6rem 3rem var(--origami-shadow),
+    inset 0 0 0 0.08rem rgba(255, 255, 255, 0.7);
+}
+
+.origami-card::before,
+.origami-card::after {
+  position: absolute;
+  z-index: -1;
+  content: "";
+}
+
+.origami-card::before {
+  inset: 1rem;
+  border-radius: 1rem;
+  background:
+    linear-gradient(
+      135deg,
+      transparent 49.5%,
+      rgba(96, 74, 48, 0.08) 50%,
+      transparent 50.5%
+    ),
+    linear-gradient(
+      45deg,
+      transparent 49.5%,
+      rgba(96, 74, 48, 0.06) 50%,
+      transparent 50.5%
+    );
+}
+
+.origami-card::after {
+  right: 1rem;
+  bottom: 1rem;
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: 0 0 0.9rem;
+  background: linear-gradient(
+    135deg,
+    rgba(224, 168, 74, 0.18),
+    rgba(255, 255, 255, 0.7)
+  );
+  clip-path: polygon(100% 0, 100% 100%, 0 100%);
+}
+
+.origami-fold-art {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.4rem;
+  width: 8.5rem;
+  height: 8.5rem;
+  filter: drop-shadow(0 1rem 1.4rem rgba(96, 74, 48, 0.2));
+  opacity: 0.9;
+}
+
+.fold {
+  position: absolute;
+  border: 1px solid rgba(96, 74, 48, 0.08);
+  background: var(--origami-paper);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+}
+
+.fold-one {
+  inset: 0.5rem 2.3rem 3rem 0.6rem;
+  background: linear-gradient(145deg, #fffef8, #f1e3ce);
+  transform: rotate(-18deg);
+}
+
+.fold-two {
+  inset: 2rem 0.8rem 1.1rem 3rem;
+  background: linear-gradient(145deg, #f8ebdc, #fffaf1);
+  transform: rotate(26deg);
+}
+
+.fold-three {
+  inset: 4.2rem 3rem 0.6rem 1.2rem;
+  background: linear-gradient(145deg, rgba(76, 139, 207, 0.18), #fffaf1);
+  transform: rotate(8deg);
+}
+
+.origami-kicker {
+  position: relative;
+  margin: 0 0 0.75rem;
+  color: var(--origami-coral);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.origami-card h1 {
+  position: relative;
+  max-width: 24rem;
+  margin: 0;
+  font-size: clamp(2.2rem, 8vw, 4rem);
+  line-height: 0.92;
+  text-wrap: balance;
+}
+
+.origami-copy {
+  position: relative;
+  max-width: 26rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--origami-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.origami-dropdown {
+  position: relative;
+  width: min(100%, 22rem);
+}
+
+.origami-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--origami-crease);
+  border-radius: 0.9rem;
+  padding: 1rem 1.1rem;
+  color: var(--origami-ink);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.72),
+      rgba(239, 224, 203, 0.8)
+    ),
+    var(--origami-paper);
+  box-shadow:
+    0 0.85rem 1.5rem rgba(96, 74, 48, 0.16),
+    inset 0 0 0 0.08rem rgba(255, 255, 255, 0.66);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.origami-trigger span {
+  color: var(--origami-coral);
+  transition: transform 220ms ease;
+}
+
+.origami-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  left: 0;
+  z-index: 4;
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0.45rem;
+  border: 1px solid var(--origami-crease);
+  border-radius: 0.9rem;
+  background: var(--origami-paper);
+  box-shadow: 0 1.4rem 2.2rem rgba(96, 74, 48, 0.22);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: rotateX(-84deg) translate3d(0, -0.25rem, 0);
+  transform-origin: top center;
+  transition:
+    opacity 160ms ease,
+    transform 280ms cubic-bezier(0.17, 0.84, 0.38, 1.2);
+}
+
+.origami-menu::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      135deg,
+      transparent 49.5%,
+      rgba(96, 74, 48, 0.08) 50%,
+      transparent 50.5%
+    ),
+    linear-gradient(
+      45deg,
+      transparent 49.5%,
+      rgba(76, 139, 207, 0.08) 50%,
+      transparent 50.5%
+    );
+  content: "";
+  pointer-events: none;
+}
+
+.origami-dropdown:hover .origami-menu,
+.origami-dropdown:focus-within .origami-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: rotateX(0deg) translate3d(0, 0, 0);
+}
+
+.origami-dropdown:hover .origami-trigger,
+.origami-dropdown:focus-within .origami-trigger {
+  border-color: rgba(239, 115, 95, 0.55);
+  box-shadow:
+    0 1rem 1.8rem rgba(96, 74, 48, 0.2),
+    0 0 0 0.18rem rgba(239, 115, 95, 0.08);
+  transform: translateY(-0.08rem);
+}
+
+.origami-dropdown:hover .origami-trigger span,
+.origami-dropdown:focus-within .origami-trigger span {
+  transform: rotate(180deg);
+}
+
+.origami-menu a {
+  position: relative;
+  display: block;
+  border-radius: 0.7rem;
+  padding: 0.84rem 0.9rem;
+  color: var(--origami-ink);
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.origami-menu a:hover,
+.origami-menu a:focus-visible {
+  color: #ffffff;
+  background: linear-gradient(
+    135deg,
+    var(--origami-coral),
+    var(--origami-blue)
+  );
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.origami-trigger:focus-visible {
+  outline: 0.2rem solid var(--origami-blue);
+  outline-offset: 0.24rem;
+}
+
+@media (max-width: 38rem) {
+  .origami-page {
+    padding: 1rem;
+  }
+
+  .origami-card {
+    padding: 1.45rem;
+    border-radius: 1.1rem;
+  }
+
+  .origami-fold-art {
+    opacity: 0.28;
+    transform: scale(0.82);
+    transform-origin: top right;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS dropdown and menu submission for the Origami Paper Fold style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic nav/button/list markup, hover plus focus-within menu access, visible focus states, paper-fold reveal motion, and reduced-motion support.

Closes #73681

## Changes Made
- Created `submissions/examples/origami-paper-dropdown-msm/`.
- Added a warm paper-inspired dropdown menu with folded-panel visuals and transform-origin reveal.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/origami-paper-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/origami-paper-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Dropdown opens on hover and `:focus-within` for keyboard access.
- Uses semantic navigation, button, list, and link elements.
- Decorative fold marks are hidden from assistive technology.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.