### PR TITLE
feat: add ease-card-stack-swipe-away-sap

### DIFF
--- a/submissions/examples/ease-card-stack-swipe-away-sap/README.md
+++ b/submissions/examples/ease-card-stack-swipe-away-sap/README.md
@@ -1,0 +1,34 @@
+# Card Stack Swipe Away
+
+A stack of task cards where clicking "Mark done" flies the top card off to
+the side, revealing the next card underneath — a button-driven (not
+drag-required) card-dismiss pattern.
+
+**Level:** Intermediate
+
+## Usage
+
+Cards stack via `position: absolute` with depth-based scale/offset per
+`:nth-child`. Clicking `#dismissBtn` adds `.is-leaving` to the current top
+card (`:last-child`), which animates it off-screen, then removes it from
+the DOM on `transitionend`.
+
+## Accessibility
+
+- Dismissal is triggered by a real, clearly labeled button ("Mark done ✓"),
+  not a swipe gesture — the entire interaction is keyboard- and
+  screen-reader-operable without any drag requirement.
+- An `aria-live="polite"` region (visually hidden via `.sr-only`)
+  announces which task was completed and how many remain after each
+  dismissal, and announces "No tasks left" if pressed on an empty stack.
+- `prefers-reduced-motion` removes the fly-off `translateX`/`rotate`
+  transform, keeping only a simple opacity fade-out for the dismissed card.
+
+## Notes
+
+- The card is only removed from the DOM after `transitionend` fires (using
+  `{ once: true }`), so the exit animation always completes visually before
+  the next card in the stack becomes the new top.
+- Unlike the `ease-drag-swipe-stack-sap` component, this one is intentionally
+  button-only (no pointer/drag handling), making it a simpler, fully
+  keyboard-native alternative for the same "dismiss top item" pattern.

--- a/submissions/examples/ease-card-stack-swipe-away-sap/demo.html
+++ b/submissions/examples/ease-card-stack-swipe-away-sap/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Card Stack Swipe Away</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Card Stack Swipe Away</h1>
+
+    <div class="task-stack" id="taskStack">
+      <div class="task-card">Review design feedback</div>
+      <div class="task-card">Update dependencies</div>
+      <div class="task-card">Write release notes</div>
+    </div>
+
+    <button class="dismiss-btn" id="dismissBtn">Mark done ✓</button>
+    <p class="sr-only" id="stackAnnounce" aria-live="polite"></p>
+  </main>
+
+  <script>
+    const stack = document.getElementById('taskStack');
+    const announce = document.getElementById('stackAnnounce');
+
+    document.getElementById('dismissBtn').addEventListener('click', () => {
+      const top = stack.querySelector('.task-card:last-child');
+      if (!top) { announce.textContent = 'No tasks left.'; return; }
+      const label = top.textContent;
+      top.classList.add('is-leaving');
+      top.addEventListener('transitionend', () => {
+        top.remove();
+        announce.textContent = `"${label}" marked done. ${stack.children.length} remaining.`;
+      }, { once: true });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-card-stack-swipe-away-sap/style.css
+++ b/submissions/examples/ease-card-stack-swipe-away-sap/style.css
@@ -1,0 +1,83 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.task-stack {
+  position: relative;
+  width: 260px;
+  height: 140px;
+}
+
+.task-card {
+  position: absolute;
+  inset: 0;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.08);
+  transition: transform 0.4s cubic-bezier(0.32, 0, 0.67, 0), opacity 0.4s ease;
+}
+
+.task-card:nth-child(1) { transform: scale(0.94) translateY(12px); z-index: 1; }
+.task-card:nth-child(2) { transform: scale(0.97) translateY(6px); z-index: 2; }
+.task-card:nth-child(3) { transform: scale(1) translateY(0); z-index: 3; }
+
+.task-card.is-leaving {
+  transform: translateX(120%) rotate(12deg);
+  opacity: 0;
+}
+
+.dismiss-btn {
+  padding: 0.65rem 1.3rem;
+  border-radius: 10px;
+  border: none;
+  background: #22c55e;
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dismiss-btn:hover { background: #16a34a; }
+
+.dismiss-btn:focus-visible {
+  outline: 2px solid #15803d;
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task-card { transition: opacity 0.25s ease; }
+  .task-card.is-leaving { transform: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-card-stack-swipe-away-sap`, a button-driven card stack where the top card flies away on dismiss.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-card-stack-swipe-away-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Dismissal is entirely button-driven (no drag requirement), making the
  full interaction keyboard- and screen-reader-operable by default.
- `aria-live="polite"` announces each completed task and remaining count,
  including the empty-stack case.

## Feature Description

Adds a reusable button-dismissed card-stack component with fly-away animation.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.