### PR TITLE
feat: add ease-hover-button-ripple-sap

### DIFF
--- a/submissions/examples/ease-hover-button-ripple-sap/README.md
+++ b/submissions/examples/ease-hover-button-ripple-sap/README.md
@@ -1,0 +1,37 @@
+# Hover Button Ripple
+
+Buttons that emit a Material-Design-style expanding ripple from the exact
+click point, cleaning itself up from the DOM once the animation finishes.
+
+**Level:** Intermediate
+
+## Usage
+
+Apply `.ripple-btn` to any button (with an optional `.ripple-outline`
+variant). JS creates a positioned `.ripple` span at the click coordinates on
+every `click` event and removes it after the ripple animation completes.
+
+## Accessibility
+
+- Ripple is a purely decorative click-feedback effect layered behind the
+  button's own text (`z-index: -1` with `isolation: isolate` on the
+  button), so it never obscures or interferes with the label.
+- `pointer-events: none` on the ripple ensures it can't intercept clicks
+  meant for the button.
+- Triggered by the `click` event (not `mousedown`/pointer-only), so it also
+  fires for keyboard-activated (Enter/Space) clicks on the button, giving
+  keyboard users the same visual feedback.
+- `prefers-reduced-motion` disables the ripple animation and hides the
+  layer entirely, so no stray unanimated circle is left visible.
+
+## Notes
+
+- Each ripple removes itself from the DOM on `animationend`, so rapid
+  repeated clicks don't accumulate leftover ripple elements.
+- Ripple size is calculated as double the button's largest dimension,
+  ensuring it fully covers the button regardless of click position before
+  fading out.
+- For keyboard-triggered clicks (no `clientX`/`clientY` from a real pointer
+  event in some browsers), the ripple may originate from `0,0` of the
+  button; centering the ripple in that fallback case would be a reasonable
+  follow-up refinement.

--- a/submissions/examples/ease-hover-button-ripple-sap/demo.html
+++ b/submissions/examples/ease-hover-button-ripple-sap/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Button Ripple</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Button Ripple</h1>
+
+    <button class="ripple-btn">Click me</button>
+    <button class="ripple-btn ripple-outline">Secondary</button>
+  </main>
+
+  <script>
+    document.querySelectorAll('.ripple-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        const rect = btn.getBoundingClientRect();
+        const ripple = document.createElement('span');
+        const size = Math.max(rect.width, rect.height) * 2;
+        ripple.className = 'ripple';
+        ripple.style.width = ripple.style.height = size + 'px';
+        ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+        ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+        btn.appendChild(ripple);
+        ripple.addEventListener('animationend', () => ripple.remove());
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-button-ripple-sap/style.css
+++ b/submissions/examples/ease-hover-button-ripple-sap/style.css
@@ -1,0 +1,72 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.ripple-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 0.8rem 2rem;
+  border-radius: 10px;
+  border: none;
+  background: #6366f1;
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  isolation: isolate;
+}
+
+.ripple-btn:hover { background: #4f46e5; }
+
+.ripple-outline {
+  background: transparent;
+  color: #6366f1;
+  border: 2px solid #6366f1;
+}
+
+.ripple-outline:hover { background: rgba(99, 102, 241, 0.06); }
+
+.ripple-btn:focus-visible {
+  outline: 2px solid #1e293b;
+  outline-offset: 3px;
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  transform: scale(0);
+  animation: ripple-expand 0.6s ease-out;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.ripple-outline .ripple {
+  background: rgba(99, 102, 241, 0.25);
+}
+
+@keyframes ripple-expand {
+  to { transform: scale(1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple { animation: none; display: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-button-ripple-sap`, buttons with a Material-style expanding click ripple.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-button-ripple-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Bound to the `click` event (not pointer-only), so it also fires for
  keyboard-activated (Enter/Space) button presses, not just mouse clicks.
- Each ripple self-removes on `animationend`, preventing buildup from rapid
  repeated clicks; README flags the coordinate fallback for non-pointer
  keyboard clicks as a follow-up refinement.

## Feature Description

Adds a reusable expanding click-ripple effect for buttons.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.