### PR TITLE
feat: add ease-player-piano-tracker (#77632)

### DIFF
--- a/submissions/examples/player-piano-tracker-ns/README.md
+++ b/submissions/examples/player-piano-tracker-ns/README.md
@@ -1,0 +1,16 @@
+# Player Piano Tracker
+
+## What does this do?
+Renders a self-contained CSS-only `ease-player-piano-tracker` demo: Player piano tracker bar reading the roll.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-player-piano-tracker`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-player-piano-tracker">
+  <div class="ease-player-piano-tracker__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/player-piano-tracker-ns/demo.html
+++ b/submissions/examples/player-piano-tracker-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Player Piano Tracker — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Player Piano Tracker demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Player Piano Tracker</h1>
+      <p class="lede">Player piano tracker bar reading the roll</p>
+    </header>
+
+    <section class="ease-player-piano-tracker" data-demo="player-piano-tracker" aria-live="polite">
+      <div class="ease-player-piano-tracker__housing">
+        <div class="ease-player-piano-tracker__bezel">
+          <div class="ease-player-piano-tracker__face">
+            <div class="ease-player-piano-tracker__readout">
+              <span class="ease-player-piano-tracker__label">Player Piano Tracker</span>
+              <span class="ease-player-piano-tracker__value">LIVE</span>
+            </div>
+            <div class="ease-player-piano-tracker__motion" aria-hidden="true">
+              <span class="ease-player-piano-tracker__a"></span>
+              <span class="ease-player-piano-tracker__b"></span>
+              <span class="ease-player-piano-tracker__c"></span>
+              <span class="ease-player-piano-tracker__d"></span>
+            </div>
+            <div class="ease-player-piano-tracker__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-player-piano-tracker__controls">
+          <button type="button" class="ease-player-piano-tracker__btn primary">Play</button>
+          <button type="button" class="ease-player-piano-tracker__btn">Rewind</button>
+          <label class="ease-player-piano-tracker__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-player-piano-tracker__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/player-piano-tracker-ns/style.css
+++ b/submissions/examples/player-piano-tracker-ns/style.css
@@ -1,0 +1,224 @@
+/* Player Piano Tracker motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eae7ee;
+  font-family: "Palatino Linotype", Palatino, serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #c8e458 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #abf089 18%, transparent), transparent 42%),
+    #150d1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-player-piano-tracker {
+  --accent: #c8e458;
+  --accent-2: #abf089;
+  --panel: color-mix(in srgb, #eae7ee 7%, #150d1c);
+  --line: color-mix(in srgb, #eae7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #150d1c 75%, #000);
+}
+
+.ease-player-piano-tracker__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-player-piano-tracker__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eae7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #150d1c 90%, #c8e458);
+}
+
+.ease-player-piano-tracker__face {
+  position: relative;
+  min-height: 262px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #150d1c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-player-piano-tracker__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-player-piano-tracker__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-player-piano-tracker__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-player-piano-tracker__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-player-piano-tracker__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-player-piano-tracker__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: player_piano_tracker_meter 4.56s linear infinite;
+}
+
+.ease-player-piano-tracker__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-player-piano-tracker__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-player-piano-tracker__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-player-piano-tracker__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-player-piano-tracker__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-player-piano-tracker__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eae7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-player-piano-tracker__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-player-piano-tracker__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-player-piano-tracker__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-player-piano-tracker__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: player_piano_tracker_status 3.19s ease-out infinite;
+}
+
+@keyframes player_piano_tracker_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes player_piano_tracker_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-player-piano-tracker__a{position:absolute;inset:24%;border-radius:50%;box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 55%,transparent);animation:player_piano_tracker_halo 4.56s ease-out infinite}
+.ease-player-piano-tracker__b{position:absolute;inset:38%;border-radius:50%;background:var(--accent-2);opacity:.8}
+.ease-player-piano-tracker__c{position:absolute;left:20%;right:20%;top:18%;height:2px;background:var(--accent);opacity:.35}
+.ease-player-piano-tracker__d{position:absolute;left:20%;right:20%;bottom:18%;height:2px;background:var(--accent);opacity:.35}
+@keyframes player_piano_tracker_halo{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 55%,transparent)}100%{box-shadow:0 0 0 28px transparent}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-player-piano-tracker__a,
+  .ease-player-piano-tracker__b,
+  .ease-player-piano-tracker__c,
+  .ease-player-piano-tracker__d,
+  .ease-player-piano-tracker__meters i::after,
+  .ease-player-piano-tracker__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-player-piano-tracker` CSS-only demo for #77632.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Player piano tracker bar reading the roll

**How does a developer use it?**

```html
<section class="ease-player-piano-tracker">
  <div class="ease-player-piano-tracker__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/player-piano-tracker-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77632
