### PR TITLE
Add bounce reveal submission

### DIFF
--- a/submissions/examples/reveal-bounce-tm/README.md
+++ b/submissions/examples/reveal-bounce-tm/README.md
@@ -1,0 +1,7 @@
+# Bounce reveal
+
+1. What does this do? An element that bounces up into place with a small overshoot.
+
+2. How is it used? Add `reveal-bounce-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro / modal pattern; the bounce uses a spring-like cubic-bezier.

--- a/submissions/examples/reveal-bounce-tm/demo.html
+++ b/submissions/examples/reveal-bounce-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Bounce — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealbounce-page-tm" data-palette="gold">
+  <h1 class="revealbounce-h-tm">Reveal Bounce</h1>
+  <p class="revealbounce-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealbounce-row-tm">
+    <article class="revealbounce-1-wrap-tm">
+      <div class="revealbounce-1-tm"></div>
+      <span class="revealbounce-lbl-tm">Example One</span>
+    </article>
+    <article class="revealbounce-2-wrap-tm">
+      <div class="revealbounce-2-tm"></div>
+      <span class="revealbounce-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealbounce-3-wrap-tm">
+      <div class="revealbounce-3-tm"></div>
+      <span class="revealbounce-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-bounce-tm/style.css
+++ b/submissions/examples/reveal-bounce-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealbounce-bg: #13110b;
+  --revealbounce-surface: #221e14;
+  --revealbounce-edge: #332c1c;
+  --revealbounce-text: #e6e8ec;
+  --revealbounce-muted: #8b909b;
+  --revealbounce-accent: #facc15;
+  --revealbounce-accent-2: #fbbf24;
+  --revealbounce-radius: 10px;
+  --revealbounce-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealbounce-bg);
+  color: var(--revealbounce-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealbounce-page-tm { max-width: 920px; margin: 0 auto; }
+.revealbounce-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealbounce-lede-tm { color: var(--revealbounce-muted); margin: 0 0 32px; }
+.revealbounce-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealbounce-1-wrap-tm, .revealbounce-2-wrap-tm, .revealbounce-3-wrap-tm {
+  background: var(--revealbounce-surface);
+  border: 1px solid var(--revealbounce-edge);
+  border-radius: var(--revealbounce-radius);
+  padding: var(--revealbounce-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealbounce-lbl-tm { color: var(--revealbounce-muted); font-size: 13px; }
+
+.revealbounce-1-tm, .revealbounce-2-tm, .revealbounce-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #facc15, #fbbf24);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      transform: scale(0.5); opacity: 0; animation: kf-revealbounce-v1 600ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+@keyframes kf-revealbounce-v1 { to { transform: scale(1); opacity: 1; } }
+.revealbounce-2-tm { background: linear-gradient(135deg, #fbbf24, #facc15); }
+.revealbounce-3-tm { background: linear-gradient(135deg, #8b909b, #332c1c); }


### PR DESCRIPTION
Closes #77574

## What
This submission adds a new EaseMotion CSS example: `reveal-bounce-tm`.

An element that bounces up into place with a small overshoot.

## How to review
1. Open `submissions/examples/reveal-bounce-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-bounce-tm/` and does not modify any existing file.
