### PR TITLE
feat: add ease-notification-toast-slide-sap

### DIFF
--- a/submissions/examples/ease-notification-toast-slide-sap/README.md
+++ b/submissions/examples/ease-notification-toast-slide-sap/README.md
@@ -1,0 +1,38 @@
+# Notification Toast Slide
+
+Toast notifications that slide in from the right edge, auto-dismiss after a
+delay, and can also be dismissed manually — stacking cleanly when multiple appear.
+
+**Level:** Intermediate
+
+## Usage
+
+Call `showToast(message)` to create and animate in a new toast. Each
+manages its own auto-dismiss timer and close button; multiple toasts stack
+vertically in `.toast-region`.
+
+## Accessibility
+
+- `.toast-region` is `aria-live="polite" aria-atomic="true"`, so each new
+  toast's message is announced by screen readers as it's added, without
+  needing focus to move.
+- Each toast has an explicit, labeled close button (`aria-label="Dismiss
+  notification"`), not just an auto-timeout — so users who need more time
+  to read aren't solely dependent on manual dismissal timing, and those who
+  want to dismiss early can.
+- Auto-dismiss timing (4 seconds) is deliberately generous for a short
+  message; longer-message use cases should extend the timeout further or
+  disable auto-dismiss.
+- `prefers-reduced-motion` removes the slide transform, keeping only an
+  opacity fade for enter/exit.
+
+## Notes
+
+- Toasts are removed from the DOM only after their exit transition
+  completes (`transitionend`, `{ once: true }`), so the slide-out animation
+  isn't cut short.
+- `aria-atomic="true"` ensures each toast's full text is announced as one
+  unit rather than being fragmented across incremental DOM updates.
+- This demo doesn't pause the auto-dismiss timer on hover/focus; adding a
+  pause-on-interaction behavior would be a good accessibility enhancement
+  for a production toast system, noted here as a follow-up.

--- a/submissions/examples/ease-notification-toast-slide-sap/demo.html
+++ b/submissions/examples/ease-notification-toast-slide-sap/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Notification Toast Slide</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Notification Toast Slide</h1>
+    <button class="trigger-btn" id="showToast">Show notification</button>
+  </main>
+
+  <div class="toast-region" id="toastRegion" aria-live="polite" aria-atomic="true"></div>
+
+  <script>
+    const region = document.getElementById('toastRegion');
+    let count = 0;
+
+    function showToast(message) {
+      count++;
+      const toast = document.createElement('div');
+      toast.className = 'toast';
+      toast.innerHTML = `
+        <span class="toast-icon">✓</span>
+        <span class="toast-msg">${message}</span>
+        <button class="toast-close" aria-label="Dismiss notification">✕</button>
+      `;
+      region.appendChild(toast);
+      requestAnimationFrame(() => toast.classList.add('is-in'));
+
+      function dismiss() {
+        toast.classList.remove('is-in');
+        toast.classList.add('is-out');
+        toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+      }
+
+      toast.querySelector('.toast-close').addEventListener('click', dismiss);
+      setTimeout(dismiss, 4000);
+    }
+
+    document.getElementById('showToast').addEventListener('click', () => {
+      showToast(`Change #${count + 1} saved successfully`);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-notification-toast-slide-sap/style.css
+++ b/submissions/examples/ease-notification-toast-slide-sap/style.css
@@ -1,0 +1,99 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+  text-align: center;
+}
+
+.trigger-btn {
+  display: block;
+  margin: 0 auto;
+  padding: 0.7rem 1.4rem;
+  border-radius: 10px;
+  border: none;
+  background: #6366f1;
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.trigger-btn:hover { background: #4f46e5; }
+
+.toast-region {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  z-index: 100;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 260px;
+  padding: 0.8rem 1rem;
+  background: #1e293b;
+  color: white;
+  border-radius: 10px;
+  box-shadow: 0 12px 28px rgba(0,0,0,0.25);
+
+  transform: translateX(120%);
+  opacity: 0;
+  transition: transform 0.35s cubic-bezier(0.2, 0.6, 0.3, 1), opacity 0.3s ease;
+}
+
+.toast.is-in { transform: translateX(0); opacity: 1; }
+.toast.is-out { transform: translateX(120%); opacity: 0; }
+
+.toast-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #22c55e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+.toast-msg { flex: 1; font-size: 0.85rem; }
+
+.toast-close {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem;
+}
+
+.toast-close:hover { color: white; }
+
+.toast-close:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast { transition: opacity 0.25s ease; }
+  .toast.is-in, .toast.is-out { transform: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-notification-toast-slide-sap`, slide-in toast notifications with auto-dismiss and manual close.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-notification-toast-slide-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Toast region is `aria-live="polite" aria-atomic="true"`, and every toast
  includes a labeled manual close button alongside its auto-dismiss timer.
- README flags that pause-on-hover/focus for the auto-dismiss timer is a
  worthwhile accessibility follow-up not included in this focused submission.

## Feature Description

Adds a reusable slide-in toast notification component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.