### PR TITLE
feat: add quantum energy shield dropdown menu

### DIFF
--- a/submissions/examples/quantum-energy-shield-dropdown-msm/README.md
+++ b/submissions/examples/quantum-energy-shield-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Quantum Energy Shield Dropdown
+
+## What does this do?
+
+The Quantum Energy Shield Dropdown adds a luminous HTML/CSS dropdown menu with glassy shield styling, orbital accents, and smooth reveal behavior.
+
+## How is it used?
+
+Place the dropdown in a navigation area and include the local stylesheet:
+
+```html
+<nav class="quantum-dropdown" aria-label="Shield control navigation">
+  <button class="quantum-trigger" type="button" aria-haspopup="true">
+    Shield controls
+    <span class="trigger-orb" aria-hidden="true"></span>
+  </button>
+
+  <ul class="quantum-menu" aria-label="Shield control options">
+    <li><a href="#calibrate">Calibrate field</a></li>
+    <li><a href="#pulse">Pulse barrier</a></li>
+    <li><a href="#stabilize">Stabilize core</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a high-impact dropdown pattern that stays dependency-free while supporting hover, focus-within, visible keyboard focus, responsive layout, and reduced-motion preferences.

--- a/submissions/examples/quantum-energy-shield-dropdown-msm/demo.html
+++ b/submissions/examples/quantum-energy-shield-dropdown-msm/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quantum Energy Shield Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-grid">
+      <section class="shield-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="dropdown-title">Quantum Energy Shield</h1>
+        <p class="intro">
+          A luminous dropdown pattern with orbital rings, glassy shield layers,
+          and smooth focus-friendly reveal behavior.
+        </p>
+
+        <nav class="quantum-dropdown" aria-label="Shield control navigation">
+          <button class="quantum-trigger" type="button" aria-haspopup="true">
+            Shield controls
+            <span class="trigger-orb" aria-hidden="true"></span>
+          </button>
+
+          <ul class="quantum-menu" aria-label="Shield control options">
+            <li>
+              <a href="#calibrate">
+                <span class="option-code">Q1</span>
+                Calibrate field
+              </a>
+            </li>
+            <li>
+              <a href="#pulse">
+                <span class="option-code">Q2</span>
+                Pulse barrier
+              </a>
+            </li>
+            <li>
+              <a href="#stabilize">
+                <span class="option-code">Q3</span>
+                Stabilize core
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/quantum-energy-shield-dropdown-msm/style.css
+++ b/submissions/examples/quantum-energy-shield-dropdown-msm/style.css
@@ -1,0 +1,263 @@
+:root {
+  --void: #07111f;
+  --space: #0e1d34;
+  --cyan: #61f4ff;
+  --blue: #4f8dff;
+  --violet: #9b6dff;
+  --text: #eff8ff;
+  --muted: #a9bad3;
+  --glass: rgba(13, 31, 55, 0.72);
+  --line: rgba(97, 244, 255, 0.32);
+  --shadow: rgba(32, 139, 255, 0.24);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family: "Lucida Sans", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(
+      circle at 24% 22%,
+      rgba(97, 244, 255, 0.22),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 80% 70%,
+      rgba(155, 109, 255, 0.28),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #030816 0%, var(--void) 52%, #13213a 100%);
+}
+
+.demo-grid {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.shield-card {
+  position: relative;
+  width: min(100%, 42rem);
+  overflow: visible;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(97, 244, 255, 0.22);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.12),
+      rgba(255, 255, 255, 0.035)
+    ),
+    var(--glass);
+  box-shadow:
+    0 2rem 5rem rgba(0, 0, 0, 0.32),
+    0 0 4rem rgba(79, 141, 255, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  text-align: center;
+  backdrop-filter: blur(18px);
+}
+
+.shield-card::before,
+.shield-card::after {
+  position: absolute;
+  inset: 1.1rem;
+  z-index: -1;
+  border: 1px solid rgba(97, 244, 255, 0.18);
+  border-radius: 50%;
+  content: "";
+  transform: rotate(-12deg) scaleX(1.14);
+}
+
+.shield-card::after {
+  border-color: rgba(155, 109, 255, 0.22);
+  transform: rotate(18deg) scaleX(0.94);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--cyan);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 8vw, 4.8rem);
+  line-height: 0.95;
+  text-shadow: 0 0 1.6rem rgba(97, 244, 255, 0.25);
+}
+
+.intro {
+  max-width: 33rem;
+  margin: 1.2rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.03rem;
+  line-height: 1.65;
+}
+
+.quantum-dropdown {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.quantum-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.2rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  background:
+    linear-gradient(135deg, rgba(97, 244, 255, 0.2), rgba(155, 109, 255, 0.12)),
+    rgba(10, 25, 45, 0.86);
+  box-shadow:
+    0 1rem 2rem var(--shadow),
+    inset 0 0 1.2rem rgba(97, 244, 255, 0.12);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  transition:
+    transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 300ms ease,
+    border-color 300ms ease;
+}
+
+.trigger-orb {
+  width: 0.82rem;
+  height: 0.82rem;
+  border: 2px solid var(--cyan);
+  border-radius: 999px;
+  box-shadow:
+    0 0 0.75rem rgba(97, 244, 255, 0.78),
+    inset 0 0 0.45rem rgba(97, 244, 255, 0.55);
+  transition: transform 300ms ease;
+}
+
+.quantum-menu {
+  position: absolute;
+  top: calc(100% + 0.8rem);
+  left: 50%;
+  display: grid;
+  width: min(18.5rem, 86vw);
+  margin: 0;
+  padding: 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 1.25rem;
+  list-style: none;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(97, 244, 255, 0.13),
+      rgba(155, 109, 255, 0.09)
+    ),
+    rgba(7, 17, 31, 0.94);
+  box-shadow:
+    0 1.4rem 3rem rgba(0, 0, 0, 0.36),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.6rem) scale(0.97);
+  transform-origin: top center;
+  transition:
+    opacity 240ms ease,
+    transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  backdrop-filter: blur(18px);
+}
+
+.quantum-menu a {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.88rem 0.95rem;
+  border: 1px solid transparent;
+  border-radius: 0.9rem;
+  color: var(--text);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 220ms ease,
+    border-color 220ms ease,
+    transform 220ms ease;
+}
+
+.option-code {
+  display: inline-grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--cyan);
+  background: rgba(97, 244, 255, 0.1);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.quantum-dropdown:hover .quantum-trigger,
+.quantum-dropdown:focus-within .quantum-trigger {
+  border-color: rgba(97, 244, 255, 0.7);
+  box-shadow:
+    0 1.2rem 2.4rem rgba(32, 139, 255, 0.32),
+    0 0 1.3rem rgba(97, 244, 255, 0.24);
+  transform: translateY(-0.12rem);
+}
+
+.quantum-dropdown:hover .trigger-orb,
+.quantum-dropdown:focus-within .trigger-orb {
+  transform: scale(1.18);
+}
+
+.quantum-dropdown:hover .quantum-menu,
+.quantum-dropdown:focus-within .quantum-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.quantum-menu a:hover,
+.quantum-menu a:focus-visible {
+  border-color: rgba(97, 244, 255, 0.38);
+  background: linear-gradient(
+    135deg,
+    rgba(97, 244, 255, 0.15),
+    rgba(155, 109, 255, 0.12)
+  );
+  outline: none;
+  transform: translateX(0.15rem);
+}
+
+.quantum-trigger:focus-visible {
+  outline: 3px solid var(--cyan);
+  outline-offset: 4px;
+}
+
+@media (max-width: 35rem) {
+  .demo-grid {
+    padding: 1rem;
+  }
+
+  .shield-card {
+    padding: 2rem 1.15rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Adds a new Quantum Energy Shield Dropdown submission under `submissions/examples/quantum-energy-shield-dropdown-msm/`
- Includes a self-contained `demo.html`, scoped `style.css`, and usage-focused `README.md`
- Uses semantic navigation markup, hover and focus-within reveal behavior, visible focus states, responsive sizing, and reduced-motion safeguards

Closes #73674

## Changes made
- Built a luminous shield-themed dropdown trigger and menu panel with orbital glass styling
- Added three shield-control menu options with compact quantum code markers
- Documented usage and project fit in the submission README

## Testing
- `npx.cmd prettier --write "submissions/examples/quantum-energy-shield-dropdown-msm/**/*.{html,css,md}"`
- `npx.cmd prettier --check "submissions/examples/quantum-energy-shield-dropdown-msm/**/*.{html,css,md}"` - passed
- `npx.cmd stylelint "submissions/examples/quantum-energy-shield-dropdown-msm/style.css" --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge cases handled
- Keyboard users can reveal and traverse the dropdown through `:focus-within`
- `:focus-visible` styling keeps the trigger and menu links clearly outlined
- `prefers-reduced-motion: reduce` minimizes transition and animation duration
- Mobile widths are supported with reduced card padding and viewport-safe panel sizing

## Screenshots
- Not attached; this is a static HTML/CSS submission and was validated locally with formatter/lint checks.
