### PR TITLE
feat: add pure CSS Micro-interaction Cyberpunk Neon component (#73844)

### DIFF
--- a/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/README.md
+++ b/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Micro-interactions: Cyberpunk Neon
+
+A collection of hardware-accelerated, JavaScript-free micro-interactions focused on high-contrast neon glows, sharp angled geometries, and digital glitch artifacts.
+
+## Features
+- Pure CSS and HTML implementation. No external SVG assets or JavaScript glitch libraries required.
+- **Component Architecture**: 
+  - **Neon Slice Button**: A button featuring the classic cyberpunk angled corner cut. Instead of relying on complex borders, it utilizes `clip-path: polygon()` to slice off the bottom-right corner. The neon fill on `:hover` is achieved with a `::before` pseudo-element that scales from `0` to `1` along the X-axis (`transform-origin: left`).
+  - **Glitch Text**: A highly kinetic chromatic aberration effect. It uses `data-text` attributes on the HTML element to duplicate the text into `::before` and `::after` pseudo-elements. These pseudo-elements are given contrasting neon `text-shadow` colors (Cyan and Pink). On `:hover`, rapid `@keyframes` animations alter the `clip-path` and `translate` properties, causing rapid slices of the text to shift horizontally, simulating a corrupted digital display.
+  - **Neon Trace Focus**: An interactive card that traces a glowing border around its perimeter on hover. It uses four absolute-positioned `span` elements representing the four sides. Initially translated off-screen (e.g., `transform: translateX(-100%)`), they return to `0` on hover. The seamless tracing effect is achieved by staggering their `transition-delay` values (`0s`, `0.15s`, `0.3s`, `0.45s`).
+- **Theming**: Configured via CSS Custom Properties. The color palette revolves around stark black backgrounds paired with intense Neon Cyan (`#00f3ff`), Neon Pink (`#ff003c`), and Neon Yellow (`#fcee0a`).
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by disabling the rapid glitch keyframes and the sequential tracing animations for users who prefer less motion, ensuring the interface remains usable without causing motion sickness or strobe effects.
+
+## Usage
+Open `demo.html` in your browser to view the gallery of micro-interactions. Hover the "Slice Button" for the solid fill, hover the "Glitch Text" to trigger the chromatic aberration, and hover the "Neon Trace" card to watch the sequential border animation.
+
+## Files
+- `demo.html`: The HTML structure defining the layout grid and the markup for each of the 3 cyberpunk micro-interactions (including `data-text` attributes).
+- `style.css`: The styling, the `clip-path` geometry, the complex glitch keyframes, and the staggered transition delays for the trace borders.

--- a/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/demo.html
+++ b/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Micro-interactions: Cyberpunk Neon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1>Cyberpunk Neon</h1>
+            <p>Pure CSS hardware-accelerated neon glithes and glowing traces.</p>
+        </header>
+
+        <main class="grid">
+            
+            <!-- Neon Slice Button -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Neon Slice Button</h2>
+                    <p>Hover to trigger a high-voltage neon fill.</p>
+                    
+                    <div class="component-box dark-box">
+                        <button class="btn btn-cyberpunk">
+                            AVAILABLE NOW
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Glitch Text -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Glitch Text</h2>
+                    <p>Hover to cause a chromatic aberration glitch.</p>
+                    
+                    <div class="component-box dark-box">
+                        <div class="glitch-wrapper">
+                            <h3 class="glitch" data-text="SYSTEM FAILURE">SYSTEM FAILURE</h3>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Neon Trace Card -->
+            <section class="demo-section">
+                <div class="demo-content">
+                    <h2>Neon Trace Focus</h2>
+                    <p>Hover to trace a neon border around the container.</p>
+                    
+                    <div class="component-box dark-box">
+                        <div class="neon-card">
+                            <span></span>
+                            <span></span>
+                            <span></span>
+                            <span></span>
+                            <div class="card-content">
+                                <h3>DATA UPLINK</h3>
+                                <p>Initialize sequence...</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/style.css
+++ b/submissions/examples/css-micro-interaction-cyberpunk-neon-pure/style.css
@@ -1,0 +1,300 @@
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;700&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #050505;
+    --text-primary: #f0f0f0;
+    --text-secondary: #737373;
+    
+    /* Cyberpunk Colors */
+    --neon-cyan: #00f3ff;
+    --neon-pink: #ff003c;
+    --neon-yellow: #fcee0a;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Rajdhani', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 100%;
+    max-width: 1000px;
+    padding: 40px 20px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 60px;
+}
+
+.header h1 {
+    font-size: 2.5rem;
+    margin: 0 0 10px 0;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 243, 255, 0.5);
+}
+
+.header p {
+    color: var(--text-secondary);
+    font-family: sans-serif;
+    letter-spacing: 1px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px;
+}
+
+.demo-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.demo-content h2 {
+    font-size: 1.2rem;
+    margin: 0 0 5px 0;
+    letter-spacing: 1px;
+    color: var(--neon-yellow);
+}
+
+.demo-content p {
+    color: var(--text-secondary);
+    font-family: sans-serif;
+    font-size: 0.9rem;
+    margin: 0 0 20px 0;
+}
+
+.component-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 250px;
+    background: #0a0a0a;
+    border-radius: 4px;
+    border: 1px solid #1a1a1a;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Neon Slice Button
+   Uses a clip-path for the angled edge and a pseudo-element
+   that scales across the button to simulate a neon fill.
+   ========================================= */
+.btn-cyberpunk {
+    position: relative;
+    background: transparent;
+    border: 2px solid var(--neon-yellow);
+    color: var(--neon-yellow);
+    font-family: 'Rajdhani', sans-serif;
+    font-size: 1.2rem;
+    font-weight: 700;
+    padding: 15px 40px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    /* The Cyberpunk angled slice */
+    clip-path: polygon(0 0, 100% 0, 100% calc(100% - 15px), calc(100% - 15px) 100%, 0 100%);
+    transition: all 0.2s ease;
+    z-index: 1;
+}
+
+.btn-cyberpunk::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: var(--neon-yellow);
+    z-index: -1;
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.3s cubic-bezier(0.86, 0, 0.07, 1);
+}
+
+.btn-cyberpunk:hover {
+    color: #000;
+    text-shadow: none;
+    box-shadow: 0 0 20px rgba(252, 238, 10, 0.5);
+}
+
+.btn-cyberpunk:hover::before {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Glitch Text
+   Uses pseudo-elements with `content: attr(data-text)`
+   and rapid `clip-path` keyframes to simulate screen tearing.
+   ========================================= */
+.glitch-wrapper {
+    position: relative;
+    cursor: pointer;
+}
+
+.glitch {
+    position: relative;
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: 4px;
+    margin: 0;
+    text-transform: uppercase;
+}
+
+.glitch::before,
+.glitch::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #0a0a0a;
+    opacity: 0; /* Hidden by default */
+}
+
+.glitch::before {
+    left: 3px;
+    text-shadow: -2px 0 var(--neon-pink);
+    clip-path: polygon(0 0, 100% 0, 100% 33%, 0 33%);
+}
+
+.glitch::after {
+    left: -3px;
+    text-shadow: -2px 0 var(--neon-cyan);
+    clip-path: polygon(0 66%, 100% 66%, 100% 100%, 0 100%);
+}
+
+.glitch-wrapper:hover .glitch::before {
+    opacity: 1;
+    animation: glitch-anim-1 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite;
+}
+
+.glitch-wrapper:hover .glitch::after {
+    opacity: 1;
+    animation: glitch-anim-2 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both infinite reverse;
+}
+
+@keyframes glitch-anim-1 {
+    0% { clip-path: polygon(0 2%, 100% 2%, 100% 5%, 0 5%); transform: translate(-2px, 1px); }
+    20% { clip-path: polygon(0 15%, 100% 15%, 100% 15%, 0 15%); transform: translate(2px, -1px); }
+    40% { clip-path: polygon(0 10%, 100% 10%, 100% 20%, 0 20%); transform: translate(-2px, 2px); }
+    60% { clip-path: polygon(0 80%, 100% 80%, 100% 80%, 0 80%); transform: translate(2px, -2px); }
+    80% { clip-path: polygon(0 30%, 100% 30%, 100% 40%, 0 40%); transform: translate(-2px, 1px); }
+    100% { clip-path: polygon(0 50%, 100% 50%, 100% 50%, 0 50%); transform: translate(2px, -1px); }
+}
+
+@keyframes glitch-anim-2 {
+    0% { clip-path: polygon(0 65%, 100% 65%, 100% 70%, 0 70%); transform: translate(2px, -1px); }
+    20% { clip-path: polygon(0 75%, 100% 75%, 100% 85%, 0 85%); transform: translate(-2px, 2px); }
+    40% { clip-path: polygon(0 45%, 100% 45%, 100% 55%, 0 55%); transform: translate(2px, -2px); }
+    60% { clip-path: polygon(0 90%, 100% 90%, 100% 100%, 0 100%); transform: translate(-2px, 1px); }
+    80% { clip-path: polygon(0 20%, 100% 20%, 100% 30%, 0 30%); transform: translate(2px, -1px); }
+    100% { clip-path: polygon(0 5%, 100% 5%, 100% 15%, 0 15%); transform: translate(-2px, 2px); }
+}
+
+
+/* =========================================
+   [TECHNIQUE 3] Neon Trace Focus
+   Uses 4 absolutely positioned spans that animate
+   their scale along the X or Y axis sequentially.
+   ========================================= */
+.neon-card {
+    position: relative;
+    width: 240px;
+    height: 140px;
+    background: #111;
+    overflow: hidden; /* Contains the trace lines */
+    cursor: pointer;
+}
+
+.card-content {
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+}
+
+.neon-card h3 {
+    margin: 0 0 5px 0;
+    color: var(--neon-cyan);
+    font-size: 1.2rem;
+    letter-spacing: 2px;
+}
+
+.neon-card p {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+/* The 4 border trace lines */
+.neon-card span {
+    position: absolute;
+    background: var(--neon-pink);
+    box-shadow: 0 0 10px var(--neon-pink);
+    transition: transform 0.2s linear;
+}
+
+.neon-card span:nth-child(1) {
+    top: 0; left: 0; width: 100%; height: 2px;
+    transform: translateX(-100%);
+}
+
+.neon-card span:nth-child(2) {
+    top: 0; right: 0; width: 2px; height: 100%;
+    transform: translateY(-100%);
+}
+
+.neon-card span:nth-child(3) {
+    bottom: 0; right: 0; width: 100%; height: 2px;
+    transform: translateX(100%);
+}
+
+.neon-card span:nth-child(4) {
+    bottom: 0; left: 0; width: 2px; height: 100%;
+    transform: translateY(100%);
+}
+
+/* Hover sequence via transition-delay */
+.neon-card:hover span:nth-child(1) { transform: translateX(0); transition-delay: 0s; }
+.neon-card:hover span:nth-child(2) { transform: translateY(0); transition-delay: 0.15s; }
+.neon-card:hover span:nth-child(3) { transform: translateX(0); transition-delay: 0.3s; }
+.neon-card:hover span:nth-child(4) { transform: translateY(0); transition-delay: 0.45s; }
+
+.neon-card:hover {
+    background: #150005; /* Slight red tint to match the neon pink */
+    transition: background 0.2s ease 0.6s;
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .btn-cyberpunk::before,
+    .neon-card span {
+        transition: none;
+    }
+    .btn-cyberpunk:hover::before { transform: scaleX(1); }
+    .glitch-wrapper:hover .glitch::before,
+    .glitch-wrapper:hover .glitch::after {
+        animation: none;
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a collection of hardware-accelerated, JavaScript-free micro-interactions focused on high-contrast neon glows, sharp angled geometries, and digital glitch artifacts. Resolves issue #73844.

### Changes Made:
- Added `submissions/examples/css-micro-interaction-cyberpunk-neon-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the layout grid and the markup for each of the 3 cyberpunk micro-interactions (Neon Slice Button, Glitch Text, Neon Trace Focus).
- Created `style.css` featuring the UI mechanics:
  - **Neon Slice Button**: A button featuring the classic cyberpunk angled corner cut. Instead of relying on complex borders, it utilizes `clip-path: polygon()` to slice off the bottom-right corner. The neon fill on `:hover` is achieved with a `::before` pseudo-element that scales from `0` to `1` along the X-axis (`transform-origin: left`).
  - **Glitch Text**: A highly kinetic chromatic aberration effect. It uses `data-text` attributes on the HTML element to duplicate the text into `::before` and `::after` pseudo-elements. These pseudo-elements are given contrasting neon `text-shadow` colors (Cyan and Pink). On `:hover`, rapid `@keyframes` animations alter the `clip-path` and `translate` properties, causing rapid slices of the text to shift horizontally, simulating a corrupted digital display.
  - **Neon Trace Focus**: An interactive card that traces a glowing border around its perimeter on hover. It uses four absolute-positioned `span` elements representing the four sides. Initially translated off-screen (e.g., `transform: translateX(-100%)`), they return to `0` on hover. The seamless tracing effect is achieved by staggering their `transition-delay` values (`0s`, `0.15s`, `0.3s`, `0.45s`).
  - **Theming Supported**: Configured via CSS Custom Properties. The color palette revolves around stark black backgrounds paired with intense Neon Cyan (`#00f3ff`), Neon Pink (`#ff003c`), and Neon Yellow (`#fcee0a`).
- Added `README.md` documenting usage and the technical mechanics of the `clip-path` geometry, the complex glitch keyframes, and the staggered transition delays for the trace borders.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard by disabling the rapid glitch keyframes and the sequential tracing animations for users who prefer less motion, ensuring the interface remains usable without causing motion sickness or strobe effects.

Closes #73844
