### PR TITLE
feat: add minimalist outline dropdown menu

### DIFF
--- a/submissions/examples/minimalist-outline-dropdown-msm/README.md
+++ b/submissions/examples/minimalist-outline-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Minimalist Outline Dropdown
+
+## What does this do?
+
+The Minimalist Outline Dropdown adds a crisp HTML/CSS dropdown menu with hairline borders, restrained movement, and clean focus states.
+
+## How is it used?
+
+Place the dropdown inside a navigation area and include the local stylesheet:
+
+```html
+<nav class="outline-dropdown" aria-label="Documentation navigation">
+  <button class="outline-trigger" type="button" aria-haspopup="true">
+    Documentation
+    <span class="arrow" aria-hidden="true"></span>
+  </button>
+
+  <ul class="outline-menu" aria-label="Documentation sections">
+    <li><a href="#start">Start guide</a></li>
+    <li><a href="#patterns">Patterns</a></li>
+    <li><a href="#api">API notes</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a lightweight dropdown pattern that feels precise, accessible, and easy to adapt without JavaScript or external dependencies.

--- a/submissions/examples/minimalist-outline-dropdown-msm/demo.html
+++ b/submissions/examples/minimalist-outline-dropdown-msm/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Minimalist Outline Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-wrap">
+      <section class="outline-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">Pure CSS dropdown</p>
+        <h1 id="dropdown-title">Minimalist Outline</h1>
+        <p class="intro">
+          A crisp dropdown menu with hairline borders, restrained motion, and a
+          clean editorial layout.
+        </p>
+
+        <nav class="outline-dropdown" aria-label="Documentation navigation">
+          <button class="outline-trigger" type="button" aria-haspopup="true">
+            Documentation
+            <span class="arrow" aria-hidden="true"></span>
+          </button>
+
+          <ul class="outline-menu" aria-label="Documentation sections">
+            <li>
+              <a href="#start">
+                <span>Start guide</span>
+                <small>Setup basics</small>
+              </a>
+            </li>
+            <li>
+              <a href="#patterns">
+                <span>Patterns</span>
+                <small>Reusable UI</small>
+              </a>
+            </li>
+            <li>
+              <a href="#api">
+                <span>API notes</span>
+                <small>Class details</small>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/minimalist-outline-dropdown-msm/style.css
+++ b/submissions/examples/minimalist-outline-dropdown-msm/style.css
@@ -1,0 +1,224 @@
+:root {
+  --page: #f7f4ee;
+  --ink: #171717;
+  --muted: #6b6760;
+  --line: #25221e;
+  --soft-line: rgba(37, 34, 30, 0.16);
+  --panel: rgba(255, 252, 246, 0.94);
+  --accent: #9b6a35;
+  --shadow: rgba(23, 23, 23, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  background:
+    linear-gradient(90deg, rgba(37, 34, 30, 0.06) 1px, transparent 1px),
+    linear-gradient(rgba(37, 34, 30, 0.06) 1px, transparent 1px), var(--page);
+  background-size: 2.8rem 2.8rem;
+}
+
+.demo-wrap {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.outline-card {
+  position: relative;
+  width: min(100%, 40rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1.5px solid var(--line);
+  border-radius: 1.35rem;
+  background: var(--panel);
+  box-shadow:
+    0.8rem 0.8rem 0 var(--line),
+    0 1.5rem 3rem var(--shadow);
+  text-align: center;
+}
+
+.outline-card::before,
+.outline-card::after {
+  position: absolute;
+  width: 4rem;
+  height: 4rem;
+  border-color: var(--line);
+  content: "";
+}
+
+.outline-card::before {
+  top: 1rem;
+  left: 1rem;
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+
+.outline-card::after {
+  right: 1rem;
+  bottom: 1rem;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+
+.eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.45rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 31rem;
+  margin: 1rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.outline-dropdown {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.outline-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.85rem 1.15rem;
+  border: 1.5px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  background: transparent;
+  box-shadow: 0.25rem 0.25rem 0 var(--line);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    background-color 220ms ease;
+}
+
+.arrow {
+  width: 0.58rem;
+  height: 0.58rem;
+  border-right: 2px solid currentcolor;
+  border-bottom: 2px solid currentcolor;
+  transform: translateY(-0.12rem) rotate(45deg);
+  transition: transform 220ms ease;
+}
+
+.outline-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  left: 50%;
+  display: grid;
+  width: min(18rem, 86vw);
+  margin: 0;
+  padding: 0.55rem;
+  border: 1.5px solid var(--line);
+  border-radius: 1rem;
+  list-style: none;
+  background: var(--panel);
+  box-shadow:
+    0.45rem 0.45rem 0 var(--line),
+    0 1.15rem 2rem var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.45rem);
+  transition:
+    opacity 180ms ease,
+    transform 220ms ease;
+}
+
+.outline-menu a {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid transparent;
+  border-radius: 0.7rem;
+  color: var(--ink);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.outline-menu small {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.outline-dropdown:hover .outline-trigger,
+.outline-dropdown:focus-within .outline-trigger {
+  background: #fffaf1;
+  box-shadow: 0.1rem 0.1rem 0 var(--line);
+  transform: translate(0.15rem, 0.15rem);
+}
+
+.outline-dropdown:hover .arrow,
+.outline-dropdown:focus-within .arrow {
+  transform: translateY(0.08rem) rotate(225deg);
+}
+
+.outline-dropdown:hover .outline-menu,
+.outline-dropdown:focus-within .outline-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.outline-menu a:hover,
+.outline-menu a:focus-visible {
+  border-color: var(--soft-line);
+  background: #fff8ec;
+  outline: none;
+  transform: translateX(0.12rem);
+}
+
+.outline-trigger:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+@media (max-width: 35rem) {
+  .demo-wrap {
+    padding: 1rem;
+  }
+
+  .outline-card {
+    padding: 2rem 1.2rem;
+    box-shadow:
+      0.45rem 0.45rem 0 var(--line),
+      0 1.2rem 2.2rem var(--shadow);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Adds a new Minimalist Outline Dropdown submission under `submissions/examples/minimalist-outline-dropdown-msm/`
- Includes a self-contained `demo.html`, scoped `style.css`, and usage-focused `README.md`
- Uses semantic navigation markup, hover and focus-within reveal behavior, visible focus states, responsive sizing, and reduced-motion safeguards

Closes #73675

## Changes made
- Built a crisp outline dropdown trigger and menu panel with restrained motion and editorial styling
- Added three documentation menu options with supporting descriptions
- Documented usage and project fit in the submission README

## Testing
- `npx.cmd prettier --write "submissions/examples/minimalist-outline-dropdown-msm/**/*.{html,css,md}"`
- `npx.cmd prettier --check "submissions/examples/minimalist-outline-dropdown-msm/**/*.{html,css,md}"` - passed
- `npx.cmd stylelint "submissions/examples/minimalist-outline-dropdown-msm/style.css" --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge cases handled
- Keyboard users can reveal and traverse the dropdown through `:focus-within`
- `:focus-visible` styling keeps the trigger and menu links clearly outlined
- `prefers-reduced-motion: reduce` minimizes transition and animation duration
- Mobile widths are supported with reduced card padding and viewport-safe panel sizing

## Screenshots
- Not attached; this is a static HTML/CSS submission and was validated locally with formatter/lint checks.
