### PR TITLE
feat: add ease-ink-blot-ij demo component

### DIFF
--- a/submissions/examples/ease-ink-blot-ij/README.md
+++ b/submissions/examples/ease-ink-blot-ij/README.md
@@ -1,0 +1,28 @@
+# Ink Blot
+
+A drop of ink lands and spreads into an organic, slightly irregular blot on paper.
+
+## How is it used?
+
+The entire effect is one keyframe that scales the circle up while animating `border-radius` between asymmetric values:
+
+```css
+@keyframes ink-spread {
+  0% {
+    transform: scale(0.06) rotate(0deg);
+    border-radius: 50%;
+  }
+  70% {
+    transform: scale(0.85) rotate(-4deg);
+    border-radius: 40% 60% 38% 62%;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    border-radius: 46% 54% 58% 42%;
+  }
+}
+```
+
+## Why is it useful?
+
+Morphing `border-radius` while scaling makes a plain circle feel like liquid pooling — no images or blur filters needed. The same approach animates ink, bubbles, and blobby organic transitions in modern UIs.

--- a/submissions/examples/ease-ink-blot-ij/demo.html
+++ b/submissions/examples/ease-ink-blot-ij/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ink Blot Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="paper">
+    <div class="blot" id="blot" aria-hidden="true"></div>
+    <button class="drop" id="drop" type="button">Drop Ink</button>
+    <p class="hint">A drop of ink falls and spreads into an organic blot.</p>
+  </main>
+  <script>
+    const blot = document.getElementById("blot");
+    const drop = document.getElementById("drop");
+    function dropInk() {
+      blot.classList.remove("spread");
+      void blot.offsetWidth;
+      blot.classList.add("spread");
+    }
+    drop.addEventListener("click", dropInk);
+    dropInk();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ink-blot-ij/style.css
+++ b/submissions/examples/ease-ink-blot-ij/style.css
@@ -1,0 +1,79 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f4efe4;
+  font-family: system-ui, sans-serif;
+}
+
+.paper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 22px;
+}
+
+.blot {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #1a1a2e, #10101e 70%);
+  opacity: 0;
+}
+
+.blot.spread {
+  opacity: 1;
+  animation: ink-spread 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes ink-spread {
+  0% {
+    transform: scale(0.06) rotate(0deg);
+    border-radius: 50%;
+  }
+  40% {
+    transform: scale(0.5) rotate(6deg);
+    border-radius: 44% 56% 52% 48%;
+  }
+  70% {
+    transform: scale(0.85) rotate(-4deg);
+    border-radius: 40% 60% 38% 62%;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    border-radius: 46% 54% 58% 42%;
+  }
+}
+
+.drop {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #2a2a4a;
+  color: #f4efe4;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.drop:hover {
+  background: #3d3d68;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #6d6655;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-ink-blot-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-ink-blot-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.