### PR TITLE
feat: add ease-coconut-fall-ij demo component

### DIFF
--- a/submissions/examples/ease-coconut-fall-ij/README.md
+++ b/submissions/examples/ease-coconut-fall-ij/README.md
@@ -1,0 +1,20 @@
+# Ease Coconut Fall
+
+A lightweight demo component that drops falling elements. Built with plain CSS keyframe
+animations and a couple of lines of vanilla JavaScript. No libraries, no
+build step.
+
+## Files
+
+- `demo.html` — the demo page and inline script
+- `style.css` — all styles and keyframes
+- `README.md` — this file
+
+## How to run
+
+Open `demo.html` in any modern browser, or serve this folder with a static
+file server such as `npx serve`.
+
+## Interactivity
+
+Press the **Pause / Play** button to pause or resume the animation.

--- a/submissions/examples/ease-coconut-fall-ij/demo.html
+++ b/submissions/examples/ease-coconut-fall-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Coconut Fall Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage">
+    <header class="stage-header">
+      <h1>Coconut Fall</h1>
+      <p>Plain CSS animation demo with a pause toggle.</p>
+    </header>
+    <section class="scene" aria-label="Coconut Fall animation">
+      <div class="faller f1" role="presentation"></div><div class="faller f2" role="presentation"></div><div class="faller f3" role="presentation"></div>
+    </section>
+    <button class="toggle" type="button">Pause</button>
+  </main>
+  <script>
+    (function () {
+      var toggle = document.querySelector(".toggle");
+      var scene = document.querySelector(".scene");
+      toggle.addEventListener("click", function () {
+        var paused = scene.classList.toggle("paused");
+        toggle.textContent = paused ? "Play" : "Pause";
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-coconut-fall-ij/style.css
+++ b/submissions/examples/ease-coconut-fall-ij/style.css
@@ -1,0 +1,89 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1020;
+  color: #e8ecff;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.stage {
+  width: min(640px, 92vw);
+  padding: 2.5rem 2rem;
+  border-radius: 24px;
+  background: #151b2e;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.stage-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  color: #4cd9e6;
+}
+
+.stage-header p {
+  margin: 0 0 1.5rem;
+  color: #8b93b8;
+}
+
+.scene {
+  position: relative;
+  height: 260px;
+  margin: 0 auto;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #10152a;
+  display: grid;
+  place-items: center;
+}
+
+.scene.paused * {
+  animation-play-state: paused;
+}
+
+.toggle {
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: transparent;
+  color: #e8ecff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle:hover {
+  background: #4cd9e6;
+  color: #0b1020;
+  border-color: transparent;
+}
+
+
+.faller {
+  position: absolute;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #6c6cef;
+  animation: coconutfall-fall 2.4s ease-in infinite;
+}
+
+.faller.f1 { left: 20%; }
+.faller.f2 { left: 55%; background: #4cd9e6; animation-delay: 0.8s; }
+.faller.f3 { left: 75%; animation-delay: 1.6s; }
+
+@keyframes coconutfall-fall {
+  0% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(300px); opacity: 0.2; }
+}


### PR DESCRIPTION
Adds a working `ease-coconut-fall-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-coconut-fall-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.