### PR TITLE
Add scroll-reveal entry animation submission

### DIFF
--- a/submissions/examples/scroll-reveal-tm/README.md
+++ b/submissions/examples/scroll-reveal-tm/README.md
@@ -1,0 +1,7 @@
+# Scroll-reveal entry
+
+1. What does this do? Elements with `reveal-tm` fade and slide up as they enter the viewport, using the CSS `animation-timeline: view()` API.
+
+2. How is it used? Add `reveal-tm` to any block-level element. Modifiers: `rv-slow-tm` (longer travel), `rv-fade-tm` (opacity only, no movement).
+
+3. Why is it useful? It draws the eye down a long page without scroll listeners, IntersectionObserver wiring, or any JavaScript bundle.

--- a/submissions/examples/scroll-reveal-tm/demo.html
+++ b/submissions/examples/scroll-reveal-tm/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Scroll-reveal — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<header class="rv-hero-tm">
+  <h1>Scroll reveal</h1>
+  <p>Scroll the page to see each section rise into place.</p>
+</header>
+
+<section class="reveal-tm rv-card-tm">
+  <h2>First reveal</h2>
+  <p>Slides up from below as it enters the viewport.</p>
+</section>
+
+<section class="reveal-tm rv-card-tm rv-slow-tm">
+  <h2>Slower, deeper</h2>
+  <p>Travels further before settling. Useful for hero blocks.</p>
+</section>
+
+<section class="reveal-tm rv-card-tm rv-fade-tm">
+  <h2>Fade only</h2>
+  <p>For dense text sections where movement would be distracting.</p>
+</section>
+
+<section class="reveal-tm rv-card-tm">
+  <h2>Final reveal</h2>
+  <p>Repeats the same effect at the bottom of the page.</p>
+</section>
+</body>
+</html>

--- a/submissions/examples/scroll-reveal-tm/style.css
+++ b/submissions/examples/scroll-reveal-tm/style.css
@@ -1,0 +1,71 @@
+:root {
+  --rv-bg: #0f1115;
+  --rv-surface: #1a1d24;
+  --rv-edge: #262a33;
+  --rv-text: #e6e8ec;
+  --rv-muted: #8b909b;
+  --rv-accent: #ffd166;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--rv-bg);
+  color: var(--rv-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  line-height: 1.55;
+}
+
+.rv-hero-tm {
+  padding: 96px 24px 64px;
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.rv-hero-tm h1 { font-size: 36px; margin: 0 0 12px; }
+.rv-hero-tm p { color: var(--rv-muted); margin: 0; }
+
+.rv-card-tm {
+  max-width: 720px;
+  margin: 64px auto;
+  padding: 32px;
+  background: var(--rv-surface);
+  border: 1px solid var(--rv-edge);
+  border-radius: 16px;
+}
+
+.rv-card-tm h2 { margin: 0 0 12px; font-size: 22px; }
+.rv-card-tm p { margin: 0; color: var(--rv-muted); }
+
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(48px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes reveal-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.reveal-tm {
+  animation: reveal-up linear both;
+  animation-timeline: view();
+  animation-range: entry 0% cover 30%;
+}
+
+.rv-slow-tm {
+  animation-name: reveal-up;
+  animation-range: entry 0% cover 50%;
+}
+
+.rv-fade-tm {
+  animation-name: reveal-fade;
+  animation-range: entry 0% cover 25%;
+}
+
+@supports not (animation-timeline: view()) {
+  .reveal-tm { animation: none; opacity: 1; transform: none; }
+}


### PR DESCRIPTION
Closes #76538

## What
This submission adds a new EaseMotion CSS example: `scroll-reveal-tm`.

Elements that fade and slide into place as they enter the viewport, using the modern CSS `animation-timeline: view()` API. Pure CSS, no scroll listeners.

## How to review
1. Open `submissions/examples/scroll-reveal-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/scroll-reveal-tm/` and does not modify any existing file.
