### PR TITLE
feat: add ease-celesta-bar-strike (#77628)

### DIFF
--- a/submissions/examples/celesta-bar-strike-ns/README.md
+++ b/submissions/examples/celesta-bar-strike-ns/README.md
@@ -1,0 +1,16 @@
+# Celesta Bar Strike
+
+## What does this do?
+Renders a self-contained CSS-only `ease-celesta-bar-strike` demo: Celesta bar struck by a felt hammer.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-celesta-bar-strike`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-celesta-bar-strike">
+  <div class="ease-celesta-bar-strike__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/celesta-bar-strike-ns/demo.html
+++ b/submissions/examples/celesta-bar-strike-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Celesta Bar Strike — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Celesta Bar Strike demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Celesta Bar Strike</h1>
+      <p class="lede">Celesta bar struck by a felt hammer</p>
+    </header>
+
+    <section class="ease-celesta-bar-strike" data-demo="celesta-bar-strike" aria-live="polite">
+      <div class="ease-celesta-bar-strike__housing">
+        <div class="ease-celesta-bar-strike__bezel">
+          <div class="ease-celesta-bar-strike__face">
+            <div class="ease-celesta-bar-strike__readout">
+              <span class="ease-celesta-bar-strike__label">Celesta Bar Strike</span>
+              <span class="ease-celesta-bar-strike__value">LIVE</span>
+            </div>
+            <div class="ease-celesta-bar-strike__motion" aria-hidden="true">
+              <span class="ease-celesta-bar-strike__a"></span>
+              <span class="ease-celesta-bar-strike__b"></span>
+              <span class="ease-celesta-bar-strike__c"></span>
+              <span class="ease-celesta-bar-strike__d"></span>
+            </div>
+            <div class="ease-celesta-bar-strike__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-celesta-bar-strike__controls">
+          <button type="button" class="ease-celesta-bar-strike__btn primary">Strike</button>
+          <button type="button" class="ease-celesta-bar-strike__btn">Damp</button>
+          <label class="ease-celesta-bar-strike__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-celesta-bar-strike__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/celesta-bar-strike-ns/style.css
+++ b/submissions/examples/celesta-bar-strike-ns/style.css
@@ -1,0 +1,224 @@
+/* stage: celesta-bar-strike */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeede7;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 40% 100%, color-mix(in srgb, #5880e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 80% 20%, color-mix(in srgb, #a889f0 18%, transparent), transparent 42%),
+    #1f200e;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-celesta-bar-strike {
+  --accent: #5880e4;
+  --accent-2: #a889f0;
+  --panel: color-mix(in srgb, #eeede7 7%, #1f200e);
+  --line: color-mix(in srgb, #eeede7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 17px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1f200e 75%, #000);
+}
+
+.ease-celesta-bar-strike__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-celesta-bar-strike__bezel {
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeede7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1f200e 90%, #5880e4);
+}
+
+.ease-celesta-bar-strike__face {
+  position: relative;
+  min-height: 253px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1f200e 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-celesta-bar-strike__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-celesta-bar-strike__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-celesta-bar-strike__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-celesta-bar-strike__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-celesta-bar-strike__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-celesta-bar-strike__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: celesta_bar_strike_meter 3.96s linear infinite;
+}
+
+.ease-celesta-bar-strike__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-celesta-bar-strike__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-celesta-bar-strike__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-celesta-bar-strike__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-celesta-bar-strike__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-celesta-bar-strike__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+.ease-celesta-bar-strike__meters i:nth-child(8)::after { animation-delay: 0.64s; }
+
+.ease-celesta-bar-strike__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-celesta-bar-strike__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeede7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-celesta-bar-strike__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-celesta-bar-strike__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-celesta-bar-strike__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-celesta-bar-strike__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: celesta_bar_strike_status 2.77s ease-out infinite;
+}
+
+@keyframes celesta_bar_strike_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes celesta_bar_strike_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-celesta-bar-strike__a{position:absolute;left:18%;right:18%;top:22%;bottom:22%;border-radius:12px;background:color-mix(in srgb,var(--accent) 12%,transparent);animation:celesta_bar_strike_bellows 3.96s ease-in-out infinite;transform-origin:50% 100%}
+.ease-celesta-bar-strike__b{position:absolute;left:30%;right:30%;top:18%;height:8px;border-radius:4px;background:var(--accent-2)}
+.ease-celesta-bar-strike__c{position:absolute;left:24%;right:24%;bottom:18%;height:6px;border-radius:3px;background:var(--accent);opacity:.7}
+.ease-celesta-bar-strike__d{position:absolute;left:48%;top:12%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:celesta_bar_strike_pulse 3.96s ease-out infinite}
+@keyframes celesta_bar_strike_bellows{0%,100%{transform:scaleY(.55)}50%{transform:scaleY(1)}}
+@keyframes celesta_bar_strike_pulse{0%{transform:scale(.7);opacity:1}100%{transform:scale(1.8);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-celesta-bar-strike__a,
+  .ease-celesta-bar-strike__b,
+  .ease-celesta-bar-strike__c,
+  .ease-celesta-bar-strike__d,
+  .ease-celesta-bar-strike__meters i::after,
+  .ease-celesta-bar-strike__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-celesta-bar-strike` CSS-only demo for #77628.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Celesta bar struck by a felt hammer

**How does a developer use it?**

```html
<section class="ease-celesta-bar-strike">
  <div class="ease-celesta-bar-strike__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/celesta-bar-strike-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77628
