### PR TITLE
Add kanban column hover submission

### DIFF
--- a/submissions/examples/kanban-tm/README.md
+++ b/submissions/examples/kanban-tm/README.md
@@ -1,0 +1,7 @@
+# Kanban column hover
+
+1. What does this do? A three-column kanban where the column header shifts on hover.
+
+2. How is it used? Add `kanban-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Project board pattern; columns highlight on hover to indicate drop targets.

--- a/submissions/examples/kanban-tm/demo.html
+++ b/submissions/examples/kanban-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Kanban — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="kanban-page-tm" data-palette="forest">
+  <h1 class="kanban-h-tm">Kanban</h1>
+  <p class="kanban-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="kanban-row-tm">
+    <article class="kanban-1-wrap-tm">
+      <div class="kanban-1-tm"></div>
+      <span class="kanban-lbl-tm">Example One</span>
+    </article>
+    <article class="kanban-2-wrap-tm">
+      <div class="kanban-2-tm"></div>
+      <span class="kanban-lbl-tm">Example Two</span>
+    </article>
+    <article class="kanban-3-wrap-tm">
+      <div class="kanban-3-tm"></div>
+      <span class="kanban-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/kanban-tm/style.css
+++ b/submissions/examples/kanban-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --kanban-bg: #0d1612;
+  --kanban-surface: #152721;
+  --kanban-edge: #1f3530;
+  --kanban-text: #e6e8ec;
+  --kanban-muted: #8b909b;
+  --kanban-accent: #2ecc71;
+  --kanban-accent-2: #a3e635;
+  --kanban-radius: 10px;
+  --kanban-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--kanban-bg);
+  color: var(--kanban-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.kanban-page-tm { max-width: 920px; margin: 0 auto; }
+.kanban-h-tm { font-size: 28px; margin: 0 0 8px; }
+.kanban-lede-tm { color: var(--kanban-muted); margin: 0 0 32px; }
+.kanban-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.kanban-1-wrap-tm, .kanban-2-wrap-tm, .kanban-3-wrap-tm {
+  background: var(--kanban-surface);
+  border: 1px solid var(--kanban-edge);
+  border-radius: var(--kanban-radius);
+  padding: var(--kanban-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.kanban-lbl-tm { color: var(--kanban-muted); font-size: 13px; }
+
+.kanban-1-tm, .kanban-2-tm, .kanban-3-tm {
+      display: flex; flex-direction: column; gap: 8px; padding: 12px; width: 100%;
+      min-height: 120px; background: #152721; border: 1px solid #1f3530; border-radius: 8px;
+      transition: background 200ms;
+}
+.kanban-1-tm:hover { background: #2ecc7111; border-color: #2ecc71; }
+.kanban-1-tm h4 { margin: 0 0 4px; font-size: 12px; color: #8b909b; text-transform: uppercase; letter-spacing: 0.05em; }
+.kanban-2-tm:hover { background: #a3e63511; border-color: #a3e635; }
+.kanban-3-tm:hover { background: #8b909b11; border-color: #8b909b; }


### PR DESCRIPTION
Closes #77027

## What
This submission adds a new EaseMotion CSS example: `kanban-tm`.

A three-column kanban where the column header shifts on hover.

## How to review
1. Open `submissions/examples/kanban-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/kanban-tm/` and does not modify any existing file.
