### PR TITLE
Add animated underline-grow link submission

### DIFF
--- a/submissions/examples/underline-grow-tm/README.md
+++ b/submissions/examples/underline-grow-tm/README.md
@@ -1,0 +1,7 @@
+# Underline-grow link
+
+1. What does this do? An inline link whose underline draws in from the left on hover, with a subtle text colour shift.
+
+2. How is it used? Apply `ulink-tm` to any `<a>` element. Add `ulink-lg-tm` for a heavier weight.
+
+3. Why is it useful? It reads as a richer, more deliberate interaction than the default underline, while still being a single class.

--- a/submissions/examples/underline-grow-tm/demo.html
+++ b/submissions/examples/underline-grow-tm/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Underline-grow link — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="ul-page-tm">
+  <h1>Underline-grow</h1>
+  <p class="ul-lede-tm">Hover any link to see the underline draw in from the left.</p>
+
+  <nav class="ul-nav-tm">
+    <a class="ulink-tm" href="#">Overview</a>
+    <a class="ulink-tm" href="#">Components</a>
+    <a class="ulink-tm" href="#">Animations</a>
+    <a class="ulink-tm" href="#">Playground</a>
+  </nav>
+
+  <p class="ul-prose-tm">
+    This is a paragraph with a
+    <a class="ulink-tm" href="#">link in the middle of a sentence</a>
+    to show how the effect reads inside running text. The underline should
+    draw across without shifting the line height.
+  </p>
+
+  <p class="ul-prose-tm">
+    Larger links:
+    <a class="ulink-tm ulink-lg-tm" href="#">View case study</a>
+  </p>
+</main>
+</body>
+</html>

--- a/submissions/examples/underline-grow-tm/style.css
+++ b/submissions/examples/underline-grow-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --ul-bg: #0f1115;
+  --ul-text: #e6e8ec;
+  --ul-muted: #8b909b;
+  --ul-accent: #ff6a3d;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ul-bg);
+  color: var(--ul-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.6;
+}
+
+.ul-page-tm { max-width: 720px; margin: 0 auto; }
+.ul-page-tm h1 { font-size: 28px; margin: 0 0 8px; }
+.ul-lede-tm { color: var(--ul-muted); margin: 0 0 28px; }
+
+.ul-nav-tm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-bottom: 36px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #1a1d24;
+}
+
+.ul-prose-tm { font-size: 17px; margin: 0 0 20px; }
+
+.ulink-tm {
+  color: var(--ul-text);
+  text-decoration: none;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 1px;
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  transition: background-size 280ms ease-out, color 200ms ease-out;
+  padding-bottom: 2px;
+}
+
+.ulink-tm:hover,
+.ulink-tm:focus-visible {
+  background-size: 100% 1px;
+  color: var(--ul-accent);
+  outline: none;
+}
+
+.ulink-lg-tm { font-size: 20px; font-weight: 600; }


### PR DESCRIPTION
Closes #76556

## What
This submission adds a new EaseMotion CSS example: `underline-grow-tm`.

Inline links whose underline grows from the left on hover, with a soft colour shift on the text. Pure CSS, accessible by default.

## How to review
1. Open `submissions/examples/underline-grow-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/underline-grow-tm/` and does not modify any existing file.
