### PR TITLE
Add pagination dots submission

### DIFF
--- a/submissions/examples/nav-pager-tm/README.md
+++ b/submissions/examples/nav-pager-tm/README.md
@@ -1,0 +1,7 @@
+# Pagination dots
+
+1. What does this do? A row of dots indicating pages, with the active dot wider.
+
+2. How is it used? Add `nav-pager-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Carousel / stepper pattern; active dot is wider via scaleX.

--- a/submissions/examples/nav-pager-tm/demo.html
+++ b/submissions/examples/nav-pager-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Nav Pager — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="navpager-page-tm" data-palette="teal">
+  <h1 class="navpager-h-tm">Nav Pager</h1>
+  <p class="navpager-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="navpager-row-tm">
+    <article class="navpager-1-wrap-tm">
+      <div class="navpager-1-tm"></div>
+      <span class="navpager-lbl-tm">Example One</span>
+    </article>
+    <article class="navpager-2-wrap-tm">
+      <div class="navpager-2-tm"></div>
+      <span class="navpager-lbl-tm">Example Two</span>
+    </article>
+    <article class="navpager-3-wrap-tm">
+      <div class="navpager-3-tm"></div>
+      <span class="navpager-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/nav-pager-tm/style.css
+++ b/submissions/examples/nav-pager-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --navpager-bg: #08161a;
+  --navpager-surface: #0f2429;
+  --navpager-edge: #163239;
+  --navpager-text: #e6e8ec;
+  --navpager-muted: #8b909b;
+  --navpager-accent: #14b8a6;
+  --navpager-accent-2: #5eead4;
+  --navpager-radius: 10px;
+  --navpager-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--navpager-bg);
+  color: var(--navpager-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.navpager-page-tm { max-width: 920px; margin: 0 auto; }
+.navpager-h-tm { font-size: 28px; margin: 0 0 8px; }
+.navpager-lede-tm { color: var(--navpager-muted); margin: 0 0 32px; }
+.navpager-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.navpager-1-wrap-tm, .navpager-2-wrap-tm, .navpager-3-wrap-tm {
+  background: var(--navpager-surface);
+  border: 1px solid var(--navpager-edge);
+  border-radius: var(--navpager-radius);
+  padding: var(--navpager-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.navpager-lbl-tm { color: var(--navpager-muted); font-size: 13px; }
+
+.navpager-1-tm, .navpager-2-tm, .navpager-3-tm {
+      display: flex; gap: 6px; align-items: center; justify-content: center; padding: 8px;
+}
+.navpager-1-tm span { width: 8px; height: 8px; border-radius: 50%; background: #163239; transition: all 240ms; cursor: pointer; }
+.navpager-1-tm span.active { width: 20px; border-radius: 4px; background: #14b8a6; }
+.navpager-2-tm span.active { background: #5eead4; }
+.navpager-3-tm span.active { background: #8b909b; }


### PR DESCRIPTION
Closes #77424

## What
This submission adds a new EaseMotion CSS example: `nav-pager-tm`.

A row of dots indicating pages, with the active dot wider.

## How to review
1. Open `submissions/examples/nav-pager-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/nav-pager-tm/` and does not modify any existing file.
