### PR TITLE
feat: add ease-scytale-wrap-strip (#77678)

### DIFF
--- a/submissions/examples/scytale-wrap-strip-ns/README.md
+++ b/submissions/examples/scytale-wrap-strip-ns/README.md
@@ -1,0 +1,16 @@
+# Scytale Wrap Strip
+
+## What does this do?
+Renders a self-contained CSS-only `ease-scytale-wrap-strip` demo: Scytale wrap revealing the letter grid.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-scytale-wrap-strip`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-scytale-wrap-strip">
+  <div class="ease-scytale-wrap-strip__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/scytale-wrap-strip-ns/demo.html
+++ b/submissions/examples/scytale-wrap-strip-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scytale Wrap Strip — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Scytale Wrap Strip demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Scytale Wrap Strip</h1>
+      <p class="lede">Scytale wrap revealing the letter grid</p>
+    </header>
+
+    <section class="ease-scytale-wrap-strip" data-demo="scytale-wrap-strip" aria-live="polite">
+      <div class="ease-scytale-wrap-strip__housing">
+        <div class="ease-scytale-wrap-strip__bezel">
+          <div class="ease-scytale-wrap-strip__face">
+            <div class="ease-scytale-wrap-strip__readout">
+              <span class="ease-scytale-wrap-strip__label">Scytale Wrap Strip</span>
+              <span class="ease-scytale-wrap-strip__value">LIVE</span>
+            </div>
+            <div class="ease-scytale-wrap-strip__motion" aria-hidden="true">
+              <span class="ease-scytale-wrap-strip__a"></span>
+              <span class="ease-scytale-wrap-strip__b"></span>
+              <span class="ease-scytale-wrap-strip__c"></span>
+              <span class="ease-scytale-wrap-strip__d"></span>
+            </div>
+            <div class="ease-scytale-wrap-strip__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-scytale-wrap-strip__controls">
+          <button type="button" class="ease-scytale-wrap-strip__btn primary">Wrap</button>
+          <button type="button" class="ease-scytale-wrap-strip__btn">Unwind</button>
+          <label class="ease-scytale-wrap-strip__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-scytale-wrap-strip__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/scytale-wrap-strip-ns/style.css
+++ b/submissions/examples/scytale-wrap-strip-ns/style.css
@@ -1,0 +1,221 @@
+/* stage: scytale-wrap-strip */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeebe7;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #58aae4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #8989f0 18%, transparent), transparent 42%),
+    #151209;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-scytale-wrap-strip {
+  --accent: #58aae4;
+  --accent-2: #8989f0;
+  --panel: color-mix(in srgb, #eeebe7 7%, #151209);
+  --line: color-mix(in srgb, #eeebe7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #151209 75%, #000);
+}
+
+.ease-scytale-wrap-strip__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-scytale-wrap-strip__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeebe7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #151209 90%, #58aae4);
+}
+
+.ease-scytale-wrap-strip__face {
+  position: relative;
+  min-height: 235px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #151209 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-scytale-wrap-strip__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-scytale-wrap-strip__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-scytale-wrap-strip__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-scytale-wrap-strip__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-scytale-wrap-strip__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-scytale-wrap-strip__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: scytale_wrap_strip_meter 3.48s linear infinite;
+}
+
+.ease-scytale-wrap-strip__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-scytale-wrap-strip__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-scytale-wrap-strip__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-scytale-wrap-strip__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-scytale-wrap-strip__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-scytale-wrap-strip__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-scytale-wrap-strip__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeebe7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-scytale-wrap-strip__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-scytale-wrap-strip__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-scytale-wrap-strip__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-scytale-wrap-strip__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: scytale_wrap_strip_status 2.44s ease-out infinite;
+}
+
+@keyframes scytale_wrap_strip_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes scytale_wrap_strip_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-scytale-wrap-strip__a{position:absolute;inset:17%;border-radius:50%;border:2px solid var(--accent);animation:scytale_wrap_strip_ratchet 3.48s steps(8) infinite}
+.ease-scytale-wrap-strip__b{position:absolute;left:50%;top:22%;width:3px;height:28%;background:var(--accent-2);transform-origin:50% 100%;animation:scytale_wrap_strip_ratchet 3.48s steps(8) infinite}
+.ease-scytale-wrap-strip__c{position:absolute;inset:38%;border-radius:50%;background:var(--accent);opacity:.55}
+.ease-scytale-wrap-strip__d{position:absolute;left:18%;right:18%;bottom:16%;height:2px;background:var(--accent);opacity:.3}
+@keyframes scytale_wrap_strip_ratchet{to{transform:rotate(360deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-scytale-wrap-strip__a,
+  .ease-scytale-wrap-strip__b,
+  .ease-scytale-wrap-strip__c,
+  .ease-scytale-wrap-strip__d,
+  .ease-scytale-wrap-strip__meters i::after,
+  .ease-scytale-wrap-strip__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scytale-wrap-strip` CSS-only demo for #77678.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Scytale wrap revealing the letter grid

**How does a developer use it?**

```html
<section class="ease-scytale-wrap-strip">
  <div class="ease-scytale-wrap-strip__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/scytale-wrap-strip-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77678
