### PR TITLE
feat: add ease-jackhammer-pound-ij demo component

### DIFF
--- a/submissions/examples/ease-jackhammer-pound-ij/README.md
+++ b/submissions/examples/ease-jackhammer-pound-ij/README.md
@@ -1,0 +1,31 @@
+# Jackhammer Pound
+
+A breaker hammer rocks back and forth while chips fly off a concrete slab at the point of impact.
+
+## How is it used?
+
+The hammer pivots on a top handle via `transform-origin: 50% 12px`; chips share a flick-loop with negative delays. A `.pounding` class starts and stops everything:
+
+```css
+.rig.pounding .jackhammer {
+  animation: pound 0.45s ease-in-out infinite;
+}
+
+@keyframes pound {
+  0% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(9deg);
+  }
+}
+
+.rig.pounding .chip-2 {
+  animation: chip-fly 0.45s linear infinite;
+  animation-delay: -0.15s;
+}
+```
+
+## Why is it useful?
+
+Toggling one class on a parent controls every child animation at once — no per-element JS. Matching the chip loop to the hammer loop keeps the debris timed to each strike, the same pattern behind drills, presses, and percussion loaders.

--- a/submissions/examples/ease-jackhammer-pound-ij/demo.html
+++ b/submissions/examples/ease-jackhammer-pound-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jackhammer Pound Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="site">
+    <div class="hammer-rig" id="hammerRig" aria-hidden="true">
+      <div class="jackhammer"></div>
+      <div class="concrete"></div>
+      <div class="chips chip-1"></div>
+      <div class="chips chip-2"></div>
+      <div class="chips chip-3"></div>
+    </div>
+    <button class="jack" id="jack" type="button">Start Jackhammer</button>
+    <p class="hint">The breaker pounds the slab while tiny chips fly off the impact point.</p>
+  </main>
+  <script>
+    const rig = document.getElementById("hammerRig");
+    const jack = document.getElementById("jack");
+    let running = false;
+    function toggle() {
+      running = !running;
+      rig.classList.toggle("pounding", running);
+      jack.textContent = running ? "Stop" : "Start Jackhammer";
+    }
+    jack.addEventListener("click", toggle);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-jackhammer-pound-ij/style.css
+++ b/submissions/examples/ease-jackhammer-pound-ij/style.css
@@ -1,0 +1,173 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #20232a;
+  font-family: system-ui, sans-serif;
+}
+
+.site {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.hammer-rig {
+  position: relative;
+  width: 220px;
+  height: 240px;
+}
+
+.jackhammer {
+  position: absolute;
+  top: 0;
+  left: 90px;
+  width: 40px;
+  height: 120px;
+  background: linear-gradient(90deg, #6b7280, #9aa1ad 40%, #6b7280);
+  border-radius: 6px;
+  transform-origin: 50% 12px;
+}
+
+.jackhammer::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: -8px;
+  width: 56px;
+  height: 18px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #4b5563, #374151);
+}
+
+.jackhammer::after {
+  content: "";
+  position: absolute;
+  bottom: -14px;
+  left: 14px;
+  width: 12px;
+  height: 22px;
+  border-radius: 3px;
+  background: #2c333b;
+}
+
+.rig.pounding .jackhammer {
+  animation: pound 0.45s ease-in-out infinite;
+}
+
+@keyframes pound {
+  0% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(9deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+.concrete {
+  position: absolute;
+  bottom: 0;
+  left: 30px;
+  width: 160px;
+  height: 70px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #9aa1ad, #6b7280 70%);
+}
+
+.concrete::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  background: repeating-linear-gradient(90deg, transparent 0 12px, #4b5563 12px 16px);
+}
+
+.chips {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #c9cfd8;
+  opacity: 0;
+}
+
+.chip-1 {
+  bottom: 76px;
+  left: 96px;
+}
+
+.chip-2 {
+  bottom: 76px;
+  left: 110px;
+}
+
+.chip-3 {
+  bottom: 76px;
+  left: 102px;
+}
+
+.rig.pounding .chip-1 {
+  animation: chip-fly 0.45s linear infinite;
+}
+
+.rig.pounding .chip-2 {
+  animation: chip-fly 0.45s linear infinite;
+  animation-delay: -0.15s;
+}
+
+.rig.pounding .chip-3 {
+  animation: chip-fly 0.45s linear infinite;
+  animation-delay: -0.3s;
+}
+
+@keyframes chip-fly {
+  0% {
+    transform: translate(0, 0) scale(1);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-26px, -34px) scale(0.4);
+    opacity: 0;
+  }
+}
+
+.jack {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #ffb020;
+  color: #2a1c05;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.jack:hover {
+  background: #ffc855;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #b6bcc6;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-jackhammer-pound-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-jackhammer-pound-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.