### PR TITLE
Add stacked cards submission

### DIFF
--- a/submissions/examples/stack-card-tm/README.md
+++ b/submissions/examples/stack-card-tm/README.md
@@ -1,0 +1,7 @@
+# Stacked cards
+
+1. What does this do? A stack of three cards that fan out on hover, like a hand of cards.
+
+2. How is it used? Add `stack-card-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Card / list pattern; the fan uses individual transforms on each child.

--- a/submissions/examples/stack-card-tm/demo.html
+++ b/submissions/examples/stack-card-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Stack Card — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="stackcard-page-tm" data-palette="teal">
+  <h1 class="stackcard-h-tm">Stack Card</h1>
+  <p class="stackcard-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="stackcard-row-tm">
+    <article class="stackcard-1-wrap-tm">
+      <div class="stackcard-1-tm"></div>
+      <span class="stackcard-lbl-tm">Example One</span>
+    </article>
+    <article class="stackcard-2-wrap-tm">
+      <div class="stackcard-2-tm"></div>
+      <span class="stackcard-lbl-tm">Example Two</span>
+    </article>
+    <article class="stackcard-3-wrap-tm">
+      <div class="stackcard-3-tm"></div>
+      <span class="stackcard-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/stack-card-tm/style.css
+++ b/submissions/examples/stack-card-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --stackcard-bg: #08161a;
+  --stackcard-surface: #0f2429;
+  --stackcard-edge: #163239;
+  --stackcard-text: #e6e8ec;
+  --stackcard-muted: #8b909b;
+  --stackcard-accent: #14b8a6;
+  --stackcard-accent-2: #5eead4;
+  --stackcard-radius: 10px;
+  --stackcard-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--stackcard-bg);
+  color: var(--stackcard-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.stackcard-page-tm { max-width: 920px; margin: 0 auto; }
+.stackcard-h-tm { font-size: 28px; margin: 0 0 8px; }
+.stackcard-lede-tm { color: var(--stackcard-muted); margin: 0 0 32px; }
+.stackcard-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.stackcard-1-wrap-tm, .stackcard-2-wrap-tm, .stackcard-3-wrap-tm {
+  background: var(--stackcard-surface);
+  border: 1px solid var(--stackcard-edge);
+  border-radius: var(--stackcard-radius);
+  padding: var(--stackcard-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.stackcard-lbl-tm { color: var(--stackcard-muted); font-size: 13px; }
+
+.stackcard-1-tm, .stackcard-2-tm, .stackcard-3-tm {
+      width: 80%; height: 60px; margin: 0 auto; background: #0f2429; border: 1px solid #163239;
+      border-radius: 10px; position: relative;
+}
+.stackcard-1-tm { background: #14b8a6; }
+.stackcard-2-tm { background: #5eead4; transform: translateY(-50px); }
+.stackcard-3-tm { background: #8b909b; transform: translateY(-100px); }


### PR DESCRIPTION
Closes #77381

## What
This submission adds a new EaseMotion CSS example: `stack-card-tm`.

A stack of three cards that fan out on hover, like a hand of cards.

## How to review
1. Open `submissions/examples/stack-card-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/stack-card-tm/` and does not modify any existing file.
