### PR TITLE
feat: add retro arcade pixel dropdown menu

### DIFF
--- a/submissions/examples/retro-arcade-pixel-dropdown-msm/README.md
+++ b/submissions/examples/retro-arcade-pixel-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Retro Arcade Pixel Dropdown
+
+## What does this do?
+
+The Retro Arcade Pixel Dropdown adds a blocky HTML/CSS dropdown menu with pixel borders, neon colors, and scanline-inspired atmosphere.
+
+## How is it used?
+
+Place the dropdown in a navigation area and include the local stylesheet:
+
+```html
+<nav class="pixel-dropdown" aria-label="Arcade navigation">
+  <button class="pixel-trigger" type="button" aria-haspopup="true">
+    Select stage
+    <span class="pixel-caret" aria-hidden="true"></span>
+  </button>
+
+  <ul class="pixel-menu" aria-label="Arcade stages">
+    <li><a href="#level-one">Neon rooftops</a></li>
+    <li><a href="#level-two">Laser tunnel</a></li>
+    <li><a href="#level-three">Pixel fortress</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a playful dropdown style that remains dependency-free while supporting hover, focus-within, visible keyboard focus, responsive layout, and reduced-motion preferences.

--- a/submissions/examples/retro-arcade-pixel-dropdown-msm/demo.html
+++ b/submissions/examples/retro-arcade-pixel-dropdown-msm/demo.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Retro Arcade Pixel Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="arcade-stage">
+      <section class="arcade-cabinet" aria-labelledby="dropdown-title">
+        <p class="coin-label">Insert CSS</p>
+        <h1 id="dropdown-title">Retro Arcade Pixel</h1>
+        <p class="intro">
+          A blocky dropdown menu with pixel borders, neon scanline atmosphere,
+          and keyboard-friendly focus behavior.
+        </p>
+
+        <nav class="pixel-dropdown" aria-label="Arcade navigation">
+          <button class="pixel-trigger" type="button" aria-haspopup="true">
+            Select stage
+            <span class="pixel-caret" aria-hidden="true"></span>
+          </button>
+
+          <ul class="pixel-menu" aria-label="Arcade stages">
+            <li>
+              <a href="#level-one">
+                <span class="level-code">1UP</span>
+                Neon rooftops
+              </a>
+            </li>
+            <li>
+              <a href="#level-two">
+                <span class="level-code">2UP</span>
+                Laser tunnel
+              </a>
+            </li>
+            <li>
+              <a href="#level-three">
+                <span class="level-code">BOS</span>
+                Pixel fortress
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/retro-arcade-pixel-dropdown-msm/style.css
+++ b/submissions/examples/retro-arcade-pixel-dropdown-msm/style.css
@@ -1,0 +1,247 @@
+:root {
+  --cabinet: #160b2f;
+  --screen: #071026;
+  --pink: #ff4fd8;
+  --cyan: #45f6ff;
+  --yellow: #ffe66d;
+  --green: #80ff72;
+  --text: #fff8d8;
+  --muted: #a9b6ff;
+  --shadow: rgba(255, 79, 216, 0.26);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  font-family: "Courier New", Courier, monospace;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    radial-gradient(
+      circle at 22% 22%,
+      rgba(255, 79, 216, 0.3),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 82% 76%,
+      rgba(69, 246, 255, 0.28),
+      transparent 25rem
+    ),
+    linear-gradient(135deg, #060512 0%, #100723 54%, #020511 100%);
+  background-size:
+    100% 0.45rem,
+    auto,
+    auto,
+    auto;
+}
+
+.arcade-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.arcade-cabinet {
+  position: relative;
+  width: min(100%, 42rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 0.28rem solid var(--cyan);
+  background:
+    linear-gradient(135deg, rgba(255, 79, 216, 0.16), rgba(69, 246, 255, 0.08)),
+    var(--screen);
+  box-shadow:
+    0.7rem 0.7rem 0 var(--pink),
+    -0.7rem -0.7rem 0 rgba(69, 246, 255, 0.28),
+    0 2rem 5rem rgba(0, 0, 0, 0.42);
+  text-align: center;
+}
+
+.arcade-cabinet::before {
+  position: absolute;
+  inset: 0.9rem;
+  border: 1px dashed rgba(255, 230, 109, 0.36);
+  content: "";
+  pointer-events: none;
+}
+
+.coin-label {
+  display: inline-block;
+  margin: 0 0 0.9rem;
+  padding: 0.25rem 0.55rem;
+  color: var(--screen);
+  background: var(--yellow);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(2.25rem, 7vw, 4.5rem);
+  line-height: 0.95;
+  text-shadow:
+    0.18rem 0.18rem 0 var(--pink),
+    -0.18rem -0.18rem 0 var(--cyan);
+  text-transform: uppercase;
+}
+
+.intro {
+  max-width: 34rem;
+  margin: 1.2rem auto 2rem;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.pixel-dropdown {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.pixel-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.9rem 1.15rem;
+  border: 0.18rem solid var(--yellow);
+  color: var(--text);
+  background: var(--cabinet);
+  box-shadow:
+    0.35rem 0.35rem 0 var(--cyan),
+    0 0 1.3rem var(--shadow);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  text-transform: uppercase;
+  transition:
+    transform 180ms steps(2, end),
+    box-shadow 180ms steps(2, end),
+    border-color 180ms steps(2, end);
+}
+
+.pixel-caret {
+  width: 0;
+  height: 0;
+  border-top: 0.48rem solid var(--green);
+  border-right: 0.36rem solid transparent;
+  border-left: 0.36rem solid transparent;
+  transition: transform 180ms steps(2, end);
+}
+
+.pixel-menu {
+  position: absolute;
+  top: calc(100% + 0.9rem);
+  left: 50%;
+  display: grid;
+  width: min(19rem, 88vw);
+  margin: 0;
+  padding: 0.55rem;
+  border: 0.18rem solid var(--cyan);
+  list-style: none;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    rgba(7, 16, 38, 0.97);
+  background-size: 100% 0.4rem;
+  box-shadow:
+    0.45rem 0.45rem 0 var(--pink),
+    0 1.2rem 2.4rem rgba(0, 0, 0, 0.38);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.5rem);
+  transition:
+    opacity 160ms steps(2, end),
+    transform 180ms steps(2, end);
+}
+
+.pixel-menu a {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 0.95rem;
+  border: 0.12rem solid transparent;
+  color: var(--text);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 160ms steps(2, end),
+    border-color 160ms steps(2, end),
+    transform 160ms steps(2, end);
+}
+
+.level-code {
+  display: inline-grid;
+  width: 2.25rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--screen);
+  background: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.pixel-dropdown:hover .pixel-trigger,
+.pixel-dropdown:focus-within .pixel-trigger {
+  border-color: var(--green);
+  box-shadow:
+    0.15rem 0.15rem 0 var(--cyan),
+    0 0 1.5rem rgba(69, 246, 255, 0.34);
+  transform: translate(0.2rem, 0.2rem);
+}
+
+.pixel-dropdown:hover .pixel-caret,
+.pixel-dropdown:focus-within .pixel-caret {
+  transform: rotate(180deg);
+}
+
+.pixel-dropdown:hover .pixel-menu,
+.pixel-dropdown:focus-within .pixel-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.pixel-menu a:hover,
+.pixel-menu a:focus-visible {
+  border-color: var(--yellow);
+  background: rgba(255, 79, 216, 0.18);
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.pixel-trigger:focus-visible {
+  outline: 0.22rem solid var(--green);
+  outline-offset: 0.3rem;
+}
+
+@media (max-width: 35rem) {
+  .arcade-stage {
+    padding: 1rem;
+  }
+
+  .arcade-cabinet {
+    padding: 2rem 1rem;
+    box-shadow:
+      0.4rem 0.4rem 0 var(--pink),
+      -0.4rem -0.4rem 0 rgba(69, 246, 255, 0.28);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Adds a new Retro Arcade Pixel Dropdown submission under `submissions/examples/retro-arcade-pixel-dropdown-msm/`
- Includes a self-contained `demo.html`, scoped `style.css`, and usage-focused `README.md`
- Uses semantic navigation markup, hover and focus-within reveal behavior, visible focus states, responsive sizing, and reduced-motion safeguards

Closes #73673

## Changes made
- Built a retro arcade pixel dropdown trigger and menu panel with neon scanline styling
- Added three arcade stage options with compact pixel-code markers
- Documented usage and project fit in the submission README

## Testing
- `npx.cmd prettier --write "submissions/examples/retro-arcade-pixel-dropdown-msm/**/*.{html,css,md}"`
- `npx.cmd prettier --check "submissions/examples/retro-arcade-pixel-dropdown-msm/**/*.{html,css,md}"` - passed
- `npx.cmd stylelint "submissions/examples/retro-arcade-pixel-dropdown-msm/style.css" --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge cases handled
- Keyboard users can reveal and traverse the dropdown through `:focus-within`
- `:focus-visible` styling keeps the trigger and menu links clearly outlined
- `prefers-reduced-motion: reduce` minimizes transition and animation duration
- Mobile widths are supported with reduced card padding and viewport-safe panel sizing

## Screenshots
- Not attached; this is a static HTML/CSS submission and was validated locally with formatter/lint checks.
