### PR TITLE
feat: add ease-pendulum-wave-chain-ij demo component

### DIFF
--- a/submissions/examples/ease-pendulum-wave-chain-ij/README.md
+++ b/submissions/examples/ease-pendulum-wave-chain-ij/README.md
@@ -1,0 +1,36 @@
+# Pendulum Wave Chain
+
+Nine pendulums with slightly different lengths swing together, their phases drifting into a traveling wave.
+
+## How is it used?
+
+Each pendulum gets a unique duration and arm length; the shared swing keyframe runs at its own speed:
+
+```js
+p.style.setProperty("--dur", (1.3 + i * 0.16).toFixed(2) + "s");
+p.style.setProperty("--len", (86 - i * 6).toFixed(0) + "px");
+```
+
+```css
+.pendulum {
+  transform-origin: 50% 0;
+  animation: swing var(--dur) ease-in-out infinite;
+}
+
+@keyframes swing {
+  0%, 100% {
+    transform: rotate(24deg);
+  }
+  50% {
+    transform: rotate(-24deg);
+  }
+}
+
+.bob {
+  top: var(--len);
+}
+```
+
+## Why is it useful?
+
+Slightly-offset periods naturally desynchronize over time — the pendulums start in sync, spiral into a wave, and drift back. No timing math needed; just slightly different durations. This emergent behavior is great for loading states and ambient physics.

--- a/submissions/examples/ease-pendulum-wave-chain-ij/demo.html
+++ b/submissions/examples/ease-pendulum-wave-chain-ij/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pendulum Wave Chain Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="physics">
+    <div class="bar"></div>
+    <div class="pendulums" id="pendulums" aria-hidden="true"></div>
+    <p class="hint">A row of pendulums swings at slightly different lengths, making a traveling wave.</p>
+  </main>
+  <script>
+    const pendulums = document.getElementById("pendulums");
+    for (let i = 0; i < 9; i++) {
+      const p = document.createElement("div");
+      p.className = "pendulum";
+      p.style.left = 14 + i * 40 + "px";
+      p.style.setProperty("--dur", (1.3 + i * 0.16).toFixed(2) + "s");
+      p.style.setProperty("--len", (86 - i * 6).toFixed(0) + "px");
+      p.innerHTML = '<span class="arm"></span><span class="bob"></span>';
+      pendulums.appendChild(p);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-pendulum-wave-chain-ij/style.css
+++ b/submissions/examples/ease-pendulum-wave-chain-ij/style.css
@@ -1,0 +1,87 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #10161d;
+  font-family: system-ui, sans-serif;
+}
+
+.physics {
+  position: relative;
+  width: 360px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: #0c1117;
+}
+
+.bar {
+  position: absolute;
+  top: 34px;
+  left: 8px;
+  right: 8px;
+  height: 8px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #5c6672, #8a94a0 50%, #5c6672);
+}
+
+.pendulums {
+  position: absolute;
+  inset: 0;
+}
+
+.pendulum {
+  position: absolute;
+  top: 40px;
+  width: 4px;
+  transform-origin: 50% 0;
+  animation: swing var(--dur) ease-in-out infinite;
+}
+
+@keyframes swing {
+  0%,
+  100% {
+    transform: rotate(24deg);
+  }
+  50% {
+    transform: rotate(-24deg);
+  }
+}
+
+.arm {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2px;
+  height: var(--len);
+  background: #b8c0ca;
+}
+
+.bob {
+  position: absolute;
+  top: var(--len);
+  left: -6px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #ffd166, #c98a2e 65%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.hint {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #9aa6b0;
+  font-size: 12px;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Adds a working `ease-pendulum-wave-chain-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-pendulum-wave-chain-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.