### PR TITLE
feat: add basic user mention row demo

### DIFF
--- a/submissions/examples/basic-user-mention-row-kk/README.md
+++ b/submissions/examples/basic-user-mention-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic User Mention Row
+
+## What it does
+
+This submission adds a simple CSS-only user mention row for member lists, reviewer panels, comment summaries, assignment rows, and team sections.
+
+It aligns a small avatar marker, person name, supporting text, and right-side status in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing an avatar marker, user copy, and optional status:
+
+```html
+<div class="basic-user-mention-row">
+  <span class="user-avatar" aria-hidden="true">KR</span>
+  <div class="user-copy">
+    <strong>Kriti Sharma</strong>
+    <p>Frontend contributor</p>
+  </div>
+  <span class="user-status">Owner</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across team cards, dashboard panels, profile sections, reviewer lists, and activity summaries. It stays fully CSS-only and does not require external images.
+
+## Included features
+
+- Avatar marker, name, description, and status layout
+- Circular initials avatar styling
+- Divider support between rows
+- Text truncation for long descriptions
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the user mention row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-user-mention-row-kk/demo.html
+++ b/submissions/examples/basic-user-mention-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic User Mention Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic User Mention Row</p>
+          <h1>Compact people rows for mentions, teams, and reviewers.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a small avatar marker, person details,
+            and a right-side action or status for member lists and review panels.
+          </p>
+        </header>
+
+        <section class="mention-panel" aria-label="User mention row examples">
+          <div class="basic-user-mention-row">
+            <span class="user-avatar" aria-hidden="true">KR</span>
+            <div class="user-copy">
+              <strong>Kriti Sharma</strong>
+              <p>Frontend contributor</p>
+            </div>
+            <span class="user-status">Owner</span>
+          </div>
+
+          <div class="basic-user-mention-row">
+            <span class="user-avatar" aria-hidden="true">AM</span>
+            <div class="user-copy">
+              <strong>Aman Verma</strong>
+              <p>Requested review on the latest demo.</p>
+            </div>
+            <span class="user-status">Review</span>
+          </div>
+
+          <div class="basic-user-mention-row">
+            <span class="user-avatar" aria-hidden="true">SN</span>
+            <div class="user-copy">
+              <strong>Sneha Rao</strong>
+              <p>Updated the design notes.</p>
+            </div>
+            <span class="user-status">Active</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-user-mention-row"&gt;
+  &lt;span class="user-avatar" aria-hidden="true"&gt;KR&lt;/span&gt;
+  &lt;div class="user-copy"&gt;
+    &lt;strong&gt;Kriti Sharma&lt;/strong&gt;
+    &lt;p&gt;Frontend contributor&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="user-status"&gt;Owner&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-user-mention-row-kk/style.css
+++ b/submissions/examples/basic-user-mention-row-kk/style.css
@@ -1,0 +1,154 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #f0abfc;
+  --accent-soft: rgba(240, 171, 252, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(240, 171, 252, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.11), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.mention-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-user-mention-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-user-mention-row + .basic-user-mention-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.user-avatar {
+  width: 2.65rem;
+  height: 2.65rem;
+  flex: 0 0 2.65rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(240, 171, 252, 0.32);
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.user-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.user-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.user-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-status {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.4rem 0.68rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-user-mention-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .user-status {
+    margin-left: 3.5rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic User Mention Row demo inside `submissions/examples/basic-user-mention-row-kk/`. This submission introduces a compact CSS-only row pattern for member lists, reviewer panels, comment summaries, assignment rows, and team sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only user mention row for showing an avatar marker, person name, supporting text, and right-side status in one compact layout.

**How does a developer use it?**

```html
<div class="basic-user-mention-row">
  <span class="user-avatar" aria-hidden="true">KR</span>
  <div class="user-copy">
    <strong>Kriti Sharma</strong>
    <p>Frontend contributor</p>
  </div>
  <span class="user-status">Owner</span>
</div>