### PR TITLE
Add CSS terminal window component

### DIFF
--- a/submissions/examples/css-terminal-window/README.md
+++ b/submissions/examples/css-terminal-window/README.md
@@ -1,0 +1,27 @@
+# CSS Terminal Window
+
+A pure CSS styled terminal window component featuring window control buttons, path prompts, sequential typing animations, and output logs. Built without JavaScript dependencies.
+
+## How it works
+
+The terminal frame (`.ease-terminal-card`) utilizes dark theme variables and monospace typography. Command inputs (`.ease-typing-text`) use CSS `steps()` character keyframe sequences (`@keyframes ease-type-cmd1`, `@keyframes ease-type-cmd2`) to simulate typing. Command execution logs fade into view sequentially via `@keyframes ease-fade-output`.
+
+## Files
+
+`demo.html`, `style.css`, `README.md`
+
+## Custom properties
+
+- `--ease-term-bg`: Terminal interior backdrop (`#090a0f`)
+- `--ease-term-card-bg`: Card surface background (`#0f172a`)
+- `--ease-term-header-bg`: Window control bar background (`#1e293b`)
+- `--ease-term-border`: Boundary line color (`#334155`)
+- `--ease-term-text`: Command input text color (`#f8fafc`)
+- `--ease-term-muted`: Output log text color (`#94a3b8`)
+- `--ease-term-accent`: Symbol accent color (`#38bdf8`)
+- `--ease-term-path`: Terminal directory path color (`#a855f7`)
+
+## Accessibility & Performance
+
+- Accessible using semantic tags (`role="region"`, `aria-label`), clean contrast ratios, and screen-reader accessible command lines.
+- Full support for `@media (prefers-reduced-motion: reduce)` which bypasses typing steps and fade-in animations, immediately displaying full terminal output logs.

--- a/submissions/examples/css-terminal-window/demo.html
+++ b/submissions/examples/css-terminal-window/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Terminal Window — Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">Developer Console</p>
+    <h1 class="ease-heading">Terminal Window</h1>
+    <p class="ease-subtitle">Pure CSS styled terminal window featuring prompt execution and typing sequence animations.</p>
+
+    <div class="ease-terminal-card" role="region" aria-label="Command line terminal window">
+      <!-- Window Controls Header -->
+      <div class="ease-terminal-header">
+        <div class="ease-terminal-controls" aria-hidden="true">
+          <span class="ease-control-dot close"></span>
+          <span class="ease-control-dot minimize"></span>
+          <span class="ease-control-dot maximize"></span>
+        </div>
+        <span class="ease-terminal-title">zsh — easemotion-dev-node</span>
+        <div class="ease-header-spacer"></div>
+      </div>
+
+      <!-- Terminal Body / Console Output -->
+      <div class="ease-terminal-body">
+        <!-- Command 1 -->
+        <div class="ease-terminal-line">
+          <span class="ease-prompt-path">~/project/easemotion</span>
+          <span class="ease-prompt-symbol">$</span>
+          <span class="ease-typing-text cmd-1">npm install easemotion-css</span>
+        </div>
+
+        <!-- Output 1 -->
+        <div class="ease-terminal-output out-1">
+          <p class="ease-out-text"><span class="ease-tag success">added 42 packages</span> in 1.4s</p>
+        </div>
+
+        <!-- Command 2 -->
+        <div class="ease-terminal-line line-2">
+          <span class="ease-prompt-path">~/project/easemotion</span>
+          <span class="ease-prompt-symbol">$</span>
+          <span class="ease-typing-text cmd-2">npx easemotion build --prod</span>
+        </div>
+
+        <!-- Output 2 -->
+        <div class="ease-terminal-output out-2">
+          <p class="ease-out-text">✔ Compiling stylesheets...</p>
+          <p class="ease-out-text"><span class="ease-tag info">Bundle Size:</span> 12.4 kB (gzipped)</p>
+          <p class="ease-out-text"><span class="ease-tag highlight">Build completed successfully!</span></p>
+        </div>
+
+        <!-- Active Prompt Line -->
+        <div class="ease-terminal-line line-3">
+          <span class="ease-prompt-path">~/project/easemotion</span>
+          <span class="ease-prompt-symbol">$</span>
+          <span class="ease-active-cmd">_</span>
+          <span class="ease-cursor" aria-hidden="true">█</span>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/css-terminal-window/style.css
+++ b/submissions/examples/css-terminal-window/style.css
@@ -1,0 +1,252 @@
+:root {
+  --ease-term-bg: #090a0f;
+  --ease-term-card-bg: #0f172a;
+  --ease-term-header-bg: #1e293b;
+  --ease-term-border: #334155;
+  --ease-term-text: #f8fafc;
+  --ease-term-muted: #94a3b8;
+  --ease-term-accent: #38bdf8;
+  --ease-term-path: #a855f7;
+  --ease-term-success: #10b981;
+  --ease-term-warning: #f59e0b;
+  
+  --ease-term-radius: 12px;
+  --ease-term-duration: 5s;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #020617;
+  color: var(--ease-term-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-term-accent);
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.ease-heading {
+  font-size: 1.6rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-term-muted);
+  margin: 0 0 2rem;
+  font-size: 0.9rem;
+}
+
+/* Main Terminal Outer Window */
+.ease-terminal-card {
+  background: var(--ease-term-bg);
+  border: 1px solid var(--ease-term-border);
+  border-radius: var(--ease-term-radius);
+  overflow: hidden;
+  box-shadow: 0 20px 30px -10px rgba(0, 0, 0, 0.8),
+              0 0 20px rgba(56, 189, 248, 0.05);
+}
+
+/* Header Window Controls Bar */
+.ease-terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--ease-term-header-bg);
+  border-bottom: 1px solid var(--ease-term-border);
+}
+
+.ease-terminal-controls {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.ease-control-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+
+.ease-control-dot.close { background: #f43f5e; }
+.ease-control-dot.minimize { background: #f59e0b; }
+.ease-control-dot.maximize { background: #10b981; }
+
+.ease-terminal-title {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+  color: var(--ease-term-muted);
+  font-weight: 500;
+}
+
+.ease-header-spacer {
+  width: 45px;
+}
+
+/* Terminal Body Console Area */
+.ease-terminal-body {
+  padding: 1.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 240px;
+}
+
+/* Command Prompt Line */
+.ease-terminal-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.ease-prompt-path {
+  color: var(--ease-term-path);
+  font-weight: 600;
+}
+
+.ease-prompt-symbol {
+  color: var(--ease-term-accent);
+  font-weight: bold;
+}
+
+/* Animated Command Typing Text */
+.ease-typing-text {
+  color: var(--ease-term-text);
+  overflow: hidden;
+  white-space: nowrap;
+  width: 0;
+  display: inline-block;
+}
+
+.cmd-1 {
+  animation: ease-type-cmd1 1.4s steps(26) 0.3s forwards;
+}
+
+.cmd-2 {
+  animation: ease-type-cmd2 1.4s steps(27) 2.2s forwards;
+}
+
+/* Terminal Output Lines */
+.ease-terminal-output {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--ease-term-muted);
+  font-size: 0.82rem;
+  padding-left: 0.5rem;
+  border-left: 2px solid var(--ease-term-border);
+  opacity: 0;
+}
+
+.out-1 {
+  animation: ease-fade-output 0.3s ease 1.8s forwards;
+}
+
+.out-2 {
+  animation: ease-fade-output 0.3s ease 3.8s forwards;
+}
+
+.ease-out-text {
+  margin: 0;
+}
+
+/* Status Tags */
+.ease-tag {
+  font-weight: 600;
+}
+
+.ease-tag.success { color: var(--ease-term-success); }
+.ease-tag.info { color: var(--ease-term-accent); }
+.ease-tag.highlight { color: var(--ease-term-warning); }
+
+/* Blinking Cursor for Active Line */
+.ease-cursor {
+  color: var(--ease-term-accent);
+  font-size: 0.9rem;
+  animation: ease-blink-cursor 0.75s step-end infinite alternate;
+}
+
+/* Keyframe Animations */
+@keyframes ease-type-cmd1 {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes ease-type-cmd2 {
+  from { width: 0; }
+  to { width: 100%; }
+}
+
+@keyframes ease-fade-output {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ease-blink-cursor {
+  from, to { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* Mobile Breakpoint Adjustment */
+@media (max-width: 540px) {
+  body {
+    padding: 2rem 1rem;
+  }
+  .ease-heading {
+    font-size: 1.35rem;
+  }
+  .ease-terminal-body {
+    padding: 1rem;
+    font-size: 0.8rem;
+  }
+  .ease-terminal-line {
+    white-space: normal;
+    word-break: break-all;
+  }
+  .ease-typing-text {
+    white-space: normal;
+  }
+}
+
+/* Reduced Motion Accessibility Fallback */
+@media (prefers-reduced-motion: reduce) {
+  .ease-typing-text {
+    width: 100% !important;
+    animation: none !important;
+  }
+  .ease-terminal-output {
+    opacity: 1 !important;
+    animation: none !important;
+    transform: none !important;
+  }
+  .ease-cursor {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #70170

Adds a pure CSS/HTML Terminal Window component featuring a styled console header, command prompts, typing step sequences, and output response logs.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] All changes inside `submissions/examples/css-terminal-window/`
- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] No changes to `core/` or `components/`
- [x] One feature per PR

## Feature Description
**What does this add?** A developer terminal window component with customizable CSS variables (`--ease-term-accent`, `--ease-term-path`) that animates command executions sequentially using pure CSS keyframes.
**Why does it fit?** Expands EaseMotion CSS showcase components with modern developer tooling console layouts built entirely with pure CSS.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
Includes full screen reader accessibility (`role="region"`, `aria-label`) and `prefers-reduced-motion` fallbacks (disabling typing step keyframes and displaying static commands).