### PR TITLE
feat: add ease-solar-flare-ij demo component

### DIFF
--- a/submissions/examples/ease-solar-flare-ij/README.md
+++ b/submissions/examples/ease-solar-flare-ij/README.md
@@ -1,0 +1,35 @@
+# Solar Flare
+
+A pulsing sun disc hurls arcs of plasma outward from four limbs in synchronized bursts.
+
+## How is it used?
+
+Each `.flare` is a radial-gradient ellipse anchored to the sun's rim via `transform-origin`, erupting and flying outward with a matched 3.2s loop:
+
+```css
+.flare-a {
+  top: -14px;
+  left: 44px;
+  transform-origin: 50% 200%;
+  animation: flare-a 3.2s ease-in infinite;
+}
+
+@keyframes flare-a {
+  0% {
+    transform: scale(0.2) rotate(0deg);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.95;
+    transform: scale(1.15) rotate(14deg);
+  }
+  100% {
+    transform: scale(1.5) rotate(28deg) translateY(-26px);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+Same-duration loops on all flares keep the eruption in sync with the sun's `sun-breathe` pulse, selling cause and effect. Origin-anchored rotations let one ellipse fake an arc of plasma, useful for energy, magic, and warning effects.

--- a/submissions/examples/ease-solar-flare-ij/demo.html
+++ b/submissions/examples/ease-solar-flare-ij/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Solar Flare Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="sunspace">
+    <div class="sun" id="sun" aria-hidden="true">
+      <div class="disc"></div>
+      <div class="corona"></div>
+      <div class="flare flare-a"></div>
+      <div class="flare flare-b"></div>
+      <div class="flare flare-c"></div>
+      <div class="flare flare-d"></div>
+    </div>
+    <p class="hint">The sun pulses and hurls arcs of plasma into the void.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-solar-flare-ij/style.css
+++ b/submissions/examples/ease-solar-flare-ij/style.css
@@ -1,0 +1,182 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b060f;
+  font-family: system-ui, sans-serif;
+}
+
+.sunspace {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 340px;
+  height: 300px;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 60%, #1b1030, #0b060f 70%);
+}
+
+.sun {
+  position: relative;
+  width: 180px;
+  height: 180px;
+}
+
+.disc {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #fff3c4, #ffd166 45%, #ff9d4d 75%, #e0622a);
+  animation: sun-breathe 3.2s ease-in-out infinite;
+}
+
+@keyframes sun-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  50% {
+    transform: scale(1.05);
+    filter: brightness(1.15);
+  }
+}
+
+.corona {
+  position: absolute;
+  inset: -14%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 180, 90, 0.45), transparent 65%);
+  filter: blur(6px);
+  animation: corona-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes corona-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 0.9;
+  }
+}
+
+.flare {
+  position: absolute;
+  width: 46px;
+  height: 24px;
+  border-radius: 50%;
+  opacity: 0;
+}
+
+.flare-a {
+  top: -14px;
+  left: 44px;
+  background: radial-gradient(ellipse, #ffb56b, #ff6b3d 70%, transparent);
+  transform-origin: 50% 200%;
+  animation: flare-a 3.2s ease-in infinite;
+}
+
+.flare-b {
+  bottom: -10px;
+  left: 60px;
+  background: radial-gradient(ellipse, #ffd166, #ff7b3d 70%, transparent);
+  transform-origin: 50% -100%;
+  animation: flare-b 3.2s ease-in infinite;
+}
+
+.flare-c {
+  top: 52px;
+  right: -18px;
+  background: radial-gradient(ellipse, #ffe9b0, #ff9d4d 70%, transparent);
+  transform-origin: -80% 50%;
+  animation: flare-c 3.2s ease-in infinite;
+}
+
+.flare-d {
+  top: 60px;
+  left: -16px;
+  background: radial-gradient(ellipse, #ff9d6b, #ff6b3d 70%, transparent);
+  transform-origin: 180% 50%;
+  animation: flare-d 3.2s ease-in infinite;
+}
+
+@keyframes flare-a {
+  0% {
+    transform: scale(0.2) rotate(0deg);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.95;
+    transform: scale(1.15) rotate(14deg);
+  }
+  100% {
+    transform: scale(1.5) rotate(28deg) translateY(-26px);
+    opacity: 0;
+  }
+}
+
+@keyframes flare-b {
+  0% {
+    transform: scale(0.2) rotate(0deg);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.9;
+    transform: scale(1.1) rotate(-10deg);
+  }
+  100% {
+    transform: scale(1.45) rotate(-24deg) translateY(24px);
+    opacity: 0;
+  }
+}
+
+@keyframes flare-c {
+  0% {
+    transform: scale(0.2);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.9;
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1.5) translateX(26px);
+    opacity: 0;
+  }
+}
+
+@keyframes flare-d {
+  0% {
+    transform: scale(0.2);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.9;
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1.5) translateX(-26px);
+    opacity: 0;
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #c89bd8;
+  font-size: 12px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Adds a working `ease-solar-flare-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-solar-flare-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.