### PR TITLE
feat: add CSS Noodle Loader (#70291)

### DIFF
--- a/submissions/examples/css-noodle-loader-70291/README.md
+++ b/submissions/examples/css-noodle-loader-70291/README.md
@@ -1,0 +1,7 @@
+# CSS Noodle Loader
+
+1. What does this do? Renders a loading animation of a wavy noodle/rope that winds and unwinds while sliding along a bowl, with rising steam wisps.
+2. How is it used? Drop the `.stage` block (bowl, `.noodle` with six `.noodle__seg` segments, and `.steam` wisps) into a container; the winding, sliding, and steam animations run via CSS keyframes.
+3. Why is it useful? Adds a playful, no-JavaScript loading indicator with staggered segment timing and `prefers-reduced-motion` support.
+
+Closes #70291

--- a/submissions/examples/css-noodle-loader-70291/demo.html
+++ b/submissions/examples/css-noodle-loader-70291/demo.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Noodle Loader</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" aria-labelledby="title">
+        <p class="eyebrow">EaseMotion CSS</p>
+        <h1 id="title">Noodle Loader</h1>
+        <p class="copy">
+          A wavy noodle/rope that winds and unwinds while it slides along its
+          bowl. Pure CSS, no JavaScript.
+        </p>
+
+        <div class="stage" role="img" aria-label="Loading">
+          <div class="bowl" aria-hidden="true">
+            <div class="bowl__rim"></div>
+            <div class="bowl__inner"></div>
+          </div>
+
+          <div class="noodle" aria-hidden="true">
+            <span class="noodle__seg"></span>
+            <span class="noodle__seg"></span>
+            <span class="noodle__seg"></span>
+            <span class="noodle__seg"></span>
+            <span class="noodle__seg"></span>
+            <span class="noodle__seg"></span>
+          </div>
+
+          <div class="steam" aria-hidden="true">
+            <span class="steam__wisp"></span>
+            <span class="steam__wisp"></span>
+            <span class="steam__wisp"></span>
+          </div>
+        </div>
+
+        <p class="hint">Winding + sliding noodle with rising steam.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-noodle-loader-70291/style.css
+++ b/submissions/examples/css-noodle-loader-70291/style.css
@@ -1,0 +1,223 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --noodle: #f5d27a;
+  --noodle-deep: #e0a93c;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(120% 120% at 50% 0%, #1f1f23 0%, #09090b 60%);
+}
+
+.shell {
+  width: min(92vw, 520px);
+}
+.card {
+  padding: 40px;
+  border-radius: 28px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+#title {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+.copy {
+  margin: 0 0 24px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+.hint {
+  margin: 22px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+/* Stage */
+.stage {
+  position: relative;
+  height: 220px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+/* Bowl */
+.bowl {
+  position: relative;
+  width: 200px;
+  height: 90px;
+}
+.bowl__rim {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #3a3a40, #232328);
+  border: 1px solid #3f3f46;
+  box-shadow: inset 0 6px 14px rgba(0, 0, 0, 0.5);
+}
+.bowl__inner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  height: 16px;
+  border-radius: 50%;
+  background: #16161a;
+  box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.7);
+}
+.bowl::after {
+  content: "";
+  position: absolute;
+  top: 22px;
+  left: -10px;
+  right: -10px;
+  bottom: -40px;
+  border-radius: 0 0 50% 50% / 0 0 80% 80%;
+  background: linear-gradient(180deg, #2c2c33, #16161a);
+  border: 1px solid #3f3f46;
+  border-top: none;
+}
+
+/* Noodle: a row of segments, each a wavy bit that winds + slides */
+.noodle {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  width: 220px;
+  height: 26px;
+  display: flex;
+  gap: 6px;
+  transform: translateX(-50%);
+  animation: slide 1.6s ease-in-out infinite;
+}
+
+.noodle__seg {
+  flex: 1;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--noodle), var(--noodle-deep));
+  box-shadow:
+    inset 0 -3px 6px rgba(0, 0, 0, 0.25),
+    0 2px 6px rgba(245, 210, 122, 0.25);
+  transform-origin: center;
+  animation: wind 1.2s ease-in-out infinite;
+}
+.noodle__seg:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.noodle__seg:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.noodle__seg:nth-child(4) {
+  animation-delay: 0.3s;
+}
+.noodle__seg:nth-child(5) {
+  animation-delay: 0.4s;
+}
+.noodle__seg:nth-child(6) {
+  animation-delay: 0.5s;
+}
+
+/* winding/unwinding each segment */
+@keyframes wind {
+  0%,
+  100% {
+    transform: scaleY(1) rotate(0deg);
+  }
+  50% {
+    transform: scaleY(0.55) rotate(14deg);
+  }
+}
+
+/* side-to-side sliding of the whole noodle */
+@keyframes slide {
+  0%,
+  100% {
+    transform: translateX(-50%) rotate(-3deg);
+  }
+  50% {
+    transform: translateX(-46%) rotate(3deg);
+  }
+}
+
+/* Steam wisps rising */
+.steam {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 80px;
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+}
+.steam__wisp {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  filter: blur(3px);
+  opacity: 0;
+  animation: rise 2.4s ease-in-out infinite;
+}
+.steam__wisp:nth-child(2) {
+  animation-delay: 0.6s;
+}
+.steam__wisp:nth-child(3) {
+  animation-delay: 1.2s;
+}
+@keyframes rise {
+  0% {
+    opacity: 0;
+    transform: translateY(20px) scale(0.6);
+  }
+  35% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-50px) scale(1.4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .noodle,
+  .noodle__seg,
+  .steam__wisp {
+    animation: none;
+  }
+  .noodle {
+    transform: translateX(-50%);
+  }
+  .steam__wisp {
+    opacity: 0.3;
+    transform: translateY(-10px);
+  }
+}


### PR DESCRIPTION
## CSS Noodle Loader

Adds a pure-CSS noodle/rope winding loader: six segments wind and unwind with staggered delays while the noodle slides along a bowl, plus rising steam wisps. No JavaScript.

### Files
- `submissions/examples/css-noodle-loader-70291/demo.html`
- `submissions/examples/css-noodle-loader-70291/style.css`
- `submissions/examples/css-noodle-loader-70291/README.md`

### Conformance
- `prefers-reduced-motion` guard.
- ASCII-only source.

Closes #70291

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._