### PR TITLE
Add animated number counter submission

### DIFF
--- a/submissions/examples/stat-counter-tm/README.md
+++ b/submissions/examples/stat-counter-tm/README.md
@@ -1,0 +1,7 @@
+# Animated number counter
+
+1. What does this do? A number that counts up to a target using @property and a CSS counter.
+
+2. How is it used? Add `stat-counter-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Familiar dashboard pattern; CSS-only via @property + counter-reset.

--- a/submissions/examples/stat-counter-tm/demo.html
+++ b/submissions/examples/stat-counter-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Stat Counter — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="statcounter-page-tm" data-palette="rose">
+  <h1 class="statcounter-h-tm">Stat Counter</h1>
+  <p class="statcounter-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="statcounter-row-tm">
+    <article class="statcounter-1-wrap-tm">
+      <div class="statcounter-1-tm"></div>
+      <span class="statcounter-lbl-tm">Example One</span>
+    </article>
+    <article class="statcounter-2-wrap-tm">
+      <div class="statcounter-2-tm"></div>
+      <span class="statcounter-lbl-tm">Example Two</span>
+    </article>
+    <article class="statcounter-3-wrap-tm">
+      <div class="statcounter-3-tm"></div>
+      <span class="statcounter-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/stat-counter-tm/style.css
+++ b/submissions/examples/stat-counter-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --statcounter-bg: #160d12;
+  --statcounter-surface: #26141c;
+  --statcounter-edge: #361b25;
+  --statcounter-text: #e6e8ec;
+  --statcounter-muted: #8b909b;
+  --statcounter-accent: #ff5c8a;
+  --statcounter-accent-2: #ffb4d2;
+  --statcounter-radius: 10px;
+  --statcounter-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--statcounter-bg);
+  color: var(--statcounter-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.statcounter-page-tm { max-width: 920px; margin: 0 auto; }
+.statcounter-h-tm { font-size: 28px; margin: 0 0 8px; }
+.statcounter-lede-tm { color: var(--statcounter-muted); margin: 0 0 32px; }
+.statcounter-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.statcounter-1-wrap-tm, .statcounter-2-wrap-tm, .statcounter-3-wrap-tm {
+  background: var(--statcounter-surface);
+  border: 1px solid var(--statcounter-edge);
+  border-radius: var(--statcounter-radius);
+  padding: var(--statcounter-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.statcounter-lbl-tm { color: var(--statcounter-muted); font-size: 13px; }
+
+.statcounter-1-tm, .statcounter-2-tm, .statcounter-3-tm {
+  font-size: 48px; font-weight: 800; color: #ff5c8a;
+  counter-reset: n var(--n); animation: kf-statcounter-v1 2s forwards;
+}
+.statcounter-1-tm::after, .statcounter-2-tm::after, .statcounter-3-tm::after { content: counter(n); }
+@keyframes kf-statcounter-v1 { from { --n: 0; } to { --n: 1234; } }
+@property --n { syntax: "<integer>"; initial-value: 0; inherits: false; }
+.statcounter-2-tm { color: #ffb4d2; }
+.statcounter-3-tm { color: #8b909b; }


### PR DESCRIPTION
Closes #76889

## What
This submission adds a new EaseMotion CSS example: `stat-counter-tm`.

A number that counts up to a target using @property and a CSS counter.

## How to review
1. Open `submissions/examples/stat-counter-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/stat-counter-tm/` and does not modify any existing file.
