### PR TITLE
Add animated breadcrumb submission

### DIFF
--- a/submissions/examples/breadcrumb-tm/README.md
+++ b/submissions/examples/breadcrumb-tm/README.md
@@ -1,0 +1,7 @@
+# Animated breadcrumb
+
+1. What does this do? A breadcrumb trail whose separator fades in between items on hover.
+
+2. How is it used? Add `breadcrumb-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Common nav pattern; the hover-only separator keeps the resting state clean.

--- a/submissions/examples/breadcrumb-tm/demo.html
+++ b/submissions/examples/breadcrumb-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Breadcrumb — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="breadcrumb-page-tm" data-palette="ruby">
+  <h1 class="breadcrumb-h-tm">Breadcrumb</h1>
+  <p class="breadcrumb-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="breadcrumb-row-tm">
+    <article class="breadcrumb-1-wrap-tm">
+      <div class="breadcrumb-1-tm"></div>
+      <span class="breadcrumb-lbl-tm">Example One</span>
+    </article>
+    <article class="breadcrumb-2-wrap-tm">
+      <div class="breadcrumb-2-tm"></div>
+      <span class="breadcrumb-lbl-tm">Example Two</span>
+    </article>
+    <article class="breadcrumb-3-wrap-tm">
+      <div class="breadcrumb-3-tm"></div>
+      <span class="breadcrumb-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-tm/style.css
+++ b/submissions/examples/breadcrumb-tm/style.css
@@ -1,0 +1,58 @@
+:root {
+  --breadcrumb-bg: #160a0d;
+  --breadcrumb-surface: #261418;
+  --breadcrumb-edge: #36191e;
+  --breadcrumb-text: #e6e8ec;
+  --breadcrumb-muted: #8b909b;
+  --breadcrumb-accent: #ef4444;
+  --breadcrumb-accent-2: #fb7185;
+  --breadcrumb-radius: 10px;
+  --breadcrumb-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--breadcrumb-bg);
+  color: var(--breadcrumb-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.breadcrumb-page-tm { max-width: 920px; margin: 0 auto; }
+.breadcrumb-h-tm { font-size: 28px; margin: 0 0 8px; }
+.breadcrumb-lede-tm { color: var(--breadcrumb-muted); margin: 0 0 32px; }
+.breadcrumb-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.breadcrumb-1-wrap-tm, .breadcrumb-2-wrap-tm, .breadcrumb-3-wrap-tm {
+  background: var(--breadcrumb-surface);
+  border: 1px solid var(--breadcrumb-edge);
+  border-radius: var(--breadcrumb-radius);
+  padding: var(--breadcrumb-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.breadcrumb-lbl-tm { color: var(--breadcrumb-muted); font-size: 13px; }
+
+.breadcrumb-1-tm, .breadcrumb-2-tm, .breadcrumb-3-tm {
+  display: flex; gap: 8px; align-items: center; font-size: 14px;
+}
+.breadcrumb-1-tm a, .breadcrumb-2-tm a, .breadcrumb-3-tm a {
+  color: #ef4444; text-decoration: none; padding: 4px 8px; border-radius: 4px;
+  transition: background 160ms;
+}
+.breadcrumb-1-tm a:hover { background: #ef444422; }
+.breadcrumb-1-tm span { color: #8b909b; }
+.breadcrumb-2-tm a { color: #fb7185; }
+.breadcrumb-2-tm a:hover { background: #fb718522; }
+.breadcrumb-3-tm a { color: #8b909b; }


### PR DESCRIPTION
Closes #76852

## What
This submission adds a new EaseMotion CSS example: `breadcrumb-tm`.

A breadcrumb trail whose separator fades in between items on hover.

## How to review
1. Open `submissions/examples/breadcrumb-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/breadcrumb-tm/` and does not modify any existing file.
