### PR TITLE
feat: add Foucault Pendulum Swing card variation 48

### DIFF
--- a/submissions/examples/card-foucault-pendulum-swing-48/README.md
+++ b/submissions/examples/card-foucault-pendulum-swing-48/README.md
@@ -1,0 +1,16 @@
+# Foucault Pendulum Swing Card
+
+**What does this do?**
+This adds a smooth, hardware-accelerated Foucault Pendulum swing animation to a card component that works perfectly in both light and dark modes.
+
+**How is it used?**
+Apply the `foucault-pendulum-card` class to your card element container:
+```html
+<div class="foucault-pendulum-card">
+    <h3>Pendulum Swing</h3>
+    <p>Your content here.</p>
+</div>
+```
+
+**Why is it useful?**
+It provides an elegant, physics-inspired continuous motion that draws user attention without being overly aggressive, making it ideal for featured content or interactive elements in modern web designs.

--- a/submissions/examples/card-foucault-pendulum-swing-48/demo.html
+++ b/submissions/examples/card-foucault-pendulum-swing-48/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Foucault Pendulum Swing Card Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="foucault-pendulum-card">
+        <h3>Pendulum Swing</h3>
+        <p>This card demonstrates a Foucault pendulum swing animation. It is hardware accelerated, performs a smooth continuous swing, and supports dark mode seamlessly.</p>
+    </div>
+</body>
+</html>

--- a/submissions/examples/card-foucault-pendulum-swing-48/style.css
+++ b/submissions/examples/card-foucault-pendulum-swing-48/style.css
@@ -1,0 +1,64 @@
+body {
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+.foucault-pendulum-card {
+    background: #1e1e1e;
+    border-radius: 16px;
+    padding: 2rem;
+    width: 300px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    transform-origin: top center;
+    animation: foucault-swing 3s infinite ease-in-out alternate;
+    will-change: transform;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.foucault-pendulum-card h3 {
+    margin-top: 0;
+    color: #fff;
+    font-size: 1.5rem;
+}
+
+.foucault-pendulum-card p {
+    color: #aaa;
+    line-height: 1.6;
+}
+
+@keyframes foucault-swing {
+    0% {
+        transform: rotate(-10deg) translateZ(0);
+    }
+    100% {
+        transform: rotate(10deg) translateZ(0);
+    }
+}
+
+.foucault-pendulum-card:hover {
+    animation-play-state: paused;
+}
+
+@media (prefers-color-scheme: light) {
+    body {
+        background-color: #f5f5f5;
+        color: #333;
+    }
+    .foucault-pendulum-card {
+        background: #ffffff;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+    }
+    .foucault-pendulum-card h3 {
+        color: #111;
+    }
+    .foucault-pendulum-card p {
+        color: #666;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new Foucault Pendulum Swing variation for the CSS card component (Issue #73281). It provides a smooth, hardware-accelerated swinging animation that works perfectly in both dark and light modes.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a smooth, hardware-accelerated Foucault Pendulum swing animation to a card component that natively supports both light and dark themes.

**How does a developer use it?**

```html
<div class="foucault-pendulum-card">
    <h3>Pendulum Swing</h3>
    <p>Your content here.</p>
</div>
