### PR TITLE
feat: add ease-punty-iron-transfer (#77600)

### DIFF
--- a/submissions/examples/punty-iron-transfer-ns/README.md
+++ b/submissions/examples/punty-iron-transfer-ns/README.md
@@ -1,0 +1,16 @@
+# Punty Iron Transfer
+
+## What does this do?
+Renders a self-contained CSS-only `ease-punty-iron-transfer` demo: Punty iron taking the vessel off the blowpipe.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-punty-iron-transfer`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-punty-iron-transfer">
+  <div class="ease-punty-iron-transfer__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/punty-iron-transfer-ns/demo.html
+++ b/submissions/examples/punty-iron-transfer-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Punty Iron Transfer — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Punty Iron Transfer demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Punty Iron Transfer</h1>
+      <p class="lede">Punty iron taking the vessel off the blowpipe</p>
+    </header>
+
+    <section class="ease-punty-iron-transfer" data-demo="punty-iron-transfer" aria-live="polite">
+      <div class="ease-punty-iron-transfer__housing">
+        <div class="ease-punty-iron-transfer__bezel">
+          <div class="ease-punty-iron-transfer__face">
+            <div class="ease-punty-iron-transfer__readout">
+              <span class="ease-punty-iron-transfer__label">Punty Iron Transfer</span>
+              <span class="ease-punty-iron-transfer__value">LIVE</span>
+            </div>
+            <div class="ease-punty-iron-transfer__motion" aria-hidden="true">
+              <span class="ease-punty-iron-transfer__a"></span>
+              <span class="ease-punty-iron-transfer__b"></span>
+              <span class="ease-punty-iron-transfer__c"></span>
+              <span class="ease-punty-iron-transfer__d"></span>
+            </div>
+            <div class="ease-punty-iron-transfer__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-punty-iron-transfer__controls">
+          <button type="button" class="ease-punty-iron-transfer__btn primary">Stick</button>
+          <button type="button" class="ease-punty-iron-transfer__btn">Release</button>
+          <label class="ease-punty-iron-transfer__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-punty-iron-transfer__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/punty-iron-transfer-ns/style.css
+++ b/submissions/examples/punty-iron-transfer-ns/style.css
@@ -1,0 +1,224 @@
+html { color-scheme: dark; }
+/* punty-iron-transfer */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #ede7ee;
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #8be458 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #89f0a1 18%, transparent), transparent 42%),
+    #1f0e20;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-punty-iron-transfer {
+  --accent: #8be458;
+  --accent-2: #89f0a1;
+  --panel: color-mix(in srgb, #ede7ee 7%, #1f0e20);
+  --line: color-mix(in srgb, #ede7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1f0e20 75%, #000);
+}
+
+.ease-punty-iron-transfer__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-punty-iron-transfer__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #ede7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1f0e20 90%, #8be458);
+}
+
+.ease-punty-iron-transfer__face {
+  position: relative;
+  min-height: 248px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1f0e20 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-punty-iron-transfer__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-punty-iron-transfer__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-punty-iron-transfer__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-punty-iron-transfer__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-punty-iron-transfer__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-punty-iron-transfer__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: punty_iron_transfer_meter 2.88s linear infinite;
+}
+
+.ease-punty-iron-transfer__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-punty-iron-transfer__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-punty-iron-transfer__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-punty-iron-transfer__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-punty-iron-transfer__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-punty-iron-transfer__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-punty-iron-transfer__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-punty-iron-transfer__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #ede7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-punty-iron-transfer__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-punty-iron-transfer__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-punty-iron-transfer__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-punty-iron-transfer__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: punty_iron_transfer_status 2.02s ease-out infinite;
+}
+
+@keyframes punty_iron_transfer_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes punty_iron_transfer_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-punty-iron-transfer__a{position:absolute;left:14%;right:14%;top:24%;height:52%;display:block;background:repeating-linear-gradient(180deg,var(--accent) 0 3px,transparent 3px 14px);opacity:.35;animation:punty_iron_transfer_scan 2.88s linear infinite}
+.ease-punty-iron-transfer__b{position:absolute;left:12%;right:12%;height:3px;background:var(--accent-2);animation:punty_iron_transfer_line 2.88s linear infinite}
+.ease-punty-iron-transfer__c{position:absolute;left:16%;top:18%;width:8px;height:8px;background:var(--accent)}
+.ease-punty-iron-transfer__d{position:absolute;right:16%;bottom:18%;width:8px;height:8px;background:var(--accent-2)}
+@keyframes punty_iron_transfer_scan{0%{transform:translateY(-8%)}100%{transform:translateY(8%)}}
+@keyframes punty_iron_transfer_line{0%{top:22%}100%{top:72%}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-punty-iron-transfer__a,
+  .ease-punty-iron-transfer__b,
+  .ease-punty-iron-transfer__c,
+  .ease-punty-iron-transfer__d,
+  .ease-punty-iron-transfer__meters i::after,
+  .ease-punty-iron-transfer__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-punty-iron-transfer` CSS-only demo for #77600.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Punty iron taking the vessel off the blowpipe

**How does a developer use it?**

```html
<section class="ease-punty-iron-transfer">
  <div class="ease-punty-iron-transfer__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/punty-iron-transfer-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77600
