### PR TITLE
feat: add ease-drag-range-dual-thumb-sap

### DIFF
--- a/submissions/examples/ease-drag-range-dual-thumb-sap/README.md
+++ b/submissions/examples/ease-drag-range-dual-thumb-sap/README.md
@@ -1,0 +1,36 @@
+# Drag Range Dual Thumb
+
+A dual-handle range slider (e.g. min/max price filter) with two
+independently draggable thumbs, a connecting fill bar, and full keyboard support.
+
+**Level:** Advanced
+
+## Usage
+
+Both thumbs are `role="slider"` buttons positioned by percentage along
+`.range-track`. Dragging (Pointer Events) or Arrow keys adjust each thumb's
+value, with each clamped to stay a minimum distance from the other so they
+can't cross.
+
+## Accessibility
+
+- Each thumb is an independent `role="slider"` with its own descriptive
+  `aria-label` ("Minimum price"/"Maximum price") and
+  `aria-valuemin`/`aria-valuemax`/`aria-valuenow` kept in sync.
+- Both thumbs are focusable (`tabindex="0"`) and fully operable via
+  ArrowLeft/Right/Up/Down independent of dragging.
+- The current range is also shown as visible text
+  ("$20 — $80"), not conveyed by thumb position alone.
+- `:focus-visible` outline shown on whichever thumb has keyboard focus.
+- `prefers-reduced-motion` has no continuous animation to disable here
+  (positions update directly); included for consistency with the rest of
+  the set and to cover any future transition additions.
+
+## Notes
+
+- Each thumb's movement is clamped against the other's current value (with
+  a small buffer) so the min thumb can never be dragged/keyed past the max
+  thumb and vice versa.
+- Uses Pointer Events with `setPointerCapture` per thumb, consistent with
+  other drag components in this set, for reliable independent dragging of
+  each handle.

--- a/submissions/examples/ease-drag-range-dual-thumb-sap/demo.html
+++ b/submissions/examples/ease-drag-range-dual-thumb-sap/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Range Dual Thumb</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Range Dual Thumb</h1>
+
+    <div class="dual-range">
+      <p class="range-value">$<span id="minVal">20</span> — $<span id="maxVal">80</span></p>
+      <div class="range-track" id="rangeTrack">
+        <div class="range-fill" id="rangeFill"></div>
+        <button class="range-thumb" id="thumbMin" role="slider" aria-label="Minimum price" aria-valuemin="0" aria-valuemax="100" aria-valuenow="20" tabindex="0"></button>
+        <button class="range-thumb" id="thumbMax" role="slider" aria-label="Maximum price" aria-valuemin="0" aria-valuemax="100" aria-valuenow="80" tabindex="0"></button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const track = document.getElementById('rangeTrack');
+    const fill = document.getElementById('rangeFill');
+    const thumbMin = document.getElementById('thumbMin');
+    const thumbMax = document.getElementById('thumbMax');
+    const minValEl = document.getElementById('minVal');
+    const maxValEl = document.getElementById('maxVal');
+
+    let values = { min: 20, max: 80 };
+
+    function render() {
+      thumbMin.style.left = values.min + '%';
+      thumbMax.style.left = values.max + '%';
+      fill.style.left = values.min + '%';
+      fill.style.width = (values.max - values.min) + '%';
+      thumbMin.setAttribute('aria-valuenow', Math.round(values.min));
+      thumbMax.setAttribute('aria-valuenow', Math.round(values.max));
+      minValEl.textContent = Math.round(values.min);
+      maxValEl.textContent = Math.round(values.max);
+    }
+
+    function pctFromEvent(e) {
+      const rect = track.getBoundingClientRect();
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      return Math.min(Math.max(pct, 0), 100);
+    }
+
+    function bindDrag(thumb, key, other) {
+      let dragging = false;
+      thumb.addEventListener('pointerdown', (e) => {
+        dragging = true;
+        thumb.setPointerCapture(e.pointerId);
+      });
+      thumb.addEventListener('pointermove', (e) => {
+        if (!dragging) return;
+        let pct = pctFromEvent(e);
+        if (key === 'min') pct = Math.min(pct, values.max - 2);
+        else pct = Math.max(pct, values.min + 2);
+        values[key] = pct;
+        render();
+      });
+      thumb.addEventListener('pointerup', () => { dragging = false; });
+
+      thumb.addEventListener('keydown', (e) => {
+        const step = 2;
+        let delta = 0;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowUp') delta = step;
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') delta = -step;
+        if (!delta) return;
+        e.preventDefault();
+        let next = values[key] + delta;
+        if (key === 'min') next = Math.min(Math.max(next, 0), values.max - 2);
+        else next = Math.max(Math.min(next, 100), values.min + 2);
+        values[key] = next;
+        render();
+      });
+    }
+
+    bindDrag(thumbMin, 'min');
+    bindDrag(thumbMax, 'max');
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-range-dual-thumb-sap/style.css
+++ b/submissions/examples/ease-drag-range-dual-thumb-sap/style.css
@@ -1,0 +1,69 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(320px, 90vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.75rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.range-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #4338ca;
+  margin: 0 0 1.5rem;
+}
+
+.range-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  margin: 0 10px;
+}
+
+.range-fill {
+  position: absolute;
+  height: 100%;
+  background: #6366f1;
+  border-radius: 999px;
+}
+
+.range-thumb {
+  position: absolute;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  border: 3px solid #6366f1;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  transform: translate(-50%, -50%);
+  cursor: grab;
+  touch-action: none;
+  padding: 0;
+}
+
+.range-thumb:active { cursor: grabbing; }
+
+.range-thumb:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .range-thumb, .range-fill { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-range-dual-thumb-sap`, a dual-handle draggable range slider with full keyboard support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-range-dual-thumb-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Each thumb is an independent `role="slider"` with its own ARIA
  value attributes and full Arrow-key support, clamped against the other
  thumb's value so the handles can never cross.
- Current range is also shown as visible text, not conveyed by thumb
  position alone.

## Feature Description

Adds a reusable dual-thumb draggable range slider component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.