### PR TITLE
feat: add basic resource link row demo

### DIFF
--- a/submissions/examples/basic-resource-link-row-kk/README.md
+++ b/submissions/examples/basic-resource-link-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Resource Link Row
+
+## What it does
+
+This submission adds a simple CSS-only resource link row for documentation links, reference lists, support articles, release notes, and quick resource sections.
+
+It aligns a small resource marker, link title, description, and right-side cue in one compact row.
+
+## How to use it
+
+Add the utility class to a link row:
+
+```html
+<a class="basic-resource-link-row" href="#">
+  <span class="resource-icon" aria-hidden="true">D</span>
+  <span class="resource-copy">
+    <strong>Documentation guide</strong>
+    <span>Read setup instructions and usage notes.</span>
+  </span>
+  <span class="resource-cue" aria-hidden="true">Open</span>
+</a>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across documentation pages, dashboard help panels, cards, settings sections, and onboarding screens. It stays lightweight with semantic links and CSS-only styling.
+
+## Included features
+
+- Resource marker, title, description, and cue layout
+- Hover and keyboard focus styling
+- Divider support between rows
+- Text truncation for long descriptions
+- Responsive small-screen behavior
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the resource link row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-resource-link-row-kk/demo.html
+++ b/submissions/examples/basic-resource-link-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Resource Link Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Resource Link Row</p>
+          <h1>Readable resource rows for docs, links, and references.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a small resource marker, link title,
+            description, and right-side cue for compact reference lists.
+          </p>
+        </header>
+
+        <section class="resource-panel" aria-label="Resource link row examples">
+          <a class="basic-resource-link-row" href="#">
+            <span class="resource-icon" aria-hidden="true">D</span>
+            <span class="resource-copy">
+              <strong>Documentation guide</strong>
+              <span>Read setup instructions and usage notes.</span>
+            </span>
+            <span class="resource-cue" aria-hidden="true">Open</span>
+          </a>
+
+          <a class="basic-resource-link-row" href="#">
+            <span class="resource-icon" aria-hidden="true">R</span>
+            <span class="resource-copy">
+              <strong>Release notes</strong>
+              <span>Review recent changes and improvements.</span>
+            </span>
+            <span class="resource-cue" aria-hidden="true">View</span>
+          </a>
+
+          <a class="basic-resource-link-row" href="#">
+            <span class="resource-icon" aria-hidden="true">S</span>
+            <span class="resource-copy">
+              <strong>Support article</strong>
+              <span>Find answers for common implementation questions.</span>
+            </span>
+            <span class="resource-cue" aria-hidden="true">Read</span>
+          </a>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;a class="basic-resource-link-row" href="#"&gt;
+  &lt;span class="resource-icon" aria-hidden="true"&gt;D&lt;/span&gt;
+  &lt;span class="resource-copy"&gt;
+    &lt;strong&gt;Documentation guide&lt;/strong&gt;
+    &lt;span&gt;Read setup instructions and usage notes.&lt;/span&gt;
+  &lt;/span&gt;
+  &lt;span class="resource-cue" aria-hidden="true"&gt;Open&lt;/span&gt;
+&lt;/a&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-resource-link-row-kk/style.css
+++ b/submissions/examples/basic-resource-link-row-kk/style.css
@@ -1,0 +1,167 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #a7f3d0;
+  --accent-soft: rgba(167, 243, 208, 0.13);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(167, 243, 208, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.11), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.resource-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-resource-link-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.basic-resource-link-row + .basic-resource-link-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.resource-icon {
+  width: 2.55rem;
+  height: 2.55rem;
+  flex: 0 0 2.55rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(167, 243, 208, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 800;
+}
+
+.resource-copy {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.resource-copy strong {
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.resource-copy span {
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resource-cue {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.4rem 0.68rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.basic-resource-link-row:hover .resource-cue,
+.basic-resource-link-row:focus-visible .resource-cue {
+  color: #06120d;
+  background: var(--accent);
+}
+
+.basic-resource-link-row:focus-visible {
+  border-radius: 0.9rem;
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-resource-link-row {
+    align-items: flex-start;
+  }
+
+  .resource-cue {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Resource Link Row demo inside `submissions/examples/basic-resource-link-row-kk/`. This submission introduces a compact CSS-only link row pattern for documentation links, reference lists, support articles, release notes, and quick resource sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only resource link row for showing a small resource marker, link title, description, and right-side cue in one compact layout.

**How does a developer use it?**

```html
<a class="basic-resource-link-row" href="#">
  <span class="resource-icon" aria-hidden="true">D</span>
  <span class="resource-copy">
    <strong>Documentation guide</strong>
    <span>Read setup instructions and usage notes.</span>
  </span>
  <span class="resource-cue" aria-hidden="true">Open</span>
</a>