### PR TITLE
feat: add animated inline editable text component (inline-edit-nk)

### DIFF
--- a/submissions/examples/inline-edit-nk/README.md
+++ b/submissions/examples/inline-edit-nk/README.md
@@ -1,0 +1,112 @@
+# Inline Editable Text — `inline-edit-nk`
+
+## 1. What does this do?
+
+An animated inline editable text component where a static label morphs into an input on click (scaleX expand), saves with a green background flash confirm, cancels with a scale bounce-back, and shakes with a red border on empty submit — all transitions driven by pure CSS keyframes off state classes toggled by a minimal JS bridge. Supports single-line inputs, email inputs, textareas, and fields with character counters.
+
+---
+
+## 2. How is it used?
+
+### HTML structure
+
+```html
+<div class="ie-field" data-state="view" id="field-name">
+
+  <!-- View mode -->
+  <div class="ie-view" id="view-name">
+    <span class="ie-view__text" id="text-name">Alex Johnson</span>
+    <button class="ie-view__edit-btn" aria-label="Edit name">
+      <!-- pencil SVG -->
+    </button>
+  </div>
+
+  <!-- Edit mode -->
+  <div class="ie-edit" id="edit-name" hidden>
+    <input class="ie-input" type="text" id="input-name" />
+    <div class="ie-actions">
+      <button class="ie-btn ie-btn--save"   aria-label="Save"><!-- ✓ --></button>
+      <button class="ie-btn ie-btn--cancel" aria-label="Cancel"><!-- ✗ --></button>
+    </div>
+  </div>
+
+  <p class="ie-error" role="alert" aria-live="assertive"></p>
+</div>
+```
+
+### State classes
+
+| Class / Attribute | Applied to | Effect |
+|---|---|---|
+| `data-state="view"` | `.ie-field` | View mode active |
+| `data-state="edit"` | `.ie-field` | Edit mode active |
+| `ie-edit--enter` | `.ie-edit` | scaleX morph-in expand animation |
+| `ie-edit--exit` | `.ie-edit` | scaleX collapse animation |
+| `ie-input--error` | `.ie-input` | Red border + glow |
+| `ie-input--shake` | `.ie-input` | Horizontal shake on invalid save |
+| `ie-text--confirm` | `.ie-view__text` | Green background flash on save |
+| `ie-text--cancel-bounce` | `.ie-view__text` | Scale bounce-back on cancel |
+| `ie-char-count--warn` | `.ie-char-count` | Red color when near limit |
+
+### JS bridge (minimal — only toggles classes and manages hidden state)
+
+```js
+// Open edit mode
+editEl.classList.add('ie-edit--enter');
+viewEl.hidden = true;
+editEl.hidden = false;
+
+// Save — close with confirm flash
+textEl.textContent = newValue;
+editEl.classList.add('ie-edit--exit');
+// on animationend:
+textEl.classList.add('ie-text--confirm');
+
+// Cancel — close with bounce back
+editEl.classList.add('ie-edit--exit');
+// on animationend:
+textEl.classList.add('ie-text--cancel-bounce');
+
+// Validation shake
+inputEl.classList.add('ie-input--error', 'ie-input--shake');
+```
+
+All visual transitions are pure CSS. The JS manages state, hidden attributes, and focus only.
+
+---
+
+## 3. Why is it useful?
+
+Inline editing is one of the most common patterns in data-heavy UIs — profile pages, table cells, card titles, settings panels. Most implementations do an instant swap with no spatial sense of transition.
+
+This component fits EaseMotion's philosophy because:
+
+- **Motion communicates state change.** The scaleX morph-in tells users the field is now editable. The green flash says "saved." The bounce-back says "cancelled." The shake says "fix this" — each animation is a direct message, not decoration.
+- **CSS does the heavy lifting.** All 6 keyframes (fade-up, morph-in, morph-out, shake, confirm-flash, cancel-bounce) are pure CSS driven by class toggles. The JS is ~90 lines managing state transitions and focus only — swap it for React `useState`, Alpine `x-bind`, or Svelte without touching the stylesheet.
+- **Accessible by default.** Each field has labelled `aria-label` attributes. Error messages use `role="alert"` + `aria-live="assertive"`. A global `role="status"` live region announces every transition. Keyboard: `Enter` saves, `Escape` cancels. Pencil button is always focus-visible.
+- **Zero dependencies.** Open `demo.html` directly in any modern browser — no server, no CDN, no build step.
+- **Two field types.** Single-line `<input>` and multiline `<textarea>` both supported with the same CSS and JS pattern.
+
+---
+
+## Animations used
+
+| Animation | Trigger | Effect |
+|---|---|---|
+| `ie-fade-up` | Card / hint on page load | Fade + slide up entrance |
+| `ie-morph-in` | `.ie-edit--enter` on open | scaleX expand from left with bounce |
+| `ie-morph-out` | `.ie-edit--exit` on close | scaleX collapse to left |
+| `ie-shake` | `.ie-input--shake` on empty save | Horizontal shake (7-step) |
+| `ie-confirm-flash` | `.ie-text--confirm` after save | Green background pulse fade |
+| `ie-cancel-bounce` | `.ie-text--cancel-bounce` after cancel | Scale pop bounce-back |
+
+---
+
+## Files
+
+```
+submissions/examples/inline-edit-nk/
+├── demo.html   — self-contained demo, works by opening directly in a browser
+├── style.css   — all styles, keyframes, and state transitions
+└── README.md   — this file
+```

--- a/submissions/examples/inline-edit-nk/demo.html
+++ b/submissions/examples/inline-edit-nk/demo.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inline Editable Text — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+
+      <div class="ie-card">
+        <h1 class="ie-card__title">Inline Edit Component</h1>
+        <p class="ie-card__subtitle">Click any field to edit it inline.</p>
+
+        <!-- ── Profile section ── -->
+        <div class="ie-section">
+          <p class="ie-section__label">Full Name</p>
+
+          <!-- Inline edit field: single line -->
+          <div class="ie-field" data-state="view" id="field-name">
+            <div class="ie-view" id="view-name">
+              <span class="ie-view__text" id="text-name">Alex Johnson</span>
+              <button class="ie-view__edit-btn" aria-label="Edit full name" tabindex="0">
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M11.5 2.5a1.414 1.414 0 0 1 2 2L5 13H3v-2L11.5 2.5z"
+                        stroke="currentColor" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
+
+            <div class="ie-edit" id="edit-name" hidden>
+              <input
+                class="ie-input"
+                type="text"
+                id="input-name"
+                aria-label="Edit full name"
+                autocomplete="off"
+                maxlength="60"
+              />
+              <div class="ie-actions">
+                <button class="ie-btn ie-btn--save" aria-label="Save name">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button class="ie-btn ie-btn--cancel" aria-label="Cancel editing name">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p class="ie-error" id="err-name" role="alert" aria-live="assertive"></p>
+          </div>
+        </div>
+
+        <div class="ie-divider"></div>
+
+        <!-- Email -->
+        <div class="ie-section">
+          <p class="ie-section__label">Email Address</p>
+          <div class="ie-field" data-state="view" id="field-email">
+            <div class="ie-view" id="view-email">
+              <span class="ie-view__text" id="text-email">alex@example.com</span>
+              <button class="ie-view__edit-btn" aria-label="Edit email address">
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M11.5 2.5a1.414 1.414 0 0 1 2 2L5 13H3v-2L11.5 2.5z"
+                        stroke="currentColor" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
+            <div class="ie-edit" id="edit-email" hidden>
+              <input class="ie-input" type="email" id="input-email"
+                     aria-label="Edit email address" autocomplete="off" maxlength="80"/>
+              <div class="ie-actions">
+                <button class="ie-btn ie-btn--save"   aria-label="Save email">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button class="ie-btn ie-btn--cancel" aria-label="Cancel editing email">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p class="ie-error" id="err-email" role="alert" aria-live="assertive"></p>
+          </div>
+        </div>
+
+        <div class="ie-divider"></div>
+
+        <!-- Bio — multiline textarea -->
+        <div class="ie-section">
+          <p class="ie-section__label">Bio</p>
+          <div class="ie-field ie-field--multiline" data-state="view" id="field-bio">
+            <div class="ie-view" id="view-bio">
+              <span class="ie-view__text" id="text-bio">
+                Product designer who loves clean UI and delightful micro-interactions.
+              </span>
+              <button class="ie-view__edit-btn" aria-label="Edit bio">
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M11.5 2.5a1.414 1.414 0 0 1 2 2L5 13H3v-2L11.5 2.5z"
+                        stroke="currentColor" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
+            <div class="ie-edit" id="edit-bio" hidden>
+              <textarea class="ie-input ie-textarea" id="input-bio"
+                        aria-label="Edit bio" rows="3" maxlength="200"></textarea>
+              <div class="ie-actions">
+                <button class="ie-btn ie-btn--save"   aria-label="Save bio">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button class="ie-btn ie-btn--cancel" aria-label="Cancel editing bio">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p class="ie-error" id="err-bio" role="alert" aria-live="assertive"></p>
+          </div>
+        </div>
+
+        <div class="ie-divider"></div>
+
+        <!-- Job title — with char counter -->
+        <div class="ie-section">
+          <p class="ie-section__label">Job Title</p>
+          <div class="ie-field" data-state="view" id="field-title">
+            <div class="ie-view" id="view-title">
+              <span class="ie-view__text" id="text-title">Senior Product Designer</span>
+              <button class="ie-view__edit-btn" aria-label="Edit job title">
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M11.5 2.5a1.414 1.414 0 0 1 2 2L5 13H3v-2L11.5 2.5z"
+                        stroke="currentColor" stroke-width="1.5"
+                        stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
+            <div class="ie-edit" id="edit-title" hidden>
+              <input class="ie-input" type="text" id="input-title"
+                     aria-label="Edit job title" autocomplete="off" maxlength="50"/>
+              <div class="ie-actions">
+                <span class="ie-char-count" id="count-title" aria-live="polite">0/50</span>
+                <button class="ie-btn ie-btn--save"   aria-label="Save job title">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button class="ie-btn ie-btn--cancel" aria-label="Cancel editing title">
+                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p class="ie-error" id="err-title" role="alert" aria-live="assertive"></p>
+          </div>
+        </div>
+
+      </div><!-- /card -->
+
+      <!-- Demo hint -->
+      <div class="demo-hint">
+        <p class="demo-hint__title">Try these interactions:</p>
+        <ul class="demo-hint__list">
+          <li>Click any field or pencil icon → morphs to input</li>
+          <li>Edit text → click ✓ → green flash confirm animation</li>
+          <li>Click ✗ or press <kbd>Esc</kbd> → bounce-back cancel</li>
+          <li>Clear a field → click ✓ → validation shake + red border</li>
+          <li>Press <kbd>Enter</kbd> to save, <kbd>Esc</kbd> to cancel</li>
+        </ul>
+      </div>
+
+    </div>
+
+    <!-- SR live region -->
+    <div class="ie-sr" role="status" aria-live="polite" id="ie-sr"></div>
+
+    <script>
+    (function () {
+
+      const sr = document.getElementById('ie-sr');
+
+      function announce(msg) {
+        sr.textContent = '';
+        requestAnimationFrame(() => { sr.textContent = msg; });
+      }
+
+      /* ── Field config ── */
+      const fields = [
+        {
+          id:       'name',
+          validate: v => v.trim().length > 0 || 'Name cannot be empty.',
+        },
+        {
+          id:       'email',
+          validate: v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim()) || 'Enter a valid email.',
+        },
+        {
+          id:       'bio',
+          validate: v => v.trim().length > 0 || 'Bio cannot be empty.',
+          multiline: true,
+        },
+        {
+          id:       'title',
+          validate: v => v.trim().length > 0 || 'Job title cannot be empty.',
+          charCount: true,
+        },
+      ];
+
+      fields.forEach(({ id, validate, multiline, charCount }) => {
+        const field     = document.getElementById('field-' + id);
+        const viewEl    = document.getElementById('view-'  + id);
+        const editEl    = document.getElementById('edit-'  + id);
+        const textEl    = document.getElementById('text-'  + id);
+        const inputEl   = document.getElementById('input-' + id);
+        const errEl     = document.getElementById('err-'   + id);
+        const editBtn   = viewEl.querySelector('.ie-view__edit-btn');
+        const saveBtn   = editEl.querySelector('.ie-btn--save');
+        const cancelBtn = editEl.querySelector('.ie-btn--cancel');
+        const countEl   = charCount ? document.getElementById('count-' + id) : null;
+
+        let originalValue = textEl.textContent.trim();
+
+        /* ── open edit mode ── */
+        function openEdit() {
+          originalValue       = textEl.textContent.trim();
+          inputEl.value       = originalValue;
+          errEl.textContent   = '';
+          inputEl.classList.remove('ie-input--error');
+
+          viewEl.hidden = true;
+          editEl.hidden = false;
+          field.setAttribute('data-state', 'edit');
+
+          /* morph-in animation */
+          editEl.classList.remove('ie-edit--enter');
+          void editEl.offsetWidth;
+          editEl.classList.add('ie-edit--enter');
+
+          inputEl.focus();
+          if (!multiline) {
+            inputEl.select();
+          }
+
+          if (charCount && countEl) {
+            updateCount();
+          }
+
+          announce('Editing ' + id + '. Press Enter to save, Escape to cancel.');
+        }
+
+        /* ── close edit mode ── */
+        function closeEdit(saved) {
+          editEl.classList.remove('ie-edit--enter');
+          editEl.classList.add('ie-edit--exit');
+
+          editEl.addEventListener('animationend', function handler() {
+            editEl.removeEventListener('animationend', handler);
+            editEl.classList.remove('ie-edit--exit');
+            editEl.hidden = true;
+            viewEl.hidden = false;
+            field.setAttribute('data-state', 'view');
+
+            /* view text entrance */
+            textEl.classList.remove('ie-text--confirm', 'ie-text--cancel-bounce');
+            void textEl.offsetWidth;
+            textEl.classList.add(saved ? 'ie-text--confirm' : 'ie-text--cancel-bounce');
+            textEl.addEventListener('animationend', () => {
+              textEl.classList.remove('ie-text--confirm', 'ie-text--cancel-bounce');
+            }, { once: true });
+          }, { once: true });
+        }
+
+        /* ── save ── */
+        function trySave() {
+          const val    = inputEl.value;
+          const result = validate(val);
+
+          if (result !== true) {
+            /* shake */
+            inputEl.classList.remove('ie-input--error', 'ie-input--shake');
+            void inputEl.offsetWidth;
+            inputEl.classList.add('ie-input--error', 'ie-input--shake');
+            inputEl.addEventListener('animationend', () => {
+              inputEl.classList.remove('ie-input--shake');
+            }, { once: true });
+            errEl.textContent = result;
+            inputEl.focus();
+            return;
+          }
+
+          errEl.textContent = '';
+          inputEl.classList.remove('ie-input--error');
+          textEl.textContent = val.trim();
+          announce(id + ' saved: ' + val.trim());
+          closeEdit(true);
+        }
+
+        /* ── cancel ── */
+        function doCancel() {
+          textEl.textContent = originalValue;
+          errEl.textContent  = '';
+          announce('Editing cancelled.');
+          closeEdit(false);
+        }
+
+        /* ── char counter ── */
+        function updateCount() {
+          if (!countEl) return;
+          const max = parseInt(inputEl.getAttribute('maxlength') || '50', 10);
+          const len = inputEl.value.length;
+          countEl.textContent = len + '/' + max;
+          countEl.classList.toggle('ie-char-count--warn', len >= max * 0.85);
+        }
+
+        /* ── events ── */
+        editBtn.addEventListener('click', openEdit);
+
+        /* click on text itself also opens edit */
+        textEl.addEventListener('click', openEdit);
+        textEl.style.cursor = 'text';
+
+        saveBtn.addEventListener('click', trySave);
+        cancelBtn.addEventListener('click', doCancel);
+
+        inputEl.addEventListener('keydown', e => {
+          if (!multiline && e.key === 'Enter') { e.preventDefault(); trySave(); }
+          if (e.key === 'Escape') doCancel();
+        });
+
+        if (charCount) {
+          inputEl.addEventListener('input', updateCount);
+        }
+      });
+
+    })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/inline-edit-nk/style.css
+++ b/submissions/examples/inline-edit-nk/style.css
@@ -1,0 +1,490 @@
+/* ============================================================
+   Inline Editable Text — EaseMotion CSS Submission
+   Track: Standard (HTML/CSS)
+   Component ID: inline-edit-nk
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   0. Design tokens
+   ------------------------------------------------------------ */
+:root {
+  --ie-color-bg:         #ffffff;
+  --ie-color-surface:    #f8fafc;
+  --ie-color-border:     #e2e8f0;
+  --ie-color-text:       #1e293b;
+  --ie-color-muted:      #94a3b8;
+  --ie-color-label:      #475569;
+
+  --ie-color-primary:    #6366f1;
+  --ie-color-primary-lt: #eef2ff;
+  --ie-color-success:    #10b981;
+  --ie-color-success-lt: #f0fdf4;
+  --ie-color-danger:     #ef4444;
+  --ie-color-danger-lt:  #fef2f2;
+
+  --ie-glow-primary: 0 0 0 3px rgba(99, 102, 241, 0.18);
+  --ie-glow-danger:  0 0 0 3px rgba(239, 68,  68,  0.18);
+  --ie-glow-success: 0 0 0 3px rgba(16,  185, 129, 0.18);
+
+  --ie-radius-input: 8px;
+  --ie-radius-btn:   7px;
+  --ie-radius-card:  20px;
+
+  --ie-speed-fast:   0.14s;
+  --ie-speed-mid:    0.25s;
+  --ie-speed-slow:   0.4s;
+  --ie-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+  --ie-ease-out:     cubic-bezier(0, 0, 0.2, 1);
+  --ie-ease-bounce:  cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ------------------------------------------------------------
+   1. Base reset
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f0fdf4 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--ie-color-text);
+}
+
+.ie-sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* ------------------------------------------------------------
+   2. Layout
+   ------------------------------------------------------------ */
+.demo-wrapper {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ------------------------------------------------------------
+   3. Card
+   ------------------------------------------------------------ */
+.ie-card {
+  background: var(--ie-color-bg);
+  border: 1px solid var(--ie-color-border);
+  border-radius: var(--ie-radius-card);
+  padding: 2rem 2rem 2.25rem;
+  box-shadow:
+    0 1px 3px rgba(0,0,0,.06),
+    0 12px 32px rgba(0,0,0,.09);
+  animation: ie-fade-up var(--ie-speed-slow) var(--ie-ease-out) both;
+}
+
+.ie-card__title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.ie-card__subtitle {
+  font-size: 0.875rem;
+  color: var(--ie-color-muted);
+  margin-top: 0.3rem;
+  margin-bottom: 1.75rem;
+}
+
+/* ------------------------------------------------------------
+   4. Section row
+   ------------------------------------------------------------ */
+.ie-section {
+  padding: 0.75rem 0;
+}
+
+.ie-section__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ie-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.45rem;
+}
+
+.ie-divider {
+  height: 1px;
+  background: var(--ie-color-border);
+}
+
+/* ------------------------------------------------------------
+   5. Field wrapper
+   ------------------------------------------------------------ */
+.ie-field {
+  position: relative;
+}
+
+/* ------------------------------------------------------------
+   6. VIEW mode
+   ------------------------------------------------------------ */
+.ie-view {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2rem;
+}
+
+.ie-view__text {
+  font-size: 0.9375rem;
+  color: var(--ie-color-text);
+  line-height: 1.5;
+  flex: 1;
+  border-radius: var(--ie-radius-input);
+  padding: 2px 4px;
+  transition: background var(--ie-speed-fast) var(--ie-ease);
+}
+
+.ie-view__text:hover {
+  background: var(--ie-color-surface);
+}
+
+/* Pencil edit button — fades in on row hover */
+.ie-view__edit-btn {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--ie-radius-btn);
+  color: var(--ie-color-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.85);
+  transition:
+    opacity    var(--ie-speed-fast) var(--ie-ease),
+    transform  var(--ie-speed-fast) var(--ie-ease-bounce),
+    color      var(--ie-speed-fast) var(--ie-ease),
+    background var(--ie-speed-fast) var(--ie-ease);
+  flex-shrink: 0;
+}
+
+.ie-view__edit-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.ie-view:hover .ie-view__edit-btn,
+.ie-view__edit-btn:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.ie-view__edit-btn:hover {
+  color: var(--ie-color-primary);
+  background: var(--ie-color-primary-lt);
+}
+
+.ie-view__edit-btn:focus-visible {
+  outline: 2px solid var(--ie-color-primary);
+  outline-offset: 2px;
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Multiline view text */
+.ie-field--multiline .ie-view {
+  align-items: flex-start;
+}
+
+.ie-field--multiline .ie-view__text {
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+/* ------------------------------------------------------------
+   7. EDIT mode — morph in/out
+   ------------------------------------------------------------ */
+.ie-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transform-origin: left center;
+}
+
+/* Enter: expand from left */
+.ie-edit--enter {
+  animation: ie-morph-in var(--ie-speed-mid) var(--ie-ease-bounce) both;
+}
+
+/* Exit: collapse to left */
+.ie-edit--exit {
+  animation: ie-morph-out var(--ie-speed-mid) var(--ie-ease) forwards;
+}
+
+/* ------------------------------------------------------------
+   8. Input
+   ------------------------------------------------------------ */
+.ie-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1.5px solid var(--ie-color-border);
+  border-radius: var(--ie-radius-input);
+  font-size: 0.9375rem;
+  font-family: inherit;
+  color: var(--ie-color-text);
+  background: var(--ie-color-bg);
+  outline: none;
+  transition:
+    border-color var(--ie-speed-fast) var(--ie-ease),
+    box-shadow   var(--ie-speed-fast) var(--ie-ease),
+    background   var(--ie-speed-fast) var(--ie-ease);
+  resize: none;
+}
+
+.ie-input:focus {
+  border-color: var(--ie-color-primary);
+  box-shadow: var(--ie-glow-primary);
+}
+
+.ie-textarea {
+  line-height: 1.6;
+  min-height: 5rem;
+}
+
+/* Error state */
+.ie-input--error {
+  border-color: var(--ie-color-danger) !important;
+  box-shadow: var(--ie-glow-danger) !important;
+  background: var(--ie-color-danger-lt) !important;
+}
+
+/* Shake on invalid save */
+.ie-input--shake {
+  animation: ie-shake 0.42s var(--ie-ease) both;
+}
+
+/* ------------------------------------------------------------
+   9. Actions row (save / cancel / char count)
+   ------------------------------------------------------------ */
+.ie-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
+.ie-btn {
+  width: 30px;
+  height: 30px;
+  border: 1.5px solid var(--ie-color-border);
+  border-radius: var(--ie-radius-btn);
+  background: var(--ie-color-surface);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background    var(--ie-speed-fast) var(--ie-ease),
+    border-color  var(--ie-speed-fast) var(--ie-ease),
+    color         var(--ie-speed-fast) var(--ie-ease),
+    transform     var(--ie-speed-mid)  var(--ie-ease-bounce);
+}
+
+.ie-btn svg {
+  width: 13px;
+  height: 13px;
+}
+
+.ie-btn:focus-visible {
+  outline: 2px solid var(--ie-color-primary);
+  outline-offset: 2px;
+}
+
+/* Save button */
+.ie-btn--save {
+  color: var(--ie-color-success);
+  border-color: var(--ie-color-success);
+}
+
+.ie-btn--save:hover {
+  background: var(--ie-color-success);
+  color: #fff;
+  transform: scale(1.12);
+}
+
+/* Cancel button */
+.ie-btn--cancel {
+  color: var(--ie-color-muted);
+}
+
+.ie-btn--cancel:hover {
+  background: var(--ie-color-danger-lt);
+  border-color: var(--ie-color-danger);
+  color: var(--ie-color-danger);
+  transform: scale(1.12);
+}
+
+/* Char counter */
+.ie-char-count {
+  font-size: 0.75rem;
+  color: var(--ie-color-muted);
+  margin-right: auto;
+  font-variant-numeric: tabular-nums;
+  transition: color var(--ie-speed-fast) var(--ie-ease);
+}
+
+.ie-char-count--warn {
+  color: var(--ie-color-danger);
+  font-weight: 600;
+}
+
+/* ------------------------------------------------------------
+   10. Error message
+   ------------------------------------------------------------ */
+.ie-error {
+  font-size: 0.75rem;
+  color: var(--ie-color-danger);
+  font-weight: 500;
+  min-height: 1em;
+  margin-top: 0.2rem;
+}
+
+/* ------------------------------------------------------------
+   11. Text state animations (after save/cancel)
+   ------------------------------------------------------------ */
+
+/* Green flash on save */
+.ie-text--confirm {
+  animation: ie-confirm-flash var(--ie-speed-slow) var(--ie-ease-out) both;
+}
+
+/* Bounce back on cancel */
+.ie-text--cancel-bounce {
+  animation: ie-cancel-bounce var(--ie-speed-mid) var(--ie-ease-bounce) both;
+}
+
+/* ------------------------------------------------------------
+   12. Demo hint card
+   ------------------------------------------------------------ */
+.demo-hint {
+  background: var(--ie-color-bg);
+  border: 1px solid var(--ie-color-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  animation: ie-fade-up var(--ie-speed-slow) var(--ie-ease-out) 0.1s both;
+}
+
+.demo-hint__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ie-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.demo-hint__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.demo-hint__list li {
+  font-size: 0.8125rem;
+  color: var(--ie-color-text);
+  padding-left: 1rem;
+  position: relative;
+}
+
+.demo-hint__list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--ie-color-primary);
+  font-size: 0.75rem;
+}
+
+kbd {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  background: var(--ie-color-surface);
+  border: 1px solid var(--ie-color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.75em;
+  color: var(--ie-color-label);
+}
+
+/* ------------------------------------------------------------
+   13. Keyframes
+   ------------------------------------------------------------ */
+
+/* Card entrance */
+@keyframes ie-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Edit pane morph in — scaleX expand from left */
+@keyframes ie-morph-in {
+  0%   { opacity: 0; transform: scaleX(0.88) translateY(-4px); }
+  60%  { transform: scaleX(1.02) translateY(1px); }
+  100% { opacity: 1; transform: scaleX(1) translateY(0); }
+}
+
+/* Edit pane morph out — collapse */
+@keyframes ie-morph-out {
+  0%   { opacity: 1; transform: scaleX(1) translateY(0); }
+  100% { opacity: 0; transform: scaleX(0.9) translateY(-4px); }
+}
+
+/* Input validation shake */
+@keyframes ie-shake {
+  0%,100% { transform: translateX(0); }
+  15%     { transform: translateX(-6px); }
+  30%     { transform: translateX(6px); }
+  45%     { transform: translateX(-4px); }
+  60%     { transform: translateX(4px); }
+  75%     { transform: translateX(-2px); }
+  90%     { transform: translateX(2px); }
+}
+
+/* Text confirm flash — green background pulse */
+@keyframes ie-confirm-flash {
+  0%   { background: transparent; }
+  25%  { background: rgba(16, 185, 129, 0.15); border-radius: 4px; }
+  70%  { background: rgba(16, 185, 129, 0.08); }
+  100% { background: transparent; }
+}
+
+/* Text cancel bounce — gentle scale pop */
+@keyframes ie-cancel-bounce {
+  0%   { opacity: 0.5; transform: scale(0.96); }
+  60%  { transform: scale(1.02); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* ------------------------------------------------------------
+   14. Reduced motion
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+  }
+}
+
+/* ------------------------------------------------------------
+   15. Responsive
+   ------------------------------------------------------------ */
+@media (max-width: 400px) {
+  .ie-card { padding: 1.5rem 1rem 1.75rem; }
+}


### PR DESCRIPTION
fix #76478 

## Pull Request Description

Adds an animated inline editable text component (`inline-edit-nk`) where static text morphs into an input on click via a scaleX expand animation, saves with a green background flash confirm, cancels with a scale bounce-back, and shakes with red border on empty submit - all driven by pure CSS keyframes off state classes. Supports single-line inputs, email, textarea, and fields with character counters.

## Type of Change

- [x] 🧩 New component

## Submission Checklist

- [x] All changes are inside `submissions/examples/inline-edit-nk/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description

### What does this add?

An animated inline editable field - text morphs to input on click (scaleX bounce expand), ✓ saves with green flash, ✗ cancels with bounce-back, empty save shakes red. 4 field types: text, email, textarea, and char-counter input.

### How does a developer use it?

```html
<div class="ie-field" data-state="view">
  <div class="ie-view">
    <span class="ie-view__text">Alex Johnson</span>
    <button class="ie-view__edit-btn"><!-- pencil --></button>
  </div>
  <div class="ie-edit" hidden>
    <input class="ie-input" type="text" />
    <div class="ie-actions">
      <button class="ie-btn ie-btn--save"><!-- ✓ --></button>
      <button class="ie-btn ie-btn--cancel"><!-- ✗ --></button>
    </div>
  </div>
</div>
```

JS adds `ie-edit--enter` to open, `ie-edit--exit` to close, `ie-text--confirm` after save, `ie-text--cancel-bounce` after cancel, `ie-input--shake` on validation fail. All animation is CSS.

### Why does it fit EaseMotion CSS?

Inline editing is everywhere - profile names, table cells, card titles. The scaleX morph tells users the field is editable, the green flash confirms the save, the bounce-back confirms the cancel. Motion replaces ambiguity with clarity - exactly EaseMotion's philosophy.

## Demo

- `demo.html` works by opening directly in a browser
- Click any field → scaleX morph-in animation
- Edit + save → green background flash confirm
- Cancel / Esc → scale bounce-back
- Save empty field → horizontal shake + red border

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer

All 6 keyframes use `--ie-*` CSS custom property tokens. `prefers-reduced-motion` collapses all durations to near-zero. Keyboard: `Enter` saves (single-line), `Escape` cancels on all types. The pencil icon fades in only on hover/focus-visible, keeping the UI clean at rest. JS is ~90 lines, framework-agnostic.