### PR TITLE
feat: add ease-quartz-pulse-ij demo component

### DIFF
--- a/submissions/examples/ease-quartz-pulse-ij/README.md
+++ b/submissions/examples/ease-quartz-pulse-ij/README.md
@@ -1,0 +1,32 @@
+# Quartz Pulse
+
+A crystal oscillator flashes with a sharp attack, then releases a fading pulse ring — one tick per loop.
+
+## How is it used?
+
+The gem uses a quick brightness/scale spike early in the loop; the rings expand outward from the same origin on a matching duration, offset by half a beat:
+
+```css
+.gem {
+  animation: quartz-flash 2s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.crystal .ring-2 {
+  animation-delay: -1s;
+}
+
+@keyframes pulse-ring {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(4.4);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+A hard cubic-bezier attack followed by a slow decay reads as an electronic tick — ideal for oscillators, sonar, and "live" status markers. The offset ring doubles the beat density without a second keyframe set.

--- a/submissions/examples/ease-quartz-pulse-ij/demo.html
+++ b/submissions/examples/ease-quartz-pulse-ij/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quartz Pulse Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="clock">
+    <div class="crystal" id="crystal" aria-hidden="true">
+      <div class="gem"></div>
+      <div class="ring"></div>
+      <div class="ring ring-2"></div>
+    </div>
+    <p class="hint">A crystal oscillator ticks with a sharp pulse and a spreading ring.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-quartz-pulse-ij/style.css
+++ b/submissions/examples/ease-quartz-pulse-ij/style.css
@@ -1,0 +1,101 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0d1420;
+  font-family: system-ui, sans-serif;
+}
+
+.clock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.crystal {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gem {
+  position: relative;
+  width: 74px;
+  height: 96px;
+  background: linear-gradient(160deg, #7dd3fc, #38bdf8 55%, #0284c7);
+  clip-path: polygon(50% 0%, 100% 26%, 82% 88%, 50% 100%, 18% 88%, 0% 26%);
+  box-shadow: 0 0 28px rgba(56, 189, 248, 0.5);
+  animation: quartz-flash 2s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+@keyframes quartz-flash {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  18% {
+    transform: scale(1.1);
+    filter: brightness(1.6);
+  }
+  34% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+}
+
+.ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  transform: translate(-50%, -50%);
+  border: 2px solid #7dd3fc;
+  border-radius: 50%;
+  opacity: 0;
+}
+
+.crystal .ring {
+  animation: pulse-ring 2s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.crystal .ring-2 {
+  animation-delay: -1s;
+}
+
+@keyframes pulse-ring {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.9;
+  }
+  70% {
+    opacity: 0.25;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(4.4);
+    opacity: 0;
+  }
+}
+
+.hint {
+  color: #7ea6c8;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-quartz-pulse-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-quartz-pulse-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.