### PR TITLE
feat: add ease-size-tub-soak (#77616)

### DIFF
--- a/submissions/examples/size-tub-soak-ns/README.md
+++ b/submissions/examples/size-tub-soak-ns/README.md
@@ -1,0 +1,16 @@
+# Size Tub Soak
+
+## What does this do?
+Renders a self-contained CSS-only `ease-size-tub-soak` demo: Size tub soaking the sheet for ink holdout.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-size-tub-soak`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-size-tub-soak">
+  <div class="ease-size-tub-soak__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/size-tub-soak-ns/demo.html
+++ b/submissions/examples/size-tub-soak-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Size Tub Soak — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Size Tub Soak demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Size Tub Soak</h1>
+      <p class="lede">Size tub soaking the sheet for ink holdout</p>
+    </header>
+
+    <section class="ease-size-tub-soak" data-demo="size-tub-soak" aria-live="polite">
+      <div class="ease-size-tub-soak__housing">
+        <div class="ease-size-tub-soak__bezel">
+          <div class="ease-size-tub-soak__face">
+            <div class="ease-size-tub-soak__readout">
+              <span class="ease-size-tub-soak__label">Size Tub Soak</span>
+              <span class="ease-size-tub-soak__value">LIVE</span>
+            </div>
+            <div class="ease-size-tub-soak__motion" aria-hidden="true">
+              <span class="ease-size-tub-soak__a"></span>
+              <span class="ease-size-tub-soak__b"></span>
+              <span class="ease-size-tub-soak__c"></span>
+              <span class="ease-size-tub-soak__d"></span>
+            </div>
+            <div class="ease-size-tub-soak__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-size-tub-soak__controls">
+          <button type="button" class="ease-size-tub-soak__btn primary">Soak</button>
+          <button type="button" class="ease-size-tub-soak__btn">Lift</button>
+          <label class="ease-size-tub-soak__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-size-tub-soak__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/size-tub-soak-ns/style.css
+++ b/submissions/examples/size-tub-soak-ns/style.css
@@ -1,0 +1,222 @@
+html { color-scheme: dark; }
+/* size-tub-soak */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eee7e7;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #58e4d4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #89b9f0 18%, transparent), transparent 42%),
+    #20120e;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-size-tub-soak {
+  --accent: #58e4d4;
+  --accent-2: #89b9f0;
+  --panel: color-mix(in srgb, #eee7e7 7%, #20120e);
+  --line: color-mix(in srgb, #eee7e7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #20120e 75%, #000);
+}
+
+.ease-size-tub-soak__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-size-tub-soak__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eee7e7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #20120e 90%, #58e4d4);
+}
+
+.ease-size-tub-soak__face {
+  position: relative;
+  min-height: 243px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #20120e 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-size-tub-soak__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-size-tub-soak__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-size-tub-soak__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-size-tub-soak__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-size-tub-soak__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-size-tub-soak__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: size_tub_soak_meter 4.44s linear infinite;
+}
+
+.ease-size-tub-soak__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-size-tub-soak__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-size-tub-soak__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-size-tub-soak__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-size-tub-soak__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-size-tub-soak__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-size-tub-soak__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eee7e7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-size-tub-soak__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-size-tub-soak__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-size-tub-soak__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-size-tub-soak__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: size_tub_soak_status 3.11s ease-out infinite;
+}
+
+@keyframes size_tub_soak_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes size_tub_soak_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-size-tub-soak__a{position:absolute;left:16%;width:36%;top:22%;bottom:22%;background:color-mix(in srgb,var(--accent) 28%,transparent);transform-origin:0 50%;animation:size_tub_soak_gate 4.44s ease-in-out infinite}
+.ease-size-tub-soak__b{position:absolute;right:16%;width:36%;top:22%;bottom:22%;background:color-mix(in srgb,var(--accent-2) 28%,transparent);transform-origin:100% 50%;animation:size_tub_soak_gate 4.44s ease-in-out infinite reverse}
+.ease-size-tub-soak__c{position:absolute;left:49%;top:18%;bottom:18%;width:2px;background:var(--accent)}
+.ease-size-tub-soak__d{position:absolute;left:46%;top:46%;width:12px;height:12px;border-radius:50%;background:var(--accent)}
+@keyframes size_tub_soak_gate{0%,100%{transform:scaleX(.15)}50%{transform:scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-size-tub-soak__a,
+  .ease-size-tub-soak__b,
+  .ease-size-tub-soak__c,
+  .ease-size-tub-soak__d,
+  .ease-size-tub-soak__meters i::after,
+  .ease-size-tub-soak__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-size-tub-soak` CSS-only demo for #77616.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Size tub soaking the sheet for ink holdout

**How does a developer use it?**

```html
<section class="ease-size-tub-soak">
  <div class="ease-size-tub-soak__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/size-tub-soak-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77616
