### PR TITLE
feat: add CSS Gradient Sweep Button (#70317)

### DIFF
--- a/submissions/examples/css-gradient-sweep-button-70317/README.md
+++ b/submissions/examples/css-gradient-sweep-button-70317/README.md
@@ -1,0 +1,7 @@
+# CSS Gradient Sweep Button
+
+1. What does this do? Renders a button whose background gradient swaps to a second gradient on hover/focus while a light sheen sweeps across its surface.
+2. How is it used? Use `<button class="sweep"><span>Label</span></button>`; the resting gradient sits on the element and the hover gradient lives on the `::after` layer, revealed on interaction; `::before` is the moving sheen.
+3. Why is it useful? Adds a ready-to-use animated gradient-sweep button with no JavaScript, keyboard-accessible focus state, and `prefers-reduced-motion` support.
+
+Closes #70317

--- a/submissions/examples/css-gradient-sweep-button-70317/demo.html
+++ b/submissions/examples/css-gradient-sweep-button-70317/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Gradient Sweep Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-labelledby="title">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1 id="title">Gradient Sweep Button</h1>
+        <p class="copy">
+          A button whose background sweeps from one gradient to another on hover
+          and focus. The gradient is masked by an animated highlight that sweeps
+          across the surface.
+        </p>
+
+        <div class="row">
+          <button class="sweep" type="button"><span>Launch app</span></button>
+          <button class="sweep sweep--alt" type="button"><span>Read docs</span></button>
+        </div>
+
+        <p class="hint">Hover or focus a button to see the sweep.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-gradient-sweep-button-70317/style.css
+++ b/submissions/examples/css-gradient-sweep-button-70317/style.css
@@ -1,0 +1,170 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(120% 120% at 50% 0%, #1f1f23 0%, #09090b 60%);
+}
+
+.shell {
+  width: min(92vw, 560px);
+}
+
+.card {
+  padding: 40px;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+#title {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+.copy {
+  margin: 0 0 28px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.hint {
+  margin: 22px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+/* Sweep button */
+.sweep {
+  position: relative;
+  isolation: isolate;
+  font: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #0b0b12;
+  padding: 14px 28px;
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  /* resting gradient */
+  background: linear-gradient(120deg, #a5b4fc, #818cf8 45%, #6366f1);
+  overflow: hidden;
+  transition:
+    background 360ms ease,
+    transform 240ms ease,
+    box-shadow 360ms ease;
+  box-shadow: 0 8px 22px rgba(99, 102, 241, 0.3);
+}
+
+.sweep--alt {
+  background: linear-gradient(120deg, #6ee7b7, #34d399 45%, #059669);
+  box-shadow: 0 8px 22px rgba(16, 185, 129, 0.3);
+}
+
+/* sweeping highlight layer */
+.sweep::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  /* hover gradient (the "another" gradient) */
+  background: linear-gradient(120deg, #f0abfc, #c084fc 45%, #7c3aed);
+  opacity: 0;
+  transform: translateX(-100%);
+  transition:
+    opacity 320ms ease,
+    transform 560ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sweep--alt::after {
+  background: linear-gradient(120deg, #fde68a, #fbbf24 45%, #d97706);
+}
+
+/* a moving sheen that sweeps across the surface */
+.sweep::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -120%;
+  width: 60%;
+  height: 100%;
+  z-index: 1;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    rgba(255, 255, 255, 0.55),
+    transparent
+  );
+  transform: skewX(-18deg);
+  transition: left 620ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+}
+
+.sweep span {
+  position: relative;
+  z-index: 2;
+}
+
+/* hover + keyboard focus: swap gradient and trigger the sweep */
+.sweep:hover,
+.sweep:focus-visible {
+  background: transparent; /* reveals ::after gradient */
+  transform: translateY(-2px);
+}
+.sweep:hover::after,
+.sweep:focus-visible::after {
+  opacity: 1;
+  transform: translateX(0);
+}
+.sweep:hover::before,
+.sweep:focus-visible::before {
+  left: 130%;
+}
+
+.sweep:focus-visible {
+  outline: 2px solid #c7d2fe;
+  outline-offset: 3px;
+}
+.sweep:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sweep,
+  .sweep::after,
+  .sweep::before {
+    transition: background 320ms ease;
+  }
+  .sweep:hover,
+  .sweep:focus-visible {
+    transform: none;
+  }
+  .sweep::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## CSS Gradient Sweep Button

Adds a pure-CSS gradient sweep button: an animated gradient sweeps across the button surface on hover. No JavaScript.

### Files
- `submissions/examples/css-gradient-sweep-button-70317/demo.html`
- `submissions/examples/css-gradient-sweep-button-70317/style.css`
- `submissions/examples/css-gradient-sweep-button-70317/README.md`

### Conformance
- Keyboard accessible (focus-visible).
- `prefers-reduced-motion` guard.
- ASCII-only source.

Closes #70317

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._