### PR TITLE
Add fading divider submission

### DIFF
--- a/submissions/examples/divider-fade-tm/README.md
+++ b/submissions/examples/divider-fade-tm/README.md
@@ -1,0 +1,7 @@
+# Fading divider
+
+1. What does this do? A horizontal rule that fades out at both ends.
+
+2. How is it used? Add `divider-fade-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Section divider pattern; the fade is a mask-image.

--- a/submissions/examples/divider-fade-tm/demo.html
+++ b/submissions/examples/divider-fade-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Divider Fade — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="dividerfade-page-tm" data-palette="forest">
+  <h1 class="dividerfade-h-tm">Divider Fade</h1>
+  <p class="dividerfade-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="dividerfade-row-tm">
+    <article class="dividerfade-1-wrap-tm">
+      <div class="dividerfade-1-tm"></div>
+      <span class="dividerfade-lbl-tm">Example One</span>
+    </article>
+    <article class="dividerfade-2-wrap-tm">
+      <div class="dividerfade-2-tm"></div>
+      <span class="dividerfade-lbl-tm">Example Two</span>
+    </article>
+    <article class="dividerfade-3-wrap-tm">
+      <div class="dividerfade-3-tm"></div>
+      <span class="dividerfade-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/divider-fade-tm/style.css
+++ b/submissions/examples/divider-fade-tm/style.css
@@ -1,0 +1,52 @@
+:root {
+  --dividerfade-bg: #0d1612;
+  --dividerfade-surface: #152721;
+  --dividerfade-edge: #1f3530;
+  --dividerfade-text: #e6e8ec;
+  --dividerfade-muted: #8b909b;
+  --dividerfade-accent: #2ecc71;
+  --dividerfade-accent-2: #a3e635;
+  --dividerfade-radius: 10px;
+  --dividerfade-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--dividerfade-bg);
+  color: var(--dividerfade-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.dividerfade-page-tm { max-width: 920px; margin: 0 auto; }
+.dividerfade-h-tm { font-size: 28px; margin: 0 0 8px; }
+.dividerfade-lede-tm { color: var(--dividerfade-muted); margin: 0 0 32px; }
+.dividerfade-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.dividerfade-1-wrap-tm, .dividerfade-2-wrap-tm, .dividerfade-3-wrap-tm {
+  background: var(--dividerfade-surface);
+  border: 1px solid var(--dividerfade-edge);
+  border-radius: var(--dividerfade-radius);
+  padding: var(--dividerfade-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.dividerfade-lbl-tm { color: var(--dividerfade-muted); font-size: 13px; }
+
+.dividerfade-1-tm, .dividerfade-2-tm, .dividerfade-3-tm {
+      width: 100%; height: 1px; border: 0; margin: 16px 0;
+      background: #1f3530; mask-image: linear-gradient(to right, transparent, #000 20%, #000 80%, transparent);
+}
+.dividerfade-2-tm { background: #2ecc71; opacity: 0.3; }
+.dividerfade-3-tm { background: #8b909b; opacity: 0.3; }


### PR DESCRIPTION
Closes #77514

## What
This submission adds a new EaseMotion CSS example: `divider-fade-tm`.

A horizontal rule that fades out at both ends.

## How to review
1. Open `submissions/examples/divider-fade-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/divider-fade-tm/` and does not modify any existing file.
