### PR TITLE
feat: add ease-stuff-chest-agitate (#77620)

### DIFF
--- a/submissions/examples/stuff-chest-agitate-ns/README.md
+++ b/submissions/examples/stuff-chest-agitate-ns/README.md
@@ -1,0 +1,16 @@
+# Stuff Chest Agitate
+
+## What does this do?
+Renders a self-contained CSS-only `ease-stuff-chest-agitate` demo: Stuff chest agitating pulp before the vat.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-stuff-chest-agitate`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-stuff-chest-agitate">
+  <div class="ease-stuff-chest-agitate__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/stuff-chest-agitate-ns/demo.html
+++ b/submissions/examples/stuff-chest-agitate-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stuff Chest Agitate — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Stuff Chest Agitate demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Stuff Chest Agitate</h1>
+      <p class="lede">Stuff chest agitating pulp before the vat</p>
+    </header>
+
+    <section class="ease-stuff-chest-agitate" data-demo="stuff-chest-agitate" aria-live="polite">
+      <div class="ease-stuff-chest-agitate__housing">
+        <div class="ease-stuff-chest-agitate__bezel">
+          <div class="ease-stuff-chest-agitate__face">
+            <div class="ease-stuff-chest-agitate__readout">
+              <span class="ease-stuff-chest-agitate__label">Stuff Chest Agitate</span>
+              <span class="ease-stuff-chest-agitate__value">LIVE</span>
+            </div>
+            <div class="ease-stuff-chest-agitate__motion" aria-hidden="true">
+              <span class="ease-stuff-chest-agitate__a"></span>
+              <span class="ease-stuff-chest-agitate__b"></span>
+              <span class="ease-stuff-chest-agitate__c"></span>
+              <span class="ease-stuff-chest-agitate__d"></span>
+            </div>
+            <div class="ease-stuff-chest-agitate__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-stuff-chest-agitate__controls">
+          <button type="button" class="ease-stuff-chest-agitate__btn primary">Stir</button>
+          <button type="button" class="ease-stuff-chest-agitate__btn">Settle</button>
+          <label class="ease-stuff-chest-agitate__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-stuff-chest-agitate__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/stuff-chest-agitate-ns/style.css
+++ b/submissions/examples/stuff-chest-agitate-ns/style.css
@@ -1,0 +1,222 @@
+html { color-scheme: dark; }
+/* stuff-chest-agitate */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eee7eb;
+  font-family: "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #58e480 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #89f0ea 18%, transparent), transparent 42%),
+    #1c0d13;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-stuff-chest-agitate {
+  --accent: #58e480;
+  --accent-2: #89f0ea;
+  --panel: color-mix(in srgb, #eee7eb 7%, #1c0d13);
+  --line: color-mix(in srgb, #eee7eb 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 11px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1c0d13 75%, #000);
+}
+
+.ease-stuff-chest-agitate__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-stuff-chest-agitate__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eee7eb 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1c0d13 90%, #58e480);
+}
+
+.ease-stuff-chest-agitate__face {
+  position: relative;
+  min-height: 247px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1c0d13 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-stuff-chest-agitate__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-stuff-chest-agitate__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-stuff-chest-agitate__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-stuff-chest-agitate__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-stuff-chest-agitate__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-stuff-chest-agitate__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: stuff_chest_agitate_meter 3.48s linear infinite;
+}
+
+.ease-stuff-chest-agitate__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-stuff-chest-agitate__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-stuff-chest-agitate__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-stuff-chest-agitate__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-stuff-chest-agitate__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-stuff-chest-agitate__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-stuff-chest-agitate__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eee7eb 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-stuff-chest-agitate__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-stuff-chest-agitate__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-stuff-chest-agitate__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-stuff-chest-agitate__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: stuff_chest_agitate_status 2.44s ease-out infinite;
+}
+
+@keyframes stuff_chest_agitate_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes stuff_chest_agitate_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-stuff-chest-agitate__a{position:absolute;left:28%;right:28%;top:28%;bottom:28%;border-radius:10px;background:var(--accent);animation:stuff_chest_agitate_stamp 3.48s cubic-bezier(.2,.8,.2,1) infinite}
+.ease-stuff-chest-agitate__b{position:absolute;left:22%;right:22%;bottom:16%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent-2) 40%,transparent)}
+.ease-stuff-chest-agitate__c{position:absolute;left:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent-2)}
+.ease-stuff-chest-agitate__d{position:absolute;right:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent)}
+@keyframes stuff_chest_agitate_stamp{0%,100%{transform:scale(1) translateY(0)}40%{transform:scale(.72) translateY(18px)}55%{transform:scale(1.06) translateY(0)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stuff-chest-agitate__a,
+  .ease-stuff-chest-agitate__b,
+  .ease-stuff-chest-agitate__c,
+  .ease-stuff-chest-agitate__d,
+  .ease-stuff-chest-agitate__meters i::after,
+  .ease-stuff-chest-agitate__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-stuff-chest-agitate` CSS-only demo for #77620.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Stuff chest agitating pulp before the vat

**How does a developer use it?**

```html
<section class="ease-stuff-chest-agitate">
  <div class="ease-stuff-chest-agitate__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/stuff-chest-agitate-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77620
