### PR TITLE
feat: add ease-hologram-glitch-ij demo component

### DIFF
--- a/submissions/examples/ease-hologram-glitch-ij/README.md
+++ b/submissions/examples/ease-hologram-glitch-ij/README.md
@@ -1,0 +1,27 @@
+# Hologram Glitch
+
+A floating hologram tears into horizontal slices with hue shifts when hovered or transmitted, simulating a damaged signal.
+
+## How is it used?
+
+The figure uses `clip-path` + `transform` jumps inside a single `steps()` keyframe loop:
+
+```css
+@keyframes glitch-slice {
+  0% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+    filter: hue-rotate(0deg);
+  }
+  25% {
+    clip-path: inset(20% 0 40% 0);
+    transform: translate(6px, -4px);
+    filter: hue-rotate(90deg);
+  }
+  ...
+}
+```
+
+## Why is it useful?
+
+`clip-path: inset()` slices out a horizontal band while `steps()` snaps between discrete frames instead of easing — that stepped jump is exactly what makes glitches feel digital. Combined with `hue-rotate` it reads as channel corruption without any image assets.

--- a/submissions/examples/ease-hologram-glitch-ij/demo.html
+++ b/submissions/examples/ease-hologram-glitch-ij/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hologram Glitch Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="chamber">
+    <div class="holo" id="holo">
+      <div class="fig"></div>
+      <div class="scan"></div>
+    </div>
+    <button class="transmit" id="transmit" type="button">Transmit</button>
+    <p class="hint">Hover or transmit to make the hologram tear and glitch.</p>
+  </main>
+  <script>
+    const holo = document.getElementById("holo");
+    const transmit = document.getElementById("transmit");
+    function glitch() {
+      holo.classList.remove("breaking");
+      void holo.offsetWidth;
+      holo.classList.add("breaking");
+    }
+    transmit.addEventListener("click", glitch);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hologram-glitch-ij/style.css
+++ b/submissions/examples/ease-hologram-glitch-ij/style.css
@@ -1,0 +1,141 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #060b12;
+  font-family: system-ui, sans-serif;
+}
+
+.chamber {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 22px;
+}
+
+.holo {
+  position: relative;
+  width: 180px;
+  height: 240px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 255, 200, 0.35);
+  border-radius: 12px;
+  background: radial-gradient(circle at 50% 30%, rgba(0, 255, 200, 0.08), transparent 70%);
+}
+
+.holo::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 255, 200, 0.08) 0 2px,
+    transparent 2px 6px
+  );
+  pointer-events: none;
+}
+
+.fig {
+  position: absolute;
+  left: 40px;
+  top: 40px;
+  width: 100px;
+  height: 150px;
+  background: linear-gradient(180deg, rgba(0, 255, 200, 0.6), rgba(0, 200, 255, 0.25));
+  clip-path: polygon(50% 0%, 82% 12%, 78% 48%, 92% 88%, 68% 100%, 50% 78%, 32% 100%, 8% 88%, 22% 48%, 18% 12%);
+  animation: float-idle 3s ease-in-out infinite;
+}
+
+@keyframes float-idle {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+.holo:hover .fig,
+.holo.breaking .fig {
+  animation: glitch-slice 0.5s steps(2, end) infinite;
+}
+
+@keyframes glitch-slice {
+  0% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+    filter: hue-rotate(0deg);
+  }
+  25% {
+    clip-path: inset(20% 0 40% 0);
+    transform: translate(6px, -4px);
+    filter: hue-rotate(90deg);
+  }
+  50% {
+    clip-path: inset(55% 0 10% 0);
+    transform: translate(-6px, 3px);
+    filter: hue-rotate(-60deg);
+  }
+  75% {
+    clip-path: inset(10% 0 65% 0);
+    transform: translate(4px, 2px);
+    filter: hue-rotate(40deg);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+    transform: translate(0, 0);
+    filter: hue-rotate(0deg);
+  }
+}
+
+.scan {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -20%;
+  height: 24px;
+  background: linear-gradient(180deg, transparent, rgba(0, 255, 200, 0.35), transparent);
+  animation: scan-sweep 2.6s linear infinite;
+}
+
+@keyframes scan-sweep {
+  0% {
+    top: -20%;
+  }
+  100% {
+    top: 120%;
+  }
+}
+
+.transmit {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #00e6c0;
+  color: #05130f;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.transmit:hover {
+  background: #3dffdb;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #6fc8bd;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-hologram-glitch-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-hologram-glitch-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.