### PR TITLE
Add animated input focus submission

### DIFF
--- a/submissions/examples/input-focus-tm/README.md
+++ b/submissions/examples/input-focus-tm/README.md
@@ -1,0 +1,7 @@
+# Animated input focus
+
+1. What does this do? A text input whose bottom border draws in from the centre on focus.
+
+2. How is it used? Add `input-focus-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Subtle focus affordance that reads on any background.

--- a/submissions/examples/input-focus-tm/demo.html
+++ b/submissions/examples/input-focus-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Input Focus — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="inputfocus-page-tm" data-palette="violet">
+  <h1 class="inputfocus-h-tm">Input Focus</h1>
+  <p class="inputfocus-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="inputfocus-row-tm">
+    <article class="inputfocus-1-wrap-tm">
+      <div class="inputfocus-1-tm"></div>
+      <span class="inputfocus-lbl-tm">Example One</span>
+    </article>
+    <article class="inputfocus-2-wrap-tm">
+      <div class="inputfocus-2-tm"></div>
+      <span class="inputfocus-lbl-tm">Example Two</span>
+    </article>
+    <article class="inputfocus-3-wrap-tm">
+      <div class="inputfocus-3-tm"></div>
+      <span class="inputfocus-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/input-focus-tm/style.css
+++ b/submissions/examples/input-focus-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --inputfocus-bg: #0e0a1a;
+  --inputfocus-surface: #1a1329;
+  --inputfocus-edge: #261a3a;
+  --inputfocus-text: #e6e8ec;
+  --inputfocus-muted: #8b909b;
+  --inputfocus-accent: #a78bfa;
+  --inputfocus-accent-2: #f472b6;
+  --inputfocus-radius: 10px;
+  --inputfocus-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--inputfocus-bg);
+  color: var(--inputfocus-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.inputfocus-page-tm { max-width: 920px; margin: 0 auto; }
+.inputfocus-h-tm { font-size: 28px; margin: 0 0 8px; }
+.inputfocus-lede-tm { color: var(--inputfocus-muted); margin: 0 0 32px; }
+.inputfocus-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.inputfocus-1-wrap-tm, .inputfocus-2-wrap-tm, .inputfocus-3-wrap-tm {
+  background: var(--inputfocus-surface);
+  border: 1px solid var(--inputfocus-edge);
+  border-radius: var(--inputfocus-radius);
+  padding: var(--inputfocus-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.inputfocus-lbl-tm { color: var(--inputfocus-muted); font-size: 13px; }
+
+.inputfocus-1-tm, .inputfocus-2-tm, .inputfocus-3-tm {
+  width: 100%; padding: 12px 16px; background: #1a1329; border: 0;
+  border-bottom: 2px solid #261a3a; color: inherit; font: inherit;
+  transition: border-color 200ms;
+}
+.inputfocus-1-tm:focus { border-bottom-color: #a78bfa; outline: none; }
+.inputfocus-1-tm::placeholder { color: #8b909b; }
+.inputfocus-2-tm:focus { border-bottom-color: #f472b6; outline: none; box-shadow: 0 4px 12px -4px #f472b644; }
+.inputfocus-3-tm:focus { border-bottom-color: #8b909b; outline: none; background: #261a3a; }


### PR DESCRIPTION
Closes #76840

## What
This submission adds a new EaseMotion CSS example: `input-focus-tm`.

A text input whose bottom border draws in from the centre on focus.

## How to review
1. Open `submissions/examples/input-focus-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/input-focus-tm/` and does not modify any existing file.
