### PR TITLE
feat: add ease-scroll-number-odometer-sap

### DIFF
--- a/submissions/examples/ease-scroll-number-odometer-sap/README.md
+++ b/submissions/examples/ease-scroll-number-odometer-sap/README.md
@@ -1,0 +1,36 @@
+# Scroll Number Odometer
+
+A five-digit odometer-style stat that counts up to its target value once
+scrolled into view, using `IntersectionObserver` + `requestAnimationFrame`.
+
+**Level:** Intermediate
+
+## Usage
+
+Set the target via `data-target` on `.stat-odometer`. `animate()` runs once
+the element crosses 60% visibility, updating each `.od-digit` span's text
+per animation frame based on elapsed-time progress.
+
+## Accessibility
+
+- The container has `role="status" aria-live="polite"` with `aria-label`
+  updated to the full current numeric value on every frame, so screen
+  readers get the actual number rather than needing to interpret five
+  separate rapidly-changing digit spans.
+- `font-variant-numeric: tabular-nums` keeps digit widths consistent so the
+  layout doesn't jitter as values change.
+- `prefers-reduced-motion` is checked in JS: the final target value is set
+  immediately with no counting animation, and `aria-label` updates once
+  with the final value rather than being spammed during a skipped animation.
+- The counter only triggers once (`observer.disconnect()`), so scrolling
+  back up and down doesn't restart or double-announce it.
+
+## Notes
+
+- Because `aria-live` regions announce on every DOM text change, updating
+  `aria-label` on every animation frame during a live count could be noisy
+  for screen reader users in a real product; consider updating `aria-label`
+  only at animation start/end (rather than every frame) if this becomes a
+  production component — flagged here as a refinement rather than assumed solved.
+- Digits are pre-split into fixed-width boxes (`padStart(5, '0')`), giving a
+  consistent 5-digit "odometer" look regardless of the actual number's length.

--- a/submissions/examples/ease-scroll-number-odometer-sap/demo.html
+++ b/submissions/examples/ease-scroll-number-odometer-sap/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Number Odometer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Number Odometer</h1><p>Scroll down to trigger the odometer count-up.</p></section>
+
+    <section class="stat-section">
+      <div class="stat-odometer" id="statOdometer" data-target="47200" role="status" aria-live="polite" aria-label="0">
+        <span class="od-digit" data-place="10000">0</span>
+        <span class="od-digit" data-place="1000">0</span>
+        <span class="od-digit" data-place="100">0</span>
+        <span class="od-digit" data-place="10">0</span>
+        <span class="od-digit" data-place="1">0</span>
+      </div>
+      <p class="stat-label">Downloads this year</p>
+    </section>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <script>
+    const el = document.getElementById('statOdometer');
+    const digits = Array.from(el.querySelectorAll('.od-digit'));
+    const target = parseInt(el.dataset.target, 10);
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function setDigits(value) {
+      const str = String(value).padStart(5, '0');
+      digits.forEach((d, i) => d.textContent = str[i]);
+      el.setAttribute('aria-label', String(value));
+    }
+
+    function animate() {
+      if (reduceMotion) { setDigits(target); return; }
+      const duration = 1400;
+      const start = performance.now();
+      function tick(now) {
+        const progress = Math.min((now - start) / duration, 1);
+        setDigits(Math.floor(progress * target));
+        if (progress < 1) requestAnimationFrame(tick);
+      }
+      requestAnimationFrame(tick);
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) { animate(); observer.disconnect(); }
+      });
+    }, { threshold: 0.6 });
+
+    observer.observe(el);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-number-odometer-sap/style.css
+++ b/submissions/examples/ease-scroll-number-odometer-sap/style.css
@@ -1,0 +1,58 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.content { max-width: 700px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #94a3b8; }
+
+.stat-section {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.stat-odometer {
+  display: flex;
+  gap: 4px;
+  background: #1e293b;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+}
+
+.od-digit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 52px;
+  background: #0f172a;
+  border-radius: 6px;
+  font-size: 2rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: #f8fafc;
+}
+
+.stat-label { margin-top: 0.75rem; font-size: 0.85rem; color: #94a3b8; }
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-odometer { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-number-odometer-sap`, a scroll-triggered 5-digit odometer count-up stat.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-number-odometer-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `aria-label` on the live region reflects the full numeric value rather
  than individual digit spans; README flags that updating it every
  animation frame could be noisy in production and suggests updating only
  at start/end instead.
- Reduced motion is checked in JS, rendering the final value instantly
  rather than skipping the counter or leaving it blank.

## Feature Description

Adds a reusable scroll-triggered odometer-style count-up stat component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.