### PR TITLE
feat: add pure CSS Drawer 3D Perspective Tilt component (#73584)

### DIFF
--- a/submissions/examples/css-drawer-3d-perspective-tilt-pure/README.md
+++ b/submissions/examples/css-drawer-3d-perspective-tilt-pure/README.md
@@ -1,0 +1,20 @@
+# CSS Drawer: 3D Perspective Tilt
+
+A hardware-accelerated, JavaScript-free drawer/sidebar component featuring immersive 3D transformations. When opened, the entire main page tilts backward into 3D space, creating a physical sense of depth, while the drawer panel swings open like a door.
+
+## Features
+- Pure CSS and HTML implementation. The drawer toggle mechanism relies entirely on the CSS Checkbox Hack (`:checked ~`), eliminating the need for JavaScript state management.
+- **Component Architecture**: 
+  - **3D Perspective Scene**: The entire layout is wrapped in `.perspective-wrapper`, which applies `perspective: 1500px`. This establishes a 3D camera view, allowing child elements to use Z-axis transformations and Y-axis rotations accurately.
+  - **Tilted Page Content**: The main page content acts as a rigid 3D plane. Its `transform-origin` is set to the right edge (`100% 50%`). When the hidden checkbox is checked, it transitions using `translateZ(-200px)` (pushing it backward away from the camera), `translateX(-250px)` (moving it left), and `rotateY(15deg)` (tilting the left side further back). This creates the illusion that the page is a physical object being pushed out of the way.
+  - **Swinging Drawer Panel**: The drawer itself is initially rotated `90deg` on the Y-axis, making it invisible as it points directly away from the viewer. Its `transform-origin` is also on the right edge. When opened, it rotates back to `0deg`, swinging flush with the screen like a door on a hinge.
+  - **Overlay Fade**: An absolute-positioned `.drawer-overlay` darkens the tilted page content to direct focus to the drawer and allows the user to click off to close.
+- **Theming**: Configured via CSS Custom Properties. Supports Dark Mode automatically via `@media (prefers-color-scheme: dark)`. The `body` background color acts as the "void" color seen behind the page when it tilts backward.
+- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. If reduced motion is requested, the complex 3D tilts and swings are disabled, and the drawer falls back to a standard, instantaneous 2D slide-in translation.
+
+## Usage
+Open `demo.html` in your browser. Click the "Open 3D Drawer" button to trigger the pure CSS drawer. Notice how the main content area physically tilts backward while the drawer swings in from the right edge.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox hack setup, the perspective wrapper, the tilting page content, and the swinging drawer panel.
+- `style.css`: The styling, the CSS `perspective` setup, the complex `rotateY` and `translateZ` transformation mathematics, and the fallback logic for reduced motion.

--- a/submissions/examples/css-drawer-3d-perspective-tilt-pure/demo.html
+++ b/submissions/examples/css-drawer-3d-perspective-tilt-pure/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Drawer: 3D Perspective Tilt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+      The Checkbox Hack: 
+      Controls the state of the 3D scene.
+    -->
+    <input type="checkbox" id="drawer-toggle" class="drawer-toggle-hidden">
+
+    <!-- 
+      The 3D Scene Wrapper.
+      Establishes the CSS perspective for child elements.
+    -->
+    <div class="perspective-wrapper">
+
+        <!-- The Drawer Panel (Swings in like a door) -->
+        <aside class="drawer-panel">
+            <div class="drawer-header">
+                <h2>3D NAVIGATION</h2>
+            </div>
+            
+            <nav class="drawer-nav">
+                <ul class="nav-list">
+                    <li class="nav-item active"><a href="#">Overview</a></li>
+                    <li class="nav-item"><a href="#">Projects</a></li>
+                    <li class="nav-item"><a href="#">Team</a></li>
+                    <li class="nav-item"><a href="#">Analytics</a></li>
+                    <li class="nav-item"><a href="#">Settings</a></li>
+                </ul>
+            </nav>
+            
+            <div class="drawer-footer">
+                <p>System Version 4.2.1</p>
+            </div>
+        </aside>
+
+        <!-- 
+          The Page Content Wrapper.
+          This entire section tilts backward in 3D space when the drawer opens.
+        -->
+        <div class="page-content">
+            <!-- Overlay to dim the page content when tilted -->
+            <label for="drawer-toggle" class="drawer-overlay"></label>
+
+            <div class="container">
+                <header class="header">
+                    <h1 class="tilt-title">Perspective Tilt</h1>
+                    <p>Pure CSS 3D drawer featuring hardware-accelerated rotateY and translateZ transformations.</p>
+                    
+                    <!-- The Trigger Button -->
+                    <label for="drawer-toggle" class="btn">
+                        <span class="btn-text">Open 3D Drawer ☰</span>
+                    </label>
+                </header>
+
+                <main class="grid">
+                    <div class="placeholder-content">
+                        <h2>Immersive Interaction</h2>
+                        <p>Click the button above to trigger the pure CSS drawer. Notice how this entire main content area tilts backward into 3D space, creating a physical sense of depth, while the drawer swings open like a door.</p>
+                        
+                        <div class="dummy-cards">
+                            <div class="dummy-card"></div>
+                            <div class="dummy-card"></div>
+                            <div class="dummy-card"></div>
+                        </div>
+                    </div>
+                </main>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-drawer-3d-perspective-tilt-pure/style.css
+++ b/submissions/examples/css-drawer-3d-perspective-tilt-pure/style.css
@@ -1,0 +1,282 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #111827; /* Dark Slate for page behind */
+    --bg-page: #f3f4f6; /* Light gray for the main content page */
+    --bg-drawer: #ffffff; /* White drawer */
+    
+    --text-primary: #1f2937;
+    --text-secondary: #6b7280;
+    
+    --accent-color: #3b82f6;
+    
+    --drawer-width: 300px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base); /* The void color seen when page tilts */
+    font-family: 'Inter', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+    overflow-y: hidden; /* Prevent scrolling issues during 3D transforms */
+}
+
+/* Base button styles */
+.btn {
+    display: inline-block;
+    cursor: pointer;
+    background: var(--accent-color);
+    color: #fff;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1rem;
+    box-shadow: 0 4px 6px rgba(59, 130, 246, 0.3);
+    transition: all 0.2s ease;
+}
+
+.btn:hover {
+    background: #2563eb;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 12px rgba(59, 130, 246, 0.4);
+}
+
+/* =========================================
+   [TECHNIQUE 1] 3D Perspective Wrapper
+   Establishes the CSS perspective camera.
+   ========================================= */
+.perspective-wrapper {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    /* Create a 3D space */
+    perspective: 1500px;
+    overflow: hidden;
+}
+
+/* =========================================
+   The Checkbox Hack
+   ========================================= */
+.drawer-toggle-hidden {
+    display: none;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Tilted Page Content
+   The main content acts as a 3D plane.
+   ========================================= */
+.page-content {
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background-color: var(--bg-page);
+    color: var(--text-primary);
+    overflow-y: auto;
+    
+    /* Set the hinge point for the tilt to the right edge */
+    transform-origin: 100% 50%;
+    
+    /* Smooth 3D transition */
+    transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    
+    /* Ensure content renders nicely during 3D transform */
+    will-change: transform;
+    backface-visibility: hidden;
+}
+
+/* When Drawer Opens: Tilt and push the page back */
+.drawer-toggle-hidden:checked ~ .perspective-wrapper .page-content {
+    /* 
+       translateZ: Push it backward into the screen.
+       translateX: Move it left to make room.
+       rotateY: Tilt it so the left side is further back than the right side.
+    */
+    transform: translateZ(-200px) translateX(-250px) rotateY(15deg);
+}
+
+/* The Overlay on the Page */
+.drawer-overlay {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 900;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.6s ease, visibility 0.6s ease;
+    cursor: pointer;
+    border-radius: inherit;
+}
+
+.drawer-toggle-hidden:checked ~ .perspective-wrapper .page-content .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+
+/* =========================================
+   [TECHNIQUE 3] 3D Swinging Drawer Panel
+   Acts like a door swinging open on a hinge.
+   ========================================= */
+.drawer-panel {
+    position: absolute;
+    top: 0; right: 0;
+    width: var(--drawer-width);
+    height: 100%;
+    background: var(--bg-drawer);
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    box-shadow: -5px 0 20px rgba(0,0,0,0.2);
+    
+    /* Set the hinge point to the right edge (like a door) */
+    transform-origin: 100% 50%;
+    
+    /* Initially swung shut (rotated 90deg away from viewer) */
+    transform: rotateY(90deg);
+    opacity: 0;
+    
+    /* Smooth 3D transition */
+    transition: transform 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.4s ease;
+    will-change: transform;
+}
+
+/* When Drawer Opens: Swing it flush with the screen */
+.drawer-toggle-hidden:checked ~ .perspective-wrapper .drawer-panel {
+    transform: rotateY(0deg);
+    opacity: 1;
+}
+
+
+/* =========================================
+   Layout details for Page Content
+   ========================================= */
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.tilt-title {
+    font-size: 3rem;
+    font-weight: 800;
+    margin: 0 0 10px 0;
+    letter-spacing: -1px;
+}
+
+.header p { color: var(--text-secondary); font-size: 1.1rem; max-width: 600px; margin-bottom: 40px;}
+
+.placeholder-content {
+    background: #fff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+    border: 1px solid rgba(0,0,0,0.05);
+}
+
+.placeholder-content h2 { margin-top: 0; }
+.placeholder-content p { color: var(--text-secondary); line-height: 1.6; margin-bottom: 30px; }
+
+.dummy-cards { display: flex; gap: 20px; }
+.dummy-card { flex: 1; height: 120px; background: #f3f4f6; border-radius: 8px; }
+
+
+/* =========================================
+   Drawer Inner Styling
+   ========================================= */
+.drawer-header {
+    padding: 40px 30px 20px 30px;
+}
+
+.drawer-header h2 {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 800;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.drawer-nav {
+    flex-grow: 1;
+    padding: 10px 0;
+}
+
+.nav-list {
+    list-style: none;
+    margin: 0; padding: 0;
+}
+
+.nav-item a {
+    display: block;
+    padding: 14px 30px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1.1rem;
+    transition: background 0.2s, color 0.2s, padding-left 0.2s;
+    border-left: 3px solid transparent;
+}
+
+.nav-item a:hover {
+    background: rgba(59, 130, 246, 0.05);
+    color: var(--accent-color);
+    padding-left: 35px; /* Slight push effect */
+}
+
+.nav-item.active a {
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--accent-color);
+    border-left: 3px solid var(--accent-color);
+}
+
+.drawer-footer {
+    padding: 20px 30px;
+    border-top: 1px solid #e5e7eb;
+}
+
+.drawer-footer p {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+
+/* Dark Mode Overrides (Optional fallback demo) */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-page: #1f2937;
+        --bg-drawer: #111827;
+        --text-primary: #f9fafb;
+        --text-secondary: #9ca3af;
+    }
+    .placeholder-content { background: #374151; border-color: #4b5563; box-shadow: 0 10px 30px rgba(0,0,0,0.5); }
+    .dummy-card { background: #4b5563; }
+    .drawer-footer { border-color: #374151; }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .page-content, .drawer-panel, .drawer-overlay {
+        transition: none !important;
+    }
+    
+    /* Fallback to simple translation for accessibility */
+    .drawer-toggle-hidden:checked ~ .perspective-wrapper .page-content {
+        transform: translateX(calc(var(--drawer-width) * -1));
+    }
+    
+    .drawer-panel {
+        transform: translateX(100%);
+        opacity: 1;
+    }
+    .drawer-toggle-hidden:checked ~ .perspective-wrapper .drawer-panel {
+        transform: translateX(0);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free drawer/sidebar component featuring immersive 3D transformations. When opened, the entire main page tilts backward into 3D space, creating a physical sense of depth, while the drawer panel swings open like a door. Resolves issue #73584.

### Changes Made:
- Added `submissions/examples/css-drawer-3d-perspective-tilt-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox hack setup, the perspective wrapper, the tilting page content, and the swinging drawer panel.
- Created `style.css` featuring the UI mechanics:
  - **3D Perspective Scene**: The entire layout is wrapped in `.perspective-wrapper`, which applies `perspective: 1500px`. This establishes a 3D camera view, allowing child elements to use Z-axis transformations and Y-axis rotations accurately.
  - **Tilted Page Content**: The main page content acts as a rigid 3D plane. Its `transform-origin` is set to the right edge (`100% 50%`). When the hidden checkbox is checked, it transitions using `translateZ(-200px)` (pushing it backward away from the camera), `translateX(-250px)` (moving it left), and `rotateY(15deg)` (tilting the left side further back). This creates the illusion that the page is a physical object being pushed out of the way.
  - **Swinging Drawer Panel**: The drawer itself is initially rotated `90deg` on the Y-axis, making it invisible as it points directly away from the viewer. Its `transform-origin` is also on the right edge. When opened, it rotates back to `0deg`, swinging flush with the screen like a door on a hinge.
  - **Theming Supported**: Configured via CSS Custom Properties. Supports Dark Mode automatically via `@media (prefers-color-scheme: dark)`. The `body` background color acts as the "void" color seen behind the page when it tilts backward.
- Added `README.md` documenting usage and the technical mechanics of the CSS `perspective` setup, the complex `rotateY` and `translateZ` transformation mathematics, and the fallback logic for reduced motion.
- Fully accessible semantic structure. Honors the `prefers-reduced-motion` accessibility standard. If reduced motion is requested, the complex 3D tilts and swings are disabled, and the drawer falls back to a standard, instantaneous 2D slide-in translation.

Closes #73584
