### PR TITLE
feat: add ease-waterfall-cascade-ij demo component

### DIFF
--- a/submissions/examples/ease-waterfall-cascade-ij/README.md
+++ b/submissions/examples/ease-waterfall-cascade-ij/README.md
@@ -1,0 +1,36 @@
+# Waterfall Cascade
+
+Streams of water pour over a rocky ledge, rippling as they fall into a misty pool below.
+
+## How is it used?
+
+Three falling streams share one pour keyframe with staggered delays; a blurred ellipse at the base breathes like mist:
+
+```css
+.fall {
+  transform-origin: 50% 0;
+  animation: pour 2.4s ease-in infinite;
+}
+
+.fall-2 {
+  animation-delay: -0.8s;
+}
+
+@keyframes pour {
+  0% {
+    transform: scaleY(0.4) skewX(0deg);
+    opacity: 0.85;
+  }
+  45% {
+    transform: scaleY(1) skewX(4deg);
+  }
+}
+
+.mist {
+  animation: mist-breath 2.4s ease-in-out infinite alternate;
+}
+```
+
+## Why is it useful?
+
+`scaleY` accelerates the stream's fall while `skewX` fakes turbulence — fluid motion from two transforms. Staggered delays keep streams unsynced, and a pulsing blurred ellipse sells splash and mist without particles.

--- a/submissions/examples/ease-waterfall-cascade-ij/demo.html
+++ b/submissions/examples/ease-waterfall-cascade-ij/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Waterfall Cascade Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="gorge">
+    <div class="falls" id="falls" aria-hidden="true">
+      <div class="fall fall-1"></div>
+      <div class="fall fall-2"></div>
+      <div class="fall fall-3"></div>
+      <div class="mist"></div>
+    </div>
+    <p class="hint">Water pours over the ledge in streams that ripple as they fall.</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-waterfall-cascade-ij/style.css
+++ b/submissions/examples/ease-waterfall-cascade-ij/style.css
@@ -1,0 +1,115 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1c3a38;
+  font-family: system-ui, sans-serif;
+}
+
+.gorge {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  overflow: hidden;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #8ab0a0, #5c8472 40%, #35504a 41%);
+}
+
+.gorge::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 34%;
+  background: linear-gradient(180deg, #93b8a8, #6f9888);
+  border-bottom: 6px solid #4a6a5c;
+}
+
+.falls {
+  position: absolute;
+  inset: 0;
+}
+
+.fall {
+  position: absolute;
+  top: 32%;
+  width: 18px;
+  background: linear-gradient(180deg, #d6efe8, #9fd4c8);
+  border-radius: 0 0 40% 40%;
+  transform-origin: 50% 0;
+  animation: pour 2.4s ease-in infinite;
+}
+
+.fall-1 {
+  left: 28%;
+  height: 46%;
+}
+
+.fall-2 {
+  left: 46%;
+  height: 60%;
+  animation-delay: -0.8s;
+}
+
+.fall-3 {
+  left: 62%;
+  height: 52%;
+  animation-delay: -1.6s;
+}
+
+@keyframes pour {
+  0% {
+    transform: scaleY(0.4) skewX(0deg);
+    opacity: 0.85;
+  }
+  45% {
+    transform: scaleY(1) skewX(4deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scaleY(1.05) skewX(-3deg);
+    opacity: 0.9;
+  }
+}
+
+.mist {
+  position: absolute;
+  bottom: 4%;
+  left: 20%;
+  width: 60%;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(214, 239, 232, 0.8), transparent 70%);
+  filter: blur(3px);
+  animation: mist-breath 2.4s ease-in-out infinite alternate;
+}
+
+@keyframes mist-breath {
+  0% {
+    transform: scaleX(1);
+    opacity: 0.5;
+  }
+  100% {
+    transform: scaleX(1.25);
+    opacity: 0.9;
+  }
+}
+
+.hint {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #d2e8e2;
+  font-size: 12px;
+  opacity: 0.9;
+}


### PR DESCRIPTION
Adds a working `ease-waterfall-cascade-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-waterfall-cascade-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.