### PR TITLE
Add blur-to-focus reveal submission

### DIFF
--- a/submissions/examples/reveal-blur-tm/README.md
+++ b/submissions/examples/reveal-blur-tm/README.md
@@ -1,0 +1,7 @@
+# Blur-to-focus reveal
+
+1. What does this do? An element that starts blurred and unblurs on first paint.
+
+2. How is it used? Add `reveal-blur-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro pattern; the blur uses filter.

--- a/submissions/examples/reveal-blur-tm/demo.html
+++ b/submissions/examples/reveal-blur-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Blur — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealblur-page-tm" data-palette="violet">
+  <h1 class="revealblur-h-tm">Reveal Blur</h1>
+  <p class="revealblur-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealblur-row-tm">
+    <article class="revealblur-1-wrap-tm">
+      <div class="revealblur-1-tm"></div>
+      <span class="revealblur-lbl-tm">Example One</span>
+    </article>
+    <article class="revealblur-2-wrap-tm">
+      <div class="revealblur-2-tm"></div>
+      <span class="revealblur-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealblur-3-wrap-tm">
+      <div class="revealblur-3-tm"></div>
+      <span class="revealblur-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-blur-tm/style.css
+++ b/submissions/examples/reveal-blur-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealblur-bg: #0e0a1a;
+  --revealblur-surface: #1a1329;
+  --revealblur-edge: #261a3a;
+  --revealblur-text: #e6e8ec;
+  --revealblur-muted: #8b909b;
+  --revealblur-accent: #a78bfa;
+  --revealblur-accent-2: #f472b6;
+  --revealblur-radius: 10px;
+  --revealblur-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealblur-bg);
+  color: var(--revealblur-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealblur-page-tm { max-width: 920px; margin: 0 auto; }
+.revealblur-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealblur-lede-tm { color: var(--revealblur-muted); margin: 0 0 32px; }
+.revealblur-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealblur-1-wrap-tm, .revealblur-2-wrap-tm, .revealblur-3-wrap-tm {
+  background: var(--revealblur-surface);
+  border: 1px solid var(--revealblur-edge);
+  border-radius: var(--revealblur-radius);
+  padding: var(--revealblur-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealblur-lbl-tm { color: var(--revealblur-muted); font-size: 13px; }
+
+.revealblur-1-tm, .revealblur-2-tm, .revealblur-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #a78bfa, #f472b6);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      filter: blur(12px); animation: kf-revealblur-v1 800ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealblur-v1 { to { filter: blur(0); } }
+.revealblur-2-tm { background: linear-gradient(135deg, #f472b6, #a78bfa); }
+.revealblur-3-tm { background: linear-gradient(135deg, #8b909b, #261a3a); }


### PR DESCRIPTION
Closes #77559

## What
This submission adds a new EaseMotion CSS example: `reveal-blur-tm`.

An element that starts blurred and unblurs on first paint.

## How to review
1. Open `submissions/examples/reveal-blur-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-blur-tm/` and does not modify any existing file.
