### PR TITLE
Add cross-fading text submission

### DIFF
--- a/submissions/examples/fade-text-tm/README.md
+++ b/submissions/examples/fade-text-tm/README.md
@@ -1,0 +1,7 @@
+# Cross-fading text
+
+1. What does this do? A block of text that cycles through three phrases with a soft cross-fade.
+
+2. How is it used? Add `fade-text-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Tagline / status pattern; the cross-fade is keyed off animation-delay.

--- a/submissions/examples/fade-text-tm/demo.html
+++ b/submissions/examples/fade-text-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Fade Text — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="fadetext-page-tm" data-palette="violet">
+  <h1 class="fadetext-h-tm">Fade Text</h1>
+  <p class="fadetext-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="fadetext-row-tm">
+    <article class="fadetext-1-wrap-tm">
+      <div class="fadetext-1-tm"></div>
+      <span class="fadetext-lbl-tm">Example One</span>
+    </article>
+    <article class="fadetext-2-wrap-tm">
+      <div class="fadetext-2-tm"></div>
+      <span class="fadetext-lbl-tm">Example Two</span>
+    </article>
+    <article class="fadetext-3-wrap-tm">
+      <div class="fadetext-3-tm"></div>
+      <span class="fadetext-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/fade-text-tm/style.css
+++ b/submissions/examples/fade-text-tm/style.css
@@ -1,0 +1,59 @@
+:root {
+  --fadetext-bg: #0e0a1a;
+  --fadetext-surface: #1a1329;
+  --fadetext-edge: #261a3a;
+  --fadetext-text: #e6e8ec;
+  --fadetext-muted: #8b909b;
+  --fadetext-accent: #a78bfa;
+  --fadetext-accent-2: #f472b6;
+  --fadetext-radius: 10px;
+  --fadetext-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--fadetext-bg);
+  color: var(--fadetext-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.fadetext-page-tm { max-width: 920px; margin: 0 auto; }
+.fadetext-h-tm { font-size: 28px; margin: 0 0 8px; }
+.fadetext-lede-tm { color: var(--fadetext-muted); margin: 0 0 32px; }
+.fadetext-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.fadetext-1-wrap-tm, .fadetext-2-wrap-tm, .fadetext-3-wrap-tm {
+  background: var(--fadetext-surface);
+  border: 1px solid var(--fadetext-edge);
+  border-radius: var(--fadetext-radius);
+  padding: var(--fadetext-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.fadetext-lbl-tm { color: var(--fadetext-muted); font-size: 13px; }
+
+.fadetext-1-tm, .fadetext-2-tm, .fadetext-3-tm {
+      position: relative; height: 32px; font-size: 18px; font-weight: 600;
+}
+.fadetext-1-tm span, .fadetext-2-tm span, .fadetext-3-tm span {
+      position: absolute; left: 0; opacity: 0; animation: kf-fadetext-v1 9s infinite;
+}
+.fadetext-1-tm span:nth-child(1) { animation-delay: 0s; color: #a78bfa; }
+.fadetext-1-tm span:nth-child(2) { animation-delay: 3s; color: #f472b6; }
+.fadetext-1-tm span:nth-child(3) { animation-delay: 6s; color: #8b909b; }
+@keyframes kf-fadetext-v1 {
+  0%, 30% { opacity: 1; }
+  35%, 100% { opacity: 0; }
+}


### PR DESCRIPTION
Closes #77276

## What
This submission adds a new EaseMotion CSS example: `fade-text-tm`.

A block of text that cycles through three phrases with a soft cross-fade.

## How to review
1. Open `submissions/examples/fade-text-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/fade-text-tm/` and does not modify any existing file.
