### PR TITLE
feat: add ease-drum-beat-ij demo component

### DIFF
--- a/submissions/examples/ease-drum-beat-ij/README.md
+++ b/submissions/examples/ease-drum-beat-ij/README.md
@@ -1,0 +1,20 @@
+# Ease Drum Beat
+
+A lightweight demo component that expands with pulsing rings. Built with plain CSS keyframe
+animations and a couple of lines of vanilla JavaScript. No libraries, no
+build step.
+
+## Files
+
+- `demo.html` — the demo page and inline script
+- `style.css` — all styles and keyframes
+- `README.md` — this file
+
+## How to run
+
+Open `demo.html` in any modern browser, or serve this folder with a static
+file server such as `npx serve`.
+
+## Interactivity
+
+Press the **Pause / Play** button to pause or resume the animation.

--- a/submissions/examples/ease-drum-beat-ij/demo.html
+++ b/submissions/examples/ease-drum-beat-ij/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drum Beat Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="stage">
+    <header class="stage-header">
+      <h1>Drum Beat</h1>
+      <p>Plain CSS animation demo with a pause toggle.</p>
+    </header>
+    <section class="scene" aria-label="Drum Beat animation">
+      <div class="pulse-ring r1" role="presentation"></div><div class="pulse-ring r2" role="presentation"></div><div class="pulse-ring r3" role="presentation"></div><div class="pulse-dot" role="presentation"></div>
+    </section>
+    <button class="toggle" type="button">Pause</button>
+  </main>
+  <script>
+    (function () {
+      var toggle = document.querySelector(".toggle");
+      var scene = document.querySelector(".scene");
+      toggle.addEventListener("click", function () {
+        var paused = scene.classList.toggle("paused");
+        toggle.textContent = paused ? "Play" : "Pause";
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drum-beat-ij/style.css
+++ b/submissions/examples/ease-drum-beat-ij/style.css
@@ -1,0 +1,100 @@
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1020;
+  color: #e8ecff;
+  font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.stage {
+  width: min(640px, 92vw);
+  padding: 2.5rem 2rem;
+  border-radius: 24px;
+  background: #151b2e;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.stage-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  color: #614ce6;
+}
+
+.stage-header p {
+  margin: 0 0 1.5rem;
+  color: #8b93b8;
+}
+
+.scene {
+  position: relative;
+  height: 260px;
+  margin: 0 auto;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  overflow: hidden;
+  background: #10152a;
+  display: grid;
+  place-items: center;
+}
+
+.scene.paused * {
+  animation-play-state: paused;
+}
+
+.toggle {
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: transparent;
+  color: #e8ecff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toggle:hover {
+  background: #614ce6;
+  color: #0b1020;
+  border-color: transparent;
+}
+
+
+.pulse-ring {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 3px solid #614ce6;
+  animation: drumbeat-pulse 2.6s ease-out infinite;
+}
+
+.pulse-ring.r2 { animation-delay: 0.9s; }
+.pulse-ring.r3 { animation-delay: 1.8s; }
+
+.pulse-dot {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #ef6ce8;
+  animation: drumbeat-blip 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes drumbeat-pulse {
+  from { transform: scale(0.35); opacity: 0.95; }
+  to { transform: scale(1.6); opacity: 0; }
+}
+
+@keyframes drumbeat-blip {
+  from { transform: scale(0.8); opacity: 0.5; }
+  to { transform: scale(1.2); opacity: 1; }
+}


### PR DESCRIPTION
Adds a working `ease-drum-beat-ij` demo component (demo.html, style.css, README.md) under `submissions/examples/ease-drum-beat-ij/`.

Built with plain CSS transitions and a few lines of JS, no libraries.