### PR TITLE
feat: add ease-geyser-erupt-burst-ij demo component

### DIFF
--- a/submissions/examples/ease-geyser-erupt-burst-ij/README.md
+++ b/submissions/examples/ease-geyser-erupt-burst-ij/README.md
@@ -1,0 +1,36 @@
+# Geyser Erupt Burst
+
+A geyser vent blasts three plumes of steam high into the air with staggered timing, then settles back.
+
+## How is it used?
+
+Each steam plume is a radial-gradient ellipse that shoots upward, grows, and fades. Three share one keyframe with negative delays:
+
+```css
+.geyser.blowing .steam-1 {
+  animation: blast 2.4s ease-out both;
+}
+
+.geyser.blowing .steam-2 {
+  animation: blast 2.4s ease-out both;
+  animation-delay: -0.2s;
+}
+
+@keyframes blast {
+  0% {
+    transform: translate(-50%, 0) scale(0.4);
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.95;
+  }
+  100% {
+    transform: translate(-50%, -200px) scale(1.6);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+`ease-out` plus growing `scale` makes the plume look like it's expanding while slowing — exactly how real steam behaves. Staggered plumes at different widths fake turbulence, a pattern for explosions, smoke, and celebration bursts.

--- a/submissions/examples/ease-geyser-erupt-burst-ij/demo.html
+++ b/submissions/examples/ease-geyser-erupt-burst-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Geyser Erupt Burst Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="basin">
+    <div class="geyser" id="geyser" aria-hidden="true">
+      <div class="steam steam-1"></div>
+      <div class="steam steam-2"></div>
+      <div class="steam steam-3"></div>
+      <div class="vent"></div>
+    </div>
+    <button class="erupt" id="erupt" type="button">Erupt</button>
+    <p class="hint">A geyser blasts steam and water high into the air, then settles.</p>
+  </main>
+  <script>
+    const geyser = document.getElementById("geyser");
+    const erupt = document.getElementById("erupt");
+    function eruptNow() {
+      geyser.classList.remove("blowing");
+      void geyser.offsetWidth;
+      geyser.classList.add("blowing");
+    }
+    erupt.addEventListener("click", eruptNow);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-geyser-erupt-burst-ij/style.css
+++ b/submissions/examples/ease-geyser-erupt-burst-ij/style.css
@@ -1,0 +1,116 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a2024;
+  font-family: system-ui, sans-serif;
+}
+
+.basin {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.geyser {
+  position: relative;
+  width: 260px;
+  height: 260px;
+}
+
+.basin::before {
+  content: "";
+  width: 260px;
+  height: 60px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 30%, #9aa8b2, #5c6872 75%);
+  box-shadow: inset 0 8px 14px rgba(255, 255, 255, 0.25);
+}
+
+.vent {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 90px;
+  height: 22px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(ellipse, #3d4a55, #141a20 75%);
+}
+
+.steam {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  width: 44px;
+  height: 60px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(230, 240, 248, 0.95), rgba(180, 200, 220, 0.5) 60%, transparent);
+  opacity: 0;
+}
+
+.geyser.blowing .steam-1 {
+  animation: blast 2.4s ease-out both;
+}
+
+.geyser.blowing .steam-2 {
+  animation: blast 2.4s ease-out both;
+  animation-delay: -0.2s;
+  width: 30px;
+  left: 42%;
+}
+
+.geyser.blowing .steam-3 {
+  animation: blast 2.4s ease-out both;
+  animation-delay: -0.4s;
+  width: 30px;
+  left: 58%;
+}
+
+@keyframes blast {
+  0% {
+    transform: translate(-50%, 0) scale(0.4);
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.95;
+  }
+  100% {
+    transform: translate(-50%, -200px) scale(1.6);
+    opacity: 0;
+  }
+}
+
+.erupt {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #e8d3a0;
+  color: #2a2416;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.erupt:hover {
+  background: #f5e6bd;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #c3ccd4;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-geyser-erupt-burst-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-geyser-erupt-burst-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.