### PR TITLE
test: add repeated CSS loader initialization stress tests

### DIFF
--- a/submissions/docs/repeated-loader-initialization-tests/README.md
+++ b/submissions/docs/repeated-loader-initialization-tests/README.md
@@ -1,0 +1,110 @@
+# CSS Loader Initialization Stress Tests
+
+## Overview
+
+This documentation covers stability scenarios for repeated CSS loader
+initialization and reinitialization.
+
+The goal is to identify unexpected behavior when loader initialization
+occurs repeatedly, rapidly, or across multiple elements.
+
+## Related Issue
+
+Closes #76411
+
+## Test Scenarios
+
+### 1. Repeated Initialization
+
+The same loader target is initialized multiple times.
+
+Expected behavior:
+
+- The loader remains stable.
+- No unexpected duplicate visual effects appear.
+- Existing state is not corrupted.
+
+### 2. Rapid Initialization
+
+Initialization requests occur within a short period.
+
+Expected behavior:
+
+- The loader remains responsive.
+- No inconsistent intermediate state is produced.
+- Animation behavior remains predictable.
+
+### 3. Multiple Elements
+
+Several loader elements are initialized independently.
+
+Expected behavior:
+
+- Each loader maintains its own state.
+- One loader does not interfere with another.
+- All instances render consistently.
+
+### 4. Repeated Cleanup
+
+Initialization and cleanup operations are repeated.
+
+Expected behavior:
+
+- Cleanup leaves no unexpected state behind.
+- Reinitialization works correctly after cleanup.
+- Duplicate effects are not accumulated.
+
+### 5. State Consistency
+
+The loader is subjected to multiple initialization cycles.
+
+Expected behavior:
+
+- The final state remains predictable.
+- Initialization does not progressively alter the loader.
+- Repeated cycles produce consistent results.
+
+### 6. Unexpected Duplicate Effects
+
+Repeated initialization is checked for duplicated animation layers,
+styles, listeners, or other visual effects.
+
+Expected behavior:
+
+- Only the expected effect is visible.
+- Reinitialization does not multiply the animation.
+- No unexpected DOM artifacts are produced.
+
+## Manual Verification
+
+Open `demo.html` directly in a modern browser.
+
+Verify:
+
+1. Each loader renders correctly.
+2. Multiple loaders animate independently.
+3. No visual duplication appears after repeated lifecycle operations.
+4. The animation remains stable during rapid interactions.
+5. The layout remains usable on smaller screens.
+6. `prefers-reduced-motion` disables the loader animations.
+
+## Browser Coverage
+
+The scenarios should be checked in:
+
+- Chrome
+- Firefox
+- Edge
+- Safari
+
+## Expected Outcome
+
+Repeated loader initialization and cleanup should remain stable without
+duplicate effects, corrupted state, or unexpected visual artifacts.
+
+## Accessibility
+
+The demonstration includes support for:
+
+```css
+@media (prefers-reduced-motion: reduce)

--- a/submissions/docs/repeated-loader-initialization-tests/demo.html
+++ b/submissions/docs/repeated-loader-initialization-tests/demo.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Loader Initialization Stress Tests</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="test-page">
+    <header class="test-header">
+      <p class="eyebrow">EaseMotion CSS</p>
+      <h1>CSS Loader Initialization Stress Tests</h1>
+      <p>
+        Browser-based demonstrations for repeated initialization,
+        rapid initialization, multiple elements, cleanup, and state
+        consistency scenarios.
+      </p>
+    </header>
+
+    <section class="test-grid" aria-label="Loader stress test scenarios">
+      <article class="test-card">
+        <span class="test-number">01</span>
+        <h2>Repeated Initialization</h2>
+        <p>
+          Repeatedly initialize the same loader target and verify that
+          duplicate visual effects are not created.
+        </p>
+        <div class="loader loader--repeat" aria-label="Repeated initialization loader">
+          <span></span>
+        </div>
+      </article>
+
+      <article class="test-card">
+        <span class="test-number">02</span>
+        <h2>Rapid Initialization</h2>
+        <p>
+          Simulates rapid initialization requests and checks whether
+          the visual state remains stable.
+        </p>
+        <div class="loader loader--rapid" aria-label="Rapid initialization loader">
+          <span></span>
+        </div>
+      </article>
+
+      <article class="test-card">
+        <span class="test-number">03</span>
+        <h2>Multiple Elements</h2>
+        <p>
+          Multiple loader instances run independently without affecting
+          the state of neighboring elements.
+        </p>
+        <div class="loader-row">
+          <div class="loader loader--multi"><span></span></div>
+          <div class="loader loader--multi"><span></span></div>
+          <div class="loader loader--multi"><span></span></div>
+        </div>
+      </article>
+
+      <article class="test-card">
+        <span class="test-number">04</span>
+        <h2>Repeated Cleanup</h2>
+        <p>
+          The scenario represents repeated lifecycle cleanup and
+          reinitialization cycles.
+        </p>
+        <div class="loader loader--cleanup" aria-label="Cleanup loader">
+          <span></span>
+        </div>
+      </article>
+
+      <article class="test-card">
+        <span class="test-number">05</span>
+        <h2>State Consistency</h2>
+        <p>
+          The loader should preserve a predictable visual state after
+          repeated initialization cycles.
+        </p>
+        <div class="loader loader--state" aria-label="State consistency loader">
+          <span></span>
+        </div>
+      </article>
+
+      <article class="test-card">
+        <span class="test-number">06</span>
+        <h2>Duplicate Effect Detection</h2>
+        <p>
+          Repeated initialization should not result in duplicated
+          animation layers or unexpected visual artifacts.
+        </p>
+        <div class="loader loader--duplicate" aria-label="Duplicate effect loader">
+          <span></span>
+        </div>
+      </article>
+    </section>
+
+    <footer class="test-footer">
+      <strong>Expected result:</strong>
+      All loader instances should remain visually stable, independent,
+      and free from unexpected duplicate effects during repeated
+      initialization and cleanup cycles.
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/docs/repeated-loader-initialization-tests/style.css
+++ b/submissions/docs/repeated-loader-initialization-tests/style.css
@@ -1,0 +1,177 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e7edf7;
+  background: #080b12;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(56, 189, 248, 0.12), transparent 30%),
+    radial-gradient(circle at 80% 90%, rgba(139, 92, 246, 0.12), transparent 30%),
+    #080b12;
+}
+
+.test-page {
+  width: min(1100px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 64px 0;
+}
+
+.test-header {
+  max-width: 760px;
+  margin-bottom: 42px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+h1,
+h2 {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.05;
+}
+
+.test-header p:last-child,
+.test-card p {
+  line-height: 1.7;
+  opacity: 0.78;
+}
+
+.test-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.test-card {
+  position: relative;
+  min-height: 270px;
+  padding: 28px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.test-number {
+  display: block;
+  margin-bottom: 14px;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  opacity: 0.5;
+}
+
+.loader {
+  position: relative;
+  width: 54px;
+  height: 54px;
+  margin-top: 24px;
+  border: 3px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+}
+
+.loader span {
+  position: absolute;
+  inset: 5px;
+  border: 3px solid transparent;
+  border-top-color: currentColor;
+  border-radius: inherit;
+  animation: loader-spin 1s linear infinite;
+}
+
+.loader--repeat {
+  color: #38bdf8;
+  animation: loader-pulse 1.8s ease-in-out infinite;
+}
+
+.loader--rapid {
+  color: #a78bfa;
+}
+
+.loader--rapid span {
+  animation-duration: 0.55s;
+}
+
+.loader-row {
+  display: flex;
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.loader--multi {
+  width: 42px;
+  height: 42px;
+  color: #67e8f9;
+}
+
+.loader--multi span {
+  inset: 4px;
+}
+
+.loader--cleanup {
+  color: #fbbf24;
+  animation: loader-pulse 2s ease-in-out infinite;
+}
+
+.loader--state {
+  color: #86efac;
+}
+
+.loader--duplicate {
+  color: #f472b6;
+}
+
+.test-footer {
+  margin-top: 24px;
+  padding: 20px 24px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  line-height: 1.7;
+}
+
+@keyframes loader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes loader-pulse {
+  50% {
+    transform: scale(1.08);
+    opacity: 0.72;
+  }
+}
+
+@media (max-width: 720px) {
+  .test-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .test-page {
+    padding: 40px 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loader,
+  .loader span {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a dedicated CSS loader initialization stress-test submission covering repeated and rapid initialization, multiple loader elements, repeated cleanup, state consistency, and prevention of unexpected duplicate effects.

---

## Related Issue

Closes #76411

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other — Testing / Stress-test coverage

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds stress-test coverage for repeated CSS loader initialization and reinitialization scenarios to verify stability, cleanup behavior, state consistency, and prevention of unexpected duplicate effects.

**How does a developer use it?**

```html
<div class="loader-test">
  <div class="css-loader" aria-label="Loading"></div>
</div>