### PR TITLE
feat: add CSS Holy Grail Layout (#70321)

### DIFF
--- a/submissions/examples/css-holy-grail-layout-70321/README.md
+++ b/submissions/examples/css-holy-grail-layout-70321/README.md
@@ -1,0 +1,7 @@
+# CSS Holy Grail Layout
+
+1. What does this do? Renders the classic holy grail page composition (header, left navigation sidebar, primary main column, right related-links aside, footer) using CSS Grid.
+2. How is it used? Drop `demo.html` next to `style.css`; the `.page` grid names five areas via `grid-template-areas` and reflows into a single stacked column below 768px.
+3. Why is it useful? Gives developers a ready-to-use, accessible (skip link, `role`/`aria-label`, keyboard-focusable main) holy grail layout with no JavaScript and `prefers-reduced-motion` support.
+
+Closes #70321

--- a/submissions/examples/css-holy-grail-layout-70321/demo.html
+++ b/submissions/examples/css-holy-grail-layout-70321/demo.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Holy Grail Layout</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <div class="page" id="top">
+      <header class="grail__header" role="banner">
+        <a class="brand" href="#top">EaseMotion</a>
+        <nav class="grail__nav" aria-label="Primary">
+          <a href="#main">Docs</a>
+          <a href="#main">Examples</a>
+          <a href="#main">GitHub</a>
+        </nav>
+      </header>
+
+      <div class="grail__body">
+        <aside class="grail__left" aria-label="Section navigation">
+          <nav aria-label="Table of contents">
+            <ul>
+              <li><a href="#main">Overview</a></li>
+              <li><a href="#main">Getting started</a></li>
+              <li><a href="#main">Components</a></li>
+              <li><a href="#main">Theming</a></li>
+            </ul>
+          </nav>
+        </aside>
+
+        <main class="grail__main" id="main" tabindex="-1">
+          <h1>Holy Grail Layout</h1>
+          <p>
+            A classic header / sidebar / main / aside / footer composition built with
+            CSS Grid. No JavaScript, fully responsive, and keyboard navigable.
+          </p>
+
+          <section aria-labelledby="s1">
+            <h2 id="s1">Why this layout?</h2>
+            <p>
+              The holy grail pattern keeps primary content first in source order while
+              flanking it with navigation and related links. Here the main column is
+              rendered between the two sidebars without extra wrappers.
+            </p>
+          </section>
+
+          <section aria-labelledby="s2">
+            <h2 id="s2">Responsive behavior</h2>
+            <p>
+              Below 768px the grid collapses into a single stacked column so the
+              header, navigation, main content, asides, and footer reflow on small
+              screens. The <code>tabindex="-1"</code> on main allows skip-link focus.
+            </p>
+          </section>
+        </main>
+
+        <aside class="grail__right" aria-label="Related links">
+          <h2>Related</h2>
+          <ul>
+            <li><a href="#main">Grid basics</a></li>
+            <li><a href="#main">Subgrid</a></li>
+            <li><a href="#main">Container queries</a></li>
+          </ul>
+        </aside>
+      </div>
+
+      <footer class="grail__footer" role="contentinfo">
+        <p>&copy; 2026 EaseMotion CSS &middot; Pure CSS holy grail layout</p>
+      </footer>
+    </div>
+
+    <a class="skip-link" href="#main">Skip to main content</a>
+  </body>
+</html>

--- a/submissions/examples/css-holy-grail-layout-70321/style.css
+++ b/submissions/examples/css-holy-grail-layout-70321/style.css
@@ -1,0 +1,207 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --panel-2: #1f1f23;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --accent: #818cf8;
+  --radius: 16px;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Skip link revealed on keyboard focus */
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  z-index: 10;
+  padding: 10px 16px;
+  background: var(--accent);
+  color: #0b0b12;
+  font-weight: 600;
+  border-radius: 0 0 var(--radius) 0;
+}
+.skip-link:focus {
+  left: 0;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: 100vh;
+  display: grid;
+  grid-template-areas:
+    "header header header"
+    "left   main   right"
+    "footer footer footer";
+  grid-template-columns: 220px 1fr 220px;
+  grid-template-rows: auto 1fr auto;
+  gap: 16px;
+  padding: 16px;
+}
+
+/* Header */
+.grail__header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 24px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.brand {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+.grail__nav a {
+  color: var(--muted);
+  margin-left: 18px;
+  font-weight: 500;
+}
+.grail__nav a:hover {
+  color: var(--text);
+}
+
+/* Body wrapper */
+.grail__body {
+  grid-area: left / left / right / right;
+  display: contents;
+}
+
+/* Sidebars */
+.grail__left,
+.grail__right {
+  padding: 20px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.grail__left {
+  grid-area: left;
+}
+.grail__right {
+  grid-area: right;
+}
+.grail__left nav ul,
+.grail__right ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+.grail__right h2 {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+/* Main */
+.grail__main {
+  grid-area: main;
+  padding: 28px 32px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.grail__main h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.6rem, 1rem + 2vw, 2.4rem);
+  line-height: 1.15;
+}
+.grail__main section {
+  margin-top: 24px;
+}
+.grail__main h2 {
+  font-size: 1.15rem;
+  margin-bottom: 8px;
+}
+.grail__main p {
+  color: #d4d4d8;
+}
+code {
+  background: #2a2a30;
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.9em;
+}
+
+/* Footer */
+.grail__footer {
+  grid-area: footer;
+  padding: 16px 24px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+/* Responsive: stack columns under 768px */
+@media (max-width: 768px) {
+  .page {
+    grid-template-areas:
+      "header"
+      "main"
+      "left"
+      "right"
+      "footer";
+    grid-template-columns: 1fr;
+  }
+  .grail__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .grail__nav a {
+    margin-left: 0;
+    margin-right: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## CSS Holy Grail Layout

Adds a pure-CSS Holy Grail layout example: header, three-column body (nav / main / aside), and footer, collapsing to a stacked layout on narrow viewports. No JavaScript.

### Files
- `submissions/examples/css-holy-grail-layout-70321/demo.html`
- `submissions/examples/css-holy-grail-layout-70321/style.css`
- `submissions/examples/css-holy-grail-layout-70321/README.md`

### Conformance
- Semantic landmarks, keyboard accessible.
- `prefers-reduced-motion` guard.
- ASCII-only source.

Closes #70321

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._