### PR TITLE
feat: add CSS stamp reveal text

### DIFF
--- a/submissions/examples/stamp-reveal-text/README.md
+++ b/submissions/examples/stamp-reveal-text/README.md
@@ -1,0 +1,42 @@
+# CSS Stamp Reveal Text
+
+A CSS-only text reveal animation inspired by a rubber stamp press.
+
+## Features
+
+- Pure CSS animation
+- No JavaScript
+- Responsive design
+- Rubber stamp press effect
+- Text reveal animation
+- Reduced-motion accessibility support
+- Semantic HTML structure
+
+## Files
+
+- `demo.html` - Demo page
+- `style.css` - Animation and styling
+
+## How It Works
+
+The stamp uses CSS `transform`, `opacity`, and `animation` properties
+to create a pressing effect.
+
+The heading uses a pseudo-element as a reveal mask. The mask scales
+horizontally to reveal the text.
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+No dependencies or build tools are required.
+
+## Accessibility
+
+The component uses semantic HTML and respects the user's
+`prefers-reduced-motion` setting.
+
+## Technologies
+
+- HTML5
+- CSS3

--- a/submissions/examples/stamp-reveal-text/demo.html
+++ b/submissions/examples/stamp-reveal-text/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="CSS-only rubber stamp reveal text animation"
+    >
+    <title>Stamp Reveal Text</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <main class="page">
+        <section class="stamp-demo" aria-labelledby="stamp-title">
+            <div class="stamp" aria-hidden="true">
+                <span class="stamp-mark">APPROVED</span>
+            </div>
+
+            <div class="content">
+                <p class="eyebrow">CSS Animation</p>
+
+                <h1 id="stamp-title" class="stamp-text">
+                    Stamp Reveal
+                </h1>
+
+                <p class="description">
+                    A rubber-stamp inspired text reveal created entirely
+                    with CSS animations.
+                </p>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/stamp-reveal-text/style.css
+++ b/submissions/examples/stamp-reveal-text/style.css
@@ -1,0 +1,200 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --bg: #111827;
+    --surface: #1f2937;
+    --text: #f9fafb;
+    --muted: #9ca3af;
+    --stamp: #ef4444;
+    --border: #374151;
+}
+
+body {
+    min-height: 100vh;
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+    background:
+        radial-gradient(
+            circle at center,
+            #263244 0%,
+            var(--bg) 65%
+        );
+    color: var(--text);
+}
+
+.page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+}
+
+.stamp-demo {
+    width: min(720px, 100%);
+    padding: clamp(2rem, 6vw, 4.5rem);
+    text-align: center;
+    background: rgba(31, 41, 55, 0.75);
+    border: 1px solid var(--border);
+    border-radius: 24px;
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+}
+
+.stamp {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 2rem;
+    padding: 0.7rem 1.5rem;
+    border: 4px solid var(--stamp);
+    color: var(--stamp);
+    transform-origin: center;
+    animation: stamp-press 900ms cubic-bezier(0.2, 1.5, 0.4, 1)
+        both;
+}
+
+.stamp-mark {
+    font-size: clamp(1.2rem, 4vw, 2rem);
+    font-weight: 900;
+    letter-spacing: 0.15em;
+}
+
+.content {
+    max-width: 560px;
+    margin-inline: auto;
+}
+
+.eyebrow {
+    margin-bottom: 0.75rem;
+    color: var(--muted);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+}
+
+.stamp-text {
+    position: relative;
+    display: inline-block;
+    font-size: clamp(2.5rem, 8vw, 5rem);
+    line-height: 1;
+    font-weight: 900;
+    letter-spacing: -0.05em;
+    color: var(--text);
+    overflow: hidden;
+    animation: text-reveal 800ms 450ms ease-out both;
+}
+
+.stamp-text::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--surface);
+    transform-origin: right;
+    animation: reveal-mask 900ms 450ms cubic-bezier(0.76, 0, 0.24, 1)
+        both;
+}
+
+.description {
+    margin-top: 1.5rem;
+    color: var(--muted);
+    font-size: 1rem;
+    line-height: 1.7;
+    animation: fade-up 700ms 850ms ease-out both;
+}
+
+@keyframes stamp-press {
+    0% {
+        opacity: 0;
+        transform: scale(1.8) rotate(-12deg);
+    }
+
+    45% {
+        opacity: 1;
+        transform: scale(0.85) rotate(4deg);
+    }
+
+    70% {
+        transform: scale(1.08) rotate(-2deg);
+    }
+
+    100% {
+        opacity: 1;
+        transform: scale(1) rotate(0);
+    }
+}
+
+@keyframes text-reveal {
+    from {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes reveal-mask {
+    from {
+        transform: scaleX(1);
+    }
+
+    to {
+        transform: scaleX(0);
+    }
+}
+
+@keyframes fade-up {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 600px) {
+    .page {
+        padding: 1rem;
+    }
+
+    .stamp-demo {
+        padding: 2rem 1.25rem;
+        border-radius: 18px;
+    }
+
+    .stamp {
+        padding: 0.55rem 1rem;
+        border-width: 3px;
+    }
+
+    .description {
+        font-size: 0.95rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        animation-delay: 0ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Description

Implemented the CSS Stamp Reveal Text animation for #70301.

### Changes

- Added `demo.html`
- Added `style.css`
- Added `README.md`
- Implemented rubber stamp press animation
- Implemented CSS-only text reveal effect
- Added responsive styling
- Added `prefers-reduced-motion` support
- No JavaScript or external dependencies

Closes #70301