### PR TITLE
Add accessibility focus ring submission

### DIFF
--- a/submissions/examples/focus-ring-tm/README.md
+++ b/submissions/examples/focus-ring-tm/README.md
@@ -1,0 +1,7 @@
+# Accessibility focus ring
+
+1. What does this do? A 2px focus ring drawn on :focus-visible for keyboard users.
+
+2. How is it used? Add `focus-ring-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? A11y pattern; the ring respects forced-colors mode.

--- a/submissions/examples/focus-ring-tm/demo.html
+++ b/submissions/examples/focus-ring-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Focus Ring — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="focusring-page-tm" data-palette="cool">
+  <h1 class="focusring-h-tm">Focus Ring</h1>
+  <p class="focusring-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="focusring-row-tm">
+    <article class="focusring-1-wrap-tm">
+      <div class="focusring-1-tm"></div>
+      <span class="focusring-lbl-tm">Example One</span>
+    </article>
+    <article class="focusring-2-wrap-tm">
+      <div class="focusring-2-tm"></div>
+      <span class="focusring-lbl-tm">Example Two</span>
+    </article>
+    <article class="focusring-3-wrap-tm">
+      <div class="focusring-3-tm"></div>
+      <span class="focusring-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/focus-ring-tm/style.css
+++ b/submissions/examples/focus-ring-tm/style.css
@@ -1,0 +1,53 @@
+:root {
+  --focusring-bg: #0a0e1a;
+  --focusring-surface: #131829;
+  --focusring-edge: #1d2438;
+  --focusring-text: #e6e8ec;
+  --focusring-muted: #8b909b;
+  --focusring-accent: #4dabf7;
+  --focusring-accent-2: #9b8cff;
+  --focusring-radius: 10px;
+  --focusring-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--focusring-bg);
+  color: var(--focusring-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.focusring-page-tm { max-width: 920px; margin: 0 auto; }
+.focusring-h-tm { font-size: 28px; margin: 0 0 8px; }
+.focusring-lede-tm { color: var(--focusring-muted); margin: 0 0 32px; }
+.focusring-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.focusring-1-wrap-tm, .focusring-2-wrap-tm, .focusring-3-wrap-tm {
+  background: var(--focusring-surface);
+  border: 1px solid var(--focusring-edge);
+  border-radius: var(--focusring-radius);
+  padding: var(--focusring-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.focusring-lbl-tm { color: var(--focusring-muted); font-size: 13px; }
+
+.focusring-1-tm, .focusring-2-tm, .focusring-3-tm {
+      padding: 8px 16px; background: #131829; border: 1px solid #1d2438; border-radius: 6px;
+      color: inherit; font: inherit; cursor: pointer; transition: outline 160ms;
+}
+.focusring-1-tm:focus-visible { outline: 2px solid #4dabf7; outline-offset: 3px; }
+.focusring-2-tm:focus-visible { outline: 2px solid #9b8cff; outline-offset: 3px; }
+.focusring-3-tm:focus-visible { outline: 2px solid #8b909b; outline-offset: 3px; }


### PR DESCRIPTION
Closes #77512

## What
This submission adds a new EaseMotion CSS example: `focus-ring-tm`.

A 2px focus ring drawn on :focus-visible for keyboard users.

## How to review
1. Open `submissions/examples/focus-ring-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/focus-ring-tm/` and does not modify any existing file.
