### PR TITLE
feat: add ease-carillon-clapper-fall (#77634)

### DIFF
--- a/submissions/examples/carillon-clapper-fall-ns/README.md
+++ b/submissions/examples/carillon-clapper-fall-ns/README.md
@@ -1,0 +1,16 @@
+# Carillon Clapper Fall
+
+## What does this do?
+Renders a self-contained CSS-only `ease-carillon-clapper-fall` demo: Carillon clapper falling on the bell.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-carillon-clapper-fall`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-carillon-clapper-fall">
+  <div class="ease-carillon-clapper-fall__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/carillon-clapper-fall-ns/demo.html
+++ b/submissions/examples/carillon-clapper-fall-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carillon Clapper Fall — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Carillon Clapper Fall demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Carillon Clapper Fall</h1>
+      <p class="lede">Carillon clapper falling on the bell</p>
+    </header>
+
+    <section class="ease-carillon-clapper-fall" data-demo="carillon-clapper-fall" aria-live="polite">
+      <div class="ease-carillon-clapper-fall__housing">
+        <div class="ease-carillon-clapper-fall__bezel">
+          <div class="ease-carillon-clapper-fall__face">
+            <div class="ease-carillon-clapper-fall__readout">
+              <span class="ease-carillon-clapper-fall__label">Carillon Clapper Fall</span>
+              <span class="ease-carillon-clapper-fall__value">LIVE</span>
+            </div>
+            <div class="ease-carillon-clapper-fall__motion" aria-hidden="true">
+              <span class="ease-carillon-clapper-fall__a"></span>
+              <span class="ease-carillon-clapper-fall__b"></span>
+              <span class="ease-carillon-clapper-fall__c"></span>
+              <span class="ease-carillon-clapper-fall__d"></span>
+            </div>
+            <div class="ease-carillon-clapper-fall__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-carillon-clapper-fall__controls">
+          <button type="button" class="ease-carillon-clapper-fall__btn primary">Strike</button>
+          <button type="button" class="ease-carillon-clapper-fall__btn">Catch</button>
+          <label class="ease-carillon-clapper-fall__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-carillon-clapper-fall__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/carillon-clapper-fall-ns/style.css
+++ b/submissions/examples/carillon-clapper-fall-ns/style.css
@@ -1,0 +1,226 @@
+/* Carillon Clapper Fall motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eee7ea;
+  font-family: "Gill Sans", "Gill Sans MT", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #58e490 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #89f0e3 18%, transparent), transparent 42%),
+    #231015;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-carillon-clapper-fall {
+  --accent: #58e490;
+  --accent-2: #89f0e3;
+  --panel: color-mix(in srgb, #eee7ea 7%, #231015);
+  --line: color-mix(in srgb, #eee7ea 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #231015 75%, #000);
+}
+
+.ease-carillon-clapper-fall__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-carillon-clapper-fall__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eee7ea 5%, transparent), transparent 40%),
+    color-mix(in srgb, #231015 90%, #58e490);
+}
+
+.ease-carillon-clapper-fall__face {
+  position: relative;
+  min-height: 254px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #231015 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-carillon-clapper-fall__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-carillon-clapper-fall__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-carillon-clapper-fall__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-carillon-clapper-fall__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-carillon-clapper-fall__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-carillon-clapper-fall__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: carillon_clapper_fall_meter 4.56s linear infinite;
+}
+
+.ease-carillon-clapper-fall__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-carillon-clapper-fall__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-carillon-clapper-fall__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-carillon-clapper-fall__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-carillon-clapper-fall__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-carillon-clapper-fall__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eee7ea 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-carillon-clapper-fall__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-carillon-clapper-fall__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-carillon-clapper-fall__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-carillon-clapper-fall__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: carillon_clapper_fall_status 3.19s ease-out infinite;
+}
+
+@keyframes carillon_clapper_fall_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes carillon_clapper_fall_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-carillon-clapper-fall__a{position:absolute;left:46%;top:14%;bottom:18%;width:8px;border-radius:4px;background:color-mix(in srgb,var(--accent) 30%,transparent);overflow:hidden}
+.ease-carillon-clapper-fall__a::after{content:"";position:absolute;left:0;right:0;height:22%;background:var(--accent);animation:carillon_clapper_fall_hoist 4.56s ease-in-out infinite}
+.ease-carillon-clapper-fall__b{position:absolute;left:22%;top:16%;width:12px;height:12px;border:2px solid var(--accent-2);animation:carillon_clapper_fall_sheave 4.56s linear infinite}
+.ease-carillon-clapper-fall__c{position:absolute;right:20%;top:16%;width:12px;height:12px;border:2px solid var(--accent);animation:carillon_clapper_fall_sheave 4.56s linear infinite reverse}
+.ease-carillon-clapper-fall__d{position:absolute;left:18%;right:18%;bottom:14%;height:3px;background:repeating-linear-gradient(90deg,var(--accent) 0 8px,transparent 8px 16px);opacity:.45}
+@keyframes carillon_clapper_fall_hoist{0%{transform:translateY(0)}50%{transform:translateY(280%)}100%{transform:translateY(0)}}
+@keyframes carillon_clapper_fall_sheave{to{transform:rotate(360deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-carillon-clapper-fall__a,
+  .ease-carillon-clapper-fall__b,
+  .ease-carillon-clapper-fall__c,
+  .ease-carillon-clapper-fall__d,
+  .ease-carillon-clapper-fall__meters i::after,
+  .ease-carillon-clapper-fall__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-carillon-clapper-fall` CSS-only demo for #77634.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Carillon clapper falling on the bell

**How does a developer use it?**

```html
<section class="ease-carillon-clapper-fall">
  <div class="ease-carillon-clapper-fall__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/carillon-clapper-fall-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77634
