### PR TITLE
feat: add ease-block-instrument-needle (#77655)

### DIFF
--- a/submissions/examples/block-instrument-needle-ns/README.md
+++ b/submissions/examples/block-instrument-needle-ns/README.md
@@ -1,0 +1,16 @@
+# Block Instrument Needle
+
+## What does this do?
+Renders a self-contained CSS-only `ease-block-instrument-needle` demo: Block instrument needle repeating line clear.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-block-instrument-needle`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-block-instrument-needle">
+  <div class="ease-block-instrument-needle__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/block-instrument-needle-ns/demo.html
+++ b/submissions/examples/block-instrument-needle-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Block Instrument Needle — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Block Instrument Needle demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Block Instrument Needle</h1>
+      <p class="lede">Block instrument needle repeating line clear</p>
+    </header>
+
+    <section class="ease-block-instrument-needle" data-demo="block-instrument-needle" aria-live="polite">
+      <div class="ease-block-instrument-needle__housing">
+        <div class="ease-block-instrument-needle__bezel">
+          <div class="ease-block-instrument-needle__face">
+            <div class="ease-block-instrument-needle__readout">
+              <span class="ease-block-instrument-needle__label">Block Instrument Needle</span>
+              <span class="ease-block-instrument-needle__value">LIVE</span>
+            </div>
+            <div class="ease-block-instrument-needle__motion" aria-hidden="true">
+              <span class="ease-block-instrument-needle__a"></span>
+              <span class="ease-block-instrument-needle__b"></span>
+              <span class="ease-block-instrument-needle__c"></span>
+              <span class="ease-block-instrument-needle__d"></span>
+            </div>
+            <div class="ease-block-instrument-needle__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-block-instrument-needle__controls">
+          <button type="button" class="ease-block-instrument-needle__btn primary">Bell</button>
+          <button type="button" class="ease-block-instrument-needle__btn">Idle</button>
+          <label class="ease-block-instrument-needle__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-block-instrument-needle__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/block-instrument-needle-ns/style.css
+++ b/submissions/examples/block-instrument-needle-ns/style.css
@@ -1,0 +1,224 @@
+/* Block Instrument Needle motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7e7ee;
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #e4c858 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #c0f089 18%, transparent), transparent 42%),
+    #110e20;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-block-instrument-needle {
+  --accent: #e4c858;
+  --accent-2: #c0f089;
+  --panel: color-mix(in srgb, #e7e7ee 7%, #110e20);
+  --line: color-mix(in srgb, #e7e7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #110e20 75%, #000);
+}
+
+.ease-block-instrument-needle__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-block-instrument-needle__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7e7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #110e20 90%, #e4c858);
+}
+
+.ease-block-instrument-needle__face {
+  position: relative;
+  min-height: 238px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #110e20 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-block-instrument-needle__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-block-instrument-needle__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-block-instrument-needle__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-block-instrument-needle__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-block-instrument-needle__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-block-instrument-needle__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: block_instrument_needle_meter 4.08s linear infinite;
+}
+
+.ease-block-instrument-needle__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-block-instrument-needle__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-block-instrument-needle__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-block-instrument-needle__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-block-instrument-needle__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-block-instrument-needle__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7e7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-block-instrument-needle__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-block-instrument-needle__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-block-instrument-needle__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-block-instrument-needle__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: block_instrument_needle_status 2.86s ease-out infinite;
+}
+
+@keyframes block_instrument_needle_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes block_instrument_needle_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-block-instrument-needle__a{position:absolute;left:50%;top:18%;width:4px;height:38%;background:var(--accent);transform-origin:50% 100%;animation:block_instrument_needle_needle 4.08s ease-in-out infinite}
+.ease-block-instrument-needle__b{position:absolute;inset:42%;border-radius:50%;background:var(--accent-2)}
+.ease-block-instrument-needle__c{position:absolute;inset:22%;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 40%,transparent)}
+.ease-block-instrument-needle__d{position:absolute;left:16%;right:16%;bottom:16%;height:4px;background:conic-gradient(from 180deg,var(--accent),transparent);opacity:.5}
+@keyframes block_instrument_needle_needle{0%{transform:translateX(-2px) rotate(-70deg)}50%{transform:translateX(-2px) rotate(70deg)}100%{transform:translateX(-2px) rotate(-70deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-block-instrument-needle__a,
+  .ease-block-instrument-needle__b,
+  .ease-block-instrument-needle__c,
+  .ease-block-instrument-needle__d,
+  .ease-block-instrument-needle__meters i::after,
+  .ease-block-instrument-needle__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-block-instrument-needle` CSS-only demo for #77655.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Block instrument needle repeating line clear

**How does a developer use it?**

```html
<section class="ease-block-instrument-needle">
  <div class="ease-block-instrument-needle__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/block-instrument-needle-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77655
