### PR TITLE
feat: add ease-vibraphone-fan-spin (#77629)

### DIFF
--- a/submissions/examples/vibraphone-fan-spin-ns/README.md
+++ b/submissions/examples/vibraphone-fan-spin-ns/README.md
@@ -1,0 +1,16 @@
+# Vibraphone Fan Spin
+
+## What does this do?
+Renders a self-contained CSS-only `ease-vibraphone-fan-spin` demo: Vibraphone fans spinning tremolo through the resonators.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-vibraphone-fan-spin`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-vibraphone-fan-spin">
+  <div class="ease-vibraphone-fan-spin__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/vibraphone-fan-spin-ns/demo.html
+++ b/submissions/examples/vibraphone-fan-spin-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vibraphone Fan Spin — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Vibraphone Fan Spin demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Vibraphone Fan Spin</h1>
+      <p class="lede">Vibraphone fans spinning tremolo through the resonators</p>
+    </header>
+
+    <section class="ease-vibraphone-fan-spin" data-demo="vibraphone-fan-spin" aria-live="polite">
+      <div class="ease-vibraphone-fan-spin__housing">
+        <div class="ease-vibraphone-fan-spin__bezel">
+          <div class="ease-vibraphone-fan-spin__face">
+            <div class="ease-vibraphone-fan-spin__readout">
+              <span class="ease-vibraphone-fan-spin__label">Vibraphone Fan Spin</span>
+              <span class="ease-vibraphone-fan-spin__value">LIVE</span>
+            </div>
+            <div class="ease-vibraphone-fan-spin__motion" aria-hidden="true">
+              <span class="ease-vibraphone-fan-spin__a"></span>
+              <span class="ease-vibraphone-fan-spin__b"></span>
+              <span class="ease-vibraphone-fan-spin__c"></span>
+              <span class="ease-vibraphone-fan-spin__d"></span>
+            </div>
+            <div class="ease-vibraphone-fan-spin__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-vibraphone-fan-spin__controls">
+          <button type="button" class="ease-vibraphone-fan-spin__btn primary">Spin</button>
+          <button type="button" class="ease-vibraphone-fan-spin__btn">Stop</button>
+          <label class="ease-vibraphone-fan-spin__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-vibraphone-fan-spin__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/vibraphone-fan-spin-ns/style.css
+++ b/submissions/examples/vibraphone-fan-spin-ns/style.css
@@ -1,0 +1,224 @@
+/* Vibraphone Fan Spin motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7e7ee;
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #e4c858 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c0f089 18%, transparent), transparent 42%),
+    #110e20;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-vibraphone-fan-spin {
+  --accent: #e4c858;
+  --accent-2: #c0f089;
+  --panel: color-mix(in srgb, #e7e7ee 7%, #110e20);
+  --line: color-mix(in srgb, #e7e7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #110e20 75%, #000);
+}
+
+.ease-vibraphone-fan-spin__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-vibraphone-fan-spin__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7e7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #110e20 90%, #e4c858);
+}
+
+.ease-vibraphone-fan-spin__face {
+  position: relative;
+  min-height: 238px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #110e20 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-vibraphone-fan-spin__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-vibraphone-fan-spin__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-vibraphone-fan-spin__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-vibraphone-fan-spin__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-vibraphone-fan-spin__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-vibraphone-fan-spin__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: vibraphone_fan_spin_meter 3.12s linear infinite;
+}
+
+.ease-vibraphone-fan-spin__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-vibraphone-fan-spin__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-vibraphone-fan-spin__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-vibraphone-fan-spin__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-vibraphone-fan-spin__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-vibraphone-fan-spin__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7e7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-vibraphone-fan-spin__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-vibraphone-fan-spin__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-vibraphone-fan-spin__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-vibraphone-fan-spin__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: vibraphone_fan_spin_status 2.18s ease-out infinite;
+}
+
+@keyframes vibraphone_fan_spin_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes vibraphone_fan_spin_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-vibraphone-fan-spin__a{position:absolute;left:50%;top:18%;width:4px;height:38%;background:var(--accent);transform-origin:50% 100%;animation:vibraphone_fan_spin_needle 3.12s ease-in-out infinite}
+.ease-vibraphone-fan-spin__b{position:absolute;inset:42%;border-radius:50%;background:var(--accent-2)}
+.ease-vibraphone-fan-spin__c{position:absolute;inset:22%;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 40%,transparent)}
+.ease-vibraphone-fan-spin__d{position:absolute;left:16%;right:16%;bottom:16%;height:4px;background:conic-gradient(from 180deg,var(--accent),transparent);opacity:.5}
+@keyframes vibraphone_fan_spin_needle{0%{transform:translateX(-2px) rotate(-70deg)}50%{transform:translateX(-2px) rotate(70deg)}100%{transform:translateX(-2px) rotate(-70deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-vibraphone-fan-spin__a,
+  .ease-vibraphone-fan-spin__b,
+  .ease-vibraphone-fan-spin__c,
+  .ease-vibraphone-fan-spin__d,
+  .ease-vibraphone-fan-spin__meters i::after,
+  .ease-vibraphone-fan-spin__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-vibraphone-fan-spin` CSS-only demo for #77629.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Vibraphone fans spinning tremolo through the resonators

**How does a developer use it?**

```html
<section class="ease-vibraphone-fan-spin">
  <div class="ease-vibraphone-fan-spin__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/vibraphone-fan-spin-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77629
