### PR TITLE
feat: add subtle elevate badge

### DIFF
--- a/submissions/examples/ease-subtle-elevate-badge-sku/README.md
+++ b/submissions/examples/ease-subtle-elevate-badge-sku/README.md
@@ -1,0 +1,63 @@
+# ease-badge-subtle-elevate-sku
+
+A polished, hardware-accelerated badge and chip component with smooth depth transitions, responsive light/dark themes, and high accessibility.
+
+## What does this do?
+
+This component provides a lightweight, interactive badge/chip container that elevates subtly on hover or keyboard focus, utilizing hardware-accelerated transformations and shadow shifts.
+
+## How is it used?
+
+### Basic Badge (Static)
+
+```html
+<span
+  class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-default"
+  >Default</span
+>
+<span
+  class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-primary"
+  >Primary</span
+>
+```
+
+### Interactive Badges (Buttons & Links)
+
+```html
+<button
+  class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-success"
+  type="button"
+>
+  Interactive Button
+</button>
+<a
+  href="#"
+  class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-warning"
+  >Interactive Anchor Link</a
+>
+```
+
+### Dot Indicator
+
+```html
+<span
+  class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-dot ease-badge-subtle-elevate-sku-danger"
+  >Live Alert</span
+>
+```
+
+### Sizes
+
+- `.ease-badge-subtle-elevate-sku-sm` (Small)
+- default size (Medium)
+- `.ease-badge-subtle-elevate-sku-lg` (Large)
+
+## Why is it useful?
+
+It provides a lightweight interactive micro-animation that enhances user interaction affordance without layout shifting (CLS) by utilizing GPU-friendly translation and box shadow layers, while supporting dark/light coloring dynamically via unified HSL variables.
+
+## Submission Details
+
+- **Author:** shubhanshu-ux (sku)
+- **Issue:** #73463
+- **Files:** `style.css`, `demo.html`, `README.md`

--- a/submissions/examples/ease-subtle-elevate-badge-sku/demo.html
+++ b/submissions/examples/ease-subtle-elevate-badge-sku/demo.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subtle Elevate Badge — EaseMotion CSS</title>
+
+    <!-- EaseMotion Core Styles (relative paths are required) -->
+    <link rel="stylesheet" href="../../../easemotion.css" />
+    <link rel="stylesheet" href="style.css" />
+
+    <style>
+      :root {
+        --bg-page: #f8fafc;
+        --text-page: #0f172a;
+        --card-bg: #ffffff;
+        --card-border: #e2e8f0;
+        --muted: #64748b;
+      }
+
+      /* Automatic Dark Mode theme values */
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg-page: #0f172a;
+          --text-page: #f8fafc;
+          --card-bg: #1e293b;
+          --card-border: #334155;
+          --muted: #94a3b8;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          "Open Sans",
+          "Helvetica Neue",
+          sans-serif;
+        background-color: var(--bg-page);
+        color: var(--text-page);
+        min-height: 100vh;
+        padding: 3rem 1.5rem;
+        transition:
+          background-color 0.3s ease,
+          color 0.3s ease;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .container {
+        max-width: 800px;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+      }
+
+      /* Header styling */
+      header {
+        border-bottom: 1px solid var(--card-border);
+        padding-bottom: 1.5rem;
+      }
+
+      .title-area h1 {
+        font-size: 1.75rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+
+      .title-area p {
+        font-size: 0.9rem;
+        color: var(--muted);
+        margin-top: 0.25rem;
+      }
+
+      /* Showcase cards */
+      .showcase-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .card {
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        border-radius: 16px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.02);
+      }
+
+      .card h2 {
+        font-size: 1.1rem;
+        font-weight: 700;
+      }
+
+      .card-subtitle {
+        font-size: 0.85rem;
+        color: var(--muted);
+        margin-top: -0.5rem;
+      }
+
+      .badge-row {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      /* Code block view */
+      pre {
+        background: rgba(0, 0, 0, 0.03);
+        padding: 10px;
+        border-radius: 8px;
+        font-family:
+          ui-monospace,
+          SFMono-Regular,
+          SF Pro Mono,
+          Menlo,
+          Monaco,
+          Consolas,
+          monospace;
+        font-size: 0.75rem;
+        color: var(--muted);
+        overflow-x: auto;
+        border: 1px solid var(--card-border);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        pre {
+          background: rgba(255, 255, 255, 0.03);
+        }
+      }
+
+      .a11y-guide {
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: var(--muted);
+      }
+
+      .a11y-guide strong {
+        color: var(--text-page);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <div class="title-area">
+          <h1>Subtle Elevate Badge</h1>
+          <p>
+            Pure HTML + Vanilla CSS badge with hardware-accelerated motion
+            elevation.
+          </p>
+        </div>
+      </header>
+
+      <div class="showcase-grid">
+        <!-- Section 1: Color Themes -->
+        <section class="card">
+          <h2>Color Variants</h2>
+          <div class="card-subtitle">
+            Static semantic badges. Hover to see them elevate.
+          </div>
+
+          <div class="badge-row">
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-default"
+              >Default</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-primary"
+              >Primary</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-success"
+              >Success</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-warning"
+              >Warning</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-danger"
+              >Danger</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-info"
+              >Info</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-purple"
+              >Purple</span
+            >
+          </div>
+
+          <pre><code>&lt;span class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-primary"&gt;Primary&lt;/span&gt;</code></pre>
+        </section>
+
+        <!-- Section 2: Size scale -->
+        <section class="card">
+          <h2>Size Variants</h2>
+          <div class="card-subtitle">
+            Three sizes scaled correctly for typographic layouts.
+          </div>
+
+          <div class="badge-row">
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-info ease-badge-subtle-elevate-sku-sm"
+              >Small</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-info"
+              >Default</span
+            >
+            <span
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-info ease-badge-subtle-elevate-sku-lg"
+              >Large</span
+            >
+          </div>
+
+          <pre><code>&lt;span class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-sm"&gt;Small&lt;/span&gt;</code></pre>
+        </section>
+
+        <!-- Section 3: Interactive Focus Elements -->
+        <section class="card">
+          <h2>Interactive Badges & Chips</h2>
+          <div class="card-subtitle">
+            Uses semantic buttons and anchors with keyboard focus outlines.
+          </div>
+
+          <div class="badge-row">
+            <!-- Button interaction -->
+            <button
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-primary"
+              type="button"
+            >
+              Interactive Button
+            </button>
+
+            <!-- Anchor link interaction -->
+            <a
+              href="#link"
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-success"
+            >
+              Interactive Anchor Link
+            </a>
+
+            <!-- Dot indicator status inside button -->
+            <button
+              class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku-dot ease-badge-subtle-elevate-sku-purple"
+              type="button"
+            >
+              Active Dot Indicator
+            </button>
+          </div>
+
+          <div class="a11y-guide">
+            👉 <strong>Accessibility Tip:</strong> Press the
+            <code>Tab</code> key to navigate the interactive buttons/anchors
+            above. A distinct, high-contrast outline highlights the focused
+            element.
+          </div>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/ease-subtle-elevate-badge-sku/style.css
+++ b/submissions/examples/ease-subtle-elevate-badge-sku/style.css
@@ -1,0 +1,189 @@
+/* ============================================================
+   EaseMotion CSS — ease-badge-subtle-elevate-sku
+   Submission by: shubhanshu-ux (sku)
+   Description: Subtle Elevate badge/chip component with smooth,
+                hardware-accelerated depth transitions, accessibility
+                focus styling, and adaptive dark mode.
+   ============================================================ */
+
+:root {
+  --se-badge-transition-duration: 0.25s;
+  --se-badge-transition-timing: cubic-bezier(0.25, 0.8, 0.25, 1);
+  --se-badge-elevation-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
+  --se-badge-base-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+}
+
+.ease-badge-subtle-elevate-sku {
+  --bg-opacity: 0.08;
+  --border-opacity: 0.12;
+  --text-opacity: 0.9;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-decoration: none;
+  border: 1px solid hsla(var(--h), var(--s), var(--l), var(--border-opacity));
+  background-color: hsla(var(--h), var(--s), var(--l), var(--bg-opacity));
+  color: hsla(var(--h), var(--s), calc(var(--l) * 0.7), var(--text-opacity));
+
+  /* Stacking Context Identity & Hardware Acceleration */
+  translate: 0 0;
+  scale: 1;
+  rotate: 0deg;
+  will-change: translate, box-shadow;
+
+  box-shadow: var(--se-badge-base-shadow);
+  cursor: default;
+
+  /* Hardware accelerated smooth transitions */
+  transition:
+    translate var(--se-badge-transition-duration)
+      var(--se-badge-transition-timing),
+    box-shadow var(--se-badge-transition-duration)
+      var(--se-badge-transition-timing),
+    background-color var(--se-badge-transition-duration) ease,
+    border-color var(--se-badge-transition-duration) ease,
+    color var(--se-badge-transition-duration) ease;
+}
+
+/* Focusable elements accessibility setups */
+button.ease-badge-subtle-elevate-sku,
+a.ease-badge-subtle-elevate-sku {
+  cursor: pointer;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Hover & Focus state interaction */
+.ease-badge-subtle-elevate-sku:hover,
+.ease-badge-subtle-elevate-sku:focus-visible {
+  --bg-opacity: 0.12;
+  --border-opacity: 0.2;
+
+  translate: 0 -2px;
+  box-shadow: var(--se-badge-elevation-shadow);
+}
+
+/* Custom focus ring */
+.ease-badge-subtle-elevate-sku:focus-visible {
+  outline: 2px solid hsla(var(--h), var(--s), var(--l), 0.5);
+  outline-offset: 2px;
+}
+
+/* Color theme configurations using HSL values */
+.ease-badge-subtle-elevate-sku-default {
+  --h: 215;
+  --s: 16%;
+  --l: 45%;
+}
+
+.ease-badge-subtle-elevate-sku-primary {
+  --h: 220;
+  --s: 90%;
+  --l: 50%;
+}
+
+.ease-badge-subtle-elevate-sku-success {
+  --h: 142;
+  --s: 70%;
+  --l: 40%;
+}
+
+.ease-badge-subtle-elevate-sku-danger {
+  --h: 350;
+  --s: 80%;
+  --l: 50%;
+}
+
+.ease-badge-subtle-elevate-sku-warning {
+  --h: 38;
+  --s: 95%;
+  --l: 40%;
+}
+
+.ease-badge-subtle-elevate-sku-info {
+  --h: 195;
+  --s: 85%;
+  --l: 42%;
+}
+
+.ease-badge-subtle-elevate-sku-purple {
+  --h: 270;
+  --s: 75%;
+  --l: 52%;
+}
+
+/* Size variants */
+.ease-badge-subtle-elevate-sku-sm {
+  font-size: 0.65rem;
+  padding: 2px 8px;
+}
+
+.ease-badge-subtle-elevate-sku-lg {
+  font-size: 0.875rem;
+  padding: 6px 16px;
+}
+
+/* Dot indicator style */
+.ease-badge-subtle-elevate-sku::before {
+  content: "";
+  display: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.ease-badge-subtle-elevate-sku-dot::before {
+  display: inline-block;
+}
+
+/* Adaptive Dark Mode adjustment */
+@media (prefers-color-scheme: dark) {
+  .ease-badge-subtle-elevate-sku {
+    --bg-opacity: 0.15;
+    --border-opacity: 0.22;
+    --text-opacity: 1;
+
+    color: hsla(var(--h), var(--s), calc(var(--l) * 1.3), var(--text-opacity));
+    border-color: hsla(
+      var(--h),
+      var(--s),
+      calc(var(--l) * 1.1),
+      var(--border-opacity)
+    );
+    background-color: hsla(
+      var(--h),
+      var(--s),
+      calc(var(--l) * 0.8),
+      var(--bg-opacity)
+    );
+
+    --se-badge-elevation-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.2);
+    --se-badge-base-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  }
+
+  .ease-badge-subtle-elevate-sku:hover,
+  .ease-badge-subtle-elevate-sku:focus-visible {
+    --bg-opacity: 0.22;
+    --border-opacity: 0.35;
+  }
+}
+
+/* Reduced Motion compatibility */
+@media (prefers-reduced-motion: reduce) {
+  .ease-badge-subtle-elevate-sku {
+    translate: none !important;
+    will-change: auto;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a pure HTML and vanilla CSS "Subtle Elevate" badge/chip variation for EaseMotion CSS.

The component provides subtle elevation through smooth transitions, hover/focus states, multiple color and size variants, dark-mode support, and reduced-motion support.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A subtle-elevation badge and chip component with smooth hover and focus interactions, multiple variants and sizes, and automatic light/dark theme support.

**How does a developer use it?**

```html
<span class="ease-badge-subtle-elevate-sku ease-badge-subtle-elevate-sku--primary">
  Primary
</span>

**Why does it fit EaseMotion CSS?**

A lightweight, reusable CSS component with subtle motion and visual depth.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Pure HTML and vanilla CSS implementation with dark-mode and reduced-motion support.

Closes #73463
