### PR TITLE
feat: add pulsating wave dropdown menu

### DIFF
--- a/submissions/examples/pulsating-wave-dropdown-msm/README.md
+++ b/submissions/examples/pulsating-wave-dropdown-msm/README.md
@@ -1,0 +1,28 @@
+# Pulsating Wave Dropdown
+
+## What does this do?
+
+The Pulsating Wave Dropdown adds a pure HTML/CSS navigation menu with soft pulse rings around the trigger and ripple feedback on each menu item.
+
+## How is it used?
+
+Place the dropdown in a navigation area and include the local stylesheet:
+
+```html
+<nav class="pulse-dropdown" aria-label="Pulsating wave navigation">
+  <button class="pulse-trigger" type="button" aria-haspopup="true">
+    Signal menu
+    <span class="pulse-caret" aria-hidden="true"></span>
+  </button>
+
+  <ul class="pulse-menu" aria-label="Pulsating wave navigation">
+    <li><a href="#pulse">Pulse channel</a></li>
+    <li><a href="#echo">Echo pattern</a></li>
+    <li><a href="#beacon">Beacon loop</a></li>
+  </ul>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users an energetic dropdown pattern that communicates interactivity through motion while staying dependency-free, responsive, keyboard-friendly, dark-mode compatible, and respectful of reduced-motion preferences.

--- a/submissions/examples/pulsating-wave-dropdown-msm/demo.html
+++ b/submissions/examples/pulsating-wave-dropdown-msm/demo.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pulsating Wave Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="pulse-stage">
+      <section class="pulse-card" aria-labelledby="dropdown-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="dropdown-title">Pulsating Wave</h1>
+        <p class="intro">
+          A pure CSS dropdown menu with rhythmic wave rings that pulse outward
+          from the trigger and ripple through each option.
+        </p>
+
+        <nav class="pulse-dropdown" aria-label="Pulsating wave navigation">
+          <button class="pulse-trigger" type="button" aria-haspopup="true">
+            Signal menu
+            <span class="pulse-caret" aria-hidden="true"></span>
+          </button>
+
+          <ul class="pulse-menu" aria-label="Pulsating wave navigation">
+            <li>
+              <a href="#pulse">
+                <span class="pulse-dot pulse-dot-one" aria-hidden="true"></span>
+                Pulse channel
+              </a>
+            </li>
+            <li>
+              <a href="#echo">
+                <span class="pulse-dot pulse-dot-two" aria-hidden="true"></span>
+                Echo pattern
+              </a>
+            </li>
+            <li>
+              <a href="#beacon">
+                <span
+                  class="pulse-dot pulse-dot-three"
+                  aria-hidden="true"
+                ></span>
+                Beacon loop
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/pulsating-wave-dropdown-msm/style.css
+++ b/submissions/examples/pulsating-wave-dropdown-msm/style.css
@@ -1,0 +1,367 @@
+:root {
+  --ink: #17202b;
+  --muted: #667283;
+  --paper: rgba(255, 255, 255, 0.88);
+  --mist: #f6fbff;
+  --cyan: #28d8ff;
+  --indigo: #5268ff;
+  --rose: #ff5f8f;
+  --sun: #ffc857;
+  --ring: rgba(40, 216, 255, 0.24);
+  --shadow: rgba(23, 32, 43, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: Aptos, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(
+      circle at 22% 18%,
+      rgba(40, 216, 255, 0.26),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 82% 78%,
+      rgba(255, 95, 143, 0.22),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f2fbff 0%, #f8f6ff 48%, #fff7e8 100%);
+}
+
+.pulse-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.pulse-card {
+  position: relative;
+  width: min(100%, 42rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.9),
+      rgba(246, 251, 255, 0.72)
+    ),
+    var(--paper);
+  box-shadow:
+    0 2rem 4.4rem var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  text-align: center;
+}
+
+.pulse-card::before,
+.pulse-card::after {
+  position: absolute;
+  inset: 1.1rem;
+  z-index: -1;
+  border: 1px solid var(--ring);
+  border-radius: 2.2rem;
+  content: "";
+  animation: ambient-pulse 4.8s ease-in-out infinite;
+}
+
+.pulse-card::after {
+  inset: 2rem;
+  border-color: rgba(255, 95, 143, 0.2);
+  animation-delay: 1.2s;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #4160d6;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.45rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 33rem;
+  margin: 1.15rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.pulse-dropdown {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.pulse-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.78rem;
+  min-width: 12.5rem;
+  padding: 0.98rem 1.3rem;
+  border: 0;
+  border-radius: 999px;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--indigo), #2345c9);
+  box-shadow:
+    0 1rem 2rem rgba(82, 104, 255, 0.28),
+    0 0 0 0.35rem rgba(40, 216, 255, 0.12);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  transition:
+    box-shadow 280ms ease,
+    transform 280ms ease;
+}
+
+.pulse-trigger::before,
+.pulse-trigger::after {
+  position: absolute;
+  inset: -0.55rem;
+  z-index: -1;
+  border: 2px solid rgba(40, 216, 255, 0.24);
+  border-radius: inherit;
+  content: "";
+  opacity: 0;
+  transform: scale(0.92);
+}
+
+.pulse-trigger::after {
+  border-color: rgba(255, 95, 143, 0.22);
+}
+
+.pulse-caret {
+  width: 0.66rem;
+  height: 0.66rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-0.12rem) rotate(45deg);
+  transition: transform 260ms ease;
+}
+
+.pulse-menu {
+  position: absolute;
+  top: calc(100% + 0.86rem);
+  left: 50%;
+  display: grid;
+  width: min(19rem, 86vw);
+  margin: 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.74);
+  border-radius: 1.55rem;
+  list-style: none;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1.35rem 2.8rem var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.65rem) scale(0.97);
+  transform-origin: top center;
+  transition:
+    opacity 220ms ease,
+    transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  backdrop-filter: blur(16px);
+}
+
+.pulse-menu a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  overflow: hidden;
+  padding: 0.88rem 1rem;
+  border-radius: 1rem;
+  color: var(--ink);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 220ms ease,
+    color 220ms ease,
+    transform 220ms ease;
+}
+
+.pulse-menu a::after {
+  position: absolute;
+  inset: 50% auto auto 1.48rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: rgba(40, 216, 255, 0.24);
+  content: "";
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.pulse-dot {
+  position: relative;
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--cyan);
+  box-shadow: 0 0 0 0.35rem rgba(40, 216, 255, 0.12);
+}
+
+.pulse-dot-two {
+  background: var(--rose);
+  box-shadow: 0 0 0 0.35rem rgba(255, 95, 143, 0.12);
+}
+
+.pulse-dot-three {
+  background: var(--sun);
+  box-shadow: 0 0 0 0.35rem rgba(255, 200, 87, 0.14);
+}
+
+.pulse-dropdown:hover .pulse-trigger,
+.pulse-dropdown:focus-within .pulse-trigger {
+  box-shadow:
+    0 1.25rem 2.45rem rgba(82, 104, 255, 0.34),
+    0 0 0 0.45rem rgba(40, 216, 255, 0.16);
+  transform: translateY(-0.16rem);
+}
+
+.pulse-dropdown:hover .pulse-trigger::before,
+.pulse-dropdown:focus-within .pulse-trigger::before {
+  animation: trigger-pulse 1.8s ease-out infinite;
+}
+
+.pulse-dropdown:hover .pulse-trigger::after,
+.pulse-dropdown:focus-within .pulse-trigger::after {
+  animation: trigger-pulse 1.8s ease-out 0.45s infinite;
+}
+
+.pulse-dropdown:hover .pulse-caret,
+.pulse-dropdown:focus-within .pulse-caret {
+  transform: translateY(0.08rem) rotate(225deg);
+}
+
+.pulse-dropdown:hover .pulse-menu,
+.pulse-dropdown:focus-within .pulse-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.pulse-menu a:hover,
+.pulse-menu a:focus-visible {
+  color: #304ac4;
+  background: linear-gradient(
+    90deg,
+    rgba(40, 216, 255, 0.14),
+    rgba(255, 95, 143, 0.1)
+  );
+  outline: none;
+  transform: translateX(0.18rem);
+}
+
+.pulse-menu a:hover::after,
+.pulse-menu a:focus-visible::after {
+  animation: item-ripple 720ms ease-out;
+}
+
+.pulse-trigger:focus-visible {
+  outline: 3px solid var(--rose);
+  outline-offset: 4px;
+}
+
+@keyframes ambient-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.98);
+  }
+
+  50% {
+    opacity: 0.18;
+    transform: scale(1.03);
+  }
+}
+
+@keyframes trigger-pulse {
+  0% {
+    opacity: 0.65;
+    transform: scale(0.96);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1.18);
+  }
+}
+
+@keyframes item-ripple {
+  0% {
+    opacity: 0.5;
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(16);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #edf8ff;
+    --muted: #a9b9c8;
+    --paper: rgba(11, 16, 28, 0.86);
+    --mist: #121a2b;
+    --shadow: rgba(0, 0, 0, 0.42);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 22% 18%,
+        rgba(40, 216, 255, 0.18),
+        transparent 24rem
+      ),
+      radial-gradient(
+        circle at 82% 78%,
+        rgba(255, 95, 143, 0.15),
+        transparent 28rem
+      ),
+      linear-gradient(135deg, #07111d 0%, #121329 50%, #231320 100%);
+  }
+
+  .pulse-card,
+  .pulse-menu {
+    background: var(--paper);
+  }
+}
+
+@media (max-width: 35rem) {
+  .pulse-stage {
+    padding: 1rem;
+  }
+
+  .pulse-card {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new Pulsating Wave dropdown menu example under `submissions/examples/pulsating-wave-dropdown-msm/`.
- Implements CSS pulse rings around the trigger and ripple feedback on menu items.
- Includes responsive layout, dark-mode styling, keyboard focus behavior, and reduced-motion handling.

## Linked Issue
Closes #73666

## Changes Made
- Added `demo.html` with semantic dropdown navigation markup and accessible labels.
- Added `style.css` with pure CSS pulsating wave animations and focus-visible states.
- Added `README.md` documenting purpose, usage, and EaseMotion fit.

## Testing
- `npx.cmd prettier --check submissions/examples/pulsating-wave-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/pulsating-wave-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge Cases Handled
- Keyboard interaction through `:focus-within` and `:focus-visible`.
- Mobile-friendly dropdown width and card padding.
- Dark-mode color overrides.
- Reduced-motion preference respected.

## Screenshots
- UI-only HTML/CSS example; screenshots can be captured from `submissions/examples/pulsating-wave-dropdown-msm/demo.html` if requested.

## Checklist
- [x] I read the README and CONTRIBUTING guidelines.
- [x] The issue is assigned to `@mittalsonal`.
- [x] No existing PR was found for this issue/branch.
- [x] Only required submission files are included.
- [x] Formatting, linting, and diff checks passed locally.