### PR TITLE
Add skew reveal submission

### DIFF
--- a/submissions/examples/reveal-skew-tm/README.md
+++ b/submissions/examples/reveal-skew-tm/README.md
@@ -1,0 +1,7 @@
+# Skew reveal
+
+1. What does this do? An element that unskews from a slanted state to upright on first paint.
+
+2. How is it used? Add `reveal-skew-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro pattern; the skew reads as a quick correction.

--- a/submissions/examples/reveal-skew-tm/demo.html
+++ b/submissions/examples/reveal-skew-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Skew — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealskew-page-tm" data-palette="graphite">
+  <h1 class="revealskew-h-tm">Reveal Skew</h1>
+  <p class="revealskew-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealskew-row-tm">
+    <article class="revealskew-1-wrap-tm">
+      <div class="revealskew-1-tm"></div>
+      <span class="revealskew-lbl-tm">Example One</span>
+    </article>
+    <article class="revealskew-2-wrap-tm">
+      <div class="revealskew-2-tm"></div>
+      <span class="revealskew-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealskew-3-wrap-tm">
+      <div class="revealskew-3-tm"></div>
+      <span class="revealskew-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-skew-tm/style.css
+++ b/submissions/examples/reveal-skew-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealskew-bg: #101216;
+  --revealskew-surface: #1a1d22;
+  --revealskew-edge: #25282e;
+  --revealskew-text: #e6e8ec;
+  --revealskew-muted: #8b909b;
+  --revealskew-accent: #94a3b8;
+  --revealskew-accent-2: #cbd5e1;
+  --revealskew-radius: 10px;
+  --revealskew-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealskew-bg);
+  color: var(--revealskew-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealskew-page-tm { max-width: 920px; margin: 0 auto; }
+.revealskew-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealskew-lede-tm { color: var(--revealskew-muted); margin: 0 0 32px; }
+.revealskew-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealskew-1-wrap-tm, .revealskew-2-wrap-tm, .revealskew-3-wrap-tm {
+  background: var(--revealskew-surface);
+  border: 1px solid var(--revealskew-edge);
+  border-radius: var(--revealskew-radius);
+  padding: var(--revealskew-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealskew-lbl-tm { color: var(--revealskew-muted); font-size: 13px; }
+
+.revealskew-1-tm, .revealskew-2-tm, .revealskew-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #94a3b8, #cbd5e1);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      transform: skewY(8deg); opacity: 0; animation: kf-revealskew-v1 600ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealskew-v1 { to { transform: skewY(0); opacity: 1; } }
+.revealskew-2-tm { background: linear-gradient(135deg, #cbd5e1, #94a3b8); }
+.revealskew-3-tm { background: linear-gradient(135deg, #8b909b, #25282e); }


### PR DESCRIPTION
Closes #77572

## What
This submission adds a new EaseMotion CSS example: `reveal-skew-tm`.

An element that unskews from a slanted state to upright on first paint.

## How to review
1. Open `submissions/examples/reveal-skew-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-skew-tm/` and does not modify any existing file.
