### PR TITLE
feat: add ease-timpani-pedal-tune (#77630)

### DIFF
--- a/submissions/examples/timpani-pedal-tune-ns/README.md
+++ b/submissions/examples/timpani-pedal-tune-ns/README.md
@@ -1,0 +1,16 @@
+# Timpani Pedal Tune
+
+## What does this do?
+Renders a self-contained CSS-only `ease-timpani-pedal-tune` demo: Timpani pedal retensioning the head.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-timpani-pedal-tune`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-timpani-pedal-tune">
+  <div class="ease-timpani-pedal-tune__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/timpani-pedal-tune-ns/demo.html
+++ b/submissions/examples/timpani-pedal-tune-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Timpani Pedal Tune — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Timpani Pedal Tune demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Timpani Pedal Tune</h1>
+      <p class="lede">Timpani pedal retensioning the head</p>
+    </header>
+
+    <section class="ease-timpani-pedal-tune" data-demo="timpani-pedal-tune" aria-live="polite">
+      <div class="ease-timpani-pedal-tune__housing">
+        <div class="ease-timpani-pedal-tune__bezel">
+          <div class="ease-timpani-pedal-tune__face">
+            <div class="ease-timpani-pedal-tune__readout">
+              <span class="ease-timpani-pedal-tune__label">Timpani Pedal Tune</span>
+              <span class="ease-timpani-pedal-tune__value">LIVE</span>
+            </div>
+            <div class="ease-timpani-pedal-tune__motion" aria-hidden="true">
+              <span class="ease-timpani-pedal-tune__a"></span>
+              <span class="ease-timpani-pedal-tune__b"></span>
+              <span class="ease-timpani-pedal-tune__c"></span>
+              <span class="ease-timpani-pedal-tune__d"></span>
+            </div>
+            <div class="ease-timpani-pedal-tune__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-timpani-pedal-tune__controls">
+          <button type="button" class="ease-timpani-pedal-tune__btn primary">Tune</button>
+          <button type="button" class="ease-timpani-pedal-tune__btn">Lock</button>
+          <label class="ease-timpani-pedal-tune__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-timpani-pedal-tune__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/timpani-pedal-tune-ns/style.css
+++ b/submissions/examples/timpani-pedal-tune-ns/style.css
@@ -1,0 +1,227 @@
+/* Timpani Pedal Tune motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7ecee;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e46658 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #f0ce89 18%, transparent), transparent 42%),
+    #0b1319;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-timpani-pedal-tune {
+  --accent: #e46658;
+  --accent-2: #f0ce89;
+  --panel: color-mix(in srgb, #e7ecee 7%, #0b1319);
+  --line: color-mix(in srgb, #e7ecee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1319 75%, #000);
+}
+
+.ease-timpani-pedal-tune__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-timpani-pedal-tune__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7ecee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1319 90%, #e46658);
+}
+
+.ease-timpani-pedal-tune__face {
+  position: relative;
+  min-height: 236px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0b1319 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-timpani-pedal-tune__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-timpani-pedal-tune__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-timpani-pedal-tune__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-timpani-pedal-tune__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-timpani-pedal-tune__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-timpani-pedal-tune__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: timpani_pedal_tune_meter 4.08s linear infinite;
+}
+
+.ease-timpani-pedal-tune__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-timpani-pedal-tune__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-timpani-pedal-tune__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-timpani-pedal-tune__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-timpani-pedal-tune__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-timpani-pedal-tune__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-timpani-pedal-tune__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-timpani-pedal-tune__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7ecee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-timpani-pedal-tune__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-timpani-pedal-tune__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-timpani-pedal-tune__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-timpani-pedal-tune__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: timpani_pedal_tune_status 2.86s ease-out infinite;
+}
+
+@keyframes timpani_pedal_tune_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes timpani_pedal_tune_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-timpani-pedal-tune__a{position:absolute;left:48%;top:12%;width:6px;height:40%;background:var(--accent);border-radius:3px;animation:timpani_pedal_tune_drip 4.08s ease-in infinite}
+.ease-timpani-pedal-tune__b{position:absolute;left:46%;top:48%;width:16px;height:16px;border-radius:50%;background:var(--accent-2);animation:timpani_pedal_tune_drop 4.08s ease-in infinite}
+.ease-timpani-pedal-tune__c{position:absolute;left:22%;right:22%;bottom:20%;height:10px;border-radius:50%;background:color-mix(in srgb,var(--accent) 25%,transparent)}
+.ease-timpani-pedal-tune__d{position:absolute;inset:20% 30% auto;height:8px;border-radius:8px;background:var(--accent);opacity:.5}
+@keyframes timpani_pedal_tune_drip{0%{transform:scaleY(.4);opacity:.3}70%{transform:scaleY(1);opacity:1}100%{transform:scaleY(.4);opacity:.3}}
+@keyframes timpani_pedal_tune_drop{0%{transform:translateY(0);opacity:1}100%{transform:translateY(48px);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-timpani-pedal-tune__a,
+  .ease-timpani-pedal-tune__b,
+  .ease-timpani-pedal-tune__c,
+  .ease-timpani-pedal-tune__d,
+  .ease-timpani-pedal-tune__meters i::after,
+  .ease-timpani-pedal-tune__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-timpani-pedal-tune` CSS-only demo for #77630.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Timpani pedal retensioning the head

**How does a developer use it?**

```html
<section class="ease-timpani-pedal-tune">
  <div class="ease-timpani-pedal-tune__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/timpani-pedal-tune-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77630
