### PR TITLE
feat: add ease-ripple-wave-ij demo component

### DIFF
--- a/submissions/examples/ease-ripple-wave-ij/README.md
+++ b/submissions/examples/ease-ripple-wave-ij/README.md
@@ -1,0 +1,28 @@
+# Ripple Wave
+
+Concentric rings expand from a drop point across a circular pool and fade at the edges.
+
+## How is it used?
+
+Four `.ring` elements share one expanding-and-fading keyframe, staggered with negative delays so ripples overlap continuously:
+
+```css
+.surface.wave .ring-2 {
+  animation-delay: -0.8s;
+}
+
+@keyframes ripple {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(26);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+Negative delays again let four identical elements pretend to be a continuous expanding wave. Scaling a thin ring border is far cheaper than SVG or canvas — the same trick powers radar, sonar, and focus ripples.

--- a/submissions/examples/ease-ripple-wave-ij/demo.html
+++ b/submissions/examples/ease-ripple-wave-ij/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ripple Wave Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="pool">
+    <div class="surface" id="surface">
+      <div class="ring ring-1"></div>
+      <div class="ring ring-2"></div>
+      <div class="ring ring-3"></div>
+      <div class="ring ring-4"></div>
+    </div>
+    <button class="splash" id="splash" type="button">Drop Pebble</button>
+    <p class="hint">Concentric ripples expand across the water and fade.</p>
+  </main>
+  <script>
+    const surface = document.getElementById("surface");
+    const splash = document.getElementById("splash");
+    function drop() {
+      surface.classList.remove("wave");
+      void surface.offsetWidth;
+      surface.classList.add("wave");
+    }
+    splash.addEventListener("click", drop);
+    drop();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ripple-wave-ij/style.css
+++ b/submissions/examples/ease-ripple-wave-ij/style.css
@@ -1,0 +1,110 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0e2a3a;
+  font-family: system-ui, sans-serif;
+}
+
+.pool {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.surface {
+  position: relative;
+  width: 260px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 35%, #2b6c8a, #14455e 70%);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.35);
+}
+
+.surface::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 8px 2px rgba(255, 255, 255, 0.5);
+}
+
+.ring {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border: 2px solid rgba(210, 240, 255, 0.8);
+  border-radius: 50%;
+  opacity: 0;
+}
+
+.surface.wave .ring {
+  animation: ripple 2.4s ease-out infinite;
+}
+
+.surface.wave .ring-2 {
+  animation-delay: -0.8s;
+}
+
+.surface.wave .ring-3 {
+  animation-delay: -1.6s;
+}
+
+.surface.wave .ring-4 {
+  animation-delay: -0.4s;
+}
+
+@keyframes ripple {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.9;
+  }
+  70% {
+    opacity: 0.35;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(26);
+    opacity: 0;
+  }
+}
+
+.splash {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #4cc9f0;
+  color: #06202c;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.splash:hover {
+  background: #7cdaf5;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #9fcddf;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-ripple-wave-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-ripple-wave-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.