### PR TITLE
feat: add ease-dandy-roll-watermark (#77614)

### DIFF
--- a/submissions/examples/dandy-roll-watermark-ns/README.md
+++ b/submissions/examples/dandy-roll-watermark-ns/README.md
@@ -1,0 +1,16 @@
+# Dandy Roll Watermark
+
+## What does this do?
+Renders a self-contained CSS-only `ease-dandy-roll-watermark` demo: Dandy roll pressing a watermark into the web.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-dandy-roll-watermark`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-dandy-roll-watermark">
+  <div class="ease-dandy-roll-watermark__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/dandy-roll-watermark-ns/demo.html
+++ b/submissions/examples/dandy-roll-watermark-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dandy Roll Watermark — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Dandy Roll Watermark demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Dandy Roll Watermark</h1>
+      <p class="lede">Dandy roll pressing a watermark into the web</p>
+    </header>
+
+    <section class="ease-dandy-roll-watermark" data-demo="dandy-roll-watermark" aria-live="polite">
+      <div class="ease-dandy-roll-watermark__housing">
+        <div class="ease-dandy-roll-watermark__bezel">
+          <div class="ease-dandy-roll-watermark__face">
+            <div class="ease-dandy-roll-watermark__readout">
+              <span class="ease-dandy-roll-watermark__label">Dandy Roll Watermark</span>
+              <span class="ease-dandy-roll-watermark__value">LIVE</span>
+            </div>
+            <div class="ease-dandy-roll-watermark__motion" aria-hidden="true">
+              <span class="ease-dandy-roll-watermark__a"></span>
+              <span class="ease-dandy-roll-watermark__b"></span>
+              <span class="ease-dandy-roll-watermark__c"></span>
+              <span class="ease-dandy-roll-watermark__d"></span>
+            </div>
+            <div class="ease-dandy-roll-watermark__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-dandy-roll-watermark__controls">
+          <button type="button" class="ease-dandy-roll-watermark__btn primary">Mark</button>
+          <button type="button" class="ease-dandy-roll-watermark__btn">Lift</button>
+          <label class="ease-dandy-roll-watermark__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-dandy-roll-watermark__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dandy-roll-watermark-ns/style.css
+++ b/submissions/examples/dandy-roll-watermark-ns/style.css
@@ -1,0 +1,223 @@
+html { color-scheme: dark; }
+/* dandy-roll-watermark */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeebe7;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #58b5e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #899af0 18%, transparent), transparent 42%),
+    #151109;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-dandy-roll-watermark {
+  --accent: #58b5e4;
+  --accent-2: #899af0;
+  --panel: color-mix(in srgb, #eeebe7 7%, #151109);
+  --line: color-mix(in srgb, #eeebe7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #151109 75%, #000);
+}
+
+.ease-dandy-roll-watermark__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-dandy-roll-watermark__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeebe7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #151109 90%, #58b5e4);
+}
+
+.ease-dandy-roll-watermark__face {
+  position: relative;
+  min-height: 230px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #151109 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-dandy-roll-watermark__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-dandy-roll-watermark__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-dandy-roll-watermark__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-dandy-roll-watermark__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-dandy-roll-watermark__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-dandy-roll-watermark__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: dandy_roll_watermark_meter 3.6s linear infinite;
+}
+
+.ease-dandy-roll-watermark__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-dandy-roll-watermark__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-dandy-roll-watermark__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-dandy-roll-watermark__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-dandy-roll-watermark__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-dandy-roll-watermark__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeebe7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-dandy-roll-watermark__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-dandy-roll-watermark__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-dandy-roll-watermark__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-dandy-roll-watermark__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dandy_roll_watermark_status 2.52s ease-out infinite;
+}
+
+@keyframes dandy_roll_watermark_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes dandy_roll_watermark_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-dandy-roll-watermark__a{position:absolute;inset:24%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);animation:dandy_roll_watermark_ring 3.6s ease-out infinite}
+.ease-dandy-roll-watermark__b{position:absolute;inset:34%;border-radius:50%;background:radial-gradient(circle,var(--accent-2),transparent 68%);animation:dandy_roll_watermark_core 3.6s ease-in-out infinite}
+.ease-dandy-roll-watermark__c{position:absolute;left:16%;right:16%;top:50%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 7px,transparent 7px 14px);opacity:.45}
+.ease-dandy-roll-watermark__d{position:absolute;left:50%;top:24%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:dandy_roll_watermark_spark 3.6s linear infinite}
+@keyframes dandy_roll_watermark_ring{0%{transform:scale(.82);opacity:.95}100%{transform:scale(1.28);opacity:0}}
+@keyframes dandy_roll_watermark_core{0%,100%{transform:scale(.88);opacity:.5}50%{transform:scale(1.12);opacity:1}}
+@keyframes dandy_roll_watermark_spark{0%{transform:rotate(0deg) translateX(0)}100%{transform:rotate(360deg) translateX(42px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dandy-roll-watermark__a,
+  .ease-dandy-roll-watermark__b,
+  .ease-dandy-roll-watermark__c,
+  .ease-dandy-roll-watermark__d,
+  .ease-dandy-roll-watermark__meters i::after,
+  .ease-dandy-roll-watermark__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-dandy-roll-watermark` CSS-only demo for #77614.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Dandy roll pressing a watermark into the web

**How does a developer use it?**

```html
<section class="ease-dandy-roll-watermark">
  <div class="ease-dandy-roll-watermark__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/dandy-roll-watermark-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77614
