### PR TITLE
feat: add ease-guillotine-trim-chop (#77618)

### DIFF
--- a/submissions/examples/guillotine-trim-chop-ns/README.md
+++ b/submissions/examples/guillotine-trim-chop-ns/README.md
@@ -1,0 +1,16 @@
+# Guillotine Trim Chop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-guillotine-trim-chop` demo: Guillotine trim squaring the stack.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-guillotine-trim-chop`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-guillotine-trim-chop">
+  <div class="ease-guillotine-trim-chop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/guillotine-trim-chop-ns/demo.html
+++ b/submissions/examples/guillotine-trim-chop-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guillotine Trim Chop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Guillotine Trim Chop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Guillotine Trim Chop</h1>
+      <p class="lede">Guillotine trim squaring the stack</p>
+    </header>
+
+    <section class="ease-guillotine-trim-chop" data-demo="guillotine-trim-chop" aria-live="polite">
+      <div class="ease-guillotine-trim-chop__housing">
+        <div class="ease-guillotine-trim-chop__bezel">
+          <div class="ease-guillotine-trim-chop__face">
+            <div class="ease-guillotine-trim-chop__readout">
+              <span class="ease-guillotine-trim-chop__label">Guillotine Trim Chop</span>
+              <span class="ease-guillotine-trim-chop__value">LIVE</span>
+            </div>
+            <div class="ease-guillotine-trim-chop__motion" aria-hidden="true">
+              <span class="ease-guillotine-trim-chop__a"></span>
+              <span class="ease-guillotine-trim-chop__b"></span>
+              <span class="ease-guillotine-trim-chop__c"></span>
+              <span class="ease-guillotine-trim-chop__d"></span>
+            </div>
+            <div class="ease-guillotine-trim-chop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-guillotine-trim-chop__controls">
+          <button type="button" class="ease-guillotine-trim-chop__btn primary">Chop</button>
+          <button type="button" class="ease-guillotine-trim-chop__btn">Raise</button>
+          <label class="ease-guillotine-trim-chop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-guillotine-trim-chop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/guillotine-trim-chop-ns/style.css
+++ b/submissions/examples/guillotine-trim-chop-ns/style.css
@@ -1,0 +1,222 @@
+/* stage: guillotine-trim-chop */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7e9ee;
+  font-family: "Gill Sans", "Gill Sans MT", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e4a758 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #d1f089 18%, transparent), transparent 42%),
+    #101223;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-guillotine-trim-chop {
+  --accent: #e4a758;
+  --accent-2: #d1f089;
+  --panel: color-mix(in srgb, #e7e9ee 7%, #101223);
+  --line: color-mix(in srgb, #e7e9ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #101223 75%, #000);
+}
+
+.ease-guillotine-trim-chop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-guillotine-trim-chop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7e9ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #101223 90%, #e4a758);
+}
+
+.ease-guillotine-trim-chop__face {
+  position: relative;
+  min-height: 264px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #101223 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-guillotine-trim-chop__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-guillotine-trim-chop__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-guillotine-trim-chop__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-guillotine-trim-chop__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-guillotine-trim-chop__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-guillotine-trim-chop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: guillotine_trim_chop_meter 4.8s linear infinite;
+}
+
+.ease-guillotine-trim-chop__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-guillotine-trim-chop__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-guillotine-trim-chop__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-guillotine-trim-chop__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-guillotine-trim-chop__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-guillotine-trim-chop__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-guillotine-trim-chop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-guillotine-trim-chop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7e9ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-guillotine-trim-chop__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-guillotine-trim-chop__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-guillotine-trim-chop__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-guillotine-trim-chop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: guillotine_trim_chop_status 3.36s ease-out infinite;
+}
+
+@keyframes guillotine_trim_chop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes guillotine_trim_chop_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-guillotine-trim-chop__a{position:absolute;inset:22%;border-radius:50%;border:2px solid var(--accent);animation:guillotine_trim_chop_spiral 4.8s linear infinite}
+.ease-guillotine-trim-chop__b{position:absolute;inset:34%;border-radius:50%;border:2px solid var(--accent-2);animation:guillotine_trim_chop_spiral 4.8s linear infinite reverse}
+.ease-guillotine-trim-chop__c{position:absolute;left:48%;top:20%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:guillotine_trim_chop_spiral 4.8s linear infinite}
+.ease-guillotine-trim-chop__d{position:absolute;inset:46%;border-radius:50%;background:var(--accent-2)}
+@keyframes guillotine_trim_chop_spiral{0%{transform:rotate(0deg) scale(.7)}100%{transform:rotate(360deg) scale(1.15)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-guillotine-trim-chop__a,
+  .ease-guillotine-trim-chop__b,
+  .ease-guillotine-trim-chop__c,
+  .ease-guillotine-trim-chop__d,
+  .ease-guillotine-trim-chop__meters i::after,
+  .ease-guillotine-trim-chop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-guillotine-trim-chop` CSS-only demo for #77618.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Guillotine trim squaring the stack

**How does a developer use it?**

```html
<section class="ease-guillotine-trim-chop">
  <div class="ease-guillotine-trim-chop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/guillotine-trim-chop-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77618
