### PR TITLE
Add skeleton shimmer loader submission

### DIFF
--- a/submissions/examples/skeleton-shimmer-tm/README.md
+++ b/submissions/examples/skeleton-shimmer-tm/README.md
@@ -1,0 +1,7 @@
+# Skeleton shimmer loader
+
+1. What does this do? Renders placeholder bars, circles, and rectangles that animate a soft light wave while content is loading.
+
+2. How is it used? Add the class `skel-bar-tm` to a div for a text line, `skel-circle-tm` for an avatar, `skel-rect-tm` for an image placeholder, or `skel-thumb-tm` for a card. Combine with width helpers like `skel-w60-tm`.
+
+3. Why is it useful? It signals to the user that content is on the way and reduces perceived wait time, all without any image asset or JavaScript.

--- a/submissions/examples/skeleton-shimmer-tm/demo.html
+++ b/submissions/examples/skeleton-shimmer-tm/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Skeleton shimmer loader — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="sk-page-tm">
+  <h1>Skeleton shimmer</h1>
+  <p class="sk-lede-tm">Three common shapes for placeholder loading states.</p>
+
+  <section class="sk-card-tm">
+    <div class="skel-circle-tm skel-lg-tm"></div>
+    <div class="sk-stack-tm">
+      <div class="skel-bar-tm skel-w70-tm"></div>
+      <div class="skel-bar-tm skel-w90-tm"></div>
+      <div class="skel-bar-tm skel-w40-tm"></div>
+    </div>
+  </section>
+
+  <section class="sk-card-tm">
+    <div class="skel-rect-tm"></div>
+    <div class="skel-bar-tm skel-w60-tm"></div>
+    <div class="skel-bar-tm skel-w80-tm"></div>
+  </section>
+
+  <section class="sk-row-tm">
+    <div class="skel-thumb-tm"></div>
+    <div class="skel-thumb-tm"></div>
+    <div class="skel-thumb-tm"></div>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/skeleton-shimmer-tm/style.css
+++ b/submissions/examples/skeleton-shimmer-tm/style.css
@@ -1,0 +1,86 @@
+:root {
+  --sk-base: #1a1d24;
+  --sk-shine: #2c313c;
+  --sk-edge: #262a33;
+  --sk-text: #e6e8ec;
+  --sk-muted: #8b909b;
+  --sk-accent: #4dabf7;
+  --sk-radius: 10px;
+  --sk-pad: 18px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: #0f1115;
+  color: var(--sk-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+}
+
+.sk-page-tm { max-width: 880px; margin: 0 auto; }
+.sk-page-tm h1 { font-size: 28px; margin: 0 0 8px; }
+.sk-lede-tm { color: var(--sk-muted); margin: 0 0 32px; }
+
+.sk-card-tm {
+  background: var(--sk-base);
+  border: 1px solid var(--sk-edge);
+  border-radius: 14px;
+  padding: var(--sk-pad);
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@keyframes skel-sweep {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.skel-bar-tm {
+  height: 14px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--sk-base) 0%, var(--sk-shine) 50%, var(--sk-base) 100%);
+  background-size: 200% 100%;
+  animation: skel-sweep 1.4s linear infinite;
+}
+
+.skel-w40-tm { width: 40%; }
+.skel-w60-tm { width: 60%; }
+.skel-w70-tm { width: 70%; }
+.skel-w80-tm { width: 80%; }
+.skel-w90-tm { width: 90%; }
+
+.skel-circle-tm {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(90deg, var(--sk-base) 0%, var(--sk-shine) 50%, var(--sk-base) 100%);
+  background-size: 200% 100%;
+  animation: skel-sweep 1.4s linear infinite;
+}
+
+.skel-lg-tm { width: 72px; height: 72px; }
+
+.skel-rect-tm {
+  height: 160px;
+  border-radius: var(--sk-radius);
+  background: linear-gradient(90deg, var(--sk-base) 0%, var(--sk-shine) 50%, var(--sk-base) 100%);
+  background-size: 200% 100%;
+  animation: skel-sweep 1.6s linear infinite;
+}
+
+.skel-thumb-tm {
+  flex: 1;
+  height: 90px;
+  border-radius: var(--sk-radius);
+  background: linear-gradient(90deg, var(--sk-base) 0%, var(--sk-shine) 50%, var(--sk-base) 100%);
+  background-size: 200% 100%;
+  animation: skel-sweep 1.5s linear infinite;
+}
+
+.sk-row-tm { display: flex; gap: 12px; }
+.sk-stack-tm { display: flex; flex-direction: column; gap: 10px; flex: 1; }


### PR DESCRIPTION
Closes #76522

## What
This submission adds a new EaseMotion CSS example: `skeleton-shimmer-tm`.

Loading placeholders that animate a soft light wave across their surface, signalling that content is on the way. Pure CSS, no images, no JS.

## How to review
1. Open `submissions/examples/skeleton-shimmer-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/skeleton-shimmer-tm/` and does not modify any existing file.
