### PR TITLE
feat: add ease-orbit-rings-saturn-ij demo component

### DIFF
--- a/submissions/examples/ease-orbit-rings-saturn-ij/README.md
+++ b/submissions/examples/ease-orbit-rings-saturn-ij/README.md
@@ -1,0 +1,34 @@
+# Orbit Rings Saturn
+
+A banded Saturn tilts and breathes while a moon circles it on an invisible orbital path.
+
+## How is it used?
+
+The rings are `border` circles squashed with `scaleY(0.35)` and tilted; the moon travels by rotating a zero-size orbit wrapper:
+
+```css
+.ring-ring {
+  border: 10px solid rgba(224, 190, 130, 0.55);
+  transform: translate(-50%, -50%) rotate(-18deg) scaleY(0.35);
+}
+
+.moon-orb {
+  animation: moon-orbit 7s linear infinite;
+}
+
+.moon {
+  position: absolute;
+  left: 0;
+  top: -108px;
+}
+
+@keyframes moon-orbit {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+```
+
+## Why is it useful?
+
+`scaleY` flattens a circle into an ellipse ring in one line — no SVG. Rotating the zero-size parent plus placing the moon at a fixed radius is the cleanest orbit pattern; pair it with the counter-rotation trick when the moon needs to stay upright.

--- a/submissions/examples/ease-orbit-rings-saturn-ij/demo.html
+++ b/submissions/examples/ease-orbit-rings-saturn-ij/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orbit Rings Saturn Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="system">
+    <div class="saturn" id="saturn" aria-hidden="true">
+      <div class="planet"></div>
+      <div class="ring-ring ring-outer"></div>
+      <div class="ring-ring ring-inner"></div>
+      <div class="moon-orb">
+        <div class="moon"></div>
+      </div>
+    </div>
+    <p class="hint">Saturn's rings tilt and rotate as a moon orbits the planet.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-orbit-rings-saturn-ij/style.css
+++ b/submissions/examples/ease-orbit-rings-saturn-ij/style.css
@@ -1,0 +1,124 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #07090f;
+  font-family: system-ui, sans-serif;
+}
+
+.system {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 340px;
+  height: 300px;
+  border-radius: 16px;
+  background: radial-gradient(ellipse at 50% 50%, #0d1220, #04050a 75%);
+}
+
+.saturn {
+  position: relative;
+  width: 220px;
+  height: 220px;
+}
+
+.planet {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 90px;
+  height: 90px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #f0d9a0, #d4a95c 55%, #a8773c);
+  animation: breathe 4s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 30px 4px rgba(240, 210, 140, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 44px 10px rgba(240, 210, 140, 0.5);
+  }
+}
+
+.ring-ring {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  border-radius: 50%;
+  border: 10px solid rgba(224, 190, 130, 0.55);
+  transform: translate(-50%, -50%) rotate(-18deg) scaleY(0.35);
+  animation: ring-wobble 8s ease-in-out infinite;
+}
+
+.ring-outer {
+  width: 180px;
+  height: 180px;
+}
+
+.ring-inner {
+  width: 140px;
+  height: 140px;
+  border-width: 6px;
+  border-color: rgba(230, 205, 150, 0.4);
+  animation-delay: -2s;
+}
+
+@keyframes ring-wobble {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) rotate(-18deg) scaleY(0.35);
+  }
+  50% {
+    transform: translate(-50%, -50%) rotate(-12deg) scaleY(0.42);
+  }
+}
+
+.moon-orb {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0;
+  height: 0;
+  animation: moon-orbit 7s linear infinite;
+}
+
+.moon {
+  position: absolute;
+  left: 0;
+  top: -108px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #e8e8ea, #9a9aa2);
+}
+
+@keyframes moon-orbit {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 14px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #a5acc6;
+  font-size: 12px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Adds a working `ease-orbit-rings-saturn-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-orbit-rings-saturn-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.