### PR TITLE
Add sticky scroll header submission

### DIFF
--- a/submissions/examples/sticky-header-tm/README.md
+++ b/submissions/examples/sticky-header-tm/README.md
@@ -1,0 +1,7 @@
+# Sticky scroll header
+
+1. What does this do? A page header that condenses and casts a soft shadow once the page scrolls.
+
+2. How is it used? Add `sticky-header-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Marketing / doc page pattern; header shrinks to keep the title visible.

--- a/submissions/examples/sticky-header-tm/demo.html
+++ b/submissions/examples/sticky-header-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sticky Header — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="stickyheader-page-tm" data-palette="graphite">
+  <h1 class="stickyheader-h-tm">Sticky Header</h1>
+  <p class="stickyheader-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="stickyheader-row-tm">
+    <article class="stickyheader-1-wrap-tm">
+      <div class="stickyheader-1-tm"></div>
+      <span class="stickyheader-lbl-tm">Example One</span>
+    </article>
+    <article class="stickyheader-2-wrap-tm">
+      <div class="stickyheader-2-tm"></div>
+      <span class="stickyheader-lbl-tm">Example Two</span>
+    </article>
+    <article class="stickyheader-3-wrap-tm">
+      <div class="stickyheader-3-tm"></div>
+      <span class="stickyheader-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/sticky-header-tm/style.css
+++ b/submissions/examples/sticky-header-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --stickyheader-bg: #101216;
+  --stickyheader-surface: #1a1d22;
+  --stickyheader-edge: #25282e;
+  --stickyheader-text: #e6e8ec;
+  --stickyheader-muted: #8b909b;
+  --stickyheader-accent: #94a3b8;
+  --stickyheader-accent-2: #cbd5e1;
+  --stickyheader-radius: 10px;
+  --stickyheader-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--stickyheader-bg);
+  color: var(--stickyheader-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.stickyheader-page-tm { max-width: 920px; margin: 0 auto; }
+.stickyheader-h-tm { font-size: 28px; margin: 0 0 8px; }
+.stickyheader-lede-tm { color: var(--stickyheader-muted); margin: 0 0 32px; }
+.stickyheader-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.stickyheader-1-wrap-tm, .stickyheader-2-wrap-tm, .stickyheader-3-wrap-tm {
+  background: var(--stickyheader-surface);
+  border: 1px solid var(--stickyheader-edge);
+  border-radius: var(--stickyheader-radius);
+  padding: var(--stickyheader-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.stickyheader-lbl-tm { color: var(--stickyheader-muted); font-size: 13px; }
+
+.stickyheader-1-tm, .stickyheader-2-tm, .stickyheader-3-tm {
+  position: sticky; top: 0; padding: 16px 24px; background: #1a1d22;
+  border-bottom: 1px solid #25282e; transition: padding 200ms, box-shadow 200ms;
+  z-index: 10;
+}
+.stickyheader-1-tm.is-stuck { padding: 8px 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.stickyheader-2-tm.is-stuck { background: #94a3b822; border-bottom-color: #94a3b8; }
+.stickyheader-3-tm.is-stuck { background: #cbd5e122; border-bottom-color: #cbd5e1; }


### PR DESCRIPTION
Closes #76910

## What
This submission adds a new EaseMotion CSS example: `sticky-header-tm`.

A page header that condenses and casts a soft shadow once the page scrolls.

## How to review
1. Open `submissions/examples/sticky-header-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/sticky-header-tm/` and does not modify any existing file.
