### PR TITLE
feat: add casual-stitch component

### DIFF
--- a/submissions/examples/casual-stitch/README.md
+++ b/submissions/examples/casual-stitch/README.md
@@ -1,0 +1,24 @@
+# Causal Stitch
+
+Causal Stitch is an experimental interactive component for reconstructing relationships between events.
+
+Instead of representing causality using a conventional node graph, the component treats the interface as a digital fabric.
+
+Events are loose fragments placed across the fabric.
+
+Users can select two events and stitch them together using a causal relationship.
+
+The resulting relationship becomes a curved thread connecting both events.
+
+---
+
+## Concept
+
+The central idea is:
+
+> Causality is something you reconstruct, not something you simply display.
+
+Instead of:
+
+```text
+Event A ───────> Event B

--- a/submissions/examples/casual-stitch/demo.html
+++ b/submissions/examples/casual-stitch/demo.html
@@ -1,0 +1,1335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  />
+
+  <title>Causal Stitch</title>
+
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="causal-shell">
+
+      <!-- HEADER -->
+
+      <header class="header">
+
+        <div>
+          <span class="eyebrow">
+            CAUSAL ANALYSIS / FABRIC-07
+          </span>
+
+          <h1>Causal Stitch</h1>
+
+          <p>
+            Stitch events together to reconstruct the hidden chain
+            between cause and effect.
+          </p>
+        </div>
+
+        <div class="system-status">
+
+          <span class="status-dot"></span>
+
+          <div>
+            <small>FABRIC STATE</small>
+            <strong id="fabricState">UNRESOLVED</strong>
+          </div>
+
+        </div>
+
+      </header>
+
+
+      <!-- STATS -->
+
+      <div class="stats">
+
+        <div class="stat">
+          <span>EVENTS</span>
+          <strong id="eventCount">10</strong>
+        </div>
+
+        <div class="stat">
+          <span>STITCHES</span>
+          <strong id="stitchCount">00</strong>
+        </div>
+
+        <div class="stat">
+          <span>UNRESOLVED</span>
+          <strong id="unresolvedCount">10</strong>
+        </div>
+
+        <div class="stat">
+          <span>CHAIN CONFIDENCE</span>
+          <strong id="chainConfidence">—</strong>
+        </div>
+
+      </div>
+
+
+      <!-- TOOLBAR -->
+
+      <div class="toolbar">
+
+        <div class="toolbar-left">
+
+          <button
+            class="tool-button active"
+            id="stitchMode"
+          >
+            STITCH MODE
+          </button>
+
+          <button
+            class="tool-button"
+            id="reconstruct"
+          >
+            RECONSTRUCT
+          </button>
+
+        </div>
+
+        <div class="toolbar-right">
+
+          <button
+            class="tool-button"
+            id="undo"
+          >
+            UNDO LAST
+          </button>
+
+          <button
+            class="tool-button danger"
+            id="clear"
+          >
+            CLEAR STITCHES
+          </button>
+
+        </div>
+
+      </div>
+
+
+      <!-- WORKSPACE -->
+
+      <section class="workspace">
+
+        <!-- FABRIC -->
+
+        <div
+          class="fabric"
+          id="fabric"
+        >
+
+          <div class="fabric-grid"></div>
+
+          <div class="fabric-fold fold-a"></div>
+          <div class="fabric-fold fold-b"></div>
+          <div class="fabric-fold fold-c"></div>
+
+
+          <!-- THREADS -->
+
+          <svg
+            class="thread-layer"
+            id="threadLayer"
+            viewBox="0 0 900 620"
+            preserveAspectRatio="none"
+          ></svg>
+
+
+          <!-- EVENTS -->
+
+          <button
+            class="event cause"
+            data-id="E-01"
+            data-title="Suspicious Signal"
+            data-category="CAUSE"
+            data-confidence="94"
+            data-time="14:12:08"
+            data-evidence="4"
+            style="--x: 10%; --y: 16%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-01</span>
+            <strong>Suspicious Signal</strong>
+            <small>CAUSE</small>
+          </button>
+
+
+          <button
+            class="event signal"
+            data-id="E-02"
+            data-title="Auth Request"
+            data-category="SIGNAL"
+            data-confidence="87"
+            data-time="14:18:42"
+            data-evidence="3"
+            style="--x: 40%; --y: 11%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-02</span>
+            <strong>Auth Request</strong>
+            <small>SIGNAL</small>
+          </button>
+
+
+          <button
+            class="event anomaly"
+            data-id="E-03"
+            data-title="Packet Anomaly"
+            data-category="ANOMALY"
+            data-confidence="81"
+            data-time="14:22:19"
+            data-evidence="2"
+            style="--x: 72%; --y: 16%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-03</span>
+            <strong>Packet Anomaly</strong>
+            <small>ANOMALY</small>
+          </button>
+
+
+          <button
+            class="event action"
+            data-id="E-04"
+            data-title="Access Attempt"
+            data-category="ACTION"
+            data-confidence="92"
+            data-time="14:27:51"
+            data-evidence="5"
+            style="--x: 23%; --y: 39%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-04</span>
+            <strong>Access Attempt</strong>
+            <small>ACTION</small>
+          </button>
+
+
+          <button
+            class="event effect"
+            data-id="E-05"
+            data-title="Session Created"
+            data-category="EFFECT"
+            data-confidence="89"
+            data-time="14:31:07"
+            data-evidence="4"
+            style="--x: 54%; --y: 36%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-05</span>
+            <strong>Session Created</strong>
+            <small>EFFECT</small>
+          </button>
+
+
+          <button
+            class="event anomaly"
+            data-id="E-06"
+            data-title="Privilege Spike"
+            data-category="ANOMALY"
+            data-confidence="96"
+            data-time="14:36:44"
+            data-evidence="6"
+            style="--x: 82%; --y: 42%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-06</span>
+            <strong>Privilege Spike</strong>
+            <small>ANOMALY</small>
+          </button>
+
+
+          <button
+            class="event action"
+            data-id="E-07"
+            data-title="Data Request"
+            data-category="ACTION"
+            data-confidence="85"
+            data-time="14:41:28"
+            data-evidence="3"
+            style="--x: 12%; --y: 67%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-07</span>
+            <strong>Data Request</strong>
+            <small>ACTION</small>
+          </button>
+
+
+          <button
+            class="event signal"
+            data-id="E-08"
+            data-title="External Handshake"
+            data-category="SIGNAL"
+            data-confidence="79"
+            data-time="14:46:13"
+            data-evidence="2"
+            style="--x: 43%; --y: 70%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-08</span>
+            <strong>External Handshake</strong>
+            <small>SIGNAL</small>
+          </button>
+
+
+          <button
+            class="event effect"
+            data-id="E-09"
+            data-title="Data Exposure"
+            data-category="EFFECT"
+            data-confidence="91"
+            data-time="14:52:36"
+            data-evidence="5"
+            style="--x: 73%; --y: 68%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-09</span>
+            <strong>Data Exposure</strong>
+            <small>EFFECT</small>
+          </button>
+
+
+          <button
+            class="event cause"
+            data-id="E-10"
+            data-title="Origin Confirmed"
+            data-category="CAUSE"
+            data-confidence="97"
+            data-time="14:58:04"
+            data-evidence="7"
+            style="--x: 84%; --y: 86%;"
+          >
+            <span class="pin"></span>
+            <span class="event-id">E-10</span>
+            <strong>Origin Confirmed</strong>
+            <small>CAUSE</small>
+          </button>
+
+
+          <!-- CENTER MESSAGE -->
+
+          <div class="fabric-center">
+
+            <span id="centerLabel">
+              SELECT TWO EVENTS
+            </span>
+
+            <strong id="centerSub">
+              TO BEGIN STITCHING
+            </strong>
+
+          </div>
+
+
+          <!-- HOVER TOOLTIP -->
+
+          <div
+            class="event-tooltip"
+            id="eventTooltip"
+          >
+
+            <span id="tooltipId">
+              E-01
+            </span>
+
+            <strong id="tooltipTitle">
+              Suspicious Signal
+            </strong>
+
+            <div class="tooltip-row">
+              <span>CONFIDENCE</span>
+              <b id="tooltipConfidence">94%</b>
+            </div>
+
+            <div class="tooltip-row">
+              <span>EVIDENCE</span>
+              <b id="tooltipEvidence">04</b>
+            </div>
+
+          </div>
+
+        </div>
+
+
+        <!-- INSPECTOR -->
+
+        <aside class="inspector">
+
+          <div class="inspector-header">
+
+            <span>STITCH INSPECTOR</span>
+
+            <span id="inspectorState">
+              IDLE
+            </span>
+
+          </div>
+
+
+          <div class="inspector-body">
+
+            <div class="selection-block">
+
+              <span>SELECTED EVENTS</span>
+
+              <div class="selected-events">
+
+                <div id="selectedA">
+                  —
+                </div>
+
+                <span>↓</span>
+
+                <div id="selectedB">
+                  —
+                </div>
+
+              </div>
+
+            </div>
+
+
+            <div class="relationship">
+
+              <span>RELATIONSHIP</span>
+
+              <div class="relation-options">
+
+                <button
+                  class="relation active"
+                  data-relation="CAUSED"
+                >
+                  CAUSED
+                </button>
+
+                <button
+                  class="relation"
+                  data-relation="TRIGGERED"
+                >
+                  TRIGGERED
+                </button>
+
+                <button
+                  class="relation"
+                  data-relation="AMPLIFIED"
+                >
+                  AMPLIFIED
+                </button>
+
+                <button
+                  class="relation"
+                  data-relation="BLOCKED"
+                >
+                  BLOCKED
+                </button>
+
+                <button
+                  class="relation"
+                  data-relation="FOLLOWED"
+                >
+                  FOLLOWED
+                </button>
+
+              </div>
+
+            </div>
+
+
+            <div class="confidence">
+
+              <div>
+
+                <span>CAUSAL CONFIDENCE</span>
+
+                <strong id="confidenceValue">
+                  —
+                </strong>
+
+              </div>
+
+              <div class="confidence-bar">
+
+                <span id="confidenceBar"></span>
+
+              </div>
+
+            </div>
+
+
+            <div class="evidence">
+
+              <span>EVIDENCE</span>
+
+              <strong id="evidenceValue">
+                —
+              </strong>
+
+            </div>
+
+
+            <button
+              class="confirm-button"
+              id="confirmStitch"
+              disabled
+            >
+              STITCH EVENTS
+            </button>
+
+
+            <div class="chain-summary">
+
+              <span>CAUSAL SUMMARY</span>
+
+              <p id="summary">
+                Select two events to construct
+                a causal relationship.
+              </p>
+
+            </div>
+
+          </div>
+
+
+          <div class="inspector-footer">
+
+            <span>CLICK EVENT</span>
+            <span>SELECT RELATION</span>
+
+          </div>
+
+        </aside>
+
+      </section>
+
+
+      <!-- FOOTER -->
+
+      <footer class="footer">
+
+        <span>
+          CAUSAL STITCH / FABRIC-07
+        </span>
+
+        <span>
+          EVIDENCE RECONSTRUCTION SYSTEM
+        </span>
+
+        <span>
+          10 EVENTS
+        </span>
+
+      </footer>
+
+    </section>
+
+  </main>
+
+
+  <script>
+
+    const fabric = document.getElementById("fabric");
+    const events = [...document.querySelectorAll(".event")];
+    const relations = [...document.querySelectorAll(".relation")];
+
+    const threadLayer = document.getElementById("threadLayer");
+
+    const selectedA = document.getElementById("selectedA");
+    const selectedB = document.getElementById("selectedB");
+
+    const inspectorState =
+      document.getElementById("inspectorState");
+
+    const confidenceValue =
+      document.getElementById("confidenceValue");
+
+    const confidenceBar =
+      document.getElementById("confidenceBar");
+
+    const evidenceValue =
+      document.getElementById("evidenceValue");
+
+    const summary =
+      document.getElementById("summary");
+
+    const confirmStitch =
+      document.getElementById("confirmStitch");
+
+    const stitchCount =
+      document.getElementById("stitchCount");
+
+    const unresolvedCount =
+      document.getElementById("unresolvedCount");
+
+    const chainConfidence =
+      document.getElementById("chainConfidence");
+
+    const fabricState =
+      document.getElementById("fabricState");
+
+    const centerLabel =
+      document.getElementById("centerLabel");
+
+    const centerSub =
+      document.getElementById("centerSub");
+
+    const tooltip =
+      document.getElementById("eventTooltip");
+
+    const tooltipId =
+      document.getElementById("tooltipId");
+
+    const tooltipTitle =
+      document.getElementById("tooltipTitle");
+
+    const tooltipConfidence =
+      document.getElementById("tooltipConfidence");
+
+    const tooltipEvidence =
+      document.getElementById("tooltipEvidence");
+
+
+    let firstEvent = null;
+    let secondEvent = null;
+
+    let selectedRelation = "CAUSED";
+
+    let stitches = [];
+
+    let stitchMode = true;
+
+
+    function getData(event) {
+
+      return {
+
+        id: event.dataset.id,
+
+        title: event.dataset.title,
+
+        category: event.dataset.category,
+
+        confidence:
+          Number(event.dataset.confidence),
+
+        time: event.dataset.time,
+
+        evidence:
+          Number(event.dataset.evidence)
+
+      };
+
+    }
+
+
+    function selectEvent(event) {
+
+      if (!stitchMode) return;
+
+      if (firstEvent === event) {
+
+        event.classList.remove("selected");
+
+        firstEvent = null;
+
+        updateInspector();
+
+        return;
+      }
+
+
+      if (secondEvent === event) {
+
+        event.classList.remove("selected");
+
+        secondEvent = null;
+
+        updateInspector();
+
+        return;
+      }
+
+
+      if (!firstEvent) {
+
+        firstEvent = event;
+
+        event.classList.add("selected");
+
+      } else if (!secondEvent) {
+
+        secondEvent = event;
+
+        event.classList.add("selected");
+
+      } else {
+
+        firstEvent.classList.remove("selected");
+
+        firstEvent = secondEvent;
+
+        secondEvent = event;
+
+        firstEvent.classList.add("selected");
+
+      }
+
+      updateInspector();
+
+    }
+
+
+    function updateInspector() {
+
+      selectedA.textContent =
+        firstEvent
+          ? firstEvent.dataset.id
+          : "—";
+
+      selectedB.textContent =
+        secondEvent
+          ? secondEvent.dataset.id
+          : "—";
+
+
+      if (firstEvent && secondEvent) {
+
+        const a = getData(firstEvent);
+        const b = getData(secondEvent);
+
+        const confidence =
+          Math.round(
+            (a.confidence + b.confidence) / 2
+          );
+
+        const evidence =
+          a.evidence + b.evidence;
+
+        confidenceValue.textContent =
+          confidence + "%";
+
+        confidenceBar.style.width =
+          confidence + "%";
+
+        evidenceValue.textContent =
+          String(evidence).padStart(2, "0");
+
+        inspectorState.textContent =
+          "READY";
+
+        confirmStitch.disabled = false;
+
+        centerLabel.textContent =
+          "RELATIONSHIP READY";
+
+        centerSub.textContent =
+          "CONFIRM THE STITCH";
+
+        summary.textContent =
+          `${a.title} ${selectedRelation.toLowerCase()} ${b.title}.`;
+
+      } else {
+
+        confidenceValue.textContent =
+          "—";
+
+        confidenceBar.style.width =
+          "0%";
+
+        evidenceValue.textContent =
+          "—";
+
+        inspectorState.textContent =
+          firstEvent
+            ? "WAITING"
+            : "IDLE";
+
+        confirmStitch.disabled = true;
+
+        centerLabel.textContent =
+          firstEvent
+            ? "SELECT SECOND EVENT"
+            : "SELECT TWO EVENTS";
+
+        centerSub.textContent =
+          firstEvent
+            ? "TO COMPLETE THE STITCH"
+            : "TO BEGIN STITCHING";
+
+        summary.textContent =
+          "Select two events to construct a causal relationship.";
+
+      }
+
+    }
+
+
+    events.forEach(event => {
+
+      event.addEventListener("click", () => {
+
+        selectEvent(event);
+
+      });
+
+
+      event.addEventListener("mouseenter", () => {
+
+        const data = getData(event);
+
+        tooltipId.textContent =
+          data.id;
+
+        tooltipTitle.textContent =
+          data.title;
+
+        tooltipConfidence.textContent =
+          data.confidence + "%";
+
+        tooltipEvidence.textContent =
+          String(data.evidence).padStart(2, "0");
+
+        tooltip.classList.add("visible");
+
+      });
+
+
+      event.addEventListener("mouseleave", () => {
+
+        tooltip.classList.remove("visible");
+
+      });
+
+    });
+
+
+    relations.forEach(button => {
+
+      button.addEventListener("click", () => {
+
+        relations.forEach(item =>
+          item.classList.remove("active")
+        );
+
+        button.classList.add("active");
+
+        selectedRelation =
+          button.dataset.relation;
+
+        updateInspector();
+
+      });
+
+    });
+
+
+    function getPosition(event) {
+
+      const rect =
+        fabric.getBoundingClientRect();
+
+      const eventRect =
+        event.getBoundingClientRect();
+
+      return {
+
+        x:
+          eventRect.left +
+          eventRect.width / 2 -
+          rect.left,
+
+        y:
+          eventRect.top +
+          eventRect.height / 2 -
+          rect.top
+
+      };
+
+    }
+
+
+    function drawThread(a, b, relation, confidence) {
+
+      const start =
+        getPosition(a);
+
+      const end =
+        getPosition(b);
+
+      const rect =
+        fabric.getBoundingClientRect();
+
+      const width =
+        rect.width;
+
+      const height =
+        rect.height;
+
+      const x1 =
+        (start.x / width) * 900;
+
+      const y1 =
+        (start.y / height) * 620;
+
+      const x2 =
+        (end.x / width) * 900;
+
+      const y2 =
+        (end.y / height) * 620;
+
+      const middleX =
+        (x1 + x2) / 2;
+
+      const middleY =
+        (y1 + y2) / 2;
+
+      const curve =
+        50 +
+        Math.abs(x2 - x1) * .12;
+
+      const path =
+        document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "path"
+        );
+
+      path.setAttribute(
+        "d",
+        `M ${x1} ${y1}
+         Q ${middleX} ${middleY - curve}
+         ${x2} ${y2}`
+      );
+
+      path.classList.add("causal-thread");
+
+      path.dataset.relation =
+        relation;
+
+      path.dataset.confidence =
+        confidence;
+
+
+      path.addEventListener(
+        "mouseenter",
+        () => {
+
+          a.classList.add("thread-focus");
+          b.classList.add("thread-focus");
+
+          path.classList.add("thread-active");
+
+        }
+      );
+
+
+      path.addEventListener(
+        "mouseleave",
+        () => {
+
+          a.classList.remove("thread-focus");
+          b.classList.remove("thread-focus");
+
+          path.classList.remove("thread-active");
+
+        }
+      );
+
+
+      threadLayer.appendChild(path);
+
+    }
+
+
+    function createStitch() {
+
+      if (!firstEvent || !secondEvent)
+        return;
+
+
+      const a =
+        getData(firstEvent);
+
+      const b =
+        getData(secondEvent);
+
+      const confidence =
+        Math.round(
+          (a.confidence + b.confidence) / 2
+        );
+
+
+      stitches.push({
+
+        a: firstEvent,
+
+        b: secondEvent,
+
+        relation:
+          selectedRelation,
+
+        confidence
+
+      });
+
+
+      drawThread(
+        firstEvent,
+        secondEvent,
+        selectedRelation,
+        confidence
+      );
+
+
+      firstEvent.classList.add("stitched");
+      secondEvent.classList.add("stitched");
+
+
+      firstEvent.classList.remove("selected");
+      secondEvent.classList.remove("selected");
+
+
+      firstEvent = null;
+      secondEvent = null;
+
+
+      updateStats();
+
+      updateInspector();
+
+    }
+
+
+    confirmStitch.addEventListener(
+      "click",
+      createStitch
+    );
+
+
+    function updateStats() {
+
+      const count =
+        stitches.length;
+
+      stitchCount.textContent =
+        String(count).padStart(2, "0");
+
+      const connected =
+        new Set();
+
+      stitches.forEach(stitch => {
+
+        connected.add(stitch.a);
+        connected.add(stitch.b);
+
+      });
+
+      unresolvedCount.textContent =
+        String(
+          events.length -
+          connected.size
+        ).padStart(2, "0");
+
+
+      if (count === 0) {
+
+        fabricState.textContent =
+          "UNRESOLVED";
+
+        chainConfidence.textContent =
+          "—";
+
+      } else if (count < 3) {
+
+        fabricState.textContent =
+          "PARTIAL";
+
+      } else {
+
+        fabricState.textContent =
+          "CONNECTED";
+
+        const average =
+          Math.round(
+            stitches.reduce(
+              (sum, stitch) =>
+                sum + stitch.confidence,
+              0
+            ) / stitches.length
+          );
+
+        chainConfidence.textContent =
+          average + "%";
+
+      }
+
+    }
+
+
+    document
+      .getElementById("stitchMode")
+      .addEventListener(
+        "click",
+        function () {
+
+          stitchMode =
+            !stitchMode;
+
+          this.classList.toggle(
+            "active",
+            stitchMode
+          );
+
+          this.textContent =
+            stitchMode
+              ? "STITCH MODE"
+              : "INSPECT MODE";
+
+        }
+      );
+
+
+    document
+      .getElementById("undo")
+      .addEventListener(
+        "click",
+        () => {
+
+          const last =
+            stitches.pop();
+
+          if (!last)
+            return;
+
+
+          const paths =
+            [...document.querySelectorAll(
+              ".causal-thread"
+            )];
+
+          const path =
+            paths[paths.length - 1];
+
+          if (path)
+            path.remove();
+
+
+          const stillConnectedA =
+            stitches.some(
+              stitch =>
+                stitch.a === last.a ||
+                stitch.b === last.a
+            );
+
+          const stillConnectedB =
+            stitches.some(
+              stitch =>
+                stitch.a === last.b ||
+                stitch.b === last.b
+            );
+
+
+          if (!stillConnectedA)
+            last.a.classList.remove("stitched");
+
+          if (!stillConnectedB)
+            last.b.classList.remove("stitched");
+
+
+          updateStats();
+
+        }
+      );
+
+
+    document
+      .getElementById("clear")
+      .addEventListener(
+        "click",
+        () => {
+
+          stitches = [];
+
+          threadLayer.innerHTML = "";
+
+          events.forEach(event => {
+
+            event.classList.remove(
+              "selected",
+              "stitched",
+              "thread-focus"
+            );
+
+          });
+
+          firstEvent = null;
+          secondEvent = null;
+
+          updateStats();
+          updateInspector();
+
+        }
+      );
+
+
+    document
+      .getElementById("reconstruct")
+      .addEventListener(
+        "click",
+        async () => {
+
+          const pairs = [
+
+            [events[0], events[1]],
+
+            [events[1], events[3]],
+
+            [events[3], events[4]],
+
+            [events[4], events[5]],
+
+            [events[5], events[8]],
+
+            [events[8], events[9]]
+
+          ];
+
+
+          for (const [a, b] of pairs) {
+
+            if (
+              stitches.some(
+                stitch =>
+                  (
+                    stitch.a === a &&
+                    stitch.b === b
+                  ) ||
+                  (
+                    stitch.a === b &&
+                    stitch.b === a
+                  )
+              )
+            ) {
+
+              continue;
+
+            }
+
+
+            drawThread(
+              a,
+              b,
+              "TRIGGERED",
+              Math.round(
+                (
+                  Number(a.dataset.confidence) +
+                  Number(b.dataset.confidence)
+                ) / 2
+              )
+            );
+
+
+            stitches.push({
+
+              a,
+              b,
+
+              relation:
+                "TRIGGERED",
+
+              confidence:
+                Math.round(
+                  (
+                    Number(a.dataset.confidence) +
+                    Number(b.dataset.confidence)
+                  ) / 2
+                )
+
+            });
+
+
+            a.classList.add("stitched");
+            b.classList.add("stitched");
+
+            updateStats();
+
+            await new Promise(
+              resolve =>
+                setTimeout(resolve, 350)
+            );
+
+          }
+
+        }
+      );
+
+
+    fabric.addEventListener(
+      "mousemove",
+      event => {
+
+        const rect =
+          fabric.getBoundingClientRect();
+
+        const x =
+          event.clientX - rect.left;
+
+        const y =
+          event.clientY - rect.top;
+
+        tooltip.style.left =
+          Math.min(
+            x + 18,
+            rect.width - 180
+          ) + "px";
+
+        tooltip.style.top =
+          Math.min(
+            y + 18,
+            rect.height - 120
+          ) + "px";
+
+      }
+    );
+
+
+    window.addEventListener(
+      "resize",
+      () => {
+
+        threadLayer.innerHTML = "";
+
+        stitches.forEach(stitch => {
+
+          drawThread(
+            stitch.a,
+            stitch.b,
+            stitch.relation,
+            stitch.confidence
+          );
+
+        });
+
+      }
+    );
+
+
+    updateStats();
+    updateInspector();
+
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/casual-stitch/style.css
+++ b/submissions/examples/casual-stitch/style.css
@@ -1,0 +1,1238 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #080908;
+  --surface: #0d100e;
+  --surface-2: #111511;
+
+  --border: #29302a;
+  --border-soft: #1c221d;
+
+  --text: #e8eee8;
+  --muted: #899389;
+  --dim: #535c54;
+
+  --thread: #b8e6b8;
+  --thread-soft: rgba(184, 230, 184, .12);
+
+  --accent: #d2f4c9;
+  --danger: #e8a6a6;
+}
+
+html {
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 50% 20%,
+      rgba(150, 210, 150, .045),
+      transparent 38%
+    ),
+    var(--bg);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+button {
+  font: inherit;
+}
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 35px 18px;
+}
+
+.causal-shell {
+  width: min(1220px, 100%);
+
+  padding: 42px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 28px;
+
+  background:
+    rgba(10, 12, 10, .97);
+
+  box-shadow:
+    0 50px 120px rgba(0, 0, 0, .55);
+}
+
+
+/* HEADER */
+
+.header {
+  display: flex;
+
+  justify-content: space-between;
+  align-items: flex-start;
+
+  gap: 30px;
+
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  display: block;
+
+  margin-bottom: 10px;
+
+  color: var(--accent);
+
+  font-size: 7px;
+
+  font-weight: 800;
+
+  letter-spacing: .2em;
+}
+
+.header h1 {
+  font-size:
+    clamp(42px, 6vw, 68px);
+
+  line-height: .9;
+
+  letter-spacing: -.075em;
+}
+
+.header p {
+  max-width: 570px;
+
+  margin-top: 15px;
+
+  color: var(--muted);
+
+  font-size: 13px;
+
+  line-height: 1.65;
+}
+
+.system-status {
+  display: flex;
+
+  align-items: center;
+
+  gap: 10px;
+
+  padding: 11px 14px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 10px;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+
+  border-radius: 50%;
+
+  background: var(--thread);
+
+  box-shadow:
+    0 0 14px rgba(184, 230, 184, .65);
+}
+
+.system-status small {
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+.system-status strong {
+  display: block;
+
+  margin-top: 3px;
+
+  font-size: 9px;
+
+  letter-spacing: .1em;
+}
+
+
+/* STATS */
+
+.stats {
+  display: grid;
+
+  grid-template-columns:
+    repeat(4, 1fr);
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 12px;
+
+  overflow: hidden;
+
+  margin-bottom: 12px;
+}
+
+.stat {
+  padding: 13px 15px;
+
+  border-right:
+    1px solid var(--border);
+}
+
+.stat:last-child {
+  border-right: 0;
+}
+
+.stat span {
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .13em;
+}
+
+.stat strong {
+  display: block;
+
+  margin-top: 6px;
+
+  font-size: 17px;
+
+  letter-spacing: -.03em;
+}
+
+
+/* TOOLBAR */
+
+.toolbar {
+  display: flex;
+
+  justify-content: space-between;
+
+  gap: 10px;
+
+  margin-bottom: 12px;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+
+  gap: 6px;
+}
+
+.tool-button {
+  padding: 8px 11px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 7px;
+
+  color: var(--muted);
+
+  background:
+    rgba(255, 255, 255, .015);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .11em;
+
+  cursor: pointer;
+}
+
+.tool-button:hover,
+.tool-button.active {
+  color: var(--text);
+
+  border-color:
+    rgba(184, 230, 184, .35);
+
+  background:
+    var(--thread-soft);
+}
+
+.tool-button.danger:hover {
+  color: var(--danger);
+
+  border-color:
+    rgba(232, 166, 166, .3);
+}
+
+
+/* WORKSPACE */
+
+.workspace {
+  display: grid;
+
+  grid-template-columns:
+    minmax(0, 1fr)
+    285px;
+
+  gap: 12px;
+}
+
+
+/* FABRIC */
+
+.fabric {
+  position: relative;
+
+  min-height: 620px;
+
+  overflow: hidden;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 19px;
+
+  background:
+    radial-gradient(
+      circle at 50% 50%,
+      rgba(184, 230, 184, .035),
+      transparent 55%
+    ),
+    #0b0e0b;
+
+  isolation: isolate;
+}
+
+.fabric-grid {
+  position: absolute;
+
+  inset: 0;
+
+  opacity: .3;
+
+  background-image:
+    linear-gradient(
+      rgba(180, 220, 180, .025) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(180, 220, 180, .025) 1px,
+      transparent 1px
+    );
+
+  background-size: 32px 32px;
+}
+
+.fabric-fold {
+  position: absolute;
+
+  pointer-events: none;
+
+  opacity: .18;
+
+  border-radius: 50%;
+
+  filter: blur(20px);
+}
+
+.fold-a {
+  width: 500px;
+  height: 120px;
+
+  left: -100px;
+  top: 150px;
+
+  transform:
+    rotate(20deg);
+
+  background:
+    rgba(170, 210, 170, .035);
+}
+
+.fold-b {
+  width: 550px;
+  height: 100px;
+
+  right: -150px;
+  top: 320px;
+
+  transform:
+    rotate(-17deg);
+
+  background:
+    rgba(180, 220, 180, .035);
+}
+
+.fold-c {
+  width: 450px;
+  height: 90px;
+
+  left: 200px;
+  bottom: 40px;
+
+  transform:
+    rotate(8deg);
+
+  background:
+    rgba(180, 220, 180, .025);
+}
+
+
+/* SVG THREAD LAYER */
+
+.thread-layer {
+  position: absolute;
+
+  inset: 0;
+
+  z-index: 4;
+
+  width: 100%;
+  height: 100%;
+
+  pointer-events: none;
+
+  overflow: visible;
+}
+
+.causal-thread {
+  fill: none;
+
+  stroke:
+    var(--thread);
+
+  stroke-width: 1.3;
+
+  stroke-dasharray: 5 6;
+
+  opacity: .42;
+
+  pointer-events: stroke;
+
+  cursor: pointer;
+
+  filter:
+    drop-shadow(
+      0 0 5px
+      rgba(184, 230, 184, .2)
+    );
+
+  animation:
+    threadAppear .8s ease forwards;
+}
+
+.causal-thread:hover,
+.causal-thread.thread-active {
+  stroke-width: 2.6;
+
+  opacity: .95;
+
+  stroke-dasharray: none;
+
+  filter:
+    drop-shadow(
+      0 0 9px
+      rgba(184, 230, 184, .55)
+    );
+}
+
+@keyframes threadAppear {
+  from {
+    stroke-dashoffset: 180;
+    opacity: 0;
+  }
+
+  to {
+    stroke-dashoffset: 0;
+    opacity: .42;
+  }
+}
+
+
+/* EVENTS */
+
+.event {
+  position: absolute;
+
+  z-index: 8;
+
+  left: var(--x);
+  top: var(--y);
+
+  width: 138px;
+  min-height: 88px;
+
+  padding: 15px 13px 12px;
+
+  text-align: left;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 8px 14px 10px 16px;
+
+  color: var(--text);
+
+  background:
+    rgba(14, 18, 14, .92);
+
+  box-shadow:
+    0 15px 30px rgba(0, 0, 0, .25);
+
+  cursor: pointer;
+
+  transform:
+    translate(-50%, -50%)
+    rotate(var(--rotation, 0deg));
+
+  transition:
+    transform .25s ease,
+    border-color .25s ease,
+    background .25s ease,
+    box-shadow .25s ease;
+}
+
+.event:nth-of-type(2n) {
+  --rotation: -1.5deg;
+}
+
+.event:nth-of-type(3n) {
+  --rotation: 1.8deg;
+}
+
+.event:nth-of-type(4n) {
+  --rotation: -.8deg;
+}
+
+.event:hover,
+.event:focus-visible {
+  z-index: 15;
+
+  border-color:
+    rgba(210, 244, 201, .45);
+
+  background:
+    rgba(20, 27, 20, .98);
+
+  transform:
+    translate(-50%, -54%)
+    rotate(var(--rotation))
+    scale(1.035);
+
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, .35),
+    0 0 20px rgba(184, 230, 184, .06);
+}
+
+.event:focus-visible {
+  outline:
+    1px solid var(--accent);
+
+  outline-offset:
+    5px;
+}
+
+.event.selected {
+  border-color:
+    var(--accent);
+
+  box-shadow:
+    0 0 0 4px
+    rgba(184, 230, 184, .07),
+    0 0 30px
+    rgba(184, 230, 184, .12);
+}
+
+.event.stitched {
+  border-color:
+    rgba(184, 230, 184, .28);
+}
+
+.event.thread-focus {
+  z-index: 16;
+
+  border-color:
+    var(--accent);
+
+  box-shadow:
+    0 0 25px
+    rgba(184, 230, 184, .15);
+}
+
+.pin {
+  position: absolute;
+
+  top: 10px;
+  right: 10px;
+
+  width: 5px;
+  height: 5px;
+
+  border-radius: 50%;
+
+  background:
+    var(--thread);
+}
+
+.event-id {
+  display: block;
+
+  margin-bottom: 8px;
+
+  color: var(--dim);
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 6px;
+
+  letter-spacing: .1em;
+}
+
+.event strong {
+  display: block;
+
+  font-size: 10px;
+
+  line-height: 1.25;
+}
+
+.event small {
+  display: block;
+
+  margin-top: 8px;
+
+  color: var(--muted);
+
+  font-size: 5px;
+
+  font-weight: 800;
+
+  letter-spacing: .13em;
+}
+
+
+/* CATEGORY VARIANTS */
+
+.event.cause .pin {
+  background: #d2f4c9;
+}
+
+.event.signal .pin {
+  background: #b7d7ff;
+}
+
+.event.action .pin {
+  background: #e8d0a6;
+}
+
+.event.effect .pin {
+  background: #d8b7ff;
+}
+
+.event.anomaly .pin {
+  background: #f1a9a9;
+}
+
+
+/* CENTER */
+
+.fabric-center {
+  position: absolute;
+
+  z-index: 3;
+
+  left: 50%;
+  top: 50%;
+
+  transform:
+    translate(-50%, -50%);
+
+  width: 150px;
+
+  text-align: center;
+
+  pointer-events: none;
+
+  opacity: .65;
+}
+
+.fabric-center::before {
+  content: "";
+
+  position: absolute;
+
+  z-index: -1;
+
+  left: 50%;
+  top: 50%;
+
+  width: 160px;
+  height: 160px;
+
+  transform:
+    translate(-50%, -50%);
+
+  border:
+    1px dashed
+    rgba(184, 230, 184, .08);
+
+  border-radius: 50%;
+}
+
+.fabric-center span {
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .14em;
+}
+
+.fabric-center strong {
+  display: block;
+
+  margin-top: 7px;
+
+  color: var(--muted);
+
+  font-size: 7px;
+
+  letter-spacing: .08em;
+}
+
+
+/* TOOLTIP */
+
+.event-tooltip {
+  position: absolute;
+
+  z-index: 30;
+
+  width: 165px;
+
+  padding: 12px;
+
+  pointer-events: none;
+
+  opacity: 0;
+
+  transform:
+    translateY(5px);
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 8px;
+
+  background:
+    rgba(8, 11, 9, .96);
+
+  box-shadow:
+    0 15px 35px rgba(0, 0, 0, .45);
+
+  transition:
+    opacity .15s ease,
+    transform .15s ease;
+}
+
+.event-tooltip.visible {
+  opacity: 1;
+
+  transform:
+    translateY(0);
+}
+
+.event-tooltip > span {
+  display: block;
+
+  color: var(--dim);
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 6px;
+}
+
+.event-tooltip > strong {
+  display: block;
+
+  margin-top: 5px;
+
+  font-size: 10px;
+}
+
+.tooltip-row {
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 12px;
+
+  padding-top: 8px;
+
+  border-top:
+    1px solid var(--border-soft);
+
+  font-size: 6px;
+}
+
+.tooltip-row span {
+  color: var(--dim);
+}
+
+.tooltip-row b {
+  color: var(--text);
+}
+
+
+/* INSPECTOR */
+
+.inspector {
+  display: flex;
+
+  flex-direction: column;
+
+  min-height: 620px;
+
+  overflow: hidden;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 18px;
+
+  background:
+    rgba(255, 255, 255, .012);
+}
+
+.inspector-header {
+  display: flex;
+
+  justify-content: space-between;
+
+  padding: 15px;
+
+  border-bottom:
+    1px solid var(--border);
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .13em;
+}
+
+.inspector-body {
+  flex: 1;
+
+  padding: 23px 17px;
+}
+
+.selection-block > span,
+.relationship > span,
+.confidence > div > span,
+.evidence > span,
+.chain-summary > span {
+  display: block;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .13em;
+}
+
+.selected-events {
+  display: grid;
+
+  grid-template-columns:
+    1fr
+    auto
+    1fr;
+
+  align-items: center;
+
+  gap: 7px;
+
+  margin-top: 12px;
+}
+
+.selected-events div {
+  padding: 11px 8px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 6px;
+
+  text-align: center;
+
+  font-family:
+    ui-monospace,
+    monospace;
+
+  font-size: 8px;
+}
+
+.selected-events span {
+  color: var(--dim);
+
+  font-size: 9px;
+}
+
+
+/* RELATIONS */
+
+.relationship {
+  margin-top: 28px;
+}
+
+.relation-options {
+  display: flex;
+
+  flex-wrap: wrap;
+
+  gap: 5px;
+
+  margin-top: 10px;
+}
+
+.relation {
+  padding: 6px 7px;
+
+  border:
+    1px solid var(--border);
+
+  border-radius: 5px;
+
+  color: var(--muted);
+
+  background:
+    transparent;
+
+  font-size: 5px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+
+  cursor: pointer;
+}
+
+.relation:hover,
+.relation.active {
+  color: var(--text);
+
+  border-color:
+    rgba(184, 230, 184, .35);
+
+  background:
+    var(--thread-soft);
+}
+
+
+/* CONFIDENCE */
+
+.confidence {
+  margin-top: 28px;
+}
+
+.confidence > div:first-child {
+  display: flex;
+
+  justify-content: space-between;
+
+  align-items: center;
+}
+
+.confidence strong {
+  font-size: 10px;
+}
+
+.confidence-bar {
+  height: 3px;
+
+  margin-top: 10px;
+
+  overflow: hidden;
+
+  border-radius: 10px;
+
+  background:
+    var(--border);
+}
+
+.confidence-bar span {
+  display: block;
+
+  width: 0;
+  height: 100%;
+
+  background:
+    var(--thread);
+
+  transition:
+    width .3s ease;
+}
+
+
+/* EVIDENCE */
+
+.evidence {
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 25px;
+
+  padding-top: 13px;
+
+  border-top:
+    1px solid var(--border);
+}
+
+.evidence strong {
+  font-size: 10px;
+}
+
+
+/* CONFIRM */
+
+.confirm-button {
+  width: 100%;
+
+  margin-top: 25px;
+
+  padding: 11px;
+
+  border:
+    1px solid rgba(184, 230, 184, .3);
+
+  border-radius: 7px;
+
+  color: var(--text);
+
+  background:
+    var(--thread-soft);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .12em;
+
+  cursor: pointer;
+}
+
+.confirm-button:hover:not(:disabled) {
+  background:
+    rgba(184, 230, 184, .17);
+}
+
+.confirm-button:disabled {
+  opacity: .3;
+
+  cursor: not-allowed;
+}
+
+
+/* SUMMARY */
+
+.chain-summary {
+  margin-top: 30px;
+
+  padding-top: 16px;
+
+  border-top:
+    1px solid var(--border);
+}
+
+.chain-summary p {
+  margin-top: 9px;
+
+  color: var(--muted);
+
+  font-size: 11px;
+
+  line-height: 1.6;
+}
+
+
+/* INSPECTOR FOOTER */
+
+.inspector-footer {
+  display: flex;
+
+  justify-content: space-between;
+
+  padding: 12px 15px;
+
+  border-top:
+    1px solid var(--border);
+
+  color: var(--dim);
+
+  font-size: 5px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* FOOTER */
+
+.footer {
+  display: flex;
+
+  justify-content: space-between;
+
+  margin-top: 16px;
+
+  color: var(--dim);
+
+  font-size: 6px;
+
+  font-weight: 800;
+
+  letter-spacing: .1em;
+}
+
+
+/* RESPONSIVE */
+
+@media (max-width: 950px) {
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .inspector {
+    min-height: auto;
+  }
+
+  .inspector-body {
+    padding-bottom: 25px;
+  }
+
+}
+
+
+@media (max-width: 650px) {
+
+  .page {
+    padding: 12px 8px;
+  }
+
+  .causal-shell {
+    padding: 22px 14px;
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .system-status {
+    width: 100%;
+  }
+
+  .stats {
+    grid-template-columns:
+      repeat(2, 1fr);
+  }
+
+  .stat:nth-child(2) {
+    border-right: 0;
+  }
+
+  .stat:nth-child(-n + 2) {
+    border-bottom:
+      1px solid var(--border);
+  }
+
+  .toolbar {
+    flex-direction: column;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    flex-wrap: wrap;
+  }
+
+  .fabric {
+    min-height: 650px;
+  }
+
+  .event {
+    width: 105px;
+    min-height: 70px;
+
+    padding: 10px;
+  }
+
+  .event strong {
+    font-size: 8px;
+  }
+
+  .event small {
+    margin-top: 5px;
+  }
+
+  .event-tooltip {
+    display: none;
+  }
+
+  .footer {
+    flex-direction: column;
+    gap: 7px;
+  }
+
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+
+}


### PR DESCRIPTION
## Description

closes #76246 

This PR adds the new `Causal Stitch` interactive component.

The component provides an experimental way to reconstruct relationships between events using a digital fabric and interactive causal threads.

## What Changed

- Added interactive causal fabric
- Added 10 event fragments
- Added five event categories
- Added Stitch Mode
- Added five causal relationship types
- Added curved SVG causal threads
- Added causal confidence calculation
- Added evidence aggregation
- Added Stitch Inspector
- Added thread hover interactions
- Added dynamic statistics
- Added causal reconstruction mode
- Added Undo Last Stitch
- Added Clear Stitches
- Added responsive behavior
- Added keyboard accessibility
- Added visible focus states
- Added reduced-motion support

## Interaction

Users can:

1. Select an event.
2. Select another event.
3. Choose a causal relationship.
4. Stitch the events together.

The resulting relationship is visualized as a curved thread.

Users can also:

- Hover over events
- Hover over causal threads
- Undo the latest stitch
- Clear all stitches
- Automatically reconstruct a predefined causal chain

## Accessibility

Event fragments use native HTML buttons.

Keyboard users can navigate and activate events using the keyboard.

Visible focus states are included.

The component also supports:

```css
@media (prefers-reduced-motion: reduce)