### PR TITLE
added css-tab-cyberpunk-neon

### DIFF
--- a/submissions/examples/css-tab-neon/README.md
+++ b/submissions/examples/css-tab-neon/README.md
@@ -1,0 +1,15 @@
+# CSS Tab: Cyberpunk Neon Variation
+
+A high-performance, hardware-accelerated pure CSS segmented tab control featuring vibrant Cyberpunk Neon aesthetic styling.
+
+## Design Highlights
+
+- **Cyberpunk Aesthetic**: Features electric cyan (`#00f0ff`) and hot magenta (`#ff0055`) neon glow highlights using CSS `text-shadow` and `box-shadow`.
+- **Polygon Geometry**: Uses `clip-path: polygon()` to produce sharp, angled tech cuts on tab borders.
+- **Pure CSS Navigation**: Uses native radio inputs (`:checked`) for zero-JS tab switching.
+- **Performance & Accessibility**: Optimized hardware transitions with explicit `:focus-visible` outline rings for keyboard accessibility.
+
+## Usage
+
+1. Copy the structure from `demo.html`.
+2. Link `style.css` in your project to enable Cyberpunk Neon tab styling.

--- a/submissions/examples/css-tab-neon/demo.html
+++ b/submissions/examples/css-tab-neon/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Tab: Cyberpunk Neon Variation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="cyber-container">
+    <h1 class="glitch-title">CYBERPUNK NEON TABS</h1>
+    <p class="subtitle">Pure CSS segmented control featuring electric cyan & magenta neon glow effects.</p>
+
+    <!-- Cyberpunk Neon Tab Component -->
+    <div class="cyber-tabs-wrapper">
+      <!-- Radio inputs for pure CSS state management -->
+      <input type="radio" name="cyber-tabs" id="tab-1" class="tab-radio" checked>
+      <input type="radio" name="cyber-tabs" id="tab-2" class="tab-radio">
+      <input type="radio" name="cyber-tabs" id="tab-3" class="tab-radio">
+
+      <!-- Navigation Bar -->
+      <nav class="cyber-tab-bar" aria-label="Cyberpunk Neon Navigation">
+        <label for="tab-1" class="cyber-tab">
+          <span class="tab-label">// SYSTEM</span>
+        </label>
+        <label for="tab-2" class="cyber-tab">
+          <span class="tab-label">// MATRIX</span>
+        </label>
+        <label for="tab-3" class="cyber-tab">
+          <span class="tab-label">// NETWORK</span>
+        </label>
+      </nav>
+
+      <!-- Content Panels -->
+      <div class="panels-container">
+        <section class="panel panel-1">
+          <h2>[SYSTEM STATUS: ONLINE]</h2>
+          <p>Cyberpunk Neon segmented control styled with electric cyan drop-shadows and angled cut corners using <code>clip-path</code> polygon geometry.</p>
+        </section>
+
+        <section class="panel panel-2">
+          <h2>[MATRIX DATA LOADED]</h2>
+          <p>Zero JavaScript runtime dependencies. Tab switching is driven entirely by native CSS <code>:checked</code> state selectors.</p>
+        </section>
+
+        <section class="panel panel-3">
+          <h2>[NETWORK SECURE]</h2>
+          <p>Hardware-accelerated glow transitions and high-contrast dark themes ensure maximum performance and accessibility support.</p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-tab-neon/style.css
+++ b/submissions/examples/css-tab-neon/style.css
@@ -1,0 +1,160 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background-color: #05050a;
+  color: #00f0ff;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.cyber-container {
+  width: 100%;
+  max-width: 650px;
+  text-align: center;
+}
+
+.glitch-title {
+  font-size: 2.25rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  color: #fff;
+  text-shadow: 0 0 10px #00f0ff, 0 0 20px #00f0ff, 0 0 30px #ff0055;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #a0a0c0;
+  font-size: 0.95rem;
+  margin-bottom: 2.5rem;
+  letter-spacing: 0.05em;
+}
+
+/* Hidden Radio Controls */
+.tab-radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Tab Bar Layout */
+.cyber-tab-bar {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 1.5rem;
+}
+
+/* Cyberpunk Neon Tab Button Styling */
+.cyber-tab {
+  position: relative;
+  padding: 0.75rem 1.75rem;
+  background: #0d0e1b;
+  border: 1px solid #1a1c38;
+  color: #8a8ab0;
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  user-select: none;
+  /* Angled Cyberpunk Cut Corners */
+  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cyber-tab:hover {
+  color: #00f0ff;
+  border-color: #00f0ff;
+  box-shadow: 0 0 10px rgba(0, 240, 255, 0.3);
+}
+
+/* Active Tab State: Electric Cyan & Magenta Glow */
+#tab-1:checked ~ .cyber-tab-bar label[for="tab-1"],
+#tab-2:checked ~ .cyber-tab-bar label[for="tab-2"],
+#tab-3:checked ~ .cyber-tab-bar label[for="tab-3"] {
+  background: #00f0ff;
+  color: #05050a;
+  border-color: #00f0ff;
+  font-weight: 800;
+  box-shadow: 0 0 20px #00f0ff, 0 0 35px rgba(255, 0, 85, 0.6);
+  transform: translateY(-2px);
+}
+
+/* Accessibility Focus Indicator */
+.tab-radio:focus-visible ~ .cyber-tab-bar label[for="tab-1"],
+.tab-radio:focus-visible ~ .cyber-tab-bar label[for="tab-2"],
+.tab-radio:focus-visible ~ .cyber-tab-bar label[for="tab-3"] {
+  outline: 2px solid #ff0055;
+  outline-offset: 4px;
+}
+
+/* Panels Styling */
+.panels-container {
+  background: #0c0d1a;
+  border: 1px solid #00f0ff;
+  border-radius: 4px;
+  padding: 2rem;
+  text-align: left;
+  box-shadow: 0 0 20px rgba(0, 240, 255, 0.15), inset 0 0 15px rgba(255, 0, 85, 0.1);
+  position: relative;
+}
+
+.panel {
+  display: none;
+  animation: cyberFade 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.panel h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: #ff0055;
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 8px rgba(255, 0, 85, 0.5);
+}
+
+.panel p {
+  color: #c0c0e0;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+code {
+  background: #14152b;
+  padding: 2px 6px;
+  border-radius: 3px;
+  color: #00f0ff;
+  font-family: monospace;
+}
+
+/* Tab Switching Logic */
+#tab-1:checked ~ .panels-container .panel-1,
+#tab-2:checked ~ .panels-container .panel-2,
+#tab-3:checked ~ .panels-container .panel-3 {
+  display: block;
+}
+
+@keyframes cyberFade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Responsive Adjustments */
+@media (max-width: 480px) {
+  .cyber-tab-bar {
+    flex-direction: column;
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
# CSS Tab: Cyberpunk Neon Variation

A high-performance, hardware-accelerated pure CSS segmented tab control featuring vibrant Cyberpunk Neon aesthetic styling.

## Design Highlights

- **Cyberpunk Aesthetic**: Features electric cyan (`#00f0ff`) and hot magenta (`#ff0055`) neon glow highlights using CSS `text-shadow` and `box-shadow`.
- **Polygon Geometry**: Uses `clip-path: polygon()` to produce sharp, angled tech cuts on tab borders.
- **Pure CSS Navigation**: Uses native radio inputs (`:checked`) for zero-JS tab switching.
- **Performance & Accessibility**: Optimized hardware transitions with explicit `:focus-visible` outline rings for keyboard accessibility.

## Usage

1. Copy the structure from `demo.html`.
2. Link `style.css` in your project to enable Cyberpunk Neon tab styling.