### PR TITLE
Add flip reveal submission

### DIFF
--- a/submissions/examples/reveal-flip-tm/README.md
+++ b/submissions/examples/reveal-flip-tm/README.md
@@ -1,0 +1,7 @@
+# Flip reveal
+
+1. What does this do? An element that flips 180° on its X axis on first paint.
+
+2. How is it used? Add `reveal-flip-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro / transition pattern; uses rotateX with backface-visibility.

--- a/submissions/examples/reveal-flip-tm/demo.html
+++ b/submissions/examples/reveal-flip-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Flip — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealflip-page-tm" data-palette="ruby">
+  <h1 class="revealflip-h-tm">Reveal Flip</h1>
+  <p class="revealflip-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealflip-row-tm">
+    <article class="revealflip-1-wrap-tm">
+      <div class="revealflip-1-tm"></div>
+      <span class="revealflip-lbl-tm">Example One</span>
+    </article>
+    <article class="revealflip-2-wrap-tm">
+      <div class="revealflip-2-tm"></div>
+      <span class="revealflip-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealflip-3-wrap-tm">
+      <div class="revealflip-3-tm"></div>
+      <span class="revealflip-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-flip-tm/style.css
+++ b/submissions/examples/reveal-flip-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealflip-bg: #160a0d;
+  --revealflip-surface: #261418;
+  --revealflip-edge: #36191e;
+  --revealflip-text: #e6e8ec;
+  --revealflip-muted: #8b909b;
+  --revealflip-accent: #ef4444;
+  --revealflip-accent-2: #fb7185;
+  --revealflip-radius: 10px;
+  --revealflip-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealflip-bg);
+  color: var(--revealflip-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealflip-page-tm { max-width: 920px; margin: 0 auto; }
+.revealflip-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealflip-lede-tm { color: var(--revealflip-muted); margin: 0 0 32px; }
+.revealflip-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealflip-1-wrap-tm, .revealflip-2-wrap-tm, .revealflip-3-wrap-tm {
+  background: var(--revealflip-surface);
+  border: 1px solid var(--revealflip-edge);
+  border-radius: var(--revealflip-radius);
+  padding: var(--revealflip-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealflip-lbl-tm { color: var(--revealflip-muted); font-size: 13px; }
+
+.revealflip-1-tm, .revealflip-2-tm, .revealflip-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #ef4444, #fb7185);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      transform: rotateX(-90deg); animation: kf-revealflip-v1 700ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealflip-v1 { to { transform: rotateX(0); } }
+.revealflip-2-tm { background: linear-gradient(135deg, #fb7185, #ef4444); }
+.revealflip-3-tm { background: linear-gradient(135deg, #8b909b, #36191e); }


### PR DESCRIPTION
Closes #77567

## What
This submission adds a new EaseMotion CSS example: `reveal-flip-tm`.

An element that flips 180° on its X axis on first paint.

## How to review
1. Open `submissions/examples/reveal-flip-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-flip-tm/` and does not modify any existing file.
