### PR TITLE
feat: add pure CSS Checkbox Ripple component (#70077)

### DIFF
--- a/submissions/examples/css-checkbox-ripple-check-pure/README.md
+++ b/submissions/examples/css-checkbox-ripple-check-pure/README.md
@@ -1,0 +1,22 @@
+# CSS Checkbox Ripple Check
+
+A meticulously crafted, JavaScript-free custom checkbox featuring a material-design-inspired ripple burst and an SVG "draw" animation upon selection.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript event listeners are required to track state or trigger animations.
+- **Component Architecture & Animation Techniques**: 
+  - **Native State Binding**: The component uses a hidden `<input type="checkbox">` wrapped inside a `<label>`. This allows clicking anywhere on the label to natively toggle the input's `:checked` state, which we use to drive all CSS animations.
+  - **The Ripple Effect**: An absolutely positioned `.ripple` element sits behind the visual checkbox box. When the input is checked (`input:checked ~ .checkmark-box .ripple`), an `@keyframes` animation (`ripple-burst`) scales the element from `0` to `2.5` while simultaneously fading its `opacity` to `0`. This creates a satisfying, organic burst of color radiating outward.
+  - **SVG Draw Animation**: The checkmark itself is an inline SVG. By manipulating `stroke-dasharray` (creating dashes) and `stroke-dashoffset` (pushing the dash off-screen), the SVG is initially hidden. On check, the `draw-check` animation brings the `stroke-dashoffset` to `0`, creating the illusion that the checkmark is being hand-drawn onto the screen.
+- **Theming & States**: 
+  - Configured via CSS Custom Properties at the `:root` level. 
+  - Includes full styling for `hover`, `focus-visible` (for keyboard accessibility), and `disabled` states.
+  - Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`.
+- Fully accessible semantic structure. Because it relies on a real `<input type="checkbox">`, it natively supports Spacebar toggling and form submission. Honors the `prefers-reduced-motion` accessibility standard by disabling the ripple completely and instantly revealing the checkmark without the draw animation if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. Click the labels to observe the blue ripple burst from behind the checkbox, followed milliseconds later by the white checkmark drawing itself into existence. Try using the `Tab` key to focus the checkbox and press `Space` to toggle it, observing the accessible focus ring.
+
+## Files
+- `demo.html`: The HTML structure defining the `<label>`, the hidden input, and the inline SVG checkmark.
+- `style.css`: The styling, the `:checked` state management, the `@keyframes` for the ripple, and the `stroke-dashoffset` trick for drawing the SVG.

--- a/submissions/examples/css-checkbox-ripple-check-pure/demo.html
+++ b/submissions/examples/css-checkbox-ripple-check-pure/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Checkbox Ripple Check</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Ripple Checkbox</h1>
+            <p>A beautifully animated checkbox with an expanding ripple and SVG draw effect.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <div class="checkbox-group">
+                
+                <!-- Option 1 -->
+                <label class="custom-checkbox">
+                    <!-- The hidden native checkbox -->
+                    <input type="checkbox" name="option1" checked>
+                    
+                    <!-- The visual replacement -->
+                    <span class="checkmark-box">
+                        <!-- Ripple Effect Element -->
+                        <span class="ripple"></span>
+                        
+                        <!-- SVG Checkmark for the 'draw' animation -->
+                        <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="20 6 9 17 4 12"></polyline>
+                        </svg>
+                    </span>
+                    
+                    <span class="label-text">Enable Notifications</span>
+                </label>
+
+                <!-- Option 2 -->
+                <label class="custom-checkbox">
+                    <input type="checkbox" name="option2">
+                    
+                    <span class="checkmark-box">
+                        <span class="ripple"></span>
+                        <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="20 6 9 17 4 12"></polyline>
+                        </svg>
+                    </span>
+                    
+                    <span class="label-text">Auto-update Applications</span>
+                </label>
+
+                <!-- Option 3 (Disabled state demo) -->
+                <label class="custom-checkbox disabled">
+                    <input type="checkbox" name="option3" disabled>
+                    
+                    <span class="checkmark-box">
+                        <!-- No ripple needed for disabled state, but keeping structure uniform -->
+                        <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="20 6 9 17 4 12"></polyline>
+                        </svg>
+                    </span>
+                    
+                    <span class="label-text">Beta Features (Unavailable)</span>
+                </label>
+
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-checkbox-ripple-check-pure/style.css
+++ b/submissions/examples/css-checkbox-ripple-check-pure/style.css
@@ -1,0 +1,267 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #f9fafb;
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    
+    --checkbox-border: #d1d5db;
+    --checkbox-bg: #ffffff;
+    
+    /* Active States */
+    --primary-color: #3b82f6;      /* Blue */
+    --primary-hover: #2563eb;
+    --check-color: #ffffff;
+    
+    /* Ripple */
+    --ripple-color: rgba(59, 130, 246, 0.3);
+    
+    /* Disabled */
+    --disabled-bg: #f3f4f6;
+    --disabled-border: #e5e7eb;
+    --disabled-text: #9ca3af;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+}
+
+.container {
+    width: 100%;
+    max-width: 400px;
+    background: #fff;
+    padding: 40px;
+    border-radius: 20px;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.05);
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin: 0 0 10px 0;
+}
+
+.header p { 
+    color: var(--text-secondary); 
+    font-size: 0.95rem; 
+    margin: 0;
+}
+
+.checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+
+/* =========================================
+   Checkbox Base Styling
+   ========================================= */
+.custom-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    position: relative;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent; /* Remove mobile tap highlight */
+}
+
+/* Hide the native checkbox completely */
+.custom-checkbox input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+}
+
+/* 
+   The Visual Box 
+*/
+.checkmark-box {
+    position: relative;
+    width: 24px;
+    height: 24px;
+    background-color: var(--checkbox-bg);
+    border: 2px solid var(--checkbox-border);
+    border-radius: 6px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.label-text {
+    font-size: 1rem;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+/* Hover State */
+.custom-checkbox:hover input ~ .checkmark-box {
+    border-color: var(--primary-color);
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] The Expanding Ripple
+   ========================================= */
+.ripple {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    width: 40px; /* Larger than the box */
+    height: 40px;
+    background-color: var(--ripple-color);
+    border-radius: 50%;
+    pointer-events: none; /* Let clicks pass through to label */
+    z-index: -1;          /* Sit behind the box */
+}
+
+/* Trigger ripple on check */
+.custom-checkbox input:checked ~ .checkmark-box .ripple {
+    animation: ripple-burst 0.6s ease-out forwards;
+}
+
+@keyframes ripple-burst {
+    0% {
+        transform: translate(-50%, -50%) scale(0);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(2.5);
+        opacity: 0;
+    }
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] SVG Draw Checkmark
+   ========================================= */
+.check-icon {
+    width: 14px;
+    height: 14px;
+    color: var(--check-color);
+    
+    /* 
+       Prepare for the draw animation.
+       stroke-dasharray dictates the length of the dashes and gaps.
+       stroke-dashoffset pushes the dash out of view initially.
+    */
+    stroke-dasharray: 30;
+    stroke-dashoffset: 30;
+    opacity: 0;
+}
+
+/* State Change: Checked */
+.custom-checkbox input:checked ~ .checkmark-box {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+
+/* Trigger the SVG draw animation */
+.custom-checkbox input:checked ~ .checkmark-box .check-icon {
+    opacity: 1;
+    animation: draw-check 0.4s ease forwards;
+    animation-delay: 0.1s; /* Slight delay feels more natural */
+}
+
+@keyframes draw-check {
+    to {
+        stroke-dashoffset: 0; /* Brings the stroke into view, "drawing" it */
+    }
+}
+
+
+/* =========================================
+   Disabled State
+   ========================================= */
+.custom-checkbox.disabled {
+    cursor: not-allowed;
+}
+
+.custom-checkbox.disabled .checkmark-box {
+    background-color: var(--disabled-bg);
+    border-color: var(--disabled-border);
+}
+
+.custom-checkbox.disabled .label-text {
+    color: var(--disabled-text);
+}
+
+/* If a disabled checkbox happens to be checked (loaded that way) */
+.custom-checkbox.disabled input:checked ~ .checkmark-box {
+    background-color: var(--disabled-border);
+}
+.custom-checkbox.disabled input:checked ~ .checkmark-box .check-icon {
+    opacity: 1;
+    stroke-dashoffset: 0; /* Instantly visible, no animation */
+    animation: none;
+    color: var(--disabled-text);
+}
+
+
+/* Focus Accessibility */
+.custom-checkbox input:focus-visible ~ .checkmark-box {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 3px;
+}
+
+
+/* Dark Mode Compatibility */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #111827;
+        --text-primary: #f9fafb;
+        --text-secondary: #9ca3af;
+        
+        --checkbox-border: #4b5563;
+        --checkbox-bg: #1f2937;
+        
+        --disabled-bg: #374151;
+        --disabled-border: #4b5563;
+        --disabled-text: #6b7280;
+    }
+    
+    .container {
+        background: #1f2937;
+        box-shadow: 0 10px 25px rgba(0,0,0,0.3);
+    }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .ripple {
+        display: none; /* Disable ripple completely */
+    }
+    
+    .check-icon {
+        animation: none !important;
+    }
+    
+    /* Make check instantly appear instead of drawing */
+    .custom-checkbox input:checked ~ .checkmark-box .check-icon {
+        stroke-dashoffset: 0; 
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a meticulously crafted, JavaScript-free custom checkbox featuring a material-design-inspired ripple burst and an SVG "draw" animation upon selection. Resolves issue #70077.

### Changes Made:
- Added `submissions/examples/css-checkbox-ripple-check-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the `<label>`, the hidden input, and the inline SVG checkmark.
- Created `style.css` featuring the UI mechanics:
  - **Native State Binding**: The component uses a hidden `<input type="checkbox">` wrapped inside a `<label>`. This allows clicking anywhere on the label to natively toggle the input's `:checked` state, which we use to drive all CSS animations.
  - **The Ripple Effect**: An absolutely positioned `.ripple` element sits behind the visual checkbox box. When the input is checked (`input:checked ~ .checkmark-box .ripple`), an `@keyframes` animation (`ripple-burst`) scales the element from `0` to `2.5` while simultaneously fading its `opacity` to `0`. This creates a satisfying, organic burst of color radiating outward.
  - **SVG Draw Animation**: The checkmark itself is an inline SVG. By manipulating `stroke-dasharray` (creating dashes) and `stroke-dashoffset` (pushing the dash off-screen), the SVG is initially hidden. On check, the `draw-check` animation brings the `stroke-dashoffset` to `0`, creating the illusion that the checkmark is being hand-drawn onto the screen.
  - **Theming & States Supported**: Configured via CSS Custom Properties. Includes full styling for `hover`, `focus-visible` (for keyboard accessibility), and `disabled` states. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`.
- Added `README.md` documenting usage and the technical mechanics of the ripple keyframes and the `stroke-dashoffset` trick for drawing the SVG.
- Fully accessible semantic structure. Because it relies on a real `<input type="checkbox">`, it natively supports Spacebar toggling and form submission. Honors the `prefers-reduced-motion` accessibility standard by disabling the ripple completely and instantly revealing the checkmark without the draw animation if requested by the OS.

Closes #70077
