### PR TITLE
feat(examples): Cinematic Depth-of-Field Parallax (#74082)

### DIFF
--- a/submissions/examples/ease-cinematic-parallax/README.md
+++ b/submissions/examples/ease-cinematic-parallax/README.md
@@ -1,0 +1,65 @@
+# Cinematic Depth-of-Field Parallax
+
+> Issue: [#74082](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/74082)
+
+An ultra-premium, GPU-accelerated multi-layer depth-of-field (DoF) camera parallax effect powered natively by CSS `animation-timeline: scroll()`.
+
+---
+
+## ✨ Features & Architectural Highlights
+
+- **Native CSS Scroll-Driven Rack Focus:** Mathematically maps `translateY` velocity and dynamic `filter: blur()` focus depth directly to the scrollbar without a single line of JavaScript.
+- **Physical Camera Lens Simulation:** Emulates an 85mm f/1.2 prime lens focal plane shift from foreground bokeh to primary subject clarity, receding into deep background horizon focus.
+- **Pure CSS Focal Plane Controls:** Interactive focal plane preview selector built with CSS pseudo-class radio inputs (`:checked`).
+- **Zero-JS Runtime Overhead:** Runs 100% on the GPU compositor thread for silky smooth 60 FPS performance without main-thread scroll listeners.
+- **Progressive Enhancement & Fallback:** Includes `@supports not (animation-timeline: scroll())` ambient floating fallback for legacy browsers.
+- **Accessible Design:** Full `@media (prefers-reduced-motion: reduce)` overrides to flatten 3D perspective and disable motion/blur for users with motion sensitivity.
+
+---
+
+## 🎨 CSS Custom Properties (Design Tokens)
+
+```css
+:root {
+  --dof-bg-base: #04060c;
+  --dof-bg-card: rgba(18, 24, 43, 0.65);
+  --dof-primary: #00f0ff;
+  --dof-secondary: #7000ff;
+  --dof-accent: #ff0055;
+
+  /* Focal Plane Depth Parameters */
+  --dof-blur-far: 16px;
+  --dof-blur-mid: 8px;
+  --dof-blur-sharp: 0px;
+  --dof-blur-foreground: 22px;
+}
+```
+
+---
+
+## 🚀 Usage & Integration
+
+1. Copy `ease-cinematic-parallax/` into your project under `submissions/examples/`.
+2. Link `style.css` in your HTML document `<head>`:
+   ```html
+   <link rel="stylesheet" href="style.css" />
+   ```
+3. Use the multi-layer HTML structure provided in `demo.html`:
+   ```html
+   <main class="dof-scene">
+     <div class="dof-stage">
+       <div class="dof-layer dof-layer-far-bg">...</div>
+       <div class="dof-layer dof-layer-midground">...</div>
+       <div class="dof-layer dof-layer-subject">...</div>
+       <div class="dof-layer dof-layer-foreground">...</div>
+     </div>
+   </main>
+   ```
+
+---
+
+## 📂 File Summary
+
+- `demo.html` — HTML5 showcase page with multi-layer stage, interactive pure-CSS lens controls, and technical feature grid.
+- `style.css` — Complete stylesheet featuring scroll-driven animation keyframe timelines, design tokens, fallback rules, and accessibility overrides.
+- `README.md` — Technical documentation manual.

--- a/submissions/examples/ease-cinematic-parallax/demo.html
+++ b/submissions/examples/ease-cinematic-parallax/demo.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cinematic Depth-of-Field Parallax - EaseMotion CSS</title>
+    <meta
+      name="description"
+      content="GPU-accelerated native CSS scroll-driven Cinematic Depth-of-Field (DoF) Parallax without JavaScript."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Pure CSS Focus Plane State Controllers -->
+    <input
+      type="radio"
+      name="focus-mode"
+      id="focus-auto"
+      class="dof-focus-control"
+      checked
+    />
+    <input
+      type="radio"
+      name="focus-mode"
+      id="focus-fg"
+      class="dof-focus-control"
+    />
+    <input
+      type="radio"
+      name="focus-mode"
+      id="focus-subject"
+      class="dof-focus-control"
+    />
+    <input
+      type="radio"
+      name="focus-mode"
+      id="focus-bg"
+      class="dof-focus-control"
+    />
+
+    <!-- HUD Navigation & Lens Aperture Bar -->
+    <header class="dof-hud-nav" id="dof-nav">
+      <div class="dof-brand">
+        <span class="dof-aperture-icon" aria-hidden="true"></span>
+        <span>ASTRAL REACH // DoF</span>
+      </div>
+
+      <!-- Manual Lens Focal Control Selector (Pure CSS Radio Labels) -->
+      <nav class="dof-control-bar" aria-label="Camera Focal Plane Controls">
+        <label
+          for="focus-auto"
+          class="dof-control-btn"
+          title="Automatic Scroll-Driven Rack Focus"
+          >Scroll DoF</label
+        >
+        <label
+          for="focus-fg"
+          class="dof-control-btn"
+          title="Lock Focus to Foreground Plane"
+          >Fg Focus</label
+        >
+        <label
+          for="focus-subject"
+          class="dof-control-btn"
+          title="Lock Focus to Subject Plane"
+          >Subject Focus</label
+        >
+        <label
+          for="focus-bg"
+          class="dof-control-btn"
+          title="Lock Focus to Deep Background Horizon"
+          >Bg Focus</label
+        >
+      </nav>
+
+      <div class="dof-camera-badge">
+        <span class="dof-status-dot"></span>
+        <span>GPU Rack Focus: Active</span>
+      </div>
+    </header>
+
+    <!-- Multi-Layer Parallax Scene Stage -->
+    <main class="dof-scene" id="main-scene">
+      <div class="dof-stage">
+        <!-- Layer 1: Far Background (Deep Celestial Core & Nebula Grid) -->
+        <div class="dof-layer dof-layer-far-bg" aria-hidden="true">
+          <div class="dof-star-grid"></div>
+          <div class="dof-celestial-orb"></div>
+        </div>
+
+        <!-- Layer 2: Midground (Orbital Tech Ring & Sci-Fi Columns) -->
+        <div class="dof-layer dof-layer-midground" aria-hidden="true">
+          <div class="dof-orbital-ring"></div>
+          <div class="dof-tech-column-left"></div>
+          <div class="dof-tech-column-right"></div>
+        </div>
+
+        <!-- Layer 3: Subject Focal Plane (Primary Hero Content & Specs) -->
+        <div class="dof-layer dof-layer-subject">
+          <article class="dof-hero-card">
+            <p class="dof-tagline">Issue #74082 // Standard Track Example</p>
+            <h1 class="dof-title">Cinematic Depth-of-Field Parallax</h1>
+            <p class="dof-description">
+              Experience physical camera lens rack focus natively on the GPU. By
+              mathematically binding both <code>translateY</code> velocity and
+              CSS <code>filter: blur()</code> directly to the scrollbar using
+              CSS <code>animation-timeline: scroll()</code>, the focal plane
+              dynamically sweeps across multi-layered depth planes without a
+              single line of JavaScript.
+            </p>
+
+            <div class="dof-feature-grid">
+              <div class="dof-feature-box">
+                <h2 class="dof-feature-title">⚡ 0ms JS Runtime</h2>
+                <p class="dof-feature-desc">
+                  100% native compositor thread execution. Zero main-thread
+                  blocking or intersection observer lag.
+                </p>
+              </div>
+              <div class="dof-feature-box">
+                <h2 class="dof-feature-title">🎥 Physical DoF Simulation</h2>
+                <p class="dof-feature-desc">
+                  Simulates a variable 85mm f/1.2 prime lens with progressive
+                  focal plane rack focus shifts.
+                </p>
+              </div>
+              <div class="dof-feature-box">
+                <h2 class="dof-feature-title">🌐 Graceful Fallbacks</h2>
+                <p class="dof-feature-desc">
+                  Includes <code>@supports</code> ambient depth pulses and full
+                  <code>prefers-reduced-motion</code> overrides.
+                </p>
+              </div>
+            </div>
+          </article>
+
+          <!-- Scroll Indicator Hint -->
+          <div class="dof-scroll-hint" aria-hidden="true">
+            <div class="dof-mouse-icon">
+              <div class="dof-mouse-wheel"></div>
+            </div>
+            <span>Scroll to Rack Focus</span>
+          </div>
+        </div>
+
+        <!-- Layer 4: Foreground (Bokeh Dust Nodes & Camera Viewfinder) -->
+        <div class="dof-layer dof-layer-foreground" aria-hidden="true">
+          <div class="dof-bokeh-node dof-bokeh-1"></div>
+          <div class="dof-bokeh-node dof-bokeh-2"></div>
+          <div class="dof-bokeh-node dof-bokeh-3"></div>
+
+          <div class="dof-viewfinder">
+            <span class="dof-viewfinder-corner dof-tl"></span>
+            <span class="dof-viewfinder-corner dof-tr"></span>
+            <span class="dof-viewfinder-corner dof-bl"></span>
+            <span class="dof-viewfinder-corner dof-br"></span>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Technical Footer -->
+    <footer class="dof-footer">
+      <p>
+        Created for
+        <a
+          href="https://github.com/SAPTARSHI-coder/EaseMotion-css"
+          target="_blank"
+          rel="noopener noreferrer"
+          >EaseMotion-css</a
+        >
+        — Powered by CSS Scroll-Driven Animations.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/submissions/examples/ease-cinematic-parallax/style.css
+++ b/submissions/examples/ease-cinematic-parallax/style.css
@@ -1,0 +1,816 @@
+/* ==========================================================================
+   EaseMotion CSS - Cinematic Depth-of-Field (DoF) Parallax
+   Issue #74082 Submission
+   ========================================================================== */
+
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800;900&family=Space+Grotesk:wght@400;600;700&display=swap");
+
+:root {
+  /* Theme Palette - AAA Sci-Fi Cyberpunk */
+  --dof-bg-base: #04060c;
+  --dof-bg-surface: rgba(12, 17, 29, 0.75);
+  --dof-bg-surface-border: rgba(255, 255, 255, 0.08);
+  --dof-bg-card: rgba(18, 24, 43, 0.65);
+
+  --dof-primary: #00f0ff;
+  --dof-primary-glow: rgba(0, 240, 255, 0.35);
+  --dof-secondary: #7000ff;
+  --dof-secondary-glow: rgba(112, 0, 255, 0.35);
+  --dof-accent: #ff0055;
+  --dof-text-main: #f0f4f8;
+  --dof-text-muted: #8e9bb0;
+
+  /* Focal Plane Depth Parameters */
+  --dof-blur-far: 16px;
+  --dof-blur-mid: 8px;
+  --dof-blur-sharp: 0px;
+  --dof-blur-foreground: 22px;
+
+  /* Fonts */
+  --dof-font-heading: "Outfit", -apple-system, BlinkMacSystemFont, sans-serif;
+  --dof-font-mono: "Space Grotesk", monospace;
+}
+
+/* Base Setup */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  color-scheme: dark;
+  background-color: var(--dof-bg-base);
+  font-family: var(--dof-font-heading);
+  color: var(--dof-text-main);
+  scroll-behavior: smooth;
+}
+
+body {
+  overflow-x: hidden;
+  min-height: 100vh;
+  background: radial-gradient(
+    circle at 50% 20%,
+    #0d1226 0%,
+    var(--dof-bg-base) 70%
+  );
+}
+
+/* Hidden Radio Inputs for Pure CSS Camera Focus Control */
+.dof-focus-control {
+  display: none;
+}
+
+/* Navbar & Camera HUD Bar */
+.dof-hud-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 2.5rem;
+  background: rgba(4, 6, 12, 0.8);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--dof-bg-surface-border);
+}
+
+.dof-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+}
+
+.dof-aperture-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px dashed var(--dof-primary);
+  display: inline-block;
+  animation: dof-spin 12s linear infinite;
+  box-shadow: 0 0 12px var(--dof-primary-glow);
+}
+
+.dof-camera-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(0, 240, 255, 0.08);
+  border: 1px solid rgba(0, 240, 255, 0.25);
+  font-family: var(--dof-font-mono);
+  font-size: 0.75rem;
+  color: var(--dof-primary);
+  text-transform: uppercase;
+}
+
+.dof-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--dof-primary);
+  box-shadow: 0 0 8px var(--dof-primary);
+  animation: dof-pulse 2s ease-in-out infinite;
+}
+
+/* Mode Controls Switcher Bar */
+.dof-control-bar {
+  display: flex;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.25rem;
+  border-radius: 8px;
+  border: 1px solid var(--dof-bg-surface-border);
+}
+
+.dof-control-btn {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+  font-family: var(--dof-font-mono);
+  color: var(--dof-text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  user-select: none;
+}
+
+.dof-control-btn:hover {
+  color: var(--dof-text-main);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Radio Control Active States */
+#focus-auto:checked ~ .dof-hud-nav .dof-control-btn[for="focus-auto"],
+#focus-fg:checked ~ .dof-hud-nav .dof-control-btn[for="focus-fg"],
+#focus-subject:checked ~ .dof-hud-nav .dof-control-btn[for="focus-subject"],
+#focus-bg:checked ~ .dof-hud-nav .dof-control-btn[for="focus-bg"] {
+  background: var(--dof-primary);
+  color: #04060c;
+  font-weight: 700;
+  box-shadow: 0 0 12px var(--dof-primary-glow);
+}
+
+/* Pure CSS Override when specific focus mode is chosen manually */
+#focus-fg:checked ~ .dof-scene .dof-layer-foreground {
+  filter: blur(0px) !important;
+  opacity: 1 !important;
+}
+#focus-fg:checked ~ .dof-scene .dof-layer-subject,
+#focus-fg:checked ~ .dof-scene .dof-layer-midground,
+#focus-fg:checked ~ .dof-scene .dof-layer-far-bg {
+  filter: blur(14px) !important;
+}
+
+#focus-subject:checked ~ .dof-scene .dof-layer-subject {
+  filter: blur(0px) !important;
+  opacity: 1 !important;
+}
+#focus-subject:checked ~ .dof-scene .dof-layer-foreground {
+  filter: blur(18px) !important;
+}
+#focus-subject:checked ~ .dof-scene .dof-layer-far-bg {
+  filter: blur(12px) !important;
+}
+
+#focus-bg:checked ~ .dof-scene .dof-layer-far-bg {
+  filter: blur(0px) !important;
+  opacity: 1 !important;
+}
+#focus-bg:checked ~ .dof-scene .dof-layer-subject,
+#focus-bg:checked ~ .dof-scene .dof-layer-foreground,
+#focus-bg:checked ~ .dof-scene .dof-layer-midground {
+  filter: blur(16px) !important;
+}
+
+/* Scene Container */
+.dof-scene {
+  position: relative;
+  width: 100%;
+  min-height: 350vh; /* Provides plenty of scrollable track for DoF Rack Focus */
+}
+
+/* Sticky Viewport Stage */
+.dof-stage {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  perspective: 1200px;
+  transform-style: preserve-3d;
+}
+
+/* Common Layer Settings */
+.dof-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  will-change: transform, filter, opacity;
+  transition:
+    filter 0.2s ease-out,
+    transform 0.2s ease-out;
+}
+
+/* Layer 1: Far Background (Deep Celestial Core & Nebula Grid) */
+.dof-layer-far-bg {
+  z-index: 1;
+  background:
+    radial-gradient(
+      circle at 70% 30%,
+      rgba(112, 0, 255, 0.25),
+      transparent 50%
+    ),
+    radial-gradient(circle at 30% 70%, rgba(0, 240, 255, 0.15), transparent 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  filter: blur(var(--dof-blur-far));
+}
+
+.dof-celestial-orb {
+  position: absolute;
+  width: 550px;
+  height: 550px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 35%,
+    #00f0ff,
+    #7000ff 60%,
+    transparent 80%
+  );
+  filter: blur(40px);
+  opacity: 0.6;
+  animation: dof-pulse 8s ease-in-out infinite alternate;
+}
+
+.dof-star-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(1.5px 1.5px at 20px 30px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(
+      2px 2px at 150px 80px,
+      rgba(0, 240, 255, 0.8),
+      rgba(0, 0, 0, 0)
+    ),
+    radial-gradient(1px 1px at 280px 240px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(
+      2px 2px at 400px 120px,
+      rgba(112, 0, 255, 0.9),
+      rgba(0, 0, 0, 0)
+    );
+  background-repeat: repeat;
+  background-size: 500px 500px;
+  opacity: 0.7;
+}
+
+/* Layer 2: Midground (Orbital Tech Ring & Grid Structures) */
+.dof-layer-midground {
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  filter: blur(var(--dof-blur-mid));
+}
+
+.dof-orbital-ring {
+  width: 700px;
+  height: 700px;
+  border: 1px solid rgba(0, 240, 255, 0.2);
+  border-radius: 50%;
+  position: absolute;
+  box-shadow:
+    0 0 40px rgba(0, 240, 255, 0.1),
+    inset 0 0 40px rgba(0, 240, 255, 0.1);
+  transform: rotateX(65deg) rotateY(15deg);
+}
+
+.dof-tech-column-left,
+.dof-tech-column-right {
+  position: absolute;
+  top: 15%;
+  width: 180px;
+  height: 70%;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.03),
+    rgba(255, 255, 255, 0.01)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.dof-tech-column-left {
+  left: 5%;
+  transform: rotateY(25deg);
+}
+.dof-tech-column-right {
+  right: 5%;
+  transform: rotateY(-25deg);
+}
+
+/* Layer 3: Subject Focal Plane (Hero Title, Spec Cards, Interactive UI) */
+.dof-layer-subject {
+  z-index: 3;
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  filter: blur(var(--dof-blur-sharp));
+}
+
+.dof-hero-card {
+  max-width: 860px;
+  width: 100%;
+  padding: 3rem;
+  background: var(--dof-bg-card);
+  border: 1px solid var(--dof-bg-surface-border);
+  border-radius: 24px;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.dof-hero-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -50%;
+  width: 200%;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--dof-primary),
+    transparent
+  );
+  animation: dof-shimmer 4s linear infinite;
+}
+
+.dof-tagline {
+  font-family: var(--dof-font-mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.25em;
+  color: var(--dof-primary);
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.dof-title {
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 900;
+  line-height: 1.05;
+  margin-bottom: 1.25rem;
+  background: linear-gradient(135deg, #ffffff 0%, #a5b4fc 50%, #00f0ff 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.dof-description {
+  font-size: 1.15rem;
+  color: var(--dof-text-muted);
+  line-height: 1.6;
+  max-width: 680px;
+  margin: 0 auto 2.25rem auto;
+}
+
+/* Feature Grid inside Subject Plane */
+.dof-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  width: 100%;
+  margin-top: 1.5rem;
+}
+
+.dof-feature-box {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 1.25rem;
+  text-align: left;
+  transition:
+    transform 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.dof-feature-box:hover {
+  transform: translateY(-4px);
+  border-color: rgba(0, 240, 255, 0.4);
+}
+
+.dof-feature-title {
+  font-family: var(--dof-font-mono);
+  font-size: 0.95rem;
+  color: var(--dof-primary);
+  margin-bottom: 0.4rem;
+}
+
+.dof-feature-desc {
+  font-size: 0.85rem;
+  color: var(--dof-text-muted);
+  line-height: 1.4;
+}
+
+/* Layer 4: Foreground (Bokeh Dust & Camera Crosshairs Overlay) */
+.dof-layer-foreground {
+  z-index: 4;
+  filter: blur(var(--dof-blur-foreground));
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4rem;
+}
+
+.dof-bokeh-node {
+  position: absolute;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(0, 240, 255, 0.8) 0%,
+    rgba(0, 240, 255, 0) 70%
+  );
+  pointer-events: none;
+}
+
+.dof-bokeh-1 {
+  width: 140px;
+  height: 140px;
+  top: 15%;
+  left: 8%;
+}
+.dof-bokeh-2 {
+  width: 220px;
+  height: 220px;
+  bottom: 12%;
+  right: 6%;
+  background: radial-gradient(
+    circle,
+    rgba(112, 0, 255, 0.7) 0%,
+    transparent 70%
+  );
+}
+.dof-bokeh-3 {
+  width: 90px;
+  height: 90px;
+  top: 60%;
+  left: 15%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 0, 85, 0.6) 0%,
+    transparent 70%
+  );
+}
+
+/* Viewfinder View Overlay */
+.dof-viewfinder {
+  position: absolute;
+  inset: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  pointer-events: none;
+}
+
+.dof-viewfinder-corner {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-color: var(--dof-primary);
+  border-style: solid;
+}
+
+.dof-tl {
+  top: 0;
+  left: 0;
+  border-width: 2px 0 0 2px;
+}
+.dof-tr {
+  top: 0;
+  right: 0;
+  border-width: 2px 2px 0 0;
+}
+.dof-bl {
+  bottom: 0;
+  left: 0;
+  border-width: 0 0 2px 2px;
+}
+.dof-br {
+  bottom: 0;
+  right: 0;
+  border-width: 0 2px 2px 0;
+}
+
+/* Scroll Indicator Bar */
+.dof-scroll-hint {
+  position: absolute;
+  bottom: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--dof-font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: var(--dof-text-muted);
+  text-transform: uppercase;
+}
+
+.dof-mouse-icon {
+  width: 22px;
+  height: 36px;
+  border: 2px solid var(--dof-text-muted);
+  border-radius: 12px;
+  position: relative;
+}
+
+.dof-mouse-wheel {
+  width: 4px;
+  height: 8px;
+  background: var(--dof-primary);
+  border-radius: 2px;
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: dof-scroll-wheel 2s ease-in-out infinite;
+}
+
+/* Footer Section */
+.dof-footer {
+  position: relative;
+  z-index: 10;
+  padding: 4rem 2rem;
+  text-align: center;
+  background: #020307;
+  border-top: 1px solid var(--dof-bg-surface-border);
+  font-family: var(--dof-font-mono);
+  font-size: 0.85rem;
+  color: var(--dof-text-muted);
+}
+
+.dof-footer a {
+  color: var(--dof-primary);
+  text-decoration: none;
+}
+
+.dof-footer a:hover {
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   SCROLL-DRIVEN ANIMATIONS ENGINE (Native GPU-Accelerated DoF Rack Focus)
+   ========================================================================== */
+
+@supports (animation-timeline: scroll()) {
+  /* Foreground Layer Scroll Mapping: Moves up fast, blurs out as camera rack-focuses away */
+  .dof-layer-foreground {
+    animation: dof-fg-rack-focus linear both;
+    animation-timeline: scroll(root);
+    animation-range: 0% 50%;
+  }
+
+  /* Subject Layer Scroll Mapping: Starts blurred, comes into crystal sharp focal point at 25-40%, then softly recedes */
+  .dof-layer-subject {
+    animation: dof-subject-rack-focus linear both;
+    animation-timeline: scroll(root);
+    animation-range: 0% 100%;
+  }
+
+  /* Midground Layer Scroll Mapping: Shifts from soft blur to focused depth as user scrolls deeper */
+  .dof-layer-midground {
+    animation: dof-midground-rack-focus linear both;
+    animation-timeline: scroll(root);
+    animation-range: 15% 85%;
+  }
+
+  /* Far Background Layer Scroll Mapping: Slow velocity parallax, shifts into deep focal view at max scroll depth */
+  .dof-layer-far-bg {
+    animation: dof-far-bg-rack-focus linear both;
+    animation-timeline: scroll(root);
+    animation-range: 0% 100%;
+  }
+}
+
+/* Keyframes for Rack Focus & Velocity Transformations */
+@keyframes dof-fg-rack-focus {
+  0% {
+    transform: translateY(0) scale(1);
+    filter: blur(0px);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(-80vh) scale(1.3);
+    filter: blur(28px);
+    opacity: 0.15;
+  }
+  100% {
+    transform: translateY(-140vh) scale(1.6);
+    filter: blur(40px);
+    opacity: 0;
+  }
+}
+
+@keyframes dof-subject-rack-focus {
+  0% {
+    transform: translateY(25vh) scale(0.92);
+    filter: blur(10px);
+    opacity: 0.6;
+  }
+  25% {
+    transform: translateY(0) scale(1);
+    filter: blur(0px);
+    opacity: 1;
+  }
+  55% {
+    transform: translateY(-15vh) scale(1.02);
+    filter: blur(0px);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-75vh) scale(1.15);
+    filter: blur(16px);
+    opacity: 0.25;
+  }
+}
+
+@keyframes dof-midground-rack-focus {
+  0% {
+    transform: translateY(40vh) scale(0.9);
+    filter: blur(14px);
+  }
+  50% {
+    transform: translateY(0) scale(1);
+    filter: blur(2px);
+  }
+  100% {
+    transform: translateY(-50vh) scale(1.1);
+    filter: blur(10px);
+  }
+}
+
+@keyframes dof-far-bg-rack-focus {
+  0% {
+    transform: translateY(0) scale(1);
+    filter: blur(20px);
+  }
+  70% {
+    transform: translateY(-10vh) scale(1.05);
+    filter: blur(6px);
+  }
+  100% {
+    transform: translateY(-20vh) scale(1.1);
+    filter: blur(1px);
+  }
+}
+
+/* Standard Keyframe Utility Animations */
+@keyframes dof-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dof-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.04);
+  }
+}
+
+@keyframes dof-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes dof-scroll-wheel {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 14px);
+  }
+}
+
+/* ==========================================================================
+   FALLBACK FOR BROWSERS WITHOUT ANIMATION-TIMELINE SUPPORT
+   ========================================================================== */
+@supports not (animation-timeline: scroll()) {
+  .dof-layer-far-bg {
+    animation: dof-fallback-bg 12s ease-in-out infinite alternate;
+  }
+  .dof-layer-midground {
+    animation: dof-fallback-mid 9s ease-in-out infinite alternate;
+  }
+  .dof-layer-foreground {
+    animation: dof-fallback-fg 7s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes dof-fallback-bg {
+  0% {
+    filter: blur(16px);
+    transform: scale(1);
+  }
+  100% {
+    filter: blur(4px);
+    transform: scale(1.08);
+  }
+}
+
+@keyframes dof-fallback-mid {
+  0% {
+    filter: blur(10px);
+    transform: translateY(20px);
+  }
+  100% {
+    filter: blur(1px);
+    transform: translateY(-20px);
+  }
+}
+
+@keyframes dof-fallback-fg {
+  0% {
+    filter: blur(0px);
+    transform: translateY(0);
+  }
+  100% {
+    filter: blur(20px);
+    transform: translateY(-60px);
+  }
+}
+
+/* ==========================================================================
+   ACCESSIBILITY: PREFERS-REDUCED-MOTION OVERRIDES
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .dof-layer,
+  .dof-aperture-icon,
+  .dof-celestial-orb,
+  .dof-mouse-wheel {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .dof-layer-far-bg,
+  .dof-layer-midground,
+  .dof-layer-subject,
+  .dof-layer-foreground {
+    filter: blur(0px) !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}
+
+/* Responsive Rules */
+@media (max-width: 768px) {
+  .dof-hud-nav {
+    padding: 1rem 1.25rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  .dof-control-bar {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+  .dof-hero-card {
+    padding: 2rem 1.5rem;
+  }
+  .dof-feature-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Description
Standard parallax simply moves background layers slower than foreground layers. Premium "cinematic" parallax physically blurs the foreground and background based on scroll depth to simulate a physical camera's Depth of Field (DoF).

This PR adds `submissions/examples/ease-cinematic-parallax/` featuring:
- **Zero-JS CSS Scroll-Driven Animations**: Uses `animation-timeline: scroll()` to dynamically bind `translateY` velocity and `filter: blur()` rack-focus values natively on the GPU.
- **Physical DoF Lens Simulation**: Focal plane shifts from foreground bokeh nodes to primary subject clarity (`.dof-hero-card`) and recedes into deep background horizon focus as the user scrolls.
- **Pure CSS Interactive Lens Controls**: Built-in camera mode selector (`:checked` pseudo-class radios) for live focal plane testing.
- **Fallbacks & Accessibility**: Includes `@supports not (animation-timeline: scroll())` ambient floating fallback and full `@media (prefers-reduced-motion: reduce)` accessibility overrides.

### Directory Structure
submissions/examples/ease-cinematic-parallax/
├── demo.html
├── style.css
└── README.md

Resolves #74082