### PR TITLE
feat: add memory-shard component

### DIFF
--- a/submissions/examples/memory-shard/README.md
+++ b/submissions/examples/memory-shard/README.md
@@ -1,0 +1,51 @@
+# Memory Shard
+
+Memory Shard is an experimental interactive interface for exploring fragmented information.
+
+Instead of displaying information as conventional cards, the component represents a damaged memory as a collection of independent shards.
+
+Users can inspect individual fragments and progressively reconstruct the entire memory.
+
+---
+
+## Concept
+
+The interface is based around a simple idea:
+
+> Information can survive even when its structure is broken.
+
+The central object represents a corrupted memory.
+
+Each shard contains one piece of information.
+
+As shards are reconstructed, the overall memory gradually becomes complete.
+
+---
+
+## Features
+
+- 10 interactive memory shards
+- Irregular shard geometry
+- Hover inspection
+- Click reconstruction
+- Keyboard accessibility
+- Dynamic reconstruction percentage
+- Dynamic archive state
+- Fragment inspector
+- Reconstruction preview
+- Restore All
+- Reset Memory
+- Responsive layout
+- Reduced-motion support
+- No external dependencies
+
+---
+
+## Memory States
+
+The component has three primary states.
+
+### Fragmented
+
+```text
+0% — 39%

--- a/submissions/examples/memory-shard/demo.html
+++ b/submissions/examples/memory-shard/demo.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="Memory Shard interactive fractured-memory component"
+  >
+
+  <title>Memory Shard</title>
+
+  <link
+    rel="stylesheet"
+    href="style.css"
+  >
+
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="memory-interface">
+
+      <header class="header">
+
+        <div>
+
+          <span class="eyebrow">
+            ARCHIVE RECOVERY / MS-17
+          </span>
+
+          <h1>
+            Memory Shard
+          </h1>
+
+          <p>
+            Recover fragmented information from a damaged memory structure.
+          </p>
+
+        </div>
+
+        <div class="system-state">
+
+          <span class="state-dot"></span>
+
+          <div>
+
+            <small>
+              ARCHIVE STATE
+            </small>
+
+            <strong id="systemState">
+              FRAGMENTED
+            </strong>
+
+          </div>
+
+        </div>
+
+      </header>
+
+
+      <section class="workspace">
+
+
+        <div class="memory-stage">
+
+          <div class="stage-label top">
+            MEMORY CORE / 01
+          </div>
+
+          <div class="stage-label bottom">
+            10 FRAGMENTS DETECTED
+          </div>
+
+
+          <div
+            class="memory-core"
+            id="memoryCore"
+          >
+
+            <div class="fracture fracture-a"></div>
+            <div class="fracture fracture-b"></div>
+            <div class="fracture fracture-c"></div>
+            <div class="fracture fracture-d"></div>
+
+
+            <button
+              class="shard shard-1"
+              data-id="SHARD-01"
+              data-type="LOCATION"
+              data-time="14:21:08"
+              data-confidence="96%"
+              data-content="North entrance detected."
+              aria-label="Memory shard 1"
+            >
+              <span>01</span>
+            </button>
+
+
+            <button
+              class="shard shard-2"
+              data-id="SHARD-02"
+              data-type="IDENTITY"
+              data-time="14:24:17"
+              data-confidence="91%"
+              data-content="Unknown subject entered the corridor."
+              aria-label="Memory shard 2"
+            >
+              <span>02</span>
+            </button>
+
+
+            <button
+              class="shard shard-3"
+              data-id="SHARD-03"
+              data-type="AUDIO"
+              data-time="14:27:43"
+              data-confidence="78%"
+              data-content="Low-frequency signal detected."
+              aria-label="Memory shard 3"
+            >
+              <span>03</span>
+            </button>
+
+
+            <button
+              class="shard shard-4"
+              data-id="SHARD-04"
+              data-type="MOTION"
+              data-time="14:32:08"
+              data-confidence="94%"
+              data-content="Movement detected in the east corridor."
+              aria-label="Memory shard 4"
+            >
+              <span>04</span>
+            </button>
+
+
+            <button
+              class="shard shard-5"
+              data-id="SHARD-05"
+              data-type="SYSTEM"
+              data-time="14:35:52"
+              data-confidence="82%"
+              data-content="Security protocol entered standby."
+              aria-label="Memory shard 5"
+            >
+              <span>05</span>
+            </button>
+
+
+            <button
+              class="shard shard-6"
+              data-id="SHARD-06"
+              data-type="EVENT"
+              data-time="14:38:31"
+              data-confidence="88%"
+              data-content="Unauthorized access detected."
+              aria-label="Memory shard 6"
+            >
+              <span>06</span>
+            </button>
+
+
+            <button
+              class="shard shard-7"
+              data-id="SHARD-07"
+              data-type="VISUAL"
+              data-time="14:42:12"
+              data-confidence="73%"
+              data-content="Light source detected behind sealed door."
+              aria-label="Memory shard 7"
+            >
+              <span>07</span>
+            </button>
+
+
+            <button
+              class="shard shard-8"
+              data-id="SHARD-08"
+              data-type="NETWORK"
+              data-time="14:47:09"
+              data-confidence="89%"
+              data-content="External network handshake initiated."
+              aria-label="Memory shard 8"
+            >
+              <span>08</span>
+            </button>
+
+
+            <button
+              class="shard shard-9"
+              data-id="SHARD-09"
+              data-type="THREAT"
+              data-time="14:51:44"
+              data-confidence="97%"
+              data-content="Threat classification confirmed."
+              aria-label="Memory shard 9"
+            >
+              <span>09</span>
+            </button>
+
+
+            <button
+              class="shard shard-10"
+              data-id="SHARD-10"
+              data-type="RECOVERY"
+              data-time="14:58:02"
+              data-confidence="93%"
+              data-content="Emergency restoration sequence initiated."
+              aria-label="Memory shard 10"
+            >
+              <span>10</span>
+            </button>
+
+
+            <div class="core-label">
+
+              <span>
+                MEMORY
+              </span>
+
+              <strong id="progress">
+                0%
+              </strong>
+
+              <small>
+                RESTORED
+              </small>
+
+            </div>
+
+          </div>
+
+
+          <div class="stage-controls">
+
+            <button
+              id="restoreAll"
+              class="control-button"
+            >
+              RESTORE ALL
+            </button>
+
+            <button
+              id="resetMemory"
+              class="control-button secondary"
+            >
+              RESET MEMORY
+            </button>
+
+          </div>
+
+        </div>
+
+
+        <aside class="inspector">
+
+          <div class="inspector-header">
+
+            <span>
+              FRAGMENT INSPECTOR
+            </span>
+
+            <span id="fragmentCount">
+              00 / 10
+            </span>
+
+          </div>
+
+
+          <div class="inspector-body">
+
+            <span class="fragment-label">
+              SELECTED FRAGMENT
+            </span>
+
+            <h2 id="fragmentId">
+              SHARD-01
+            </h2>
+
+            <div class="fragment-type">
+              LOCATION
+            </div>
+
+
+            <div class="fragment-metadata">
+
+              <div>
+
+                <small>
+                  TIMESTAMP
+                </small>
+
+                <strong id="fragmentTime">
+                  14:21:08
+                </strong>
+
+              </div>
+
+
+              <div>
+
+                <small>
+                  CONFIDENCE
+                </small>
+
+                <strong id="fragmentConfidence">
+                  96%
+                </strong>
+
+              </div>
+
+            </div>
+
+
+            <div class="fragment-content">
+
+              <small>
+                RECOVERED CONTENT
+              </small>
+
+              <p id="fragmentContent">
+                North entrance detected.
+              </p>
+
+            </div>
+
+
+            <div class="preview">
+
+              <span>
+                RECONSTRUCTION PREVIEW
+              </span>
+
+              <div class="preview-lines">
+
+                <i></i>
+                <i></i>
+                <i></i>
+                <i></i>
+
+              </div>
+
+            </div>
+
+          </div>
+
+
+          <div class="inspector-footer">
+
+            <span>
+              HOVER TO INSPECT
+            </span>
+
+            <span>
+              ENTER TO RESTORE
+            </span>
+
+          </div>
+
+        </aside>
+
+      </section>
+
+
+      <footer class="footer">
+
+        <span>
+          MEMORY SHARD / MS-17
+        </span>
+
+        <span>
+          ARCHIVE RECOVERY SYSTEM
+        </span>
+
+        <span>
+          10 FRAGMENTS
+        </span>
+
+      </footer>
+
+    </section>
+
+  </main>
+
+
+  <script src="script.js"></script>
+
+</body>
+
+</html>

--- a/submissions/examples/memory-shard/style.css
+++ b/submissions/examples/memory-shard/style.css
@@ -1,0 +1,1192 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+
+:root {
+
+  --bg: #07080b;
+  --surface: #0c0e13;
+
+  --border: #272c35;
+  --border-soft: #1b1f27;
+
+  --text: #edf1f5;
+  --muted: #858d98;
+  --dim: #4e5661;
+
+  --accent: #c5a7ff;
+  --accent-soft: rgba(197,167,255,.11);
+
+  --success: #a7ffc9;
+}
+
+
+html {
+  color-scheme: dark;
+}
+
+
+body {
+
+  min-height: 100vh;
+
+  background:
+    radial-gradient(
+      circle at 50% 20%,
+      rgba(197,167,255,.07),
+      transparent 38%
+    ),
+    var(--bg);
+
+  color: var(--text);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+
+button {
+  font: inherit;
+}
+
+
+.page {
+
+  min-height: 100vh;
+
+  display: grid;
+
+  place-items: center;
+
+  padding: 40px 20px;
+}
+
+
+.memory-interface {
+
+  width: min(1120px, 100%);
+
+  padding: 44px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 28px;
+
+  background:
+    rgba(10,12,17,.96);
+
+  box-shadow:
+    0 50px 130px rgba(0,0,0,.55);
+}
+
+
+/* HEADER */
+
+
+.header {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  align-items: flex-start;
+
+  gap: 30px;
+
+  margin-bottom: 32px;
+}
+
+
+.eyebrow {
+
+  display: block;
+
+  margin-bottom: 10px;
+
+  color: var(--accent);
+
+  font-size: 8px;
+
+  font-weight: 800;
+
+  letter-spacing: .2em;
+}
+
+
+.header h1 {
+
+  font-size:
+    clamp(40px,6vw,64px);
+
+  line-height: .9;
+
+  letter-spacing: -.07em;
+}
+
+
+.header p {
+
+  max-width: 520px;
+
+  margin-top: 14px;
+
+  color: var(--muted);
+
+  font-size: 13px;
+
+  line-height: 1.6;
+}
+
+
+.system-state {
+
+  display: flex;
+
+  align-items: center;
+
+  gap: 10px;
+
+  padding: 11px 14px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 11px;
+}
+
+
+.state-dot {
+
+  width: 7px;
+
+  height: 7px;
+
+  border-radius: 50%;
+
+  background: var(--accent);
+
+  box-shadow:
+    0 0 14px rgba(197,167,255,.7);
+}
+
+
+.system-state small {
+
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+
+.system-state strong {
+
+  display: block;
+
+  margin-top: 3px;
+
+  font-size: 9px;
+
+  letter-spacing: .1em;
+}
+
+
+/* WORKSPACE */
+
+
+.workspace {
+
+  display: grid;
+
+  grid-template-columns:
+    minmax(0,1fr)
+    280px;
+
+  gap: 16px;
+}
+
+
+/* MEMORY STAGE */
+
+
+.memory-stage {
+
+  position: relative;
+
+  min-height: 650px;
+
+  overflow: hidden;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 20px;
+
+  background:
+    radial-gradient(
+      circle at center,
+      rgba(197,167,255,.045),
+      transparent 55%
+    ),
+    #080a0f;
+}
+
+
+.memory-stage::before {
+
+  content: "";
+
+  position: absolute;
+
+  inset: 0;
+
+  background:
+    linear-gradient(
+      45deg,
+      transparent 49.8%,
+      rgba(255,255,255,.018) 50%,
+      transparent 50.2%
+    );
+
+  background-size:
+    30px 30px;
+
+  opacity: .4;
+}
+
+
+.stage-label {
+
+  position: absolute;
+
+  z-index: 20;
+
+  color: var(--dim);
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 6px;
+
+  letter-spacing: .15em;
+}
+
+
+.stage-label.top {
+
+  top: 16px;
+
+  left: 18px;
+}
+
+
+.stage-label.bottom {
+
+  bottom: 16px;
+
+  left: 18px;
+}
+
+
+/* CORE */
+
+
+.memory-core {
+
+  position: absolute;
+
+  left: 50%;
+
+  top: 47%;
+
+  width: 440px;
+
+  height: 440px;
+
+  transform:
+    translate(-50%,-50%)
+    rotate(-4deg);
+
+  filter:
+    drop-shadow(
+      0 0 45px
+      rgba(197,167,255,.06)
+    );
+}
+
+
+/* FRACTURES */
+
+
+.fracture {
+
+  position: absolute;
+
+  z-index: 7;
+
+  pointer-events: none;
+
+  background:
+    rgba(197,167,255,.18);
+
+  transform-origin: center;
+
+  transition:
+    background 300ms ease,
+    box-shadow 300ms ease;
+}
+
+
+.fracture-a {
+
+  left: 42%;
+
+  top: 4%;
+
+  width: 1px;
+
+  height: 93%;
+
+  transform:
+    rotate(15deg);
+}
+
+
+.fracture-b {
+
+  left: 8%;
+
+  top: 48%;
+
+  width: 87%;
+
+  height: 1px;
+
+  transform:
+    rotate(-23deg);
+}
+
+
+.fracture-c {
+
+  left: 28%;
+
+  top: 13%;
+
+  width: 1px;
+
+  height: 82%;
+
+  transform:
+    rotate(-43deg);
+}
+
+
+.fracture-d {
+
+  left: 9%;
+
+  top: 34%;
+
+  width: 86%;
+
+  height: 1px;
+
+  transform:
+    rotate(38deg);
+}
+
+
+/* SHARDS */
+
+
+.shard {
+
+  position: absolute;
+
+  z-index: 10;
+
+  display: grid;
+
+  place-items: center;
+
+  border: 0;
+
+  cursor: pointer;
+
+  color: rgba(255,255,255,.35);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(197,167,255,.09),
+      rgba(255,255,255,.018)
+    );
+
+  clip-path:
+    polygon(
+      13% 4%,
+      82% 0%,
+      100% 35%,
+      84% 93%,
+      32% 100%,
+      0% 63%
+    );
+
+  transition:
+    transform 260ms ease,
+    background 260ms ease,
+    color 260ms ease,
+    filter 260ms ease;
+}
+
+
+.shard span {
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 8px;
+
+  letter-spacing: .08em;
+}
+
+
+.shard::after {
+
+  content: "";
+
+  position: absolute;
+
+  inset: 10px;
+
+  border:
+    1px solid rgba(255,255,255,.04);
+
+  clip-path:
+    inherit;
+}
+
+
+/* SHARD POSITIONS */
+
+
+.shard-1 {
+
+  left: 8%;
+
+  top: 7%;
+
+  width: 150px;
+
+  height: 145px;
+}
+
+
+.shard-2 {
+
+  left: 39%;
+
+  top: 1%;
+
+  width: 160px;
+
+  height: 135px;
+}
+
+
+.shard-3 {
+
+  right: 3%;
+
+  top: 13%;
+
+  width: 135px;
+
+  height: 155px;
+}
+
+
+.shard-4 {
+
+  left: 0;
+
+  top: 39%;
+
+  width: 155px;
+
+  height: 165px;
+}
+
+
+.shard-5 {
+
+  left: 34%;
+
+  top: 31%;
+
+  width: 155px;
+
+  height: 150px;
+}
+
+
+.shard-6 {
+
+  right: 0;
+
+  top: 39%;
+
+  width: 160px;
+
+  height: 155px;
+}
+
+
+.shard-7 {
+
+  left: 8%;
+
+  bottom: 1%;
+
+  width: 150px;
+
+  height: 145px;
+}
+
+
+.shard-8 {
+
+  left: 39%;
+
+  bottom: 0;
+
+  width: 155px;
+
+  height: 150px;
+}
+
+
+.shard-9 {
+
+  right: 4%;
+
+  bottom: 4%;
+
+  width: 145px;
+
+  height: 150px;
+}
+
+
+.shard-10 {
+
+  left: 32%;
+
+  top: 54%;
+
+  width: 170px;
+
+  height: 160px;
+}
+
+
+/* INTERACTION */
+
+
+.shard:hover,
+.shard:focus-visible {
+
+  z-index: 25;
+
+  color: var(--text);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(197,167,255,.25),
+      rgba(197,167,255,.05)
+    );
+
+  transform:
+    scale(1.06)
+    translateY(-5px);
+
+  filter:
+    drop-shadow(
+      0 0 20px
+      rgba(197,167,255,.2)
+    );
+}
+
+
+.shard:focus-visible {
+
+  outline:
+    1px solid var(--accent);
+
+  outline-offset:
+    7px;
+}
+
+
+.shard.reconstructed {
+
+  color: var(--text);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(197,167,255,.32),
+      rgba(197,167,255,.07)
+    );
+
+  filter:
+    drop-shadow(
+      0 0 22px
+      rgba(197,167,255,.22)
+    );
+}
+
+
+.shard.reconstructed::after {
+
+  border-color:
+    rgba(197,167,255,.2);
+}
+
+
+/* CORE LABEL */
+
+
+.core-label {
+
+  position: absolute;
+
+  z-index: 5;
+
+  left: 50%;
+
+  top: 50%;
+
+  width: 105px;
+
+  height: 105px;
+
+  transform:
+    translate(-50%,-50%)
+    rotate(4deg);
+
+  display: flex;
+
+  flex-direction: column;
+
+  align-items: center;
+
+  justify-content: center;
+
+  border:
+    1px solid rgba(197,167,255,.2);
+
+  border-radius: 50%;
+
+  background:
+    rgba(8,10,15,.72);
+
+  backdrop-filter:
+    blur(10px);
+}
+
+
+.core-label span {
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .16em;
+}
+
+
+.core-label strong {
+
+  margin-top: 5px;
+
+  color: var(--accent);
+
+  font-size: 24px;
+
+  letter-spacing: -.05em;
+}
+
+
+.core-label small {
+
+  margin-top: 2px;
+
+  color: var(--dim);
+
+  font-size: 5px;
+
+  letter-spacing: .13em;
+}
+
+
+/* CONTROLS */
+
+
+.stage-controls {
+
+  position: absolute;
+
+  z-index: 30;
+
+  right: 16px;
+
+  bottom: 14px;
+
+  display: flex;
+
+  gap: 6px;
+}
+
+
+.control-button {
+
+  padding: 8px 10px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 7px;
+
+  color: var(--muted);
+
+  background:
+    rgba(8,10,15,.8);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+
+  cursor: pointer;
+}
+
+
+.control-button:hover {
+
+  border-color:
+    rgba(197,167,255,.35);
+
+  color: var(--text);
+}
+
+
+.control-button.secondary {
+
+  color: var(--dim);
+}
+
+
+/* INSPECTOR */
+
+
+.inspector {
+
+  display: flex;
+
+  flex-direction: column;
+
+  min-height: 650px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 18px;
+
+  background:
+    rgba(255,255,255,.012);
+
+  overflow: hidden;
+}
+
+
+.inspector-header {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  padding: 15px;
+
+  border-bottom:
+    1px solid var(--border);
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .13em;
+}
+
+
+.inspector-body {
+
+  flex: 1;
+
+  padding: 25px 18px;
+}
+
+
+.fragment-label {
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+
+.inspector h2 {
+
+  margin-top: 8px;
+
+  font-size: 30px;
+
+  letter-spacing: -.06em;
+}
+
+
+.fragment-type {
+
+  display: inline-block;
+
+  margin-top: 7px;
+
+  padding: 5px 7px;
+
+  border:
+    1px solid rgba(197,167,255,.2);
+
+  border-radius: 5px;
+
+  color: var(--accent);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.fragment-metadata {
+
+  display: grid;
+
+  grid-template-columns:
+    1fr 1fr;
+
+  gap: 10px;
+
+  margin-top: 30px;
+}
+
+
+.fragment-metadata div {
+
+  padding-top: 12px;
+
+  border-top:
+    1px solid var(--border);
+}
+
+
+.fragment-metadata small,
+.fragment-content small {
+
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.fragment-metadata strong {
+
+  display: block;
+
+  margin-top: 6px;
+
+  font-size: 9px;
+}
+
+
+.fragment-content {
+
+  margin-top: 30px;
+}
+
+
+.fragment-content p {
+
+  margin-top: 9px;
+
+  color: var(--muted);
+
+  font-size: 12px;
+
+  line-height: 1.7;
+}
+
+
+/* PREVIEW */
+
+
+.preview {
+
+  margin-top: 30px;
+
+  padding-top: 15px;
+
+  border-top:
+    1px solid var(--border);
+}
+
+
+.preview > span {
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+}
+
+
+.preview-lines {
+
+  margin-top: 14px;
+}
+
+
+.preview-lines i {
+
+  display: block;
+
+  width: 100%;
+
+  height: 2px;
+
+  margin-top: 6px;
+
+  background:
+    rgba(197,167,255,.16);
+}
+
+
+.preview-lines i:nth-child(2) {
+  width: 72%;
+}
+
+
+.preview-lines i:nth-child(3) {
+  width: 87%;
+}
+
+
+.preview-lines i:nth-child(4) {
+  width: 48%;
+}
+
+
+/* INSPECTOR FOOTER */
+
+
+.inspector-footer {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  padding: 12px 15px;
+
+  border-top:
+    1px solid var(--border);
+
+  color: var(--dim);
+
+  font-size: 5px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* FOOTER */
+
+
+.footer {
+
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 18px;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* RESPONSIVE */
+
+
+@media (max-width: 900px) {
+
+  .workspace {
+
+    grid-template-columns:
+      1fr;
+  }
+
+
+  .inspector {
+
+    min-height:
+      400px;
+  }
+
+}
+
+
+@media (max-width: 650px) {
+
+  .page {
+
+    padding: 15px 9px;
+  }
+
+
+  .memory-interface {
+
+    padding: 22px 15px;
+  }
+
+
+  .header {
+
+    flex-direction:
+      column;
+  }
+
+
+  .system-state {
+
+    width: 100%;
+  }
+
+
+  .memory-stage {
+
+    min-height:
+      470px;
+  }
+
+
+  .memory-core {
+
+    width: 330px;
+
+    height: 330px;
+  }
+
+
+  .shard-1,
+  .shard-2,
+  .shard-3,
+  .shard-4,
+  .shard-5,
+  .shard-6,
+  .shard-7,
+  .shard-8,
+  .shard-9,
+  .shard-10 {
+
+    width: 105px;
+
+    height: 105px;
+  }
+
+
+  .core-label {
+
+    width: 80px;
+
+    height: 80px;
+  }
+
+
+  .core-label strong {
+
+    font-size: 18px;
+  }
+
+
+  .footer {
+
+    flex-direction:
+      column;
+
+    gap: 8px;
+  }
+
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+
+  .shard,
+  .fracture,
+  .control-button {
+
+    transition: none;
+  }
+
+}


### PR DESCRIPTION
## Description

closes #76217

This PR adds the new `Memory Shard` interactive component.

The component visualizes fragmented information as a fractured digital memory structure that users can inspect and progressively reconstruct.

## What Changed

- Added Memory Shard interactive visualization
- Added 10 unique memory fragments
- Added irregular shard geometry
- Added hover-based fragment inspection
- Added click-to-reconstruct interaction
- Added dynamic reconstruction percentage
- Added dynamic memory state
- Added fragment inspector panel
- Added reconstruction preview
- Added Restore All functionality
- Added Reset Memory functionality
- Added keyboard interaction
- Added visible focus states
- Added responsive layouts
- Added reduced-motion support
- Added README documentation

## Interaction

Users can:

- Hover over shards to inspect their contents
- Click shards to reconstruct them
- Use Tab to navigate between shards
- Use Enter or Space to reconstruct a focused shard
- Restore the complete memory using Restore All
- Reset the memory using Reset Memory

## Accessibility

All memory shards are implemented as native buttons and are keyboard accessible.

Visible focus states are included.

The component also respects:

```css
@media (prefers-reduced-motion: reduce)