### PR TITLE
Add inline tag submission

### DIFF
--- a/submissions/examples/alert-tag-tm/README.md
+++ b/submissions/examples/alert-tag-tm/README.md
@@ -1,0 +1,7 @@
+# Inline tag
+
+1. What does this do? A small inline tag used to mark a status, a version, or a category.
+
+2. How is it used? Add `alert-tag-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Label / tag pattern; the tag has a coloured background.

--- a/submissions/examples/alert-tag-tm/demo.html
+++ b/submissions/examples/alert-tag-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Alert Tag — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="alerttag-page-tm" data-palette="teal">
+  <h1 class="alerttag-h-tm">Alert Tag</h1>
+  <p class="alerttag-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="alerttag-row-tm">
+    <article class="alerttag-1-wrap-tm">
+      <div class="alerttag-1-tm"></div>
+      <span class="alerttag-lbl-tm">Example One</span>
+    </article>
+    <article class="alerttag-2-wrap-tm">
+      <div class="alerttag-2-tm"></div>
+      <span class="alerttag-lbl-tm">Example Two</span>
+    </article>
+    <article class="alerttag-3-wrap-tm">
+      <div class="alerttag-3-tm"></div>
+      <span class="alerttag-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/alert-tag-tm/style.css
+++ b/submissions/examples/alert-tag-tm/style.css
@@ -1,0 +1,52 @@
+:root {
+  --alerttag-bg: #08161a;
+  --alerttag-surface: #0f2429;
+  --alerttag-edge: #163239;
+  --alerttag-text: #e6e8ec;
+  --alerttag-muted: #8b909b;
+  --alerttag-accent: #14b8a6;
+  --alerttag-accent-2: #5eead4;
+  --alerttag-radius: 10px;
+  --alerttag-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--alerttag-bg);
+  color: var(--alerttag-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.alerttag-page-tm { max-width: 920px; margin: 0 auto; }
+.alerttag-h-tm { font-size: 28px; margin: 0 0 8px; }
+.alerttag-lede-tm { color: var(--alerttag-muted); margin: 0 0 32px; }
+.alerttag-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.alerttag-1-wrap-tm, .alerttag-2-wrap-tm, .alerttag-3-wrap-tm {
+  background: var(--alerttag-surface);
+  border: 1px solid var(--alerttag-edge);
+  border-radius: var(--alerttag-radius);
+  padding: var(--alerttag-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.alerttag-lbl-tm { color: var(--alerttag-muted); font-size: 13px; }
+
+.alerttag-1-tm, .alerttag-2-tm, .alerttag-3-tm {
+      display: inline-block; padding: 2px 8px; border-radius: 4px;
+      background: #14b8a622; color: #14b8a6; font-size: 12px; font-weight: 600;
+}
+.alerttag-2-tm { background: #5eead422; color: #5eead4; }
+.alerttag-3-tm { background: #8b909b22; color: #8b909b; }


### PR DESCRIPTION
Closes #77473

## What
This submission adds a new EaseMotion CSS example: `alert-tag-tm`.

A small inline tag used to mark a status, a version, or a category.

## How to review
1. Open `submissions/examples/alert-tag-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/alert-tag-tm/` and does not modify any existing file.
