### PR TITLE
feat: add CSS Quick Action Sheet (#70315)

### DIFF
--- a/submissions/examples/css-quick-action-sheet-70315/README.md
+++ b/submissions/examples/css-quick-action-sheet-70315/README.md
@@ -1,0 +1,7 @@
+# CSS Quick Action Sheet
+
+1. What does this do? Renders an iOS-style quick action bottom sheet with an options list and a Cancel/dismiss control, sliding up from the bottom with a scrim.
+2. How is it used? A hidden `<input type="checkbox" id="qa-toggle">` drives state; `<label for="qa-toggle">` elements act as the trigger, scrim, each option, and the Cancel button, so the sheet opens and dismisses with no JavaScript.
+3. Why is it useful? Adds a ready-to-use mobile-style action sheet with no JS, ARIA dialog semantics, keyboard-accessible trigger, and `prefers-reduced-motion` support.
+
+Closes #70315

--- a/submissions/examples/css-quick-action-sheet-70315/demo.html
+++ b/submissions/examples/css-quick-action-sheet-70315/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Quick Action Sheet</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <!-- Hidden checkbox drives open/close; label toggles it. -->
+    <input type="checkbox" id="qa-toggle" class="qa-toggle" aria-hidden="true" />
+
+    <main class="shell">
+      <section class="card" aria-labelledby="title">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1 id="title">Quick Action Sheet</h1>
+        <p class="copy">
+          An iOS-style quick action bottom sheet with an options list. Open and
+          dismiss it without any JavaScript — using only CSS.
+        </p>
+
+        <label for="qa-toggle" class="open-btn">Open actions</label>
+
+        <p class="hint">
+          Tap the scrim or the Cancel button to dismiss. Keyboard: Tab to the
+          trigger and press Enter/Space.
+        </p>
+      </section>
+    </main>
+
+    <!-- The sheet -->
+    <div class="qa" role="dialog" aria-modal="true" aria-labelledby="qa-title">
+      <label for="qa-toggle" class="qa__scrim" aria-label="Dismiss sheet"></label>
+
+      <section class="qa__panel">
+        <h2 id="qa-title" class="qa__title">Quick actions</h2>
+        <span class="qa__grip" aria-hidden="true"></span>
+
+        <ul class="qa__list" role="list">
+          <li>
+            <label for="qa-toggle" class="qa__item">
+              <span class="qa__ico" aria-hidden="true">&#9998;</span>
+              <span class="qa__label">Edit post</span>
+            </label>
+          </li>
+          <li>
+            <label for="qa-toggle" class="qa__item">
+              <span class="qa__ico" aria-hidden="true">&#8681;</span>
+              <span class="qa__label">Share</span>
+            </label>
+          </li>
+          <li>
+            <label for="qa-toggle" class="qa__item">
+              <span class="qa__ico" aria-hidden="true">&#9745;</span>
+              <span class="qa__label">Mark as done</span>
+            </label>
+          </li>
+          <li>
+            <label for="qa-toggle" class="qa__item qa__item--danger">
+              <span class="qa__ico" aria-hidden="true">&#9851;</span>
+              <span class="qa__label">Delete</span>
+            </label>
+          </li>
+        </ul>
+
+        <label for="qa-toggle" class="qa__cancel">Cancel</label>
+      </section>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-quick-action-sheet-70315/demo.html
+++ b/submissions/examples/css-quick-action-sheet-70315/demo.html
@@ -16,7 +16,7 @@
         <h1 id="title">Quick Action Sheet</h1>
         <p class="copy">
           An iOS-style quick action bottom sheet with an options list. Open and
-          dismiss it without any JavaScript — using only CSS.
+          dismiss it without any JavaScript -- using only CSS.
         </p>
 
         <label for="qa-toggle" class="open-btn">Open actions</label>

--- a/submissions/examples/css-quick-action-sheet-70315/style.css
+++ b/submissions/examples/css-quick-action-sheet-70315/style.css
@@ -1,0 +1,195 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --accent: #818cf8;
+  --danger: #f87171;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(120% 120% at 50% 0%, #1f1f23 0%, #09090b 60%);
+}
+
+/* Hide the native checkbox visually but keep it keyboard-focusable */
+.qa-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.shell {
+  width: min(92vw, 520px);
+}
+.card {
+  padding: 40px;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+#title {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+.copy {
+  margin: 0 0 28px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+.hint {
+  margin: 22px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.open-btn {
+  display: inline-block;
+  padding: 14px 26px;
+  font-weight: 600;
+  color: #0b0b12;
+  background: linear-gradient(180deg, var(--accent), #6366f1);
+  border-radius: 14px;
+  cursor: pointer;
+  user-select: none;
+}
+.qa-toggle:focus-visible + .shell .open-btn {
+  outline: 2px solid #c7d2fe;
+  outline-offset: 3px;
+}
+
+/* The sheet wrapper */
+.qa {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+}
+
+/* Scrim */
+.qa__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 280ms ease;
+}
+
+/* Panel */
+.qa__panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  transform: translateY(110%);
+  transition: transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  padding: 12px 12px calc(12px + env(safe-area-inset-bottom));
+  display: grid;
+  gap: 8px;
+}
+
+.qa__title {
+  margin: 8px 4px 4px;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: center;
+}
+.qa__grip {
+  width: 40px;
+  height: 5px;
+  margin: 4px auto 8px;
+  border-radius: 999px;
+  background: #3f3f46;
+}
+
+.qa__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+.qa__item,
+.qa__cancel {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  background: #232328;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: background 160ms ease, transform 120ms ease;
+}
+.qa__item:first-child {
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+.qa__item:hover,
+.qa__cancel:hover {
+  background: #2a2a31;
+}
+.qa__item:active,
+.qa__cancel:active {
+  transform: scale(0.99);
+}
+.qa__item--danger {
+  color: var(--danger);
+}
+.qa__ico {
+  font-size: 1.1rem;
+  width: 1.6em;
+  text-align: center;
+}
+.qa__cancel {
+  justify-content: center;
+  margin-top: 6px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+/* Open state: driven by the checkbox */
+.qa-toggle:checked ~ .qa .qa__scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+.qa-toggle:checked ~ .qa .qa__panel {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qa__panel {
+    transition: opacity 200ms ease;
+  }
+  .qa__scrim {
+    transition: opacity 200ms ease;
+  }
+}


### PR DESCRIPTION
## CSS Quick Action Sheet

Adds a pure-CSS iOS-style bottom action sheet that slides up with a backdrop and dismiss affordances, driven by a hidden checkbox toggle (no JavaScript).

### Files
- `submissions/examples/css-quick-action-sheet-70315/demo.html`
- `submissions/examples/css-quick-action-sheet-70315/style.css`
- `submissions/examples/css-quick-action-sheet-70315/README.md`

### Conformance
- Keyboard accessible (focus-visible, label-driven toggle).
- `prefers-reduced-motion` guard.
- ASCII-only source (icon glyphs use HTML numeric entities).

Closes #70315

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._