### PR TITLE
Add step indicator submission

### DIFF
--- a/submissions/examples/step-indicator-tm/README.md
+++ b/submissions/examples/step-indicator-tm/README.md
@@ -1,0 +1,7 @@
+# Step indicator
+
+1. What does this do? A row of numbered circles connected by lines, with a current step highlighted.
+
+2. How is it used? Add `step-indicator-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Wizard / form-step pattern; current step pulses subtly.

--- a/submissions/examples/step-indicator-tm/demo.html
+++ b/submissions/examples/step-indicator-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Step Indicator — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="stepindicator-page-tm" data-palette="forest">
+  <h1 class="stepindicator-h-tm">Step Indicator</h1>
+  <p class="stepindicator-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="stepindicator-row-tm">
+    <article class="stepindicator-1-wrap-tm">
+      <div class="stepindicator-1-tm"></div>
+      <span class="stepindicator-lbl-tm">Example One</span>
+    </article>
+    <article class="stepindicator-2-wrap-tm">
+      <div class="stepindicator-2-tm"></div>
+      <span class="stepindicator-lbl-tm">Example Two</span>
+    </article>
+    <article class="stepindicator-3-wrap-tm">
+      <div class="stepindicator-3-tm"></div>
+      <span class="stepindicator-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/step-indicator-tm/style.css
+++ b/submissions/examples/step-indicator-tm/style.css
@@ -1,0 +1,57 @@
+:root {
+  --stepindicator-bg: #0d1612;
+  --stepindicator-surface: #152721;
+  --stepindicator-edge: #1f3530;
+  --stepindicator-text: #e6e8ec;
+  --stepindicator-muted: #8b909b;
+  --stepindicator-accent: #2ecc71;
+  --stepindicator-accent-2: #a3e635;
+  --stepindicator-radius: 10px;
+  --stepindicator-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--stepindicator-bg);
+  color: var(--stepindicator-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.stepindicator-page-tm { max-width: 920px; margin: 0 auto; }
+.stepindicator-h-tm { font-size: 28px; margin: 0 0 8px; }
+.stepindicator-lede-tm { color: var(--stepindicator-muted); margin: 0 0 32px; }
+.stepindicator-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.stepindicator-1-wrap-tm, .stepindicator-2-wrap-tm, .stepindicator-3-wrap-tm {
+  background: var(--stepindicator-surface);
+  border: 1px solid var(--stepindicator-edge);
+  border-radius: var(--stepindicator-radius);
+  padding: var(--stepindicator-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.stepindicator-lbl-tm { color: var(--stepindicator-muted); font-size: 13px; }
+
+.stepindicator-1-tm, .stepindicator-2-tm, .stepindicator-3-tm {
+      display: flex; align-items: center; gap: 8px; padding: 8px 0;
+}
+.stepindicator-1-tm span, .stepindicator-2-tm span, .stepindicator-3-tm span {
+      width: 28px; height: 28px; border-radius: 50%; display: grid; place-items: center;
+      background: #1f3530; color: #8b909b; font-size: 12px; font-weight: 600;
+}
+.stepindicator-1-tm span.done { background: #2ecc71; color: #0f1115; }
+.stepindicator-1-tm span.current { background: #a3e635; color: #0a0e1a; box-shadow: 0 0 0 4px #a3e63533; }
+.stepindicator-2-tm span.done { background: #a3e635; color: #0a0e1a; }
+.stepindicator-3-tm span.done { background: #8b909b; color: #0e0a1a; }


### PR DESCRIPTION
Closes #77258

## What
This submission adds a new EaseMotion CSS example: `step-indicator-tm`.

A row of numbered circles connected by lines, with a current step highlighted.

## How to review
1. Open `submissions/examples/step-indicator-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/step-indicator-tm/` and does not modify any existing file.
