### PR TITLE
Add glitch text effect submission

### DIFF
--- a/submissions/examples/glitch-text-tm/README.md
+++ b/submissions/examples/glitch-text-tm/README.md
@@ -1,0 +1,7 @@
+# Glitch text effect
+
+1. What does this do? A headline whose RGB layers offset briefly to evoke a digital glitch.
+
+2. How is it used? Add `glitch-text-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Hero, error-state, or loading pattern; the offset is short and intentional.

--- a/submissions/examples/glitch-text-tm/demo.html
+++ b/submissions/examples/glitch-text-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Glitch Text — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="glitchtext-page-tm" data-palette="violet">
+  <h1 class="glitchtext-h-tm">Glitch Text</h1>
+  <p class="glitchtext-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="glitchtext-row-tm">
+    <article class="glitchtext-1-wrap-tm">
+      <div class="glitchtext-1-tm"></div>
+      <span class="glitchtext-lbl-tm">Example One</span>
+    </article>
+    <article class="glitchtext-2-wrap-tm">
+      <div class="glitchtext-2-tm"></div>
+      <span class="glitchtext-lbl-tm">Example Two</span>
+    </article>
+    <article class="glitchtext-3-wrap-tm">
+      <div class="glitchtext-3-tm"></div>
+      <span class="glitchtext-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/glitch-text-tm/style.css
+++ b/submissions/examples/glitch-text-tm/style.css
@@ -1,0 +1,65 @@
+:root {
+  --glitchtext-bg: #0e0a1a;
+  --glitchtext-surface: #1a1329;
+  --glitchtext-edge: #261a3a;
+  --glitchtext-text: #e6e8ec;
+  --glitchtext-muted: #8b909b;
+  --glitchtext-accent: #a78bfa;
+  --glitchtext-accent-2: #f472b6;
+  --glitchtext-radius: 10px;
+  --glitchtext-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--glitchtext-bg);
+  color: var(--glitchtext-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.glitchtext-page-tm { max-width: 920px; margin: 0 auto; }
+.glitchtext-h-tm { font-size: 28px; margin: 0 0 8px; }
+.glitchtext-lede-tm { color: var(--glitchtext-muted); margin: 0 0 32px; }
+.glitchtext-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.glitchtext-1-wrap-tm, .glitchtext-2-wrap-tm, .glitchtext-3-wrap-tm {
+  background: var(--glitchtext-surface);
+  border: 1px solid var(--glitchtext-edge);
+  border-radius: var(--glitchtext-radius);
+  padding: var(--glitchtext-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.glitchtext-lbl-tm { color: var(--glitchtext-muted); font-size: 13px; }
+
+.glitchtext-1-tm, .glitchtext-2-tm, .glitchtext-3-tm {
+  position: relative; font-size: 36px; font-weight: 800; color: #a78bfa;
+}
+.glitchtext-1-tm::before, .glitchtext-1-tm::after,
+.glitchtext-2-tm::before, .glitchtext-2-tm::after,
+.glitchtext-3-tm::before, .glitchtext-3-tm::after {
+  content: attr(data-text); position: absolute; inset: 0; pointer-events: none;
+}
+.glitchtext-1-tm::before { color: #ff0066; transform: translate(-2px, 0); animation: kf-glitchtext-v1 2.4s infinite; }
+.glitchtext-1-tm::after { color: #00ffff; transform: translate(2px, 0); animation: kf-glitchtext-v1 2.4s infinite reverse; }
+@keyframes kf-glitchtext-v1 {
+  0%, 90%, 100% { transform: translate(0, 0); }
+  92% { transform: translate(-3px, 1px); }
+  94% { transform: translate(3px, -1px); }
+  96% { transform: translate(-1px, 2px); }
+}
+.glitchtext-2-tm { color: #f472b6; }
+.glitchtext-2-tm::before { color: #ff0066; }
+.glitchtext-2-tm::after { color: #a78bfa; }


### PR DESCRIPTION
Closes #76899

## What
This submission adds a new EaseMotion CSS example: `glitch-text-tm`.

A headline whose RGB layers offset briefly to evoke a digital glitch.

## How to review
1. Open `submissions/examples/glitch-text-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/glitch-text-tm/` and does not modify any existing file.
