### PR TITLE
Add 3D flip card submission

### DIFF
--- a/submissions/examples/flip-card-3d-tm/README.md
+++ b/submissions/examples/flip-card-3d-tm/README.md
@@ -1,0 +1,7 @@
+# 3D flip card
+
+1. What does this do? A card that flips 180° in 3D space on hover or focus, revealing a back face.
+
+2. How is it used? Wrap two faces in `<div class="flip-inner-tm">` inside `<div class="flip-tm" tabindex="0">`. Add `flip-v-tm` for vertical, `flip-fast-tm` for a quicker flip.
+
+3. Why is it useful? It's a familiar pattern done with one class and a single keyframe-free transition, and it works with the keyboard via focus.

--- a/submissions/examples/flip-card-3d-tm/demo.html
+++ b/submissions/examples/flip-card-3d-tm/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>3D flip card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="fp-page-tm">
+  <h1>3D flip card</h1>
+  <p class="fp-lede-tm">Hover or focus a card to flip it. Tab to try with the keyboard.</p>
+
+  <section class="fp-grid-tm">
+    <div class="flip-tm" tabindex="0">
+      <div class="flip-inner-tm">
+        <div class="flip-face-tm flip-front-tm">
+          <h3>Hover me</h3>
+          <p>Front face content.</p>
+        </div>
+        <div class="flip-face-tm flip-back-tm">
+          <h3>Surprise</h3>
+          <p>Back face reveals more detail.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="flip-tm flip-v-tm" tabindex="0">
+      <div class="flip-inner-tm">
+        <div class="flip-face-tm flip-front-tm flip-front-alt-tm">
+          <h3>Vertical flip</h3>
+          <p>Modifier for top-to-bottom motion.</p>
+        </div>
+        <div class="flip-face-tm flip-back-tm flip-back-alt-tm">
+          <h3>Hidden side</h3>
+          <p>Good for compact product cards.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="flip-tm flip-fast-tm" tabindex="0">
+      <div class="flip-inner-tm">
+        <div class="flip-face-tm flip-front-tm flip-front-cool-tm">
+          <h3>Faster flip</h3>
+          <p>Shorter transition.</p>
+        </div>
+        <div class="flip-face-tm flip-back-tm flip-back-cool-tm">
+          <h3>Back side</h3>
+          <p>Reads in under a second.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/flip-card-3d-tm/style.css
+++ b/submissions/examples/flip-card-3d-tm/style.css
@@ -1,0 +1,83 @@
+:root {
+  --fp-bg: #0f1115;
+  --fp-text: #e6e8ec;
+  --fp-muted: #8b909b;
+  --fp-edge: #262a33;
+  --fp-surface: #1a1d24;
+  --fp-accent: #ff6a3d;
+  --fp-cool: #4dabf7;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--fp-bg);
+  color: var(--fp-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+}
+
+.fp-page-tm { max-width: 920px; margin: 0 auto; }
+.fp-page-tm h1 { font-size: 28px; margin: 0 0 8px; }
+.fp-lede-tm { color: var(--fp-muted); margin: 0 0 28px; }
+
+.fp-grid-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.flip-tm {
+  perspective: 1200px;
+  height: 220px;
+  outline: none;
+}
+
+.flip-tm:focus-visible { box-shadow: 0 0 0 3px rgba(77, 171, 247, 0.4); border-radius: 14px; }
+
+.flip-inner-tm {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 700ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.flip-tm:hover .flip-inner-tm,
+.flip-tm:focus-within .flip-inner-tm {
+  transform: rotateY(180deg);
+}
+
+.flip-v-tm:hover .flip-inner-tm,
+.flip-v-tm:focus-within .flip-inner-tm {
+  transform: rotateX(180deg);
+}
+
+.flip-fast-tm .flip-inner-tm { transition-duration: 360ms; }
+
+.flip-face-tm {
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  border: 1px solid var(--fp-edge);
+  background: var(--fp-surface);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+.flip-face-tm h3 { margin: 0 0 8px; font-size: 18px; }
+.flip-face-tm p { margin: 0; color: var(--fp-muted); }
+
+.flip-back-tm { transform: rotateY(180deg); background: var(--fp-surface); }
+
+.flip-front-alt-tm { background: #14171c; }
+.flip-back-alt-tm { background: #1f242d; transform: rotateX(180deg); }
+
+.flip-front-cool-tm { border-color: rgba(77, 171, 247, 0.4); }
+.flip-back-cool-tm { border-color: rgba(77, 171, 247, 0.4); transform: rotateY(180deg); }


### PR DESCRIPTION
Closes #76565

## What
This submission adds a new EaseMotion CSS example: `flip-card-3d-tm`.

A card that flips 180° in 3D space on hover or focus, revealing a back face. Pure CSS, keyboard-accessible.

## How to review
1. Open `submissions/examples/flip-card-3d-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/flip-card-3d-tm/` and does not modify any existing file.
