### PR TITLE
feat: add ease-blowpipe-parison-inflate (#77606)

### DIFF
--- a/submissions/examples/blowpipe-parison-inflate-ns/README.md
+++ b/submissions/examples/blowpipe-parison-inflate-ns/README.md
@@ -1,0 +1,16 @@
+# Blowpipe Parison Inflate
+
+## What does this do?
+Renders a self-contained CSS-only `ease-blowpipe-parison-inflate` demo: Blowpipe parison inflating the first bubble.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-blowpipe-parison-inflate`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-blowpipe-parison-inflate">
+  <div class="ease-blowpipe-parison-inflate__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/blowpipe-parison-inflate-ns/demo.html
+++ b/submissions/examples/blowpipe-parison-inflate-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blowpipe Parison Inflate — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Blowpipe Parison Inflate demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Blowpipe Parison Inflate</h1>
+      <p class="lede">Blowpipe parison inflating the first bubble</p>
+    </header>
+
+    <section class="ease-blowpipe-parison-inflate" data-demo="blowpipe-parison-inflate" aria-live="polite">
+      <div class="ease-blowpipe-parison-inflate__housing">
+        <div class="ease-blowpipe-parison-inflate__bezel">
+          <div class="ease-blowpipe-parison-inflate__face">
+            <div class="ease-blowpipe-parison-inflate__readout">
+              <span class="ease-blowpipe-parison-inflate__label">Blowpipe Parison Inflate</span>
+              <span class="ease-blowpipe-parison-inflate__value">LIVE</span>
+            </div>
+            <div class="ease-blowpipe-parison-inflate__motion" aria-hidden="true">
+              <span class="ease-blowpipe-parison-inflate__a"></span>
+              <span class="ease-blowpipe-parison-inflate__b"></span>
+              <span class="ease-blowpipe-parison-inflate__c"></span>
+              <span class="ease-blowpipe-parison-inflate__d"></span>
+            </div>
+            <div class="ease-blowpipe-parison-inflate__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-blowpipe-parison-inflate__controls">
+          <button type="button" class="ease-blowpipe-parison-inflate__btn primary">Blow</button>
+          <button type="button" class="ease-blowpipe-parison-inflate__btn">Vent</button>
+          <label class="ease-blowpipe-parison-inflate__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-blowpipe-parison-inflate__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/blowpipe-parison-inflate-ns/style.css
+++ b/submissions/examples/blowpipe-parison-inflate-ns/style.css
@@ -1,0 +1,223 @@
+html { color-scheme: dark; }
+/* blowpipe-parison-inflate */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeebe7;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #58b5e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #899af0 18%, transparent), transparent 42%),
+    #151109;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-blowpipe-parison-inflate {
+  --accent: #58b5e4;
+  --accent-2: #899af0;
+  --panel: color-mix(in srgb, #eeebe7 7%, #151109);
+  --line: color-mix(in srgb, #eeebe7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #151109 75%, #000);
+}
+
+.ease-blowpipe-parison-inflate__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-blowpipe-parison-inflate__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeebe7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #151109 90%, #58b5e4);
+}
+
+.ease-blowpipe-parison-inflate__face {
+  position: relative;
+  min-height: 230px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #151109 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-blowpipe-parison-inflate__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-blowpipe-parison-inflate__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-blowpipe-parison-inflate__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-blowpipe-parison-inflate__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-blowpipe-parison-inflate__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-blowpipe-parison-inflate__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: blowpipe_parison_inflate_meter 4.8s linear infinite;
+}
+
+.ease-blowpipe-parison-inflate__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-blowpipe-parison-inflate__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-blowpipe-parison-inflate__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-blowpipe-parison-inflate__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-blowpipe-parison-inflate__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-blowpipe-parison-inflate__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeebe7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-blowpipe-parison-inflate__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-blowpipe-parison-inflate__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-blowpipe-parison-inflate__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-blowpipe-parison-inflate__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: blowpipe_parison_inflate_status 3.36s ease-out infinite;
+}
+
+@keyframes blowpipe_parison_inflate_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes blowpipe_parison_inflate_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-blowpipe-parison-inflate__a{position:absolute;inset:24%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);animation:blowpipe_parison_inflate_ring 4.8s ease-out infinite}
+.ease-blowpipe-parison-inflate__b{position:absolute;inset:34%;border-radius:50%;background:radial-gradient(circle,var(--accent-2),transparent 68%);animation:blowpipe_parison_inflate_core 4.8s ease-in-out infinite}
+.ease-blowpipe-parison-inflate__c{position:absolute;left:16%;right:16%;top:50%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 7px,transparent 7px 14px);opacity:.45}
+.ease-blowpipe-parison-inflate__d{position:absolute;left:50%;top:24%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:blowpipe_parison_inflate_spark 4.8s linear infinite}
+@keyframes blowpipe_parison_inflate_ring{0%{transform:scale(.82);opacity:.95}100%{transform:scale(1.28);opacity:0}}
+@keyframes blowpipe_parison_inflate_core{0%,100%{transform:scale(.88);opacity:.5}50%{transform:scale(1.12);opacity:1}}
+@keyframes blowpipe_parison_inflate_spark{0%{transform:rotate(0deg) translateX(0)}100%{transform:rotate(360deg) translateX(42px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-blowpipe-parison-inflate__a,
+  .ease-blowpipe-parison-inflate__b,
+  .ease-blowpipe-parison-inflate__c,
+  .ease-blowpipe-parison-inflate__d,
+  .ease-blowpipe-parison-inflate__meters i::after,
+  .ease-blowpipe-parison-inflate__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-blowpipe-parison-inflate` CSS-only demo for #77606.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Blowpipe parison inflating the first bubble

**How does a developer use it?**

```html
<section class="ease-blowpipe-parison-inflate">
  <div class="ease-blowpipe-parison-inflate__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/blowpipe-parison-inflate-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77606
