### PR TITLE
feat: add ease-punched-tape-sprocket (#77682)

### DIFF
--- a/submissions/examples/punched-tape-sprocket-ns/README.md
+++ b/submissions/examples/punched-tape-sprocket-ns/README.md
@@ -1,0 +1,16 @@
+# Punched Tape Sprocket
+
+## What does this do?
+Renders a self-contained CSS-only `ease-punched-tape-sprocket` demo: Punched tape sprocket advancing a row.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-punched-tape-sprocket`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-punched-tape-sprocket">
+  <div class="ease-punched-tape-sprocket__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/punched-tape-sprocket-ns/demo.html
+++ b/submissions/examples/punched-tape-sprocket-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Punched Tape Sprocket — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Punched Tape Sprocket demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Punched Tape Sprocket</h1>
+      <p class="lede">Punched tape sprocket advancing a row</p>
+    </header>
+
+    <section class="ease-punched-tape-sprocket" data-demo="punched-tape-sprocket" aria-live="polite">
+      <div class="ease-punched-tape-sprocket__housing">
+        <div class="ease-punched-tape-sprocket__bezel">
+          <div class="ease-punched-tape-sprocket__face">
+            <div class="ease-punched-tape-sprocket__readout">
+              <span class="ease-punched-tape-sprocket__label">Punched Tape Sprocket</span>
+              <span class="ease-punched-tape-sprocket__value">LIVE</span>
+            </div>
+            <div class="ease-punched-tape-sprocket__motion" aria-hidden="true">
+              <span class="ease-punched-tape-sprocket__a"></span>
+              <span class="ease-punched-tape-sprocket__b"></span>
+              <span class="ease-punched-tape-sprocket__c"></span>
+              <span class="ease-punched-tape-sprocket__d"></span>
+            </div>
+            <div class="ease-punched-tape-sprocket__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-punched-tape-sprocket__controls">
+          <button type="button" class="ease-punched-tape-sprocket__btn primary">Feed</button>
+          <button type="button" class="ease-punched-tape-sprocket__btn">Stop</button>
+          <label class="ease-punched-tape-sprocket__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-punched-tape-sprocket__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/punched-tape-sprocket-ns/style.css
+++ b/submissions/examples/punched-tape-sprocket-ns/style.css
@@ -1,0 +1,224 @@
+/* Punched Tape Sprocket motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeeee7;
+  font-family: Georgia, "Times New Roman", serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #5874e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #b989f0 18%, transparent), transparent 42%),
+    #1d200e;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-punched-tape-sprocket {
+  --accent: #5874e4;
+  --accent-2: #b989f0;
+  --panel: color-mix(in srgb, #eeeee7 7%, #1d200e);
+  --line: color-mix(in srgb, #eeeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1d200e 75%, #000);
+}
+
+.ease-punched-tape-sprocket__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-punched-tape-sprocket__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1d200e 90%, #5874e4);
+}
+
+.ease-punched-tape-sprocket__face {
+  position: relative;
+  min-height: 258px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1d200e 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-punched-tape-sprocket__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-punched-tape-sprocket__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-punched-tape-sprocket__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-punched-tape-sprocket__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-punched-tape-sprocket__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-punched-tape-sprocket__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: punched_tape_sprocket_meter 4.56s linear infinite;
+}
+
+.ease-punched-tape-sprocket__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-punched-tape-sprocket__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-punched-tape-sprocket__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-punched-tape-sprocket__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-punched-tape-sprocket__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-punched-tape-sprocket__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-punched-tape-sprocket__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-punched-tape-sprocket__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-punched-tape-sprocket__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-punched-tape-sprocket__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: punched_tape_sprocket_status 3.19s ease-out infinite;
+}
+
+@keyframes punched_tape_sprocket_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes punched_tape_sprocket_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-punched-tape-sprocket__a{position:absolute;left:50%;top:18%;width:4px;height:38%;background:var(--accent);transform-origin:50% 100%;animation:punched_tape_sprocket_needle 4.56s ease-in-out infinite}
+.ease-punched-tape-sprocket__b{position:absolute;inset:42%;border-radius:50%;background:var(--accent-2)}
+.ease-punched-tape-sprocket__c{position:absolute;inset:22%;border-radius:50%;border:1px solid color-mix(in srgb,var(--accent) 40%,transparent)}
+.ease-punched-tape-sprocket__d{position:absolute;left:16%;right:16%;bottom:16%;height:4px;background:conic-gradient(from 180deg,var(--accent),transparent);opacity:.5}
+@keyframes punched_tape_sprocket_needle{0%{transform:translateX(-2px) rotate(-70deg)}50%{transform:translateX(-2px) rotate(70deg)}100%{transform:translateX(-2px) rotate(-70deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-punched-tape-sprocket__a,
+  .ease-punched-tape-sprocket__b,
+  .ease-punched-tape-sprocket__c,
+  .ease-punched-tape-sprocket__d,
+  .ease-punched-tape-sprocket__meters i::after,
+  .ease-punched-tape-sprocket__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-punched-tape-sprocket` CSS-only demo for #77682.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Punched tape sprocket advancing a row

**How does a developer use it?**

```html
<section class="ease-punched-tape-sprocket">
  <div class="ease-punched-tape-sprocket__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/punched-tape-sprocket-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77682
