### PR TITLE
feat: add ease-solar-system-ij demo component

### DIFF
--- a/submissions/examples/ease-solar-system-ij/README.md
+++ b/submissions/examples/ease-solar-system-ij/README.md
@@ -1,0 +1,20 @@
+# Ease Solar System
+
+A lightweight demo component that keeps satellites orbiting a core. Built with plain CSS keyframe
+animations and a couple of lines of vanilla JavaScript. No libraries, no
+build step.
+
+## Files
+
+- `demo.html` — the demo page and inline script
+- `style.css` — all styles and keyframes
+- `README.md` — this file
+
+## How to run
+
+Open `demo.html` in any modern browser, or serve this folder with a static
+file server such as `npx serve`.
+
+## Interactivity
+
+Press the **Pause / Play** button to pause or resume the animation.

--- a/submissions/examples/ease-solar-system-ij/demo.html
+++ b/submissions/examples/ease-solar-system-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Solar System Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage">
+    <header class="stage-header">
+      <h1>Solar System</h1>
+      <p>Plain CSS animation demo with a pause toggle.</p>
+    </header>
+    <section class="scene" aria-label="Solar System animation">
+      <div class="orbit-system" role="presentation"><div class="orbit-core"></div><div class="orbit-ring ring1"><div class="orbit-sat"></div></div><div class="orbit-ring ring2"><div class="orbit-sat"></div></div></div>
+    </section>
+    <button class="toggle" type="button">Pause</button>
+  </main>
+  <script>
+    (function () {
+      var toggle = document.querySelector(".toggle");
+      var scene = document.querySelector(".scene");
+      toggle.addEventListener("click", function () {
+        var paused = scene.classList.toggle("paused");
+        toggle.textContent = paused ? "Play" : "Pause";
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-solar-system-ij/style.css
+++ b/submissions/examples/ease-solar-system-ij/style.css
@@ -1,0 +1,112 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1020;
+  color: #e8ecff;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.stage {
+  width: min(640px, 92vw);
+  padding: 2.5rem 2rem;
+  border-radius: 24px;
+  background: #151b2e;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.stage-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  color: #4c82e6;
+}
+
+.stage-header p {
+  margin: 0 0 1.5rem;
+  color: #8b93b8;
+}
+
+.scene {
+  position: relative;
+  height: 260px;
+  margin: 0 auto;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #10152a;
+  display: grid;
+  place-items: center;
+}
+
+.scene.paused * {
+  animation-play-state: paused;
+}
+
+.toggle {
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: transparent;
+  color: #e8ecff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle:hover {
+  background: #4c82e6;
+  color: #0b1020;
+  border-color: transparent;
+}
+
+
+.orbit-system {
+  position: relative;
+  width: 180px;
+  height: 180px;
+}
+
+.orbit-core {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 36px;
+  height: 36px;
+  margin: -18px 0 0 -18px;
+  border-radius: 50%;
+  background: #4c82e6;
+}
+
+.orbit-ring {
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+}
+
+.orbit-ring.ring1 { animation: solarsystem-orbit 4s linear infinite; }
+.orbit-ring.ring2 { animation: solarsystem-orbit 7s linear infinite reverse; }
+
+.orbit-sat {
+  position: absolute;
+  top: -7px;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  border-radius: 50%;
+  background: #b66cef;
+}
+
+@keyframes solarsystem-orbit {
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Adds a working `ease-solar-system-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-solar-system-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.