### PR TITLE
feat: add ease-bubble-column-rise-ij demo component

### DIFF
--- a/submissions/examples/ease-bubble-column-rise-ij/README.md
+++ b/submissions/examples/ease-bubble-column-rise-ij/README.md
@@ -1,0 +1,33 @@
+# Bubble Column Rise
+
+Bubbles wobble upward through a deep aquarium column, fading in at the bottom and popping at the surface.
+
+## How is it used?
+
+Each bubble is a radial-gradient circle with a `border` rim, sized and timed via custom properties:
+
+```css
+.bubble {
+  width: var(--size);
+  animation: rise var(--dur) linear infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes rise {
+  0% {
+    transform: translateY(0) translateX(0);
+    opacity: 0;
+  }
+  12% {
+    opacity: 0.95;
+  }
+  100% {
+    transform: translateY(-360px) translateX(14px);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+The radial highlight inside the circle sells a glossy bubble without images. Random delays + durations from a few lines of JS keep the column dense but organic — the same recipe powers rising particles, confetti, and rain.

--- a/submissions/examples/ease-bubble-column-rise-ij/demo.html
+++ b/submissions/examples/ease-bubble-column-rise-ij/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bubble Column Rise Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="aquarium">
+    <div class="column" id="column" aria-hidden="true"></div>
+    <div class="light-rays" aria-hidden="true"></div>
+    <p class="hint">Bubbles wobble up the column and pop as they reach the surface.</p>
+  </main>
+  <script>
+    const column = document.getElementById("column");
+    for (let i = 0; i < 18; i++) {
+      const b = document.createElement("span");
+      b.className = "bubble";
+      b.style.setProperty("--size", (6 + Math.random() * 12).toFixed(1) + "px");
+      b.style.setProperty("--left", Math.floor(Math.random() * 80 + 10) + "%");
+      b.style.setProperty("--dur", (2.4 + Math.random() * 2.6).toFixed(2) + "s");
+      b.style.setProperty("--delay", (-Math.random() * 5).toFixed(2) + "s");
+      column.appendChild(b);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-bubble-column-rise-ij/style.css
+++ b/submissions/examples/ease-bubble-column-rise-ij/style.css
@@ -1,0 +1,84 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #06202e;
+  font-family: system-ui, sans-serif;
+}
+
+.aquarium {
+  position: relative;
+  width: 260px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #0e4a66, #07354d 60%, #041c2c);
+}
+
+.light-rays {
+  position: absolute;
+  top: -10%;
+  left: 20%;
+  width: 60%;
+  height: 60%;
+  background: linear-gradient(
+    160deg,
+    rgba(140, 220, 255, 0.16),
+    transparent 60%
+  );
+  transform: rotate(12deg);
+}
+
+.column {
+  position: absolute;
+  inset: 0;
+}
+
+.bubble {
+  position: absolute;
+  bottom: -24px;
+  left: var(--left);
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  border: 1px solid rgba(200, 240, 255, 0.7);
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.5), transparent 60%);
+  animation: rise linear infinite;
+  animation-duration: var(--dur);
+  animation-delay: var(--delay);
+}
+
+@keyframes rise {
+  0% {
+    transform: translateY(0) translateX(0);
+    opacity: 0;
+  }
+  12% {
+    opacity: 0.95;
+  }
+  88% {
+    opacity: 0.85;
+  }
+  100% {
+    transform: translateY(-360px) translateX(14px);
+    opacity: 0;
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #a5dcef;
+  font-size: 12px;
+  opacity: 0.85;
+}


### PR DESCRIPTION
Adds a working `ease-bubble-column-rise-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-bubble-column-rise-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.