### PR TITLE
feat: add ease-hughes-typotelegraph (#77675)

### DIFF
--- a/submissions/examples/hughes-typotelegraph-ns/README.md
+++ b/submissions/examples/hughes-typotelegraph-ns/README.md
@@ -1,0 +1,16 @@
+# Hughes Typotelegraph
+
+## What does this do?
+Renders a self-contained CSS-only `ease-hughes-typotelegraph` demo: Hughes typotelegraph printing a received letter.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-hughes-typotelegraph`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-hughes-typotelegraph">
+  <div class="ease-hughes-typotelegraph__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/hughes-typotelegraph-ns/demo.html
+++ b/submissions/examples/hughes-typotelegraph-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hughes Typotelegraph — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Hughes Typotelegraph demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Hughes Typotelegraph</h1>
+      <p class="lede">Hughes typotelegraph printing a received letter</p>
+    </header>
+
+    <section class="ease-hughes-typotelegraph" data-demo="hughes-typotelegraph" aria-live="polite">
+      <div class="ease-hughes-typotelegraph__housing">
+        <div class="ease-hughes-typotelegraph__bezel">
+          <div class="ease-hughes-typotelegraph__face">
+            <div class="ease-hughes-typotelegraph__readout">
+              <span class="ease-hughes-typotelegraph__label">Hughes Typotelegraph</span>
+              <span class="ease-hughes-typotelegraph__value">LIVE</span>
+            </div>
+            <div class="ease-hughes-typotelegraph__motion" aria-hidden="true">
+              <span class="ease-hughes-typotelegraph__a"></span>
+              <span class="ease-hughes-typotelegraph__b"></span>
+              <span class="ease-hughes-typotelegraph__c"></span>
+              <span class="ease-hughes-typotelegraph__d"></span>
+            </div>
+            <div class="ease-hughes-typotelegraph__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-hughes-typotelegraph__controls">
+          <button type="button" class="ease-hughes-typotelegraph__btn primary">Print</button>
+          <button type="button" class="ease-hughes-typotelegraph__btn">Idle</button>
+          <label class="ease-hughes-typotelegraph__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-hughes-typotelegraph__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hughes-typotelegraph-ns/style.css
+++ b/submissions/examples/hughes-typotelegraph-ns/style.css
@@ -1,0 +1,221 @@
+html { color-scheme: dark; }
+/* hughes-typotelegraph */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7e9ee;
+  font-family: "Palatino Linotype", Palatino, serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #e4a358 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #d8f089 18%, transparent), transparent 42%),
+    #0d0f1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-hughes-typotelegraph {
+  --accent: #e4a358;
+  --accent-2: #d8f089;
+  --panel: color-mix(in srgb, #e7e9ee 7%, #0d0f1c);
+  --line: color-mix(in srgb, #e7e9ee 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d0f1c 75%, #000);
+}
+
+.ease-hughes-typotelegraph__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-hughes-typotelegraph__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7e9ee 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d0f1c 90%, #e4a358);
+}
+
+.ease-hughes-typotelegraph__face {
+  position: relative;
+  min-height: 262px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d0f1c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-hughes-typotelegraph__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-hughes-typotelegraph__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-hughes-typotelegraph__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-hughes-typotelegraph__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-hughes-typotelegraph__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-hughes-typotelegraph__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: hughes_typotelegraph_meter 3.12s linear infinite;
+}
+
+.ease-hughes-typotelegraph__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-hughes-typotelegraph__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-hughes-typotelegraph__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-hughes-typotelegraph__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-hughes-typotelegraph__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-hughes-typotelegraph__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7e9ee 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-hughes-typotelegraph__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-hughes-typotelegraph__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-hughes-typotelegraph__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-hughes-typotelegraph__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: hughes_typotelegraph_status 2.18s ease-out infinite;
+}
+
+@keyframes hughes_typotelegraph_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes hughes_typotelegraph_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-hughes-typotelegraph__a{position:absolute;inset:24%;border-radius:50%;box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 55%,transparent);animation:hughes_typotelegraph_halo 3.12s ease-out infinite}
+.ease-hughes-typotelegraph__b{position:absolute;inset:38%;border-radius:50%;background:var(--accent-2);opacity:.8}
+.ease-hughes-typotelegraph__c{position:absolute;left:20%;right:20%;top:18%;height:2px;background:var(--accent);opacity:.35}
+.ease-hughes-typotelegraph__d{position:absolute;left:20%;right:20%;bottom:18%;height:2px;background:var(--accent);opacity:.35}
+@keyframes hughes_typotelegraph_halo{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 55%,transparent)}100%{box-shadow:0 0 0 28px transparent}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-hughes-typotelegraph__a,
+  .ease-hughes-typotelegraph__b,
+  .ease-hughes-typotelegraph__c,
+  .ease-hughes-typotelegraph__d,
+  .ease-hughes-typotelegraph__meters i::after,
+  .ease-hughes-typotelegraph__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hughes-typotelegraph` CSS-only demo for #77675.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Hughes typotelegraph printing a received letter

**How does a developer use it?**

```html
<section class="ease-hughes-typotelegraph">
  <div class="ease-hughes-typotelegraph__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/hughes-typotelegraph-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77675
