### PR TITLE
Add 404 state submission

### DIFF
--- a/submissions/examples/alert-404-tm/README.md
+++ b/submissions/examples/alert-404-tm/README.md
@@ -1,0 +1,7 @@
+# 404 state
+
+1. What does this do? A 404 not-found page with a big number, a heading, and a link home.
+
+2. How is it used? Add `alert-404-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Error page pattern; the 404 uses display font for impact.

--- a/submissions/examples/alert-404-tm/demo.html
+++ b/submissions/examples/alert-404-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Alert 404 — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="alert404-page-tm" data-palette="warm">
+  <h1 class="alert404-h-tm">Alert 404</h1>
+  <p class="alert404-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="alert404-row-tm">
+    <article class="alert404-1-wrap-tm">
+      <div class="alert404-1-tm"></div>
+      <span class="alert404-lbl-tm">Example One</span>
+    </article>
+    <article class="alert404-2-wrap-tm">
+      <div class="alert404-2-tm"></div>
+      <span class="alert404-lbl-tm">Example Two</span>
+    </article>
+    <article class="alert404-3-wrap-tm">
+      <div class="alert404-3-tm"></div>
+      <span class="alert404-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/alert-404-tm/style.css
+++ b/submissions/examples/alert-404-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --alert404-bg: #0f1115;
+  --alert404-surface: #1a1d24;
+  --alert404-edge: #262a33;
+  --alert404-text: #e6e8ec;
+  --alert404-muted: #8b909b;
+  --alert404-accent: #ff6a3d;
+  --alert404-accent-2: #ffd166;
+  --alert404-radius: 10px;
+  --alert404-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--alert404-bg);
+  color: var(--alert404-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.alert404-page-tm { max-width: 920px; margin: 0 auto; }
+.alert404-h-tm { font-size: 28px; margin: 0 0 8px; }
+.alert404-lede-tm { color: var(--alert404-muted); margin: 0 0 32px; }
+.alert404-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.alert404-1-wrap-tm, .alert404-2-wrap-tm, .alert404-3-wrap-tm {
+  background: var(--alert404-surface);
+  border: 1px solid var(--alert404-edge);
+  border-radius: var(--alert404-radius);
+  padding: var(--alert404-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.alert404-lbl-tm { color: var(--alert404-muted); font-size: 13px; }
+
+.alert404-1-tm, .alert404-2-tm, .alert404-3-tm {
+      width: 100%; padding: 32px 16px; text-align: center;
+}
+.alert404-1-tm::before { content: "404"; display: block; font-size: 72px; font-weight: 800; color: #ff6a3d; line-height: 1; }
+.alert404-1-tm::after { content: "Page not found"; display: block; margin-top: 12px; color: #8b909b; }
+.alert404-2-tm::before { color: #ffd166; }
+.alert404-3-tm::before { color: #8b909b; }


### PR DESCRIPTION
Closes #77487

## What
This submission adds a new EaseMotion CSS example: `alert-404-tm`.

A 404 not-found page with a big number, a heading, and a link home.

## How to review
1. Open `submissions/examples/alert-404-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/alert-404-tm/` and does not modify any existing file.
