### PR TITLE
Add square icon button submission

### DIFF
--- a/submissions/examples/icon-button-tm/README.md
+++ b/submissions/examples/icon-button-tm/README.md
@@ -1,0 +1,7 @@
+# Square icon button
+
+1. What does this do? A round-edged square button designed for a single icon glyph.
+
+2. How is it used? Add `icon-button-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Toolbar / inline-action pattern; matches the soft dark theme of the library.

--- a/submissions/examples/icon-button-tm/demo.html
+++ b/submissions/examples/icon-button-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Icon Button — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="iconbutton-page-tm" data-palette="cool">
+  <h1 class="iconbutton-h-tm">Icon Button</h1>
+  <p class="iconbutton-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="iconbutton-row-tm">
+    <article class="iconbutton-1-wrap-tm">
+      <div class="iconbutton-1-tm"></div>
+      <span class="iconbutton-lbl-tm">Example One</span>
+    </article>
+    <article class="iconbutton-2-wrap-tm">
+      <div class="iconbutton-2-tm"></div>
+      <span class="iconbutton-lbl-tm">Example Two</span>
+    </article>
+    <article class="iconbutton-3-wrap-tm">
+      <div class="iconbutton-3-tm"></div>
+      <span class="iconbutton-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/icon-button-tm/style.css
+++ b/submissions/examples/icon-button-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --iconbutton-bg: #0a0e1a;
+  --iconbutton-surface: #131829;
+  --iconbutton-edge: #1d2438;
+  --iconbutton-text: #e6e8ec;
+  --iconbutton-muted: #8b909b;
+  --iconbutton-accent: #4dabf7;
+  --iconbutton-accent-2: #9b8cff;
+  --iconbutton-radius: 10px;
+  --iconbutton-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--iconbutton-bg);
+  color: var(--iconbutton-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.iconbutton-page-tm { max-width: 920px; margin: 0 auto; }
+.iconbutton-h-tm { font-size: 28px; margin: 0 0 8px; }
+.iconbutton-lede-tm { color: var(--iconbutton-muted); margin: 0 0 32px; }
+.iconbutton-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.iconbutton-1-wrap-tm, .iconbutton-2-wrap-tm, .iconbutton-3-wrap-tm {
+  background: var(--iconbutton-surface);
+  border: 1px solid var(--iconbutton-edge);
+  border-radius: var(--iconbutton-radius);
+  padding: var(--iconbutton-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.iconbutton-lbl-tm { color: var(--iconbutton-muted); font-size: 13px; }
+
+.iconbutton-1-tm, .iconbutton-2-tm, .iconbutton-3-tm {
+  width: 40px; height: 40px; display: inline-grid; place-items: center;
+  background: #131829; border: 1px solid #1d2438; border-radius: 10px;
+  color: #4dabf7; cursor: pointer; font-size: 18px; transition: all 160ms;
+}
+.iconbutton-1-tm:hover { background: #4dabf7; color: #0f1115; border-color: #4dabf7; }
+.iconbutton-2-tm { color: #9b8cff; border-color: #9b8cff; }
+.iconbutton-2-tm:hover { background: #9b8cff; color: #0a0e1a; }
+.iconbutton-3-tm { color: #8b909b; border-color: #8b909b; }
+.iconbutton-3-tm:hover { background: #8b909b; color: #0e0a1a; }


### PR DESCRIPTION
Closes #76951

## What
This submission adds a new EaseMotion CSS example: `icon-button-tm`.

A round-edged square button designed for a single icon glyph.

## How to review
1. Open `submissions/examples/icon-button-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/icon-button-tm/` and does not modify any existing file.
