### PR TITLE
Add curtain reveal submission

### DIFF
--- a/submissions/examples/reveal-curtain-tm/README.md
+++ b/submissions/examples/reveal-curtain-tm/README.md
@@ -1,0 +1,7 @@
+# Curtain reveal
+
+1. What does this do? A pair of panels that slide apart to reveal the content beneath.
+
+2. How is it used? Add `reveal-curtain-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro / transition pattern; the panels use translateX.

--- a/submissions/examples/reveal-curtain-tm/demo.html
+++ b/submissions/examples/reveal-curtain-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Curtain — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealcurtain-page-tm" data-palette="amber">
+  <h1 class="revealcurtain-h-tm">Reveal Curtain</h1>
+  <p class="revealcurtain-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealcurtain-row-tm">
+    <article class="revealcurtain-1-wrap-tm">
+      <div class="revealcurtain-1-tm"></div>
+      <span class="revealcurtain-lbl-tm">Example One</span>
+    </article>
+    <article class="revealcurtain-2-wrap-tm">
+      <div class="revealcurtain-2-tm"></div>
+      <span class="revealcurtain-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealcurtain-3-wrap-tm">
+      <div class="revealcurtain-3-tm"></div>
+      <span class="revealcurtain-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-curtain-tm/style.css
+++ b/submissions/examples/reveal-curtain-tm/style.css
@@ -1,0 +1,60 @@
+:root {
+  --revealcurtain-bg: #161208;
+  --revealcurtain-surface: #261d10;
+  --revealcurtain-edge: #352817;
+  --revealcurtain-text: #e6e8ec;
+  --revealcurtain-muted: #8b909b;
+  --revealcurtain-accent: #ffb13b;
+  --revealcurtain-accent-2: #ff7b00;
+  --revealcurtain-radius: 10px;
+  --revealcurtain-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealcurtain-bg);
+  color: var(--revealcurtain-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealcurtain-page-tm { max-width: 920px; margin: 0 auto; }
+.revealcurtain-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealcurtain-lede-tm { color: var(--revealcurtain-muted); margin: 0 0 32px; }
+.revealcurtain-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealcurtain-1-wrap-tm, .revealcurtain-2-wrap-tm, .revealcurtain-3-wrap-tm {
+  background: var(--revealcurtain-surface);
+  border: 1px solid var(--revealcurtain-edge);
+  border-radius: var(--revealcurtain-radius);
+  padding: var(--revealcurtain-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealcurtain-lbl-tm { color: var(--revealcurtain-muted); font-size: 13px; }
+
+.revealcurtain-1-tm, .revealcurtain-2-tm, .revealcurtain-3-tm {
+      position: relative; width: 100%; min-height: 100px; background: #261d10;
+      display: grid; place-items: center; color: #ffb13b; font-weight: 700; overflow: hidden;
+      border-radius: 8px;
+}
+.revealcurtain-1-tm::before, .revealcurtain-1-tm::after {
+      content: ""; position: absolute; top: 0; width: 50%; height: 100%; background: #ffb13b;
+      animation: kf-revealcurtain-v1 1s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+.revealcurtain-1-tm::before { left: 0; }
+.revealcurtain-1-tm::after { right: 0; background: #ff7b00; animation-delay: 0.1s; }
+@keyframes kf-revealcurtain-v1 { to { transform: scaleX(0); } }
+.revealcurtain-2-tm::before, .revealcurtain-2-tm::after { background: #ff7b00; }
+.revealcurtain-3-tm::before, .revealcurtain-3-tm::after { background: #8b909b; }


### PR DESCRIPTION
Closes #77556

## What
This submission adds a new EaseMotion CSS example: `reveal-curtain-tm`.

A pair of panels that slide apart to reveal the content beneath.

## How to review
1. Open `submissions/examples/reveal-curtain-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-curtain-tm/` and does not modify any existing file.
