### PR TITLE
feat: add diamond facet dropdown menu

### DIFF
--- a/submissions/examples/diamond-facet-dropdown-msm/README.md
+++ b/submissions/examples/diamond-facet-dropdown-msm/README.md
@@ -1,0 +1,31 @@
+# Diamond Facet Edge Dropdown
+
+## What does this do?
+
+This submission adds a pure HTML and CSS dropdown menu with sharp diamond facet edge styling.
+
+## How is it used?
+
+Copy the dropdown markup from `demo.html` and include `style.css`:
+
+```html
+<nav class="facet-dropdown" aria-label="Diamond facet navigation">
+  <button class="facet-trigger" type="button">Open menu</button>
+  <ul class="facet-menu">
+    <li><a href="#">Facet overview</a></li>
+  </ul>
+</nav>
+```
+
+The example works by opening `demo.html` directly in a browser. It does not require JavaScript, remote fonts, images, frameworks, CDNs, or build tools.
+
+## Why is it useful?
+
+EaseMotion CSS benefits from polished interaction examples that remain lightweight. This dropdown pairs crisp geometric surfaces with smooth transform motion, keyboard-accessible focus states, dark mode compatibility, and reduced-motion support.
+
+## Accessibility Notes
+
+- Uses semantic navigation, button, list, and link elements.
+- The menu opens with hover and `:focus-within` for keyboard access.
+- The trigger and menu links include visible focus states.
+- Decorative prism facets are hidden from assistive technology.

--- a/submissions/examples/diamond-facet-dropdown-msm/demo.html
+++ b/submissions/examples/diamond-facet-dropdown-msm/demo.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diamond Facet Edge Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="facet-page">
+      <section class="facet-card" aria-labelledby="facet-title">
+        <div class="facet-crystal" aria-hidden="true">
+          <span class="facet facet-a"></span>
+          <span class="facet facet-b"></span>
+          <span class="facet facet-c"></span>
+        </div>
+
+        <p class="facet-kicker">Dropdowns &amp; Menus</p>
+        <h1 id="facet-title">Diamond Facet Menu</h1>
+        <p class="facet-copy">
+          A crisp dropdown pattern with beveled prism edges, angular highlights,
+          and keyboard-friendly menu access.
+        </p>
+
+        <nav class="facet-dropdown" aria-label="Diamond facet navigation">
+          <button class="facet-trigger" type="button">
+            Open prism menu
+            <span aria-hidden="true">⌄</span>
+          </button>
+          <ul class="facet-menu">
+            <li><a href="#">Facet overview</a></li>
+            <li><a href="#">Crystal metrics</a></li>
+            <li><a href="#">Prism timeline</a></li>
+            <li><a href="#">Edge settings</a></li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/diamond-facet-dropdown-msm/style.css
+++ b/submissions/examples/diamond-facet-dropdown-msm/style.css
@@ -1,0 +1,324 @@
+:root {
+  --facet-bg: #080c16;
+  --facet-panel: #111a2a;
+  --facet-panel-light: #19263b;
+  --facet-ink: #f3fbff;
+  --facet-muted: #aab8ce;
+  --facet-cyan: #45e6ff;
+  --facet-blue: #5c80ff;
+  --facet-violet: #b06dff;
+  --facet-pink: #ff67bd;
+  --facet-line: rgba(69, 230, 255, 0.38);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--facet-ink);
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(69, 230, 255, 0.16),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 84% 24%,
+      rgba(176, 109, 255, 0.18),
+      transparent 24rem
+    ),
+    linear-gradient(135deg, #050811 0%, var(--facet-bg) 55%, #0d0714 100%);
+  font-family: "Segoe UI", "Trebuchet MS", sans-serif;
+}
+
+.facet-page {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.facet-card {
+  position: relative;
+  isolation: isolate;
+  width: min(100%, 34rem);
+  overflow: visible;
+  padding: 2.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 32%),
+    var(--facet-panel);
+  box-shadow:
+    0 1.6rem 3.6rem rgba(0, 0, 0, 0.44),
+    inset 0 0 0 0.08rem rgba(255, 255, 255, 0.04),
+    0 0 3rem rgba(92, 128, 255, 0.16);
+}
+
+.facet-card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      128deg,
+      transparent 0 28%,
+      rgba(69, 230, 255, 0.12) 28% 30%,
+      transparent 30% 100%
+    ),
+    linear-gradient(
+      42deg,
+      transparent 0 50%,
+      rgba(255, 103, 189, 0.12) 50% 52%,
+      transparent 52% 100%
+    );
+  content: "";
+  opacity: 0.9;
+}
+
+.facet-crystal {
+  position: absolute;
+  top: 1.15rem;
+  right: 1.35rem;
+  width: 8rem;
+  height: 8rem;
+  filter: drop-shadow(0 0 1.6rem rgba(69, 230, 255, 0.3));
+  opacity: 0.86;
+}
+
+.facet {
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background:
+    linear-gradient(135deg, rgba(69, 230, 255, 0.5), rgba(176, 109, 255, 0.24)),
+    rgba(255, 255, 255, 0.08);
+  clip-path: polygon(50% 0, 100% 35%, 82% 100%, 18% 100%, 0 35%);
+}
+
+.facet-a {
+  inset: 0.7rem 2.1rem 1.6rem 1rem;
+  transform: rotate(-18deg);
+}
+
+.facet-b {
+  inset: 2rem 0.7rem 0.8rem 3rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 103, 189, 0.45),
+      rgba(69, 230, 255, 0.18)
+    ),
+    rgba(255, 255, 255, 0.08);
+  transform: rotate(19deg);
+}
+
+.facet-c {
+  inset: 4.1rem 2.8rem 0.6rem 1.9rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.58),
+      rgba(92, 128, 255, 0.22)
+    ),
+    rgba(255, 255, 255, 0.08);
+  transform: rotate(7deg);
+}
+
+.facet-kicker {
+  position: relative;
+  margin: 0 0 0.75rem;
+  color: var(--facet-cyan);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.facet-card h1 {
+  position: relative;
+  max-width: 24rem;
+  margin: 0;
+  font-size: clamp(2.2rem, 8vw, 4rem);
+  line-height: 0.92;
+  text-shadow: 0 0 1.4rem rgba(69, 230, 255, 0.18);
+  text-wrap: balance;
+}
+
+.facet-copy {
+  position: relative;
+  max-width: 26rem;
+  margin: 1rem 0 1.8rem;
+  color: var(--facet-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.facet-dropdown {
+  position: relative;
+  width: min(100%, 22rem);
+}
+
+.facet-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid rgba(69, 230, 255, 0.4);
+  border-radius: 0.85rem;
+  padding: 1rem 1.1rem;
+  color: var(--facet-ink);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(69, 230, 255, 0.16),
+      rgba(255, 103, 189, 0.12)
+    ),
+    var(--facet-panel-light);
+  box-shadow:
+    0 1rem 2rem rgba(0, 0, 0, 0.28),
+    inset 0 0 1rem rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.facet-trigger span {
+  color: var(--facet-pink);
+  transition: transform 220ms ease;
+}
+
+.facet-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  left: 0;
+  z-index: 4;
+  display: grid;
+  gap: 0.42rem;
+  margin: 0;
+  padding: 0.6rem;
+  border: 1px solid rgba(255, 103, 189, 0.32);
+  border-radius: 0.9rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(69, 230, 255, 0.12),
+      rgba(176, 109, 255, 0.14)
+    ),
+    rgba(13, 18, 31, 0.97);
+  box-shadow:
+    0 1.4rem 2.3rem rgba(0, 0, 0, 0.34),
+    0 0 2rem rgba(69, 230, 255, 0.12);
+  list-style: none;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, -0.5rem, 0) scale(0.96) skewX(-2deg);
+  transform-origin: top center;
+  transition:
+    opacity 170ms ease,
+    transform 240ms ease;
+}
+
+.facet-menu::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      135deg,
+      transparent 49.5%,
+      var(--facet-line) 50%,
+      transparent 50.5%
+    ),
+    linear-gradient(
+      45deg,
+      transparent 49.5%,
+      rgba(255, 103, 189, 0.2) 50%,
+      transparent 50.5%
+    );
+  content: "";
+  pointer-events: none;
+}
+
+.facet-dropdown:hover .facet-menu,
+.facet-dropdown:focus-within .facet-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0) scale(1) skewX(0deg);
+}
+
+.facet-dropdown:hover .facet-trigger,
+.facet-dropdown:focus-within .facet-trigger {
+  border-color: var(--facet-cyan);
+  box-shadow:
+    0 1.2rem 2.2rem rgba(0, 0, 0, 0.32),
+    0 0 1.4rem rgba(69, 230, 255, 0.22);
+  transform: translateY(-0.08rem);
+}
+
+.facet-dropdown:hover .facet-trigger span,
+.facet-dropdown:focus-within .facet-trigger span {
+  transform: rotate(180deg);
+}
+
+.facet-menu a {
+  position: relative;
+  display: block;
+  border-radius: 0.68rem;
+  padding: 0.82rem 0.9rem;
+  color: var(--facet-ink);
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.facet-menu a:hover,
+.facet-menu a:focus-visible {
+  color: #07101c;
+  background: linear-gradient(135deg, var(--facet-cyan), var(--facet-pink));
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.facet-trigger:focus-visible {
+  outline: 0.2rem solid var(--facet-cyan);
+  outline-offset: 0.24rem;
+}
+
+@media (max-width: 38rem) {
+  .facet-page {
+    padding: 1rem;
+  }
+
+  .facet-card {
+    padding: 1.45rem;
+    border-radius: 1.2rem;
+  }
+
+  .facet-crystal {
+    opacity: 0.28;
+    transform: scale(0.82);
+    transform-origin: top right;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new standard HTML/CSS dropdown and menu submission for the Diamond Facet Edge style.
- Includes a self-contained `demo.html`, scoped `style.css`, and README usage notes.
- Uses semantic nav/button/list markup, hover plus focus-within menu access, visible focus states, faceted prism styling, and reduced-motion support.

Closes #73680

## Changes Made
- Created `submissions/examples/diamond-facet-dropdown-msm/`.
- Added a dark geometric dropdown menu with diamond/prism facet edge visuals.
- Documented usage, accessibility notes, and fit for EaseMotion CSS.

## Testing
- `npx.cmd prettier --check submissions/examples/diamond-facet-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/diamond-facet-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed

## Screenshots
- Not attached; visual change is contained in the self-contained `demo.html` and can be opened directly in a browser.

## Edge Cases Handled
- Dropdown opens on hover and `:focus-within` for keyboard access.
- Uses semantic navigation, button, list, and link elements.
- Decorative prism facets are hidden from assistive technology.
- Respects `prefers-reduced-motion: reduce`.
- Uses pure HTML/CSS only; no JavaScript, CDN, framework, remote font, generated file, or binary asset.
- Keeps the PR limited to one new `submissions/examples/` folder.