### PR TITLE
Add material-style ripple submission

### DIFF
--- a/submissions/examples/ripple-button-tm/README.md
+++ b/submissions/examples/ripple-button-tm/README.md
@@ -1,0 +1,7 @@
+# Material-style ripple
+
+1. What does this do? A button that emits a circular ripple from the click point on press.
+
+2. How is it used? Add `ripple-button-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Familiar feedback; the ripple is positioned with CSS variables from a small click handler.

--- a/submissions/examples/ripple-button-tm/demo.html
+++ b/submissions/examples/ripple-button-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Ripple Button — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="ripplebutton-page-tm" data-palette="cool">
+  <h1 class="ripplebutton-h-tm">Ripple Button</h1>
+  <p class="ripplebutton-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="ripplebutton-row-tm">
+    <article class="ripplebutton-1-wrap-tm">
+      <div class="ripplebutton-1-tm"></div>
+      <span class="ripplebutton-lbl-tm">Example One</span>
+    </article>
+    <article class="ripplebutton-2-wrap-tm">
+      <div class="ripplebutton-2-tm"></div>
+      <span class="ripplebutton-lbl-tm">Example Two</span>
+    </article>
+    <article class="ripplebutton-3-wrap-tm">
+      <div class="ripplebutton-3-tm"></div>
+      <span class="ripplebutton-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/ripple-button-tm/style.css
+++ b/submissions/examples/ripple-button-tm/style.css
@@ -1,0 +1,58 @@
+:root {
+  --ripplebutton-bg: #0a0e1a;
+  --ripplebutton-surface: #131829;
+  --ripplebutton-edge: #1d2438;
+  --ripplebutton-text: #e6e8ec;
+  --ripplebutton-muted: #8b909b;
+  --ripplebutton-accent: #4dabf7;
+  --ripplebutton-accent-2: #9b8cff;
+  --ripplebutton-radius: 10px;
+  --ripplebutton-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--ripplebutton-bg);
+  color: var(--ripplebutton-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.ripplebutton-page-tm { max-width: 920px; margin: 0 auto; }
+.ripplebutton-h-tm { font-size: 28px; margin: 0 0 8px; }
+.ripplebutton-lede-tm { color: var(--ripplebutton-muted); margin: 0 0 32px; }
+.ripplebutton-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.ripplebutton-1-wrap-tm, .ripplebutton-2-wrap-tm, .ripplebutton-3-wrap-tm {
+  background: var(--ripplebutton-surface);
+  border: 1px solid var(--ripplebutton-edge);
+  border-radius: var(--ripplebutton-radius);
+  padding: var(--ripplebutton-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.ripplebutton-lbl-tm { color: var(--ripplebutton-muted); font-size: 13px; }
+
+.ripplebutton-1-tm, .ripplebutton-2-tm, .ripplebutton-3-tm {
+  position: relative; overflow: hidden; padding: 12px 24px; border: 0;
+  border-radius: 8px; background: #4dabf7; color: #0f1115; font: inherit; font-weight: 600;
+  cursor: pointer; min-width: 120px;
+}
+.ripplebutton-1-tm::before, .ripplebutton-2-tm::before, .ripplebutton-3-tm::before {
+  content: ""; position: absolute; inset: 0; background: radial-gradient(circle at var(--rx, 50%) var(--ry, 50%), #fff6 0%, transparent 60%);
+  opacity: 0; transition: opacity 600ms;
+}
+.ripplebutton-1-tm:active::before { opacity: 1; transition: opacity 0s; }
+.ripplebutton-2-tm { background: #9b8cff; color: #0a0e1a; }
+.ripplebutton-3-tm { background: #131829; color: #4dabf7; border: 1px solid #4dabf7; }


### PR DESCRIPTION
Closes #76880

## What
This submission adds a new EaseMotion CSS example: `ripple-button-tm`.

A button that emits a circular ripple from the click point on press.

## How to review
1. Open `submissions/examples/ripple-button-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/ripple-button-tm/` and does not modify any existing file.
