### PR TITLE
Add dual-ring spinner submission

### DIFF
--- a/submissions/examples/spinner-dual-tm/README.md
+++ b/submissions/examples/spinner-dual-tm/README.md
@@ -1,0 +1,7 @@
+# Dual-ring spinner
+
+1. What does this do? Two concentric rings rotating in opposite directions.
+
+2. How is it used? Add `spinner-dual-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Loading pattern with a touch more visual interest than a single ring.

--- a/submissions/examples/spinner-dual-tm/demo.html
+++ b/submissions/examples/spinner-dual-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Spinner Dual — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="spinnerdual-page-tm" data-palette="forest">
+  <h1 class="spinnerdual-h-tm">Spinner Dual</h1>
+  <p class="spinnerdual-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="spinnerdual-row-tm">
+    <article class="spinnerdual-1-wrap-tm">
+      <div class="spinnerdual-1-tm"></div>
+      <span class="spinnerdual-lbl-tm">Example One</span>
+    </article>
+    <article class="spinnerdual-2-wrap-tm">
+      <div class="spinnerdual-2-tm"></div>
+      <span class="spinnerdual-lbl-tm">Example Two</span>
+    </article>
+    <article class="spinnerdual-3-wrap-tm">
+      <div class="spinnerdual-3-tm"></div>
+      <span class="spinnerdual-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/spinner-dual-tm/style.css
+++ b/submissions/examples/spinner-dual-tm/style.css
@@ -1,0 +1,59 @@
+:root {
+  --spinnerdual-bg: #0d1612;
+  --spinnerdual-surface: #152721;
+  --spinnerdual-edge: #1f3530;
+  --spinnerdual-text: #e6e8ec;
+  --spinnerdual-muted: #8b909b;
+  --spinnerdual-accent: #2ecc71;
+  --spinnerdual-accent-2: #a3e635;
+  --spinnerdual-radius: 10px;
+  --spinnerdual-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--spinnerdual-bg);
+  color: var(--spinnerdual-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.spinnerdual-page-tm { max-width: 920px; margin: 0 auto; }
+.spinnerdual-h-tm { font-size: 28px; margin: 0 0 8px; }
+.spinnerdual-lede-tm { color: var(--spinnerdual-muted); margin: 0 0 32px; }
+.spinnerdual-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.spinnerdual-1-wrap-tm, .spinnerdual-2-wrap-tm, .spinnerdual-3-wrap-tm {
+  background: var(--spinnerdual-surface);
+  border: 1px solid var(--spinnerdual-edge);
+  border-radius: var(--spinnerdual-radius);
+  padding: var(--spinnerdual-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.spinnerdual-lbl-tm { color: var(--spinnerdual-muted); font-size: 13px; }
+
+.spinnerdual-1-tm, .spinnerdual-2-tm, .spinnerdual-3-tm {
+      width: 40px; height: 40px; position: relative;
+}
+.spinnerdual-1-tm::before, .spinnerdual-1-tm::after {
+      content: ""; position: absolute; inset: 0; border-radius: 50%;
+      border: 2px solid transparent;
+}
+.spinnerdual-1-tm::before { border-top-color: #2ecc71; animation: kf-spinnerdual-v1-a 1.2s linear infinite; }
+.spinnerdual-1-tm::after { border-bottom-color: #a3e635; animation: kf-spinnerdual-v1-b 800ms linear infinite; }
+@keyframes kf-spinnerdual-v1-a { to { transform: rotate(360deg); } }
+@keyframes kf-spinnerdual-v1-b { to { transform: rotate(-360deg); } }
+.spinnerdual-2-tm::before { border-top-color: #a3e635; border-bottom-color: #2ecc71; }
+.spinnerdual-3-tm::before { border-top-color: #8b909b; border-bottom-color: #2ecc71; }


### PR DESCRIPTION
Closes #77309

## What
This submission adds a new EaseMotion CSS example: `spinner-dual-tm`.

Two concentric rings rotating in opposite directions.

## How to review
1. Open `submissions/examples/spinner-dual-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/spinner-dual-tm/` and does not modify any existing file.
