### PR TITLE
feat: add ease-quake-rattle-shake-ij demo component

### DIFF
--- a/submissions/examples/ease-quake-rattle-shake-ij/README.md
+++ b/submissions/examples/ease-quake-rattle-shake-ij/README.md
@@ -1,0 +1,30 @@
+# Quake Rattle Shake
+
+A city skyline shudders when a tremor is triggered, with each building shaking at a different amplitude.
+
+## How is it used?
+
+Buildings rotate from their base (`transform-origin: 50% 100%`) on small alternating keyframes. Taller buildings get the wider swing; negative delays desync them:
+
+```css
+.buildings.rattling .build-2 {
+  animation: rattle-lg 0.5s ease-in-out infinite;
+  animation-delay: -0.1s;
+}
+
+@keyframes rattle-sm {
+  0%, 100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(1.2deg);
+  }
+  75% {
+    transform: rotate(-1.2deg);
+  }
+}
+```
+
+## Why is it useful?
+
+Rotating around the base is how real structures sway — no translate jitter. Different amplitudes + delays sell an earthquake; the same "shake per element" pattern powers error states, impact feedback, and screen-shake on mobile.

--- a/submissions/examples/ease-quake-rattle-shake-ij/demo.html
+++ b/submissions/examples/ease-quake-rattle-shake-ij/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Quake Rattle Shake Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="city">
+    <div class="buildings" id="buildings" aria-hidden="true">
+      <div class="build build-1"></div>
+      <div class="build build-2"></div>
+      <div class="build build-3"></div>
+      <div class="build build-4"></div>
+      <div class="build build-5"></div>
+    </div>
+    <div class="ground"></div>
+    <button class="tremor" id="tremor" type="button">Trigger Tremor</button>
+    <p class="hint">Buildings shudder at different amplitudes as a quake rolls through.</p>
+  </main>
+  <script>
+    const buildings = document.getElementById("buildings");
+    const tremor = document.getElementById("tremor");
+    function shake() {
+      buildings.classList.remove("rattling");
+      void buildings.offsetWidth;
+      buildings.classList.add("rattling");
+    }
+    tremor.addEventListener("click", shake);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-quake-rattle-shake-ij/style.css
+++ b/submissions/examples/ease-quake-rattle-shake-ij/style.css
@@ -1,0 +1,162 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a2230;
+  font-family: system-ui, sans-serif;
+}
+
+.city {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.buildings {
+  position: relative;
+  width: 320px;
+  height: 200px;
+}
+
+.build {
+  position: absolute;
+  bottom: 0;
+  border-radius: 4px 4px 0 0;
+  transform-origin: 50% 100%;
+}
+
+.build::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0 14px,
+    rgba(0, 0, 0, 0.25) 14px 16px
+  );
+}
+
+.build-1 {
+  left: 10px;
+  width: 50px;
+  height: 110px;
+  background: linear-gradient(180deg, #6f88a8, #4a5f80);
+}
+
+.build-2 {
+  left: 64px;
+  width: 60px;
+  height: 150px;
+  background: linear-gradient(180deg, #8a9a6f, #5d6b4a);
+}
+
+.build-3 {
+  left: 128px;
+  width: 70px;
+  height: 180px;
+  background: linear-gradient(180deg, #a06f8a, #6b4a60);
+}
+
+.build-4 {
+  left: 202px;
+  width: 54px;
+  height: 130px;
+  background: linear-gradient(180deg, #a89a6f, #6b624a);
+}
+
+.build-5 {
+  left: 258px;
+  width: 52px;
+  height: 96px;
+  background: linear-gradient(180deg, #6f8aa0, #4a6278);
+}
+
+.buildings.rattling .build-1 {
+  animation: rattle-sm 0.5s ease-in-out infinite;
+}
+
+.buildings.rattling .build-2 {
+  animation: rattle-lg 0.5s ease-in-out infinite;
+  animation-delay: -0.1s;
+}
+
+.buildings.rattling .build-3 {
+  animation: rattle-lg 0.5s ease-in-out infinite;
+}
+
+.buildings.rattling .build-4 {
+  animation: rattle-sm 0.5s ease-in-out infinite;
+  animation-delay: -0.2s;
+}
+
+.buildings.rattling .build-5 {
+  animation: rattle-sm 0.5s ease-in-out infinite;
+  animation-delay: -0.35s;
+}
+
+@keyframes rattle-sm {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(1.2deg);
+  }
+  75% {
+    transform: rotate(-1.2deg);
+  }
+}
+
+@keyframes rattle-lg {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(2.2deg);
+  }
+  75% {
+    transform: rotate(-2.2deg);
+  }
+}
+
+.ground {
+  width: 320px;
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #6a7684, #48525e);
+}
+
+.tremor {
+  padding: 10px 22px;
+  border: none;
+  border-radius: 8px;
+  background: #d8a24a;
+  color: #241a08;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.tremor:hover {
+  background: #eec06f;
+  transform: translateY(-2px);
+}
+
+.hint {
+  color: #b9c2ce;
+  font-size: 13px;
+  opacity: 0.8;
+  text-align: center;
+  max-width: 300px;
+}


### PR DESCRIPTION
Adds a working `ease-quake-rattle-shake-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-quake-rattle-shake-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.