### PR TITLE
feat: add diamond facet edge card variation

### DIFF
--- a/submissions/examples/css-card-diamond-facet-edge-4694/README.md
+++ b/submissions/examples/css-card-diamond-facet-edge-4694/README.md
@@ -1,0 +1,22 @@
+# Diamond Facet Edge Card
+
+## What does this do?
+Provides a premium, chiseled-edge card design featuring a 3D perspective hover effect and dynamic facet highlights.
+
+## How is it used?
+```html
+<div class="facet-card-container">
+  <div class="facet-card">
+    <div class="facet-content">
+      <div class="facet-icon">
+        <!-- Add icon SVG here -->
+      </div>
+      <h2 class="facet-title">Title Here</h2>
+      <p class="facet-desc">Description here.</p>
+    </div>
+  </div>
+</div>
+```
+
+## Why is it useful?
+It creates an elegant, gemstone-like aesthetic using only CSS `clip-path` and gradients, avoiding heavy images while maintaining smooth, hardware-accelerated transitions. It perfectly fits EaseMotion's goal of offering high-quality, performant, pure CSS interactions and components.

--- a/submissions/examples/css-card-diamond-facet-edge-4694/demo.html
+++ b/submissions/examples/css-card-diamond-facet-edge-4694/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diamond Facet Edge Card</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="facet-card-container" aria-label="Interactive diamond edge card">
+    <div class="facet-card">
+      <div class="facet-content">
+        <div class="facet-icon" aria-hidden="true">
+          <!-- Diamond shape SVG inside the diamond clip-path -->
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 3h12l4 6-10 12L2 9l4-6z"></path>
+          </svg>
+        </div>
+        <h2 class="facet-title">Diamond Facet</h2>
+        <p class="facet-desc">A premium card variation featuring chiseled edges, interactive 3D perspective, and responsive highlights.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/css-card-diamond-facet-edge-4694/style.css
+++ b/submissions/examples/css-card-diamond-facet-edge-4694/style.css
@@ -1,0 +1,138 @@
+/* style.css */
+:root {
+  --bg-color: #0f172a;
+  --card-bg: #1e293b;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --accent-color: #38bdf8;
+  --facet-light: rgba(255, 255, 255, 0.15);
+  --facet-dark: rgba(0, 0, 0, 0.4);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--bg-color);
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.facet-card-container {
+  perspective: 1200px;
+  filter: drop-shadow(0 20px 30px rgba(0, 0, 0, 0.5));
+  transition: filter 0.5s ease;
+}
+
+.facet-card-container:hover {
+  filter: drop-shadow(0 30px 40px rgba(0, 0, 0, 0.7));
+}
+
+.facet-card {
+  width: 320px;
+  padding: 3.5rem 2rem;
+  background: var(--card-bg);
+  position: relative;
+  color: var(--text-main);
+  text-align: center;
+  /* Diamond cut edges using clip-path */
+  clip-path: polygon(
+    28px 0, calc(100% - 28px) 0, 
+    100% 28px, 100% calc(100% - 28px), 
+    calc(100% - 28px) 100%, 28px 100%, 
+    0 calc(100% - 28px), 0 28px
+  );
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* The actual 3D facet illusion borders */
+.facet-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: 
+    linear-gradient(135deg, var(--facet-light) 0%, transparent 40%),
+    linear-gradient(-45deg, transparent 60%, var(--facet-dark) 100%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.facet-card::after {
+  content: '';
+  position: absolute;
+  inset: 2px; /* inner border to separate from edge */
+  clip-path: polygon(
+    27px 0, calc(100% - 27px) 0, 
+    100% 27px, 100% calc(100% - 27px), 
+    calc(100% - 27px) 100%, 27px 100%, 
+    0 calc(100% - 27px), 0 27px
+  );
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  pointer-events: none;
+  z-index: 2;
+  transition: background 0.6s ease;
+}
+
+.facet-card-container:hover .facet-card {
+  transform: translateY(-12px) rotateX(8deg) rotateY(-8deg);
+}
+
+.facet-card-container:hover .facet-card::after {
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 60%);
+}
+
+.facet-content {
+  position: relative;
+  z-index: 3;
+  transform: translateZ(40px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.facet-icon {
+  width: 64px;
+  height: 64px;
+  background: linear-gradient(135deg, var(--accent-color), #2563eb);
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.3);
+}
+
+.facet-card-container:hover .facet-icon {
+  transform: rotate(90deg) scale(1.1) translateZ(20px);
+}
+
+.facet-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.facet-desc {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .facet-card-container, .facet-card, .facet-card::after, .facet-icon {
+    transition: none;
+  }
+  .facet-card-container:hover .facet-card, .facet-card-container:hover .facet-icon {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Closes #73279.

This submission introduces the **Diamond Facet Edge** card variation (#46). It solves the need for an elegant, gemstone-like card design by utilizing CSS `clip-path` and multiple background gradients to create a 3D chiseled edge effect without relying on images. It features smooth 3D perspective hover states and responsive lighting highlights.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A premium card variation featuring chiseled diamond-cut edges, interactive 3D perspective depth, and responsive facet highlights.

**How does a developer use it?**

```html
<div class="facet-card-container">
  <div class="facet-card">
    <div class="facet-content">
      <div class="facet-icon">
        <!-- SVG Icon -->
      </div>
      <h2 class="facet-title">Diamond Facet</h2>
      <p class="facet-desc">A premium card variation featuring chiseled edges...</p>
    </div>
  </div>
</div>
