### PR TITLE
Add glowing border card submission

### DIFF
--- a/submissions/examples/glow-card-tm/README.md
+++ b/submissions/examples/glow-card-tm/README.md
@@ -1,0 +1,7 @@
+# Glowing border card
+
+1. What does this do? A card whose border glows in the accent colour on hover.
+
+2. How is it used? Add `glow-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Feature card pattern; the glow is a box-shadow with a wide spread.

--- a/submissions/examples/glow-card-tm/demo.html
+++ b/submissions/examples/glow-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Glow Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="glowcard-page-tm" data-palette="rose">
+  <h1 class="glowcard-h-tm">Glow Card</h1>
+  <p class="glowcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="glowcard-row-tm">
+    <article class="glowcard-1-wrap-tm">
+      <div class="glowcard-1-tm"></div>
+      <span class="glowcard-lbl-tm">Example One</span>
+    </article>
+    <article class="glowcard-2-wrap-tm">
+      <div class="glowcard-2-tm"></div>
+      <span class="glowcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="glowcard-3-wrap-tm">
+      <div class="glowcard-3-tm"></div>
+      <span class="glowcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/glow-card-tm/style.css
+++ b/submissions/examples/glow-card-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --glowcard-bg: #160d12;
+  --glowcard-surface: #26141c;
+  --glowcard-edge: #361b25;
+  --glowcard-text: #e6e8ec;
+  --glowcard-muted: #8b909b;
+  --glowcard-accent: #ff5c8a;
+  --glowcard-accent-2: #ffb4d2;
+  --glowcard-radius: 10px;
+  --glowcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--glowcard-bg);
+  color: var(--glowcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.glowcard-page-tm { max-width: 920px; margin: 0 auto; }
+.glowcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.glowcard-lede-tm { color: var(--glowcard-muted); margin: 0 0 32px; }
+.glowcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.glowcard-1-wrap-tm, .glowcard-2-wrap-tm, .glowcard-3-wrap-tm {
+  background: var(--glowcard-surface);
+  border: 1px solid var(--glowcard-edge);
+  border-radius: var(--glowcard-radius);
+  padding: var(--glowcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.glowcard-lbl-tm { color: var(--glowcard-muted); font-size: 13px; }
+
+.glowcard-1-tm, .glowcard-2-tm, .glowcard-3-tm {
+      width: 100%; min-height: 100px; background: #26141c; border: 1px solid #361b25;
+      border-radius: 12px; display: grid; place-items: center; text-align: center; padding: 16px;
+      transition: all 200ms;
+}
+.glowcard-1-wrap-tm:hover .glowcard-1-tm { border-color: #ff5c8a; box-shadow: 0 0 0 1px #ff5c8a, 0 0 32px 0 #ff5c8a66; }
+.glowcard-2-wrap-tm:hover .glowcard-2-tm { border-color: #ffb4d2; box-shadow: 0 0 0 1px #ffb4d2, 0 0 32px 0 #ffb4d266; }
+.glowcard-3-wrap-tm:hover .glowcard-3-tm { border-color: #8b909b; box-shadow: 0 0 0 1px #8b909b, 0 0 32px 0 #8b909b44; }


### PR DESCRIPTION
Closes #77367

## What
This submission adds a new EaseMotion CSS example: `glow-card-tm`.

A card whose border glows in the accent colour on hover.

## How to review
1. Open `submissions/examples/glow-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/glow-card-tm/` and does not modify any existing file.
