### PR TITLE
feat: add ease-tabulator-stop-hit (#77687)

### DIFF
--- a/submissions/examples/tabulator-stop-hit-ns/README.md
+++ b/submissions/examples/tabulator-stop-hit-ns/README.md
@@ -1,0 +1,16 @@
+# Tabulator Stop Hit
+
+## What does this do?
+Renders a self-contained CSS-only `ease-tabulator-stop-hit` demo: Tabulator stop catching the carriage.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-tabulator-stop-hit`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-tabulator-stop-hit">
+  <div class="ease-tabulator-stop-hit__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/tabulator-stop-hit-ns/demo.html
+++ b/submissions/examples/tabulator-stop-hit-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tabulator Stop Hit — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Tabulator Stop Hit demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Tabulator Stop Hit</h1>
+      <p class="lede">Tabulator stop catching the carriage</p>
+    </header>
+
+    <section class="ease-tabulator-stop-hit" data-demo="tabulator-stop-hit" aria-live="polite">
+      <div class="ease-tabulator-stop-hit__housing">
+        <div class="ease-tabulator-stop-hit__bezel">
+          <div class="ease-tabulator-stop-hit__face">
+            <div class="ease-tabulator-stop-hit__readout">
+              <span class="ease-tabulator-stop-hit__label">Tabulator Stop Hit</span>
+              <span class="ease-tabulator-stop-hit__value">LIVE</span>
+            </div>
+            <div class="ease-tabulator-stop-hit__motion" aria-hidden="true">
+              <span class="ease-tabulator-stop-hit__a"></span>
+              <span class="ease-tabulator-stop-hit__b"></span>
+              <span class="ease-tabulator-stop-hit__c"></span>
+              <span class="ease-tabulator-stop-hit__d"></span>
+            </div>
+            <div class="ease-tabulator-stop-hit__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-tabulator-stop-hit__controls">
+          <button type="button" class="ease-tabulator-stop-hit__btn primary">Tab</button>
+          <button type="button" class="ease-tabulator-stop-hit__btn">Clear</button>
+          <label class="ease-tabulator-stop-hit__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-tabulator-stop-hit__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tabulator-stop-hit-ns/style.css
+++ b/submissions/examples/tabulator-stop-hit-ns/style.css
@@ -1,0 +1,227 @@
+/* Tabulator Stop Hit motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7eeeb;
+  font-family: "Source Serif 4", Georgia, serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #e458b3 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #f09089 18%, transparent), transparent 42%),
+    #0b1914;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-tabulator-stop-hit {
+  --accent: #e458b3;
+  --accent-2: #f09089;
+  --panel: color-mix(in srgb, #e7eeeb 7%, #0b1914);
+  --line: color-mix(in srgb, #e7eeeb 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 11px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0b1914 75%, #000);
+}
+
+.ease-tabulator-stop-hit__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-tabulator-stop-hit__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7eeeb 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0b1914 90%, #e458b3);
+}
+
+.ease-tabulator-stop-hit__face {
+  position: relative;
+  min-height: 231px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0b1914 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-tabulator-stop-hit__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-tabulator-stop-hit__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-tabulator-stop-hit__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-tabulator-stop-hit__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-tabulator-stop-hit__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-tabulator-stop-hit__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: tabulator_stop_hit_meter 3.0s linear infinite;
+}
+
+.ease-tabulator-stop-hit__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-tabulator-stop-hit__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-tabulator-stop-hit__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-tabulator-stop-hit__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-tabulator-stop-hit__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-tabulator-stop-hit__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-tabulator-stop-hit__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7eeeb 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-tabulator-stop-hit__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-tabulator-stop-hit__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-tabulator-stop-hit__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-tabulator-stop-hit__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: tabulator_stop_hit_status 2.10s ease-out infinite;
+}
+
+@keyframes tabulator_stop_hit_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes tabulator_stop_hit_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-tabulator-stop-hit__a{position:absolute;left:10%;right:10%;top:46%;height:10px;border-radius:999px;background:color-mix(in srgb,var(--accent) 22%,transparent);overflow:hidden}
+.ease-tabulator-stop-hit__a::after{content:"";position:absolute;inset:0 auto 0 0;width:28%;background:var(--accent);animation:tabulator_stop_hit_shuttle 3.0s ease-in-out infinite}
+.ease-tabulator-stop-hit__b{position:absolute;left:8%;right:8%;top:58%;height:2px;background:repeating-linear-gradient(90deg,var(--accent-2) 0 4px,transparent 4px 10px);opacity:.4}
+.ease-tabulator-stop-hit__c{position:absolute;top:22%;left:18%;width:14px;height:14px;border-radius:3px;background:var(--accent-2);animation:tabulator_stop_hit_bob 3.0s ease-in-out infinite}
+.ease-tabulator-stop-hit__d{position:absolute;bottom:18%;right:16%;width:9px;height:9px;border-radius:50%;background:var(--accent);opacity:.7}
+@keyframes tabulator_stop_hit_shuttle{0%{transform:translateX(0)}50%{transform:translateX(240%)}100%{transform:translateX(0)}}
+@keyframes tabulator_stop_hit_bob{0%,100%{transform:translateY(0)}50%{transform:translateY(18px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabulator-stop-hit__a,
+  .ease-tabulator-stop-hit__b,
+  .ease-tabulator-stop-hit__c,
+  .ease-tabulator-stop-hit__d,
+  .ease-tabulator-stop-hit__meters i::after,
+  .ease-tabulator-stop-hit__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-tabulator-stop-hit` CSS-only demo for #77687.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Tabulator stop catching the carriage

**How does a developer use it?**

```html
<section class="ease-tabulator-stop-hit">
  <div class="ease-tabulator-stop-hit__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/tabulator-stop-hit-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77687
