### PR TITLE
Add divider with icon submission

### DIFF
--- a/submissions/examples/divider-icon-tm/README.md
+++ b/submissions/examples/divider-icon-tm/README.md
@@ -1,0 +1,7 @@
+# Divider with icon
+
+1. What does this do? A horizontal rule with a centred icon.
+
+2. How is it used? Add `divider-icon-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Section divider pattern; the icon sits in a punched-out gap.

--- a/submissions/examples/divider-icon-tm/demo.html
+++ b/submissions/examples/divider-icon-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Divider Icon — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="dividericon-page-tm" data-palette="rose">
+  <h1 class="dividericon-h-tm">Divider Icon</h1>
+  <p class="dividericon-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="dividericon-row-tm">
+    <article class="dividericon-1-wrap-tm">
+      <div class="dividericon-1-tm"></div>
+      <span class="dividericon-lbl-tm">Example One</span>
+    </article>
+    <article class="dividericon-2-wrap-tm">
+      <div class="dividericon-2-tm"></div>
+      <span class="dividericon-lbl-tm">Example Two</span>
+    </article>
+    <article class="dividericon-3-wrap-tm">
+      <div class="dividericon-3-tm"></div>
+      <span class="dividericon-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/divider-icon-tm/style.css
+++ b/submissions/examples/divider-icon-tm/style.css
@@ -1,0 +1,58 @@
+:root {
+  --dividericon-bg: #160d12;
+  --dividericon-surface: #26141c;
+  --dividericon-edge: #361b25;
+  --dividericon-text: #e6e8ec;
+  --dividericon-muted: #8b909b;
+  --dividericon-accent: #ff5c8a;
+  --dividericon-accent-2: #ffb4d2;
+  --dividericon-radius: 10px;
+  --dividericon-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--dividericon-bg);
+  color: var(--dividericon-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.dividericon-page-tm { max-width: 920px; margin: 0 auto; }
+.dividericon-h-tm { font-size: 28px; margin: 0 0 8px; }
+.dividericon-lede-tm { color: var(--dividericon-muted); margin: 0 0 32px; }
+.dividericon-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.dividericon-1-wrap-tm, .dividericon-2-wrap-tm, .dividericon-3-wrap-tm {
+  background: var(--dividericon-surface);
+  border: 1px solid var(--dividericon-edge);
+  border-radius: var(--dividericon-radius);
+  padding: var(--dividericon-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.dividericon-lbl-tm { color: var(--dividericon-muted); font-size: 13px; }
+
+.dividericon-1-tm, .dividericon-2-tm, .dividericon-3-tm {
+      display: flex; align-items: center; gap: 12px; width: 100%;
+}
+.dividericon-1-tm::before, .dividericon-1-tm::after,
+.dividericon-2-tm::before, .dividericon-2-tm::after,
+.dividericon-3-tm::before, .dividericon-3-tm::after {
+      content: ""; flex: 1; height: 1px; background: #361b25;
+}
+.dividericon-1-tm span { color: #ff5c8a; font-size: 14px; }
+.dividericon-2-tm::before, .dividericon-2-tm::after { background: #ff5c8a; opacity: 0.3; }
+.dividericon-2-tm span { color: #ffb4d2; }
+.dividericon-3-tm span { color: #8b909b; }


### PR DESCRIPTION
Closes #77518

## What
This submission adds a new EaseMotion CSS example: `divider-icon-tm`.

A horizontal rule with a centred icon.

## How to review
1. Open `submissions/examples/divider-icon-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/divider-icon-tm/` and does not modify any existing file.
