### PR TITLE
Add expanding accordion submission

### DIFF
--- a/submissions/examples/accordion-tm/README.md
+++ b/submissions/examples/accordion-tm/README.md
@@ -1,0 +1,7 @@
+# Expanding accordion
+
+1. What does this do? A list of panels that expand with a smooth height transition on click.
+
+2. How is it used? Add `accordion-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? FAQ and disclosure pattern; the height transition uses grid trick to animate auto height.

--- a/submissions/examples/accordion-tm/demo.html
+++ b/submissions/examples/accordion-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Accordion — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="accordion-page-tm" data-palette="amber">
+  <h1 class="accordion-h-tm">Accordion</h1>
+  <p class="accordion-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="accordion-row-tm">
+    <article class="accordion-1-wrap-tm">
+      <div class="accordion-1-tm"></div>
+      <span class="accordion-lbl-tm">Example One</span>
+    </article>
+    <article class="accordion-2-wrap-tm">
+      <div class="accordion-2-tm"></div>
+      <span class="accordion-lbl-tm">Example Two</span>
+    </article>
+    <article class="accordion-3-wrap-tm">
+      <div class="accordion-3-tm"></div>
+      <span class="accordion-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/accordion-tm/style.css
+++ b/submissions/examples/accordion-tm/style.css
@@ -1,0 +1,61 @@
+:root {
+  --accordion-bg: #161208;
+  --accordion-surface: #261d10;
+  --accordion-edge: #352817;
+  --accordion-text: #e6e8ec;
+  --accordion-muted: #8b909b;
+  --accordion-accent: #ffb13b;
+  --accordion-accent-2: #ff7b00;
+  --accordion-radius: 10px;
+  --accordion-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--accordion-bg);
+  color: var(--accordion-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.accordion-page-tm { max-width: 920px; margin: 0 auto; }
+.accordion-h-tm { font-size: 28px; margin: 0 0 8px; }
+.accordion-lede-tm { color: var(--accordion-muted); margin: 0 0 32px; }
+.accordion-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.accordion-1-wrap-tm, .accordion-2-wrap-tm, .accordion-3-wrap-tm {
+  background: var(--accordion-surface);
+  border: 1px solid var(--accordion-edge);
+  border-radius: var(--accordion-radius);
+  padding: var(--accordion-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.accordion-lbl-tm { color: var(--accordion-muted); font-size: 13px; }
+
+.accordion-1-tm, .accordion-2-tm, .accordion-3-tm {
+  width: 100%; padding: 14px 16px; background: #261d10; border: 1px solid #352817;
+  border-radius: 8px; color: #ffb13b; cursor: pointer; transition: all 200ms;
+}
+.accordion-1-tm::after, .accordion-2-tm::after, .accordion-3-tm::after {
+  content: "+"; float: right; transition: transform 200ms;
+}
+.accordion-1-tm[aria-expanded="true"], .accordion-2-tm[aria-expanded="true"], .accordion-3-tm[aria-expanded="true"] {
+  background: #ffb13b22; border-color: #ffb13b;
+}
+.accordion-1-tm[aria-expanded="true"]::after, .accordion-2-tm[aria-expanded="true"]::after, .accordion-3-tm[aria-expanded="true"]::after {
+  transform: rotate(45deg);
+}
+.accordion-2-tm { color: #ff7b00; border-color: #ff7b00; }
+.accordion-3-tm { color: #8b909b; }


### PR DESCRIPTION
Closes #76802

## What
This submission adds a new EaseMotion CSS example: `accordion-tm`.

A list of panels that expand with a smooth height transition on click.

## How to review
1. Open `submissions/examples/accordion-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/accordion-tm/` and does not modify any existing file.
