### PR TITLE
feat: add minimalist outline badge

### DIFF
--- a/submissions/examples/minimalist-outline-badge/README.md
+++ b/submissions/examples/minimalist-outline-badge/README.md
@@ -1,0 +1,48 @@
+# Minimalist Outline Badge
+
+A clean and lightweight pure HTML and Vanilla CSS badge/chip component featuring a Minimalist Outline design.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript
+- Lightweight outline styling
+- Multiple color variants
+- Status indicators
+- Smooth hover transitions
+- Dark mode support
+- Responsive layout
+- Reduced-motion accessibility support
+- Hardware-friendly CSS transforms
+
+## Variants
+
+The demo includes:
+
+- Active
+- Pending
+- Offline
+- Design
+- Development
+- Research
+- Featured
+- New
+- Verified
+
+## Technologies
+
+- HTML5
+- CSS3
+- CSS Transitions
+- CSS Media Queries
+
+## Usage
+
+Open `demo.html` in a browser.
+
+Example:
+
+```html
+<span class="outline-badge badge-primary">
+  New
+</span>

--- a/submissions/examples/minimalist-outline-badge/demo.html
+++ b/submissions/examples/minimalist-outline-badge/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Minimalist Outline Badges</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <section class="showcase" aria-labelledby="title">
+      <span class="eyebrow">CSS BADGES & CHIPS</span>
+
+      <h1 id="title">Minimalist Outline</h1>
+
+      <p class="intro">
+        Clean, lightweight outline badges designed for modern interfaces
+        with smooth and accessible interactions.
+      </p>
+
+      <div class="badge-panel">
+        <div class="badge-group">
+          <span class="group-title">Status</span>
+
+          <div class="badge-row">
+            <span class="outline-badge badge-success">
+              <span class="badge-dot"></span>
+              Active
+            </span>
+
+            <span class="outline-badge badge-warning">
+              <span class="badge-dot"></span>
+              Pending
+            </span>
+
+            <span class="outline-badge badge-danger">
+              <span class="badge-dot"></span>
+              Offline
+            </span>
+          </div>
+        </div>
+
+        <div class="badge-group">
+          <span class="group-title">Categories</span>
+
+          <div class="badge-row">
+            <span class="outline-badge badge-primary">Design</span>
+            <span class="outline-badge badge-purple">Development</span>
+            <span class="outline-badge badge-cyan">Research</span>
+          </div>
+        </div>
+
+        <div class="badge-group">
+          <span class="group-title">Labels</span>
+
+          <div class="badge-row">
+            <span class="outline-badge badge-neutral">Featured</span>
+            <span class="outline-badge badge-primary">New</span>
+            <span class="outline-badge badge-success">Verified</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/minimalist-outline-badge/style.css
+++ b/submissions/examples/minimalist-outline-badge/style.css
@@ -1,0 +1,282 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --background: #f6f7f9;
+  --surface: #ffffff;
+  --text: #18202d;
+  --muted: #697386;
+  --border: #d9dee7;
+
+  --primary: #315efb;
+  --success: #159447;
+  --warning: #c77700;
+  --danger: #d73737;
+  --purple: #8547d4;
+  --cyan: #087f91;
+  --neutral: #596273;
+
+  --shadow: rgba(24, 32, 45, 0.1);
+}
+
+body {
+  min-height: 100vh;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+  background: var(--background);
+}
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 64px 24px;
+}
+
+.showcase {
+  width: min(980px, 100%);
+}
+
+.eyebrow {
+  display: block;
+
+  margin-bottom: 12px;
+
+  color: var(--primary);
+
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-align: center;
+}
+
+h1 {
+  color: var(--text);
+
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+  text-align: center;
+}
+
+.intro {
+  width: min(620px, 100%);
+
+  margin: 20px auto 46px;
+
+  color: var(--muted);
+
+  font-size: 1rem;
+  line-height: 1.7;
+  text-align: center;
+}
+
+.badge-panel {
+  display: grid;
+  gap: 24px;
+
+  padding: 32px;
+
+  border: 1px solid var(--border);
+  border-radius: 24px;
+
+  background: var(--surface);
+
+  box-shadow:
+    0 18px 45px var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.badge-group {
+  display: grid;
+  gap: 14px;
+}
+
+.group-title {
+  color: var(--muted);
+
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.outline-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+
+  min-height: 36px;
+
+  padding: 7px 13px;
+
+  border: 1.5px solid currentColor;
+  border-radius: 999px;
+
+  background: transparent;
+
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1;
+
+  cursor: default;
+
+  transition:
+    transform 0.25s ease,
+    background-color 0.25s ease,
+    color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.outline-badge:hover {
+  transform: translateY(-2px);
+
+  background: currentColor;
+
+  box-shadow: 0 7px 18px var(--shadow);
+}
+
+.badge-dot {
+  width: 7px;
+  height: 7px;
+
+  flex: 0 0 7px;
+
+  border-radius: 50%;
+
+  background: currentColor;
+}
+
+/*
+ * Color variants
+ */
+
+.badge-primary {
+  color: var(--primary);
+}
+
+.badge-success {
+  color: var(--success);
+}
+
+.badge-warning {
+  color: var(--warning);
+}
+
+.badge-danger {
+  color: var(--danger);
+}
+
+.badge-purple {
+  color: var(--purple);
+}
+
+.badge-cyan {
+  color: var(--cyan);
+}
+
+.badge-neutral {
+  color: var(--neutral);
+}
+
+/*
+ * Keep text readable when the badge
+ * is hovered and its background changes.
+ */
+
+.badge-primary:hover,
+.badge-success:hover,
+.badge-warning:hover,
+.badge-danger:hover,
+.badge-purple:hover,
+.badge-cyan:hover,
+.badge-neutral:hover {
+  color: #ffffff;
+}
+
+/*
+ * Dark mode
+ */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0d121b;
+    --surface: #151c28;
+    --text: #f3f5f9;
+    --muted: #a5afbf;
+    --border: #2a3444;
+
+    --shadow: rgba(0, 0, 0, 0.35);
+  }
+
+  .badge-panel {
+    box-shadow:
+      0 20px 50px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  .outline-badge:hover {
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  }
+}
+
+/*
+ * Responsive
+ */
+
+@media (max-width: 600px) {
+  .page {
+    padding: 42px 16px;
+  }
+
+  .badge-panel {
+    padding: 22px;
+  }
+
+  .badge-row {
+    gap: 9px;
+  }
+
+  .outline-badge {
+    min-height: 34px;
+    padding: 7px 11px;
+  }
+}
+
+/*
+ * Accessibility
+ */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+
+  .outline-badge:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the Minimalist Outline Badge variation requested in #73461.

It is a critical issue for expanding the badge and chip component collection with a clean and reusable outline-based design.

### Changes

- Added Minimalist Outline badge/chip component.
- Added multiple semantic color variants.
- Added status indicator variants.
- Added smooth hover transitions.
- Added dark mode compatibility.
- Added responsive layout.
- Added reduced-motion accessibility support.
- Used only pure HTML and Vanilla CSS.

### Issue

Closes #73461