### PR TITLE
feat: add liquid wave fill dropdown menu

### DIFF
--- a/submissions/examples/liquid-wave-fill-dropdown-msm/README.md
+++ b/submissions/examples/liquid-wave-fill-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Liquid Wave Fill Dropdown
+
+## What does this do?
+
+The Liquid Wave Fill Dropdown adds a pure HTML/CSS navigation menu where animated wave layers rise through the trigger and menu items on hover or focus.
+
+## How is it used?
+
+Place the dropdown in a navigation area and include the local stylesheet:
+
+```html
+<nav class="wave-dropdown" aria-label="Liquid wave navigation">
+  <button class="wave-trigger" type="button" aria-haspopup="true">
+    Explore tides
+    <span class="wave-caret" aria-hidden="true"></span>
+  </button>
+
+  <ul class="wave-menu" aria-label="Liquid wave navigation">
+    <li><a href="#current">Ocean current</a></li>
+    <li><a href="#lagoon">Glass lagoon</a></li>
+    <li><a href="#reef">Coral reef</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users an expressive dropdown pattern that feels fluid and premium while remaining dependency-free, keyboard-friendly, responsive, dark-mode compatible, and respectful of reduced-motion preferences.

--- a/submissions/examples/liquid-wave-fill-dropdown-msm/demo.html
+++ b/submissions/examples/liquid-wave-fill-dropdown-msm/demo.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liquid Wave Fill Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="wave-stage">
+      <section class="wave-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="dropdown-title">Liquid Wave Fill</h1>
+        <p class="intro">
+          A pure CSS menu where layered liquid waves rise through the trigger
+          and softly wash across each dropdown item.
+        </p>
+
+        <nav class="wave-dropdown" aria-label="Liquid wave navigation">
+          <button class="wave-trigger" type="button" aria-haspopup="true">
+            Explore tides
+            <span class="wave-caret" aria-hidden="true"></span>
+          </button>
+
+          <ul class="wave-menu" aria-label="Liquid wave navigation">
+            <li>
+              <a href="#current">
+                <span class="wave-icon wave-icon-current" aria-hidden="true">
+                </span>
+                Ocean current
+              </a>
+            </li>
+            <li>
+              <a href="#lagoon">
+                <span class="wave-icon wave-icon-lagoon" aria-hidden="true">
+                </span>
+                Glass lagoon
+              </a>
+            </li>
+            <li>
+              <a href="#reef">
+                <span class="wave-icon wave-icon-reef" aria-hidden="true">
+                </span>
+                Coral reef
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/liquid-wave-fill-dropdown-msm/style.css
+++ b/submissions/examples/liquid-wave-fill-dropdown-msm/style.css
@@ -1,0 +1,340 @@
+:root {
+  --ink: #10212b;
+  --muted: #61737d;
+  --surface: rgba(255, 255, 255, 0.84);
+  --foam: #f2fff9;
+  --aqua: #19c7d4;
+  --blue: #2777ff;
+  --sea: #0f5f73;
+  --coral: #ff8a65;
+  --shadow: rgba(15, 95, 115, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", "Gill Sans", sans-serif;
+  background:
+    radial-gradient(
+      circle at 18% 20%,
+      rgba(25, 199, 212, 0.34),
+      transparent 25rem
+    ),
+    radial-gradient(
+      circle at 78% 78%,
+      rgba(255, 138, 101, 0.28),
+      transparent 28rem
+    ),
+    linear-gradient(145deg, #e9fbff 0%, #f7fff9 47%, #fff1e8 100%);
+}
+
+.wave-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.wave-card {
+  position: relative;
+  width: min(100%, 42rem);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.92),
+      rgba(242, 255, 249, 0.72)
+    ),
+    var(--surface);
+  box-shadow:
+    0 2rem 4rem var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  text-align: center;
+}
+
+.wave-card::before,
+.wave-card::after {
+  position: absolute;
+  right: -18%;
+  bottom: -28%;
+  width: 28rem;
+  height: 28rem;
+  border-radius: 43% 57% 52% 48% / 47% 42% 58% 53%;
+  background: rgba(25, 199, 212, 0.18);
+  content: "";
+  animation: drift 12s linear infinite;
+}
+
+.wave-card::after {
+  right: auto;
+  bottom: auto;
+  top: -24%;
+  left: -16%;
+  background: rgba(39, 119, 255, 0.12);
+  animation-duration: 16s;
+  animation-direction: reverse;
+}
+
+.eyebrow {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 0.75rem;
+  color: var(--sea);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: clamp(2.45rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  position: relative;
+  z-index: 1;
+  max-width: 33rem;
+  margin: 1.15rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.wave-dropdown {
+  position: relative;
+  z-index: 3;
+  display: inline-block;
+}
+
+.wave-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.78rem;
+  min-width: 13rem;
+  overflow: hidden;
+  padding: 0.98rem 1.28rem;
+  border: 1px solid rgba(16, 33, 43, 0.1);
+  border-radius: 999px;
+  color: #ffffff;
+  background: var(--sea);
+  box-shadow: 0 1.15rem 2.3rem rgba(15, 95, 115, 0.24);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  isolation: isolate;
+  transition:
+    box-shadow 260ms ease,
+    transform 260ms ease;
+}
+
+.wave-trigger::before,
+.wave-trigger::after {
+  position: absolute;
+  inset: 48% -18% -70%;
+  z-index: -1;
+  border-radius: 43% 57% 44% 56% / 48% 45% 55% 52%;
+  background: linear-gradient(90deg, var(--aqua), var(--blue));
+  content: "";
+  transform: translateY(55%) rotate(0deg);
+  transition: transform 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.wave-trigger::after {
+  inset: 56% -20% -78%;
+  background: rgba(255, 255, 255, 0.24);
+  transition-delay: 70ms;
+}
+
+.wave-caret {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-0.12rem) rotate(45deg);
+  transition: transform 260ms ease;
+}
+
+.wave-menu {
+  position: absolute;
+  top: calc(100% + 0.85rem);
+  left: 50%;
+  display: grid;
+  width: min(19rem, 86vw);
+  margin: 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 1.55rem;
+  list-style: none;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 1.35rem 2.8rem var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.7rem) scale(0.97);
+  transform-origin: top center;
+  transition:
+    opacity 220ms ease,
+    transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  backdrop-filter: blur(16px);
+}
+
+.wave-menu a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  overflow: hidden;
+  padding: 0.88rem 1rem;
+  border-radius: 1rem;
+  color: var(--ink);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    color 220ms ease,
+    transform 220ms ease;
+}
+
+.wave-menu a::before {
+  position: absolute;
+  inset: auto -20% -120%;
+  height: 170%;
+  border-radius: 48% 52% 45% 55% / 52% 44% 56% 48%;
+  background: linear-gradient(
+    90deg,
+    rgba(25, 199, 212, 0.22),
+    rgba(39, 119, 255, 0.18)
+  );
+  content: "";
+  transform: translateY(42%) rotate(3deg);
+  transition: transform 360ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.wave-icon {
+  position: relative;
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--aqua);
+  box-shadow: inset 0 -0.18rem 0 rgba(255, 255, 255, 0.45);
+}
+
+.wave-icon-lagoon {
+  background: var(--blue);
+}
+
+.wave-icon-reef {
+  background: var(--coral);
+}
+
+.wave-dropdown:hover .wave-trigger,
+.wave-dropdown:focus-within .wave-trigger {
+  box-shadow: 0 1.35rem 2.6rem rgba(15, 95, 115, 0.3);
+  transform: translateY(-0.16rem);
+}
+
+.wave-dropdown:hover .wave-trigger::before,
+.wave-dropdown:focus-within .wave-trigger::before,
+.wave-dropdown:hover .wave-trigger::after,
+.wave-dropdown:focus-within .wave-trigger::after {
+  transform: translateY(-18%) rotate(5deg);
+}
+
+.wave-dropdown:hover .wave-caret,
+.wave-dropdown:focus-within .wave-caret {
+  transform: translateY(0.08rem) rotate(225deg);
+}
+
+.wave-dropdown:hover .wave-menu,
+.wave-dropdown:focus-within .wave-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.wave-menu a:hover,
+.wave-menu a:focus-visible {
+  color: var(--sea);
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.wave-menu a:hover::before,
+.wave-menu a:focus-visible::before {
+  transform: translateY(0) rotate(-2deg);
+}
+
+.wave-trigger:focus-visible {
+  outline: 3px solid var(--coral);
+  outline-offset: 4px;
+}
+
+@keyframes drift {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #eafaff;
+    --muted: #a7c3ca;
+    --surface: rgba(8, 22, 28, 0.82);
+    --foam: #0c252c;
+    --shadow: rgba(0, 9, 12, 0.42);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 18% 20%,
+        rgba(25, 199, 212, 0.24),
+        transparent 25rem
+      ),
+      radial-gradient(
+        circle at 78% 78%,
+        rgba(255, 138, 101, 0.18),
+        transparent 28rem
+      ),
+      linear-gradient(145deg, #07151b 0%, #0b252d 52%, #261b18 100%);
+  }
+
+  .wave-card,
+  .wave-menu {
+    background: var(--surface);
+  }
+}
+
+@media (max-width: 35rem) {
+  .wave-stage {
+    padding: 1rem;
+  }
+
+  .wave-card {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new Liquid Wave Fill dropdown menu example under `submissions/examples/liquid-wave-fill-dropdown-msm/`.
- Implements layered CSS wave-fill effects on the trigger and menu items with hover and keyboard focus states.
- Includes responsive layout, dark-mode styling, and reduced-motion handling.

## Linked Issue
Closes #73667

## Changes Made
- Added `demo.html` with semantic navigation markup and accessible labels.
- Added `style.css` with pure CSS liquid wave animations, focus states, and responsive/dark-mode support.
- Added `README.md` documenting purpose, usage, and EaseMotion fit.

## Testing
- `npx.cmd prettier --check submissions/examples/liquid-wave-fill-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/liquid-wave-fill-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge Cases Handled
- Keyboard access via `:focus-within` and `:focus-visible` states.
- Mobile-friendly width and spacing.
- Dark-mode compatible color overrides.
- Reduced-motion preference respected.

## Screenshots
- UI-only HTML/CSS example; screenshots can be captured from `submissions/examples/liquid-wave-fill-dropdown-msm/demo.html` if requested.

## Checklist
- [x] I read the README and CONTRIBUTING guidelines.
- [x] The issue is assigned to `@mittalsonal`.
- [x] No existing PR was found for this issue/branch.
- [x] Only required submission files are included.
- [x] Formatting, linting, and diff checks passed locally.