### PR TITLE
feat: add pure CSS Drawer Foucault Pendulum Swing component (#73605)

### DIFF
--- a/submissions/examples/css-drawer-foucault-pendulum-swing-pure/README.md
+++ b/submissions/examples/css-drawer-foucault-pendulum-swing-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Drawer: Foucault Pendulum Swing
+
+A hardware-accelerated, JavaScript-free drawer/sidebar component featuring physics-based rotation that mimics the swing and momentum of a Foucault pendulum.
+
+## Features
+- Pure CSS and HTML implementation. The drawer toggle mechanism relies entirely on the CSS Checkbox Hack (`:checked ~`), eliminating the need for JavaScript state management.
+- **Component Architecture**: 
+  - **Pendulum Mechanics**: The `.drawer-panel` has its `transform-origin` set to `100% 0%` (the absolute top-right corner). This acts as the pivot point for the pendulum. A small visual `.pivot-hinge` is placed there to ground the effect.
+  - **Swing Animation**: By default, the drawer is rotated `90deg` out of frame. When opened via the hidden checkbox, it triggers the `pendulum-swing` `@keyframes` animation. Instead of a simple ease, the keyframes explicitly define overshoot angles (`-15deg`, `5deg`, `-2deg`, `0deg`) to simulate gravity, momentum, and friction as the heavy drawer settles into its final vertical resting place.
+  - **Page Content Filter**: To focus attention on the swinging drawer, the `.page-content` transitions into a blurred, dimmed state (`filter: blur(4px) brightness(0.6)`) when the drawer opens.
+- **Theming**: Configured via CSS Custom Properties. The palette utilizes a dark, sepia-toned base (`#1a1918`) with metallic gold accents (`#d4af37`), complementing the classical physics theme.
+- Fully accessible semantic structure using `<aside>` and `<nav>` tags. Honors the `prefers-reduced-motion` accessibility standard. If reduced motion is requested, the pendulum rotation keyframes are disabled, and the drawer falls back to a standard, instantaneous 2D slide-in translation.
+
+## Usage
+Open `demo.html` in your browser. Click the "Release Pendulum" button to trigger the pure CSS drawer. Notice how the drawer swings down from the top right corner, overshooting its final resting place slightly before settling, mimicking physical mass.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox hack setup, the page content, the overlay, and the drawer panel with its visual hinge.
+- `style.css`: The styling, the `transform-origin` pivot setup, the keyframe animation defining the physics overshoots (`pendulum-swing`), and the fallback logic for reduced motion.

--- a/submissions/examples/css-drawer-foucault-pendulum-swing-pure/demo.html
+++ b/submissions/examples/css-drawer-foucault-pendulum-swing-pure/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Drawer: Foucault Pendulum</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <!-- 
+      The Checkbox Hack: 
+      Controls the state of the drawer system.
+    -->
+    <input type="checkbox" id="drawer-toggle" class="drawer-toggle-hidden">
+
+    <!-- The Page Content -->
+    <div class="page-content">
+        <div class="container">
+            <header class="header">
+                <h1 class="pendulum-title">Pendulum Swing</h1>
+                <p>Pure CSS drawer featuring top-anchored rotation physics.</p>
+                
+                <!-- The Trigger Button -->
+                <label for="drawer-toggle" class="btn">
+                    <span class="btn-text">Release Pendulum ⚙</span>
+                </label>
+            </header>
+
+            <main class="grid">
+                <div class="placeholder-content">
+                    <h2>Physics-based Interaction</h2>
+                    <p>Click the button above. The drawer acts as a pendulum anchored at the top right corner. It swings in using a custom keyframe animation that simulates gravity and momentum, overshooting slightly before coming to rest.</p>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <!-- The Overlay -->
+    <label for="drawer-toggle" class="drawer-overlay"></label>
+
+    <!-- The Drawer Panel (Anchored at top-right, swings in) -->
+    <aside class="drawer-panel">
+        
+        <!-- The visual "Hinge" or pivot point -->
+        <div class="pivot-hinge"></div>
+
+        <div class="drawer-header">
+            <h2>SYSTEM CONFIG</h2>
+            <label for="drawer-toggle" class="close-btn">×</label>
+        </div>
+        
+        <nav class="drawer-nav">
+            <ul class="nav-list">
+                <li class="nav-item active">
+                    <a href="#">
+                        <span class="icon">◷</span>
+                        <span class="text">Timing</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#">
+                        <span class="icon">∿</span>
+                        <span class="text">Oscillation</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#">
+                        <span class="icon">⎍</span>
+                        <span class="text">Calibration</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#">
+                        <span class="icon">⚙</span>
+                        <span class="text">Mechanics</span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+        
+        <div class="drawer-footer">
+            <p>Foucault Protocol v1.0</p>
+        </div>
+    </aside>
+
+</body>
+</html>

--- a/submissions/examples/css-drawer-foucault-pendulum-swing-pure/style.css
+++ b/submissions/examples/css-drawer-foucault-pendulum-swing-pure/style.css
@@ -1,0 +1,273 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,600;1,600&family=Roboto:wght@400;500&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #1a1918; /* Dark sepia/charcoal */
+    --bg-drawer: #2a2826;
+    --text-primary: #e6e2dd;
+    --text-secondary: #a39c93;
+    
+    --accent-color: #d4af37; /* Metallic Gold */
+    
+    --drawer-width: 320px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+}
+
+.container {
+    width: 100%;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 60px 20px;
+}
+
+.header {
+    margin-bottom: 60px;
+}
+
+.pendulum-title {
+    font-family: 'Playfair Display', serif;
+    font-size: 3rem;
+    font-weight: 600;
+    margin: 0 0 10px 0;
+    color: var(--accent-color);
+}
+
+.header p { color: var(--text-secondary); font-size: 1.1rem; max-width: 600px; margin-bottom: 40px;}
+
+.placeholder-content {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(212, 175, 55, 0.2);
+    padding: 40px;
+    border-radius: 8px;
+}
+.placeholder-content h2 { margin-top: 0; font-family: 'Playfair Display', serif; color: var(--accent-color); }
+.placeholder-content p { color: var(--text-secondary); line-height: 1.6; }
+
+/* Base button styles */
+.btn {
+    display: inline-block;
+    cursor: pointer;
+    background: transparent;
+    border: 1px solid var(--accent-color);
+    color: var(--accent-color);
+    padding: 12px 24px;
+    border-radius: 4px;
+    font-weight: 500;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    transition: all 0.3s ease;
+}
+
+.btn:hover {
+    background: rgba(212, 175, 55, 0.1);
+    box-shadow: 0 0 15px rgba(212, 175, 55, 0.3);
+}
+
+
+/* =========================================
+   The Checkbox Hack
+   ========================================= */
+.drawer-toggle-hidden {
+    display: none;
+}
+
+/* Page Content blur effect */
+.page-content {
+    transition: filter 0.4s ease;
+}
+
+.drawer-toggle-hidden:checked ~ .page-content {
+    filter: blur(4px) brightness(0.6);
+}
+
+/* Overlay Background */
+.drawer-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 900;
+    opacity: 0;
+    visibility: hidden;
+    cursor: pointer;
+    /* Invisible layer just for clicking to close */
+}
+
+.drawer-toggle-hidden:checked ~ .drawer-overlay {
+    opacity: 1;
+    visibility: visible;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Foucault Pendulum Swing
+   Anchors the drawer at the top right, and uses
+   keyframe animations to simulate a swinging pendulum.
+   ========================================= */
+.drawer-panel {
+    position: fixed;
+    top: 0; right: 0;
+    width: var(--drawer-width);
+    height: 100vh;
+    background: var(--bg-drawer);
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    box-shadow: -10px 0 30px rgba(0,0,0,0.8);
+    border-left: 2px solid rgba(212, 175, 55, 0.3);
+    
+    /* 
+       Anchor the transform to the Top Right corner.
+       This is the pivot point of the pendulum.
+    */
+    transform-origin: 100% 0%;
+    
+    /* Initially swung all the way up and out of frame (90 degrees) */
+    transform: rotate(90deg);
+    opacity: 0;
+    
+    /* Transition for closing (smooth linear swing out) */
+    transition: transform 0.5s ease-in, opacity 0.4s ease-in;
+}
+
+/* When Drawer Opens: Trigger the pendulum swing animation */
+.drawer-toggle-hidden:checked ~ .drawer-panel {
+    /* Use forwards to keep it in the final 0deg state */
+    animation: pendulum-swing 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+    opacity: 1;
+}
+
+@keyframes pendulum-swing {
+    0% { transform: rotate(90deg); }
+    40% { transform: rotate(-15deg); }
+    65% { transform: rotate(5deg); }
+    85% { transform: rotate(-2deg); }
+    100% { transform: rotate(0deg); }
+}
+
+/* The visual hinge at the top right */
+.pivot-hinge {
+    position: absolute;
+    top: 10px; right: 10px;
+    width: 16px; height: 16px;
+    background: var(--bg-base);
+    border: 3px solid var(--accent-color);
+    border-radius: 50%;
+    z-index: 10;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.5);
+}
+
+
+/* =========================================
+   Drawer Inner Styling
+   ========================================= */
+.drawer-header {
+    padding: 40px 30px 20px 30px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid rgba(212, 175, 55, 0.1);
+}
+
+.drawer-header h2 {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--accent-color);
+    text-transform: uppercase;
+    letter-spacing: 3px;
+}
+
+.close-btn {
+    cursor: pointer;
+    font-size: 2rem;
+    color: var(--text-secondary);
+    line-height: 1;
+    transition: color 0.2s, transform 0.2s;
+}
+
+.close-btn:hover {
+    color: var(--accent-color);
+    transform: scale(1.1);
+}
+
+.drawer-nav {
+    flex-grow: 1;
+    padding: 20px 0;
+    overflow-y: auto;
+}
+
+.nav-list {
+    list-style: none;
+    margin: 0; padding: 0;
+}
+
+.nav-item a {
+    display: flex;
+    align-items: center;
+    padding: 16px 30px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 1.1rem;
+    transition: background 0.2s, color 0.2s;
+    border-left: 2px solid transparent;
+}
+
+.nav-item a:hover {
+    background: rgba(212, 175, 55, 0.05);
+    color: var(--accent-color);
+}
+
+.icon { 
+    margin-right: 15px; 
+    font-size: 1.4rem; 
+    color: var(--accent-color);
+}
+.text { flex-grow: 1; font-family: 'Playfair Display', serif; font-style: italic; }
+
+.nav-item.active a {
+    background: rgba(212, 175, 55, 0.1);
+    border-left: 2px solid var(--accent-color);
+}
+
+.drawer-footer {
+    padding: 20px 30px;
+    border-top: 1px solid rgba(212, 175, 55, 0.1);
+    text-align: center;
+}
+
+.drawer-footer p {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .drawer-panel, .page-content {
+        transition: none !important;
+        animation: none !important;
+    }
+    
+    .drawer-panel {
+        transform: translateX(100%); /* Standard slide fallback */
+    }
+    
+    .drawer-toggle-hidden:checked ~ .drawer-panel {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free drawer/sidebar component featuring physics-based rotation that mimics the swing and momentum of a Foucault pendulum. Resolves issue #73605.

### Changes Made:
- Added `submissions/examples/css-drawer-foucault-pendulum-swing-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox hack setup, the page content, the overlay, and the drawer panel with its visual hinge.
- Created `style.css` featuring the UI mechanics:
  - **Pendulum Mechanics**: The `.drawer-panel` has its `transform-origin` set to `100% 0%` (the absolute top-right corner). This acts as the pivot point for the pendulum. A small visual `.pivot-hinge` is placed there to ground the effect.
  - **Swing Animation**: By default, the drawer is rotated `90deg` out of frame. When opened via the hidden checkbox, it triggers the `pendulum-swing` `@keyframes` animation. Instead of a simple ease, the keyframes explicitly define overshoot angles (`-15deg`, `5deg`, `-2deg`, `0deg`) to simulate gravity, momentum, and friction as the heavy drawer settles into its final vertical resting place.
  - **Page Content Filter**: To focus attention on the swinging drawer, the `.page-content` transitions into a blurred, dimmed state (`filter: blur(4px) brightness(0.6)`) when the drawer opens.
  - **Theming Supported**: Configured via CSS Custom Properties. The palette utilizes a dark, sepia-toned base (`#1a1918`) with metallic gold accents (`#d4af37`), complementing the classical physics theme.
- Added `README.md` documenting usage and the technical mechanics of the `transform-origin` pivot setup, the keyframe animation defining the physics overshoots (`pendulum-swing`), and the fallback logic for reduced motion.
- Fully accessible semantic structure using `<aside>` and `<nav>` tags. Honors the `prefers-reduced-motion` accessibility standard. If reduced motion is requested, the pendulum rotation keyframes are disabled, and the drawer falls back to a standard, instantaneous 2D slide-in translation.

Closes #73605
