### PR TITLE
Add zoom reveal submission

### DIFF
--- a/submissions/examples/reveal-zoom-tm/README.md
+++ b/submissions/examples/reveal-zoom-tm/README.md
@@ -1,0 +1,7 @@
+# Zoom reveal
+
+1. What does this do? An element that scales from 0.
+
+2. How is it used? Add `reveal-zoom-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro pattern; the zoom reads as a gentle camera pull-in.

--- a/submissions/examples/reveal-zoom-tm/demo.html
+++ b/submissions/examples/reveal-zoom-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Zoom — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealzoom-page-tm" data-palette="teal">
+  <h1 class="revealzoom-h-tm">Reveal Zoom</h1>
+  <p class="revealzoom-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealzoom-row-tm">
+    <article class="revealzoom-1-wrap-tm">
+      <div class="revealzoom-1-tm"></div>
+      <span class="revealzoom-lbl-tm">Example One</span>
+    </article>
+    <article class="revealzoom-2-wrap-tm">
+      <div class="revealzoom-2-tm"></div>
+      <span class="revealzoom-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealzoom-3-wrap-tm">
+      <div class="revealzoom-3-tm"></div>
+      <span class="revealzoom-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-zoom-tm/style.css
+++ b/submissions/examples/reveal-zoom-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealzoom-bg: #08161a;
+  --revealzoom-surface: #0f2429;
+  --revealzoom-edge: #163239;
+  --revealzoom-text: #e6e8ec;
+  --revealzoom-muted: #8b909b;
+  --revealzoom-accent: #14b8a6;
+  --revealzoom-accent-2: #5eead4;
+  --revealzoom-radius: 10px;
+  --revealzoom-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealzoom-bg);
+  color: var(--revealzoom-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealzoom-page-tm { max-width: 920px; margin: 0 auto; }
+.revealzoom-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealzoom-lede-tm { color: var(--revealzoom-muted); margin: 0 0 32px; }
+.revealzoom-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealzoom-1-wrap-tm, .revealzoom-2-wrap-tm, .revealzoom-3-wrap-tm {
+  background: var(--revealzoom-surface);
+  border: 1px solid var(--revealzoom-edge);
+  border-radius: var(--revealzoom-radius);
+  padding: var(--revealzoom-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealzoom-lbl-tm { color: var(--revealzoom-muted); font-size: 13px; }
+
+.revealzoom-1-tm, .revealzoom-2-tm, .revealzoom-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #14b8a6, #5eead4);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      transform: scale(0.9); opacity: 0; animation: kf-revealzoom-v1 600ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealzoom-v1 { to { transform: scale(1); opacity: 1; } }
+.revealzoom-2-tm { background: linear-gradient(135deg, #5eead4, #14b8a6); }
+.revealzoom-3-tm { background: linear-gradient(135deg, #8b909b, #163239); }


### PR DESCRIPTION
Closes #77562

## What
This submission adds a new EaseMotion CSS example: `reveal-zoom-tm`.

An element that scales from 0.9 to 1 on first paint with a soft fade.

## How to review
1. Open `submissions/examples/reveal-zoom-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-zoom-tm/` and does not modify any existing file.
