### PR TITLE
feat: add ease-clarinet-register-key (#77638)

### DIFF
--- a/submissions/examples/clarinet-register-key-ns/README.md
+++ b/submissions/examples/clarinet-register-key-ns/README.md
@@ -1,0 +1,16 @@
+# Clarinet Register Key
+
+## What does this do?
+Renders a self-contained CSS-only `ease-clarinet-register-key` demo: Clarinet register key venting the twelfth.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-clarinet-register-key`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-clarinet-register-key">
+  <div class="ease-clarinet-register-key__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/clarinet-register-key-ns/demo.html
+++ b/submissions/examples/clarinet-register-key-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clarinet Register Key — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Clarinet Register Key demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Clarinet Register Key</h1>
+      <p class="lede">Clarinet register key venting the twelfth</p>
+    </header>
+
+    <section class="ease-clarinet-register-key" data-demo="clarinet-register-key" aria-live="polite">
+      <div class="ease-clarinet-register-key__housing">
+        <div class="ease-clarinet-register-key__bezel">
+          <div class="ease-clarinet-register-key__face">
+            <div class="ease-clarinet-register-key__readout">
+              <span class="ease-clarinet-register-key__label">Clarinet Register Key</span>
+              <span class="ease-clarinet-register-key__value">LIVE</span>
+            </div>
+            <div class="ease-clarinet-register-key__motion" aria-hidden="true">
+              <span class="ease-clarinet-register-key__a"></span>
+              <span class="ease-clarinet-register-key__b"></span>
+              <span class="ease-clarinet-register-key__c"></span>
+              <span class="ease-clarinet-register-key__d"></span>
+            </div>
+            <div class="ease-clarinet-register-key__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-clarinet-register-key__controls">
+          <button type="button" class="ease-clarinet-register-key__btn primary">Vent</button>
+          <button type="button" class="ease-clarinet-register-key__btn">Close</button>
+          <label class="ease-clarinet-register-key__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-clarinet-register-key__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/clarinet-register-key-ns/style.css
+++ b/submissions/examples/clarinet-register-key-ns/style.css
@@ -1,0 +1,222 @@
+html { color-scheme: dark; }
+/* clarinet-register-key */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eee7ee;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #69e458 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #89f0b6 18%, transparent), transparent 42%),
+    #200e1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-clarinet-register-key {
+  --accent: #69e458;
+  --accent-2: #89f0b6;
+  --panel: color-mix(in srgb, #eee7ee 7%, #200e1c);
+  --line: color-mix(in srgb, #eee7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 11px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #200e1c 75%, #000);
+}
+
+.ease-clarinet-register-key__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-clarinet-register-key__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eee7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #200e1c 90%, #69e458);
+}
+
+.ease-clarinet-register-key__face {
+  position: relative;
+  min-height: 263px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #200e1c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-clarinet-register-key__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-clarinet-register-key__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-clarinet-register-key__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-clarinet-register-key__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-clarinet-register-key__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-clarinet-register-key__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: clarinet_register_key_meter 3.72s linear infinite;
+}
+
+.ease-clarinet-register-key__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-clarinet-register-key__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-clarinet-register-key__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-clarinet-register-key__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-clarinet-register-key__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-clarinet-register-key__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-clarinet-register-key__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eee7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-clarinet-register-key__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-clarinet-register-key__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-clarinet-register-key__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-clarinet-register-key__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: clarinet_register_key_status 2.60s ease-out infinite;
+}
+
+@keyframes clarinet_register_key_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes clarinet_register_key_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-clarinet-register-key__a{position:absolute;left:16%;width:36%;top:22%;bottom:22%;background:color-mix(in srgb,var(--accent) 28%,transparent);transform-origin:0 50%;animation:clarinet_register_key_gate 3.72s ease-in-out infinite}
+.ease-clarinet-register-key__b{position:absolute;right:16%;width:36%;top:22%;bottom:22%;background:color-mix(in srgb,var(--accent-2) 28%,transparent);transform-origin:100% 50%;animation:clarinet_register_key_gate 3.72s ease-in-out infinite reverse}
+.ease-clarinet-register-key__c{position:absolute;left:49%;top:18%;bottom:18%;width:2px;background:var(--accent)}
+.ease-clarinet-register-key__d{position:absolute;left:46%;top:46%;width:12px;height:12px;border-radius:50%;background:var(--accent)}
+@keyframes clarinet_register_key_gate{0%,100%{transform:scaleX(.15)}50%{transform:scaleX(1)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-clarinet-register-key__a,
+  .ease-clarinet-register-key__b,
+  .ease-clarinet-register-key__c,
+  .ease-clarinet-register-key__d,
+  .ease-clarinet-register-key__meters i::after,
+  .ease-clarinet-register-key__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-clarinet-register-key` CSS-only demo for #77638.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Clarinet register key venting the twelfth

**How does a developer use it?**

```html
<section class="ease-clarinet-register-key">
  <div class="ease-clarinet-register-key__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/clarinet-register-key-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77638
