### PR TITLE
feat: add ease-ink-plume-diffuse-ij demo component

### DIFF
--- a/submissions/examples/ease-ink-plume-diffuse-ij/README.md
+++ b/submissions/examples/ease-ink-plume-diffuse-ij/README.md
@@ -1,0 +1,28 @@
+# Ink Plume Diffuse
+
+A drop of ink disperses through water as a slow, cloudy bloom that thins into the depths.
+
+## How is it used?
+
+Two radial-gradient overlays expand on offset scales, both easing out to a near-invisible plume:
+
+```css
+.plume.disperse::before {
+  animation: diffuse-a 3s cubic-bezier(0.33, 1, 0.68, 1) both;
+}
+
+@keyframes diffuse-a {
+  0% {
+    transform: scale(0.2);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(3.4);
+    opacity: 0;
+  }
+}
+```
+
+## Why is it useful?
+
+Two differently-sized expanding gradients blur together into a soft plume with no `filter: blur` cost. The decelerating ease mimics diffusion — ideal for liquid fills, loading "absorb" effects, and notification pings.

--- a/submissions/examples/ease-ink-plume-diffuse-ij/demo.html
+++ b/submissions/examples/ease-ink-plume-diffuse-ij/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ink Plume Diffuse Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="water">
+    <div class="plume" id="plume" aria-hidden="true"></div>
+    <button class="inject" id="inject" type="button">Inject Ink</button>
+    <p class="hint">A drop of ink disperses into the water like a slow-motion bloom.</p>
+  </main>
+  <script>
+    const plume = document.getElementById("plume");
+    const inject = document.getElementById("inject");
+    function injectInk() {
+      plume.classList.remove("disperse");
+      void plume.offsetWidth;
+      plume.classList.add("disperse");
+    }
+    inject.addEventListener("click", injectInk);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-ink-plume-diffuse-ij/style.css
+++ b/submissions/examples/ease-ink-plume-diffuse-ij/style.css
@@ -1,0 +1,105 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0c2838;
+  font-family: system-ui, sans-serif;
+}
+
+.water {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.water::before {
+  content: "";
+  width: 280px;
+  height: 200px;
+  border-radius: 14px;
+  background: radial-gradient(circle at 50% 30%, #1d5a78, #0f3a52 75%);
+  box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.35);
+}
+
+.plume {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  opacity: 0;
+}
+
+.plume::before,
+.plume::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(30, 20, 60, 0.85), transparent 70%);
+}
+
+.plume.disperse {
+  opacity: 1;
+}
+
+.plume.disperse::before {
+  animation: diffuse-a 3s cubic-bezier(0.33, 1, 0.68, 1) both;
+}
+
+.plume.disperse::after {
+  animation: diffuse-b 3s cubic-bezier(0.33, 1, 0.68, 1) both;
+}
+
+@keyframes diffuse-a {
+  0% {
+    transform: scale(0.2);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(3.4);
+    opacity: 0;
+  }
+}
+
+@keyframes diffuse-b {
+  0% {
+    transform: scale(0.15);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+.inject {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #9fd8ea;
+  color: #0c2838;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.inject:hover {
+  background: #c2ecf7;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #9cc6da;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-ink-plume-diffuse-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-ink-plume-diffuse-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.