### PR TITLE
feat: add ease-calliope-steam-whistle (#77633)

### DIFF
--- a/submissions/examples/calliope-steam-whistle-ns/README.md
+++ b/submissions/examples/calliope-steam-whistle-ns/README.md
@@ -1,0 +1,16 @@
+# Calliope Steam Whistle
+
+## What does this do?
+Renders a self-contained CSS-only `ease-calliope-steam-whistle` demo: Calliope whistle taking a steam pulse.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-calliope-steam-whistle`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-calliope-steam-whistle">
+  <div class="ease-calliope-steam-whistle__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/calliope-steam-whistle-ns/demo.html
+++ b/submissions/examples/calliope-steam-whistle-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calliope Steam Whistle — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Calliope Steam Whistle demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Calliope Steam Whistle</h1>
+      <p class="lede">Calliope whistle taking a steam pulse</p>
+    </header>
+
+    <section class="ease-calliope-steam-whistle" data-demo="calliope-steam-whistle" aria-live="polite">
+      <div class="ease-calliope-steam-whistle__housing">
+        <div class="ease-calliope-steam-whistle__bezel">
+          <div class="ease-calliope-steam-whistle__face">
+            <div class="ease-calliope-steam-whistle__readout">
+              <span class="ease-calliope-steam-whistle__label">Calliope Steam Whistle</span>
+              <span class="ease-calliope-steam-whistle__value">LIVE</span>
+            </div>
+            <div class="ease-calliope-steam-whistle__motion" aria-hidden="true">
+              <span class="ease-calliope-steam-whistle__a"></span>
+              <span class="ease-calliope-steam-whistle__b"></span>
+              <span class="ease-calliope-steam-whistle__c"></span>
+              <span class="ease-calliope-steam-whistle__d"></span>
+            </div>
+            <div class="ease-calliope-steam-whistle__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-calliope-steam-whistle__controls">
+          <button type="button" class="ease-calliope-steam-whistle__btn primary">Blast</button>
+          <button type="button" class="ease-calliope-steam-whistle__btn">Vent</button>
+          <label class="ease-calliope-steam-whistle__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-calliope-steam-whistle__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/calliope-steam-whistle-ns/style.css
+++ b/submissions/examples/calliope-steam-whistle-ns/style.css
@@ -1,0 +1,224 @@
+html { color-scheme: dark; }
+/* calliope-steam-whistle */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7edee;
+  font-family: "Palatino Linotype", Palatino, serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e45d58 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #f0c089 18%, transparent), transparent 42%),
+    #0d161c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-calliope-steam-whistle {
+  --accent: #e45d58;
+  --accent-2: #f0c089;
+  --panel: color-mix(in srgb, #e7edee 7%, #0d161c);
+  --line: color-mix(in srgb, #e7edee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d161c 75%, #000);
+}
+
+.ease-calliope-steam-whistle__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-calliope-steam-whistle__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7edee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d161c 90%, #e45d58);
+}
+
+.ease-calliope-steam-whistle__face {
+  position: relative;
+  min-height: 232px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d161c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-calliope-steam-whistle__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-calliope-steam-whistle__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-calliope-steam-whistle__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-calliope-steam-whistle__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-calliope-steam-whistle__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-calliope-steam-whistle__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: calliope_steam_whistle_meter 4.8s linear infinite;
+}
+
+.ease-calliope-steam-whistle__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-calliope-steam-whistle__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-calliope-steam-whistle__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-calliope-steam-whistle__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-calliope-steam-whistle__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-calliope-steam-whistle__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-calliope-steam-whistle__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-calliope-steam-whistle__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7edee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-calliope-steam-whistle__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-calliope-steam-whistle__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-calliope-steam-whistle__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-calliope-steam-whistle__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: calliope_steam_whistle_status 3.36s ease-out infinite;
+}
+
+@keyframes calliope_steam_whistle_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes calliope_steam_whistle_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-calliope-steam-whistle__a{position:absolute;left:50%;top:18%;width:4px;height:46%;background:linear-gradient(var(--accent),transparent);transform-origin:50% 0;animation:calliope_steam_whistle_pend 4.8s ease-in-out infinite}
+.ease-calliope-steam-whistle__b{position:absolute;left:calc(50% - 9px);top:58%;width:18px;height:18px;border-radius:50%;background:var(--accent-2);animation:calliope_steam_whistle_bob 4.8s ease-in-out infinite}
+.ease-calliope-steam-whistle__c{position:absolute;left:22%;right:22%;top:16%;height:2px;background:var(--accent);opacity:.35}
+.ease-calliope-steam-whistle__d{position:absolute;inset:28%;border:1px dashed color-mix(in srgb,var(--accent) 40%,transparent);border-radius:50%;opacity:.5}
+@keyframes calliope_steam_whistle_pend{0%{transform:rotate(-28deg)}50%{transform:rotate(28deg)}100%{transform:rotate(-28deg)}}
+@keyframes calliope_steam_whistle_bob{0%{transform:translateX(-34px)}50%{transform:translateX(34px)}100%{transform:translateX(-34px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-calliope-steam-whistle__a,
+  .ease-calliope-steam-whistle__b,
+  .ease-calliope-steam-whistle__c,
+  .ease-calliope-steam-whistle__d,
+  .ease-calliope-steam-whistle__meters i::after,
+  .ease-calliope-steam-whistle__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-calliope-steam-whistle` CSS-only demo for #77633.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Calliope whistle taking a steam pulse

**How does a developer use it?**

```html
<section class="ease-calliope-steam-whistle">
  <div class="ease-calliope-steam-whistle__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/calliope-steam-whistle-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77633
