### PR TITLE
feat: add origami tooltip example

### DIFF
--- a/submissions/examples/ease-origami-tooltip/README.md
+++ b/submissions/examples/ease-origami-tooltip/README.md
@@ -1,0 +1,23 @@
+# Origami Paper Fold Tooltip
+
+A pure CSS tooltip variation that reveals its content with a 3D paper-fold effect inspired by origami.
+
+## Features
+
+- Pure HTML and CSS
+- No JavaScript required
+- Origami-inspired 3D fold animation
+- Keyboard accessible with `:focus-visible`
+- Dark-mode support
+- Respects `prefers-reduced-motion`
+- Works with buttons and other interactive elements
+
+## Usage
+
+```html
+<button
+  class="ease-tooltip-origami"
+  data-tooltip="This tooltip unfolds like a sheet of paper."
+>
+  Hover me
+</button>

--- a/submissions/examples/ease-origami-tooltip/demo.html
+++ b/submissions/examples/ease-origami-tooltip/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Origami Paper Fold Tooltip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+  <main class="demo">
+    <h1>Origami Paper Fold Tooltip</h1>
+    <p>Hover or focus the buttons to reveal the tooltip.</p>
+
+    <div class="tooltip-demo">
+      <button
+        class="ease-tooltip-origami"
+        data-tooltip="This tooltip unfolds like a sheet of paper."
+        type="button"
+      >
+        Hover me
+      </button>
+
+      <button
+        class="ease-tooltip-origami"
+        data-tooltip="Pure CSS. No JavaScript required."
+        type="button"
+      >
+        Try me
+      </button>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-origami-tooltip/style.css
+++ b/submissions/examples/ease-origami-tooltip/style.css
@@ -1,0 +1,194 @@
+:root {
+  --origami-bg: #ffffff;
+  --origami-text: #1f2937;
+  --origami-accent: #8b5cf6;
+  --origami-shadow: rgba(15, 23, 42, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  font-family: system-ui, sans-serif;
+  background: #f5f3ff;
+  color: #1f2937;
+}
+
+.demo {
+  text-align: center;
+}
+
+.demo h1 {
+  margin-bottom: 0.5rem;
+}
+
+.demo p {
+  margin-bottom: 3rem;
+  color: #6b7280;
+}
+
+.tooltip-demo {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.ease-tooltip-origami {
+  position: relative;
+  border: 0;
+  padding: 0.8rem 1.5rem;
+  border-radius: 0.5rem;
+  background: #7c3aed;
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Tooltip sheet */
+.ease-tooltip-origami::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.75rem);
+
+  width: max-content;
+  max-width: 240px;
+  padding: 0.8rem 1rem;
+
+  background: var(--origami-bg);
+  color: var(--origami-text);
+
+  border: 1px solid #e5e7eb;
+  border-radius: 0.35rem;
+
+  box-shadow: 0 12px 30px var(--origami-shadow);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transform:
+    translateX(-50%)
+    rotateX(-75deg)
+    rotateZ(-2deg)
+    scaleY(0.15);
+
+  transform-origin: bottom center;
+
+  transition:
+    transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.25s ease,
+    visibility 0.45s ease;
+
+  transform-style: preserve-3d;
+}
+
+/* Origami folded corner */
+.ease-tooltip-origami::before {
+  content: "";
+  position: absolute;
+
+  left: 50%;
+  bottom: calc(100% + 0.35rem);
+
+  width: 14px;
+  height: 14px;
+
+  background: var(--origami-bg);
+  border-right: 1px solid #e5e7eb;
+  border-bottom: 1px solid #e5e7eb;
+
+  transform:
+    translateX(-50%)
+    rotate(45deg)
+    rotateX(75deg)
+    scale(0);
+
+  opacity: 0;
+
+  transition:
+    transform 0.35s ease 0.12s,
+    opacity 0.2s ease;
+}
+
+/* Reveal */
+.ease-tooltip-origami:hover::after,
+.ease-tooltip-origami:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+
+  transform:
+    translateX(-50%)
+    rotateX(0)
+    rotateZ(0)
+    scaleY(1);
+}
+
+.ease-tooltip-origami:hover::before,
+.ease-tooltip-origami:focus-visible::before {
+  opacity: 1;
+
+  transform:
+    translateX(-50%)
+    rotate(45deg)
+    rotateX(0)
+    scale(1);
+}
+
+/* Keyboard accessibility */
+.ease-tooltip-origami:focus-visible {
+  outline: 3px solid var(--origami-accent);
+  outline-offset: 4px;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --origami-bg: #1f2937;
+    --origami-text: #f9fafb;
+    --origami-shadow: rgba(0, 0, 0, 0.4);
+  }
+
+  body {
+    background: #111827;
+    color: #f9fafb;
+  }
+
+  .demo p {
+    color: #9ca3af;
+  }
+
+  .ease-tooltip-origami::after {
+    border-color: #374151;
+  }
+
+  .ease-tooltip-origami::before {
+    border-color: #374151;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip-origami::after,
+  .ease-tooltip-origami::before {
+    transition: none;
+    transform: none;
+  }
+
+  .ease-tooltip-origami::after {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .ease-tooltip-origami:hover::after,
+  .ease-tooltip-origami:focus-visible::after {
+    opacity: 1;
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
\## Description

Adds a pure CSS origami-style tooltip animation that reveals the tooltip with a 3D paper-fold effect.

### Changes

* Added an origami-inspired tooltip demo.
* Implemented the fold animation using CSS transforms and pseudo-elements.
* Added keyboard accessibility with `:focus-visible`.
* Added dark-mode support.
* Added `prefers-reduced-motion` support.
* No JavaScript or external dependencies required.

### Files Added

* `demo.html`
* `style.css`
* `README.md`

Closes #69541
