### PR TITLE
feat: add mini cart dropdown

### DIFF
--- a/submissions/examples/mini-cart-dropdown-msm/README.md
+++ b/submissions/examples/mini-cart-dropdown-msm/README.md
@@ -1,0 +1,32 @@
+# Mini Cart Dropdown
+
+## What does this do?
+
+The Mini Cart Dropdown adds a pure HTML/CSS cart preview menu with item rows, order total, and a checkout call to action.
+
+## How is it used?
+
+Place the dropdown in a shopping header or checkout area and include the local stylesheet:
+
+```html
+<nav class="mini-cart" aria-label="Shopping cart preview">
+  <button class="cart-trigger" type="button" aria-haspopup="true">
+    <span class="cart-icon" aria-hidden="true">Cart</span>
+    <span class="cart-copy">
+      <span class="cart-label">Your cart</span>
+      <span class="cart-count">3 items</span>
+    </span>
+  </button>
+
+  <section class="cart-dropdown" aria-label="Cart preview">
+    <header class="cart-header">
+      <strong>Order preview</strong>
+      <span>$86.00</span>
+    </header>
+  </section>
+</nav>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS users a practical ecommerce dropdown pattern that previews cart contents while staying dependency-free, responsive, keyboard-friendly, dark-mode compatible, and respectful of reduced-motion preferences.

--- a/submissions/examples/mini-cart-dropdown-msm/demo.html
+++ b/submissions/examples/mini-cart-dropdown-msm/demo.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mini Cart Dropdown</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="cart-stage">
+      <section class="cart-card" aria-labelledby="cart-title">
+        <p class="eyebrow">EaseMotion CSS dropdown</p>
+        <h1 id="cart-title">Mini Cart</h1>
+        <p class="intro">
+          A pure CSS cart dropdown that previews selected items, totals, and a
+          checkout action with smooth hover and keyboard focus states.
+        </p>
+
+        <nav class="mini-cart" aria-label="Shopping cart preview">
+          <button class="cart-trigger" type="button" aria-haspopup="true">
+            <span class="cart-icon" aria-hidden="true">Cart</span>
+            <span class="cart-copy">
+              <span class="cart-label">Your cart</span>
+              <span class="cart-count">3 items</span>
+            </span>
+          </button>
+
+          <section class="cart-dropdown" aria-label="Cart preview">
+            <header class="cart-header">
+              <strong>Order preview</strong>
+              <span>$86.00</span>
+            </header>
+
+            <ul class="cart-items">
+              <li>
+                <span
+                  class="item-thumb item-thumb-one"
+                  aria-hidden="true"
+                ></span>
+                <span>
+                  <strong>Motion Kit</strong>
+                  <small>1 x $32.00</small>
+                </span>
+              </li>
+              <li>
+                <span
+                  class="item-thumb item-thumb-two"
+                  aria-hidden="true"
+                ></span>
+                <span>
+                  <strong>Glow Pack</strong>
+                  <small>2 x $18.00</small>
+                </span>
+              </li>
+              <li>
+                <span
+                  class="item-thumb item-thumb-three"
+                  aria-hidden="true"
+                ></span>
+                <span>
+                  <strong>UI Tokens</strong>
+                  <small>1 x $18.00</small>
+                </span>
+              </li>
+            </ul>
+
+            <footer class="cart-footer">
+              <span>Total</span>
+              <strong>$86.00</strong>
+            </footer>
+
+            <a class="checkout-link" href="#checkout">Checkout now</a>
+          </section>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/mini-cart-dropdown-msm/style.css
+++ b/submissions/examples/mini-cart-dropdown-msm/style.css
@@ -1,0 +1,355 @@
+:root {
+  --ink: #1d2230;
+  --muted: #687386;
+  --paper: rgba(255, 255, 255, 0.9);
+  --line: rgba(29, 34, 48, 0.12);
+  --mint: #36d399;
+  --blue: #4776ff;
+  --orange: #ff9a3d;
+  --rose: #f45d8f;
+  --shadow: rgba(29, 34, 48, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Segoe UI", Verdana, sans-serif;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(54, 211, 153, 0.28),
+      transparent 25rem
+    ),
+    radial-gradient(
+      circle at 82% 78%,
+      rgba(255, 154, 61, 0.24),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #f3fff9 0%, #f8f6ff 50%, #fff5e9 100%);
+}
+
+.cart-stage {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.cart-card {
+  width: min(100%, 42rem);
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 2rem;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.95),
+      rgba(243, 255, 249, 0.7)
+    ),
+    var(--paper);
+  box-shadow:
+    0 2rem 4.4rem var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.96);
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #27845f;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.45rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.intro {
+  max-width: 34rem;
+  margin: 1.15rem auto 2rem;
+  color: var(--muted);
+  font-size: 1.04rem;
+  line-height: 1.65;
+}
+
+.mini-cart {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+  text-align: left;
+}
+
+.cart-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 13.5rem;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.35rem;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 1rem 2rem rgba(29, 34, 48, 0.12);
+  cursor: pointer;
+  font: inherit;
+  transition:
+    border-color 240ms ease,
+    box-shadow 260ms ease,
+    transform 260ms ease;
+}
+
+.cart-icon {
+  display: grid;
+  width: 2.65rem;
+  height: 2.65rem;
+  place-items: center;
+  border-radius: 1rem;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--mint), var(--blue));
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  box-shadow: 0 0.7rem 1.4rem rgba(54, 211, 153, 0.24);
+}
+
+.cart-copy {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.cart-label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cart-count {
+  font-weight: 850;
+}
+
+.cart-dropdown {
+  position: absolute;
+  top: calc(100% + 0.85rem);
+  right: 0;
+  display: grid;
+  width: min(21rem, 86vw);
+  padding: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.74);
+  border-radius: 1.55rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1.35rem 2.8rem var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.65rem) scale(0.97);
+  transform-origin: top right;
+  transition:
+    opacity 220ms ease,
+    transform 300ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  backdrop-filter: blur(16px);
+}
+
+.cart-header,
+.cart-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0.8rem;
+}
+
+.cart-header {
+  border-bottom: 1px solid var(--line);
+}
+
+.cart-header span {
+  color: var(--mint);
+  font-weight: 900;
+}
+
+.cart-items {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.7rem 0;
+  list-style: none;
+}
+
+.cart-items li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.7rem 0.8rem;
+  border-radius: 1rem;
+  transition:
+    background 220ms ease,
+    transform 220ms ease;
+}
+
+.cart-items strong,
+.cart-items small {
+  display: block;
+}
+
+.cart-items small {
+  margin-top: 0.12rem;
+  color: var(--muted);
+}
+
+.item-thumb {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.9rem;
+  background: var(--mint);
+  box-shadow: inset 0 -0.4rem 0 rgba(255, 255, 255, 0.28);
+}
+
+.item-thumb-two {
+  background: var(--orange);
+}
+
+.item-thumb-three {
+  background: var(--rose);
+}
+
+.cart-footer {
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+}
+
+.cart-footer strong {
+  color: var(--ink);
+  font-size: 1.12rem;
+}
+
+.checkout-link {
+  display: block;
+  margin: 0.35rem 0.45rem 0.2rem;
+  padding: 0.82rem 1rem;
+  border-radius: 1rem;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--ink), #2f3b58);
+  text-align: center;
+  text-decoration: none;
+  font-weight: 900;
+  transition:
+    filter 220ms ease,
+    transform 220ms ease;
+}
+
+.mini-cart:hover .cart-trigger,
+.mini-cart:focus-within .cart-trigger {
+  border-color: rgba(54, 211, 153, 0.36);
+  box-shadow:
+    0 1.2rem 2.4rem rgba(54, 211, 153, 0.18),
+    0 0 0 0.35rem rgba(54, 211, 153, 0.1);
+  transform: translateY(-0.14rem);
+}
+
+.mini-cart:hover .cart-dropdown,
+.mini-cart:focus-within .cart-dropdown {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.cart-items li:hover,
+.cart-items li:focus-within {
+  background: linear-gradient(
+    90deg,
+    rgba(54, 211, 153, 0.12),
+    rgba(71, 118, 255, 0.1)
+  );
+  transform: translateX(0.16rem);
+}
+
+.checkout-link:hover,
+.checkout-link:focus-visible {
+  filter: brightness(1.08);
+  outline: none;
+  transform: translateY(-0.1rem);
+}
+
+.cart-trigger:focus-visible {
+  outline: 3px solid var(--orange);
+  outline-offset: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #edf8ff;
+    --muted: #a9b7c4;
+    --paper: rgba(12, 18, 28, 0.88);
+    --line: rgba(237, 248, 255, 0.13);
+    --shadow: rgba(0, 0, 0, 0.44);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 18% 18%,
+        rgba(54, 211, 153, 0.18),
+        transparent 25rem
+      ),
+      radial-gradient(
+        circle at 82% 78%,
+        rgba(255, 154, 61, 0.14),
+        transparent 28rem
+      ),
+      linear-gradient(135deg, #07140f 0%, #121224 52%, #21150c 100%);
+  }
+
+  .cart-card,
+  .cart-trigger,
+  .cart-dropdown {
+    background: var(--paper);
+  }
+
+  .checkout-link {
+    color: #132018;
+    background: linear-gradient(135deg, var(--mint), #b5ffd7);
+  }
+}
+
+@media (max-width: 35rem) {
+  .cart-stage {
+    padding: 1rem;
+  }
+
+  .cart-card {
+    padding: 2rem 1rem;
+  }
+
+  .cart-dropdown {
+    right: 50%;
+    transform: translate(50%, 0.65rem) scale(0.97);
+    transform-origin: top center;
+  }
+
+  .mini-cart:hover .cart-dropdown,
+  .mini-cart:focus-within .cart-dropdown {
+    transform: translate(50%, 0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new Mini Cart Dropdown example under `submissions/examples/mini-cart-dropdown-msm/`.
- Provides a pure HTML/CSS cart trigger with item preview rows, order total, and checkout CTA.
- Includes responsive layout, dark-mode styling, keyboard focus behavior, and reduced-motion handling.

## Linked Issue
Closes #70279

## Changes Made
- Added `demo.html` with semantic mini cart preview markup.
- Added `style.css` with smooth dropdown transitions, item hover/focus states, and responsive/dark-mode support.
- Added `README.md` documenting purpose, usage, and EaseMotion fit.

## Testing
- `npx.cmd prettier --check submissions/examples/mini-cart-dropdown-msm/**/*.{html,css,md}` - passed
- `npx.cmd stylelint submissions/examples/mini-cart-dropdown-msm/style.css --ignore-path .stylelintignore-does-not-exist` - passed
- `git diff --check` - passed
- `git diff --cached --check` - passed

## Edge Cases Handled
- Keyboard access through `:focus-within` and `:focus-visible` states.
- Mobile-friendly dropdown positioning and width.
- Dark-mode color overrides.
- Reduced-motion preference respected.

## Screenshots
- UI-only HTML/CSS example; screenshots can be captured from `submissions/examples/mini-cart-dropdown-msm/demo.html` if requested.

## Checklist
- [x] I read the README and CONTRIBUTING guidelines.
- [x] The issue is assigned to `@mittalsonal`.
- [x] No existing PR was found for this issue/branch.
- [x] Only required submission files are included.
- [x] Formatting, linting, and diff checks passed locally.