### PR TITLE
feat: add ease-dna-helix-ij demo component

### DIFF
--- a/submissions/examples/ease-dna-helix-ij/README.md
+++ b/submissions/examples/ease-dna-helix-ij/README.md
@@ -1,0 +1,29 @@
+# DNA Helix
+
+A double helix rotates continuously while rung bars rise and fall, using 3D transforms and staggered delays.
+
+## How is it used?
+
+Two strand bars spin with `rotateY` while scaling down mid-rotation to fake depth; the rungs share the same 6s loop but are phase-shifted by 1s each:
+
+```css
+.strand {
+  animation: helix-spin 6s linear infinite;
+  transform-style: preserve-3d;
+}
+
+@keyframes helix-spin {
+  0% {
+    transform: rotateY(0deg) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: rotateY(180deg) scale(0.55);
+    opacity: 0.45;
+  }
+}
+```
+
+## Why is it useful?
+
+`scale()` inside a `rotateY` loop is a cheap way to fake 3D depth on any axis. Negative/positive delays make several elements share one loop while never overlapping — the core trick behind equalizer bars, marquees, and conveyor animations.

--- a/submissions/examples/ease-dna-helix-ij/demo.html
+++ b/submissions/examples/ease-dna-helix-ij/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DNA Helix Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="lab">
+    <div class="helix" id="helix" aria-hidden="true">
+      <div class="strand strand-left"></div>
+      <div class="strand strand-right"></div>
+      <div class="rung rung-1"></div>
+      <div class="rung rung-2"></div>
+      <div class="rung rung-3"></div>
+      <div class="rung rung-4"></div>
+      <div class="rung rung-5"></div>
+      <div class="rung rung-6"></div>
+    </div>
+    <p class="hint">The double helix rotates while rungs rise and fall through the frame.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-dna-helix-ij/style.css
+++ b/submissions/examples/ease-dna-helix-ij/style.css
@@ -1,0 +1,126 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a1622;
+  font-family: system-ui, sans-serif;
+}
+
+.lab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.helix {
+  position: relative;
+  width: 200px;
+  height: 260px;
+  perspective: 600px;
+}
+
+.strand {
+  position: absolute;
+  top: 0;
+  width: 22px;
+  height: 100%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #38d9a9, #12b886 40%, #0ca678);
+  animation: helix-spin 6s linear infinite;
+  transform-style: preserve-3d;
+}
+
+.strand-left {
+  left: 24px;
+}
+
+.strand-right {
+  right: 24px;
+  animation-delay: -3s;
+}
+
+@keyframes helix-spin {
+  0% {
+    transform: rotateY(0deg) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: rotateY(180deg) scale(0.55);
+    opacity: 0.45;
+  }
+  100% {
+    transform: rotateY(360deg) scale(1);
+    opacity: 1;
+  }
+}
+
+.rung {
+  position: absolute;
+  left: 34px;
+  width: 132px;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #4dd2ff, #a066ff);
+  animation: rung-rise 6s linear infinite;
+  transform-style: preserve-3d;
+}
+
+.rung-1 {
+  top: 12%;
+}
+
+.rung-2 {
+  top: 28%;
+  animation-delay: -1s;
+}
+
+.rung-3 {
+  top: 44%;
+  animation-delay: -2s;
+}
+
+.rung-4 {
+  top: 60%;
+  animation-delay: -3s;
+}
+
+.rung-5 {
+  top: 76%;
+  animation-delay: -4s;
+}
+
+.rung-6 {
+  top: 92%;
+  animation-delay: -5s;
+}
+
+@keyframes rung-rise {
+  0% {
+    transform: rotateY(0deg) translateZ(12px) scaleX(1);
+    opacity: 1;
+  }
+  50% {
+    transform: rotateY(180deg) translateZ(-12px) scaleX(0.7);
+    opacity: 0.5;
+  }
+  100% {
+    transform: rotateY(360deg) translateZ(12px) scaleX(1);
+    opacity: 1;
+  }
+}
+
+.hint {
+  color: #8fc3e8;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-dna-helix-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-dna-helix-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.