### PR TITLE
feat: add CSS Morphing Pill Button (#70323)

### DIFF
--- a/submissions/examples/css-morphing-pill-button-70323/README.md
+++ b/submissions/examples/css-morphing-pill-button-70323/README.md
@@ -1,0 +1,7 @@
+# CSS Morphing Pill Button
+
+1. What does this do? Renders a button that morphs its `border-radius` between a fully rounded pill and a square shape on hover/focus, with a gentle lift and color glow.
+2. How is it used? Add a `<button class="btn btn--pill">`; the radius is driven by a single `--r` custom property that transitions on `:hover`/`:focus-visible`.
+3. Why is it useful? Adds a ready-to-use morphing button animation with no JavaScript, keyboard-accessible focus state, and `prefers-reduced-motion` support.
+
+Closes #70323

--- a/submissions/examples/css-morphing-pill-button-70323/demo.html
+++ b/submissions/examples/css-morphing-pill-button-70323/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Morphing Pill Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-labelledby="title">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1 id="title">Morphing Pill Button</h1>
+        <p class="copy">
+          A button that morphs between a rounded pill and a square shape on hover
+          and focus, using only CSS transitions. Try keyboard focus (Tab) too.
+        </p>
+
+        <div class="row">
+          <button class="btn btn--pill" type="button">Save changes</button>
+          <button class="btn btn--pill" type="button">Subscribe</button>
+          <button class="btn btn--pill" type="button">Get started</button>
+        </div>
+
+        <p class="hint">Hover or focus a button to watch it morph shape.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-morphing-pill-button-70323/style.css
+++ b/submissions/examples/css-morphing-pill-button-70323/style.css
@@ -1,0 +1,117 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --accent: #818cf8;
+  --accent-strong: #6366f1;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(120% 120% at 50% 0%, #1f1f23 0%, #09090b 60%);
+}
+
+.shell {
+  width: min(92vw, 560px);
+}
+
+.card {
+  padding: 40px;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+#title {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+.copy {
+  margin: 0 0 28px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.hint {
+  margin: 22px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+/* The morphing button */
+.btn {
+  --r: 999px; /* pill radius */
+  font: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 14px 26px;
+  color: #0b0b12;
+  background: linear-gradient(180deg, var(--accent), var(--accent-strong));
+  border: none;
+  border-radius: var(--r);
+  cursor: pointer;
+  /* The actual morph: radius + a small translate for a subtle "pop" */
+  transition:
+    border-radius 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 200ms ease,
+    box-shadow 320ms ease;
+  box-shadow: 0 6px 18px rgba(99, 102, 241, 0.35);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  --r: 10px; /* square-ish */
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px rgba(99, 102, 241, 0.45);
+}
+
+.btn:active {
+  transform: translateY(0);
+  filter: brightness(0.95);
+}
+
+.btn:focus-visible {
+  outline: 2px solid #c7d2fe;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition:
+      filter 200ms ease,
+      box-shadow 200ms ease;
+  }
+  .btn:hover,
+  .btn:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## CSS Morphing Pill Button

Adds a pure-CSS morphing pill button example: a pill-shaped button that morphs shape on hover/press with smooth transitions. No JavaScript.

### Files
- `submissions/examples/css-morphing-pill-button-70323/demo.html`
- `submissions/examples/css-morphing-pill-button-70323/style.css`
- `submissions/examples/css-morphing-pill-button-70323/README.md`

### Conformance
- Keyboard accessible (focus-visible).
- `prefers-reduced-motion` guard.
- ASCII-only source.

Closes #70323

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._