### PR TITLE
feat: add basic count summary row demo

### DIFF
--- a/submissions/examples/basic-count-summary-row-kk/README.md
+++ b/submissions/examples/basic-count-summary-row-kk/README.md
@@ -1,0 +1,40 @@
+# Basic Count Summary Row
+
+## What it does
+
+This submission adds a simple CSS-only count summary row for showing a count value, descriptive text, and a small right-side label.
+
+It works well for dashboards, admin panels, list summaries, profile sections, project cards, and compact overview blocks.
+
+## How to use it
+
+Add the utility class to a row containing a count, copy, and optional label:
+
+```html
+<div class="basic-count-summary-row">
+  <strong>128</strong>
+  <div class="count-copy">
+    <span>Total files</span>
+    <p>Documents uploaded this month.</p>
+  </div>
+  <span class="count-label">Updated</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across common summary interfaces. The layout makes counts and supporting information easy to scan without JavaScript or external libraries.
+
+## Included features
+
+- Count value, label, helper copy, and status layout
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the count summary row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-count-summary-row-kk/demo.html
+++ b/submissions/examples/basic-count-summary-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Count Summary Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Count Summary Row</p>
+          <h1>Compact count rows for lists, dashboards, and summaries.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a count value with descriptive copy
+            and a small right-side label for quick dashboard summaries.
+          </p>
+        </header>
+
+        <section class="count-panel" aria-label="Count summary row examples">
+          <div class="basic-count-summary-row">
+            <strong>128</strong>
+            <div class="count-copy">
+              <span>Total files</span>
+              <p>Documents uploaded this month.</p>
+            </div>
+            <span class="count-label">Updated</span>
+          </div>
+
+          <div class="basic-count-summary-row">
+            <strong>24</strong>
+            <div class="count-copy">
+              <span>Open tasks</span>
+              <p>Items waiting for review.</p>
+            </div>
+            <span class="count-label">Active</span>
+          </div>
+
+          <div class="basic-count-summary-row">
+            <strong>09</strong>
+            <div class="count-copy">
+              <span>Team notes</span>
+              <p>Shared updates from collaborators.</p>
+            </div>
+            <span class="count-label">New</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-count-summary-row"&gt;
+  &lt;strong&gt;128&lt;/strong&gt;
+  &lt;div class="count-copy"&gt;
+    &lt;span&gt;Total files&lt;/span&gt;
+    &lt;p&gt;Documents uploaded this month.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="count-label"&gt;Updated&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-count-summary-row-kk/style.css
+++ b/submissions/examples/basic-count-summary-row-kk/style.css
@@ -1,0 +1,150 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #93c5fd;
+  --accent-soft: rgba(147, 197, 253, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(147, 197, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(167, 243, 208, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.count-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-count-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-count-summary-row + .basic-count-summary-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-count-summary-row > strong {
+  width: 3.1rem;
+  flex: 0 0 3.1rem;
+  color: var(--accent);
+  font-size: 1.55rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.count-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.count-copy span {
+  display: block;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.count-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.count-label {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.4rem 0.68rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-count-summary-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .count-label {
+    margin-left: 4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Count Summary Row demo inside `submissions/examples/basic-count-summary-row-kk/`. This submission introduces a compact CSS-only row pattern for showing counts, helper copy, and small labels in dashboards, admin panels, list summaries, and overview blocks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only count summary row for showing a count value, descriptive text, and a small right-side label.

**How does a developer use it?**

```html
<div class="basic-count-summary-row">
  <strong>128</strong>
  <div class="count-copy">
    <span>Total files</span>
    <p>Documents uploaded this month.</p>
  </div>
  <span class="count-label">Updated</span>
</div>