### PR TITLE
feat: add ease-binary-rain-ij demo component

### DIFF
--- a/submissions/examples/ease-binary-rain-ij/README.md
+++ b/submissions/examples/ease-binary-rain-ij/README.md
@@ -1,0 +1,36 @@
+# Binary Rain
+
+Columns of `0`s and `1`s stream down a dark screen with glowing trails, like a digital downpour.
+
+## How is it used?
+
+A tiny script generates 12 columns, each a pre-built string of binary digits. Every column gets a random duration and a negative delay so the rain is already flowing on load:
+
+```js
+const col = document.createElement("span");
+col.className = "col";
+col.style.left = c * 8 + "%";
+col.style.animationDuration = 2.2 + Math.random() * 2 + "s";
+col.style.animationDelay = -Math.random() * 4 + "s";
+```
+
+```css
+.col {
+  animation: rain-fall linear infinite;
+}
+
+@keyframes rain-fall {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(420%);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+Negative animation delays fake a mid-stream state, so the effect is alive the instant the page paints. The same stagger trick powers any falling/marquee stream without a timer.

--- a/submissions/examples/ease-binary-rain-ij/demo.html
+++ b/submissions/examples/ease-binary-rain-ij/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Binary Rain Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="screen">
+    <div class="rain" id="rain" aria-hidden="true"></div>
+    <p class="hint">Columns of 0s and 1s stream down the screen with fading trails.</p>
+  </main>
+  <script>
+    const rain = document.getElementById("rain");
+    const chars = ["0", "1"];
+    for (let c = 0; c < 12; c++) {
+      const col = document.createElement("span");
+      col.className = "col";
+      col.style.left = c * 8 + "%";
+      col.style.animationDuration = 2.2 + Math.random() * 2 + "s";
+      col.style.animationDelay = -Math.random() * 4 + "s";
+      let text = "";
+      for (let i = 0; i < 18; i++) {
+        text += chars[Math.floor(Math.random() * 2)] + "\n";
+      }
+      col.textContent = text;
+      rain.appendChild(col);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-binary-rain-ij/style.css
+++ b/submissions/examples/ease-binary-rain-ij/style.css
@@ -1,0 +1,72 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #050b07;
+  font-family: system-ui, sans-serif;
+}
+
+.screen {
+  position: relative;
+  width: 340px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 20%, #08140c, #020604 70%);
+  border: 1px solid #12331f;
+}
+
+.rain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.85;
+}
+
+.col {
+  position: absolute;
+  top: -120%;
+  width: 24px;
+  color: #35ff7a;
+  font-family: "Courier New", monospace;
+  font-size: 14px;
+  line-height: 1.15;
+  white-space: pre;
+  text-align: center;
+  animation: rain-fall linear infinite;
+  text-shadow: 0 0 6px #2aff6e;
+}
+
+@keyframes rain-fall {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  8% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateY(420%);
+    opacity: 0;
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #57e08a;
+  font-size: 12px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Adds a working `ease-binary-rain-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-binary-rain-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.