### PR TITLE
feat: add ease-scroll-image-reveal-clip-sap

### DIFF
--- a/submissions/examples/ease-scroll-image-reveal-clip-sap/README.md
+++ b/submissions/examples/ease-scroll-image-reveal-clip-sap/README.md
@@ -1,0 +1,33 @@
+# Scroll Image Reveal Clip
+
+An image that's initially clipped to zero visible width and wipes fully
+into view (left to right) as it enters the viewport, via an animated
+`clip-path`.
+
+**Level:** Intermediate
+
+## Usage
+
+`.clip-img` starts fully clipped (`inset(0 100% 0 0)`). An
+`IntersectionObserver` adds `.is-revealed` once the image crosses 30%
+visibility, animating `clip-path` to `inset(0 0 0 0)` — a left-to-right wipe.
+
+## Accessibility
+
+- The `<img>` retains its full, real `alt` text at all times — the clip is
+  a pure visual reveal effect and doesn't affect the image's presence or
+  description in the accessibility tree.
+- The reveal triggers once (`unobserve` after triggering), so re-scrolling
+  past the image doesn't repeatedly re-clip and re-reveal it.
+- `prefers-reduced-motion` sets the image to its fully-revealed clip state
+  immediately with no transition, so the image is never left artificially
+  hidden for motion-reduced users who might not trigger a scroll-based reveal.
+
+## Notes
+
+- Using `clip-path: inset()` (rather than `width`/`transform`) means the
+  image element keeps its full final layout box the whole time — only the
+  visible painted region changes — which avoids any layout reflow during
+  the reveal animation.
+- The `round 16px` argument on `inset()` keeps the image's rounded corners
+  consistent throughout the wipe, rather than only appearing once fully revealed.

--- a/submissions/examples/ease-scroll-image-reveal-clip-sap/demo.html
+++ b/submissions/examples/ease-scroll-image-reveal-clip-sap/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Image Reveal Clip</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Image Reveal Clip</h1><p>Scroll down — the image reveals via an expanding clip-path.</p></section>
+
+    <section class="reveal-section">
+      <figure class="clip-frame">
+        <img src="https://picsum.photos/seed/clipreveal/560/360" alt="Coastal cliffside view" class="clip-img" id="clipImg">
+      </figure>
+    </section>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <script>
+    const img = document.getElementById('clipImg');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          img.classList.add('is-revealed');
+          observer.unobserve(img);
+        }
+      });
+    }, { threshold: 0.3 });
+    observer.observe(img);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-image-reveal-clip-sap/style.css
+++ b/submissions/examples/ease-scroll-image-reveal-clip-sap/style.css
@@ -1,0 +1,47 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #fafaf9;
+  color: #1c1917;
+  margin: 0;
+}
+
+.content { max-width: 700px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #78716c; }
+
+.reveal-section {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.clip-frame { margin: 0; width: 100%; max-width: 560px; }
+
+.clip-img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 16px;
+  clip-path: inset(0 100% 0 0 round 16px);
+  transition: clip-path 1s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.clip-img.is-revealed {
+  clip-path: inset(0 0 0 0 round 16px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .clip-img { transition: none; clip-path: inset(0 0 0 0 round 16px); }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-image-reveal-clip-sap`, a scroll-triggered clip-path image wipe reveal.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-image-reveal-clip-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses `clip-path: inset()` rather than `width`/`transform`, keeping the
  image's layout box constant throughout so no reflow occurs during reveal.
- Reduced motion sets the image to its fully-revealed clip state
  immediately, so it's never stuck hidden for users who don't trigger a
  scroll-based observer callback in an unusual way.

## Feature Description

Adds a reusable scroll-triggered clip-path image reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.