### PR TITLE
Add blink spinner submission

### DIFF
--- a/submissions/examples/spinner-blink-tm/README.md
+++ b/submissions/examples/spinner-blink-tm/README.md
@@ -1,0 +1,7 @@
+# Blink spinner
+
+1. What does this do? Three dots that fade in sequence to read as a typing indicator.
+
+2. How is it used? Add `spinner-blink-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Loading / chat pattern; the blink uses opacity.

--- a/submissions/examples/spinner-blink-tm/demo.html
+++ b/submissions/examples/spinner-blink-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Spinner Blink — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="spinnerblink-page-tm" data-palette="graphite">
+  <h1 class="spinnerblink-h-tm">Spinner Blink</h1>
+  <p class="spinnerblink-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="spinnerblink-row-tm">
+    <article class="spinnerblink-1-wrap-tm">
+      <div class="spinnerblink-1-tm"></div>
+      <span class="spinnerblink-lbl-tm">Example One</span>
+    </article>
+    <article class="spinnerblink-2-wrap-tm">
+      <div class="spinnerblink-2-tm"></div>
+      <span class="spinnerblink-lbl-tm">Example Two</span>
+    </article>
+    <article class="spinnerblink-3-wrap-tm">
+      <div class="spinnerblink-3-tm"></div>
+      <span class="spinnerblink-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/spinner-blink-tm/style.css
+++ b/submissions/examples/spinner-blink-tm/style.css
@@ -1,0 +1,59 @@
+:root {
+  --spinnerblink-bg: #101216;
+  --spinnerblink-surface: #1a1d22;
+  --spinnerblink-edge: #25282e;
+  --spinnerblink-text: #e6e8ec;
+  --spinnerblink-muted: #8b909b;
+  --spinnerblink-accent: #94a3b8;
+  --spinnerblink-accent-2: #cbd5e1;
+  --spinnerblink-radius: 10px;
+  --spinnerblink-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--spinnerblink-bg);
+  color: var(--spinnerblink-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.spinnerblink-page-tm { max-width: 920px; margin: 0 auto; }
+.spinnerblink-h-tm { font-size: 28px; margin: 0 0 8px; }
+.spinnerblink-lede-tm { color: var(--spinnerblink-muted); margin: 0 0 32px; }
+.spinnerblink-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.spinnerblink-1-wrap-tm, .spinnerblink-2-wrap-tm, .spinnerblink-3-wrap-tm {
+  background: var(--spinnerblink-surface);
+  border: 1px solid var(--spinnerblink-edge);
+  border-radius: var(--spinnerblink-radius);
+  padding: var(--spinnerblink-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.spinnerblink-lbl-tm { color: var(--spinnerblink-muted); font-size: 13px; }
+
+.spinnerblink-1-tm, .spinnerblink-2-tm, .spinnerblink-3-tm {
+      display: flex; gap: 6px;
+}
+.spinnerblink-1-tm span, .spinnerblink-2-tm span, .spinnerblink-3-tm span {
+      width: 8px; height: 8px; background: #94a3b8; border-radius: 50%;
+      animation: kf-spinnerblink-v1 1.4s infinite; opacity: 0.3;
+}
+.spinnerblink-1-tm span:nth-child(1) { animation-delay: 0s; }
+.spinnerblink-1-tm span:nth-child(2) { animation-delay: 0.2s; }
+.spinnerblink-1-tm span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes kf-spinnerblink-v1 { 0%, 80%, 100% { opacity: 0.3; } 40% { opacity: 1; } }
+.spinnerblink-2-tm span { background: #cbd5e1; }
+.spinnerblink-3-tm span { background: #8b909b; }


### PR DESCRIPTION
Closes #77334

## What
This submission adds a new EaseMotion CSS example: `spinner-blink-tm`.

Three dots that fade in sequence to read as a typing indicator.

## How to review
1. Open `submissions/examples/spinner-blink-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/spinner-blink-tm/` and does not modify any existing file.
