### PR TITLE
feat: add CSS Pinned Message Banner (#70280)

### DIFF
--- a/submissions/examples/css-pinned-message-banner-70280/README.md
+++ b/submissions/examples/css-pinned-message-banner-70280/README.md
@@ -1,0 +1,7 @@
+# CSS Pinned Message Banner
+
+1. What does this do? Renders a pinned message banner fixed at the top of a chat that can be dismissed and later restored, collapsing out of flow.
+2. How is it used? A hidden `<input type="checkbox" id="pin-dismiss">` drives state; `<label for="pin-dismiss">` elements act as the dismiss and restore controls, so the banner collapses/expands with no JavaScript.
+3. Why is it useful? Adds a ready-to-use pinned-message banner with no JS, keyboard-accessible controls, and `prefers-reduced-motion` support.
+
+Closes #70280

--- a/submissions/examples/css-pinned-message-banner-70280/demo.html
+++ b/submissions/examples/css-pinned-message-banner-70280/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Pinned Message Banner</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <input type="checkbox" id="pin-dismiss" class="pin-dismiss" aria-hidden="true" />
+
+    <div class="chat">
+      <!-- Pinned banner lives at the top of the chat -->
+      <div class="pin" role="status">
+        <span class="pin__pin" aria-hidden="true">&#128204;</span>
+        <div class="pin__body">
+          <strong class="pin__title">Pinned</strong>
+          <p class="pin__text">
+            Demo night starts at 7pm UTC in #showcase. Bring a screen and a
+            demo link.
+          </p>
+        </div>
+        <label for="pin-dismiss" class="pin__close" aria-label="Dismiss pinned message">
+          <span aria-hidden="true"></span>
+        </label>
+      </div>
+
+      <main class="shell">
+        <section class="card" aria-labelledby="title">
+          <p class="eyebrow">EaseMotion CSS</p>
+          <h1 id="title">Pinned Message Banner</h1>
+          <p class="copy">
+            A banner pinned at the top of the chat. Dismiss it without any
+            JavaScript using a hidden checkbox + label toggle.
+          </p>
+
+          <div class="messages" aria-label="Chat messages">
+            <div class="bubble bubble--in">
+              <span class="bubble__author">Maya</span>
+              Ready for tonight?
+            </div>
+            <div class="bubble bubble--out">
+              <span class="bubble__author">You</span>
+              Yep, just reviewing the pinned note.
+            </div>
+            <div class="bubble bubble--in">
+              <span class="bubble__author">Maya</span>
+              Great, see you at 7.
+            </div>
+          </div>
+
+          <p class="hint">
+            Dismiss the banner above to collapse it out of the chat flow.
+          </p>
+
+          <!-- After dismissal, show a tiny "jump back" affordance to restore -->
+          <label for="pin-dismiss" class="restore">Pin still relevant? Show it again</label>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/submissions/examples/css-pinned-message-banner-70280/style.css
+++ b/submissions/examples/css-pinned-message-banner-70280/style.css
@@ -1,0 +1,212 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #09090b;
+  --panel: #18181b;
+  --border: #27272a;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --accent: #818cf8;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(120% 120% at 50% 0%, #1f1f23 0%, #09090b 60%);
+}
+
+.pin-dismiss {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.chat {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  align-items: start;
+}
+
+/* Pinned banner */
+.pin {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 14px 18px;
+  background: linear-gradient(90deg, rgba(129, 140, 248, 0.16), rgba(129, 140, 248, 0.06));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  transform-origin: top;
+  transition:
+    max-height 320ms ease,
+    opacity 280ms ease,
+    padding 320ms ease,
+    margin 320ms ease;
+  max-height: 160px;
+  overflow: hidden;
+}
+.pin__pin {
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+.pin__body {
+  min-width: 0;
+}
+.pin__title {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 4px;
+}
+.pin__text {
+  margin: 0;
+  color: #e4e4e7;
+  line-height: 1.5;
+}
+.pin__close {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--muted);
+  transition: background 160ms ease, color 160ms ease;
+}
+.pin__close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+.pin__close span,
+.pin__close span::before,
+.pin__close span::after {
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+}
+.pin__close span::before,
+.pin__close span::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.pin__close span::before {
+  transform: rotate(45deg);
+}
+.pin__close span::after {
+  transform: rotate(-45deg);
+}
+
+/* Dismissed state */
+.pin-dismiss:checked ~ .chat .pin {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-bottom: -1px; /* collapse the border */
+  pointer-events: none;
+}
+
+/* Restore link is hidden while banner is visible */
+.restore {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 0.85rem;
+  color: var(--accent);
+  cursor: pointer;
+  user-select: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+}
+.pin-dismiss:checked ~ .chat .restore {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Chat body */
+.shell {
+  width: min(92vw, 560px);
+  margin: 28px auto;
+}
+.card {
+  padding: 32px;
+  border-radius: 24px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+#title {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+}
+.copy {
+  margin: 0 0 24px;
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+.hint {
+  margin: 22px 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.messages {
+  display: grid;
+  gap: 10px;
+}
+.bubble {
+  max-width: 80%;
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: #232328;
+  border: 1px solid var(--border);
+  line-height: 1.4;
+}
+.bubble--in {
+  justify-self: start;
+  border-bottom-left-radius: 4px;
+}
+.bubble--out {
+  justify-self: end;
+  background: linear-gradient(180deg, var(--accent), #6366f1);
+  color: #0b0b12;
+  border-color: transparent;
+  border-bottom-right-radius: 4px;
+}
+.bubble__author {
+  display: block;
+  font-size: 0.72rem;
+  opacity: 0.7;
+  margin-bottom: 2px;
+  letter-spacing: 0.04em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pin,
+  .restore {
+    transition: opacity 200ms ease;
+  }
+}


### PR DESCRIPTION
## CSS Pinned Message Banner

Adds a pure-CSS pinned message banner fixed at the top of a chat that can be dismissed and later restored, collapsing out of flow. Driven by a hidden checkbox + label toggles (no JavaScript).

### Files
- `submissions/examples/css-pinned-message-banner-70280/demo.html`
- `submissions/examples/css-pinned-message-banner-70280/style.css`
- `submissions/examples/css-pinned-message-banner-70280/README.md`

### Conformance
- Keyboard accessible (label-driven toggle).
- `prefers-reduced-motion` guard.
- ASCII-only source.

Closes #70280

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._