### PR TITLE
Add morphing nav indicator submission

### DIFF
--- a/submissions/examples/nav-morph-tm/README.md
+++ b/submissions/examples/nav-morph-tm/README.md
@@ -1,0 +1,7 @@
+# Morphing nav indicator
+
+1. What does this do? A nav where the indicator morphs width and position to follow the active item.
+
+2. How is it used? Add `nav-morph-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Nav pattern; the indicator is a separate, positioned element.

--- a/submissions/examples/nav-morph-tm/demo.html
+++ b/submissions/examples/nav-morph-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Nav Morph — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="navmorph-page-tm" data-palette="rose">
+  <h1 class="navmorph-h-tm">Nav Morph</h1>
+  <p class="navmorph-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="navmorph-row-tm">
+    <article class="navmorph-1-wrap-tm">
+      <div class="navmorph-1-tm"></div>
+      <span class="navmorph-lbl-tm">Example One</span>
+    </article>
+    <article class="navmorph-2-wrap-tm">
+      <div class="navmorph-2-tm"></div>
+      <span class="navmorph-lbl-tm">Example Two</span>
+    </article>
+    <article class="navmorph-3-wrap-tm">
+      <div class="navmorph-3-tm"></div>
+      <span class="navmorph-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/nav-morph-tm/style.css
+++ b/submissions/examples/nav-morph-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --navmorph-bg: #160d12;
+  --navmorph-surface: #26141c;
+  --navmorph-edge: #361b25;
+  --navmorph-text: #e6e8ec;
+  --navmorph-muted: #8b909b;
+  --navmorph-accent: #ff5c8a;
+  --navmorph-accent-2: #ffb4d2;
+  --navmorph-radius: 10px;
+  --navmorph-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--navmorph-bg);
+  color: var(--navmorph-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.navmorph-page-tm { max-width: 920px; margin: 0 auto; }
+.navmorph-h-tm { font-size: 28px; margin: 0 0 8px; }
+.navmorph-lede-tm { color: var(--navmorph-muted); margin: 0 0 32px; }
+.navmorph-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.navmorph-1-wrap-tm, .navmorph-2-wrap-tm, .navmorph-3-wrap-tm {
+  background: var(--navmorph-surface);
+  border: 1px solid var(--navmorph-edge);
+  border-radius: var(--navmorph-radius);
+  padding: var(--navmorph-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.navmorph-lbl-tm { color: var(--navmorph-muted); font-size: 13px; }
+
+.navmorph-1-tm, .navmorph-2-tm, .navmorph-3-tm {
+      display: flex; gap: 4px; padding: 4px; background: #26141c; border-radius: 10px; width: 100%; position: relative;
+}
+.navmorph-1-tm span { flex: 1; padding: 8px 12px; text-align: center; cursor: pointer; font-size: 13px; color: #8b909b; z-index: 1; }
+.navmorph-1-tm span.active { color: #0f1115; font-weight: 600; }
+.navmorph-1-tm::after { content: ""; position: absolute; top: 4px; left: 4px; height: calc(100% - 8px); width: calc(33.33% - 4px); background: #ff5c8a; border-radius: 6px; transition: transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.navmorph-1-tm span:nth-child(2).active ~ ::after { transform: translateX(100%); }


### PR DESCRIPTION
Closes #77415

## What
This submission adds a new EaseMotion CSS example: `nav-morph-tm`.

A nav where the indicator morphs width and position to follow the active item.

## How to review
1. Open `submissions/examples/nav-morph-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/nav-morph-tm/` and does not modify any existing file.
