### PR TITLE
feat: add ease-type-guide-align (#77690)

### DIFF
--- a/submissions/examples/type-guide-align-ns/README.md
+++ b/submissions/examples/type-guide-align-ns/README.md
@@ -1,0 +1,16 @@
+# Type Guide Align
+
+## What does this do?
+Renders a self-contained CSS-only `ease-type-guide-align` demo: Type guide aligning the print point.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-type-guide-align`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-type-guide-align">
+  <div class="ease-type-guide-align__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/type-guide-align-ns/demo.html
+++ b/submissions/examples/type-guide-align-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Type Guide Align — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Type Guide Align demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Type Guide Align</h1>
+      <p class="lede">Type guide aligning the print point</p>
+    </header>
+
+    <section class="ease-type-guide-align" data-demo="type-guide-align" aria-live="polite">
+      <div class="ease-type-guide-align__housing">
+        <div class="ease-type-guide-align__bezel">
+          <div class="ease-type-guide-align__face">
+            <div class="ease-type-guide-align__readout">
+              <span class="ease-type-guide-align__label">Type Guide Align</span>
+              <span class="ease-type-guide-align__value">LIVE</span>
+            </div>
+            <div class="ease-type-guide-align__motion" aria-hidden="true">
+              <span class="ease-type-guide-align__a"></span>
+              <span class="ease-type-guide-align__b"></span>
+              <span class="ease-type-guide-align__c"></span>
+              <span class="ease-type-guide-align__d"></span>
+            </div>
+            <div class="ease-type-guide-align__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-type-guide-align__controls">
+          <button type="button" class="ease-type-guide-align__btn primary">Align</button>
+          <button type="button" class="ease-type-guide-align__btn">Idle</button>
+          <label class="ease-type-guide-align__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-type-guide-align__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/type-guide-align-ns/style.css
+++ b/submissions/examples/type-guide-align-ns/style.css
@@ -1,0 +1,225 @@
+/* stage: type-guide-align */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeeae7;
+  font-family: "Franklin Gothic Medium", "Arial Narrow", sans-serif;
+  background:
+    radial-gradient(ellipse at 40% 100%, color-mix(in srgb, #58b8e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 80% 20%, color-mix(in srgb, #899ef0 18%, transparent), transparent 42%),
+    #231c10;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-type-guide-align {
+  --accent: #58b8e4;
+  --accent-2: #899ef0;
+  --panel: color-mix(in srgb, #eeeae7 7%, #231c10);
+  --line: color-mix(in srgb, #eeeae7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 17px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #231c10 75%, #000);
+}
+
+.ease-type-guide-align__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-type-guide-align__bezel {
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeeae7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #231c10 90%, #58b8e4);
+}
+
+.ease-type-guide-align__face {
+  position: relative;
+  min-height: 269px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #231c10 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-type-guide-align__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-type-guide-align__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-type-guide-align__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-type-guide-align__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-type-guide-align__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-type-guide-align__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: type_guide_align_meter 3.48s linear infinite;
+}
+
+.ease-type-guide-align__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-type-guide-align__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-type-guide-align__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-type-guide-align__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-type-guide-align__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-type-guide-align__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+.ease-type-guide-align__meters i:nth-child(8)::after { animation-delay: 0.64s; }
+
+.ease-type-guide-align__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-type-guide-align__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeeae7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-type-guide-align__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-type-guide-align__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-type-guide-align__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-type-guide-align__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: type_guide_align_status 2.44s ease-out infinite;
+}
+
+@keyframes type_guide_align_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes type_guide_align_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-type-guide-align__a{position:absolute;left:20%;right:20%;top:38%;height:16px;border-radius:8px;background:color-mix(in srgb,var(--accent) 20%,transparent);overflow:hidden}
+.ease-type-guide-align__a::after{content:"";position:absolute;inset:2px auto 2px 2px;width:24%;border-radius:6px;background:var(--accent);animation:type_guide_align_fill 3.48s ease-in-out infinite}
+.ease-type-guide-align__b{position:absolute;left:22%;top:22%;width:10px;height:10px;border-radius:2px;background:var(--accent-2);animation:type_guide_align_tick 3.48s steps(6) infinite}
+.ease-type-guide-align__c{position:absolute;right:22%;top:22%;width:10px;height:10px;border-radius:2px;background:var(--accent);animation:type_guide_align_tick 3.48s steps(6) infinite reverse}
+.ease-type-guide-align__d{position:absolute;left:18%;right:18%;bottom:18%;height:2px;background:var(--accent);opacity:.35}
+@keyframes type_guide_align_fill{0%{width:18%}50%{width:78%}100%{width:18%}}
+@keyframes type_guide_align_tick{to{transform:translateX(28px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-type-guide-align__a,
+  .ease-type-guide-align__b,
+  .ease-type-guide-align__c,
+  .ease-type-guide-align__d,
+  .ease-type-guide-align__meters i::after,
+  .ease-type-guide-align__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-type-guide-align` CSS-only demo for #77690.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Type guide aligning the print point

**How does a developer use it?**

```html
<section class="ease-type-guide-align">
  <div class="ease-type-guide-align__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/type-guide-align-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77690
