### PR TITLE
feat: add pure CSS Nav Diamond Facet Edge component (#73332)

### DIFF
--- a/submissions/examples/css-nav-diamond-facet-edge-pure/README.md
+++ b/submissions/examples/css-nav-diamond-facet-edge-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Nav: Diamond Facet Edge
+
+A hardware-accelerated, JavaScript-free navigation component featuring a 3D "diamond facet" edge effect on hover and active states using modern CSS `clip-path` techniques.
+
+## Features
+- Pure CSS and HTML implementation. No SVGs, complex nested spans, or JavaScript required for the hover interactions.
+- **Component Architecture & Styling Mechanics**: 
+  - **CSS Clip-Path Polygon**: The core of the diamond edge shape is achieved using `clip-path: polygon()`. By mapping 6 points `(10px 50%, 0 100%, 100% 100%, calc(100% - 10px) 50%, 100% 0, 0 0)`, we cut the standard rectangular pseudo-element into a custom polygon with inset diamond edges on both the left and right sides.
+  - **Layered Pseudo-Elements for 3D Depth**: The `.nav-link` utilizes both `::before` (the primary color layer) and `::after` (the darker shadow layer). Both layers share the exact same `clip-path`. The shadow layer is slightly offset downward and to the left to simulate a 3D facet or extrusion.
+  - **Staggered Hover Animation**: When a link is hovered or marked `.active`, both pseudo-elements fade in and scale up from `0.9` to `1`. A subtle `transition-delay: 0.05s` is applied to the shadow layer, creating a satisfying "pop" as the layers lock into place.
+- **Theming**: Configured via CSS Custom Properties. The palette utilizes a clean, minimal background with vibrant accent colors (blue for light mode, purple for dark mode). Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`.
+- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and standard `<a>` tags with `aria-label` and `aria-current="page"` for proper screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale and transform transitions if requested by the OS, providing an instant state change instead.
+
+## Usage
+Open `demo.html` in your browser. Hover your mouse over the navigation links. Observe the blue (or purple in dark mode) diamond-edged background elements smoothly scale up and fade into view. Note the subtle staggered timing of the underlying drop-shadow layer that provides the 3D faceted effect.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic `<nav>` list and the active link classes.
+- `style.css`: The styling, the layered `::before` and `::after` pseudo-elements, the `clip-path` polygon definitions, and the transition delay timing.

--- a/submissions/examples/css-nav-diamond-facet-edge-pure/demo.html
+++ b/submissions/examples/css-nav-diamond-facet-edge-pure/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Nav: Diamond Facet Edge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Diamond Facet Navigation</h1>
+            <p>Hover over the links to reveal the pure CSS diamond edge facet animations.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <nav class="diamond-nav" aria-label="Main Navigation">
+                <ul class="nav-list">
+                    <li class="nav-item">
+                        <a href="#" class="nav-link active" aria-current="page">
+                            <span class="link-text">Dashboard</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Analytics</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Settings</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Profile</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-nav-diamond-facet-edge-pure/style.css
+++ b/submissions/examples/css-nav-diamond-facet-edge-pure/style.css
@@ -1,0 +1,169 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #f0f2f5;
+    --nav-bg: #ffffff;
+    --text-primary: #1e293b;
+    --text-muted: #64748b;
+    
+    --facet-color: #3b82f6; /* Blue Accent */
+    --facet-shadow: #1d4ed8;
+    
+    --transition-speed: 0.35s;
+    --transition-curve: cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Space Grotesk', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+.title { margin: 0 0 10px 0; font-size: 2rem; font-weight: 700; }
+.header p { margin: 0; color: var(--text-muted); }
+
+
+/* =========================================
+   Navigation Container
+   ========================================= */
+.diamond-nav {
+    background: var(--nav-bg);
+    padding: 10px 20px;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+}
+
+.nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 15px;
+}
+
+.nav-item {
+    position: relative;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Diamond Facet Base
+   ========================================= */
+.nav-link {
+    display: inline-block;
+    padding: 14px 24px;
+    text-decoration: none;
+    color: var(--text-muted);
+    font-weight: 500;
+    font-size: 1.05rem;
+    position: relative;
+    z-index: 1;
+    transition: color var(--transition-speed) ease;
+}
+
+/* 
+   The Facet Edge 
+   Using pseudo-elements to create the animated background shape
+*/
+.nav-link::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: var(--facet-color);
+    z-index: -1;
+    
+    /* 
+       [TECHNIQUE 2] CSS Clip-Path Diamond Edge
+       This cuts the rectangle into a chevron/diamond edge on both sides.
+    */
+    clip-path: polygon(10px 50%, 0 100%, 100% 100%, calc(100% - 10px) 50%, 100% 0, 0 0);
+    
+    /* Initially hidden by scaling down and fading out */
+    opacity: 0;
+    transform: scale(0.9) translateY(5px);
+    transition: all var(--transition-speed) var(--transition-curve);
+}
+
+/* 
+   The Drop Shadow Facet Layer
+   To give it a 3D faceted look, we add a darker layer underneath
+*/
+.nav-link::after {
+    content: '';
+    position: absolute;
+    top: 4px; left: -2px; width: 100%; height: 100%;
+    background: var(--facet-shadow);
+    z-index: -2;
+    clip-path: polygon(10px 50%, 0 100%, 100% 100%, calc(100% - 10px) 50%, 100% 0, 0 0);
+    opacity: 0;
+    transform: scale(0.9) translateY(5px);
+    transition: all var(--transition-speed) var(--transition-curve);
+}
+
+
+/* =========================================
+   Interaction States (Hover & Active)
+   ========================================= */
+.nav-link:hover,
+.nav-link.active {
+    color: #ffffff;
+}
+
+/* Reveal the diamond facets */
+.nav-link:hover::before,
+.nav-link.active::before {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+}
+
+/* Stagger the shadow facet slightly for depth */
+.nav-link:hover::after,
+.nav-link.active::after {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+    /* Slight delay on the shadow creates a pop-out effect */
+    transition-delay: 0.05s; 
+}
+
+
+/* Dark Mode Compatibility */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --nav-bg: #1e293b;
+        --text-primary: #f8fafc;
+        --text-muted: #94a3b8;
+        
+        --facet-color: #8b5cf6; /* Purple Accent for dark mode */
+        --facet-shadow: #6d28d9;
+    }
+    
+    .diamond-nav {
+        box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+    }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .nav-link,
+    .nav-link::before,
+    .nav-link::after {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free navigation component featuring a 3D "diamond facet" edge effect on hover and active states using modern CSS `clip-path` techniques. Resolves issue #73332.

### Changes Made:
- Added `submissions/examples/css-nav-diamond-facet-edge-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic `<nav>` list and the active link classes.
- Created `style.css` featuring the UI mechanics:
  - **CSS Clip-Path Polygon**: The core of the diamond edge shape is achieved using `clip-path: polygon()`. By mapping 6 points `(10px 50%, 0 100%, 100% 100%, calc(100% - 10px) 50%, 100% 0, 0 0)`, we cut the standard rectangular pseudo-element into a custom polygon with inset diamond edges on both the left and right sides.
  - **Layered Pseudo-Elements for 3D Depth**: The `.nav-link` utilizes both `::before` (the primary color layer) and `::after` (the darker shadow layer). Both layers share the exact same `clip-path`. The shadow layer is slightly offset downward and to the left to simulate a 3D facet or extrusion.
  - **Staggered Hover Animation**: When a link is hovered or marked `.active`, both pseudo-elements fade in and scale up from `0.9` to `1`. A subtle `transition-delay: 0.05s` is applied to the shadow layer, creating a satisfying "pop" as the layers lock into place.
  - **Theming Supported**: Configured via CSS Custom Properties. The palette utilizes a clean, minimal background with vibrant accent colors (blue for light mode, purple for dark mode). Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`.
- Added `README.md` documenting usage and the technical mechanics of the layered `::before` and `::after` pseudo-elements, the `clip-path` polygon definitions, and the transition delay timing.
- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and standard `<a>` tags with `aria-label` and `aria-current="page"` for proper screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale and transform transitions if requested by the OS, providing an instant state change instead.

Closes #73332
