### PR TITLE
Add character reveal submission

### DIFF
--- a/submissions/examples/split-text-tm/README.md
+++ b/submissions/examples/split-text-tm/README.md
@@ -1,0 +1,7 @@
+# Character reveal
+
+1. What does this do? A headline whose characters fade and rise into place on first paint.
+
+2. How is it used? Add `split-text-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Hero / intro pattern; characters are wrapped in spans via JS or HTML.

--- a/submissions/examples/split-text-tm/demo.html
+++ b/submissions/examples/split-text-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Split Text — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="splittext-page-tm" data-palette="amber">
+  <h1 class="splittext-h-tm">Split Text</h1>
+  <p class="splittext-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="splittext-row-tm">
+    <article class="splittext-1-wrap-tm">
+      <div class="splittext-1-tm"></div>
+      <span class="splittext-lbl-tm">Example One</span>
+    </article>
+    <article class="splittext-2-wrap-tm">
+      <div class="splittext-2-tm"></div>
+      <span class="splittext-lbl-tm">Example Two</span>
+    </article>
+    <article class="splittext-3-wrap-tm">
+      <div class="splittext-3-tm"></div>
+      <span class="splittext-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/split-text-tm/style.css
+++ b/submissions/examples/split-text-tm/style.css
@@ -1,0 +1,61 @@
+:root {
+  --splittext-bg: #161208;
+  --splittext-surface: #261d10;
+  --splittext-edge: #352817;
+  --splittext-text: #e6e8ec;
+  --splittext-muted: #8b909b;
+  --splittext-accent: #ffb13b;
+  --splittext-accent-2: #ff7b00;
+  --splittext-radius: 10px;
+  --splittext-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--splittext-bg);
+  color: var(--splittext-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.splittext-page-tm { max-width: 920px; margin: 0 auto; }
+.splittext-h-tm { font-size: 28px; margin: 0 0 8px; }
+.splittext-lede-tm { color: var(--splittext-muted); margin: 0 0 32px; }
+.splittext-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.splittext-1-wrap-tm, .splittext-2-wrap-tm, .splittext-3-wrap-tm {
+  background: var(--splittext-surface);
+  border: 1px solid var(--splittext-edge);
+  border-radius: var(--splittext-radius);
+  padding: var(--splittext-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.splittext-lbl-tm { color: var(--splittext-muted); font-size: 13px; }
+
+.splittext-1-tm, .splittext-2-tm, .splittext-3-tm {
+      font-size: 32px; font-weight: 700;
+}
+.splittext-1-tm span, .splittext-2-tm span, .splittext-3-tm span {
+      display: inline-block; opacity: 0; transform: translateY(20px);
+      animation: kf-splittext-v1 500ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+.splittext-1-tm span:nth-child(1) { animation-delay: 0ms; }
+.splittext-1-tm span:nth-child(2) { animation-delay: 60ms; }
+.splittext-1-tm span:nth-child(3) { animation-delay: 120ms; }
+.splittext-1-tm span:nth-child(4) { animation-delay: 180ms; }
+.splittext-1-tm span:nth-child(5) { animation-delay: 240ms; }
+@keyframes kf-splittext-v1 { to { opacity: 1; transform: translateY(0); } }
+.splittext-2-tm { color: #ff7b00; }
+.splittext-3-tm { color: #8b909b; }


### PR DESCRIPTION
Closes #77274

## What
This submission adds a new EaseMotion CSS example: `split-text-tm`.

A headline whose characters fade and rise into place on first paint.

## How to review
1. Open `submissions/examples/split-text-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/split-text-tm/` and does not modify any existing file.
