### PR TITLE
feat: add basic deadline reminder row demo

### DIFF
--- a/submissions/examples/basic-deadline-reminder-row-kk/README.md
+++ b/submissions/examples/basic-deadline-reminder-row-kk/README.md
@@ -1,0 +1,42 @@
+# Basic Deadline Reminder Row
+
+## What it does
+
+This submission adds a simple CSS-only deadline reminder row for tasks, upcoming dates, project deadlines, reminders, and planning cards.
+
+It aligns a reminder marker, task title, helper text, due date, and urgency label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a marker, task copy, date, and status:
+
+```html
+<div class="basic-deadline-reminder-row">
+  <span class="deadline-marker" aria-hidden="true">01</span>
+  <div class="deadline-copy">
+    <strong>Submit project brief</strong>
+    <p>Finalize the summary and attach reference notes.</p>
+  </div>
+  <time datetime="2026-08-14">Aug 14</time>
+  <span class="deadline-state is-soon">Due soon</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across dashboards, task cards, planning panels, reminders, and project management sections. It uses semantic HTML and CSS only.
+
+## Included features
+
+- Reminder marker, task copy, date, and status layout
+- Due soon, planned, and ready examples
+- Semantic `time` element usage
+- Text truncation for long helper copy
+- Responsive stacked layout on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the deadline reminder row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-deadline-reminder-row-kk/demo.html
+++ b/submissions/examples/basic-deadline-reminder-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Deadline Reminder Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Deadline Reminder Row</p>
+          <h1>Readable reminder rows for tasks, dates, and deadlines.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a reminder marker, task copy, due date,
+            and urgency label for compact project and dashboard sections.
+          </p>
+        </header>
+
+        <section class="deadline-panel" aria-label="Deadline reminder row examples">
+          <div class="basic-deadline-reminder-row">
+            <span class="deadline-marker" aria-hidden="true">01</span>
+            <div class="deadline-copy">
+              <strong>Submit project brief</strong>
+              <p>Finalize the summary and attach reference notes.</p>
+            </div>
+            <time datetime="2026-08-14">Aug 14</time>
+            <span class="deadline-state is-soon">Due soon</span>
+          </div>
+
+          <div class="basic-deadline-reminder-row">
+            <span class="deadline-marker" aria-hidden="true">02</span>
+            <div class="deadline-copy">
+              <strong>Review design checklist</strong>
+              <p>Confirm spacing, responsiveness, and accessibility notes.</p>
+            </div>
+            <time datetime="2026-08-18">Aug 18</time>
+            <span class="deadline-state">Planned</span>
+          </div>
+
+          <div class="basic-deadline-reminder-row">
+            <span class="deadline-marker" aria-hidden="true">03</span>
+            <div class="deadline-copy">
+              <strong>Update release notes</strong>
+              <p>Add the latest frontend improvements.</p>
+            </div>
+            <time datetime="2026-08-20">Aug 20</time>
+            <span class="deadline-state is-done">Ready</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-deadline-reminder-row"&gt;
+  &lt;span class="deadline-marker" aria-hidden="true"&gt;01&lt;/span&gt;
+  &lt;div class="deadline-copy"&gt;
+    &lt;strong&gt;Submit project brief&lt;/strong&gt;
+    &lt;p&gt;Finalize the summary and attach reference notes.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;time datetime="2026-08-14"&gt;Aug 14&lt;/time&gt;
+  &lt;span class="deadline-state is-soon"&gt;Due soon&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-deadline-reminder-row-kk/style.css
+++ b/submissions/examples/basic-deadline-reminder-row-kk/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #fcd34d;
+  --accent-soft: rgba(252, 211, 77, 0.14);
+  --success: #86efac;
+  --danger: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(252, 211, 77, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.11), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.deadline-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-deadline-reminder-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-deadline-reminder-row + .basic-deadline-reminder-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.deadline-marker {
+  width: 2.35rem;
+  height: 2.35rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(252, 211, 77, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.deadline-copy {
+  min-width: 0;
+}
+
+.deadline-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.deadline-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.basic-deadline-reminder-row time {
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.deadline-state {
+  border-radius: 999px;
+  padding: 0.4rem 0.68rem;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.86rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.deadline-state.is-soon {
+  color: var(--danger);
+  background: rgba(252, 165, 165, 0.13);
+}
+
+.deadline-state.is-done {
+  color: var(--success);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .basic-deadline-reminder-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .basic-deadline-reminder-row time,
+  .deadline-state {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Deadline Reminder Row demo inside `submissions/examples/basic-deadline-reminder-row-kk/`. This submission introduces a compact CSS-only row pattern for tasks, upcoming dates, project deadlines, reminders, and planning cards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only deadline reminder row for showing a reminder marker, task title, helper text, due date, and urgency label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-deadline-reminder-row">
  <span class="deadline-marker" aria-hidden="true">01</span>
  <div class="deadline-copy">
    <strong>Submit project brief</strong>
    <p>Finalize the summary and attach reference notes.</p>
  </div>
  <time datetime="2026-08-14">Aug 14</time>
  <span class="deadline-state is-soon">Due soon</span>
</div>