### PR TITLE
feat: add ease-jellyfish-float-ij demo component

### DIFF
--- a/submissions/examples/ease-jellyfish-float-ij/README.md
+++ b/submissions/examples/ease-jellyfish-float-ij/README.md
@@ -1,0 +1,32 @@
+# Jellyfish Float
+
+A translucent jellyfish bell pulses while its tentacles sway on offset timings, drifting gently through the water.
+
+## How is it used?
+
+The bell squashes vertically with `scale(1.12, 0.88)` — a sine-like pulse — while each tentacle rotates on its own delayed sway loop:
+
+```css
+.bell {
+  transform-origin: 50% 10%;
+  animation: bell-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes bell-pulse {
+  0%, 100% {
+    transform: scale(1, 1);
+  }
+  50% {
+    transform: scale(1.12, 0.88);
+  }
+}
+
+.tentacle-1 {
+  animation: sway 3.6s ease-in-out infinite;
+  animation-delay: -0.9s;
+}
+```
+
+## Why is it useful?
+
+Separate loops with negative delays create organic, never-synced motion from a tiny amount of CSS. The pulsing-bell + trailing-sway pair is the recipe behind any "alive" organism-style UI, from loaders to mascots.

--- a/submissions/examples/ease-jellyfish-float-ij/demo.html
+++ b/submissions/examples/ease-jellyfish-float-ij/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jellyfish Float Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="ocean">
+    <div class="jelly" id="jelly" aria-hidden="true">
+      <div class="bell"></div>
+      <div class="tentacle tentacle-1"></div>
+      <div class="tentacle tentacle-2"></div>
+      <div class="tentacle tentacle-3"></div>
+      <div class="tentacle tentacle-4"></div>
+    </div>
+    <p class="hint">A translucent jellyfish pulses and drifts through the deep.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-jellyfish-float-ij/style.css
+++ b/submissions/examples/ease-jellyfish-float-ij/style.css
@@ -1,0 +1,122 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #05141f;
+  font-family: system-ui, sans-serif;
+}
+
+.ocean {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 340px;
+  height: 300px;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 20%, #0a2a3f, #04101a 75%);
+  box-shadow: inset 0 0 40px rgba(0, 160, 200, 0.15);
+}
+
+.jelly {
+  position: relative;
+  width: 140px;
+  height: 220px;
+  animation: jelly-drift 6s ease-in-out infinite;
+}
+
+@keyframes jelly-drift {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-18px);
+  }
+}
+
+.bell {
+  position: absolute;
+  top: 0;
+  left: 20px;
+  width: 100px;
+  height: 70px;
+  border-radius: 50% 50% 44% 44%;
+  background: radial-gradient(circle at 40% 30%, rgba(190, 220, 255, 0.55), rgba(120, 180, 230, 0.25) 60%, rgba(80, 150, 210, 0.15));
+  transform-origin: 50% 10%;
+  animation: bell-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes bell-pulse {
+  0%,
+  100% {
+    transform: scale(1, 1);
+  }
+  50% {
+    transform: scale(1.12, 0.88);
+  }
+}
+
+.tentacle {
+  position: absolute;
+  top: 56px;
+  left: 62px;
+  width: 3px;
+  height: 120px;
+  background: linear-gradient(180deg, rgba(150, 200, 255, 0.6), rgba(150, 200, 255, 0.05));
+  transform-origin: 50% 0;
+  animation: sway 3.6s ease-in-out infinite;
+}
+
+.tentacle-1 {
+  left: 38px;
+  height: 140px;
+  animation-delay: -0.9s;
+}
+
+.tentacle-2 {
+  left: 62px;
+  animation-delay: -1.8s;
+}
+
+.tentacle-3 {
+  left: 86px;
+  height: 135px;
+  animation-delay: -0.5s;
+}
+
+.tentacle-4 {
+  left: 98px;
+  height: 115px;
+  animation-delay: -2.4s;
+}
+
+@keyframes sway {
+  0%,
+  100% {
+    transform: rotate(0deg) scaleY(1);
+  }
+  25% {
+    transform: rotate(9deg) scaleY(1.1);
+  }
+  75% {
+    transform: rotate(-9deg) scaleY(0.92);
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #7fc4e0;
+  font-size: 12px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Adds a working `ease-jellyfish-float-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-jellyfish-float-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.