### PR TITLE
feat: add ease-murrine-slice-stack (#77605)

### DIFF
--- a/submissions/examples/murrine-slice-stack-ns/README.md
+++ b/submissions/examples/murrine-slice-stack-ns/README.md
@@ -1,0 +1,16 @@
+# Murrine Slice Stack
+
+## What does this do?
+Renders a self-contained CSS-only `ease-murrine-slice-stack` demo: Murrine slice stacking a mosaic cane cross-section.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-murrine-slice-stack`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-murrine-slice-stack">
+  <div class="ease-murrine-slice-stack__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/murrine-slice-stack-ns/demo.html
+++ b/submissions/examples/murrine-slice-stack-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Murrine Slice Stack — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Murrine Slice Stack demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Murrine Slice Stack</h1>
+      <p class="lede">Murrine slice stacking a mosaic cane cross-section</p>
+    </header>
+
+    <section class="ease-murrine-slice-stack" data-demo="murrine-slice-stack" aria-live="polite">
+      <div class="ease-murrine-slice-stack__housing">
+        <div class="ease-murrine-slice-stack__bezel">
+          <div class="ease-murrine-slice-stack__face">
+            <div class="ease-murrine-slice-stack__readout">
+              <span class="ease-murrine-slice-stack__label">Murrine Slice Stack</span>
+              <span class="ease-murrine-slice-stack__value">LIVE</span>
+            </div>
+            <div class="ease-murrine-slice-stack__motion" aria-hidden="true">
+              <span class="ease-murrine-slice-stack__a"></span>
+              <span class="ease-murrine-slice-stack__b"></span>
+              <span class="ease-murrine-slice-stack__c"></span>
+              <span class="ease-murrine-slice-stack__d"></span>
+            </div>
+            <div class="ease-murrine-slice-stack__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-murrine-slice-stack__controls">
+          <button type="button" class="ease-murrine-slice-stack__btn primary">Slice</button>
+          <button type="button" class="ease-murrine-slice-stack__btn">Stack</button>
+          <label class="ease-murrine-slice-stack__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-murrine-slice-stack__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/murrine-slice-stack-ns/style.css
+++ b/submissions/examples/murrine-slice-stack-ns/style.css
@@ -1,0 +1,221 @@
+/* stage: murrine-slice-stack */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeede7;
+  font-family: "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #588ee4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #9389f0 18%, transparent), transparent 42%),
+    #1c1b0d;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-murrine-slice-stack {
+  --accent: #588ee4;
+  --accent-2: #9389f0;
+  --panel: color-mix(in srgb, #eeede7 7%, #1c1b0d);
+  --line: color-mix(in srgb, #eeede7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 11px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1c1b0d 75%, #000);
+}
+
+.ease-murrine-slice-stack__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-murrine-slice-stack__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeede7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1c1b0d 90%, #588ee4);
+}
+
+.ease-murrine-slice-stack__face {
+  position: relative;
+  min-height: 247px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1c1b0d 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-murrine-slice-stack__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-murrine-slice-stack__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-murrine-slice-stack__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-murrine-slice-stack__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-murrine-slice-stack__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-murrine-slice-stack__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: murrine_slice_stack_meter 4.44s linear infinite;
+}
+
+.ease-murrine-slice-stack__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-murrine-slice-stack__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-murrine-slice-stack__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-murrine-slice-stack__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-murrine-slice-stack__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-murrine-slice-stack__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-murrine-slice-stack__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeede7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-murrine-slice-stack__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-murrine-slice-stack__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-murrine-slice-stack__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-murrine-slice-stack__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: murrine_slice_stack_status 3.11s ease-out infinite;
+}
+
+@keyframes murrine_slice_stack_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes murrine_slice_stack_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-murrine-slice-stack__a{position:absolute;left:28%;right:28%;top:28%;bottom:28%;border-radius:10px;background:var(--accent);animation:murrine_slice_stack_stamp 4.44s cubic-bezier(.2,.8,.2,1) infinite}
+.ease-murrine-slice-stack__b{position:absolute;left:22%;right:22%;bottom:16%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent-2) 40%,transparent)}
+.ease-murrine-slice-stack__c{position:absolute;left:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent-2)}
+.ease-murrine-slice-stack__d{position:absolute;right:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent)}
+@keyframes murrine_slice_stack_stamp{0%,100%{transform:scale(1) translateY(0)}40%{transform:scale(.72) translateY(18px)}55%{transform:scale(1.06) translateY(0)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-murrine-slice-stack__a,
+  .ease-murrine-slice-stack__b,
+  .ease-murrine-slice-stack__c,
+  .ease-murrine-slice-stack__d,
+  .ease-murrine-slice-stack__meters i::after,
+  .ease-murrine-slice-stack__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-murrine-slice-stack` CSS-only demo for #77605.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Murrine slice stacking a mosaic cane cross-section

**How does a developer use it?**

```html
<section class="ease-murrine-slice-stack">
  <div class="ease-murrine-slice-stack__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/murrine-slice-stack-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77605
