### PR TITLE
Add mask reveal submission

### DIFF
--- a/submissions/examples/reveal-mask-tm/README.md
+++ b/submissions/examples/reveal-mask-tm/README.md
@@ -1,0 +1,7 @@
+# Mask reveal
+
+1. What does this do? An element whose content is revealed by a sweeping mask on first paint.
+
+2. How is it used? Add `reveal-mask-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro pattern; the mask is a linear-gradient that translates across.

--- a/submissions/examples/reveal-mask-tm/demo.html
+++ b/submissions/examples/reveal-mask-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Mask — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealmask-page-tm" data-palette="cool">
+  <h1 class="revealmask-h-tm">Reveal Mask</h1>
+  <p class="revealmask-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealmask-row-tm">
+    <article class="revealmask-1-wrap-tm">
+      <div class="revealmask-1-tm"></div>
+      <span class="revealmask-lbl-tm">Example One</span>
+    </article>
+    <article class="revealmask-2-wrap-tm">
+      <div class="revealmask-2-tm"></div>
+      <span class="revealmask-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealmask-3-wrap-tm">
+      <div class="revealmask-3-tm"></div>
+      <span class="revealmask-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-mask-tm/style.css
+++ b/submissions/examples/reveal-mask-tm/style.css
@@ -1,0 +1,55 @@
+:root {
+  --revealmask-bg: #0a0e1a;
+  --revealmask-surface: #131829;
+  --revealmask-edge: #1d2438;
+  --revealmask-text: #e6e8ec;
+  --revealmask-muted: #8b909b;
+  --revealmask-accent: #4dabf7;
+  --revealmask-accent-2: #9b8cff;
+  --revealmask-radius: 10px;
+  --revealmask-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealmask-bg);
+  color: var(--revealmask-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealmask-page-tm { max-width: 920px; margin: 0 auto; }
+.revealmask-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealmask-lede-tm { color: var(--revealmask-muted); margin: 0 0 32px; }
+.revealmask-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealmask-1-wrap-tm, .revealmask-2-wrap-tm, .revealmask-3-wrap-tm {
+  background: var(--revealmask-surface);
+  border: 1px solid var(--revealmask-edge);
+  border-radius: var(--revealmask-radius);
+  padding: var(--revealmask-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealmask-lbl-tm { color: var(--revealmask-muted); font-size: 13px; }
+
+.revealmask-1-tm, .revealmask-2-tm, .revealmask-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #4dabf7, #9b8cff);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      mask: linear-gradient(to right, #000 50%, transparent 50%); mask-size: 200% 100%;
+      animation: kf-revealmask-v1 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealmask-v1 { to { mask-position: -100% 0; } }
+.revealmask-2-tm { background: linear-gradient(135deg, #9b8cff, #4dabf7); }
+.revealmask-3-tm { background: linear-gradient(135deg, #8b909b, #1d2438); }


### PR DESCRIPTION
Closes #77547

## What
This submission adds a new EaseMotion CSS example: `reveal-mask-tm`.

An element whose content is revealed by a sweeping mask on first paint.

## How to review
1. Open `submissions/examples/reveal-mask-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-mask-tm/` and does not modify any existing file.
