### PR TITLE
feat: add ease-dewdrop-slide-ij demo component

### DIFF
--- a/submissions/examples/ease-dewdrop-slide-ij/README.md
+++ b/submissions/examples/ease-dewdrop-slide-ij/README.md
@@ -1,0 +1,27 @@
+# Dewdrop Slide
+
+A glossy dew drop gathers at the tip of a leaf, slides along its curve, and falls away.
+
+## How is it used?
+
+The drop accelerates along the leaf with an ease-in, dips, then plunges off the edge while shrinking and fading:
+
+```css
+@keyframes drop-slide {
+  0% {
+    transform: translateX(0) translateY(0) scale(1);
+    opacity: 0.9;
+  }
+  35% {
+    transform: translateX(60px) translateY(8px) scale(1.06);
+  }
+  100% {
+    transform: translateX(108px) translateY(70px) scale(0.7);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+A single asymmetric keyframe narrates "gather → roll → release" with no physics library. The radial highlight and `border-radius` asymmetry make the blob read as a wet drop — handy for droplet, teardrop, and liquid-gesture micro-interactions.

--- a/submissions/examples/ease-dewdrop-slide-ij/demo.html
+++ b/submissions/examples/ease-dewdrop-slide-ij/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dewdrop Slide Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="leaf">
+    <div class="dewdrop" id="dewdrop" aria-hidden="true">
+      <div class="drop"></div>
+      <div class="shine"></div>
+    </div>
+    <button class="drip" id="drip" type="button">Shake Leaf</button>
+    <p class="hint">A dew drop gathers, slides along the leaf, and falls off.</p>
+  </main>
+  <script>
+    const dewdrop = document.getElementById("dewdrop");
+    const drip = document.getElementById("drip");
+    function shake() {
+      dewdrop.classList.remove("slide");
+      void dewdrop.offsetWidth;
+      dewdrop.classList.add("slide");
+    }
+    drip.addEventListener("click", shake);
+    shake();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-dewdrop-slide-ij/style.css
+++ b/submissions/examples/ease-dewdrop-slide-ij/style.css
@@ -1,0 +1,107 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #173f28;
+  font-family: system-ui, sans-serif;
+}
+
+.leaf {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.leaf::before {
+  content: "";
+  width: 300px;
+  height: 120px;
+  background: radial-gradient(ellipse at 50% 0%, #5aa05a, #2c6e43 70%);
+  border-radius: 90% 90% 8% 8%;
+  box-shadow: inset 0 10px 20px rgba(220, 255, 220, 0.25),
+    inset 0 -14px 24px rgba(0, 40, 10, 0.4);
+}
+
+.dewdrop {
+  position: absolute;
+  top: 96px;
+  width: 26px;
+  height: 26px;
+}
+
+.drop {
+  position: absolute;
+  inset: 0;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  background: radial-gradient(circle at 35% 30%, #eafcff, #7fd6ef 60%, #3aa5c9);
+  opacity: 0.9;
+}
+
+.shine {
+  position: absolute;
+  top: 5px;
+  left: 7px;
+  width: 5px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  transform: rotate(18deg);
+}
+
+.dewdrop.slide .drop,
+.dewdrop.slide .shine {
+  animation: drop-slide 2.2s cubic-bezier(0.4, 0, 0.6, 1) both;
+}
+
+@keyframes drop-slide {
+  0% {
+    transform: translateX(0) translateY(0) scale(1);
+    opacity: 0.9;
+  }
+  35% {
+    transform: translateX(60px) translateY(8px) scale(1.06);
+    opacity: 0.95;
+  }
+  55% {
+    transform: translateX(108px) translateY(20px) scale(0.96);
+    opacity: 0.95;
+  }
+  100% {
+    transform: translateX(108px) translateY(70px) scale(0.7);
+    opacity: 0;
+  }
+}
+
+.drip {
+  margin-top: 20px;
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #8fd98f;
+  color: #10301c;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.drip:hover {
+  background: #aee8ae;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #b8e3c4;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-dewdrop-slide-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-dewdrop-slide-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.