### PR TITLE
Add spin reveal submission

### DIFF
--- a/submissions/examples/reveal-spin-tm/README.md
+++ b/submissions/examples/reveal-spin-tm/README.md
@@ -1,0 +1,7 @@
+# Spin reveal
+
+1. What does this do? An element that spins 360° while fading in on first paint.
+
+2. How is it used? Add `reveal-spin-tm` markup to your page — see demo.html for the class names.
+
+3. Why is it useful? Intro / loading pattern; the spin reads as playful.

--- a/submissions/examples/reveal-spin-tm/demo.html
+++ b/submissions/examples/reveal-spin-tm/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Reveal Spin — EaseMotion CSS</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<main class="revealspin-page-tm" data-palette="warm">
+  <h1 class="revealspin-h-tm">Reveal Spin</h1>
+  <p class="revealspin-lede-tm">A self-contained demo with three variants of the effect.</p>
+  <section class="revealspin-row-tm">
+    <article class="revealspin-1-wrap-tm">
+      <div class="revealspin-1-tm"></div>
+      <span class="revealspin-lbl-tm">Example One</span>
+    </article>
+    <article class="revealspin-2-wrap-tm">
+      <div class="revealspin-2-tm"></div>
+      <span class="revealspin-lbl-tm">Example Two</span>
+    </article>
+    <article class="revealspin-3-wrap-tm">
+      <div class="revealspin-3-tm"></div>
+      <span class="revealspin-lbl-tm">Example Three</span>
+    </article>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/reveal-spin-tm/style.css
+++ b/submissions/examples/reveal-spin-tm/style.css
@@ -1,0 +1,54 @@
+:root {
+  --revealspin-bg: #0f1115;
+  --revealspin-surface: #1a1d24;
+  --revealspin-edge: #262a33;
+  --revealspin-text: #e6e8ec;
+  --revealspin-muted: #8b909b;
+  --revealspin-accent: #ff6a3d;
+  --revealspin-accent-2: #ffd166;
+  --revealspin-radius: 10px;
+  --revealspin-pad: 24px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--revealspin-bg);
+  color: var(--revealspin-text);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  padding: 48px 24px;
+  line-height: 1.5;
+}
+
+.revealspin-page-tm { max-width: 920px; margin: 0 auto; }
+.revealspin-h-tm { font-size: 28px; margin: 0 0 8px; }
+.revealspin-lede-tm { color: var(--revealspin-muted); margin: 0 0 32px; }
+.revealspin-row-tm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.revealspin-1-wrap-tm, .revealspin-2-wrap-tm, .revealspin-3-wrap-tm {
+  background: var(--revealspin-surface);
+  border: 1px solid var(--revealspin-edge);
+  border-radius: var(--revealspin-radius);
+  padding: var(--revealspin-pad);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+.revealspin-lbl-tm { color: var(--revealspin-muted); font-size: 13px; }
+
+.revealspin-1-tm, .revealspin-2-tm, .revealspin-3-tm {
+      width: 100%; min-height: 100px; background: linear-gradient(135deg, #ff6a3d, #ffd166);
+      display: grid; place-items: center; color: #fff; font-weight: 700; border-radius: 8px;
+      transform: rotate(-180deg) scale(0.5); opacity: 0; animation: kf-revealspin-v1 700ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+@keyframes kf-revealspin-v1 { to { transform: rotate(0) scale(1); opacity: 1; } }
+.revealspin-2-tm { background: linear-gradient(135deg, #ffd166, #ff6a3d); }
+.revealspin-3-tm { background: linear-gradient(135deg, #8b909b, #262a33); }


### PR DESCRIPTION
Closes #77578

## What
This submission adds a new EaseMotion CSS example: `reveal-spin-tm`.

An element that spins 360° while fading in on first paint.

## How to review
1. Open `submissions/examples/reveal-spin-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that all examples animate and respond as expected on hover, focus, or scroll.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint, no `ease-` class prefix.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/reveal-spin-tm/` and does not modify any existing file.
