### PR TITLE
feat: add ease-baudot-distributor-arm (#77669)

### DIFF
--- a/submissions/examples/baudot-distributor-arm-ns/README.md
+++ b/submissions/examples/baudot-distributor-arm-ns/README.md
@@ -1,0 +1,16 @@
+# Baudot Distributor Arm
+
+## What does this do?
+Renders a self-contained CSS-only `ease-baudot-distributor-arm` demo: Baudot distributor arm sampling the five bits.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-baudot-distributor-arm`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-baudot-distributor-arm">
+  <div class="ease-baudot-distributor-arm__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/baudot-distributor-arm-ns/demo.html
+++ b/submissions/examples/baudot-distributor-arm-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baudot Distributor Arm — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Baudot Distributor Arm demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Baudot Distributor Arm</h1>
+      <p class="lede">Baudot distributor arm sampling the five bits</p>
+    </header>
+
+    <section class="ease-baudot-distributor-arm" data-demo="baudot-distributor-arm" aria-live="polite">
+      <div class="ease-baudot-distributor-arm__housing">
+        <div class="ease-baudot-distributor-arm__bezel">
+          <div class="ease-baudot-distributor-arm__face">
+            <div class="ease-baudot-distributor-arm__readout">
+              <span class="ease-baudot-distributor-arm__label">Baudot Distributor Arm</span>
+              <span class="ease-baudot-distributor-arm__value">LIVE</span>
+            </div>
+            <div class="ease-baudot-distributor-arm__motion" aria-hidden="true">
+              <span class="ease-baudot-distributor-arm__a"></span>
+              <span class="ease-baudot-distributor-arm__b"></span>
+              <span class="ease-baudot-distributor-arm__c"></span>
+              <span class="ease-baudot-distributor-arm__d"></span>
+            </div>
+            <div class="ease-baudot-distributor-arm__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-baudot-distributor-arm__controls">
+          <button type="button" class="ease-baudot-distributor-arm__btn primary">Scan</button>
+          <button type="button" class="ease-baudot-distributor-arm__btn">Stop</button>
+          <label class="ease-baudot-distributor-arm__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-baudot-distributor-arm__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/baudot-distributor-arm-ns/style.css
+++ b/submissions/examples/baudot-distributor-arm-ns/style.css
@@ -1,0 +1,223 @@
+/* stage: baudot-distributor-arm */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e8e7ee;
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e4df58 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #bdf089 18%, transparent), transparent 42%),
+    #130e20;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-baudot-distributor-arm {
+  --accent: #e4df58;
+  --accent-2: #bdf089;
+  --panel: color-mix(in srgb, #e8e7ee 7%, #130e20);
+  --line: color-mix(in srgb, #e8e7ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #130e20 75%, #000);
+}
+
+.ease-baudot-distributor-arm__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-baudot-distributor-arm__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e8e7ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #130e20 90%, #e4df58);
+}
+
+.ease-baudot-distributor-arm__face {
+  position: relative;
+  min-height: 248px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #130e20 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-baudot-distributor-arm__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-baudot-distributor-arm__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-baudot-distributor-arm__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-baudot-distributor-arm__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-baudot-distributor-arm__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-baudot-distributor-arm__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: baudot_distributor_arm_meter 3.84s linear infinite;
+}
+
+.ease-baudot-distributor-arm__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-baudot-distributor-arm__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-baudot-distributor-arm__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-baudot-distributor-arm__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-baudot-distributor-arm__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-baudot-distributor-arm__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-baudot-distributor-arm__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-baudot-distributor-arm__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e8e7ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-baudot-distributor-arm__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-baudot-distributor-arm__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-baudot-distributor-arm__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-baudot-distributor-arm__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: baudot_distributor_arm_status 2.69s ease-out infinite;
+}
+
+@keyframes baudot_distributor_arm_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes baudot_distributor_arm_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-baudot-distributor-arm__a{position:absolute;left:14%;right:14%;top:24%;height:52%;display:block;background:repeating-linear-gradient(180deg,var(--accent) 0 3px,transparent 3px 14px);opacity:.35;animation:baudot_distributor_arm_scan 3.84s linear infinite}
+.ease-baudot-distributor-arm__b{position:absolute;left:12%;right:12%;height:3px;background:var(--accent-2);animation:baudot_distributor_arm_line 3.84s linear infinite}
+.ease-baudot-distributor-arm__c{position:absolute;left:16%;top:18%;width:8px;height:8px;background:var(--accent)}
+.ease-baudot-distributor-arm__d{position:absolute;right:16%;bottom:18%;width:8px;height:8px;background:var(--accent-2)}
+@keyframes baudot_distributor_arm_scan{0%{transform:translateY(-8%)}100%{transform:translateY(8%)}}
+@keyframes baudot_distributor_arm_line{0%{top:22%}100%{top:72%}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-baudot-distributor-arm__a,
+  .ease-baudot-distributor-arm__b,
+  .ease-baudot-distributor-arm__c,
+  .ease-baudot-distributor-arm__d,
+  .ease-baudot-distributor-arm__meters i::after,
+  .ease-baudot-distributor-arm__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-baudot-distributor-arm` CSS-only demo for #77669.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Baudot distributor arm sampling the five bits

**How does a developer use it?**

```html
<section class="ease-baudot-distributor-arm">
  <div class="ease-baudot-distributor-arm__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/baudot-distributor-arm-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77669
