### PR TITLE
Add noise texture background submission

### DIFF
--- a/submissions/examples/noise-bg-tm/README.md
+++ b/submissions/examples/noise-bg-tm/README.md
@@ -1,0 +1,7 @@
+# Noise texture background
+
+1. What does this do? A background with a subtle film-grain noise overlay.
+
+2. How is it used? Add `noise-bg-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Hero / detail-page pattern; noise adds texture without an image asset.

--- a/submissions/examples/noise-bg-tm/demo.html
+++ b/submissions/examples/noise-bg-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Noise Bg — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="noisebg-page-tm" data-palette="rose">
+  <h1 class="noisebg-h-tm">Noise Bg</h1>
+  <p class="noisebg-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="noisebg-row-tm">
+    <article class="noisebg-1-wrap-tm">
+      <div class="noisebg-1-tm"></div>
+      <span class="noisebg-lbl-tm">Example One</span>
+    </article>
+    <article class="noisebg-2-wrap-tm">
+      <div class="noisebg-2-tm"></div>
+      <span class="noisebg-lbl-tm">Example Two</span>
+    </article>
+    <article class="noisebg-3-wrap-tm">
+      <div class="noisebg-3-tm"></div>
+      <span class="noisebg-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/noise-bg-tm/style.css
+++ b/submissions/examples/noise-bg-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --noisebg-bg: #160d12;
+  --noisebg-surface: #26141c;
+  --noisebg-edge: #361b25;
+  --noisebg-text: #e6e8ec;
+  --noisebg-muted: #8b909b;
+  --noisebg-accent: #ff5c8a;
+  --noisebg-accent-2: #ffb4d2;
+  --noisebg-radius: 10px;
+  --noisebg-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--noisebg-bg);
+  color: var(--noisebg-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.noisebg-page-tm { max-width: 920px; margin: 0 auto; }
+.noisebg-h-tm { font-size: 28px; margin: 0 0 8px; }
+.noisebg-lede-tm { color: var(--noisebg-muted); margin: 0 0 32px; }
+.noisebg-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.noisebg-1-wrap-tm, .noisebg-2-wrap-tm, .noisebg-3-wrap-tm {
+  background: var(--noisebg-surface);
+  border: 1px solid var(--noisebg-edge);
+  border-radius: var(--noisebg-radius);
+  padding: var(--noisebg-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.noisebg-lbl-tm { color: var(--noisebg-muted); font-size: 13px; }
+
+.noisebg-1-tm, .noisebg-2-tm, .noisebg-3-tm {
+      width: 100%; min-height: 120px; border-radius: 12px; background: #26141c; position: relative; overflow: hidden;
+}
+.noisebg-1-tm::after, .noisebg-2-tm::after, .noisebg-3-tm::after {
+      content: ""; position: absolute; inset: 0; opacity: 0.15; mix-blend-mode: overlay;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns=%27http://www.w3.org/2000/svg%27 width=%27120%27 height=%27120%27><filter id=%27n%27><feTurbulence type=%27fractalNoise%27 baseFrequency=%270.9%27/></filter><rect width=%27100%25%27 height=%27100%25%27 filter=%27url(%23n)%27 opacity=%270.4%27/></svg>");
+}
+.noisebg-1-tm { background: linear-gradient(135deg, #ff5c8a22, #26141c); }
+.noisebg-2-tm { background: linear-gradient(135deg, #ffb4d222, #26141c); }
+.noisebg-3-tm { background: linear-gradient(135deg, #8b909b22, #26141c); }


### PR DESCRIPTION
Closes #77101

## What
This submission adds a new EaseMotion CSS example: `noise-bg-tm`.

A background with a subtle film-grain noise overlay.

## How to review
1. Open `submissions/examples/noise-bg-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/noise-bg-tm/` and does not modify any existing file.
