### PR TITLE
feat: add velvet smooth dropdown menu

### DIFF
--- a/submissions/examples/velvet-smooth-dropdown-msm/README.md
+++ b/submissions/examples/velvet-smooth-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Velvet Smooth Dropdown
+
+## What does this do?
+
+The Velvet Smooth Dropdown adds a polished HTML/CSS dropdown menu with soft layered gradients, tactile easing, and keyboard-visible focus states.
+
+## How is it used?
+
+Place the dropdown markup inside a navigation area and include the local stylesheet:
+
+```html
+<nav class="velvet-dropdown" aria-label="Product navigation">
+  <button class="dropdown-trigger" type="button" aria-haspopup="true">
+    Explore library
+    <span aria-hidden="true" class="trigger-icon"></span>
+  </button>
+
+  <ul class="dropdown-panel" aria-label="Library sections">
+    <li><a href="#animations">Animation presets</a></li>
+    <li><a href="#components">Component patterns</a></li>
+    <li><a href="#tokens">Design tokens</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a refined dropdown pattern that feels animated and expressive while remaining dependency-free, responsive, and accessible through hover and focus-within interactions.

--- a/submissions/examples/velvet-smooth-dropdown-msm/demo.html
+++ b/submissions/examples/velvet-smooth-dropdown-msm/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Velvet Smooth Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="hero-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">EaseMotion CSS component demo</p>
+        <h1 id="dropdown-title">Velvet Smooth Dropdown</h1>
+        <p class="intro">
+          A soft, tactile dropdown menu with layered velvet gradients, gentle
+          easing, and accessible focus states.
+        </p>
+
+        <nav class="velvet-dropdown" aria-label="Product navigation">
+          <button class="dropdown-trigger" type="button" aria-haspopup="true">
+            Explore library
+            <span aria-hidden="true" class="trigger-icon"></span>
+          </button>
+
+          <ul class="dropdown-panel" aria-label="Library sections">
+            <li>
+              <a href="#animations">
+                <span class="item-kicker">Motion</span>
+                Animation presets
+              </a>
+            </li>
+            <li>
+              <a href="#components">
+                <span class="item-kicker">UI</span>
+                Component patterns
+              </a>
+            </li>
+            <li>
+              <a href="#tokens">
+                <span class="item-kicker">System</span>
+                Design tokens
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/velvet-smooth-dropdown-msm/style.css
+++ b/submissions/examples/velvet-smooth-dropdown-msm/style.css
@@ -1,0 +1,251 @@
+:root {
+  --velvet-bg: #160f1e;
+  --velvet-plum: #5f234d;
+  --velvet-rose: #b76383;
+  --velvet-cream: #fff4e6;
+  --velvet-muted: #d9bdd0;
+  --velvet-shadow: rgba(25, 9, 24, 0.42);
+  --velvet-focus: #ffd38a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--velvet-cream);
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(183, 99, 131, 0.45),
+      transparent 32rem
+    ),
+    radial-gradient(
+      circle at 82% 78%,
+      rgba(109, 45, 89, 0.62),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #0f0a14 0%, var(--velvet-bg) 54%, #271127 100%);
+}
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.hero-card {
+  position: relative;
+  width: min(100%, 42rem);
+  overflow: visible;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 244, 230, 0.18);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 244, 230, 0.13),
+      rgba(255, 244, 230, 0.035)
+    ),
+    rgba(58, 25, 53, 0.64);
+  box-shadow:
+    0 2rem 5rem var(--velvet-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+  text-align: center;
+  backdrop-filter: blur(18px);
+}
+
+.hero-card::before {
+  position: absolute;
+  inset: 1rem;
+  z-index: -1;
+  border-radius: 1.6rem;
+  background: linear-gradient(
+    120deg,
+    rgba(255, 211, 138, 0.22),
+    transparent 48%
+  );
+  content: "";
+  filter: blur(24px);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--velvet-focus);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  line-height: 0.9;
+}
+
+.intro {
+  max-width: 31rem;
+  margin: 1.25rem auto 2rem;
+  color: var(--velvet-muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.velvet-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.95rem 1.25rem;
+  border: 1px solid rgba(255, 244, 230, 0.2);
+  border-radius: 999px;
+  color: var(--velvet-cream);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 244, 230, 0.18),
+      rgba(255, 244, 230, 0.04)
+    ),
+    linear-gradient(135deg, var(--velvet-plum), #35182f);
+  box-shadow:
+    0 1rem 2.25rem rgba(31, 12, 32, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  transition:
+    transform 360ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 360ms ease,
+    border-color 360ms ease;
+}
+
+.trigger-icon {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-right: 2px solid currentcolor;
+  border-bottom: 2px solid currentcolor;
+  transform: translateY(-0.12rem) rotate(45deg);
+  transition: transform 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dropdown-panel {
+  position: absolute;
+  top: calc(100% + 0.85rem);
+  left: 50%;
+  z-index: 3;
+  display: grid;
+  width: min(18rem, 86vw);
+  margin: 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(255, 244, 230, 0.18);
+  border-radius: 1.25rem;
+  list-style: none;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 244, 230, 0.16),
+      rgba(255, 244, 230, 0.04)
+    ),
+    rgba(42, 17, 38, 0.94);
+  box-shadow:
+    0 1.4rem 3rem rgba(16, 7, 20, 0.48),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.65rem) scale(0.96);
+  transform-origin: top center;
+  transition:
+    opacity 260ms ease,
+    transform 360ms cubic-bezier(0.18, 0.9, 0.25, 1);
+  backdrop-filter: blur(20px);
+}
+
+.dropdown-panel a {
+  display: grid;
+  gap: 0.18rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  color: var(--velvet-cream);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 260ms ease,
+    transform 260ms ease,
+    color 260ms ease;
+}
+
+.item-kicker {
+  color: var(--velvet-focus);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.velvet-dropdown:hover .dropdown-trigger,
+.velvet-dropdown:focus-within .dropdown-trigger {
+  border-color: rgba(255, 211, 138, 0.56);
+  box-shadow:
+    0 1.35rem 2.8rem rgba(31, 12, 32, 0.4),
+    0 0 0 0.3rem rgba(255, 211, 138, 0.12);
+  transform: translateY(-0.12rem);
+}
+
+.velvet-dropdown:hover .trigger-icon,
+.velvet-dropdown:focus-within .trigger-icon {
+  transform: translateY(0.08rem) rotate(225deg);
+}
+
+.velvet-dropdown:hover .dropdown-panel,
+.velvet-dropdown:focus-within .dropdown-panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.dropdown-panel a:hover,
+.dropdown-panel a:focus-visible {
+  color: #fffaf3;
+  background: linear-gradient(
+    135deg,
+    rgba(183, 99, 131, 0.35),
+    rgba(255, 211, 138, 0.13)
+  );
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.dropdown-trigger:focus-visible {
+  outline: 3px solid var(--velvet-focus);
+  outline-offset: 4px;
+}
+
+@media (max-width: 35rem) {
+  .demo-shell {
+    padding: 1rem;
+  }
+
+  .hero-card {
+    padding: 2rem 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Adds a new Velvet Smooth Dropdown submission under `submissions/examples/velvet-smooth-dropdown-msm/`
- Includes a self-contained `demo.html`, scoped `style.css`, and usage-focused `README.md`
- Uses semantic navigation markup, hover and focus-within reveal behavior, visible focus states, responsive sizing, and reduced-motion safeguards

Closes #73679

## Changes made
- Built a velvet-inspired dropdown trigger and menu panel with layered gradients and smooth transitions
- Added three dropdown menu links with readable labels and supporting kicker text
- Documented usage and project fit in the submission README

## Testing
- `npx.cmd prettier --write "submissions/examples/velvet-smooth-dropdown-msm/**/*.{html,css,md}"`
- `npx.cmd prettier --check "submissions/examples/velvet-smooth-dropdown-msm/**/*.{html,css,md}"` - passed
- `npx.cmd stylelint "submissions/examples/velvet-smooth-dropdown-msm/style.css" --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge cases handled
- Keyboard users can reveal and traverse the dropdown through `:focus-within`
- `:focus-visible` styling keeps the trigger and menu links clearly outlined
- `prefers-reduced-motion: reduce` minimizes transition and animation duration
- Mobile widths are supported with reduced card padding and viewport-safe panel sizing

## Screenshots
- Not attached; this is a static HTML/CSS submission and was validated locally with formatter/lint checks.
