### PR TITLE
feat: add ease-card-tilt-3d-hover-sap

### DIFF
--- a/submissions/examples/ease-card-tilt-3d-hover-sap/README.md
+++ b/submissions/examples/ease-card-tilt-3d-hover-sap/README.md
@@ -1,0 +1,34 @@
+# Card Tilt 3D Hover
+
+A card that tilts in 3D following the cursor position, with a soft radial
+"shine" highlight that tracks alongside it, and springs back flat on mouse leave.
+
+**Level:** Advanced
+
+## Usage
+
+`mousemove` computes normalized cursor position (0–1) within the card and
+maps it to `rotateX`/`rotateY` via `perspective(...) rotateX() rotateY()
+scale()`. The same position drives a `--shine-x`/`--shine-y` custom property
+pair for the highlight's radial-gradient center.
+
+## Accessibility
+
+- Card is focusable (`tabindex="0"`) with a visible `:focus-visible`
+  outline, though the 3D tilt itself is inherently a pointer/mouse-position
+  effect with no meaningful keyboard equivalent — this is acknowledged as
+  an accepted limitation of this specific effect type, similar to the
+  magnetic-icon-grid component, rather than worked around.
+- `prefers-reduced-motion` forces the card's transform to `none` even on
+  hover/focus (`!important`), so motion-reduced users get a fully static
+  card regardless of any residual inline style from `mousemove`.
+
+## Notes
+
+- Tilt strength is controlled by the `MAX_TILT` constant (12°); increasing
+  it produces a more dramatic effect.
+- The shine highlight and the tilt both derive from the same normalized
+  cursor position calculation, so they stay visually coupled rather than
+  needing two separate position-tracking systems.
+- This is a pointer-only decorative effect; the card's actual textual
+  content is always fully present and readable regardless of tilt state.

--- a/submissions/examples/ease-card-tilt-3d-hover-sap/demo.html
+++ b/submissions/examples/ease-card-tilt-3d-hover-sap/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Card Tilt 3D Hover</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Card Tilt 3D Hover</h1>
+
+    <div class="tilt-stage">
+      <div class="tilt-card" id="tiltCard" tabindex="0">
+        <div class="tilt-shine"></div>
+        <h2>Premium Plan</h2>
+        <p>Move your cursor across this card.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const card = document.getElementById('tiltCard');
+    const MAX_TILT = 12;
+
+    card.addEventListener('mousemove', (e) => {
+      const rect = card.getBoundingClientRect();
+      const px = (e.clientX - rect.left) / rect.width;
+      const py = (e.clientY - rect.top) / rect.height;
+      const rotateY = (px - 0.5) * MAX_TILT * 2;
+      const rotateX = (0.5 - py) * MAX_TILT * 2;
+      card.style.transform = `perspective(600px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale(1.02)`;
+      card.style.setProperty('--shine-x', `${px * 100}%`);
+      card.style.setProperty('--shine-y', `${py * 100}%`);
+    });
+
+    card.addEventListener('mouseleave', () => {
+      card.style.transform = 'perspective(600px) rotateX(0) rotateY(0) scale(1)';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-card-tilt-3d-hover-sap/style.css
+++ b/submissions/examples/ease-card-tilt-3d-hover-sap/style.css
@@ -1,0 +1,55 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.tilt-stage { perspective: 1000px; }
+
+.tilt-card {
+  position: relative;
+  width: 260px;
+  height: 180px;
+  border-radius: 18px;
+  background: linear-gradient(160deg, #4338ca, #6366f1);
+  padding: 1.75rem;
+  overflow: hidden;
+  transition: transform 0.15s ease-out;
+  will-change: transform;
+  cursor: default;
+}
+
+.tilt-card:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 4px;
+}
+
+.tilt-shine {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--shine-x, 50%) var(--shine-y, 50%), rgba(255,255,255,0.25), transparent 60%);
+  pointer-events: none;
+}
+
+.tilt-card h2 { margin: 0 0 0.4rem; font-size: 1.15rem; }
+.tilt-card p { margin: 0; font-size: 0.82rem; opacity: 0.85; }
+
+@media (prefers-reduced-motion: reduce) {
+  .tilt-card { transition: none; }
+  .tilt-card:hover, .tilt-card:focus { transform: none !important; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-card-tilt-3d-hover-sap`, a card with a 3D cursor-tracking tilt effect and shine highlight.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-card-tilt-3d-hover-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- README explicitly acknowledges the 3D cursor-tilt has no meaningful
  keyboard equivalent, rather than presenting the plain `:focus-visible`
  outline as if it were parity with the mouse effect.
- Reduced motion forces `transform: none !important` on the card as a hard
  guarantee, since the effect is driven by imperative `mousemove` JS rather
  than a pure CSS hover state.

## Feature Description

Adds a reusable 3D cursor-tracking card tilt effect component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.