### PR TITLE
feat: add morphing shape dropdown menu

### DIFF
--- a/submissions/examples/morphing-shape-dropdown-msm/README.md
+++ b/submissions/examples/morphing-shape-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Morphing Shape Dropdown
+
+## What does this do?
+
+The Morphing Shape Dropdown adds a fluid HTML/CSS dropdown menu with soft blob-like corners and shape-shifting hover and focus transitions.
+
+## How is it used?
+
+Place the dropdown in a navigation area and include the local stylesheet:
+
+```html
+<nav class="morph-dropdown" aria-label="Creative navigation">
+  <button class="morph-trigger" type="button" aria-haspopup="true">
+    Creative tools
+    <span class="morph-symbol" aria-hidden="true"></span>
+  </button>
+
+  <ul class="morph-menu" aria-label="Creative tools">
+    <li><a href="#sketch">Sketch flows</a></li>
+    <li><a href="#blend">Blend layers</a></li>
+    <li><a href="#export">Export motion</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a playful dropdown pattern that feels organic and animated while staying dependency-free, responsive, keyboard-friendly, and respectful of reduced-motion preferences.

--- a/submissions/examples/morphing-shape-dropdown-msm/demo.html
+++ b/submissions/examples/morphing-shape-dropdown-msm/demo.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Morphing Shape Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="morph-stage">
+      <section class="morph-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="dropdown-title">Morphing Shape</h1>
+        <p class="intro">
+          A fluid dropdown menu whose trigger and panel subtly reshape as the
+          user hovers or tabs through the navigation.
+        </p>
+
+        <nav class="morph-dropdown" aria-label="Creative navigation">
+          <button class="morph-trigger" type="button" aria-haspopup="true">
+            Creative tools
+            <span class="morph-symbol" aria-hidden="true"></span>
+          </button>
+
+          <ul class="morph-menu" aria-label="Creative tools">
+            <li>
+              <a href="#sketch">
+                <span class="shape-dot shape-dot-one" aria-hidden="true"></span>
+                Sketch flows
+              </a>
+            </li>
+            <li>
+              <a href="#blend">
+                <span class="shape-dot shape-dot-two" aria-hidden="true"></span>
+                Blend layers
+              </a>
+            </li>
+            <li>
+              <a href="#export">
+                <span
+                  class="shape-dot shape-dot-three"
+                  aria-hidden="true"
+                ></span>
+                Export motion
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/morphing-shape-dropdown-msm/style.css
+++ b/submissions/examples/morphing-shape-dropdown-msm/style.css
@@ -1,0 +1,255 @@
+:root {
+  --ink: #1d2433;
+  --muted: #657084;
+  --cream: #fff7eb;
+  --coral: #ff7b6e;
+  --amber: #ffc857;
+  --teal: #3bd4c6;
+  --violet: #8d7dff;
+  --line: rgba(29, 36, 51, 0.12);
+  --shadow: rgba(29, 36, 51, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Segoe UI", Verdana, sans-serif;
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(255, 123, 110, 0.36),
+      transparent 26rem
+    ),
+    radial-gradient(
+      circle at 82% 76%,
+      rgba(59, 212, 198, 0.28),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #fff4df 0%, #ecf7f5 54%, #f4efff 100%);
+}
+
+.morph-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.morph-card {
+  position: relative;
+  width: min(100%, 42rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.75);
+  border-radius: 42% 58% 55% 45% / 48% 43% 57% 52%;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.86),
+      rgba(255, 247, 235, 0.68)
+    ),
+    var(--cream);
+  box-shadow:
+    0 2rem 4.4rem var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  text-align: center;
+}
+
+.morph-card::before {
+  position: absolute;
+  inset: 1rem;
+  z-index: -1;
+  border-radius: 55% 45% 42% 58% / 45% 55% 45% 55%;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 200, 87, 0.44),
+    rgba(141, 125, 255, 0.28)
+  );
+  content: "";
+  filter: blur(1rem);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #af4b44;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 33rem;
+  margin: 1.15rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.morph-dropdown {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.morph-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.92rem 1.18rem;
+  border: 1px solid rgba(29, 36, 51, 0.1);
+  border-radius: 1.8rem 2.8rem 2rem 2.5rem / 2.5rem 1.8rem 2.6rem 2rem;
+  color: var(--ink);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.72),
+      rgba(255, 255, 255, 0.34)
+    ),
+    linear-gradient(135deg, rgba(255, 200, 87, 0.5), rgba(59, 212, 198, 0.34));
+  box-shadow: 0 1rem 2rem rgba(29, 36, 51, 0.14);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  transition:
+    border-radius 340ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.morph-symbol {
+  width: 0.82rem;
+  height: 0.82rem;
+  border-radius: 40% 60% 55% 45% / 55% 45% 55% 45%;
+  background: var(--coral);
+  box-shadow:
+    0.45rem 0.2rem 0 var(--teal),
+    -0.25rem 0.42rem 0 var(--violet);
+  transition: transform 300ms ease;
+}
+
+.morph-menu {
+  position: absolute;
+  top: calc(100% + 0.8rem);
+  left: 50%;
+  display: grid;
+  width: min(18.5rem, 86vw);
+  margin: 0;
+  padding: 0.62rem;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 2rem 1.35rem 1.8rem 1.45rem / 1.35rem 2rem 1.35rem 1.8rem;
+  list-style: none;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 1.4rem 2.8rem var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.58rem) scale(0.97);
+  transform-origin: top center;
+  transition:
+    opacity 230ms ease,
+    border-radius 340ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  backdrop-filter: blur(16px);
+}
+
+.morph-menu a {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.86rem 0.95rem;
+  border-radius: 1rem 1.45rem 1rem 1.35rem / 1.4rem 1rem 1.35rem 1rem;
+  color: var(--ink);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 220ms ease,
+    border-radius 260ms ease,
+    transform 220ms ease;
+}
+
+.shape-dot {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  border-radius: 45% 55% 50% 50% / 55% 45% 55% 45%;
+}
+
+.shape-dot-one {
+  background: var(--coral);
+}
+
+.shape-dot-two {
+  background: var(--teal);
+}
+
+.shape-dot-three {
+  background: var(--violet);
+}
+
+.morph-dropdown:hover .morph-trigger,
+.morph-dropdown:focus-within .morph-trigger {
+  border-radius: 2.7rem 1.8rem 2.6rem 1.9rem / 1.9rem 2.8rem 1.8rem 2.5rem;
+  box-shadow: 0 1.25rem 2.35rem rgba(29, 36, 51, 0.18);
+  transform: translateY(-0.14rem);
+}
+
+.morph-dropdown:hover .morph-symbol,
+.morph-dropdown:focus-within .morph-symbol {
+  transform: rotate(135deg) scale(1.12);
+}
+
+.morph-dropdown:hover .morph-menu,
+.morph-dropdown:focus-within .morph-menu {
+  border-radius: 1.35rem 2rem 1.45rem 1.8rem / 2rem 1.35rem 1.8rem 1.35rem;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.morph-menu a:hover,
+.morph-menu a:focus-visible {
+  border-radius: 1.45rem 1rem 1.35rem 1rem / 1rem 1.45rem 1rem 1.35rem;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 200, 87, 0.22),
+    rgba(59, 212, 198, 0.18)
+  );
+  outline: none;
+  transform: translateX(0.16rem);
+}
+
+.morph-trigger:focus-visible {
+  outline: 3px solid var(--coral);
+  outline-offset: 4px;
+}
+
+@media (max-width: 35rem) {
+  .morph-stage {
+    padding: 1rem;
+  }
+
+  .morph-card {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Adds a new Morphing Shape Dropdown submission under `submissions/examples/morphing-shape-dropdown-msm/`
- Includes a self-contained `demo.html`, scoped `style.css`, and usage-focused `README.md`
- Uses semantic navigation markup, hover and focus-within reveal behavior, visible focus states, responsive sizing, and reduced-motion safeguards

Closes #73668

## Changes made
- Built a fluid morphing dropdown trigger and panel with blob-like shape transitions
- Added three creative-tool menu options with colored shape markers
- Documented usage and project fit in the submission README

## Testing
- `npx.cmd prettier --write "submissions/examples/morphing-shape-dropdown-msm/**/*.{html,css,md}"`
- `npx.cmd prettier --check "submissions/examples/morphing-shape-dropdown-msm/**/*.{html,css,md}"` - passed
- `npx.cmd stylelint "submissions/examples/morphing-shape-dropdown-msm/style.css" --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge cases handled
- Keyboard users can reveal and traverse the dropdown through `:focus-within`
- `:focus-visible` styling keeps the trigger and menu links clearly outlined
- `prefers-reduced-motion: reduce` minimizes transition and animation duration
- Mobile widths are supported with reduced card padding and viewport-safe panel sizing

## Screenshots
- Not attached; this is a static HTML/CSS submission and was validated locally with formatter/lint checks.
