### PR TITLE
feat: add ease-pontil-snap-break (#77602)

### DIFF
--- a/submissions/examples/pontil-snap-break-ns/README.md
+++ b/submissions/examples/pontil-snap-break-ns/README.md
@@ -1,0 +1,16 @@
+# Pontil Snap Break
+
+## What does this do?
+Renders a self-contained CSS-only `ease-pontil-snap-break` demo: Pontil snap breaking the vessel free of the iron.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-pontil-snap-break`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-pontil-snap-break">
+  <div class="ease-pontil-snap-break__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/pontil-snap-break-ns/demo.html
+++ b/submissions/examples/pontil-snap-break-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pontil Snap Break — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Pontil Snap Break demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Pontil Snap Break</h1>
+      <p class="lede">Pontil snap breaking the vessel free of the iron</p>
+    </header>
+
+    <section class="ease-pontil-snap-break" data-demo="pontil-snap-break" aria-live="polite">
+      <div class="ease-pontil-snap-break__housing">
+        <div class="ease-pontil-snap-break__bezel">
+          <div class="ease-pontil-snap-break__face">
+            <div class="ease-pontil-snap-break__readout">
+              <span class="ease-pontil-snap-break__label">Pontil Snap Break</span>
+              <span class="ease-pontil-snap-break__value">LIVE</span>
+            </div>
+            <div class="ease-pontil-snap-break__motion" aria-hidden="true">
+              <span class="ease-pontil-snap-break__a"></span>
+              <span class="ease-pontil-snap-break__b"></span>
+              <span class="ease-pontil-snap-break__c"></span>
+              <span class="ease-pontil-snap-break__d"></span>
+            </div>
+            <div class="ease-pontil-snap-break__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-pontil-snap-break__controls">
+          <button type="button" class="ease-pontil-snap-break__btn primary">Snap</button>
+          <button type="button" class="ease-pontil-snap-break__btn">Hold</button>
+          <label class="ease-pontil-snap-break__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-pontil-snap-break__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pontil-snap-break-ns/style.css
+++ b/submissions/examples/pontil-snap-break-ns/style.css
@@ -1,0 +1,225 @@
+/* Pontil Snap Break motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7edee;
+  font-family: "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #e4585f 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #f0ce89 18%, transparent), transparent 42%),
+    #0d181c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-pontil-snap-break {
+  --accent: #e4585f;
+  --accent-2: #f0ce89;
+  --panel: color-mix(in srgb, #e7edee 7%, #0d181c);
+  --line: color-mix(in srgb, #e7edee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d181c 75%, #000);
+}
+
+.ease-pontil-snap-break__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-pontil-snap-break__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7edee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d181c 90%, #e4585f);
+}
+
+.ease-pontil-snap-break__face {
+  position: relative;
+  min-height: 267px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d181c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-pontil-snap-break__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pontil-snap-break__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-pontil-snap-break__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-pontil-snap-break__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-pontil-snap-break__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-pontil-snap-break__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: pontil_snap_break_meter 4.2s linear infinite;
+}
+
+.ease-pontil-snap-break__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-pontil-snap-break__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-pontil-snap-break__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-pontil-snap-break__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-pontil-snap-break__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-pontil-snap-break__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-pontil-snap-break__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7edee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-pontil-snap-break__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-pontil-snap-break__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-pontil-snap-break__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-pontil-snap-break__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pontil_snap_break_status 2.94s ease-out infinite;
+}
+
+@keyframes pontil_snap_break_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes pontil_snap_break_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-pontil-snap-break__a{position:absolute;left:28%;right:28%;top:28%;bottom:28%;border-radius:10px;background:var(--accent);animation:pontil_snap_break_stamp 4.2s cubic-bezier(.2,.8,.2,1) infinite}
+.ease-pontil-snap-break__b{position:absolute;left:22%;right:22%;bottom:16%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent-2) 40%,transparent)}
+.ease-pontil-snap-break__c{position:absolute;left:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent-2)}
+.ease-pontil-snap-break__d{position:absolute;right:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent)}
+@keyframes pontil_snap_break_stamp{0%,100%{transform:scale(1) translateY(0)}40%{transform:scale(.72) translateY(18px)}55%{transform:scale(1.06) translateY(0)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pontil-snap-break__a,
+  .ease-pontil-snap-break__b,
+  .ease-pontil-snap-break__c,
+  .ease-pontil-snap-break__d,
+  .ease-pontil-snap-break__meters i::after,
+  .ease-pontil-snap-break__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pontil-snap-break` CSS-only demo for #77602.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Pontil snap breaking the vessel free of the iron

**How does a developer use it?**

```html
<section class="ease-pontil-snap-break">
  <div class="ease-pontil-snap-break__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/pontil-snap-break-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77602
