### PR TITLE
feat: add neumorphic soft shadow drawer

### DIFF
--- a/submissions/examples/neumorphic-soft-shadow-drawer-msm/README.md
+++ b/submissions/examples/neumorphic-soft-shadow-drawer-msm/README.md
@@ -1,0 +1,22 @@
+# Neumorphic Soft Shadow Drawer
+
+## What does this do?
+
+This submission adds a pure HTML and CSS sidebar drawer with a neumorphic soft shadow visual treatment.
+
+## How is it used?
+
+Add the checkbox toggle, open trigger, backdrop, and drawer panel to your page, then include the local stylesheet.
+
+```html
+<input class="drawer-toggle" type="checkbox" id="soft-drawer-toggle" />
+<label class="open-drawer" for="soft-drawer-toggle">Open soft drawer</label>
+<label class="drawer-backdrop" for="soft-drawer-toggle"></label>
+<aside class="soft-drawer" aria-label="Neumorphic soft shadow drawer">
+  <div class="drawer-content">Drawer content goes here.</div>
+</aside>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a tactile drawer pattern with layered inset and outset shadows, accessible focus states, responsive behavior, dark-mode support, and reduced-motion safety without JavaScript.

--- a/submissions/examples/neumorphic-soft-shadow-drawer-msm/demo.html
+++ b/submissions/examples/neumorphic-soft-shadow-drawer-msm/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Neumorphic Soft Shadow Drawer</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="soft-stage">
+      <section class="workspace-card" aria-labelledby="drawer-title">
+        <p class="eyebrow">CSS Drawer</p>
+        <h1 id="drawer-title">Neumorphic soft shadow sidebar</h1>
+        <p>
+          A pure CSS drawer that slides in like a raised control surface, using
+          layered soft shadows for a calm, tactile navigation experience.
+        </p>
+
+        <input
+          class="drawer-toggle"
+          type="checkbox"
+          id="soft-drawer-toggle"
+          aria-label="Toggle neumorphic drawer"
+        />
+        <label class="open-drawer" for="soft-drawer-toggle">
+          Open soft drawer
+        </label>
+
+        <label
+          class="drawer-backdrop"
+          for="soft-drawer-toggle"
+          aria-label="Close drawer overlay"
+        ></label>
+
+        <aside class="soft-drawer" aria-label="Neumorphic soft shadow drawer">
+          <label
+            class="close-drawer"
+            for="soft-drawer-toggle"
+            aria-label="Close neumorphic drawer"
+          >
+            &times;
+          </label>
+
+          <div class="drawer-content">
+            <span class="drawer-pill">Soft UI</span>
+            <h2>Control Center</h2>
+            <p>
+              Keep frequent actions nearby with a drawer that feels pressed from
+              the interface instead of floating above it.
+            </p>
+
+            <nav class="soft-links" aria-label="Drawer links">
+              <a href="#profile">Profile Surface</a>
+              <a href="#tasks">Task Capsules</a>
+              <a href="#reports">Quiet Reports</a>
+            </nav>
+          </div>
+        </aside>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/neumorphic-soft-shadow-drawer-msm/style.css
+++ b/submissions/examples/neumorphic-soft-shadow-drawer-msm/style.css
@@ -1,0 +1,348 @@
+:root {
+  --soft-bg: #e8edf4;
+  --soft-panel: #eef3f8;
+  --soft-ink: #263442;
+  --soft-muted: #68798b;
+  --soft-blue: #6d8dff;
+  --soft-lilac: #c8b6ff;
+  --soft-shadow-dark: rgba(122, 138, 156, 0.45);
+  --soft-shadow-light: rgba(255, 255, 255, 0.88);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--soft-ink);
+  font-family: "Gill Sans", "Trebuchet MS", sans-serif;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      rgba(200, 182, 255, 0.34),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 84% 16%,
+      rgba(109, 141, 255, 0.22),
+      transparent 30%
+    ),
+    var(--soft-bg);
+}
+
+.soft-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.workspace-card {
+  position: relative;
+  width: min(100%, 920px);
+  min-height: 560px;
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 5rem);
+  border-radius: 38px;
+  background: var(--soft-panel);
+  box-shadow:
+    24px 24px 58px var(--soft-shadow-dark),
+    -24px -24px 58px var(--soft-shadow-light),
+    inset 1px 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.workspace-card::after {
+  position: absolute;
+  right: -70px;
+  bottom: -80px;
+  width: 280px;
+  height: 280px;
+  content: "";
+  border-radius: 50%;
+  background: linear-gradient(145deg, #eef3f8, #dbe3ee);
+  box-shadow:
+    22px 22px 46px rgba(122, 138, 156, 0.32),
+    -22px -22px 46px rgba(255, 255, 255, 0.72);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--soft-blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  max-width: 620px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.8rem, 8vw, 5.6rem);
+  line-height: 0.94;
+}
+
+h2 {
+  margin: 1rem 0 0.8rem;
+  font-size: clamp(2rem, 7vw, 4.2rem);
+  line-height: 0.98;
+}
+
+p {
+  color: var(--soft-muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.drawer-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.open-drawer,
+.close-drawer,
+.drawer-backdrop {
+  cursor: pointer;
+}
+
+.open-drawer {
+  display: inline-flex;
+  align-items: center;
+  min-height: 3.45rem;
+  margin-top: 1.25rem;
+  padding: 0 1.5rem;
+  border-radius: 999px;
+  color: var(--soft-blue);
+  font-weight: 800;
+  background: var(--soft-panel);
+  box-shadow:
+    10px 10px 24px var(--soft-shadow-dark),
+    -10px -10px 24px var(--soft-shadow-light);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    color 180ms ease;
+}
+
+.open-drawer:hover,
+.open-drawer:focus-visible {
+  color: #536ed6;
+  transform: translateY(-3px);
+  box-shadow:
+    14px 14px 30px var(--soft-shadow-dark),
+    -14px -14px 30px var(--soft-shadow-light);
+  outline: 3px solid rgba(109, 141, 255, 0.28);
+  outline-offset: 5px;
+}
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 5;
+  visibility: hidden;
+  background: rgba(58, 73, 92, 0.28);
+  opacity: 0;
+  backdrop-filter: blur(4px);
+  transition:
+    opacity 300ms ease,
+    visibility 300ms ease;
+}
+
+.soft-drawer {
+  position: fixed;
+  inset: 1rem auto 1rem 1rem;
+  z-index: 10;
+  width: min(88vw, 390px);
+  overflow: hidden;
+  border-radius: 34px;
+  color: var(--soft-ink);
+  background: var(--soft-panel);
+  box-shadow:
+    28px 28px 64px rgba(102, 118, 138, 0.4),
+    -18px -18px 42px rgba(255, 255, 255, 0.78),
+    inset 1px 1px 0 rgba(255, 255, 255, 0.8);
+  transform: translateX(calc(-100% - 2rem));
+  transition: transform 420ms cubic-bezier(0.18, 0.84, 0.3, 1);
+}
+
+.soft-drawer::before,
+.soft-drawer::after {
+  position: absolute;
+  content: "";
+  border-radius: 50%;
+}
+
+.soft-drawer::before {
+  top: -56px;
+  right: -42px;
+  width: 180px;
+  height: 180px;
+  background: linear-gradient(145deg, #f7faff, #d6dfeb);
+  box-shadow:
+    inset 12px 12px 26px rgba(122, 138, 156, 0.22),
+    inset -12px -12px 26px rgba(255, 255, 255, 0.8);
+}
+
+.soft-drawer::after {
+  left: -54px;
+  bottom: -68px;
+  width: 220px;
+  height: 220px;
+  background: linear-gradient(
+    145deg,
+    rgba(200, 182, 255, 0.65),
+    rgba(109, 141, 255, 0.28)
+  );
+  box-shadow:
+    16px 16px 38px rgba(122, 138, 156, 0.28),
+    -16px -16px 38px rgba(255, 255, 255, 0.66);
+}
+
+.drawer-toggle:checked ~ .soft-drawer {
+  transform: translateX(0);
+}
+
+.drawer-toggle:checked ~ .drawer-backdrop {
+  visibility: visible;
+  opacity: 1;
+}
+
+.drawer-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: calc(100vh - 2rem);
+  flex-direction: column;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.drawer-pill {
+  width: max-content;
+  padding: 0.48rem 0.8rem;
+  border-radius: 999px;
+  color: var(--soft-blue);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: var(--soft-panel);
+  box-shadow:
+    inset 5px 5px 12px rgba(122, 138, 156, 0.2),
+    inset -5px -5px 12px rgba(255, 255, 255, 0.84);
+}
+
+.soft-links {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.soft-links a {
+  padding: 1rem 1.1rem;
+  border-radius: 20px;
+  color: var(--soft-ink);
+  font-weight: 700;
+  text-decoration: none;
+  background: var(--soft-panel);
+  box-shadow:
+    8px 8px 18px rgba(122, 138, 156, 0.28),
+    -8px -8px 18px rgba(255, 255, 255, 0.78);
+  transition:
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.soft-links a:hover,
+.soft-links a:focus-visible {
+  transform: translateX(6px);
+  box-shadow:
+    inset 6px 6px 14px rgba(122, 138, 156, 0.22),
+    inset -6px -6px 14px rgba(255, 255, 255, 0.78);
+  outline: 2px solid rgba(109, 141, 255, 0.36);
+  outline-offset: 4px;
+}
+
+.close-drawer {
+  position: absolute;
+  top: 1.15rem;
+  right: 1.15rem;
+  z-index: 2;
+  display: grid;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 50%;
+  color: var(--soft-blue);
+  font-size: 2rem;
+  line-height: 1;
+  background: var(--soft-panel);
+  box-shadow:
+    8px 8px 18px rgba(122, 138, 156, 0.28),
+    -8px -8px 18px rgba(255, 255, 255, 0.78);
+  place-items: center;
+}
+
+.close-drawer:focus-visible {
+  outline: 3px solid rgba(109, 141, 255, 0.38);
+  outline-offset: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --soft-bg: #182231;
+    --soft-panel: #202c3d;
+    --soft-ink: #edf4fb;
+    --soft-muted: #adbbca;
+    --soft-shadow-dark: rgba(3, 7, 18, 0.48);
+    --soft-shadow-light: rgba(255, 255, 255, 0.06);
+  }
+
+  .workspace-card::after,
+  .soft-drawer::before {
+    background: linear-gradient(145deg, #263449, #182231);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .soft-stage {
+    padding: 1rem;
+  }
+
+  .workspace-card {
+    min-height: 620px;
+    padding: 2rem;
+    border-radius: 28px;
+  }
+
+  .soft-drawer {
+    inset: 0;
+    width: min(92vw, 360px);
+    border-radius: 0 30px 30px 0;
+  }
+
+  .drawer-content {
+    min-height: 100vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a pure HTML/CSS Neumorphic Soft Shadow drawer submission under `submissions/examples/neumorphic-soft-shadow-drawer-msm/`
- Uses checkbox-driven open/close behavior with accessible labels and an overlay close target
- Includes layered inset/outset shadows, responsive layout, dark-mode support, visible focus states, and reduced-motion handling

Closes #73583

## Changes made
- Added `demo.html` with a self-contained drawer demo
- Added `style.css` for the neumorphic soft shadow drawer styling and transitions
- Added `README.md` with usage instructions and EaseMotion rationale

## Testing
- `npx.cmd prettier --write submissions/examples/neumorphic-soft-shadow-drawer-msm/**/*.{html,css,md}`
- `npx.cmd prettier --check submissions/examples/neumorphic-soft-shadow-drawer-msm/**/*.{html,css,md}`
- `npx.cmd stylelint submissions/examples/neumorphic-soft-shadow-drawer-msm/style.css --ignore-path .stylelintignore-does-not-exist`
- `git diff --check`
- `git diff --cached --check`

## Edge cases handled
- Keyboard-visible focus states for drawer controls and links
- `prefers-reduced-motion` support for users who reduce animation
- Responsive mobile drawer layout
- Dark-mode compatible design tokens

## Checklist
- [x] Only files inside `submissions/examples/neumorphic-soft-shadow-drawer-msm/` were added
- [x] Includes exactly `demo.html`, `style.css`, and `README.md`
- [x] No framework/core files were modified
- [x] Local formatting and lint checks passed