### PR TITLE
feat: add ease-cane-pull-stretch (#77604)

### DIFF
--- a/submissions/examples/cane-pull-stretch-ns/README.md
+++ b/submissions/examples/cane-pull-stretch-ns/README.md
@@ -1,0 +1,16 @@
+# Cane Pull Stretch
+
+## What does this do?
+Renders a self-contained CSS-only `ease-cane-pull-stretch` demo: Cane pull stretching molten color into a thread.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-cane-pull-stretch`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-cane-pull-stretch">
+  <div class="ease-cane-pull-stretch__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/cane-pull-stretch-ns/demo.html
+++ b/submissions/examples/cane-pull-stretch-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cane Pull Stretch — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Cane Pull Stretch demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Cane Pull Stretch</h1>
+      <p class="lede">Cane pull stretching molten color into a thread</p>
+    </header>
+
+    <section class="ease-cane-pull-stretch" data-demo="cane-pull-stretch" aria-live="polite">
+      <div class="ease-cane-pull-stretch__housing">
+        <div class="ease-cane-pull-stretch__bezel">
+          <div class="ease-cane-pull-stretch__face">
+            <div class="ease-cane-pull-stretch__readout">
+              <span class="ease-cane-pull-stretch__label">Cane Pull Stretch</span>
+              <span class="ease-cane-pull-stretch__value">LIVE</span>
+            </div>
+            <div class="ease-cane-pull-stretch__motion" aria-hidden="true">
+              <span class="ease-cane-pull-stretch__a"></span>
+              <span class="ease-cane-pull-stretch__b"></span>
+              <span class="ease-cane-pull-stretch__c"></span>
+              <span class="ease-cane-pull-stretch__d"></span>
+            </div>
+            <div class="ease-cane-pull-stretch__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-cane-pull-stretch__controls">
+          <button type="button" class="ease-cane-pull-stretch__btn primary">Pull</button>
+          <button type="button" class="ease-cane-pull-stretch__btn">Cut</button>
+          <label class="ease-cane-pull-stretch__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-cane-pull-stretch__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cane-pull-stretch-ns/style.css
+++ b/submissions/examples/cane-pull-stretch-ns/style.css
@@ -1,0 +1,221 @@
+html { color-scheme: dark; }
+/* cane-pull-stretch */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeeee7;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #5862e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #b689f0 18%, transparent), transparent 42%),
+    #15190b;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-cane-pull-stretch {
+  --accent: #5862e4;
+  --accent-2: #b689f0;
+  --panel: color-mix(in srgb, #eeeee7 7%, #15190b);
+  --line: color-mix(in srgb, #eeeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #15190b 75%, #000);
+}
+
+.ease-cane-pull-stretch__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-cane-pull-stretch__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #15190b 90%, #5862e4);
+}
+
+.ease-cane-pull-stretch__face {
+  position: relative;
+  min-height: 266px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #15190b 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-cane-pull-stretch__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-cane-pull-stretch__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-cane-pull-stretch__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-cane-pull-stretch__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-cane-pull-stretch__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-cane-pull-stretch__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: cane_pull_stretch_meter 4.8s linear infinite;
+}
+
+.ease-cane-pull-stretch__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-cane-pull-stretch__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-cane-pull-stretch__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-cane-pull-stretch__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-cane-pull-stretch__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-cane-pull-stretch__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-cane-pull-stretch__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-cane-pull-stretch__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-cane-pull-stretch__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-cane-pull-stretch__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: cane_pull_stretch_status 3.36s ease-out infinite;
+}
+
+@keyframes cane_pull_stretch_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes cane_pull_stretch_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-cane-pull-stretch__a{position:absolute;inset:0;background:linear-gradient(115deg,transparent 35%,color-mix(in srgb,var(--accent) 35%,transparent) 50%,transparent 65%);background-size:220% 220%;animation:cane_pull_stretch_drift 4.8s linear infinite}
+.ease-cane-pull-stretch__b{position:absolute;inset:30%;border-radius:50%;border:2px solid var(--accent-2);opacity:.7}
+.ease-cane-pull-stretch__c{position:absolute;left:20%;right:20%;top:50%;height:2px;background:var(--accent);opacity:.4}
+.ease-cane-pull-stretch__d{position:absolute;left:50%;top:22%;width:7px;height:7px;border-radius:50%;background:var(--accent)}
+@keyframes cane_pull_stretch_drift{0%{background-position:0% 50%}100%{background-position:100% 50%}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cane-pull-stretch__a,
+  .ease-cane-pull-stretch__b,
+  .ease-cane-pull-stretch__c,
+  .ease-cane-pull-stretch__d,
+  .ease-cane-pull-stretch__meters i::after,
+  .ease-cane-pull-stretch__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-cane-pull-stretch` CSS-only demo for #77604.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Cane pull stretching molten color into a thread

**How does a developer use it?**

```html
<section class="ease-cane-pull-stretch">
  <div class="ease-cane-pull-stretch__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/cane-pull-stretch-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77604
