### PR TITLE
Add avatar group hover submission

### DIFF
--- a/submissions/examples/avatar-group-tm/README.md
+++ b/submissions/examples/avatar-group-tm/README.md
@@ -1,0 +1,7 @@
+# Avatar group hover
+
+1. What does this do? A row of overlapping avatars that spread out on hover.
+
+2. How is it used? Add `avatar-group-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Team / collaboration pattern; the spread is a translate on each child.

--- a/submissions/examples/avatar-group-tm/demo.html
+++ b/submissions/examples/avatar-group-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Avatar Group — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="avatargroup-page-tm" data-palette="graphite">
+  <h1 class="avatargroup-h-tm">Avatar Group</h1>
+  <p class="avatargroup-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="avatargroup-row-tm">
+    <article class="avatargroup-1-wrap-tm">
+      <div class="avatargroup-1-tm"></div>
+      <span class="avatargroup-lbl-tm">Example One</span>
+    </article>
+    <article class="avatargroup-2-wrap-tm">
+      <div class="avatargroup-2-tm"></div>
+      <span class="avatargroup-lbl-tm">Example Two</span>
+    </article>
+    <article class="avatargroup-3-wrap-tm">
+      <div class="avatargroup-3-tm"></div>
+      <span class="avatargroup-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/avatar-group-tm/style.css
+++ b/submissions/examples/avatar-group-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --avatargroup-bg: #101216;
+  --avatargroup-surface: #1a1d22;
+  --avatargroup-edge: #25282e;
+  --avatargroup-text: #e6e8ec;
+  --avatargroup-muted: #8b909b;
+  --avatargroup-accent: #94a3b8;
+  --avatargroup-accent-2: #cbd5e1;
+  --avatargroup-radius: 10px;
+  --avatargroup-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--avatargroup-bg);
+  color: var(--avatargroup-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.avatargroup-page-tm { max-width: 920px; margin: 0 auto; }
+.avatargroup-h-tm { font-size: 28px; margin: 0 0 8px; }
+.avatargroup-lede-tm { color: var(--avatargroup-muted); margin: 0 0 32px; }
+.avatargroup-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.avatargroup-1-wrap-tm, .avatargroup-2-wrap-tm, .avatargroup-3-wrap-tm {
+  background: var(--avatargroup-surface);
+  border: 1px solid var(--avatargroup-edge);
+  border-radius: var(--avatargroup-radius);
+  padding: var(--avatargroup-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.avatargroup-lbl-tm { color: var(--avatargroup-muted); font-size: 13px; }
+
+.avatargroup-1-tm, .avatargroup-2-tm, .avatargroup-3-tm {
+      display: flex; align-items: center; gap: -8px;
+}
+.avatargroup-1-tm span { width: 32px; height: 32px; border-radius: 50%; background: #94a3b8; display: grid; place-items: center; font-size: 11px; font-weight: 600; color: #0f1115; border: 2px solid #1a1d22; margin-left: -8px; transition: transform 200ms; }
+.avatargroup-1-tm:hover span:nth-child(1) { transform: translateX(4px); }
+.avatargroup-1-tm:hover span:nth-child(2) { transform: translateX(8px); }
+.avatargroup-1-tm:hover span:nth-child(3) { transform: translateX(12px); }
+.avatargroup-2-tm span { background: #cbd5e1; color: #0a0e1a; }
+.avatargroup-3-tm span { background: #8b909b; color: #0e0a1a; }


### PR DESCRIPTION
Closes #77531

## What
This submission adds a new EaseMotion CSS example: `avatar-group-tm`.

A row of overlapping avatars that spread out on hover.

## How to review
1. Open `submissions/examples/avatar-group-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/avatar-group-tm/` and does not modify any existing file.
