### PR TITLE
feat: add ease-night-sky-twinkle-ij demo component

### DIFF
--- a/submissions/examples/ease-night-sky-twinkle-ij/README.md
+++ b/submissions/examples/ease-night-sky-twinkle-ij/README.md
@@ -1,0 +1,35 @@
+# Night Sky Twinkle
+
+Stars blink at staggered rates and sizes beneath a crescent moon, powered by a few lines of JS and one keyframe.
+
+## How is it used?
+
+A loop scatters stars and gives each its own size, duration, and negative delay:
+
+```js
+star.style.setProperty("--size", (1 + Math.random() * 2).toFixed(1) + "px");
+star.style.setProperty("--dur", (1.4 + Math.random() * 3).toFixed(2) + "s");
+star.style.setProperty("--delay", (-Math.random() * 4).toFixed(2) + "s");
+```
+
+```css
+.star {
+  animation: twinkle var(--dur) ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes twinkle {
+  0%, 100% {
+    opacity: 0.25;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.3);
+  }
+}
+```
+
+## Why is it useful?
+
+Randomized duration + delay desynchronizes every star, so no two blink in unison. The moon's crescent is a simple circle-with-overlap trick — a tiny ambient background that costs almost nothing to animate.

--- a/submissions/examples/ease-night-sky-twinkle-ij/demo.html
+++ b/submissions/examples/ease-night-sky-twinkle-ij/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Night Sky Twinkle Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="night">
+    <div class="sky" id="sky" aria-hidden="true"></div>
+    <div class="moon"></div>
+    <p class="hint">Stars blink at staggered rates under a silver moon.</p>
+  </main>
+  <script>
+    const sky = document.getElementById("sky");
+    for (let i = 0; i < 40; i++) {
+      const star = document.createElement("span");
+      star.className = "star";
+      star.style.left = Math.random() * 100 + "%";
+      star.style.top = Math.random() * 100 + "%";
+      star.style.setProperty("--size", (1 + Math.random() * 2).toFixed(1) + "px");
+      star.style.setProperty("--dur", (1.4 + Math.random() * 3).toFixed(2) + "s");
+      star.style.setProperty("--delay", (-Math.random() * 4).toFixed(2) + "s");
+      sky.appendChild(star);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-night-sky-twinkle-ij/style.css
+++ b/submissions/examples/ease-night-sky-twinkle-ij/style.css
@@ -1,0 +1,85 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a1220;
+  font-family: system-ui, sans-serif;
+}
+
+.night {
+  position: relative;
+  width: 360px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #060b16, #0d1a30 70%, #12233f);
+}
+
+.sky {
+  position: absolute;
+  inset: 0;
+}
+
+.star {
+  position: absolute;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  background: #e8f0ff;
+  box-shadow: 0 0 4px rgba(220, 235, 255, 0.7);
+  animation: twinkle var(--dur) ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: 0.25;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.3);
+  }
+}
+
+.moon {
+  position: absolute;
+  top: 30px;
+  right: 44px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #fff8e0, #e8dcb0);
+  box-shadow: 0 0 24px 6px rgba(240, 230, 190, 0.4);
+}
+
+.moon::after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -6px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #0d1a30;
+  transform: translate(14px, 6px);
+}
+
+.hint {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #b7c6e2;
+  font-size: 12px;
+  opacity: 0.85;
+}


### PR DESCRIPTION
Adds a working `ease-night-sky-twinkle-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-night-sky-twinkle-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.