### PR TITLE
Add avatar tile submission

### DIFF
--- a/submissions/examples/avatar-tile-tm/README.md
+++ b/submissions/examples/avatar-tile-tm/README.md
@@ -1,0 +1,7 @@
+# Avatar tile
+
+1. What does this do? A square tile that pairs an avatar with a name and role.
+
+2. How is it used? Add `avatar-tile-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Team / contact-card pattern; avatar is centred in a coloured background.

--- a/submissions/examples/avatar-tile-tm/demo.html
+++ b/submissions/examples/avatar-tile-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Avatar Tile — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="avatartile-page-tm" data-palette="ruby">
+  <h1 class="avatartile-h-tm">Avatar Tile</h1>
+  <p class="avatartile-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="avatartile-row-tm">
+    <article class="avatartile-1-wrap-tm">
+      <div class="avatartile-1-tm"></div>
+      <span class="avatartile-lbl-tm">Example One</span>
+    </article>
+    <article class="avatartile-2-wrap-tm">
+      <div class="avatartile-2-tm"></div>
+      <span class="avatartile-lbl-tm">Example Two</span>
+    </article>
+    <article class="avatartile-3-wrap-tm">
+      <div class="avatartile-3-tm"></div>
+      <span class="avatartile-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/avatar-tile-tm/style.css
+++ b/submissions/examples/avatar-tile-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --avatartile-bg: #160a0d;
+  --avatartile-surface: #261418;
+  --avatartile-edge: #36191e;
+  --avatartile-text: #e6e8ec;
+  --avatartile-muted: #8b909b;
+  --avatartile-accent: #ef4444;
+  --avatartile-accent-2: #fb7185;
+  --avatartile-radius: 10px;
+  --avatartile-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--avatartile-bg);
+  color: var(--avatartile-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.avatartile-page-tm { max-width: 920px; margin: 0 auto; }
+.avatartile-h-tm { font-size: 28px; margin: 0 0 8px; }
+.avatartile-lede-tm { color: var(--avatartile-muted); margin: 0 0 32px; }
+.avatartile-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.avatartile-1-wrap-tm, .avatartile-2-wrap-tm, .avatartile-3-wrap-tm {
+  background: var(--avatartile-surface);
+  border: 1px solid var(--avatartile-edge);
+  border-radius: var(--avatartile-radius);
+  padding: var(--avatartile-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.avatartile-lbl-tm { color: var(--avatartile-muted); font-size: 13px; }
+
+.avatartile-1-tm, .avatartile-2-tm, .avatartile-3-tm {
+      display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 16px;
+      background: #261418; border: 1px solid #36191e; border-radius: 12px; text-align: center;
+}
+.avatartile-1-tm span, .avatartile-2-tm span, .avatartile-3-tm span {
+      width: 56px; height: 56px; border-radius: 14px; background: #ef444433; color: #ef4444;
+      display: grid; place-items: center; font-weight: 700; font-size: 18px;
+}
+.avatartile-2-tm span { background: #fb718533; color: #fb7185; }
+.avatartile-3-tm span { background: #8b909b33; color: #8b909b; }


### PR DESCRIPTION
Closes #77046

## What
This submission adds a new EaseMotion CSS example: `avatar-tile-tm`.

A square tile that pairs an avatar with a name and role.

## How to review
1. Open `submissions/examples/avatar-tile-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/avatar-tile-tm/` and does not modify any existing file.
