### PR TITLE
feat: add signal-wake component

### DIFF
--- a/submissions/examples/signal-wake/README.md
+++ b/submissions/examples/signal-wake/README.md
@@ -1,0 +1,24 @@
+# Signal Wake
+
+Signal Wake is an experimental interactive telemetry visualization where active signals travel through a field and leave fading wake trails behind them.
+
+Instead of representing activity using conventional charts, the component visualizes the movement history of each signal as a physical wake.
+
+---
+
+## Concept
+
+Every signal is treated like an object travelling through a telemetry field.
+
+As it moves, it leaves behind a fading trace.
+
+The trace represents the recent history of the signal.
+
+```text
+                    SIGNAL
+                       ●
+                      ╱
+                     ╱
+                    ╱
+───────────────╱────╯
+        previous movement

--- a/submissions/examples/signal-wake/demo.html
+++ b/submissions/examples/signal-wake/demo.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="Signal Wake interactive visualization"
+  >
+
+  <title>Signal Wake</title>
+
+  <link
+    rel="stylesheet"
+    href="style.css"
+  >
+
+</head>
+
+
+<body>
+
+  <main class="page">
+
+    <section class="wake-card">
+
+      <header class="header">
+
+        <div>
+
+          <span class="eyebrow">
+            TELEMETRY FIELD / SW-09
+          </span>
+
+          <h1>
+            Signal Wake
+          </h1>
+
+          <p>
+            Track the movement history left behind by active signals.
+          </p>
+
+        </div>
+
+
+        <div class="field-status">
+
+          <span class="status-pulse"></span>
+
+          <div>
+
+            <small>
+              FIELD STATUS
+            </small>
+
+            <strong>
+              MONITORING
+            </strong>
+
+          </div>
+
+        </div>
+
+      </header>
+
+
+      <section
+        class="signal-field"
+        id="signalField"
+        aria-label="Signal tracking field"
+      >
+
+        <div class="field-grid"></div>
+
+        <div class="field-crosshair horizontal"></div>
+        <div class="field-crosshair vertical"></div>
+
+
+        <div class="field-label top-left">
+          FIELD / 09
+        </div>
+
+        <div class="field-label top-right">
+          LIVE
+        </div>
+
+        <div class="field-label bottom-left">
+          X 000 — 100
+        </div>
+
+        <div class="field-label bottom-right">
+          Y 000 — 100
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-01"
+          data-category="NETWORK"
+          data-intensity="82%"
+          data-velocity="84 px/s"
+          data-status="ACTIVE"
+          style="--x: 18%; --y: 25%; --delay: 0s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-02"
+          data-category="DATABASE"
+          data-intensity="64%"
+          data-velocity="52 px/s"
+          data-status="STABLE"
+          style="--x: 67%; --y: 21%; --delay: -3s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-03"
+          data-category="TRAFFIC"
+          data-intensity="91%"
+          data-velocity="102 px/s"
+          data-status="PEAK"
+          style="--x: 82%; --y: 45%; --delay: -6s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-04"
+          data-category="CACHE"
+          data-intensity="43%"
+          data-velocity="38 px/s"
+          data-status="LOW"
+          style="--x: 31%; --y: 62%; --delay: -2s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-05"
+          data-category="CPU"
+          data-intensity="76%"
+          data-velocity="73 px/s"
+          data-status="ACTIVE"
+          style="--x: 56%; --y: 72%; --delay: -8s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-06"
+          data-category="MEMORY"
+          data-intensity="57%"
+          data-velocity="61 px/s"
+          data-status="STABLE"
+          style="--x: 12%; --y: 76%; --delay: -5s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-07"
+          data-category="QUEUE"
+          data-intensity="69%"
+          data-velocity="67 px/s"
+          data-status="ACTIVE"
+          style="--x: 75%; --y: 78%; --delay: -10s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="signal"
+          tabindex="0"
+          data-id="SIGNAL-08"
+          data-category="STORAGE"
+          data-intensity="35%"
+          data-velocity="29 px/s"
+          data-status="LOW"
+          style="--x: 44%; --y: 35%; --delay: -12s;"
+        >
+
+          <span class="wake"></span>
+          <span class="signal-core"></span>
+
+        </div>
+
+
+        <div
+          class="inspection"
+          id="inspection"
+          aria-live="polite"
+        >
+
+          <div class="inspection-line"></div>
+
+          <span class="inspection-label">
+            TRACKING SIGNAL
+          </span>
+
+          <strong id="inspectionId">
+            SIGNAL-01
+          </strong>
+
+          <span id="inspectionCategory">
+            NETWORK
+          </span>
+
+        </div>
+
+      </section>
+
+
+      <div class="controls">
+
+        <span>
+          HOVER TO TRACK
+        </span>
+
+        <span>
+          CLICK TO LOCK
+        </span>
+
+        <span>
+          ESC TO RELEASE
+        </span>
+
+      </div>
+
+
+      <section class="analysis">
+
+        <div class="analysis-main">
+
+          <div class="analysis-heading">
+
+            <span>
+              SELECTED SIGNAL
+            </span>
+
+            <h2 id="detailId">
+              SIGNAL-01
+            </h2>
+
+          </div>
+
+
+          <div class="metrics">
+
+            <div>
+              <small>
+                CATEGORY
+              </small>
+
+              <strong id="detailCategory">
+                NETWORK
+              </strong>
+            </div>
+
+
+            <div>
+              <small>
+                INTENSITY
+              </small>
+
+              <strong id="detailIntensity">
+                82%
+              </strong>
+            </div>
+
+
+            <div>
+              <small>
+                VELOCITY
+              </small>
+
+              <strong id="detailVelocity">
+                84 px/s
+              </strong>
+            </div>
+
+
+            <div>
+              <small>
+                STATUS
+              </small>
+
+              <strong id="detailStatus">
+                ACTIVE
+              </strong>
+            </div>
+
+          </div>
+
+        </div>
+
+
+        <div class="waveform">
+
+          <div class="wave-label">
+            WAKE RECONSTRUCTION
+          </div>
+
+          <svg
+            viewBox="0 0 500 100"
+            preserveAspectRatio="none"
+            aria-label="Signal wake reconstruction"
+          >
+
+            <path
+              id="wavePath"
+              d="M0 55
+                 C35 55 35 55 60 55
+                 C75 55 80 15 100 15
+                 C120 15 125 75 145 75
+                 C170 75 170 38 195 38
+                 C220 38 225 62 250 62
+                 C280 62 280 25 305 25
+                 C335 25 330 55 360 55
+                 C390 55 395 45 425 45
+                 C450 45 455 55 500 55"
+            />
+
+          </svg>
+
+        </div>
+
+      </section>
+
+
+      <section class="registry">
+
+        <div class="registry-header">
+
+          <span>
+            SIGNAL REGISTRY
+          </span>
+
+          <span>
+            08 ACTIVE TRACES
+          </span>
+
+        </div>
+
+
+        <div class="registry-grid" id="registry">
+
+        </div>
+
+      </section>
+
+
+      <footer class="footer">
+
+        <span>
+          SIGNAL WAKE / SW-09
+        </span>
+
+        <span>
+          TELEMETRY FIELD
+        </span>
+
+        <span>
+          TRACKING MODE
+        </span>
+
+      </footer>
+
+    </section>
+
+  </main>
+
+
+  <script src="script.js"></script>
+
+</body>
+
+</html>

--- a/submissions/examples/signal-wake/style.css
+++ b/submissions/examples/signal-wake/style.css
@@ -1,0 +1,1059 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+
+:root {
+
+  --bg: #07090d;
+  --surface: #0d1117;
+  --border: #252b34;
+  --border-soft: #1a2028;
+
+  --text: #edf2f5;
+  --muted: #7f8994;
+  --dim: #4d5660;
+
+  --accent: #8ee8ff;
+  --accent-soft: rgba(142,232,255,0.12);
+
+  --green: #9cffc0;
+}
+
+
+html {
+  color-scheme: dark;
+}
+
+
+body {
+
+  min-height: 100vh;
+
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(142,232,255,0.05),
+      transparent 38%
+    ),
+    var(--bg);
+
+  color: var(--text);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+
+.page {
+
+  min-height: 100vh;
+
+  display: grid;
+
+  place-items: center;
+
+  padding: 40px 20px;
+}
+
+
+.wake-card {
+
+  width: min(1100px, 100%);
+
+  padding: 44px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 28px;
+
+  background:
+    rgba(11,14,19,0.96);
+
+  box-shadow:
+    0 45px 120px rgba(0,0,0,0.5);
+}
+
+
+/* HEADER */
+
+
+.header {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  align-items: flex-start;
+
+  gap: 30px;
+
+  margin-bottom: 32px;
+}
+
+
+.eyebrow {
+
+  display: block;
+
+  margin-bottom: 10px;
+
+  color: var(--accent);
+
+  font-size: 8px;
+
+  font-weight: 800;
+
+  letter-spacing: 0.2em;
+}
+
+
+.header h1 {
+
+  font-size:
+    clamp(40px, 6vw, 64px);
+
+  line-height: .9;
+
+  letter-spacing: -.07em;
+}
+
+
+.header p {
+
+  margin-top: 14px;
+
+  max-width: 500px;
+
+  color: var(--muted);
+
+  font-size: 13px;
+
+  line-height: 1.6;
+}
+
+
+.field-status {
+
+  display: flex;
+
+  align-items: center;
+
+  gap: 10px;
+
+  padding: 11px 14px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 12px;
+}
+
+
+.status-pulse {
+
+  width: 7px;
+
+  height: 7px;
+
+  border-radius: 50%;
+
+  background: var(--green);
+
+  box-shadow:
+    0 0 14px rgba(156,255,192,.6);
+}
+
+
+.field-status small {
+
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+
+.field-status strong {
+
+  display: block;
+
+  margin-top: 3px;
+
+  font-size: 9px;
+
+  letter-spacing: .1em;
+}
+
+
+/* FIELD */
+
+
+.signal-field {
+
+  position: relative;
+
+  width: 100%;
+
+  aspect-ratio: 16 / 9;
+
+  min-height: 520px;
+
+  overflow: hidden;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 20px;
+
+  background:
+    #080b10;
+
+  isolation: isolate;
+}
+
+
+.field-grid {
+
+  position: absolute;
+
+  inset: 0;
+
+  background:
+    linear-gradient(
+      rgba(255,255,255,.022) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255,255,255,.022) 1px,
+      transparent 1px
+    );
+
+  background-size:
+    42px 42px;
+}
+
+
+.field-grid::after {
+
+  content: "";
+
+  position: absolute;
+
+  inset: 0;
+
+  background:
+    radial-gradient(
+      circle at center,
+      transparent 20%,
+      rgba(0,0,0,.35) 100%
+    );
+}
+
+
+.field-crosshair {
+
+  position: absolute;
+
+  pointer-events: none;
+
+  opacity: .35;
+
+  background:
+    rgba(142,232,255,.12);
+}
+
+
+.field-crosshair.horizontal {
+
+  top: 50%;
+
+  left: 0;
+
+  width: 100%;
+
+  height: 1px;
+}
+
+
+.field-crosshair.vertical {
+
+  left: 50%;
+
+  top: 0;
+
+  width: 1px;
+
+  height: 100%;
+}
+
+
+.field-label {
+
+  position: absolute;
+
+  z-index: 4;
+
+  color: var(--dim);
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 6px;
+
+  letter-spacing: .12em;
+}
+
+
+.top-left {
+  top: 13px;
+  left: 16px;
+}
+
+
+.top-right {
+  top: 13px;
+  right: 16px;
+}
+
+
+.bottom-left {
+  bottom: 13px;
+  left: 16px;
+}
+
+
+.bottom-right {
+  bottom: 13px;
+  right: 16px;
+}
+
+
+/* SIGNALS */
+
+
+.signal {
+
+  position: absolute;
+
+  left: var(--x);
+
+  top: var(--y);
+
+  width: 12px;
+
+  height: 12px;
+
+  z-index: 8;
+
+  cursor: pointer;
+
+  outline: none;
+
+  animation:
+    drift 9s ease-in-out infinite;
+
+  animation-delay:
+    var(--delay);
+}
+
+
+.signal-core {
+
+  position: absolute;
+
+  inset: 3px;
+
+  border-radius: 50%;
+
+  background: var(--accent);
+
+  box-shadow:
+    0 0 10px var(--accent),
+    0 0 24px rgba(142,232,255,.55);
+
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+
+.signal::before {
+
+  content: "";
+
+  position: absolute;
+
+  inset: -7px;
+
+  border:
+    1px solid rgba(142,232,255,.12);
+
+  border-radius: 50%;
+
+  opacity: .8;
+}
+
+
+.signal::after {
+
+  content: "";
+
+  position: absolute;
+
+  width: 45px;
+
+  height: 1px;
+
+  top: 50%;
+
+  right: 100%;
+
+  transform-origin: right;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      rgba(142,232,255,.22)
+    );
+}
+
+
+/* WAKE */
+
+
+.wake {
+
+  position: absolute;
+
+  right: 100%;
+
+  top: 50%;
+
+  width: 150px;
+
+  height: 2px;
+
+  transform:
+    translateY(-50%);
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      rgba(142,232,255,.08),
+      rgba(142,232,255,.3)
+    );
+
+  filter:
+    blur(.2px);
+
+  transform-origin: right;
+}
+
+
+.wake::after {
+
+  content: "";
+
+  position: absolute;
+
+  left: 0;
+
+  top: -3px;
+
+  width: 100%;
+
+  height: 7px;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      rgba(142,232,255,.08)
+    );
+
+  filter:
+    blur(5px);
+}
+
+
+.signal:hover .signal-core,
+.signal:focus-visible .signal-core,
+.signal.locked .signal-core {
+
+  transform: scale(1.7);
+
+  box-shadow:
+    0 0 14px var(--accent),
+    0 0 35px rgba(142,232,255,.75);
+}
+
+
+.signal:focus-visible {
+
+  outline:
+    1px solid var(--accent);
+
+  outline-offset:
+    8px;
+
+  border-radius:
+    50%;
+}
+
+
+.signal.locked {
+
+  z-index: 20;
+
+  animation-play-state: paused;
+}
+
+
+.signal.locked::before {
+
+  inset: -12px;
+
+  border-color:
+    rgba(142,232,255,.5);
+
+  box-shadow:
+    0 0 25px rgba(142,232,255,.15);
+}
+
+
+/* MOVEMENT */
+
+
+@keyframes drift {
+
+  0%,
+  100% {
+    transform: translate3d(0,0,0);
+  }
+
+  25% {
+    transform: translate3d(18px,-12px,0);
+  }
+
+  50% {
+    transform: translate3d(35px,10px,0);
+  }
+
+  75% {
+    transform: translate3d(10px,20px,0);
+  }
+
+}
+
+
+/* INSPECTION */
+
+
+.inspection {
+
+  position: absolute;
+
+  z-index: 30;
+
+  left: 50%;
+
+  top: 16%;
+
+  min-width: 150px;
+
+  padding: 13px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 10px;
+
+  background:
+    rgba(8,11,16,.92);
+
+  backdrop-filter:
+    blur(12px);
+
+  opacity: 0;
+
+  transform:
+    translateY(8px);
+
+  pointer-events:
+    none;
+
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+
+.inspection.visible {
+
+  opacity: 1;
+
+  transform:
+    translateY(0);
+}
+
+
+.inspection-line {
+
+  position: absolute;
+
+  left: 50%;
+
+  bottom: 100%;
+
+  width: 1px;
+
+  height: 35px;
+
+  background:
+    rgba(142,232,255,.35);
+}
+
+
+.inspection-label {
+
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.inspection strong {
+
+  display: block;
+
+  margin-top: 4px;
+
+  color: var(--accent);
+
+  font-size: 13px;
+}
+
+
+.inspection > span:last-child {
+
+  display: block;
+
+  margin-top: 3px;
+
+  color: var(--muted);
+
+  font-size: 7px;
+}
+
+
+/* CONTROLS */
+
+
+.controls {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 13px;
+
+  color: var(--dim);
+
+  font-size: 7px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* ANALYSIS */
+
+
+.analysis {
+
+  margin-top: 24px;
+
+  padding: 23px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 17px;
+
+  background:
+    rgba(255,255,255,.015);
+}
+
+
+.analysis-main {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  gap: 30px;
+}
+
+
+.analysis-heading > span {
+
+  color: var(--dim);
+
+  font-size: 7px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+
+.analysis-heading h2 {
+
+  margin-top: 6px;
+
+  font-size: 30px;
+
+  letter-spacing: -.06em;
+}
+
+
+.metrics {
+
+  display: grid;
+
+  grid-template-columns:
+    repeat(4, minmax(80px,1fr));
+
+  gap: 25px;
+}
+
+
+.metrics small {
+
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+.metrics strong {
+
+  display: block;
+
+  margin-top: 5px;
+
+  font-size: 11px;
+}
+
+
+/* WAVEFORM */
+
+
+.waveform {
+
+  margin-top: 22px;
+
+  padding-top: 17px;
+
+  border-top:
+    1px solid var(--border);
+}
+
+
+.wave-label {
+
+  margin-bottom: 9px;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.waveform svg {
+
+  display: block;
+
+  width: 100%;
+
+  height: 80px;
+
+  overflow: visible;
+}
+
+
+.waveform path {
+
+  fill: none;
+
+  stroke: var(--accent);
+
+  stroke-width: 1.5;
+
+  vector-effect:
+    non-scaling-stroke;
+
+  filter:
+    drop-shadow(
+      0 0 5px
+      rgba(142,232,255,.35)
+    );
+}
+
+
+/* REGISTRY */
+
+
+.registry {
+
+  margin-top: 24px;
+}
+
+
+.registry-header {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-bottom: 10px;
+
+  color: var(--dim);
+
+  font-size: 7px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.registry-grid {
+
+  display: grid;
+
+  grid-template-columns:
+    repeat(4, 1fr);
+
+  gap: 6px;
+}
+
+
+.registry-item {
+
+  padding: 12px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 9px;
+
+  background:
+    rgba(255,255,255,.012);
+
+  cursor: pointer;
+
+  transition:
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+
+.registry-item:hover,
+.registry-item.selected {
+
+  border-color:
+    rgba(142,232,255,.3);
+
+  background:
+    var(--accent-soft);
+}
+
+
+.registry-item strong {
+
+  display: block;
+
+  font-size: 8px;
+}
+
+
+.registry-item span {
+
+  display: block;
+
+  margin-top: 4px;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  letter-spacing: .08em;
+}
+
+
+/* FOOTER */
+
+
+.footer {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 18px;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* RESPONSIVE */
+
+
+@media (max-width: 850px) {
+
+  .wake-card {
+    padding: 30px;
+  }
+
+
+  .analysis-main {
+
+    flex-direction:
+      column;
+  }
+
+
+  .metrics {
+
+    width: 100%;
+  }
+
+
+  .registry-grid {
+
+    grid-template-columns:
+      repeat(2,1fr);
+  }
+
+}
+
+
+@media (max-width: 600px) {
+
+  .page {
+    padding: 15px 9px;
+  }
+
+
+  .wake-card {
+    padding: 22px 15px;
+  }
+
+
+  .header {
+
+    flex-direction:
+      column;
+  }
+
+
+  .field-status {
+    width: 100%;
+  }
+
+
+  .signal-field {
+
+    aspect-ratio:
+      1 / 1;
+
+    min-height:
+      430px;
+  }
+
+
+  .metrics {
+
+    grid-template-columns:
+      repeat(2,1fr);
+
+    gap: 17px;
+  }
+
+
+  .registry-grid {
+
+    grid-template-columns:
+      1fr;
+  }
+
+
+  .controls,
+  .footer {
+
+    flex-direction:
+      column;
+
+    gap: 8px;
+  }
+
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+
+  .signal {
+
+    animation:
+      none;
+  }
+
+  .signal-core,
+  .inspection,
+  .registry-item {
+
+    transition:
+      none;
+  }
+
+}


### PR DESCRIPTION
## Description

closes #76203

This PR adds the new `Signal Wake` interactive visualization component.

The component represents telemetry activity as moving signals that leave fading wake trails behind them.

Rather than using a conventional chart or dashboard, the visualization treats each signal as a moving object whose wake communicates its recent activity.

## What Changed

- Added interactive Signal Wake visualization
- Added 8 independent signal objects
- Added animated signal movement
- Added fading wake trails
- Added hover-to-track interaction
- Added click-to-lock interaction
- Added Escape-to-release behavior
- Added signal inspection panel
- Added dynamic signal metadata
- Added wake reconstruction waveform
- Added signal registry
- Added keyboard accessibility
- Added visible focus states
- Added responsive layouts
- Added reduced-motion support
- Added README documentation

## Interaction

Users can:

- Hover over a signal to inspect it
- Click a signal to lock it
- Use keyboard focus to inspect signals
- Press Escape to release the selected signal
- Select signals directly from the registry

## Accessibility

Signals are keyboard accessible through:

```html
tabindex="0"