### PR TITLE
feat: add ease-margin-bell-ring (#77688)

### DIFF
--- a/submissions/examples/margin-bell-ring-ns/README.md
+++ b/submissions/examples/margin-bell-ring-ns/README.md
@@ -1,0 +1,16 @@
+# Margin Bell Ring
+
+## What does this do?
+Renders a self-contained CSS-only `ease-margin-bell-ring` demo: Margin bell ringing before the line end.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-margin-bell-ring`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-margin-bell-ring">
+  <div class="ease-margin-bell-ring__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/margin-bell-ring-ns/demo.html
+++ b/submissions/examples/margin-bell-ring-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Margin Bell Ring — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Margin Bell Ring demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Margin Bell Ring</h1>
+      <p class="lede">Margin bell ringing before the line end</p>
+    </header>
+
+    <section class="ease-margin-bell-ring" data-demo="margin-bell-ring" aria-live="polite">
+      <div class="ease-margin-bell-ring__housing">
+        <div class="ease-margin-bell-ring__bezel">
+          <div class="ease-margin-bell-ring__face">
+            <div class="ease-margin-bell-ring__readout">
+              <span class="ease-margin-bell-ring__label">Margin Bell Ring</span>
+              <span class="ease-margin-bell-ring__value">LIVE</span>
+            </div>
+            <div class="ease-margin-bell-ring__motion" aria-hidden="true">
+              <span class="ease-margin-bell-ring__a"></span>
+              <span class="ease-margin-bell-ring__b"></span>
+              <span class="ease-margin-bell-ring__c"></span>
+              <span class="ease-margin-bell-ring__d"></span>
+            </div>
+            <div class="ease-margin-bell-ring__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-margin-bell-ring__controls">
+          <button type="button" class="ease-margin-bell-ring__btn primary">Ring</button>
+          <button type="button" class="ease-margin-bell-ring__btn">Mute</button>
+          <label class="ease-margin-bell-ring__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-margin-bell-ring__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/margin-bell-ring-ns/style.css
+++ b/submissions/examples/margin-bell-ring-ns/style.css
@@ -1,0 +1,227 @@
+/* Margin Bell Ring motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7eeed;
+  font-family: "Palatino Linotype", Palatino, serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #e45882 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #f09a89 18%, transparent), transparent 42%),
+    #0d1c1c;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-margin-bell-ring {
+  --accent: #e45882;
+  --accent-2: #f09a89;
+  --panel: color-mix(in srgb, #e7eeed 7%, #0d1c1c);
+  --line: color-mix(in srgb, #e7eeed 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d1c1c 75%, #000);
+}
+
+.ease-margin-bell-ring__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-margin-bell-ring__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7eeed 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d1c1c 90%, #e45882);
+}
+
+.ease-margin-bell-ring__face {
+  position: relative;
+  min-height: 252px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d1c1c 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-margin-bell-ring__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-margin-bell-ring__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-margin-bell-ring__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-margin-bell-ring__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-margin-bell-ring__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-margin-bell-ring__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: margin_bell_ring_meter 3.12s linear infinite;
+}
+
+.ease-margin-bell-ring__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-margin-bell-ring__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-margin-bell-ring__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-margin-bell-ring__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-margin-bell-ring__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-margin-bell-ring__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-margin-bell-ring__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-margin-bell-ring__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7eeed 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-margin-bell-ring__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-margin-bell-ring__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-margin-bell-ring__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-margin-bell-ring__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: margin_bell_ring_status 2.18s ease-out infinite;
+}
+
+@keyframes margin_bell_ring_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes margin_bell_ring_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-margin-bell-ring__a{position:absolute;left:50%;top:18%;width:4px;height:46%;background:linear-gradient(var(--accent),transparent);transform-origin:50% 0;animation:margin_bell_ring_pend 3.12s ease-in-out infinite}
+.ease-margin-bell-ring__b{position:absolute;left:calc(50% - 9px);top:58%;width:18px;height:18px;border-radius:50%;background:var(--accent-2);animation:margin_bell_ring_bob 3.12s ease-in-out infinite}
+.ease-margin-bell-ring__c{position:absolute;left:22%;right:22%;top:16%;height:2px;background:var(--accent);opacity:.35}
+.ease-margin-bell-ring__d{position:absolute;inset:28%;border:1px dashed color-mix(in srgb,var(--accent) 40%,transparent);border-radius:50%;opacity:.5}
+@keyframes margin_bell_ring_pend{0%{transform:rotate(-28deg)}50%{transform:rotate(28deg)}100%{transform:rotate(-28deg)}}
+@keyframes margin_bell_ring_bob{0%{transform:translateX(-34px)}50%{transform:translateX(34px)}100%{transform:translateX(-34px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-margin-bell-ring__a,
+  .ease-margin-bell-ring__b,
+  .ease-margin-bell-ring__c,
+  .ease-margin-bell-ring__d,
+  .ease-margin-bell-ring__meters i::after,
+  .ease-margin-bell-ring__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-margin-bell-ring` CSS-only demo for #77688.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Margin bell ringing before the line end

**How does a developer use it?**

```html
<section class="ease-margin-bell-ring">
  <div class="ease-margin-bell-ring__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/margin-bell-ring-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77688
