### PR TITLE
Add word-by-word reveal submission

### DIFF
--- a/submissions/examples/reveal-word-tm/README.md
+++ b/submissions/examples/reveal-word-tm/README.md
@@ -1,0 +1,7 @@
+# Word-by-word reveal
+
+1. What does this do? A paragraph whose words fade in in sequence on first paint.
+
+2. How is it used? Add `reveal-word-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro pattern; words are wrapped in spans.

--- a/submissions/examples/reveal-word-tm/demo.html
+++ b/submissions/examples/reveal-word-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Word — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealword-page-tm" data-palette="rose">
+  <h1 class="revealword-h-tm">Reveal Word</h1>
+  <p class="revealword-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealword-row-tm">
+    <article class="revealword-1-wrap-tm">
+      <div class="revealword-1-tm"></div>
+      <span class="revealword-lbl-tm">Example One</span>
+    </article>
+    <article class="revealword-2-wrap-tm">
+      <div class="revealword-2-tm"></div>
+      <span class="revealword-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealword-3-wrap-tm">
+      <div class="revealword-3-tm"></div>
+      <span class="revealword-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-word-tm/style.css
+++ b/submissions/examples/reveal-word-tm/style.css
@@ -1,0 +1,58 @@
+:root {
+  --revealword-bg: #160d12;
+  --revealword-surface: #26141c;
+  --revealword-edge: #361b25;
+  --revealword-text: #e6e8ec;
+  --revealword-muted: #8b909b;
+  --revealword-accent: #ff5c8a;
+  --revealword-accent-2: #ffb4d2;
+  --revealword-radius: 10px;
+  --revealword-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealword-bg);
+  color: var(--revealword-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealword-page-tm { max-width: 920px; margin: 0 auto; }
+.revealword-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealword-lede-tm { color: var(--revealword-muted); margin: 0 0 32px; }
+.revealword-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealword-1-wrap-tm, .revealword-2-wrap-tm, .revealword-3-wrap-tm {
+  background: var(--revealword-surface);
+  border: 1px solid var(--revealword-edge);
+  border-radius: var(--revealword-radius);
+  padding: var(--revealword-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealword-lbl-tm { color: var(--revealword-muted); font-size: 13px; }
+
+.revealword-1-tm, .revealword-2-tm, .revealword-3-tm {
+      width: 100%; min-height: 60px; font-size: 18px; text-align: center; padding: 16px;
+}
+.revealword-1-tm span { display: inline-block; opacity: 0; animation: kf-revealword-v1 500ms forwards; margin: 0 4px; }
+.revealword-1-tm span:nth-child(1) { animation-delay: 0ms; }
+.revealword-1-tm span:nth-child(2) { animation-delay: 100ms; }
+.revealword-1-tm span:nth-child(3) { animation-delay: 200ms; }
+.revealword-1-tm span:nth-child(4) { animation-delay: 300ms; }
+.revealword-1-tm span:nth-child(5) { animation-delay: 400ms; }
+@keyframes kf-revealword-v1 { to { opacity: 1; } }
+.revealword-2-tm { color: #ffb4d2; }
+.revealword-3-tm { color: #8b909b; }


### PR DESCRIPTION
Closes #77554

## What
This submission adds a new EaseMotion CSS example: `reveal-word-tm`.

A paragraph whose words fade in in sequence on first paint.

## How to review
1. Open `submissions/examples/reveal-word-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-word-tm/` and does not modify any existing file.
