### PR TITLE
Add tooltip pop submission

### DIFF
--- a/submissions/examples/tooltip-tm/README.md
+++ b/submissions/examples/tooltip-tm/README.md
@@ -1,0 +1,7 @@
+# Tooltip pop
+
+1. What does this do? A small label that pops above an element on hover or focus.
+
+2. How is it used? Add `tooltip-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Standard hover label; pops rather than fades for clarity.

--- a/submissions/examples/tooltip-tm/demo.html
+++ b/submissions/examples/tooltip-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Tooltip — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="tooltip-page-tm" data-palette="gold">
+  <h1 class="tooltip-h-tm">Tooltip</h1>
+  <p class="tooltip-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="tooltip-row-tm">
+    <article class="tooltip-1-wrap-tm">
+      <div class="tooltip-1-tm"></div>
+      <span class="tooltip-lbl-tm">Example One</span>
+    </article>
+    <article class="tooltip-2-wrap-tm">
+      <div class="tooltip-2-tm"></div>
+      <span class="tooltip-lbl-tm">Example Two</span>
+    </article>
+    <article class="tooltip-3-wrap-tm">
+      <div class="tooltip-3-tm"></div>
+      <span class="tooltip-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/tooltip-tm/style.css
+++ b/submissions/examples/tooltip-tm/style.css
@@ -1,0 +1,60 @@
+:root {
+  --tooltip-bg: #13110b;
+  --tooltip-surface: #221e14;
+  --tooltip-edge: #332c1c;
+  --tooltip-text: #e6e8ec;
+  --tooltip-muted: #8b909b;
+  --tooltip-accent: #facc15;
+  --tooltip-accent-2: #fbbf24;
+  --tooltip-radius: 10px;
+  --tooltip-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.tooltip-page-tm { max-width: 920px; margin: 0 auto; }
+.tooltip-h-tm { font-size: 28px; margin: 0 0 8px; }
+.tooltip-lede-tm { color: var(--tooltip-muted); margin: 0 0 32px; }
+.tooltip-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.tooltip-1-wrap-tm, .tooltip-2-wrap-tm, .tooltip-3-wrap-tm {
+  background: var(--tooltip-surface);
+  border: 1px solid var(--tooltip-edge);
+  border-radius: var(--tooltip-radius);
+  padding: var(--tooltip-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.tooltip-lbl-tm { color: var(--tooltip-muted); font-size: 13px; }
+
+.tooltip-1-tm, .tooltip-2-tm, .tooltip-3-tm {
+  position: relative; width: 48px; height: 48px; border-radius: 50%;
+  background: #221e14; border: 1px solid #332c1c; cursor: help;
+  display: grid; place-items: center; font-size: 20px;
+}
+.tooltip-1-tm::after, .tooltip-2-tm::after, .tooltip-3-tm::after {
+  content: attr(data-tip); position: absolute; bottom: calc(100% + 8px); left: 50%;
+  transform: translate(-50%, 4px); background: #facc15; color: #0f1115;
+  padding: 4px 8px; border-radius: 4px; font-size: 12px; white-space: nowrap;
+  opacity: 0; transition: opacity 160ms, transform 160ms; pointer-events: none;
+}
+.tooltip-1-tm:hover::after { opacity: 1; transform: translate(-50%, 0); }
+.tooltip-2-tm::after { background: #fbbf24; color: #0a0e1a; }
+.tooltip-3-tm::after { background: #8b909b; color: #0e0a1a; }


### PR DESCRIPTION
Closes #76861

## What
This submission adds a new EaseMotion CSS example: `tooltip-tm`.

A small label that pops above an element on hover or focus.

## How to review
1. Open `submissions/examples/tooltip-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/tooltip-tm/` and does not modify any existing file.
