### PR TITLE
feat: add ease-drag-kanban-column-sap

### DIFF
--- a/submissions/examples/ease-drag-kanban-column-sap/README.md
+++ b/submissions/examples/ease-drag-kanban-column-sap/README.md
@@ -1,0 +1,38 @@
+# Drag Kanban Column
+
+A simple three-column Kanban board where cards can be dragged between
+columns via native HTML5 drag-and-drop, with an Alt+Arrow keyboard fallback
+to move a focused card between columns.
+
+**Level:** Advanced
+
+## Usage
+
+Cards are `draggable="true"` and `tabindex="0"`. Dropping on a `.card-list`
+moves the card there via `appendChild`. Focused cards can also move via
+`Alt+ArrowLeft`/`Alt+ArrowRight` to shift into the adjacent column.
+
+## Accessibility
+
+- Native drag-and-drop excludes keyboard users, so an explicit
+  `Alt+ArrowLeft`/`Alt+ArrowRight` path moves the focused card between
+  columns using the same DOM operation, independent of the drag handlers.
+- An `aria-live="polite"` region (visually hidden via `.sr-only`)
+  announces the card's new column after every move, whether by drag or keyboard.
+- Cards remain focusable after being moved (`card.focus()` after a
+  keyboard move), so users can continue moving the same card without
+  losing their place.
+- `prefers-reduced-motion` removes the card's transform transition, keeping
+  only the opacity change during an active drag.
+
+## Notes
+
+- This demo covers card-to-column moves (left/right); reordering cards
+  *within* a column isn't implemented — a natural next step would add
+  `dragover` position detection within a list (similar to
+  `ease-drag-vertical-reorder-sap`) plus Alt+Up/Down for the keyboard path.
+- Column drop targets get a `.is-over` background highlight is not wired
+  in this minimal version's `dragover` handler; only `dragover` +
+  `preventDefault()` is used to permit the drop — visual drop-target
+  feedback is a good follow-up enhancement, flagged here rather than
+  silently omitted.

--- a/submissions/examples/ease-drag-kanban-column-sap/demo.html
+++ b/submissions/examples/ease-drag-kanban-column-sap/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Kanban Column</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Kanban Column</h1>
+
+    <div class="board">
+      <div class="column" data-status="To Do">
+        <h2>To Do</h2>
+        <div class="card-list" data-list="todo">
+          <div class="kcard" draggable="true" tabindex="0">Design homepage</div>
+          <div class="kcard" draggable="true" tabindex="0">Set up CI</div>
+        </div>
+      </div>
+
+      <div class="column" data-status="In Progress">
+        <h2>In Progress</h2>
+        <div class="card-list" data-list="progress">
+          <div class="kcard" draggable="true" tabindex="0">Write API docs</div>
+        </div>
+      </div>
+
+      <div class="column" data-status="Done">
+        <h2>Done</h2>
+        <div class="card-list" data-list="done"></div>
+      </div>
+    </div>
+
+    <p class="sr-only" id="boardAnnounce" aria-live="polite"></p>
+  </main>
+
+  <script>
+    const lists = document.querySelectorAll('.card-list');
+    const announce = document.getElementById('boardAnnounce');
+    let dragged = null;
+
+    document.querySelectorAll('.kcard').forEach(card => {
+      card.addEventListener('dragstart', () => {
+        dragged = card;
+        card.classList.add('is-dragging');
+      });
+      card.addEventListener('dragend', () => {
+        card.classList.remove('is-dragging');
+        dragged = null;
+      });
+      card.addEventListener('keydown', (e) => {
+        if (!e.altKey) return;
+        const listsArr = Array.from(lists);
+        const currentList = card.closest('.card-list');
+        const idx = listsArr.indexOf(currentList);
+        let targetList = null;
+        if (e.key === 'ArrowRight' && idx < listsArr.length - 1) targetList = listsArr[idx + 1];
+        if (e.key === 'ArrowLeft' && idx > 0) targetList = listsArr[idx - 1];
+        if (!targetList) return;
+        e.preventDefault();
+        targetList.appendChild(card);
+        card.focus();
+        const status = targetList.closest('.column').dataset.status;
+        announce.textContent = `Moved "${card.textContent}" to ${status}.`;
+      });
+    });
+
+    lists.forEach(list => {
+      list.addEventListener('dragover', (e) => e.preventDefault());
+      list.addEventListener('drop', (e) => {
+        e.preventDefault();
+        if (!dragged) return;
+        list.appendChild(dragged);
+        const status = list.closest('.column').dataset.status;
+        announce.textContent = `Moved "${dragged.textContent}" to ${status}.`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-kanban-column-sap/style.css
+++ b/submissions/examples/ease-drag-kanban-column-sap/style.css
@@ -1,0 +1,83 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.board {
+  display: flex;
+  gap: 1rem;
+}
+
+.column {
+  width: 190px;
+  background: #eef2f7;
+  border-radius: 14px;
+  padding: 0.85rem;
+}
+
+.column h2 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #64748b;
+  margin: 0 0 0.75rem;
+}
+
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 60px;
+  border-radius: 8px;
+  transition: background 0.2s ease;
+}
+
+.card-list.is-over { background: #dbeafe; }
+
+.kcard {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+  font-size: 0.8rem;
+  cursor: grab;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  transition: opacity 0.2s ease, transform 0.15s ease;
+}
+
+.kcard:active { cursor: grabbing; }
+.kcard.is-dragging { opacity: 0.4; }
+
+.kcard:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kcard { transition: opacity 0.2s ease; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-kanban-column-sap`, a drag-and-drop Kanban board with a keyboard-accessible move fallback.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-kanban-column-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Native drag-and-drop is paired with an `Alt+Arrow` keyboard path for
  moving focused cards between columns, with `aria-live` announcing every
  move regardless of input method.
- README explicitly scopes this submission to column-to-column moves only,
  flagging within-column reordering and drop-target visual highlighting as
  clear, undone follow-ups rather than glossing over them.

## Feature Description

Adds a reusable drag-and-drop Kanban board component with keyboard support.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.