### PR TITLE
feat: add liquid wave fill drawer

### DIFF
--- a/submissions/examples/liquid-wave-fill-drawer-msm/README.md
+++ b/submissions/examples/liquid-wave-fill-drawer-msm/README.md
@@ -1,0 +1,23 @@
+# Liquid Wave Fill Drawer
+
+## What does this do?
+
+This submission adds a pure HTML and CSS sidebar drawer with animated liquid wave fill layers and responsive open/close states.
+
+## How is it used?
+
+Add the drawer toggle, trigger, drawer panel, and scrim inside your page, then link the local stylesheet.
+
+```html
+<input class="drawer-toggle" type="checkbox" id="liquid-drawer-toggle" />
+<label class="open-drawer" for="liquid-drawer-toggle">Open drawer</label>
+<aside class="liquid-drawer" aria-label="Liquid wave drawer">
+  <label class="close-drawer" for="liquid-drawer-toggle">&times;</label>
+  <div class="drawer-content">Drawer content goes here.</div>
+</aside>
+<label class="drawer-scrim" for="liquid-drawer-toggle"></label>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a polished drawer pattern that combines fluid motion, dark-mode compatibility, keyboard-visible focus states, and reduced-motion support without requiring JavaScript.

--- a/submissions/examples/liquid-wave-fill-drawer-msm/demo.html
+++ b/submissions/examples/liquid-wave-fill-drawer-msm/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liquid Wave Fill Drawer</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="hero-panel" aria-labelledby="drawer-title">
+        <p class="eyebrow">Pure CSS Drawer</p>
+        <h1 id="drawer-title">Liquid wave fill navigation</h1>
+        <p>
+          A hardware-accelerated sidebar drawer with flowing gradient layers,
+          accessible labels, and reduced-motion friendly transitions.
+        </p>
+
+        <input
+          class="drawer-toggle"
+          type="checkbox"
+          id="liquid-drawer-toggle"
+          aria-label="Toggle liquid wave drawer"
+        />
+        <label class="open-drawer" for="liquid-drawer-toggle">
+          Open drawer
+        </label>
+
+        <aside class="liquid-drawer" aria-label="Liquid wave drawer">
+          <label
+            class="close-drawer"
+            for="liquid-drawer-toggle"
+            aria-label="Close drawer"
+          >
+            &times;
+          </label>
+
+          <div class="drawer-content">
+            <span class="status-pill">Live Flow</span>
+            <h2>Creative Workspace</h2>
+            <p>
+              Organize motion presets, reusable UI fragments, and design notes
+              in a drawer that feels fluid without JavaScript.
+            </p>
+
+            <nav class="drawer-nav" aria-label="Drawer links">
+              <a href="#palette">Palette Streams</a>
+              <a href="#motion">Motion Tokens</a>
+              <a href="#exports">Export Queue</a>
+            </nav>
+          </div>
+        </aside>
+
+        <label
+          class="drawer-scrim"
+          for="liquid-drawer-toggle"
+          aria-label="Close drawer overlay"
+        ></label>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/liquid-wave-fill-drawer-msm/style.css
+++ b/submissions/examples/liquid-wave-fill-drawer-msm/style.css
@@ -1,0 +1,342 @@
+:root {
+  --drawer-ink: #10212a;
+  --drawer-muted: #5e727b;
+  --drawer-surface: #f6fbfc;
+  --drawer-panel: rgba(255, 255, 255, 0.88);
+  --drawer-ocean: #20c7b7;
+  --drawer-lagoon: #46e39f;
+  --drawer-depth: #0e6d91;
+  --drawer-shadow: 0 28px 80px rgba(5, 41, 56, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--drawer-ink);
+  font-family: "Trebuchet MS", "Gill Sans", sans-serif;
+  background:
+    radial-gradient(
+      circle at 12% 20%,
+      rgba(70, 227, 159, 0.3),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 86% 18%,
+      rgba(32, 199, 183, 0.25),
+      transparent 32%
+    ),
+    linear-gradient(135deg, #effaf8 0%, #d8edf2 48%, #f7fbff 100%);
+}
+
+.page-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.hero-panel {
+  position: relative;
+  width: min(100%, 920px);
+  min-height: 560px;
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 5rem);
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 36px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.92),
+      rgba(236, 250, 248, 0.72)
+    ),
+    repeating-linear-gradient(
+      120deg,
+      rgba(14, 109, 145, 0.08) 0 1px,
+      transparent 1px 18px
+    );
+  box-shadow: var(--drawer-shadow);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--drawer-depth);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  max-width: 620px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.8rem, 8vw, 5.5rem);
+  line-height: 0.94;
+}
+
+h2 {
+  margin: 1rem 0 0.75rem;
+  font-size: clamp(2rem, 7vw, 4.2rem);
+  line-height: 0.98;
+}
+
+p {
+  color: var(--drawer-muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.drawer-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.open-drawer,
+.close-drawer {
+  cursor: pointer;
+}
+
+.open-drawer {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.4rem;
+  margin-top: 1.25rem;
+  padding: 0 1.5rem;
+  border: 0;
+  border-radius: 999px;
+  color: #ffffff;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  background: linear-gradient(135deg, var(--drawer-depth), var(--drawer-ocean));
+  box-shadow: 0 16px 36px rgba(14, 109, 145, 0.28);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.open-drawer:hover,
+.open-drawer:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 42px rgba(14, 109, 145, 0.34);
+  outline: 3px solid rgba(70, 227, 159, 0.5);
+  outline-offset: 4px;
+}
+
+.drawer-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 5;
+  visibility: hidden;
+  background: rgba(10, 34, 43, 0.46);
+  opacity: 0;
+  backdrop-filter: blur(5px);
+  transition:
+    opacity 320ms ease,
+    visibility 320ms ease;
+}
+
+.liquid-drawer {
+  position: fixed;
+  inset: 1rem auto 1rem 1rem;
+  z-index: 10;
+  width: min(88vw, 390px);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  border-radius: 30px;
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 24% 16%,
+      rgba(255, 255, 255, 0.26),
+      transparent 22%
+    ),
+    linear-gradient(150deg, #05384b 0%, #087a97 54%, #10b5a4 100%);
+  box-shadow: 30px 0 80px rgba(3, 31, 44, 0.36);
+  transform: translateX(calc(-100% - 2rem));
+  transition: transform 420ms cubic-bezier(0.18, 0.84, 0.28, 1);
+}
+
+.liquid-drawer::before,
+.liquid-drawer::after {
+  position: absolute;
+  right: -38%;
+  bottom: -18%;
+  width: 145%;
+  height: 60%;
+  content: "";
+  border-radius: 42% 45% 40% 48%;
+  background: rgba(70, 227, 159, 0.38);
+  transform: rotate(-8deg);
+  animation: wave-drift 8s ease-in-out infinite alternate;
+}
+
+.liquid-drawer::after {
+  right: -46%;
+  bottom: -7%;
+  background: rgba(255, 255, 255, 0.18);
+  animation-duration: 10s;
+  animation-delay: -2s;
+}
+
+.drawer-toggle:checked ~ .liquid-drawer {
+  transform: translateX(0);
+}
+
+.drawer-toggle:checked ~ .drawer-scrim {
+  visibility: visible;
+  opacity: 1;
+}
+
+.drawer-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: calc(100vh - 2rem);
+  flex-direction: column;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.status-pill {
+  width: max-content;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.36);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.drawer-content p {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.drawer-nav {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+}
+
+.drawer-nav a {
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 18px;
+  color: #ffffff;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.1);
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.drawer-nav a:hover,
+.drawer-nav a:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateX(6px);
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 3px;
+}
+
+.close-drawer {
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  z-index: 2;
+  display: grid;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 50%;
+  color: #ffffff;
+  font-size: 2rem;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.15);
+  place-items: center;
+}
+
+@keyframes wave-drift {
+  from {
+    transform: translate3d(-2%, 2%, 0) rotate(-8deg) scale(1);
+  }
+
+  to {
+    transform: translate3d(6%, -4%, 0) rotate(5deg) scale(1.05);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --drawer-ink: #e8fbfa;
+    --drawer-muted: #a6c7cc;
+    --drawer-surface: #081f2a;
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 20% 18%,
+        rgba(32, 199, 183, 0.22),
+        transparent 30%
+      ),
+      linear-gradient(135deg, #061822 0%, #0b2d3b 55%, #071118 100%);
+  }
+
+  .hero-panel {
+    border-color: rgba(255, 255, 255, 0.12);
+    background:
+      linear-gradient(145deg, rgba(7, 28, 38, 0.92), rgba(12, 56, 70, 0.7)),
+      repeating-linear-gradient(
+        120deg,
+        rgba(70, 227, 159, 0.08) 0 1px,
+        transparent 1px 18px
+      );
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    padding: 1rem;
+  }
+
+  .hero-panel {
+    min-height: 620px;
+    padding: 2rem;
+    border-radius: 26px;
+  }
+
+  .liquid-drawer {
+    inset: 0;
+    width: min(92vw, 360px);
+    border-radius: 0 28px 28px 0;
+  }
+
+  .drawer-content {
+    min-height: 100vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a pure HTML/CSS Liquid Wave Fill drawer submission under `submissions/examples/liquid-wave-fill-drawer-msm/`
- Includes checkbox-driven open/close behavior with accessible labels and overlay closing
- Adds animated liquid wave layers, dark-mode styling, focus-visible states, responsive layout, and reduced-motion support

Closes #73588

## Changes made
- Added `demo.html` with a self-contained drawer demo
- Added `style.css` for the liquid wave fill visual treatment and transitions
- Added `README.md` with usage notes and rationale

## Testing
- `npx.cmd prettier --write submissions/examples/liquid-wave-fill-drawer-msm/**/*.{html,css,md}`
- `npx.cmd prettier --check submissions/examples/liquid-wave-fill-drawer-msm/**/*.{html,css,md}`
- `npx.cmd stylelint submissions/examples/liquid-wave-fill-drawer-msm/style.css --ignore-path .stylelintignore-does-not-exist`
- `git diff --check`
- `git diff --cached --check`

## Edge cases handled
- Keyboard-visible focus styles for drawer controls and links
- `prefers-reduced-motion` support for motion-sensitive users
- Responsive mobile drawer sizing
- Dark-mode compatible color treatment

## Checklist
- [x] Only files inside `submissions/examples/liquid-wave-fill-drawer-msm/` were added
- [x] Includes exactly `demo.html`, `style.css`, and `README.md`
- [x] No framework/core files were modified
- [x] Local formatting and lint checks passed