### PR TITLE
Add stat card submission

### DIFF
--- a/submissions/examples/stat-card-tm/README.md
+++ b/submissions/examples/stat-card-tm/README.md
@@ -1,0 +1,7 @@
+# Stat card
+
+1. What does this do? A small metric card with a big number, a label, and a delta indicator.
+
+2. How is it used? Add `stat-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Dashboard tile pattern; delta can be positive (green) or negative (red).

--- a/submissions/examples/stat-card-tm/demo.html
+++ b/submissions/examples/stat-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Stat Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="statcard-page-tm" data-palette="gold">
+  <h1 class="statcard-h-tm">Stat Card</h1>
+  <p class="statcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="statcard-row-tm">
+    <article class="statcard-1-wrap-tm">
+      <div class="statcard-1-tm"></div>
+      <span class="statcard-lbl-tm">Example One</span>
+    </article>
+    <article class="statcard-2-wrap-tm">
+      <div class="statcard-2-tm"></div>
+      <span class="statcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="statcard-3-wrap-tm">
+      <div class="statcard-3-tm"></div>
+      <span class="statcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/stat-card-tm/style.css
+++ b/submissions/examples/stat-card-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --statcard-bg: #13110b;
+  --statcard-surface: #221e14;
+  --statcard-edge: #332c1c;
+  --statcard-text: #e6e8ec;
+  --statcard-muted: #8b909b;
+  --statcard-accent: #facc15;
+  --statcard-accent-2: #fbbf24;
+  --statcard-radius: 10px;
+  --statcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--statcard-bg);
+  color: var(--statcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.statcard-page-tm { max-width: 920px; margin: 0 auto; }
+.statcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.statcard-lede-tm { color: var(--statcard-muted); margin: 0 0 32px; }
+.statcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.statcard-1-wrap-tm, .statcard-2-wrap-tm, .statcard-3-wrap-tm {
+  background: var(--statcard-surface);
+  border: 1px solid var(--statcard-edge);
+  border-radius: var(--statcard-radius);
+  padding: var(--statcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.statcard-lbl-tm { color: var(--statcard-muted); font-size: 13px; }
+
+.statcard-1-tm, .statcard-2-tm, .statcard-3-tm {
+      padding: 16px; background: #221e14; border: 1px solid #332c1c; border-radius: 10px;
+      position: relative;
+}
+.statcard-1-tm .sc-num-tm { display: block; font-size: 28px; font-weight: 800; color: #facc15; }
+.statcard-1-tm small { color: #8b909b; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+.statcard-1-tm .sc-delta-tm { position: absolute; top: 16px; right: 16px; font-size: 12px; padding: 2px 6px; border-radius: 4px; background: #2ecc7133; color: #2ecc71; }
+.statcard-2-tm .sc-num-tm { color: #fbbf24; }
+.statcard-3-tm .sc-num-tm { color: #8b909b; }


### PR DESCRIPTION
Closes #77055

## What
This submission adds a new EaseMotion CSS example: `stat-card-tm`.

A small metric card with a big number, a label, and a delta indicator.

## How to review
1. Open `submissions/examples/stat-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/stat-card-tm/` and does not modify any existing file.
