### PR TITLE
Add sliding underline nav submission

### DIFF
--- a/submissions/examples/nav-underline-tm/README.md
+++ b/submissions/examples/nav-underline-tm/README.md
@@ -1,0 +1,7 @@
+# Sliding underline nav
+
+1. What does this do? A horizontal nav whose underline slides from one item to the next.
+
+2. How is it used? Add `nav-underline-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Nav pattern; the underline is a positioned pseudo-element.

--- a/submissions/examples/nav-underline-tm/demo.html
+++ b/submissions/examples/nav-underline-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Nav Underline — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="navunderline-page-tm" data-palette="forest">
+  <h1 class="navunderline-h-tm">Nav Underline</h1>
+  <p class="navunderline-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="navunderline-row-tm">
+    <article class="navunderline-1-wrap-tm">
+      <div class="navunderline-1-tm"></div>
+      <span class="navunderline-lbl-tm">Example One</span>
+    </article>
+    <article class="navunderline-2-wrap-tm">
+      <div class="navunderline-2-tm"></div>
+      <span class="navunderline-lbl-tm">Example Two</span>
+    </article>
+    <article class="navunderline-3-wrap-tm">
+      <div class="navunderline-3-tm"></div>
+      <span class="navunderline-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/nav-underline-tm/style.css
+++ b/submissions/examples/nav-underline-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --navunderline-bg: #0d1612;
+  --navunderline-surface: #152721;
+  --navunderline-edge: #1f3530;
+  --navunderline-text: #e6e8ec;
+  --navunderline-muted: #8b909b;
+  --navunderline-accent: #2ecc71;
+  --navunderline-accent-2: #a3e635;
+  --navunderline-radius: 10px;
+  --navunderline-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--navunderline-bg);
+  color: var(--navunderline-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.navunderline-page-tm { max-width: 920px; margin: 0 auto; }
+.navunderline-h-tm { font-size: 28px; margin: 0 0 8px; }
+.navunderline-lede-tm { color: var(--navunderline-muted); margin: 0 0 32px; }
+.navunderline-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.navunderline-1-wrap-tm, .navunderline-2-wrap-tm, .navunderline-3-wrap-tm {
+  background: var(--navunderline-surface);
+  border: 1px solid var(--navunderline-edge);
+  border-radius: var(--navunderline-radius);
+  padding: var(--navunderline-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.navunderline-lbl-tm { color: var(--navunderline-muted); font-size: 13px; }
+
+.navunderline-1-tm, .navunderline-2-tm, .navunderline-3-tm {
+      display: flex; gap: 24px; padding: 8px 0; width: 100%;
+}
+.navunderline-1-tm span { position: relative; cursor: pointer; padding: 4px 0; color: #8b909b; transition: color 200ms; }
+.navunderline-1-tm span::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 2px; background: #2ecc71; transform: scaleX(0); transition: transform 220ms; transform-origin: left; }
+.navunderline-1-tm span:hover, .navunderline-1-tm span.active { color: #2ecc71; }
+.navunderline-1-tm span:hover::after, .navunderline-1-tm span.active::after { transform: scaleX(1); }


### PR DESCRIPTION
Closes #77410

## What
This submission adds a new EaseMotion CSS example: `nav-underline-tm`.

A horizontal nav whose underline slides from one item to the next.

## How to review
1. Open `submissions/examples/nav-underline-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/nav-underline-tm/` and does not modify any existing file.
