### PR TITLE
Add double-sided card submission

### DIFF
--- a/submissions/examples/flip-card-double-tm/README.md
+++ b/submissions/examples/flip-card-double-tm/README.md
@@ -1,0 +1,7 @@
+# Double-sided card
+
+1. What does this do? A card that flips on click and stays flipped, like a flashcard.
+
+2. How is it used? Add `flip-card-double-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Card pattern; click-toggle uses :checked on a hidden input.

--- a/submissions/examples/flip-card-double-tm/demo.html
+++ b/submissions/examples/flip-card-double-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Flip Card Double — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="flipcarddouble-page-tm" data-palette="gold">
+  <h1 class="flipcarddouble-h-tm">Flip Card Double</h1>
+  <p class="flipcarddouble-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="flipcarddouble-row-tm">
+    <article class="flipcarddouble-1-wrap-tm">
+      <div class="flipcarddouble-1-tm"></div>
+      <span class="flipcarddouble-lbl-tm">Example One</span>
+    </article>
+    <article class="flipcarddouble-2-wrap-tm">
+      <div class="flipcarddouble-2-tm"></div>
+      <span class="flipcarddouble-lbl-tm">Example Two</span>
+    </article>
+    <article class="flipcarddouble-3-wrap-tm">
+      <div class="flipcarddouble-3-tm"></div>
+      <span class="flipcarddouble-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/flip-card-double-tm/style.css
+++ b/submissions/examples/flip-card-double-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --flipcarddouble-bg: #13110b;
+  --flipcarddouble-surface: #221e14;
+  --flipcarddouble-edge: #332c1c;
+  --flipcarddouble-text: #e6e8ec;
+  --flipcarddouble-muted: #8b909b;
+  --flipcarddouble-accent: #facc15;
+  --flipcarddouble-accent-2: #fbbf24;
+  --flipcarddouble-radius: 10px;
+  --flipcarddouble-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--flipcarddouble-bg);
+  color: var(--flipcarddouble-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.flipcarddouble-page-tm { max-width: 920px; margin: 0 auto; }
+.flipcarddouble-h-tm { font-size: 28px; margin: 0 0 8px; }
+.flipcarddouble-lede-tm { color: var(--flipcarddouble-muted); margin: 0 0 32px; }
+.flipcarddouble-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.flipcarddouble-1-wrap-tm, .flipcarddouble-2-wrap-tm, .flipcarddouble-3-wrap-tm {
+  background: var(--flipcarddouble-surface);
+  border: 1px solid var(--flipcarddouble-edge);
+  border-radius: var(--flipcarddouble-radius);
+  padding: var(--flipcarddouble-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.flipcarddouble-lbl-tm { color: var(--flipcarddouble-muted); font-size: 13px; }
+
+.flipcarddouble-1-tm, .flipcarddouble-2-tm, .flipcarddouble-3-tm {
+      width: 100%; min-height: 100px; position: relative; transform-style: preserve-3d;
+      transition: transform 600ms;
+}
+.flipcarddouble-1-tm::before, .flipcarddouble-1-tm::after {
+      content: ""; position: absolute; inset: 0; border-radius: 12px; display: grid; place-items: center; backface-visibility: hidden;
+}
+.flipcarddouble-1-tm::before { background: #221e14; border: 1px solid #332c1c; content: "Front"; }
+.flipcarddouble-1-tm::after { background: #facc15; content: "Back"; color: #0f1115; transform: rotateY(180deg); }
+.flipcarddouble-1-tm.is-flipped { transform: rotateY(180deg); }


### PR DESCRIPTION
Closes #77390

## What
This submission adds a new EaseMotion CSS example: `flip-card-double-tm`.

A card that flips on click and stays flipped, like a flashcard.

## How to review
1. Open `submissions/examples/flip-card-double-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/flip-card-double-tm/` and does not modify any existing file.
