### PR TITLE
feat: add pure CSS Nav Velvet Smooth Transition component (#73331)

### DIFF
--- a/submissions/examples/css-nav-velvet-smooth-transition-pure/README.md
+++ b/submissions/examples/css-nav-velvet-smooth-transition-pure/README.md
@@ -1,0 +1,19 @@
+# CSS Nav: Velvet Smooth Transition
+
+A highly performant, JavaScript-free navigation component featuring ultra-soft "velvet" transition curves that gently ease-in layered background states and glowing indicators.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required to manage hover or active states.
+- **Component Architecture & Styling Mechanics**: 
+  - **Velvet Transition Curve**: The defining feature of this component is the custom `cubic-bezier(0.22, 1, 0.36, 1)` transition timing function combined with an elongated `0.5s` duration. This creates a deeply satisfying, decelerating "velvet" slide into place.
+  - **Expanding Pill Background**: The soft background fill on hover is handled by the `::before` pseudo-element. It starts scaled down (`transform: scale(0.8)`) and fully transparent. On hover, it blooms out to `scale(1)` and fades in, creating a soft pulse effect rather than a harsh block appearing.
+  - **Glowing Indicator**: The `::after` pseudo-element acts as the underline indicator. It starts with `scaleX(0)` from the center. On hover, it expands outward symmetrically while revealing a subtle `box-shadow` glow that matches the accent color.
+- **Theming**: Configured via CSS Custom Properties. The palette utilizes a soft base with a vibrant pink velvet accent color. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, which swaps solid light backgrounds for semi-transparent glowing overlays to maintain the velvet feel against dark backgrounds.
+- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and standard `<a>` tags with `aria-label` and `aria-current="page"` for proper screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale and opacity transitions if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. Gently move your cursor across the navigation links. Observe the ultra-smooth, decelerating `cubic-bezier` curves as the pill backgrounds expand and the glowing underlines ease outward from the center of the text.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic `<nav>` list and the active link classes.
+- `style.css`: The styling, the `cubic-bezier` transition definitions, the layered `::before` and `::after` pseudo-elements, and the dark mode adjustments.

--- a/submissions/examples/css-nav-velvet-smooth-transition-pure/demo.html
+++ b/submissions/examples/css-nav-velvet-smooth-transition-pure/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS Nav: Velvet Smooth Transition</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Velvet Smooth Navigation</h1>
+            <p>Experience the ultra-soft, hardware-accelerated CSS hover states.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <nav class="velvet-nav" aria-label="Main Navigation">
+                <ul class="nav-list">
+                    <li class="nav-item">
+                        <a href="#" class="nav-link active" aria-current="page">
+                            <span class="link-text">Home</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Discover</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Library</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">
+                            <span class="link-text">Settings</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-nav-velvet-smooth-transition-pure/style.css
+++ b/submissions/examples/css-nav-velvet-smooth-transition-pure/style.css
@@ -1,0 +1,183 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #f8fafc;
+    --nav-bg: #ffffff;
+    --text-primary: #0f172a;
+    --text-muted: #64748b;
+    
+    /* Velvet Accent Colors */
+    --velvet-color: #ec4899; /* Pink */
+    --velvet-glow: rgba(236, 72, 153, 0.2);
+    --velvet-bg: #fdf2f8; /* Very light pink for hover bg */
+    
+    /* Ultra-smooth transition curves */
+    --ease-velvet: cubic-bezier(0.22, 1, 0.36, 1);
+    --duration-velvet: 0.5s;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Plus Jakarta Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+.title { margin: 0 0 10px 0; font-size: 2.2rem; font-weight: 600; letter-spacing: -0.5px; }
+.header p { margin: 0; color: var(--text-muted); }
+
+
+/* =========================================
+   Navigation Container
+   ========================================= */
+.velvet-nav {
+    background: var(--nav-bg);
+    padding: 8px;
+    border-radius: 99px; /* Pill shape */
+    box-shadow: 0 4px 20px rgba(0,0,0,0.03), 0 1px 3px rgba(0,0,0,0.02);
+    border: 1px solid rgba(0,0,0,0.02);
+}
+
+.nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 4px;
+}
+
+.nav-item {
+    position: relative;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Velvet Smooth Base
+   ========================================= */
+.nav-link {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px 24px;
+    text-decoration: none;
+    color: var(--text-muted);
+    font-weight: 500;
+    font-size: 1.05rem;
+    border-radius: 99px;
+    position: relative;
+    z-index: 1;
+    overflow: hidden; /* Contains the expanding background */
+    transition: color var(--duration-velvet) var(--ease-velvet);
+}
+
+/* 
+   The Expanding Pill Background
+*/
+.nav-link::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background-color: var(--velvet-bg);
+    z-index: -1;
+    border-radius: 99px;
+    
+    /* Initially small and faded */
+    transform: scale(0.8);
+    opacity: 0;
+    /* Soft, elongated transition */
+    transition: transform var(--duration-velvet) var(--ease-velvet),
+                opacity var(--duration-velvet) var(--ease-velvet);
+}
+
+/* 
+   The Glowing Underline Indicator
+*/
+.nav-link::after {
+    content: '';
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%) scaleX(0);
+    width: 20px;
+    height: 3px;
+    background-color: var(--velvet-color);
+    border-radius: 3px;
+    box-shadow: 0 2px 8px var(--velvet-glow);
+    transition: transform var(--duration-velvet) var(--ease-velvet);
+}
+
+
+/* =========================================
+   Interaction States (Hover & Active)
+   ========================================= */
+
+/* Color shift */
+.nav-link:hover,
+.nav-link.active {
+    color: var(--velvet-color);
+}
+
+/* Background Pill expansion */
+.nav-link:hover::before,
+.nav-link.active::before {
+    opacity: 1;
+    transform: scale(1);
+}
+
+/* Underline Growth */
+.nav-link:hover::after,
+.nav-link.active::after {
+    transform: translateX(-50%) scaleX(1);
+}
+
+/* Active state is slightly more prominent */
+.nav-link.active::after {
+    width: 30px;
+}
+.nav-link.active {
+    font-weight: 600;
+}
+
+
+/* Dark Mode Compatibility */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --nav-bg: #1e293b;
+        --text-primary: #f8fafc;
+        --text-muted: #94a3b8;
+        
+        --velvet-color: #f472b6; /* Lighter pink for contrast */
+        --velvet-glow: rgba(244, 114, 182, 0.4);
+        --velvet-bg: rgba(244, 114, 182, 0.1); /* Semi-transparent instead of solid light */
+    }
+    
+    .velvet-nav {
+        border-color: #334155;
+        box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+    }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .nav-link,
+    .nav-link::before,
+    .nav-link::after {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly performant, JavaScript-free navigation component featuring ultra-soft "velvet" transition curves that gently ease-in layered background states and glowing indicators. Resolves issue #73331.

### Changes Made:
- Added `submissions/examples/css-nav-velvet-smooth-transition-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic `<nav>` list and the active link classes.
- Created `style.css` featuring the UI mechanics:
  - **Velvet Transition Curve**: The defining feature of this component is the custom `cubic-bezier(0.22, 1, 0.36, 1)` transition timing function combined with an elongated `0.5s` duration. This creates a deeply satisfying, decelerating "velvet" slide into place.
  - **Expanding Pill Background**: The soft background fill on hover is handled by the `::before` pseudo-element. It starts scaled down (`transform: scale(0.8)`) and fully transparent. On hover, it blooms out to `scale(1)` and fades in, creating a soft pulse effect rather than a harsh block appearing.
  - **Glowing Indicator**: The `::after` pseudo-element acts as the underline indicator. It starts with `scaleX(0)` from the center. On hover, it expands outward symmetrically while revealing a subtle `box-shadow` glow that matches the accent color.
  - **Theming Supported**: Configured via CSS Custom Properties. The palette utilizes a soft base with a vibrant pink velvet accent color. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, which swaps solid light backgrounds for semi-transparent glowing overlays to maintain the velvet feel against dark backgrounds.
- Added `README.md` documenting usage and the technical mechanics of the `cubic-bezier` curves, the layered `::before` and `::after` pseudo-elements, and the dark mode adjustments.
- Fully accessible semantic structure. Uses `<nav>`, `<ul>`, and standard `<a>` tags with `aria-label` and `aria-current="page"` for proper screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the scale and opacity transitions if requested by the OS.

Closes #73331
