### PR TITLE
feat: add ease-semaphore-blade-drop (#77665)

### DIFF
--- a/submissions/examples/semaphore-blade-drop-ns/README.md
+++ b/submissions/examples/semaphore-blade-drop-ns/README.md
@@ -1,0 +1,16 @@
+# Semaphore Blade Drop
+
+## What does this do?
+Renders a self-contained CSS-only `ease-semaphore-blade-drop` demo: Semaphore blade dropping to caution.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-semaphore-blade-drop`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-semaphore-blade-drop">
+  <div class="ease-semaphore-blade-drop__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/semaphore-blade-drop-ns/demo.html
+++ b/submissions/examples/semaphore-blade-drop-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Semaphore Blade Drop — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Semaphore Blade Drop demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Semaphore Blade Drop</h1>
+      <p class="lede">Semaphore blade dropping to caution</p>
+    </header>
+
+    <section class="ease-semaphore-blade-drop" data-demo="semaphore-blade-drop" aria-live="polite">
+      <div class="ease-semaphore-blade-drop__housing">
+        <div class="ease-semaphore-blade-drop__bezel">
+          <div class="ease-semaphore-blade-drop__face">
+            <div class="ease-semaphore-blade-drop__readout">
+              <span class="ease-semaphore-blade-drop__label">Semaphore Blade Drop</span>
+              <span class="ease-semaphore-blade-drop__value">LIVE</span>
+            </div>
+            <div class="ease-semaphore-blade-drop__motion" aria-hidden="true">
+              <span class="ease-semaphore-blade-drop__a"></span>
+              <span class="ease-semaphore-blade-drop__b"></span>
+              <span class="ease-semaphore-blade-drop__c"></span>
+              <span class="ease-semaphore-blade-drop__d"></span>
+            </div>
+            <div class="ease-semaphore-blade-drop__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-semaphore-blade-drop__controls">
+          <button type="button" class="ease-semaphore-blade-drop__btn primary">Drop</button>
+          <button type="button" class="ease-semaphore-blade-drop__btn">On</button>
+          <label class="ease-semaphore-blade-drop__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-semaphore-blade-drop__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/semaphore-blade-drop-ns/style.css
+++ b/submissions/examples/semaphore-blade-drop-ns/style.css
@@ -1,0 +1,223 @@
+/* stage: semaphore-blade-drop */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eceee7;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #7058e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #e689f0 18%, transparent), transparent 42%),
+    #0f1509;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-semaphore-blade-drop {
+  --accent: #7058e4;
+  --accent-2: #e689f0;
+  --panel: color-mix(in srgb, #eceee7 7%, #0f1509);
+  --line: color-mix(in srgb, #eceee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0f1509 75%, #000);
+}
+
+.ease-semaphore-blade-drop__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-semaphore-blade-drop__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eceee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0f1509 90%, #7058e4);
+}
+
+.ease-semaphore-blade-drop__face {
+  position: relative;
+  min-height: 240px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0f1509 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-semaphore-blade-drop__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-semaphore-blade-drop__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-semaphore-blade-drop__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-semaphore-blade-drop__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-semaphore-blade-drop__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-semaphore-blade-drop__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: semaphore_blade_drop_meter 2.88s linear infinite;
+}
+
+.ease-semaphore-blade-drop__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-semaphore-blade-drop__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-semaphore-blade-drop__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-semaphore-blade-drop__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-semaphore-blade-drop__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-semaphore-blade-drop__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-semaphore-blade-drop__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-semaphore-blade-drop__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eceee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-semaphore-blade-drop__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-semaphore-blade-drop__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-semaphore-blade-drop__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-semaphore-blade-drop__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: semaphore_blade_drop_status 2.02s ease-out infinite;
+}
+
+@keyframes semaphore_blade_drop_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes semaphore_blade_drop_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-semaphore-blade-drop__a{position:absolute;left:12%;right:12%;top:40%;height:28px;background:linear-gradient(90deg,transparent,var(--accent),transparent);animation:semaphore_blade_drop_shear 2.88s ease-in-out infinite}
+.ease-semaphore-blade-drop__b{position:absolute;left:18%;right:18%;top:28%;height:2px;background:var(--accent-2);opacity:.5}
+.ease-semaphore-blade-drop__c{position:absolute;left:18%;right:18%;top:72%;height:2px;background:var(--accent);opacity:.5}
+.ease-semaphore-blade-drop__d{position:absolute;left:20%;top:24%;width:10px;height:10px;background:var(--accent);animation:semaphore_blade_drop_nudge 2.88s ease-in-out infinite}
+@keyframes semaphore_blade_drop_shear{0%,100%{transform:skewX(-18deg)}50%{transform:skewX(18deg)}}
+@keyframes semaphore_blade_drop_nudge{0%,100%{transform:translateX(0)}50%{transform:translateX(160px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-semaphore-blade-drop__a,
+  .ease-semaphore-blade-drop__b,
+  .ease-semaphore-blade-drop__c,
+  .ease-semaphore-blade-drop__d,
+  .ease-semaphore-blade-drop__meters i::after,
+  .ease-semaphore-blade-drop__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-semaphore-blade-drop` CSS-only demo for #77665.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Semaphore blade dropping to caution

**How does a developer use it?**

```html
<section class="ease-semaphore-blade-drop">
  <div class="ease-semaphore-blade-drop__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/semaphore-blade-drop-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77665
