### PR TITLE
Add animated stat bar submission

### DIFF
--- a/submissions/examples/stat-bar-tm/README.md
+++ b/submissions/examples/stat-bar-tm/README.md
@@ -1,0 +1,7 @@
+# Animated stat bar
+
+1. What does this do? A horizontal bar that fills to a target percentage with a smooth ease.
+
+2. How is it used? Add `stat-bar-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Useful for skill levels, votes, completion; the bar grows on first paint.

--- a/submissions/examples/stat-bar-tm/demo.html
+++ b/submissions/examples/stat-bar-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Stat Bar — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="statbar-page-tm" data-palette="forest">
+  <h1 class="statbar-h-tm">Stat Bar</h1>
+  <p class="statbar-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="statbar-row-tm">
+    <article class="statbar-1-wrap-tm">
+      <div class="statbar-1-tm"></div>
+      <span class="statbar-lbl-tm">Example One</span>
+    </article>
+    <article class="statbar-2-wrap-tm">
+      <div class="statbar-2-tm"></div>
+      <span class="statbar-lbl-tm">Example Two</span>
+    </article>
+    <article class="statbar-3-wrap-tm">
+      <div class="statbar-3-tm"></div>
+      <span class="statbar-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/stat-bar-tm/style.css
+++ b/submissions/examples/stat-bar-tm/style.css
@@ -1,0 +1,58 @@
+:root {
+  --statbar-bg: #0d1612;
+  --statbar-surface: #152721;
+  --statbar-edge: #1f3530;
+  --statbar-text: #e6e8ec;
+  --statbar-muted: #8b909b;
+  --statbar-accent: #2ecc71;
+  --statbar-accent-2: #a3e635;
+  --statbar-radius: 10px;
+  --statbar-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--statbar-bg);
+  color: var(--statbar-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.statbar-page-tm { max-width: 920px; margin: 0 auto; }
+.statbar-h-tm { font-size: 28px; margin: 0 0 8px; }
+.statbar-lede-tm { color: var(--statbar-muted); margin: 0 0 32px; }
+.statbar-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.statbar-1-wrap-tm, .statbar-2-wrap-tm, .statbar-3-wrap-tm {
+  background: var(--statbar-surface);
+  border: 1px solid var(--statbar-edge);
+  border-radius: var(--statbar-radius);
+  padding: var(--statbar-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.statbar-lbl-tm { color: var(--statbar-muted); font-size: 13px; }
+
+.statbar-1-tm, .statbar-2-tm, .statbar-3-tm {
+  width: 100%; height: 16px; background: #1f3530; border-radius: 8px;
+  overflow: hidden; position: relative;
+}
+.statbar-1-tm::after, .statbar-2-tm::after, .statbar-3-tm::after {
+  content: ""; position: absolute; inset: 0; background: #2ecc71;
+  transform-origin: left; transform: scaleX(var(--p, 0.8));
+  animation: kf-statbar-v1 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-statbar-v1 { from { transform: scaleX(0); } to { transform: scaleX(var(--p, 0.8)); } }
+.statbar-2-tm::after { background: #a3e635; }
+.statbar-3-tm::after { background: #8b909b; }


### PR DESCRIPTION
Closes #76885

## What
This submission adds a new EaseMotion CSS example: `stat-bar-tm`.

A horizontal bar that fills to a target percentage with a smooth ease.

## How to review
1. Open `submissions/examples/stat-bar-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/stat-bar-tm/` and does not modify any existing file.
