### PR TITLE
Add custom radio submission

### DIFF
--- a/submissions/examples/radio-button-tm/README.md
+++ b/submissions/examples/radio-button-tm/README.md
@@ -1,0 +1,7 @@
+# Custom radio
+
+1. What does this do? A radio button styled as a soft ring whose inner dot scales in on select.
+
+2. How is it used? Add `radio-button-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Forms pattern; the inner dot scales from the centre on :checked.

--- a/submissions/examples/radio-button-tm/demo.html
+++ b/submissions/examples/radio-button-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Radio Button — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="radiobutton-page-tm" data-palette="violet">
+  <h1 class="radiobutton-h-tm">Radio Button</h1>
+  <p class="radiobutton-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="radiobutton-row-tm">
+    <article class="radiobutton-1-wrap-tm">
+      <div class="radiobutton-1-tm"></div>
+      <span class="radiobutton-lbl-tm">Example One</span>
+    </article>
+    <article class="radiobutton-2-wrap-tm">
+      <div class="radiobutton-2-tm"></div>
+      <span class="radiobutton-lbl-tm">Example Two</span>
+    </article>
+    <article class="radiobutton-3-wrap-tm">
+      <div class="radiobutton-3-tm"></div>
+      <span class="radiobutton-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/radio-button-tm/style.css
+++ b/submissions/examples/radio-button-tm/style.css
@@ -1,0 +1,61 @@
+:root {
+  --radiobutton-bg: #0e0a1a;
+  --radiobutton-surface: #1a1329;
+  --radiobutton-edge: #261a3a;
+  --radiobutton-text: #e6e8ec;
+  --radiobutton-muted: #8b909b;
+  --radiobutton-accent: #a78bfa;
+  --radiobutton-accent-2: #f472b6;
+  --radiobutton-radius: 10px;
+  --radiobutton-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--radiobutton-bg);
+  color: var(--radiobutton-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.radiobutton-page-tm { max-width: 920px; margin: 0 auto; }
+.radiobutton-h-tm { font-size: 28px; margin: 0 0 8px; }
+.radiobutton-lede-tm { color: var(--radiobutton-muted); margin: 0 0 32px; }
+.radiobutton-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.radiobutton-1-wrap-tm, .radiobutton-2-wrap-tm, .radiobutton-3-wrap-tm {
+  background: var(--radiobutton-surface);
+  border: 1px solid var(--radiobutton-edge);
+  border-radius: var(--radiobutton-radius);
+  padding: var(--radiobutton-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.radiobutton-lbl-tm { color: var(--radiobutton-muted); font-size: 13px; }
+
+.radiobutton-1-tm, .radiobutton-2-tm, .radiobutton-3-tm {
+  display: inline-block; width: 20px; height: 20px; border: 2px solid #261a3a;
+  border-radius: 50%; position: relative; cursor: pointer;
+  vertical-align: middle; margin-right: 8px; transition: border-color 160ms;
+}
+.radiobutton-1-tm::after {
+  content: ""; position: absolute; inset: 4px; border-radius: 50%;
+  background: #a78bfa; transform: scale(0); transition: transform 160ms;
+}
+.radiobutton-1-tm.is-checked { border-color: #a78bfa; }
+.radiobutton-1-tm.is-checked::after { transform: scale(1); }
+.radiobutton-2-tm.is-checked { border-color: #f472b6; }
+.radiobutton-2-tm::after { background: #f472b6; }
+.radiobutton-3-tm::after { background: #8b909b; }
+.radiobutton-3-tm.is-checked { border-color: #8b909b; }


### PR DESCRIPTION
Closes #76982

## What
This submission adds a new EaseMotion CSS example: `radio-button-tm`.

A radio button styled as a soft ring whose inner dot scales in on select.

## How to review
1. Open `submissions/examples/radio-button-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/radio-button-tm/` and does not modify any existing file.
