### PR TITLE
Add scroll progress bar submission

### DIFF
--- a/submissions/examples/scroll-progress-tm/README.md
+++ b/submissions/examples/scroll-progress-tm/README.md
@@ -1,0 +1,7 @@
+# Scroll progress bar
+
+1. What does this do? A thin bar at the top of the page that fills as the user scrolls down.
+
+2. How is it used? Add `scroll-progress-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Common reading-progress pattern; uses animation-timeline: scroll() for CSS-only.

--- a/submissions/examples/scroll-progress-tm/demo.html
+++ b/submissions/examples/scroll-progress-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Scroll Progress — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="scrollprogress-page-tm" data-palette="gold">
+  <h1 class="scrollprogress-h-tm">Scroll Progress</h1>
+  <p class="scrollprogress-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="scrollprogress-row-tm">
+    <article class="scrollprogress-1-wrap-tm">
+      <div class="scrollprogress-1-tm"></div>
+      <span class="scrollprogress-lbl-tm">Example One</span>
+    </article>
+    <article class="scrollprogress-2-wrap-tm">
+      <div class="scrollprogress-2-tm"></div>
+      <span class="scrollprogress-lbl-tm">Example Two</span>
+    </article>
+    <article class="scrollprogress-3-wrap-tm">
+      <div class="scrollprogress-3-tm"></div>
+      <span class="scrollprogress-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/scroll-progress-tm/style.css
+++ b/submissions/examples/scroll-progress-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --scrollprogress-bg: #13110b;
+  --scrollprogress-surface: #221e14;
+  --scrollprogress-edge: #332c1c;
+  --scrollprogress-text: #e6e8ec;
+  --scrollprogress-muted: #8b909b;
+  --scrollprogress-accent: #facc15;
+  --scrollprogress-accent-2: #fbbf24;
+  --scrollprogress-radius: 10px;
+  --scrollprogress-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--scrollprogress-bg);
+  color: var(--scrollprogress-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.scrollprogress-page-tm { max-width: 920px; margin: 0 auto; }
+.scrollprogress-h-tm { font-size: 28px; margin: 0 0 8px; }
+.scrollprogress-lede-tm { color: var(--scrollprogress-muted); margin: 0 0 32px; }
+.scrollprogress-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.scrollprogress-1-wrap-tm, .scrollprogress-2-wrap-tm, .scrollprogress-3-wrap-tm {
+  background: var(--scrollprogress-surface);
+  border: 1px solid var(--scrollprogress-edge);
+  border-radius: var(--scrollprogress-radius);
+  padding: var(--scrollprogress-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.scrollprogress-lbl-tm { color: var(--scrollprogress-muted); font-size: 13px; }
+
+.scrollprogress-1-tm, .scrollprogress-2-tm, .scrollprogress-3-tm {
+  position: fixed; top: 0; left: 0; right: 0; height: 3px;
+  background: #facc15; transform-origin: left;
+  animation: kf-scrollprogress-v1 linear; animation-timeline: scroll(root);
+}
+@keyframes kf-scrollprogress-v1 { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+.scrollprogress-2-tm { background: #fbbf24; }
+.scrollprogress-3-tm { background: #8b909b; }


### PR DESCRIPTION
Closes #76913

## What
This submission adds a new EaseMotion CSS example: `scroll-progress-tm`.

A thin bar at the top of the page that fills as the user scrolls down.

## How to review
1. Open `submissions/examples/scroll-progress-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/scroll-progress-tm/` and does not modify any existing file.
