### PR TITLE
feat: add solar flare radial tabs

### DIFF
--- a/submissions/examples/solar-flare-radial-tab-msm/README.md
+++ b/submissions/examples/solar-flare-radial-tab-msm/README.md
@@ -1,0 +1,25 @@
+# Solar Flare Radial Tabs
+
+## What does this do?
+
+This submission adds a pure HTML and CSS tab component with a solar flare radial visual treatment.
+
+## How is it used?
+
+Add grouped radio inputs, matching tab labels, and tab panels to your page, then include the local stylesheet.
+
+```html
+<input
+  type="radio"
+  name="solar-tabs"
+  id="tab-orbit"
+  class="tab-input"
+  checked
+/>
+<label class="tab-label" for="tab-orbit">Orbit</label>
+<article class="tab-panel panel-orbit">Panel content goes here.</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a warm, high-energy tab pattern with accessible labels, CSS-only state switching, responsive layout, dark-mode support, and reduced-motion safety without JavaScript.

--- a/submissions/examples/solar-flare-radial-tab-msm/demo.html
+++ b/submissions/examples/solar-flare-radial-tab-msm/demo.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Solar Flare Radial Tabs</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="sun-stage">
+      <section class="tabs-card" aria-labelledby="tabs-title">
+        <p class="eyebrow">Pure CSS Tabs</p>
+        <h1 id="tabs-title">Solar flare radial tab switcher</h1>
+        <p>
+          A warm, radiant tab component with glowing radial accents and smooth
+          CSS-only panel transitions.
+        </p>
+
+        <div class="solar-tabs">
+          <input
+            type="radio"
+            name="solar-tabs"
+            id="tab-orbit"
+            class="tab-input"
+            checked
+          />
+          <input
+            type="radio"
+            name="solar-tabs"
+            id="tab-flare"
+            class="tab-input"
+          />
+          <input
+            type="radio"
+            name="solar-tabs"
+            id="tab-core"
+            class="tab-input"
+          />
+
+          <div class="tab-list" role="tablist" aria-label="Solar tabs">
+            <label class="tab-label" for="tab-orbit" role="tab">Orbit</label>
+            <label class="tab-label" for="tab-flare" role="tab">Flare</label>
+            <label class="tab-label" for="tab-core" role="tab">Core</label>
+          </div>
+
+          <div class="tab-panels">
+            <article class="tab-panel panel-orbit">
+              <span>01</span>
+              <h2>Orbit Planning</h2>
+              <p>
+                Track active navigation paths and group related interface states
+                into clean, radiant content sections.
+              </p>
+            </article>
+
+            <article class="tab-panel panel-flare">
+              <span>02</span>
+              <h2>Flare Alerts</h2>
+              <p>
+                Highlight high-energy updates with glowing radial layers that
+                make the active tab feel alive.
+              </p>
+            </article>
+
+            <article class="tab-panel panel-core">
+              <span>03</span>
+              <h2>Core Metrics</h2>
+              <p>
+                Present compact data summaries in a bright, responsive panel
+                without depending on JavaScript.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/solar-flare-radial-tab-msm/style.css
+++ b/submissions/examples/solar-flare-radial-tab-msm/style.css
@@ -1,0 +1,316 @@
+:root {
+  --solar-ink: #2f1707;
+  --solar-muted: #895b2d;
+  --solar-cream: #fff7e6;
+  --solar-card: rgba(255, 251, 235, 0.88);
+  --solar-orange: #f97316;
+  --solar-gold: #facc15;
+  --solar-rose: #fb7185;
+  --solar-shadow: 0 28px 80px rgba(124, 45, 18, 0.24);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--solar-ink);
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(
+      circle at 12% 20%,
+      rgba(250, 204, 21, 0.3),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 84% 16%,
+      rgba(249, 115, 22, 0.24),
+      transparent 34%
+    ),
+    linear-gradient(135deg, #fff7ed 0%, #ffedd5 45%, #fff7e6 100%);
+}
+
+.sun-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.tabs-card {
+  position: relative;
+  width: min(100%, 960px);
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 4.5rem);
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 36px;
+  background:
+    radial-gradient(
+      circle at 82% 22%,
+      rgba(250, 204, 21, 0.34),
+      transparent 24%
+    ),
+    linear-gradient(145deg, var(--solar-card), rgba(255, 237, 213, 0.72));
+  box-shadow: var(--solar-shadow);
+}
+
+.tabs-card::before {
+  position: absolute;
+  top: -120px;
+  right: -90px;
+  width: 330px;
+  height: 330px;
+  content: "";
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 12deg,
+      rgba(249, 115, 22, 0.24) 0deg 10deg,
+      rgba(250, 204, 21, 0.1) 10deg 20deg
+    ),
+    radial-gradient(circle, rgba(250, 204, 21, 0.55), transparent 64%);
+  filter: blur(0.2px);
+  animation: solar-spin 18s linear infinite;
+}
+
+.eyebrow {
+  position: relative;
+  margin: 0 0 0.75rem;
+  color: #c2410c;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  position: relative;
+  max-width: 680px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.7rem, 8vw, 5.5rem);
+  line-height: 0.96;
+}
+
+p {
+  color: var(--solar-muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.solar-tabs {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 760px);
+  margin-top: 2rem;
+}
+
+.tab-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.tab-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  padding: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow:
+    inset 0 0 0 1px rgba(249, 115, 22, 0.14),
+    0 14px 32px rgba(124, 45, 18, 0.12);
+}
+
+.tab-label {
+  display: grid;
+  min-height: 3.1rem;
+  cursor: pointer;
+  border-radius: 999px;
+  color: #9a3412;
+  font-family: "Trebuchet MS", sans-serif;
+  font-weight: 800;
+  place-items: center;
+  transition:
+    color 180ms ease,
+    transform 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.tab-label:hover,
+.tab-label:focus-visible {
+  color: var(--solar-ink);
+  transform: translateY(-2px);
+  outline: 3px solid rgba(250, 204, 21, 0.42);
+  outline-offset: 3px;
+}
+
+#tab-orbit:checked ~ .tab-list label[for="tab-orbit"],
+#tab-flare:checked ~ .tab-list label[for="tab-flare"],
+#tab-core:checked ~ .tab-list label[for="tab-core"] {
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 30% 20%,
+      rgba(255, 255, 255, 0.42),
+      transparent 22%
+    ),
+    linear-gradient(135deg, var(--solar-orange), var(--solar-gold));
+  box-shadow: 0 16px 34px rgba(249, 115, 22, 0.32);
+}
+
+.tab-panels {
+  position: relative;
+  min-height: 280px;
+  margin-top: 1rem;
+}
+
+.tab-panel {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  padding: clamp(1.5rem, 5vw, 2.4rem);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 30px;
+  background:
+    radial-gradient(
+      circle at 90% 10%,
+      rgba(250, 204, 21, 0.34),
+      transparent 28%
+    ),
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(255, 237, 213, 0.66)
+    );
+  box-shadow: 0 24px 52px rgba(124, 45, 18, 0.16);
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  transition:
+    opacity 260ms ease,
+    transform 260ms ease;
+}
+
+.tab-panel::after {
+  position: absolute;
+  right: -72px;
+  bottom: -80px;
+  width: 210px;
+  height: 210px;
+  content: "";
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      rgba(249, 115, 22, 0.2) 0deg 12deg,
+      rgba(251, 113, 133, 0.08) 12deg 24deg
+    ),
+    radial-gradient(circle, rgba(250, 204, 21, 0.4), transparent 62%);
+}
+
+.tab-panel span {
+  color: rgba(194, 65, 12, 0.5);
+  font-family: "Trebuchet MS", sans-serif;
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+}
+
+.tab-panel h2 {
+  margin: 0.6rem 0;
+  font-size: clamp(2rem, 6vw, 3.7rem);
+  line-height: 0.98;
+}
+
+.tab-panel p {
+  max-width: 520px;
+  margin: 0;
+}
+
+#tab-orbit:checked ~ .tab-panels .panel-orbit,
+#tab-flare:checked ~ .tab-panels .panel-flare,
+#tab-core:checked ~ .tab-panels .panel-core {
+  position: relative;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+@keyframes solar-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --solar-ink: #fff7ed;
+    --solar-muted: #fed7aa;
+    --solar-card: rgba(67, 32, 11, 0.88);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 12% 20%,
+        rgba(249, 115, 22, 0.22),
+        transparent 32%
+      ),
+      linear-gradient(135deg, #1f1308 0%, #431407 50%, #111827 100%);
+  }
+
+  .tab-list,
+  .tab-panel {
+    background:
+      radial-gradient(
+        circle at 86% 12%,
+        rgba(250, 204, 21, 0.2),
+        transparent 26%
+      ),
+      linear-gradient(145deg, rgba(67, 32, 11, 0.92), rgba(30, 41, 59, 0.72));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .sun-stage {
+    padding: 1rem;
+  }
+
+  .tabs-card {
+    padding: 2rem;
+    border-radius: 28px;
+  }
+
+  .tab-list {
+    grid-template-columns: 1fr;
+    border-radius: 24px;
+  }
+
+  .tab-label {
+    border-radius: 18px;
+  }
+
+  .tab-panels {
+    min-height: 340px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a pure HTML/CSS Solar Flare Radial tabs submission under `submissions/examples/solar-flare-radial-tab-msm/`
- Uses radio-button driven tab switching with matching labels and self-contained panels
- Includes glowing radial flare styling, responsive stacked tabs, dark-mode support, visible focus states, and reduced-motion handling

Closes #73578

## Changes made
- Added `demo.html` with a self-contained tab switcher demo
- Added `style.css` for the solar flare radial tab styling and transitions
- Added `README.md` with usage instructions and EaseMotion rationale

## Testing
- `npx.cmd prettier --write submissions/examples/solar-flare-radial-tab-msm/**/*.{html,css,md}`
- `npx.cmd prettier --check submissions/examples/solar-flare-radial-tab-msm/**/*.{html,css,md}`
- `npx.cmd stylelint submissions/examples/solar-flare-radial-tab-msm/style.css --ignore-path .stylelintignore-does-not-exist`
- `git diff --check`
- `git diff --cached --check`

## Edge cases handled
- Keyboard-visible focus states for tab labels
- `prefers-reduced-motion` support for users who reduce animation
- Responsive mobile tab layout
- Dark-mode compatible design tokens

## Checklist
- [x] Only files inside `submissions/examples/solar-flare-radial-tab-msm/` were added
- [x] Includes exactly `demo.html`, `style.css`, and `README.md`
- [x] No framework/core files were modified
- [x] Local formatting and lint checks passed