### PR TITLE
Add linear progress bar submission

### DIFF
--- a/submissions/examples/progress-line-tm/README.md
+++ b/submissions/examples/progress-line-tm/README.md
@@ -1,0 +1,7 @@
+# Linear progress bar
+
+1. What does this do? A horizontal bar that fills to a target percentage with a smooth ease.
+
+2. How is it used? Add `progress-line-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Loading / completion pattern; bar grows on first paint.

--- a/submissions/examples/progress-line-tm/demo.html
+++ b/submissions/examples/progress-line-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Progress Line — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="progressline-page-tm" data-palette="cool">
+  <h1 class="progressline-h-tm">Progress Line</h1>
+  <p class="progressline-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="progressline-row-tm">
+    <article class="progressline-1-wrap-tm">
+      <div class="progressline-1-tm"></div>
+      <span class="progressline-lbl-tm">Example One</span>
+    </article>
+    <article class="progressline-2-wrap-tm">
+      <div class="progressline-2-tm"></div>
+      <span class="progressline-lbl-tm">Example Two</span>
+    </article>
+    <article class="progressline-3-wrap-tm">
+      <div class="progressline-3-tm"></div>
+      <span class="progressline-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/progress-line-tm/style.css
+++ b/submissions/examples/progress-line-tm/style.css
@@ -1,0 +1,57 @@
+:root {
+  --progressline-bg: #0a0e1a;
+  --progressline-surface: #131829;
+  --progressline-edge: #1d2438;
+  --progressline-text: #e6e8ec;
+  --progressline-muted: #8b909b;
+  --progressline-accent: #4dabf7;
+  --progressline-accent-2: #9b8cff;
+  --progressline-radius: 10px;
+  --progressline-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--progressline-bg);
+  color: var(--progressline-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.progressline-page-tm { max-width: 920px; margin: 0 auto; }
+.progressline-h-tm { font-size: 28px; margin: 0 0 8px; }
+.progressline-lede-tm { color: var(--progressline-muted); margin: 0 0 32px; }
+.progressline-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.progressline-1-wrap-tm, .progressline-2-wrap-tm, .progressline-3-wrap-tm {
+  background: var(--progressline-surface);
+  border: 1px solid var(--progressline-edge);
+  border-radius: var(--progressline-radius);
+  padding: var(--progressline-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.progressline-lbl-tm { color: var(--progressline-muted); font-size: 13px; }
+
+.progressline-1-tm, .progressline-2-tm, .progressline-3-tm {
+      width: 100%; height: 8px; background: #1d2438; border-radius: 4px; overflow: hidden;
+}
+.progressline-1-tm::after, .progressline-2-tm::after, .progressline-3-tm::after {
+      content: ""; display: block; height: 100%; width: 60%;
+      background: linear-gradient(to right, #4dabf7, #9b8cff);
+      animation: kf-progressline-v1 1.6s ease-in-out infinite alternate;
+}
+@keyframes kf-progressline-v1 { from { width: 30%; } to { width: 80%; } }
+.progressline-2-tm::after { background: linear-gradient(to right, #9b8cff, #4dabf7); }
+.progressline-3-tm::after { background: #8b909b; }


### PR DESCRIPTION
Closes #77249

## What
This submission adds a new EaseMotion CSS example: `progress-line-tm`.

A horizontal bar that fills to a target percentage with a smooth ease.

## How to review
1. Open `submissions/examples/progress-line-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/progress-line-tm/` and does not modify any existing file.
