### PR TITLE
feat: add ease-pantograph-contact-rise (#77651)

### DIFF
--- a/submissions/examples/pantograph-contact-rise-ns/README.md
+++ b/submissions/examples/pantograph-contact-rise-ns/README.md
@@ -1,0 +1,16 @@
+# Pantograph Contact Rise
+
+## What does this do?
+Renders a self-contained CSS-only `ease-pantograph-contact-rise` demo: Pantograph rising to the contact wire.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-pantograph-contact-rise`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-pantograph-contact-rise">
+  <div class="ease-pantograph-contact-rise__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/pantograph-contact-rise-ns/demo.html
+++ b/submissions/examples/pantograph-contact-rise-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pantograph Contact Rise — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Pantograph Contact Rise demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Pantograph Contact Rise</h1>
+      <p class="lede">Pantograph rising to the contact wire</p>
+    </header>
+
+    <section class="ease-pantograph-contact-rise" data-demo="pantograph-contact-rise" aria-live="polite">
+      <div class="ease-pantograph-contact-rise__housing">
+        <div class="ease-pantograph-contact-rise__bezel">
+          <div class="ease-pantograph-contact-rise__face">
+            <div class="ease-pantograph-contact-rise__readout">
+              <span class="ease-pantograph-contact-rise__label">Pantograph Contact Rise</span>
+              <span class="ease-pantograph-contact-rise__value">LIVE</span>
+            </div>
+            <div class="ease-pantograph-contact-rise__motion" aria-hidden="true">
+              <span class="ease-pantograph-contact-rise__a"></span>
+              <span class="ease-pantograph-contact-rise__b"></span>
+              <span class="ease-pantograph-contact-rise__c"></span>
+              <span class="ease-pantograph-contact-rise__d"></span>
+            </div>
+            <div class="ease-pantograph-contact-rise__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-pantograph-contact-rise__controls">
+          <button type="button" class="ease-pantograph-contact-rise__btn primary">Raise</button>
+          <button type="button" class="ease-pantograph-contact-rise__btn">Drop</button>
+          <label class="ease-pantograph-contact-rise__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-pantograph-contact-rise__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/pantograph-contact-rise-ns/style.css
+++ b/submissions/examples/pantograph-contact-rise-ns/style.css
@@ -1,0 +1,226 @@
+html { color-scheme: dark; }
+/* pantograph-contact-rise */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #edeee7;
+  font-family: "Franklin Gothic Medium", "Arial Narrow", sans-serif;
+  background:
+    radial-gradient(ellipse at 40% 100%, color-mix(in srgb, #585be4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 80% 20%, color-mix(in srgb, #c089f0 18%, transparent), transparent 42%),
+    #1d2310;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-pantograph-contact-rise {
+  --accent: #585be4;
+  --accent-2: #c089f0;
+  --panel: color-mix(in srgb, #edeee7 7%, #1d2310);
+  --line: color-mix(in srgb, #edeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 17px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1d2310 75%, #000);
+}
+
+.ease-pantograph-contact-rise__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-pantograph-contact-rise__bezel {
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #edeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1d2310 90%, #585be4);
+}
+
+.ease-pantograph-contact-rise__face {
+  position: relative;
+  min-height: 269px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1d2310 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-pantograph-contact-rise__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-pantograph-contact-rise__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-pantograph-contact-rise__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-pantograph-contact-rise__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-pantograph-contact-rise__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-pantograph-contact-rise__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: pantograph_contact_rise_meter 3.96s linear infinite;
+}
+
+.ease-pantograph-contact-rise__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-pantograph-contact-rise__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-pantograph-contact-rise__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-pantograph-contact-rise__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-pantograph-contact-rise__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-pantograph-contact-rise__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+.ease-pantograph-contact-rise__meters i:nth-child(8)::after { animation-delay: 0.64s; }
+
+.ease-pantograph-contact-rise__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-pantograph-contact-rise__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #edeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-pantograph-contact-rise__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-pantograph-contact-rise__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-pantograph-contact-rise__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-pantograph-contact-rise__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pantograph_contact_rise_status 2.77s ease-out infinite;
+}
+
+@keyframes pantograph_contact_rise_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes pantograph_contact_rise_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-pantograph-contact-rise__a{position:absolute;left:20%;right:20%;top:38%;height:16px;border-radius:8px;background:color-mix(in srgb,var(--accent) 20%,transparent);overflow:hidden}
+.ease-pantograph-contact-rise__a::after{content:"";position:absolute;inset:2px auto 2px 2px;width:24%;border-radius:6px;background:var(--accent);animation:pantograph_contact_rise_fill 3.96s ease-in-out infinite}
+.ease-pantograph-contact-rise__b{position:absolute;left:22%;top:22%;width:10px;height:10px;border-radius:2px;background:var(--accent-2);animation:pantograph_contact_rise_tick 3.96s steps(6) infinite}
+.ease-pantograph-contact-rise__c{position:absolute;right:22%;top:22%;width:10px;height:10px;border-radius:2px;background:var(--accent);animation:pantograph_contact_rise_tick 3.96s steps(6) infinite reverse}
+.ease-pantograph-contact-rise__d{position:absolute;left:18%;right:18%;bottom:18%;height:2px;background:var(--accent);opacity:.35}
+@keyframes pantograph_contact_rise_fill{0%{width:18%}50%{width:78%}100%{width:18%}}
+@keyframes pantograph_contact_rise_tick{to{transform:translateX(28px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pantograph-contact-rise__a,
+  .ease-pantograph-contact-rise__b,
+  .ease-pantograph-contact-rise__c,
+  .ease-pantograph-contact-rise__d,
+  .ease-pantograph-contact-rise__meters i::after,
+  .ease-pantograph-contact-rise__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-pantograph-contact-rise` CSS-only demo for #77651.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Pantograph rising to the contact wire

**How does a developer use it?**

```html
<section class="ease-pantograph-contact-rise">
  <div class="ease-pantograph-contact-rise__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/pantograph-contact-rise-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77651
