### PR TITLE
Add bottom navigation submission

### DIFF
--- a/submissions/examples/nav-bottom-tm/README.md
+++ b/submissions/examples/nav-bottom-tm/README.md
@@ -1,0 +1,7 @@
+# Bottom navigation
+
+1. What does this do? A horizontal nav fixed to the bottom of a mobile-sized viewport.
+
+2. How is it used? Add `nav-bottom-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Mobile pattern; the active item has a coloured top bar.

--- a/submissions/examples/nav-bottom-tm/demo.html
+++ b/submissions/examples/nav-bottom-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Nav Bottom — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="navbottom-page-tm" data-palette="gold">
+  <h1 class="navbottom-h-tm">Nav Bottom</h1>
+  <p class="navbottom-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="navbottom-row-tm">
+    <article class="navbottom-1-wrap-tm">
+      <div class="navbottom-1-tm"></div>
+      <span class="navbottom-lbl-tm">Example One</span>
+    </article>
+    <article class="navbottom-2-wrap-tm">
+      <div class="navbottom-2-tm"></div>
+      <span class="navbottom-lbl-tm">Example Two</span>
+    </article>
+    <article class="navbottom-3-wrap-tm">
+      <div class="navbottom-3-tm"></div>
+      <span class="navbottom-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/nav-bottom-tm/style.css
+++ b/submissions/examples/nav-bottom-tm/style.css
@@ -1,0 +1,56 @@
+:root {
+  --navbottom-bg: #13110b;
+  --navbottom-surface: #221e14;
+  --navbottom-edge: #332c1c;
+  --navbottom-text: #e6e8ec;
+  --navbottom-muted: #8b909b;
+  --navbottom-accent: #facc15;
+  --navbottom-accent-2: #fbbf24;
+  --navbottom-radius: 10px;
+  --navbottom-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--navbottom-bg);
+  color: var(--navbottom-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.navbottom-page-tm { max-width: 920px; margin: 0 auto; }
+.navbottom-h-tm { font-size: 28px; margin: 0 0 8px; }
+.navbottom-lede-tm { color: var(--navbottom-muted); margin: 0 0 32px; }
+.navbottom-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.navbottom-1-wrap-tm, .navbottom-2-wrap-tm, .navbottom-3-wrap-tm {
+  background: var(--navbottom-surface);
+  border: 1px solid var(--navbottom-edge);
+  border-radius: var(--navbottom-radius);
+  padding: var(--navbottom-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.navbottom-lbl-tm { color: var(--navbottom-muted); font-size: 13px; }
+
+.navbottom-1-tm, .navbottom-2-tm, .navbottom-3-tm {
+      display: flex; justify-content: space-around; padding: 8px; background: #221e14;
+      border-top: 1px solid #332c1c; width: 100%;
+}
+.navbottom-1-tm span { position: relative; padding: 8px 12px; font-size: 18px; color: #8b909b; cursor: pointer; transition: color 200ms; }
+.navbottom-1-tm span.active { color: #facc15; }
+.navbottom-1-tm span.active::before { content: ""; position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 24px; height: 2px; background: #facc15; border-radius: 0 0 2px 2px; }
+.navbottom-2-tm span.active { color: #fbbf24; }
+.navbottom-2-tm span.active::before { background: #fbbf24; }
+.navbottom-3-tm span.active { color: #8b909b; }


### PR DESCRIPTION
Closes #77436

## What
This submission adds a new EaseMotion CSS example: `nav-bottom-tm`.

A horizontal nav fixed to the bottom of a mobile-sized viewport.

## How to review
1. Open `submissions/examples/nav-bottom-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/nav-bottom-tm/` and does not modify any existing file.
