### PR TITLE
feat: add smooth select dropdown

### DIFF
--- a/submissions/examples/smooth-select-dropdown-msm/README.md
+++ b/submissions/examples/smooth-select-dropdown-msm/README.md
@@ -1,0 +1,29 @@
+# Smooth Select Dropdown
+
+## What does this do?
+
+The Smooth Select Dropdown adds a pure HTML/CSS select-style menu that expands with a smooth height transition and polished option states.
+
+## How is it used?
+
+Place the dropdown in a form or settings area and include the local stylesheet:
+
+```html
+<details class="smooth-select">
+  <summary>
+    <span class="select-label">Choose destination</span>
+    <span class="select-value">Aurora Studio</span>
+    <span class="select-arrow" aria-hidden="true"></span>
+  </summary>
+
+  <ul class="select-options" aria-label="Destination options">
+    <li><a href="#aurora">Aurora Studio</a></li>
+    <li><a href="#cascade">Cascade Lab</a></li>
+    <li><a href="#harbor">Harbor Console</a></li>
+  </ul>
+</details>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a compact select-style pattern that feels smooth and modern while staying dependency-free, responsive, keyboard-friendly, dark-mode compatible, and respectful of reduced-motion preferences.

--- a/submissions/examples/smooth-select-dropdown-msm/demo.html
+++ b/submissions/examples/smooth-select-dropdown-msm/demo.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smooth Select Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="select-stage">
+      <section class="select-card" aria-labelledby="select-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="select-title">Smooth Select</h1>
+        <p class="intro">
+          A pure HTML and CSS select-style dropdown with graceful height
+          expansion, keyboard support, and polished option states.
+        </p>
+
+        <details class="smooth-select">
+          <summary>
+            <span class="select-label">Choose destination</span>
+            <span class="select-value">Aurora Studio</span>
+            <span class="select-arrow" aria-hidden="true"></span>
+          </summary>
+
+          <ul class="select-options" aria-label="Destination options">
+            <li>
+              <a href="#aurora">
+                <span class="option-dot option-dot-one" aria-hidden="true">
+                </span>
+                Aurora Studio
+              </a>
+            </li>
+            <li>
+              <a href="#cascade">
+                <span class="option-dot option-dot-two" aria-hidden="true">
+                </span>
+                Cascade Lab
+              </a>
+            </li>
+            <li>
+              <a href="#harbor">
+                <span class="option-dot option-dot-three" aria-hidden="true">
+                </span>
+                Harbor Console
+              </a>
+            </li>
+          </ul>
+        </details>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/smooth-select-dropdown-msm/style.css
+++ b/submissions/examples/smooth-select-dropdown-msm/style.css
@@ -1,0 +1,280 @@
+:root {
+  --ink: #172033;
+  --muted: #657189;
+  --paper: rgba(255, 255, 255, 0.9);
+  --line: rgba(23, 32, 51, 0.12);
+  --blue: #4169e1;
+  --teal: #21c7b7;
+  --amber: #ffbf47;
+  --rose: #f45f8c;
+  --shadow: rgba(23, 32, 51, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Segoe UI", Verdana, sans-serif;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(65, 105, 225, 0.24),
+      transparent 26rem
+    ),
+    radial-gradient(
+      circle at 82% 76%,
+      rgba(33, 199, 183, 0.26),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f6f8ff 0%, #f2fffb 52%, #fff8ec 100%);
+}
+
+.select-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.select-card {
+  width: min(100%, 42rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.94),
+      rgba(246, 248, 255, 0.68)
+    ),
+    var(--paper);
+  box-shadow:
+    0 2rem 4.4rem var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.45rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 33rem;
+  margin: 1.15rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.smooth-select {
+  position: relative;
+  width: min(100%, 22rem);
+  margin: 0 auto;
+  text-align: left;
+}
+
+.smooth-select summary {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.35rem 0.8rem;
+  align-items: center;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 1rem 2rem rgba(23, 32, 51, 0.12);
+  cursor: pointer;
+  list-style: none;
+  transition:
+    border-color 240ms ease,
+    border-radius 260ms ease,
+    box-shadow 260ms ease,
+    transform 260ms ease;
+}
+
+.smooth-select summary::-webkit-details-marker {
+  display: none;
+}
+
+.select-label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.select-value {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.select-arrow {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  width: 0.72rem;
+  height: 0.72rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-0.18rem) rotate(45deg);
+  transition: transform 260ms ease;
+}
+
+.select-options {
+  display: grid;
+  max-height: 0;
+  margin: 0;
+  padding: 0 0.55rem;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 0 0 1.35rem 1.35rem;
+  list-style: none;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1.35rem 2.8rem rgba(23, 32, 51, 0.14);
+  opacity: 0;
+  transform: translateY(-0.35rem);
+  transition:
+    max-height 420ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 240ms ease,
+    padding 300ms ease,
+    transform 300ms ease,
+    border-color 240ms ease;
+  backdrop-filter: blur(16px);
+}
+
+.select-options a {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.88rem 0.8rem;
+  border-radius: 0.92rem;
+  color: var(--ink);
+  text-decoration: none;
+  transition:
+    background 220ms ease,
+    color 220ms ease,
+    transform 220ms ease;
+}
+
+.option-dot {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--blue);
+  box-shadow: 0 0 0 0.28rem rgba(65, 105, 225, 0.12);
+}
+
+.option-dot-two {
+  background: var(--teal);
+  box-shadow: 0 0 0 0.28rem rgba(33, 199, 183, 0.12);
+}
+
+.option-dot-three {
+  background: var(--rose);
+  box-shadow: 0 0 0 0.28rem rgba(244, 95, 140, 0.12);
+}
+
+.smooth-select[open] summary {
+  border-color: rgba(65, 105, 225, 0.32);
+  border-radius: 1.35rem 1.35rem 0.9rem 0.9rem;
+  box-shadow: 0 1.2rem 2.4rem rgba(65, 105, 225, 0.16);
+  transform: translateY(-0.12rem);
+}
+
+.smooth-select[open] .select-arrow {
+  transform: translateY(0.18rem) rotate(225deg);
+}
+
+.smooth-select[open] .select-options {
+  max-height: 15rem;
+  padding: 0.55rem;
+  border-color: rgba(65, 105, 225, 0.14);
+  opacity: 1;
+  transform: translateY(0.35rem);
+}
+
+.select-options a:hover,
+.select-options a:focus-visible {
+  color: var(--blue);
+  background: linear-gradient(
+    90deg,
+    rgba(65, 105, 225, 0.12),
+    rgba(33, 199, 183, 0.1)
+  );
+  outline: none;
+  transform: translateX(0.16rem);
+}
+
+.smooth-select summary:focus-visible {
+  outline: 3px solid var(--amber);
+  outline-offset: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #eef6ff;
+    --muted: #aab7c9;
+    --paper: rgba(11, 16, 28, 0.86);
+    --line: rgba(238, 246, 255, 0.14);
+    --shadow: rgba(0, 0, 0, 0.42);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 18% 18%,
+        rgba(65, 105, 225, 0.18),
+        transparent 26rem
+      ),
+      radial-gradient(
+        circle at 82% 76%,
+        rgba(33, 199, 183, 0.16),
+        transparent 28rem
+      ),
+      linear-gradient(135deg, #0a1020 0%, #0d1d23 52%, #201910 100%);
+  }
+
+  .select-card,
+  .smooth-select summary,
+  .select-options {
+    background: var(--paper);
+  }
+}
+
+@media (max-width: 35rem) {
+  .select-stage {
+    padding: 1rem;
+  }
+
+  .select-card {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new Smooth Select Dropdown example under `submissions/examples/smooth-select-dropdown-msm/`.
- Uses native `<details>`/`<summary>` behavior for a CSS-only select-style dropdown with smooth height expansion.
- Includes responsive layout, dark-mode styling, keyboard focus behavior, and reduced-motion handling.

## Linked Issue
Closes #70333

## Changes Made
- Added `demo.html` with semantic select-style dropdown markup.
- Added `style.css` with smooth open-state transitions, option hover/focus states, and responsive/dark-mode support.
- Added `README.md` documenting purpose, usage, and EaseMotion fit.

## Testing
- `npx.cmd prettier --check submissions/examples/smooth-select-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/smooth-select-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge Cases Handled
- Keyboard interaction through native `<summary>` focus behavior and `:focus-visible` states.
- Mobile-friendly width and card spacing.
- Dark-mode color overrides.
- Reduced-motion preference respected.

## Screenshots
- UI-only HTML/CSS example; screenshots can be captured from `submissions/examples/smooth-select-dropdown-msm/demo.html` if requested.

## Checklist
- [x] I read the README and CONTRIBUTING guidelines.
- [x] The issue is assigned to `@mittalsonal`.
- [x] No existing PR was found for this issue/branch.
- [x] Only required submission files are included.
- [x] Formatting, linting, and diff checks passed locally.