### PR TITLE
Add peek preview submission

### DIFF
--- a/submissions/examples/peek-card-tm/README.md
+++ b/submissions/examples/peek-card-tm/README.md
@@ -1,0 +1,7 @@
+# Peek preview
+
+1. What does this do? A card that slides a second card into view on hover, like a stack.
+
+2. How is it used? Add `peek-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Card-stack pattern; the second card is positioned absolute.

--- a/submissions/examples/peek-card-tm/demo.html
+++ b/submissions/examples/peek-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Peek Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="peekcard-page-tm" data-palette="violet">
+  <h1 class="peekcard-h-tm">Peek Card</h1>
+  <p class="peekcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="peekcard-row-tm">
+    <article class="peekcard-1-wrap-tm">
+      <div class="peekcard-1-tm"></div>
+      <span class="peekcard-lbl-tm">Example One</span>
+    </article>
+    <article class="peekcard-2-wrap-tm">
+      <div class="peekcard-2-tm"></div>
+      <span class="peekcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="peekcard-3-wrap-tm">
+      <div class="peekcard-3-tm"></div>
+      <span class="peekcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/peek-card-tm/style.css
+++ b/submissions/examples/peek-card-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --peekcard-bg: #0e0a1a;
+  --peekcard-surface: #1a1329;
+  --peekcard-edge: #261a3a;
+  --peekcard-text: #e6e8ec;
+  --peekcard-muted: #8b909b;
+  --peekcard-accent: #a78bfa;
+  --peekcard-accent-2: #f472b6;
+  --peekcard-radius: 10px;
+  --peekcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--peekcard-bg);
+  color: var(--peekcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.peekcard-page-tm { max-width: 920px; margin: 0 auto; }
+.peekcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.peekcard-lede-tm { color: var(--peekcard-muted); margin: 0 0 32px; }
+.peekcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.peekcard-1-wrap-tm, .peekcard-2-wrap-tm, .peekcard-3-wrap-tm {
+  background: var(--peekcard-surface);
+  border: 1px solid var(--peekcard-edge);
+  border-radius: var(--peekcard-radius);
+  padding: var(--peekcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.peekcard-lbl-tm { color: var(--peekcard-muted); font-size: 13px; }
+
+.peekcard-1-tm, .peekcard-2-tm, .peekcard-3-tm {
+      width: 100%; min-height: 80px; background: #1a1329; border: 1px solid #261a3a;
+      border-radius: 12px; display: grid; place-items: center;
+      transition: transform 200ms;
+}
+.peekcard-1-wrap-tm:hover .peekcard-1-tm { transform: translateY(-4px) rotate(-2deg); border-color: #a78bfa; }
+.peekcard-2-tm { background: #a78bfa11; }
+.peekcard-2-wrap-tm:hover .peekcard-2-tm { transform: translateY(-6px) rotate(2deg); }
+.peekcard-3-tm { background: #f472b611; }
+.peekcard-3-wrap-tm:hover .peekcard-3-tm { transform: translateY(-2px) rotate(0deg); }


### PR DESCRIPTION
Closes #77378

## What
This submission adds a new EaseMotion CSS example: `peek-card-tm`.

A card that slides a second card into view on hover, like a stack.

## How to review
1. Open `submissions/examples/peek-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/peek-card-tm/` and does not modify any existing file.
