### PR TITLE
feat: add animated file upload dropzone component (file-upload-dropzone-nk)

### DIFF
--- a/submissions/examples/file-upload-dropzone-nk/README.md
+++ b/submissions/examples/file-upload-dropzone-nk/README.md
@@ -1,0 +1,114 @@
+# File Upload Dropzone — `file-upload-dropzone-nk`
+
+## 1. What does this do?
+
+An animated file upload dropzone that cycles through four CSS-driven states — idle (marching dashed border + icon bounce on hover), drag-over (zone pulse + scale pop), uploading (circular SVG progress ring sweep), and success (drawn SVG checkmark burst) — all transitions triggered by `data-state` attribute and state classes toggled by a minimal JS bridge.
+
+---
+
+## 2. How is it used?
+
+### HTML structure
+
+```html
+<div class="fud-zone" id="fud-zone" role="button" tabindex="0"
+     data-state="idle" aria-label="File upload area">
+
+  <input class="fud-input" type="file" />
+
+  <!-- Idle state -->
+  <div class="fud-state fud-state--idle fud-state--active" id="state-idle">
+    <svg class="fud-dashed-border" viewBox="0 0 400 200" preserveAspectRatio="none">
+      <rect class="fud-dash-rect" x="2" y="2" width="396" height="196" rx="14"/>
+    </svg>
+    <div class="fud-idle__body">...</div>
+  </div>
+
+  <!-- Drag-over state -->
+  <div class="fud-state fud-state--dragover" id="state-dragover" hidden>...</div>
+
+  <!-- Uploading state with progress ring -->
+  <div class="fud-state fud-state--uploading" id="state-uploading" hidden>
+    <div class="fud-ring-wrap">
+      <svg class="fud-ring-svg" viewBox="0 0 80 80">
+        <circle class="fud-ring-track" cx="40" cy="40" r="32"/>
+        <circle class="fud-ring-fill"  cx="40" cy="40" r="32" id="fud-ring-fill"/>
+      </svg>
+      <span class="fud-ring-pct" aria-live="polite">0%</span>
+    </div>
+  </div>
+
+  <!-- Success state -->
+  <div class="fud-state fud-state--success" id="state-success" hidden>
+    <svg class="fud-success__svg" viewBox="0 0 80 80">
+      <circle class="fud-success__circle" cx="40" cy="40" r="34"/>
+      <path   class="fud-success__check" d="M24 40l10 10 22-22"/>
+    </svg>
+  </div>
+
+</div>
+```
+
+### State transitions
+
+| `data-state` | Active class | Visual |
+|---|---|---|
+| `idle` | `fud-state--idle` | Marching dashed border + icon bounce on hover |
+| `dragover` | `fud-state--dragover` | Zone scale-pulse + indigo background fill |
+| `uploading` | `fud-state--uploading` | SVG progress ring sweeps from 0→100% |
+| `success` | `fud-state--success` | Circle draw + checkmark draw + fade-up text |
+
+### JS bridge (minimal — only sets `data-state` and `strokeDashoffset`)
+
+```js
+// Show a state
+zone.setAttribute('data-state', 'uploading');
+
+// Update progress ring (circumference = 2π × 32 ≈ 201.06)
+const CIRCUMFERENCE = 201.06;
+ringFill.style.strokeDashoffset = CIRCUMFERENCE - (pct / 100) * CIRCUMFERENCE;
+
+// Trigger error shake
+zone.classList.add('fud-zone--error');
+```
+
+All visual transitions — dashed march, icon bounce, dragover pulse, ring sweep, circle draw, checkmark draw, success entrance — are pure CSS. The JS manages state and computes `strokeDashoffset` only.
+
+---
+
+## 3. Why is it useful?
+
+File uploads are one of the most anxiety-inducing interactions on the web. Users don't know if the drag worked, how long it will take, or if it succeeded. Static zones with no animation provide zero feedback.
+
+This component fits EaseMotion's philosophy because:
+
+- **Motion replaces anxiety with confidence.** The marching dashes say "this is interactive." The bounce icon says "drop here." The ring sweep gives live progress. The checkmark draw says "done" in a way a static success message never can.
+- **CSS does the heavy lifting.** All 7 keyframes (dash-march, icon-bounce, dragover-pulse, fade-up, success-entrance, draw-circle, draw-check) are pure CSS. The JS is ~100 lines and only manages state transitions and the `strokeDashoffset` calculation — swap it for any framework without touching the stylesheet.
+- **Accessible by default.** The zone uses `role="button"` + `tabindex="0"` for keyboard access. A `role="status"` live region announces every state change. Progress uses `aria-live="polite"`. `prefers-reduced-motion` collapses all durations to near-zero.
+- **Zero dependencies.** Open `demo.html` directly in any modern browser — no server, no CDN, no build step.
+
+---
+
+## Animations used
+
+| Animation | Trigger | Effect |
+|---|---|---|
+| `fud-fade-up` | Card, state panes on mount | Fade + slide up entrance |
+| `fud-dash-march` | `.fud-dash-rect` on hover/dragover | Dashed border marches infinitely |
+| `fud-icon-bounce` | Upload icon on hover | Vertical bounce |
+| `fud-dragover-pulse` | `.fud-state--dragover` on enter | Zone scale pop + indigo bg |
+| `fud-shake` | `.fud-zone--error` on oversized file | Horizontal shake |
+| `fud-success-entrance` | SVG container on success | Scale pop from 0.6 → 1 |
+| `fud-draw-circle` | `.fud-success__circle` | Stroke-dashoffset draw |
+| `fud-draw-check` | `.fud-success__check` | Stroke-dashoffset draw (delayed) |
+
+---
+
+## Files
+
+```
+submissions/examples/file-upload-dropzone-nk/
+├── demo.html   — self-contained demo, works by opening directly in a browser
+├── style.css   — all styles, keyframes, and state transitions
+└── README.md   — this file
+```

--- a/submissions/examples/file-upload-dropzone-nk/demo.html
+++ b/submissions/examples/file-upload-dropzone-nk/demo.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>File Upload Dropzone — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+
+      <div class="fud-card">
+        <h1 class="fud-card__title">Upload a File</h1>
+        <p class="fud-card__subtitle">Drag &amp; drop or click to browse.</p>
+
+        <!-- ── Dropzone ── -->
+        <div
+          class="fud-zone"
+          id="fud-zone"
+          role="button"
+          tabindex="0"
+          aria-label="File upload area. Press Enter or Space to browse files."
+          aria-describedby="fud-hint"
+        >
+          <!-- Hidden real file input -->
+          <input
+            class="fud-input"
+            type="file"
+            id="fud-input"
+            accept="image/*,.pdf,.zip,.doc,.docx"
+            aria-hidden="true"
+            tabindex="-1"
+          />
+
+          <!-- ── IDLE state ── -->
+          <div class="fud-state fud-state--idle" id="state-idle">
+            <!-- Animated dashed border SVG -->
+            <svg class="fud-dashed-border" viewBox="0 0 400 200"
+                 preserveAspectRatio="none" aria-hidden="true">
+              <rect class="fud-dash-rect" x="2" y="2" width="396" height="196" rx="14" ry="14"/>
+            </svg>
+
+            <div class="fud-idle__body">
+              <!-- Upload icon -->
+              <div class="fud-icon-wrap" aria-hidden="true">
+                <svg class="fud-icon-upload" viewBox="0 0 48 48" fill="none"
+                     xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="24" cy="24" r="22" class="fud-icon-circle"/>
+                  <path d="M24 32V20M24 20l-5 5M24 20l5 5" class="fud-icon-arrow"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M16 34h16" class="fud-icon-base"
+                        stroke-linecap="round"/>
+                </svg>
+              </div>
+
+              <p class="fud-idle__label">
+                <span class="fud-idle__primary">Drop your file here</span>
+                <span class="fud-idle__or">or</span>
+                <span class="fud-idle__browse">browse</span>
+              </p>
+              <p class="fud-idle__hint" id="fud-hint">
+                PNG, JPG, PDF, ZIP — max 10 MB
+              </p>
+            </div>
+          </div>
+
+          <!-- ── DRAG-OVER state ── -->
+          <div class="fud-state fud-state--dragover" id="state-dragover" hidden>
+            <div class="fud-dragover__body">
+              <div class="fud-dragover__icon" aria-hidden="true">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M8 40l10-10m0 0l6-6m-6 6l-6-6m6 6l6 6"
+                        stroke="currentColor" stroke-width="2.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                  <path d="M24 8v20M24 8l-6 6M24 8l6 6"
+                        stroke="currentColor" stroke-width="2.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </div>
+              <p class="fud-dragover__label">Release to upload</p>
+            </div>
+          </div>
+
+          <!-- ── UPLOADING state ── -->
+          <div class="fud-state fud-state--uploading" id="state-uploading" hidden>
+            <div class="fud-upload__body">
+              <!-- Circular SVG progress ring -->
+              <div class="fud-ring-wrap" aria-hidden="true">
+                <svg class="fud-ring-svg" viewBox="0 0 80 80">
+                  <circle class="fud-ring-track" cx="40" cy="40" r="32"/>
+                  <circle class="fud-ring-fill"  cx="40" cy="40" r="32" id="fud-ring-fill"/>
+                </svg>
+                <span class="fud-ring-pct" id="fud-ring-pct" aria-live="polite">0%</span>
+              </div>
+
+              <p class="fud-upload__filename" id="fud-upload-filename">Uploading…</p>
+              <p class="fud-upload__sub" id="fud-upload-sub">Please wait</p>
+            </div>
+          </div>
+
+          <!-- ── SUCCESS state ── -->
+          <div class="fud-state fud-state--success" id="state-success" hidden>
+            <div class="fud-success__body">
+              <svg class="fud-success__svg" viewBox="0 0 80 80"
+                   xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <circle class="fud-success__circle" cx="40" cy="40" r="34"/>
+                <path   class="fud-success__check" d="M24 40l10 10 22-22"
+                        fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <p class="fud-success__name"  id="fud-success-name">file.png</p>
+              <p class="fud-success__size"  id="fud-success-size">2.4 MB</p>
+              <button class="fud-success__reset" id="fud-reset" type="button">
+                Upload another
+              </button>
+            </div>
+          </div>
+
+        </div><!-- /zone -->
+
+        <!-- ── File list (queued) ── -->
+        <ul class="fud-list" id="fud-list" aria-label="Queued files" hidden></ul>
+
+        <!-- SR live region -->
+        <div class="fud-sr" role="status" aria-live="polite" id="fud-sr"></div>
+      </div>
+
+      <!-- Demo hint -->
+      <div class="demo-hint">
+        <p class="demo-hint__title">Try these interactions:</p>
+        <ul class="demo-hint__list">
+          <li>Click the zone → pick any file → watch the progress ring sweep</li>
+          <li>Drag a file over → drag-over pulse state activates</li>
+          <li>Drop the file → progress ring fills → checkmark draws</li>
+          <li>Click <strong>Upload another</strong> → resets to idle</li>
+        </ul>
+      </div>
+
+    </div><!-- /wrapper -->
+
+    <script>
+    (function () {
+      const zone       = document.getElementById('fud-zone');
+      const input      = document.getElementById('fud-input');
+      const sr         = document.getElementById('fud-sr');
+
+      const stateIdle      = document.getElementById('state-idle');
+      const stateDragover  = document.getElementById('state-dragover');
+      const stateUploading = document.getElementById('state-uploading');
+      const stateSuccess   = document.getElementById('state-success');
+
+      const ringFill  = document.getElementById('fud-ring-fill');
+      const ringPct   = document.getElementById('fud-ring-pct');
+      const uploadFn  = document.getElementById('fud-upload-filename');
+      const uploadSub = document.getElementById('fud-upload-sub');
+      const successNm = document.getElementById('fud-success-name');
+      const successSz = document.getElementById('fud-success-size');
+      const resetBtn  = document.getElementById('fud-reset');
+
+      /* Ring circumference: 2π × 32 ≈ 201.06 */
+      const CIRCUMFERENCE = 2 * Math.PI * 32;
+
+      function announce(msg) {
+        sr.textContent = '';
+        requestAnimationFrame(() => { sr.textContent = msg; });
+      }
+
+      /* ── show a state ── */
+      function showState(id) {
+        [stateIdle, stateDragover, stateUploading, stateSuccess].forEach(s => {
+          s.hidden = true;
+          s.classList.remove('fud-state--active');
+        });
+        const el = document.getElementById('state-' + id);
+        el.hidden = false;
+        el.classList.add('fud-state--active');
+        zone.setAttribute('data-state', id);
+      }
+
+      /* ── set progress ring ── */
+      function setProgress(pct) {
+        const offset = CIRCUMFERENCE - (pct / 100) * CIRCUMFERENCE;
+        ringFill.style.strokeDashoffset = offset;
+        ringPct.textContent = Math.round(pct) + '%';
+      }
+
+      /* ── format bytes ── */
+      function formatSize(bytes) {
+        if (bytes < 1024)       return bytes + ' B';
+        if (bytes < 1048576)    return (bytes / 1024).toFixed(1) + ' KB';
+        return (bytes / 1048576).toFixed(1) + ' MB';
+      }
+
+      /* ── simulate upload with progress ── */
+      function simulateUpload(file) {
+        showState('uploading');
+        uploadFn.textContent = file.name.length > 28
+          ? file.name.slice(0, 25) + '…'
+          : file.name;
+        uploadSub.textContent = formatSize(file.size);
+
+        ringFill.style.strokeDasharray  = CIRCUMFERENCE;
+        ringFill.style.strokeDashoffset = CIRCUMFERENCE;
+        setProgress(0);
+        announce('Uploading ' + file.name);
+
+        let pct = 0;
+        /* Simulate varying speed — fast start, slow middle, fast end */
+        const steps = [
+          { target: 30,  delay: 80  },
+          { target: 60,  delay: 120 },
+          { target: 85,  delay: 150 },
+          { target: 100, delay: 80  },
+        ];
+
+        let stepIdx = 0;
+
+        function tick() {
+          if (stepIdx >= steps.length) return;
+          const { target, delay } = steps[stepIdx];
+
+          if (pct < target) {
+            pct = Math.min(pct + 1, target);
+            setProgress(pct);
+            setTimeout(tick, delay / (target - (stepIdx > 0 ? steps[stepIdx-1].target : 0)));
+          } else {
+            stepIdx++;
+            if (stepIdx < steps.length) setTimeout(tick, 200);
+            else {
+              /* done */
+              setTimeout(() => triggerSuccess(file), 300);
+            }
+          }
+        }
+        tick();
+      }
+
+      /* ── success ── */
+      function triggerSuccess(file) {
+        successNm.textContent = file.name.length > 28
+          ? file.name.slice(0, 25) + '…'
+          : file.name;
+        successSz.textContent = formatSize(file.size);
+        showState('success');
+        announce(file.name + ' uploaded successfully.');
+      }
+
+      /* ── reset ── */
+      function reset() {
+        input.value = '';
+        setProgress(0);
+        showState('idle');
+        announce('Ready to upload a new file.');
+      }
+
+      /* ── file picked ── */
+      function handleFile(file) {
+        if (!file) return;
+        /* basic size check — 10 MB */
+        if (file.size > 10 * 1024 * 1024) {
+          zone.classList.add('fud-zone--error');
+          announce('File too large. Maximum size is 10 MB.');
+          zone.addEventListener('animationend', () => {
+            zone.classList.remove('fud-zone--error');
+          }, { once: true });
+          return;
+        }
+        simulateUpload(file);
+      }
+
+      /* ── event: click / keyboard ── */
+      zone.addEventListener('click', () => {
+        if (zone.getAttribute('data-state') !== 'idle') return;
+        input.click();
+      });
+
+      zone.addEventListener('keydown', e => {
+        if ((e.key === 'Enter' || e.key === ' ') &&
+             zone.getAttribute('data-state') === 'idle') {
+          e.preventDefault();
+          input.click();
+        }
+      });
+
+      input.addEventListener('change', () => {
+        if (input.files && input.files[0]) handleFile(input.files[0]);
+      });
+
+      /* ── drag events ── */
+      zone.addEventListener('dragenter', e => {
+        e.preventDefault();
+        if (zone.getAttribute('data-state') !== 'idle') return;
+        showState('dragover');
+      });
+
+      zone.addEventListener('dragover', e => {
+        e.preventDefault();
+      });
+
+      zone.addEventListener('dragleave', e => {
+        /* only reset if leaving the zone entirely */
+        if (!zone.contains(e.relatedTarget)) {
+          if (zone.getAttribute('data-state') === 'dragover') showState('idle');
+        }
+      });
+
+      zone.addEventListener('drop', e => {
+        e.preventDefault();
+        const file = e.dataTransfer?.files?.[0];
+        if (file) handleFile(file);
+        else showState('idle');
+      });
+
+      /* ── reset button ── */
+      resetBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        reset();
+      });
+
+      /* ── init ── */
+      showState('idle');
+
+    })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/file-upload-dropzone-nk/style.css
+++ b/submissions/examples/file-upload-dropzone-nk/style.css
@@ -1,0 +1,576 @@
+/* ============================================================
+   File Upload Dropzone — EaseMotion CSS Submission
+   Track: Standard (HTML/CSS)
+   Component ID: file-upload-dropzone-nk
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   0. Design tokens
+   ------------------------------------------------------------ */
+:root {
+  --fud-color-bg:           #ffffff;
+  --fud-color-surface:      #f8fafc;
+  --fud-color-border:       #e2e8f0;
+  --fud-color-text:         #1e293b;
+  --fud-color-muted:        #94a3b8;
+  --fud-color-label:        #475569;
+
+  --fud-color-primary:      #6366f1;
+  --fud-color-primary-lt:   #eef2ff;
+  --fud-color-primary-mid:  #a5b4fc;
+  --fud-color-success:      #10b981;
+  --fud-color-success-lt:   #f0fdf4;
+  --fud-color-danger:       #ef4444;
+  --fud-color-danger-lt:    #fef2f2;
+
+  --fud-glow-primary: 0 0 0 4px rgba(99, 102, 241, 0.15);
+  --fud-glow-success: 0 0 0 4px rgba(16, 185, 129, 0.15);
+  --fud-glow-danger:  0 0 0 4px rgba(239, 68,  68,  0.15);
+
+  --fud-radius-zone: 16px;
+  --fud-radius-card: 20px;
+  --fud-radius-btn:  10px;
+  --fud-radius-pill: 9999px;
+
+  --fud-speed-fast:  0.15s;
+  --fud-speed-mid:   0.28s;
+  --fud-speed-slow:  0.45s;
+  --fud-ease:        cubic-bezier(0.4, 0, 0.2, 1);
+  --fud-ease-out:    cubic-bezier(0, 0, 0.2, 1);
+  --fud-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ------------------------------------------------------------
+   1. Base reset
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f0fdf4 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--fud-color-text);
+}
+
+.fud-sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* ------------------------------------------------------------
+   2. Wrapper & card
+   ------------------------------------------------------------ */
+.demo-wrapper {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.fud-card {
+  background: var(--fud-color-bg);
+  border: 1px solid var(--fud-color-border);
+  border-radius: var(--fud-radius-card);
+  padding: 2rem 2rem 2.25rem;
+  box-shadow:
+    0 1px 3px rgba(0,0,0,.06),
+    0 12px 32px rgba(0,0,0,.09);
+  animation: fud-fade-up var(--fud-speed-slow) var(--fud-ease-out) both;
+}
+
+.fud-card__title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--fud-color-text);
+}
+
+.fud-card__subtitle {
+  margin-top: 0.3rem;
+  font-size: 0.875rem;
+  color: var(--fud-color-muted);
+  margin-bottom: 1.5rem;
+}
+
+/* ------------------------------------------------------------
+   3. Dropzone
+   ------------------------------------------------------------ */
+.fud-zone {
+  position: relative;
+  width: 100%;
+  min-height: 200px;
+  border-radius: var(--fud-radius-zone);
+  background: var(--fud-color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  outline: none;
+  overflow: hidden;
+  transition:
+    background   var(--fud-speed-fast) var(--fud-ease),
+    box-shadow   var(--fud-speed-fast) var(--fud-ease);
+}
+
+.fud-zone:focus-visible {
+  box-shadow: var(--fud-glow-primary);
+}
+
+/* Error shake */
+.fud-zone--error {
+  animation: fud-shake 0.45s var(--fud-ease) both;
+  background: var(--fud-color-danger-lt);
+}
+
+/* Hidden real input */
+.fud-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  pointer-events: none;
+}
+
+/* ------------------------------------------------------------
+   4. Shared state styles
+   ------------------------------------------------------------ */
+.fud-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fud-state--active {
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) both;
+}
+
+/* ------------------------------------------------------------
+   5. IDLE state
+   ------------------------------------------------------------ */
+.fud-state--idle { flex-direction: column; }
+
+/* Animated dashed SVG border */
+.fud-dashed-border {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.fud-dash-rect {
+  fill: none;
+  stroke: var(--fud-color-border);
+  stroke-width: 2;
+  stroke-dasharray: 8 6;
+  stroke-linecap: round;
+  transition: stroke var(--fud-speed-mid) var(--fud-ease);
+}
+
+/* On hover / dragover — animate dashes marching */
+.fud-zone:hover .fud-dash-rect,
+.fud-zone[data-state="dragover"] .fud-dash-rect {
+  stroke: var(--fud-color-primary);
+  animation: fud-dash-march 0.6s linear infinite;
+}
+
+.fud-idle__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+/* Upload icon */
+.fud-icon-wrap {
+  margin-bottom: 0.25rem;
+  transition: transform var(--fud-speed-mid) var(--fud-ease-bounce);
+}
+
+.fud-zone:hover .fud-icon-wrap {
+  transform: translateY(-4px);
+  animation: fud-icon-bounce 0.6s var(--fud-ease-bounce);
+}
+
+.fud-icon-upload {
+  width: 52px;
+  height: 52px;
+}
+
+.fud-icon-circle {
+  fill: var(--fud-color-primary-lt);
+  stroke: var(--fud-color-primary-mid);
+  stroke-width: 1.5;
+  transition: fill var(--fud-speed-fast) var(--fud-ease);
+}
+
+.fud-zone:hover .fud-icon-circle {
+  fill: #e0e7ff;
+}
+
+.fud-icon-arrow,
+.fud-icon-base {
+  stroke: var(--fud-color-primary);
+  stroke-width: 2.5;
+}
+
+.fud-idle__label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 0.9375rem;
+}
+
+.fud-idle__primary {
+  font-weight: 600;
+  color: var(--fud-color-text);
+}
+
+.fud-idle__or {
+  color: var(--fud-color-muted);
+  font-size: 0.875rem;
+}
+
+.fud-idle__browse {
+  font-weight: 600;
+  color: var(--fud-color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.fud-idle__hint {
+  font-size: 0.8125rem;
+  color: var(--fud-color-muted);
+}
+
+/* ------------------------------------------------------------
+   6. DRAG-OVER state
+   ------------------------------------------------------------ */
+.fud-state--dragover {
+  background: var(--fud-color-primary-lt);
+  animation: fud-dragover-pulse 0.5s var(--fud-ease-bounce) both;
+}
+
+.fud-dragover__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--fud-color-primary);
+}
+
+.fud-dragover__icon {
+  width: 52px;
+  height: 52px;
+  animation: fud-icon-bounce 0.5s var(--fud-ease-bounce) both;
+}
+
+.fud-dragover__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.fud-dragover__label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--fud-color-primary);
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) 0.1s both;
+}
+
+/* ------------------------------------------------------------
+   7. UPLOADING state — circular progress ring
+   ------------------------------------------------------------ */
+.fud-state--uploading {
+  background: var(--fud-color-surface);
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) both;
+}
+
+.fud-upload__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+}
+
+.fud-ring-wrap {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.fud-ring-svg {
+  width: 80px;
+  height: 80px;
+  transform: rotate(-90deg);
+}
+
+.fud-ring-track {
+  fill: none;
+  stroke: var(--fud-color-border);
+  stroke-width: 5;
+}
+
+.fud-ring-fill {
+  fill: none;
+  stroke: var(--fud-color-primary);
+  stroke-width: 5;
+  stroke-linecap: round;
+  /* circumference = 2π × 32 ≈ 201.06 */
+  stroke-dasharray: 201.06;
+  stroke-dashoffset: 201.06;
+  transition: stroke-dashoffset 0.25s var(--fud-ease-out);
+}
+
+.fud-ring-pct {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--fud-color-primary);
+}
+
+.fud-upload__filename {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--fud-color-text);
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.fud-upload__sub {
+  font-size: 0.8125rem;
+  color: var(--fud-color-muted);
+}
+
+/* ------------------------------------------------------------
+   8. SUCCESS state — SVG draw checkmark
+   ------------------------------------------------------------ */
+.fud-state--success {
+  background: var(--fud-color-success-lt);
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) both;
+}
+
+.fud-success__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.fud-success__svg {
+  width: 80px;
+  height: 80px;
+  animation: fud-success-entrance var(--fud-speed-slow) var(--fud-ease-bounce) both;
+}
+
+.fud-success__circle {
+  fill: none;
+  stroke: var(--fud-color-success);
+  stroke-width: 2.5;
+  stroke-dasharray: 214;
+  stroke-dashoffset: 214;
+  stroke-linecap: round;
+  animation: fud-draw-circle 0.5s var(--fud-ease-out) 0.1s forwards;
+}
+
+.fud-success__check {
+  stroke: var(--fud-color-success);
+  stroke-width: 4;
+  stroke-dasharray: 60;
+  stroke-dashoffset: 60;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  animation: fud-draw-check 0.35s var(--fud-ease-out) 0.55s forwards;
+}
+
+.fud-success__name {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--fud-color-text);
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) 0.7s both;
+}
+
+.fud-success__size {
+  font-size: 0.8125rem;
+  color: var(--fud-color-muted);
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) 0.8s both;
+}
+
+.fud-success__reset {
+  margin-top: 0.5rem;
+  padding: 0.45rem 1.125rem;
+  border: 1.5px solid var(--fud-color-success);
+  border-radius: var(--fud-radius-btn);
+  background: transparent;
+  color: var(--fud-color-success);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background  var(--fud-speed-fast) var(--fud-ease),
+    color       var(--fud-speed-fast) var(--fud-ease),
+    transform   var(--fud-speed-mid)  var(--fud-ease-bounce);
+  animation: fud-fade-up var(--fud-speed-mid) var(--fud-ease-out) 0.9s both;
+}
+
+.fud-success__reset:hover {
+  background: var(--fud-color-success);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+/* ------------------------------------------------------------
+   9. Demo hint
+   ------------------------------------------------------------ */
+.demo-hint {
+  background: var(--fud-color-bg);
+  border: 1px solid var(--fud-color-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  animation: fud-fade-up var(--fud-speed-slow) var(--fud-ease-out) 0.1s both;
+}
+
+.demo-hint__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--fud-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.demo-hint__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.demo-hint__list li {
+  font-size: 0.8125rem;
+  color: var(--fud-color-text);
+  padding-left: 1rem;
+  position: relative;
+}
+
+.demo-hint__list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--fud-color-primary);
+  font-size: 0.75rem;
+}
+
+/* ------------------------------------------------------------
+   10. Keyframe animations
+   ------------------------------------------------------------ */
+
+/* Card / state entrance */
+@keyframes fud-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Marching dashes */
+@keyframes fud-dash-march {
+  to { stroke-dashoffset: -28; }
+}
+
+/* Upload icon bounce */
+@keyframes fud-icon-bounce {
+  0%   { transform: translateY(0); }
+  40%  { transform: translateY(-10px); }
+  65%  { transform: translateY(-4px); }
+  80%  { transform: translateY(-7px); }
+  100% { transform: translateY(-4px); }
+}
+
+/* Drag-over zone pop */
+@keyframes fud-dragover-pulse {
+  0%   { transform: scale(1);    opacity: 0; }
+  60%  { transform: scale(1.01); opacity: 1; }
+  100% { transform: scale(1);    opacity: 1; }
+}
+
+/* Error shake */
+@keyframes fud-shake {
+  0%,100% { transform: translateX(0); }
+  15%     { transform: translateX(-7px); }
+  30%     { transform: translateX(7px); }
+  45%     { transform: translateX(-5px); }
+  60%     { transform: translateX(5px); }
+  75%     { transform: translateX(-3px); }
+  90%     { transform: translateX(3px); }
+}
+
+/* Success container entrance */
+@keyframes fud-success-entrance {
+  0%   { opacity: 0; transform: scale(0.6); }
+  60%  { transform: scale(1.1); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* SVG circle draw */
+@keyframes fud-draw-circle {
+  to { stroke-dashoffset: 0; }
+}
+
+/* SVG checkmark draw */
+@keyframes fud-draw-check {
+  to { stroke-dashoffset: 0; }
+}
+
+/* ------------------------------------------------------------
+   11. Reduced motion
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+  }
+
+  .fud-ring-fill {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ------------------------------------------------------------
+   12. Responsive
+   ------------------------------------------------------------ */
+@media (max-width: 400px) {
+  .fud-card { padding: 1.5rem 1rem 1.75rem; }
+  .fud-zone { min-height: 170px; }
+  .fud-idle__label { font-size: 0.875rem; }
+}


### PR DESCRIPTION
fix #76448 

## Pull Request Description

Adds a fully animated file upload dropzone (`file-upload-dropzone-nk`) with 4 CSS-driven states: idle (marching dashed border + icon bounce on hover), drag-over (zone pulse + scale pop), uploading (circular SVG progress ring sweep), and success (drawn SVG checkmark burst) - all visual transitions driven by CSS keyframes off `data-state` attribute toggled by a minimal JS bridge.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/file-upload-dropzone-nk/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

### What does this add?

An animated file upload dropzone with marching dashed border on hover, drag-over bounce pulse, circular SVG progress ring sweep during upload, and drawn circle + checkmark success state - 4 complete states with 8 keyframe animations, all CSS-driven.

### How does a developer use it?

```html
<div class="fud-zone" data-state="idle" role="button" tabindex="0">
  <input class="fud-input" type="file" />
  <div class="fud-state fud-state--idle">...</div>
  <div class="fud-state fud-state--dragover" hidden>...</div>
  <div class="fud-state fud-state--uploading" hidden>...</div>
  <div class="fud-state fud-state--success"  hidden>...</div>
</div>
```

JS sets `data-state` and computes `strokeDashoffset` for the ring. All animation is CSS.

### Why does it fit EaseMotion CSS?

File uploads are anxiety-inducing. The marching dashes say "interactive," the bounce says "drop here," the ring sweep gives live progress, the checkmark draw says "done" - motion replaces anxiety with confidence. Every keyframe delivers meaning, not decoration.

## Demo

- `demo.html` works by opening directly in a browser
- Click zone → pick file → progress ring sweeps 0→100% → checkmark draws
- Drag file over zone → pulse state activates → drop → upload simulation
- File over 10 MB → error shake + red glow

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer

All 8 keyframes use `--fud-*` CSS custom property tokens. `prefers-reduced-motion` collapses all durations to near-zero including the ring transition. Ring circumference is `2π × 32 ≈ 201.06` - hardcoded in both CSS and JS for the 80×80 SVG viewport with `r="32"`. Upload progress is simulated; swap the `simulateUpload` function for a real `fetch` + `XMLHttpRequest.upload.onprogress` without touching the stylesheet.