### PR TITLE
feat: add ease-wheatstone-abc-dial (#77666)

### DIFF
--- a/submissions/examples/wheatstone-abc-dial-ns/README.md
+++ b/submissions/examples/wheatstone-abc-dial-ns/README.md
@@ -1,0 +1,16 @@
+# Wheatstone Abc Dial
+
+## What does this do?
+Renders a self-contained CSS-only `ease-wheatstone-abc-dial` demo: Wheatstone ABC dial hunting the next letter.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-wheatstone-abc-dial`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-wheatstone-abc-dial">
+  <div class="ease-wheatstone-abc-dial__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/wheatstone-abc-dial-ns/demo.html
+++ b/submissions/examples/wheatstone-abc-dial-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wheatstone Abc Dial — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Wheatstone Abc Dial demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Wheatstone Abc Dial</h1>
+      <p class="lede">Wheatstone ABC dial hunting the next letter</p>
+    </header>
+
+    <section class="ease-wheatstone-abc-dial" data-demo="wheatstone-abc-dial" aria-live="polite">
+      <div class="ease-wheatstone-abc-dial__housing">
+        <div class="ease-wheatstone-abc-dial__bezel">
+          <div class="ease-wheatstone-abc-dial__face">
+            <div class="ease-wheatstone-abc-dial__readout">
+              <span class="ease-wheatstone-abc-dial__label">Wheatstone Abc Dial</span>
+              <span class="ease-wheatstone-abc-dial__value">LIVE</span>
+            </div>
+            <div class="ease-wheatstone-abc-dial__motion" aria-hidden="true">
+              <span class="ease-wheatstone-abc-dial__a"></span>
+              <span class="ease-wheatstone-abc-dial__b"></span>
+              <span class="ease-wheatstone-abc-dial__c"></span>
+              <span class="ease-wheatstone-abc-dial__d"></span>
+            </div>
+            <div class="ease-wheatstone-abc-dial__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-wheatstone-abc-dial__controls">
+          <button type="button" class="ease-wheatstone-abc-dial__btn primary">Hunt</button>
+          <button type="button" class="ease-wheatstone-abc-dial__btn">Rest</button>
+          <label class="ease-wheatstone-abc-dial__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-wheatstone-abc-dial__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/wheatstone-abc-dial-ns/style.css
+++ b/submissions/examples/wheatstone-abc-dial-ns/style.css
@@ -1,0 +1,224 @@
+html { color-scheme: dark; }
+/* wheatstone-abc-dial */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7eeeb;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e458a7 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #f08990 18%, transparent), transparent 42%),
+    #0b1915;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-wheatstone-abc-dial {
+  --accent: #e458a7;
+  --accent-2: #f08990;
+  --panel: color-mix(in srgb, #e7eeeb 7%, #0b1915);
+  --line: color-mix(in srgb, #e7eeeb 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1915 75%, #000);
+}
+
+.ease-wheatstone-abc-dial__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-wheatstone-abc-dial__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7eeeb 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1915 90%, #e458a7);
+}
+
+.ease-wheatstone-abc-dial__face {
+  position: relative;
+  min-height: 236px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0b1915 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-wheatstone-abc-dial__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-wheatstone-abc-dial__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-wheatstone-abc-dial__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-wheatstone-abc-dial__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-wheatstone-abc-dial__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-wheatstone-abc-dial__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: wheatstone_abc_dial_meter 2.64s linear infinite;
+}
+
+.ease-wheatstone-abc-dial__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-wheatstone-abc-dial__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-wheatstone-abc-dial__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-wheatstone-abc-dial__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-wheatstone-abc-dial__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-wheatstone-abc-dial__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-wheatstone-abc-dial__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-wheatstone-abc-dial__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7eeeb 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-wheatstone-abc-dial__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-wheatstone-abc-dial__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-wheatstone-abc-dial__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-wheatstone-abc-dial__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: wheatstone_abc_dial_status 1.85s ease-out infinite;
+}
+
+@keyframes wheatstone_abc_dial_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes wheatstone_abc_dial_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-wheatstone-abc-dial__a{position:absolute;left:48%;top:12%;width:6px;height:40%;background:var(--accent);border-radius:3px;animation:wheatstone_abc_dial_drip 2.64s ease-in infinite}
+.ease-wheatstone-abc-dial__b{position:absolute;left:46%;top:48%;width:16px;height:16px;border-radius:50%;background:var(--accent-2);animation:wheatstone_abc_dial_drop 2.64s ease-in infinite}
+.ease-wheatstone-abc-dial__c{position:absolute;left:22%;right:22%;bottom:20%;height:10px;border-radius:50%;background:color-mix(in srgb,var(--accent) 25%,transparent)}
+.ease-wheatstone-abc-dial__d{position:absolute;inset:20% 30% auto;height:8px;border-radius:8px;background:var(--accent);opacity:.5}
+@keyframes wheatstone_abc_dial_drip{0%{transform:scaleY(.4);opacity:.3}70%{transform:scaleY(1);opacity:1}100%{transform:scaleY(.4);opacity:.3}}
+@keyframes wheatstone_abc_dial_drop{0%{transform:translateY(0);opacity:1}100%{transform:translateY(48px);opacity:0}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-wheatstone-abc-dial__a,
+  .ease-wheatstone-abc-dial__b,
+  .ease-wheatstone-abc-dial__c,
+  .ease-wheatstone-abc-dial__d,
+  .ease-wheatstone-abc-dial__meters i::after,
+  .ease-wheatstone-abc-dial__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-wheatstone-abc-dial` CSS-only demo for #77666.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Wheatstone ABC dial hunting the next letter

**How does a developer use it?**

```html
<section class="ease-wheatstone-abc-dial">
  <div class="ease-wheatstone-abc-dial__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/wheatstone-abc-dial-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77666
