### PR TITLE
feat: add ease-hover-image-zoom-frame-sap

### DIFF
--- a/submissions/examples/ease-hover-image-zoom-frame-sap/README.md
+++ b/submissions/examples/ease-hover-image-zoom-frame-sap/README.md
@@ -1,0 +1,30 @@
+# Hover Image Zoom Frame
+
+Image cards with a fixed-size clipped frame; the photo inside gently zooms
+on hover/focus while a caption gradient stays anchored at the bottom.
+
+**Level:** Beginner
+
+## Usage
+
+Wrap an `<img>` and a `.zoom-caption` span in `.zoom-frame` (an `<a>` in
+this demo, since these link to a fuller view). `overflow: hidden` on the
+frame clips the scaled-up image to the fixed frame size.
+
+## Accessibility
+
+- Every image carries real descriptive `alt` text.
+- Zoom triggers on `:focus-visible` as well as `:hover`, giving keyboard
+  users the same feedback as mouse users, plus a separate visible outline.
+- The caption text sits over a gradient scrim for contrast, and remains
+  static (non-scaling) while only the photo zooms, keeping it legible
+  throughout the hover interaction.
+- `prefers-reduced-motion` removes the image scale transition entirely.
+
+## Notes
+
+- Only the `<img>` itself scales via `transform`; the containing frame
+  size never changes, so `overflow: hidden` reliably clips the zoomed image
+  without affecting surrounding grid layout.
+- Caption uses a `linear-gradient` scrim (not a solid background) so it
+  blends naturally with varying photo content underneath.

--- a/submissions/examples/ease-hover-image-zoom-frame-sap/demo.html
+++ b/submissions/examples/ease-hover-image-zoom-frame-sap/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Image Zoom Frame</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Image Zoom Frame</h1>
+
+    <div class="zoom-grid">
+      <a href="#" class="zoom-frame">
+        <img src="https://picsum.photos/seed/zoomframe1/360/260" alt="Forest trail in autumn">
+        <span class="zoom-caption">Autumn Trail</span>
+      </a>
+      <a href="#" class="zoom-frame">
+        <img src="https://picsum.photos/seed/zoomframe2/360/260" alt="City skyline at dusk">
+        <span class="zoom-caption">City Dusk</span>
+      </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-hover-image-zoom-frame-sap/style.css
+++ b/submissions/examples/ease-hover-image-zoom-frame-sap/style.css
@@ -1,0 +1,72 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.zoom-grid {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.zoom-frame {
+  position: relative;
+  display: block;
+  width: 240px;
+  height: 170px;
+  border-radius: 14px;
+  overflow: hidden;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+}
+
+.zoom-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.zoom-frame:hover img,
+.zoom-frame:focus-visible img {
+  transform: scale(1.15);
+}
+
+.zoom-caption {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.6rem 0.8rem;
+  background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);
+  color: white;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.zoom-frame:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zoom-frame img { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-image-zoom-frame-sap`, framed image cards with a hover/focus zoom effect and caption overlay.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-image-zoom-frame-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Zoom triggers on `:focus-visible` as well as `:hover`, with a separate
  outline shown, so keyboard users get equal feedback.
- Only the image scales (frame size is fixed), so `overflow: hidden`
  reliably clips the zoom without disturbing surrounding grid layout.

## Feature Description

Adds a reusable framed hover-zoom image card component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.