### PR TITLE
Add curtain reveal submission

### DIFF
--- a/submissions/examples/flip-card-curtain-tm/README.md
+++ b/submissions/examples/flip-card-curtain-tm/README.md
@@ -1,0 +1,7 @@
+# Curtain reveal
+
+1. What does this do? A card whose front slides up like a curtain to reveal the back face.
+
+2. How is it used? Add `flip-card-curtain-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Card pattern; the front translates up on hover.

--- a/submissions/examples/flip-card-curtain-tm/demo.html
+++ b/submissions/examples/flip-card-curtain-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Flip Card Curtain — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="flipcardcurtain-page-tm" data-palette="warm">
+  <h1 class="flipcardcurtain-h-tm">Flip Card Curtain</h1>
+  <p class="flipcardcurtain-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="flipcardcurtain-row-tm">
+    <article class="flipcardcurtain-1-wrap-tm">
+      <div class="flipcardcurtain-1-tm"></div>
+      <span class="flipcardcurtain-lbl-tm">Example One</span>
+    </article>
+    <article class="flipcardcurtain-2-wrap-tm">
+      <div class="flipcardcurtain-2-tm"></div>
+      <span class="flipcardcurtain-lbl-tm">Example Two</span>
+    </article>
+    <article class="flipcardcurtain-3-wrap-tm">
+      <div class="flipcardcurtain-3-tm"></div>
+      <span class="flipcardcurtain-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/flip-card-curtain-tm/style.css
+++ b/submissions/examples/flip-card-curtain-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --flipcardcurtain-bg: #0f1115;
+  --flipcardcurtain-surface: #1a1d24;
+  --flipcardcurtain-edge: #262a33;
+  --flipcardcurtain-text: #e6e8ec;
+  --flipcardcurtain-muted: #8b909b;
+  --flipcardcurtain-accent: #ff6a3d;
+  --flipcardcurtain-accent-2: #ffd166;
+  --flipcardcurtain-radius: 10px;
+  --flipcardcurtain-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--flipcardcurtain-bg);
+  color: var(--flipcardcurtain-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.flipcardcurtain-page-tm { max-width: 920px; margin: 0 auto; }
+.flipcardcurtain-h-tm { font-size: 28px; margin: 0 0 8px; }
+.flipcardcurtain-lede-tm { color: var(--flipcardcurtain-muted); margin: 0 0 32px; }
+.flipcardcurtain-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.flipcardcurtain-1-wrap-tm, .flipcardcurtain-2-wrap-tm, .flipcardcurtain-3-wrap-tm {
+  background: var(--flipcardcurtain-surface);
+  border: 1px solid var(--flipcardcurtain-edge);
+  border-radius: var(--flipcardcurtain-radius);
+  padding: var(--flipcardcurtain-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.flipcardcurtain-lbl-tm { color: var(--flipcardcurtain-muted); font-size: 13px; }
+
+.flipcardcurtain-1-tm, .flipcardcurtain-2-tm, .flipcardcurtain-3-tm {
+      width: 100%; min-height: 100px; position: relative; overflow: hidden; border-radius: 12px;
+}
+.flipcardcurtain-1-tm::before, .flipcardcurtain-1-tm::after {
+      content: ""; position: absolute; inset: 0; transition: transform 400ms;
+}
+.flipcardcurtain-1-tm::before { background: #ff6a3d; content: "Front"; display: grid; place-items: center; color: #0f1115; }
+.flipcardcurtain-1-tm::after { background: #1a1d24; content: "Back"; display: grid; place-items: center; }
+.flipcardcurtain-1-wrap-tm:hover .flipcardcurtain-1-tm::before { transform: translateY(-100%); }


### PR DESCRIPTION
Closes #77393

## What
This submission adds a new EaseMotion CSS example: `flip-card-curtain-tm`.

A card whose front slides up like a curtain to reveal the back face.

## How to review
1. Open `submissions/examples/flip-card-curtain-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/flip-card-curtain-tm/` and does not modify any existing file.
