### PR TITLE
feat: add ease-vatman-mould-dip (#77615)

### DIFF
--- a/submissions/examples/vatman-mould-dip-ns/README.md
+++ b/submissions/examples/vatman-mould-dip-ns/README.md
@@ -1,0 +1,16 @@
+# Vatman Mould Dip
+
+## What does this do?
+Renders a self-contained CSS-only `ease-vatman-mould-dip` demo: Vatman dipping the mould into the vat.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-vatman-mould-dip`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-vatman-mould-dip">
+  <div class="ease-vatman-mould-dip__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/vatman-mould-dip-ns/demo.html
+++ b/submissions/examples/vatman-mould-dip-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vatman Mould Dip — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Vatman Mould Dip demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Vatman Mould Dip</h1>
+      <p class="lede">Vatman dipping the mould into the vat</p>
+    </header>
+
+    <section class="ease-vatman-mould-dip" data-demo="vatman-mould-dip" aria-live="polite">
+      <div class="ease-vatman-mould-dip__housing">
+        <div class="ease-vatman-mould-dip__bezel">
+          <div class="ease-vatman-mould-dip__face">
+            <div class="ease-vatman-mould-dip__readout">
+              <span class="ease-vatman-mould-dip__label">Vatman Mould Dip</span>
+              <span class="ease-vatman-mould-dip__value">LIVE</span>
+            </div>
+            <div class="ease-vatman-mould-dip__motion" aria-hidden="true">
+              <span class="ease-vatman-mould-dip__a"></span>
+              <span class="ease-vatman-mould-dip__b"></span>
+              <span class="ease-vatman-mould-dip__c"></span>
+              <span class="ease-vatman-mould-dip__d"></span>
+            </div>
+            <div class="ease-vatman-mould-dip__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-vatman-mould-dip__controls">
+          <button type="button" class="ease-vatman-mould-dip__btn primary">Dip</button>
+          <button type="button" class="ease-vatman-mould-dip__btn">Drain</button>
+          <label class="ease-vatman-mould-dip__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-vatman-mould-dip__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/vatman-mould-dip-ns/style.css
+++ b/submissions/examples/vatman-mould-dip-ns/style.css
@@ -1,0 +1,220 @@
+/* stage: vatman-mould-dip */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #ebeee7;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #7e58e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #dc89f0 18%, transparent), transparent 42%),
+    #10190b;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-vatman-mould-dip {
+  --accent: #7e58e4;
+  --accent-2: #dc89f0;
+  --panel: color-mix(in srgb, #ebeee7 7%, #10190b);
+  --line: color-mix(in srgb, #ebeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #10190b 75%, #000);
+}
+
+.ease-vatman-mould-dip__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-vatman-mould-dip__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #ebeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #10190b 90%, #7e58e4);
+}
+
+.ease-vatman-mould-dip__face {
+  position: relative;
+  min-height: 246px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #10190b 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-vatman-mould-dip__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-vatman-mould-dip__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-vatman-mould-dip__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-vatman-mould-dip__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-vatman-mould-dip__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-vatman-mould-dip__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: vatman_mould_dip_meter 2.88s linear infinite;
+}
+
+.ease-vatman-mould-dip__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-vatman-mould-dip__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-vatman-mould-dip__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-vatman-mould-dip__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-vatman-mould-dip__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-vatman-mould-dip__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #ebeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-vatman-mould-dip__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-vatman-mould-dip__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-vatman-mould-dip__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-vatman-mould-dip__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: vatman_mould_dip_status 2.02s ease-out infinite;
+}
+
+@keyframes vatman_mould_dip_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes vatman_mould_dip_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-vatman-mould-dip__a{position:absolute;inset:0;background:linear-gradient(115deg,transparent 35%,color-mix(in srgb,var(--accent) 35%,transparent) 50%,transparent 65%);background-size:220% 220%;animation:vatman_mould_dip_drift 2.88s linear infinite}
+.ease-vatman-mould-dip__b{position:absolute;inset:30%;border-radius:50%;border:2px solid var(--accent-2);opacity:.7}
+.ease-vatman-mould-dip__c{position:absolute;left:20%;right:20%;top:50%;height:2px;background:var(--accent);opacity:.4}
+.ease-vatman-mould-dip__d{position:absolute;left:50%;top:22%;width:7px;height:7px;border-radius:50%;background:var(--accent)}
+@keyframes vatman_mould_dip_drift{0%{background-position:0% 50%}100%{background-position:100% 50%}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-vatman-mould-dip__a,
+  .ease-vatman-mould-dip__b,
+  .ease-vatman-mould-dip__c,
+  .ease-vatman-mould-dip__d,
+  .ease-vatman-mould-dip__meters i::after,
+  .ease-vatman-mould-dip__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-vatman-mould-dip` CSS-only demo for #77615.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Vatman dipping the mould into the vat

**How does a developer use it?**

```html
<section class="ease-vatman-mould-dip">
  <div class="ease-vatman-mould-dip__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/vatman-mould-dip-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77615
