### PR TITLE
feat: add ease-sand-dome-drop (#77657)

### DIFF
--- a/submissions/examples/sand-dome-drop-ns/README.md
+++ b/submissions/examples/sand-dome-drop-ns/README.md
@@ -1,0 +1,16 @@
+# Sand Dome Drop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-sand-dome-drop` demo: Sand dome dropping grit to the rail.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-sand-dome-drop`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-sand-dome-drop">
+  <div class="ease-sand-dome-drop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/sand-dome-drop-ns/demo.html
+++ b/submissions/examples/sand-dome-drop-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sand Dome Drop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Sand Dome Drop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Sand Dome Drop</h1>
+      <p class="lede">Sand dome dropping grit to the rail</p>
+    </header>
+
+    <section class="ease-sand-dome-drop" data-demo="sand-dome-drop" aria-live="polite">
+      <div class="ease-sand-dome-drop__housing">
+        <div class="ease-sand-dome-drop__bezel">
+          <div class="ease-sand-dome-drop__face">
+            <div class="ease-sand-dome-drop__readout">
+              <span class="ease-sand-dome-drop__label">Sand Dome Drop</span>
+              <span class="ease-sand-dome-drop__value">LIVE</span>
+            </div>
+            <div class="ease-sand-dome-drop__motion" aria-hidden="true">
+              <span class="ease-sand-dome-drop__a"></span>
+              <span class="ease-sand-dome-drop__b"></span>
+              <span class="ease-sand-dome-drop__c"></span>
+              <span class="ease-sand-dome-drop__d"></span>
+            </div>
+            <div class="ease-sand-dome-drop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-sand-dome-drop__controls">
+          <button type="button" class="ease-sand-dome-drop__btn primary">Sand</button>
+          <button type="button" class="ease-sand-dome-drop__btn">Stop</button>
+          <label class="ease-sand-dome-drop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-sand-dome-drop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sand-dome-drop-ns/style.css
+++ b/submissions/examples/sand-dome-drop-ns/style.css
@@ -1,0 +1,226 @@
+/* Sand Dome Drop motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7e7ee;
+  font-family: "Gill Sans", "Gill Sans MT", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e4d658 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #caf089 18%, transparent), transparent 42%),
+    #141023;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-sand-dome-drop {
+  --accent: #e4d658;
+  --accent-2: #caf089;
+  --panel: color-mix(in srgb, #e7e7ee 7%, #141023);
+  --line: color-mix(in srgb, #e7e7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #141023 75%, #000);
+}
+
+.ease-sand-dome-drop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-sand-dome-drop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7e7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #141023 90%, #e4d658);
+}
+
+.ease-sand-dome-drop__face {
+  position: relative;
+  min-height: 244px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #141023 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-sand-dome-drop__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-sand-dome-drop__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-sand-dome-drop__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-sand-dome-drop__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-sand-dome-drop__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-sand-dome-drop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: sand_dome_drop_meter 4.32s linear infinite;
+}
+
+.ease-sand-dome-drop__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-sand-dome-drop__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-sand-dome-drop__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-sand-dome-drop__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-sand-dome-drop__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-sand-dome-drop__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-sand-dome-drop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-sand-dome-drop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7e7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-sand-dome-drop__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-sand-dome-drop__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-sand-dome-drop__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-sand-dome-drop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: sand_dome_drop_status 3.02s ease-out infinite;
+}
+
+@keyframes sand_dome_drop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes sand_dome_drop_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-sand-dome-drop__a{position:absolute;inset:22%;border-radius:50%;border:2px solid var(--accent);animation:sand_dome_drop_spiral 4.32s linear infinite}
+.ease-sand-dome-drop__b{position:absolute;inset:34%;border-radius:50%;border:2px solid var(--accent-2);animation:sand_dome_drop_spiral 4.32s linear infinite reverse}
+.ease-sand-dome-drop__c{position:absolute;left:48%;top:20%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:sand_dome_drop_spiral 4.32s linear infinite}
+.ease-sand-dome-drop__d{position:absolute;inset:46%;border-radius:50%;background:var(--accent-2)}
+@keyframes sand_dome_drop_spiral{0%{transform:rotate(0deg) scale(.7)}100%{transform:rotate(360deg) scale(1.15)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-sand-dome-drop__a,
+  .ease-sand-dome-drop__b,
+  .ease-sand-dome-drop__c,
+  .ease-sand-dome-drop__d,
+  .ease-sand-dome-drop__meters i::after,
+  .ease-sand-dome-drop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-sand-dome-drop` CSS-only demo for #77657.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Sand dome dropping grit to the rail

**How does a developer use it?**

```html
<section class="ease-sand-dome-drop">
  <div class="ease-sand-dome-drop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/sand-dome-drop-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77657
