### PR TITLE
feat: add ease-vortex-suction-ij demo component

### DIFF
--- a/submissions/examples/ease-vortex-suction-ij/README.md
+++ b/submissions/examples/ease-vortex-suction-ij/README.md
@@ -1,0 +1,31 @@
+# Vortex Suction
+
+Motes spiral around a glowing whirlpool and get pulled into the center as they shrink.
+
+## How is it used?
+
+Each spark orbits via the rotate-translate-counter-rotate trick, but instead of counter-rotating, the translate distance collapses to `0` so it spirals inward:
+
+```css
+.spark {
+  animation: suck-in 3s linear infinite;
+}
+
+@keyframes suck-in {
+  0% {
+    transform: rotate(0deg) translateX(100px) scale(1);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: rotate(720deg) translateX(0) scale(0.2);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+Shrinking the translate radius across the loop creates an inward spiral with a single keyframe. Offset by negative delays, six sparks form a continuous vortex — a great metaphor for loading, draining, or "capturing" states.

--- a/submissions/examples/ease-vortex-suction-ij/demo.html
+++ b/submissions/examples/ease-vortex-suction-ij/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vortex Suction Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="portal">
+    <div class="vortex" id="vortex" aria-hidden="true">
+      <div class="whirl"></div>
+      <div class="spark spark-1"></div>
+      <div class="spark spark-2"></div>
+      <div class="spark spark-3"></div>
+      <div class="spark spark-4"></div>
+      <div class="spark spark-5"></div>
+      <div class="spark spark-6"></div>
+    </div>
+    <p class="hint">Motes spiral inward and are sucked down the funnel.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-vortex-suction-ij/style.css
+++ b/submissions/examples/ease-vortex-suction-ij/style.css
@@ -1,0 +1,112 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #080a14;
+  font-family: system-ui, sans-serif;
+}
+
+.portal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.vortex {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, #0d1020, #05060d 70%);
+  box-shadow: inset 0 0 30px rgba(80, 60, 255, 0.25);
+  overflow: hidden;
+}
+
+.whirl {
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(
+    from 0deg,
+    rgba(80, 60, 255, 0.12),
+    rgba(80, 60, 255, 0.5),
+    transparent 65%,
+    rgba(80, 60, 255, 0.12)
+  );
+  border-radius: 50%;
+  animation: whirl-turn 3s linear infinite;
+}
+
+@keyframes whirl-turn {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.spark {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #c7c9ff;
+  box-shadow: 0 0 6px #7b6bff;
+  animation: suck-in 3s linear infinite;
+}
+
+.spark-1 {
+  animation-delay: 0s;
+}
+
+.spark-2 {
+  animation-delay: -0.5s;
+}
+
+.spark-3 {
+  animation-delay: -1s;
+}
+
+.spark-4 {
+  animation-delay: -1.5s;
+}
+
+.spark-5 {
+  animation-delay: -2s;
+}
+
+.spark-6 {
+  animation-delay: -2.5s;
+}
+
+@keyframes suck-in {
+  0% {
+    transform: rotate(0deg) translateX(100px) scale(1);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: rotate(720deg) translateX(0) scale(0.2);
+    opacity: 0;
+  }
+}
+
+.hint {
+  color: #a0a4d8;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-vortex-suction-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-vortex-suction-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.