### PR TITLE
feat: add ease-dead-key-hold (#77691)

### DIFF
--- a/submissions/examples/dead-key-hold-ns/README.md
+++ b/submissions/examples/dead-key-hold-ns/README.md
@@ -1,0 +1,16 @@
+# Dead Key Hold
+
+## What does this do?
+Renders a self-contained CSS-only `ease-dead-key-hold` demo: Dead key holding for an accent.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-dead-key-hold`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-dead-key-hold">
+  <div class="ease-dead-key-hold__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/dead-key-hold-ns/demo.html
+++ b/submissions/examples/dead-key-hold-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dead Key Hold — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Dead Key Hold demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Dead Key Hold</h1>
+      <p class="lede">Dead key holding for an accent</p>
+    </header>
+
+    <section class="ease-dead-key-hold" data-demo="dead-key-hold" aria-live="polite">
+      <div class="ease-dead-key-hold__housing">
+        <div class="ease-dead-key-hold__bezel">
+          <div class="ease-dead-key-hold__face">
+            <div class="ease-dead-key-hold__readout">
+              <span class="ease-dead-key-hold__label">Dead Key Hold</span>
+              <span class="ease-dead-key-hold__value">LIVE</span>
+            </div>
+            <div class="ease-dead-key-hold__motion" aria-hidden="true">
+              <span class="ease-dead-key-hold__a"></span>
+              <span class="ease-dead-key-hold__b"></span>
+              <span class="ease-dead-key-hold__c"></span>
+              <span class="ease-dead-key-hold__d"></span>
+            </div>
+            <div class="ease-dead-key-hold__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-dead-key-hold__controls">
+          <button type="button" class="ease-dead-key-hold__btn primary">Hold</button>
+          <button type="button" class="ease-dead-key-hold__btn">Release</button>
+          <label class="ease-dead-key-hold__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-dead-key-hold__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dead-key-hold-ns/style.css
+++ b/submissions/examples/dead-key-hold-ns/style.css
@@ -1,0 +1,222 @@
+/* stage: dead-key-hold */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeece7;
+  font-family: "Gill Sans", "Gill Sans MT", sans-serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #5895e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #a889f0 18%, transparent), transparent 42%),
+    #232110;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-dead-key-hold {
+  --accent: #5895e4;
+  --accent-2: #a889f0;
+  --panel: color-mix(in srgb, #eeece7 7%, #232110);
+  --line: color-mix(in srgb, #eeece7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #232110 75%, #000);
+}
+
+.ease-dead-key-hold__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-dead-key-hold__bezel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeece7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #232110 90%, #5895e4);
+}
+
+.ease-dead-key-hold__face {
+  position: relative;
+  min-height: 244px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #232110 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-dead-key-hold__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-dead-key-hold__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-dead-key-hold__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-dead-key-hold__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-dead-key-hold__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-dead-key-hold__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: dead_key_hold_meter 2.4s linear infinite;
+}
+
+.ease-dead-key-hold__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-dead-key-hold__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-dead-key-hold__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-dead-key-hold__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-dead-key-hold__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-dead-key-hold__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-dead-key-hold__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-dead-key-hold__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeece7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-dead-key-hold__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-dead-key-hold__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-dead-key-hold__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-dead-key-hold__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dead_key_hold_status 1.68s ease-out infinite;
+}
+
+@keyframes dead_key_hold_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes dead_key_hold_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-dead-key-hold__a{position:absolute;inset:22%;border-radius:50%;border:2px solid var(--accent);animation:dead_key_hold_spiral 2.4s linear infinite}
+.ease-dead-key-hold__b{position:absolute;inset:34%;border-radius:50%;border:2px solid var(--accent-2);animation:dead_key_hold_spiral 2.4s linear infinite reverse}
+.ease-dead-key-hold__c{position:absolute;left:48%;top:20%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:dead_key_hold_spiral 2.4s linear infinite}
+.ease-dead-key-hold__d{position:absolute;inset:46%;border-radius:50%;background:var(--accent-2)}
+@keyframes dead_key_hold_spiral{0%{transform:rotate(0deg) scale(.7)}100%{transform:rotate(360deg) scale(1.15)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dead-key-hold__a,
+  .ease-dead-key-hold__b,
+  .ease-dead-key-hold__c,
+  .ease-dead-key-hold__d,
+  .ease-dead-key-hold__meters i::after,
+  .ease-dead-key-hold__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-dead-key-hold` CSS-only demo for #77691.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Dead key holding for an accent

**How does a developer use it?**

```html
<section class="ease-dead-key-hold">
  <div class="ease-dead-key-hold__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/dead-key-hold-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77691
