### PR TITLE
feat: add ease-oscilloscope-wave-ij demo component

### DIFF
--- a/submissions/examples/ease-oscilloscope-wave-ij/README.md
+++ b/submissions/examples/ease-oscilloscope-wave-ij/README.md
@@ -1,0 +1,20 @@
+# Ease Oscilloscope Wave
+
+A lightweight demo component that undulates like a wave. Built with plain CSS keyframe
+animations and a couple of lines of vanilla JavaScript. No libraries, no
+build step.
+
+## Files
+
+- `demo.html` — the demo page and inline script
+- `style.css` — all styles and keyframes
+- `README.md` — this file
+
+## How to run
+
+Open `demo.html` in any modern browser, or serve this folder with a static
+file server such as `npx serve`.
+
+## Interactivity
+
+Press the **Pause / Play** button to pause or resume the animation.

--- a/submissions/examples/ease-oscilloscope-wave-ij/demo.html
+++ b/submissions/examples/ease-oscilloscope-wave-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Oscilloscope Wave Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage">
+    <header class="stage-header">
+      <h1>Oscilloscope Wave</h1>
+      <p>Plain CSS animation demo with a pause toggle.</p>
+    </header>
+    <section class="scene" aria-label="Oscilloscope Wave animation">
+      <div class="wave" role="presentation"><span class="bar b1"></span><span class="bar b2"></span><span class="bar b3"></span><span class="bar b4"></span><span class="bar b5"></span><span class="bar b6"></span><span class="bar b7"></span><span class="bar b8"></span><span class="bar b9"></span><span class="bar b10"></span></div>
+    </section>
+    <button class="toggle" type="button">Pause</button>
+  </main>
+  <script>
+    (function () {
+      var toggle = document.querySelector(".toggle");
+      var scene = document.querySelector(".scene");
+      toggle.addEventListener("click", function () {
+        var paused = scene.classList.toggle("paused");
+        toggle.textContent = paused ? "Play" : "Pause";
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-oscilloscope-wave-ij/style.css
+++ b/submissions/examples/ease-oscilloscope-wave-ij/style.css
@@ -1,0 +1,101 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1020;
+  color: #e8ecff;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.stage {
+  width: min(640px, 92vw);
+  padding: 2.5rem 2rem;
+  border-radius: 24px;
+  background: #151b2e;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.stage-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  color: #e6734c;
+}
+
+.stage-header p {
+  margin: 0 0 1.5rem;
+  color: #8b93b8;
+}
+
+.scene {
+  position: relative;
+  height: 260px;
+  margin: 0 auto;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #10152a;
+  display: grid;
+  place-items: center;
+}
+
+.scene.paused * {
+  animation-play-state: paused;
+}
+
+.toggle {
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: transparent;
+  color: #e8ecff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle:hover {
+  background: #e6734c;
+  color: #0b1020;
+  border-color: transparent;
+}
+
+
+.wave {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 120px;
+}
+
+.bar {
+  width: 14px;
+  height: 50%;
+  border-radius: 6px;
+  background: #e6734c;
+  animation: oscilloscopewave-wave 1.2s ease-in-out infinite;
+}
+
+.bar.b1 { animation-delay: 0s; height: 40%; }
+.bar.b2 { animation-delay: 0.1s; height: 65%; }
+.bar.b3 { animation-delay: 0.2s; height: 90%; }
+.bar.b4 { animation-delay: 0.3s; height: 100%; background: #d9ef6c; }
+.bar.b5 { animation-delay: 0.4s; height: 70%; }
+.bar.b6 { animation-delay: 0.5s; height: 50%; }
+.bar.b7 { animation-delay: 0.6s; height: 85%; background: #d9ef6c; }
+.bar.b8 { animation-delay: 0.7s; height: 60%; }
+.bar.b9 { animation-delay: 0.8s; height: 40%; }
+.bar.b10 { animation-delay: 0.9s; height: 75%; }
+
+@keyframes oscilloscopewave-wave {
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(1); }
+}


### PR DESCRIPTION
Adds a working `ease-oscilloscope-wave-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-oscilloscope-wave-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.