### PR TITLE
feat: add icon reveal button submission

### DIFF
--- a/submissions/examples/icon-reveal-button/README.md
+++ b/submissions/examples/icon-reveal-button/README.md
@@ -1,0 +1,5 @@
+# Icon Reveal Button
+
+1. What does this do? Slides a trailing arrow icon into view on hover.
+2. How is it used? Apply the class `.icon-reveal-btn` with a `.label` and `.arrow` span.
+3. Why is it useful? It hints at navigation affordances with a subtle micro-interaction.

--- a/submissions/examples/icon-reveal-button/demo.html
+++ b/submissions/examples/icon-reveal-button/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icon Reveal Button</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage">
+    <h1>Icon Reveal Button</h1>
+    <button class="icon-reveal-btn" type="button">
+      <span class="label">View docs</span>
+      <span class="arrow" aria-hidden="true">&rarr;</span>
+    </button>
+  </main>
+</body>
+</html>

--- a/submissions/examples/icon-reveal-button/style.css
+++ b/submissions/examples/icon-reveal-button/style.css
@@ -1,0 +1,46 @@
+.stage {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  gap: 2rem;
+  background: #fefce8;
+  font-family: system-ui, sans-serif;
+  text-align: center;
+}
+
+.stage h1 {
+  color: #713f12;
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.icon-reveal-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.9rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #713f12;
+  background: #fff;
+  border: 2px solid #d6b25a;
+  border-radius: 12px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.icon-reveal-btn .arrow {
+  display: inline-block;
+  transform: translateX(-8px);
+  opacity: 0;
+  transition: transform 240ms ease, opacity 240ms ease;
+}
+
+.icon-reveal-btn:hover .arrow {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.icon-reveal-btn:hover .label {
+  transform: translateX(-3px);
+}


### PR DESCRIPTION
Closes #76407

## What
Adds a button where a trailing arrow icon slides into view on hover.

## Folder
`submissions/examples/icon-reveal-button/` with `demo.html`, `style.css`, `README.md`.

## How to review
Open `demo.html` directly in a browser — the effect works standalone with no server or dependencies.