### PR TITLE
Add lift card on hover submission

### DIFF
--- a/submissions/examples/lift-card-tm/README.md
+++ b/submissions/examples/lift-card-tm/README.md
@@ -1,0 +1,7 @@
+# Lift card on hover
+
+1. What does this do? A card that lifts, gains a soft shadow, and slightly scales on hover.
+
+2. How is it used? Add `lift-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Standard card pattern; lift is subtle and accessible.

--- a/submissions/examples/lift-card-tm/demo.html
+++ b/submissions/examples/lift-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Lift Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="liftcard-page-tm" data-palette="forest">
+  <h1 class="liftcard-h-tm">Lift Card</h1>
+  <p class="liftcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="liftcard-row-tm">
+    <article class="liftcard-1-wrap-tm">
+      <div class="liftcard-1-tm"></div>
+      <span class="liftcard-lbl-tm">Example One</span>
+    </article>
+    <article class="liftcard-2-wrap-tm">
+      <div class="liftcard-2-tm"></div>
+      <span class="liftcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="liftcard-3-wrap-tm">
+      <div class="liftcard-3-tm"></div>
+      <span class="liftcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/lift-card-tm/style.css
+++ b/submissions/examples/lift-card-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --liftcard-bg: #0d1612;
+  --liftcard-surface: #152721;
+  --liftcard-edge: #1f3530;
+  --liftcard-text: #e6e8ec;
+  --liftcard-muted: #8b909b;
+  --liftcard-accent: #2ecc71;
+  --liftcard-accent-2: #a3e635;
+  --liftcard-radius: 10px;
+  --liftcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--liftcard-bg);
+  color: var(--liftcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.liftcard-page-tm { max-width: 920px; margin: 0 auto; }
+.liftcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.liftcard-lede-tm { color: var(--liftcard-muted); margin: 0 0 32px; }
+.liftcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.liftcard-1-wrap-tm, .liftcard-2-wrap-tm, .liftcard-3-wrap-tm {
+  background: var(--liftcard-surface);
+  border: 1px solid var(--liftcard-edge);
+  border-radius: var(--liftcard-radius);
+  padding: var(--liftcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.liftcard-lbl-tm { color: var(--liftcard-muted); font-size: 13px; }
+
+.liftcard-1-tm, .liftcard-2-tm, .liftcard-3-tm {
+      width: 100%; min-height: 100px; background: #152721; border: 1px solid #1f3530;
+      border-radius: 12px; display: grid; place-items: center; text-align: center; padding: 16px;
+      transition: all 200ms;
+}
+.liftcard-1-wrap-tm:hover .liftcard-1-tm { transform: translateY(-6px); box-shadow: 0 12px 32px -10px rgba(0,0,0,0.4); border-color: #2ecc71; }
+.liftcard-2-wrap-tm:hover .liftcard-2-tm { transform: translateY(-8px) scale(1.02); box-shadow: 0 16px 40px -10px #a3e63566; border-color: #a3e635; }
+.liftcard-3-wrap-tm:hover .liftcard-3-tm { transform: translateY(-4px); box-shadow: 0 8px 16px rgba(0,0,0,0.2); }


### PR DESCRIPTION
Closes #77364

## What
This submission adds a new EaseMotion CSS example: `lift-card-tm`.

A card that lifts, gains a soft shadow, and slightly scales on hover.

## How to review
1. Open `submissions/examples/lift-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/lift-card-tm/` and does not modify any existing file.
