### PR TITLE
Add overlapping avatar stack submission

### DIFF
--- a/submissions/examples/avatar-stack-tm/README.md
+++ b/submissions/examples/avatar-stack-tm/README.md
@@ -1,0 +1,7 @@
+# Overlapping avatar stack
+
+1. What does this do? A row of circular avatars that overlap, with hover-to-spread on the group.
+
+2. How is it used? Add `avatar-stack-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Common in social, collaboration, and team-list patterns.

--- a/submissions/examples/avatar-stack-tm/demo.html
+++ b/submissions/examples/avatar-stack-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Avatar Stack — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="avatarstack-page-tm" data-palette="warm">
+  <h1 class="avatarstack-h-tm">Avatar Stack</h1>
+  <p class="avatarstack-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="avatarstack-row-tm">
+    <article class="avatarstack-1-wrap-tm">
+      <div class="avatarstack-1-tm"></div>
+      <span class="avatarstack-lbl-tm">Example One</span>
+    </article>
+    <article class="avatarstack-2-wrap-tm">
+      <div class="avatarstack-2-tm"></div>
+      <span class="avatarstack-lbl-tm">Example Two</span>
+    </article>
+    <article class="avatarstack-3-wrap-tm">
+      <div class="avatarstack-3-tm"></div>
+      <span class="avatarstack-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/avatar-stack-tm/style.css
+++ b/submissions/examples/avatar-stack-tm/style.css
@@ -1,0 +1,60 @@
+:root {
+  --avatarstack-bg: #0f1115;
+  --avatarstack-surface: #1a1d24;
+  --avatarstack-edge: #262a33;
+  --avatarstack-text: #e6e8ec;
+  --avatarstack-muted: #8b909b;
+  --avatarstack-accent: #ff6a3d;
+  --avatarstack-accent-2: #ffd166;
+  --avatarstack-radius: 10px;
+  --avatarstack-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--avatarstack-bg);
+  color: var(--avatarstack-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.avatarstack-page-tm { max-width: 920px; margin: 0 auto; }
+.avatarstack-h-tm { font-size: 28px; margin: 0 0 8px; }
+.avatarstack-lede-tm { color: var(--avatarstack-muted); margin: 0 0 32px; }
+.avatarstack-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.avatarstack-1-wrap-tm, .avatarstack-2-wrap-tm, .avatarstack-3-wrap-tm {
+  background: var(--avatarstack-surface);
+  border: 1px solid var(--avatarstack-edge);
+  border-radius: var(--avatarstack-radius);
+  padding: var(--avatarstack-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.avatarstack-lbl-tm { color: var(--avatarstack-muted); font-size: 13px; }
+
+.avatarstack-1-tm, .avatarstack-2-tm, .avatarstack-3-tm {
+  display: flex; align-items: center;
+}
+.avatarstack-1-tm span, .avatarstack-2-tm span, .avatarstack-3-tm span {
+  width: 36px; height: 36px; border-radius: 50%; background: #ff6a3d;
+  display: grid; place-items: center; font-size: 12px; font-weight: 600; color: #0f1115;
+  border: 2px solid #1a1d24;
+}
+.avatarstack-1-tm span:not(:first-child), .avatarstack-2-tm span:not(:first-child), .avatarstack-3-tm span:not(:first-child) {
+  margin-left: -10px; transition: transform 200ms;
+}
+.avatarstack-1-tm:hover span { transform: translateX(calc(var(--i, 0) * 6px)); }
+.avatarstack-2-tm span { background: #ffd166; color: #0a0e1a; }
+.avatarstack-3-tm span { background: #8b909b; color: #0e0a1a; }


### PR DESCRIPTION
Closes #76916

## What
This submission adds a new EaseMotion CSS example: `avatar-stack-tm`.

A row of circular avatars that overlap, with hover-to-spread on the group.

## How to review
1. Open `submissions/examples/avatar-stack-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/avatar-stack-tm/` and does not modify any existing file.
