### PR TITLE
feat: add ease-magnet-particles-align-ij demo component

### DIFF
--- a/submissions/examples/ease-magnet-particles-align-ij/README.md
+++ b/submissions/examples/ease-magnet-particles-align-ij/README.md
@@ -1,0 +1,29 @@
+# Magnet Particles Align
+
+Scattered iron filings rotate into vertical alignment along a magnet's field, snapping with a springy overshoot.
+
+## How is it used?
+
+JS scatters `.particle` spans, each storing a random start angle and a small stagger delay; the `align` keyframe rotates them to 90°:
+
+```js
+p.style.setProperty("--start", Math.floor(Math.random() * 360) + "deg");
+p.style.setProperty("--delay", (Math.random() * 0.25).toFixed(2) + "s");
+```
+
+```css
+.magnet.on .particle {
+  animation: align 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: var(--delay);
+}
+
+@keyframes align {
+  100% {
+    transform: translate(-50%, -50%) rotate(90deg) scale(1.15);
+  }
+}
+```
+
+## Why is it useful?
+
+The overshoot bezier (`1.56` elasticity) makes each filing snap into place. Per-particle delays create a satisfying cascade. This rotation-alignment pattern doubles for buttons, tooltips, and "settle into place" list items.

--- a/submissions/examples/ease-magnet-particles-align-ij/demo.html
+++ b/submissions/examples/ease-magnet-particles-align-ij/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Magnet Particles Align Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="bench">
+    <div class="magnet" id="magnet" aria-hidden="true">
+      <div class="rod"></div>
+      <div class="pole"></div>
+      <div class="field-line"></div>
+    </div>
+    <button class="pull" id="pull" type="button">Pull the Magnet</button>
+    <p class="hint">Scattered iron filings snap into alignment along the magnetic field.</p>
+  </main>
+  <script>
+    const magnet = document.getElementById("magnet");
+    const pull = document.getElementById("pull");
+    for (let i = 0; i < 26; i++) {
+      const p = document.createElement("span");
+      p.className = "particle";
+      p.style.left = 10 + Math.random() * 280 + "px";
+      p.style.top = 92 + Math.random() * 120 + "px";
+      p.style.setProperty("--start", Math.floor(Math.random() * 360) + "deg");
+      p.style.setProperty("--delay", (Math.random() * 0.25).toFixed(2) + "s");
+      magnet.appendChild(p);
+    }
+    function engage() {
+      magnet.classList.remove("on");
+      void magnet.offsetWidth;
+      magnet.classList.add("on");
+    }
+    pull.addEventListener("click", engage);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-magnet-particles-align-ij/style.css
+++ b/submissions/examples/ease-magnet-particles-align-ij/style.css
@@ -1,0 +1,127 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #141a1f;
+  font-family: system-ui, sans-serif;
+}
+
+.bench {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.magnet {
+  position: relative;
+  width: 300px;
+  height: 220px;
+}
+
+.rod {
+  position: absolute;
+  top: 60px;
+  left: 30px;
+  width: 240px;
+  height: 36px;
+  border-radius: 10px;
+  background: linear-gradient(90deg, #3a6ea8 0 45%, #b03030 55% 100%);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+
+.pole {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  border-radius: 10px 0 0 10px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.12) 0 10px,
+    transparent 10px 20px
+  );
+}
+
+.field-line {
+  position: absolute;
+  top: 100px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(80, 140, 200, 0.7), transparent 30%, transparent 70%, rgba(220, 90, 90, 0.7));
+  opacity: 0.5;
+}
+
+.particle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 5px;
+  height: 14px;
+  border-radius: 3px;
+  background: #c9cdd4;
+  opacity: 0.85;
+  transform-origin: 50% 50%;
+}
+
+.magnet.on .field-line {
+  animation: line-pulse 1s ease-in-out infinite;
+}
+
+@keyframes line-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+.magnet.on .particle {
+  animation: align 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: var(--delay);
+}
+
+@keyframes align {
+  0% {
+    transform: translate(-50%, -50%) rotate(var(--start)) scale(1);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(90deg) scale(1.15);
+  }
+}
+
+.pull {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #e8e2d8;
+  color: #22262a;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.pull:hover {
+  background: #ffffff;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #9aa6b0;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 280px;
+}


### PR DESCRIPTION
Adds a working `ease-magnet-particles-align-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-magnet-particles-align-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.