### PR TITLE
Add icon breadcrumb submission

### DIFF
--- a/submissions/examples/nav-bread-tm/README.md
+++ b/submissions/examples/nav-bread-tm/README.md
@@ -1,0 +1,7 @@
+# Icon breadcrumb
+
+1. What does this do? A breadcrumb trail that includes small icons beside each label.
+
+2. How is it used? Add `nav-bread-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Nav pattern; icons add visual anchoring to hierarchy.

--- a/submissions/examples/nav-bread-tm/demo.html
+++ b/submissions/examples/nav-bread-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Nav Bread — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="navbread-page-tm" data-palette="violet">
+  <h1 class="navbread-h-tm">Nav Bread</h1>
+  <p class="navbread-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="navbread-row-tm">
+    <article class="navbread-1-wrap-tm">
+      <div class="navbread-1-tm"></div>
+      <span class="navbread-lbl-tm">Example One</span>
+    </article>
+    <article class="navbread-2-wrap-tm">
+      <div class="navbread-2-tm"></div>
+      <span class="navbread-lbl-tm">Example Two</span>
+    </article>
+    <article class="navbread-3-wrap-tm">
+      <div class="navbread-3-tm"></div>
+      <span class="navbread-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/nav-bread-tm/style.css
+++ b/submissions/examples/nav-bread-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --navbread-bg: #0e0a1a;
+  --navbread-surface: #1a1329;
+  --navbread-edge: #261a3a;
+  --navbread-text: #e6e8ec;
+  --navbread-muted: #8b909b;
+  --navbread-accent: #a78bfa;
+  --navbread-accent-2: #f472b6;
+  --navbread-radius: 10px;
+  --navbread-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--navbread-bg);
+  color: var(--navbread-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.navbread-page-tm { max-width: 920px; margin: 0 auto; }
+.navbread-h-tm { font-size: 28px; margin: 0 0 8px; }
+.navbread-lede-tm { color: var(--navbread-muted); margin: 0 0 32px; }
+.navbread-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.navbread-1-wrap-tm, .navbread-2-wrap-tm, .navbread-3-wrap-tm {
+  background: var(--navbread-surface);
+  border: 1px solid var(--navbread-edge);
+  border-radius: var(--navbread-radius);
+  padding: var(--navbread-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.navbread-lbl-tm { color: var(--navbread-muted); font-size: 13px; }
+
+.navbread-1-tm, .navbread-2-tm, .navbread-3-tm {
+      display: flex; gap: 6px; align-items: center; font-size: 13px; width: 100%;
+}
+.navbread-1-tm span { color: #a78bfa; }
+.navbread-1-tm span:last-child { color: #8b909b; }
+.navbread-1-tm em { color: #8b909b; font-style: normal; }
+.navbread-2-tm span { color: #f472b6; }
+.navbread-3-tm span { color: #8b909b; }


### PR DESCRIPTION
Closes #77422

## What
This submission adds a new EaseMotion CSS example: `nav-bread-tm`.

A breadcrumb trail that includes small icons beside each label.

## How to review
1. Open `submissions/examples/nav-bread-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/nav-bread-tm/` and does not modify any existing file.
