### PR TITLE
Add parallax depth card submission

### DIFF
--- a/submissions/examples/parallax-card-tm/README.md
+++ b/submissions/examples/parallax-card-tm/README.md
@@ -1,0 +1,7 @@
+# Parallax depth card
+
+1. What does this do? A card whose inner image shifts against the cursor on hover for a 3D feel.
+
+2. How is it used? Add `parallax-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Marketing / product card pattern; depth sells interactivity.

--- a/submissions/examples/parallax-card-tm/demo.html
+++ b/submissions/examples/parallax-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Parallax Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="parallaxcard-page-tm" data-palette="ruby">
+  <h1 class="parallaxcard-h-tm">Parallax Card</h1>
+  <p class="parallaxcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="parallaxcard-row-tm">
+    <article class="parallaxcard-1-wrap-tm">
+      <div class="parallaxcard-1-tm"></div>
+      <span class="parallaxcard-lbl-tm">Example One</span>
+    </article>
+    <article class="parallaxcard-2-wrap-tm">
+      <div class="parallaxcard-2-tm"></div>
+      <span class="parallaxcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="parallaxcard-3-wrap-tm">
+      <div class="parallaxcard-3-tm"></div>
+      <span class="parallaxcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/parallax-card-tm/style.css
+++ b/submissions/examples/parallax-card-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --parallaxcard-bg: #160a0d;
+  --parallaxcard-surface: #261418;
+  --parallaxcard-edge: #36191e;
+  --parallaxcard-text: #e6e8ec;
+  --parallaxcard-muted: #8b909b;
+  --parallaxcard-accent: #ef4444;
+  --parallaxcard-accent-2: #fb7185;
+  --parallaxcard-radius: 10px;
+  --parallaxcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--parallaxcard-bg);
+  color: var(--parallaxcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.parallaxcard-page-tm { max-width: 920px; margin: 0 auto; }
+.parallaxcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.parallaxcard-lede-tm { color: var(--parallaxcard-muted); margin: 0 0 32px; }
+.parallaxcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.parallaxcard-1-wrap-tm, .parallaxcard-2-wrap-tm, .parallaxcard-3-wrap-tm {
+  background: var(--parallaxcard-surface);
+  border: 1px solid var(--parallaxcard-edge);
+  border-radius: var(--parallaxcard-radius);
+  padding: var(--parallaxcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.parallaxcard-lbl-tm { color: var(--parallaxcard-muted); font-size: 13px; }
+
+.parallaxcard-1-tm, .parallaxcard-2-tm, .parallaxcard-3-tm {
+  width: 100%; height: 100px; border-radius: 8px;
+  background: linear-gradient(135deg, #ef4444, #fb7185);
+  transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.parallaxcard-1-wrap-tm:hover .parallaxcard-1-tm { transform: scale(1.06) translateZ(20px); }
+.parallaxcard-2-tm { background: linear-gradient(135deg, #fb7185, #ef4444); }
+.parallaxcard-2-wrap-tm:hover .parallaxcard-2-tm { transform: scale(1.04) translateY(-4px); }
+.parallaxcard-3-tm { background: linear-gradient(135deg, #8b909b, #36191e); }
+.parallaxcard-3-wrap-tm:hover .parallaxcard-3-tm { transform: scale(1.02); }


### PR DESCRIPTION
Closes #76906

## What
This submission adds a new EaseMotion CSS example: `parallax-card-tm`.

A card whose inner image shifts against the cursor on hover for a 3D feel.

## How to review
1. Open `submissions/examples/parallax-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/parallax-card-tm/` and does not modify any existing file.
