### PR TITLE
Add notification toast slide-in submission

### DIFF
--- a/submissions/examples/toast-slide-in-tm/README.md
+++ b/submissions/examples/toast-slide-in-tm/README.md
@@ -1,0 +1,7 @@
+# Notification toast
+
+1. What does this do? A toast that slides in from the right, lingers for about four seconds, then slides out.
+
+2. How is it used? Add `toast-tm` plus a variant (`toast-ok-tm`, `toast-warn-tm`, `toast-err-tm`). Use `role="status"` for non-critical, `role="alert"` for errors.
+
+3. Why is it useful? It gives feedback without a modal, fits the EaseMotion minimal-motion aesthetic, and stacks cleanly with no extra positioning CSS.

--- a/submissions/examples/toast-slide-in-tm/demo.html
+++ b/submissions/examples/toast-slide-in-tm/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Notification toast — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="ts-page-tm">
+  <h1>Notification toasts</h1>
+  <p class="ts-lede-tm">Three semantic variants. The animation re-runs on page reload.</p>
+
+  <ul class="ts-stack-tm">
+    <li class="toast-tm toast-ok-tm" role="status">
+      <strong>Saved</strong>
+      <span>Your changes are live.</span>
+    </li>
+    <li class="toast-tm toast-warn-tm" role="status">
+      <strong>Heads up</strong>
+      <span>You have unsaved changes.</span>
+    </li>
+    <li class="toast-tm toast-err-tm" role="alert">
+      <strong>Upload failed</strong>
+      <span>The file is larger than 10 MB.</span>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/toast-slide-in-tm/style.css
+++ b/submissions/examples/toast-slide-in-tm/style.css
@@ -1,0 +1,65 @@
+:root {
+  --ts-bg: #0f1115;
+  --ts-surface: #1a1d24;
+  --ts-edge: #262a33;
+  --ts-text: #e6e8ec;
+  --ts-muted: #8b909b;
+  --ts-ok: #2ecc71;
+  --ts-warn: #ffd166;
+  --ts-err: #ff5c5c;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ts-bg);
+  color: var(--ts-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+}
+
+.ts-page-tm { max-width: 560px; margin: 0 auto; }
+.ts-page-tm h1 { font-size: 28px; margin: 0 0 8px; }
+.ts-lede-tm { color: var(--ts-muted); margin: 0 0 28px; }
+
+.ts-stack-tm {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toast-tm {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--ts-surface);
+  border: 1px solid var(--ts-edge);
+  border-left: 4px solid var(--ts-muted);
+  border-radius: 10px;
+  transform: translateX(0);
+  animation: toast-in 360ms cubic-bezier(0.2, 0.8, 0.2, 1) both,
+             toast-out 320ms 4.2s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+.toast-tm strong { font-weight: 600; }
+.toast-tm span { color: var(--ts-muted); }
+
+.toast-ok-tm { border-left-color: var(--ts-ok); }
+.toast-warn-tm { border-left-color: var(--ts-warn); }
+.toast-err-tm { border-left-color: var(--ts-err); }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(40px); }
+}


### PR DESCRIPTION
Closes #76548

## What
This submission adds a new EaseMotion CSS example: `toast-slide-in-tm`.

A notification toast that slides in from the top-right, lingers, then slides out. Variants for success, warning, and error.

## How to review
1. Open `submissions/examples/toast-slide-in-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/toast-slide-in-tm/` and does not modify any existing file.
