### PR TITLE
feat: add ease-dimple-pin-stack (#77700)

### DIFF
--- a/submissions/examples/dimple-pin-stack-ns/README.md
+++ b/submissions/examples/dimple-pin-stack-ns/README.md
@@ -1,0 +1,16 @@
+# Dimple Pin Stack
+
+## What does this do?
+Renders a self-contained CSS-only `ease-dimple-pin-stack` demo: Dimple pin stack reaching shear.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-dimple-pin-stack`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-dimple-pin-stack">
+  <div class="ease-dimple-pin-stack__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/dimple-pin-stack-ns/demo.html
+++ b/submissions/examples/dimple-pin-stack-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dimple Pin Stack — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Dimple Pin Stack demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Dimple Pin Stack</h1>
+      <p class="lede">Dimple pin stack reaching shear</p>
+    </header>
+
+    <section class="ease-dimple-pin-stack" data-demo="dimple-pin-stack" aria-live="polite">
+      <div class="ease-dimple-pin-stack__housing">
+        <div class="ease-dimple-pin-stack__bezel">
+          <div class="ease-dimple-pin-stack__face">
+            <div class="ease-dimple-pin-stack__readout">
+              <span class="ease-dimple-pin-stack__label">Dimple Pin Stack</span>
+              <span class="ease-dimple-pin-stack__value">LIVE</span>
+            </div>
+            <div class="ease-dimple-pin-stack__motion" aria-hidden="true">
+              <span class="ease-dimple-pin-stack__a"></span>
+              <span class="ease-dimple-pin-stack__b"></span>
+              <span class="ease-dimple-pin-stack__c"></span>
+              <span class="ease-dimple-pin-stack__d"></span>
+            </div>
+            <div class="ease-dimple-pin-stack__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-dimple-pin-stack__controls">
+          <button type="button" class="ease-dimple-pin-stack__btn primary">Set</button>
+          <button type="button" class="ease-dimple-pin-stack__btn">Drop</button>
+          <label class="ease-dimple-pin-stack__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-dimple-pin-stack__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dimple-pin-stack-ns/style.css
+++ b/submissions/examples/dimple-pin-stack-ns/style.css
@@ -1,0 +1,224 @@
+html { color-scheme: dark; }
+/* dimple-pin-stack */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #edeee7;
+  font-family: "Palatino Linotype", Palatino, serif;
+  background:
+    radial-gradient(ellipse at 70% 0%, color-mix(in srgb, #5d58e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 12% 100%, color-mix(in srgb, #ca89f0 18%, transparent), transparent 42%),
+    #161c0d;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-dimple-pin-stack {
+  --accent: #5d58e4;
+  --accent-2: #ca89f0;
+  --panel: color-mix(in srgb, #edeee7 7%, #161c0d);
+  --line: color-mix(in srgb, #edeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #161c0d 75%, #000);
+}
+
+.ease-dimple-pin-stack__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-dimple-pin-stack__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #edeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #161c0d 90%, #5d58e4);
+}
+
+.ease-dimple-pin-stack__face {
+  position: relative;
+  min-height: 232px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #161c0d 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-dimple-pin-stack__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-dimple-pin-stack__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-dimple-pin-stack__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-dimple-pin-stack__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-dimple-pin-stack__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-dimple-pin-stack__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: dimple_pin_stack_meter 3.12s linear infinite;
+}
+
+.ease-dimple-pin-stack__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-dimple-pin-stack__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-dimple-pin-stack__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-dimple-pin-stack__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-dimple-pin-stack__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-dimple-pin-stack__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+
+.ease-dimple-pin-stack__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-dimple-pin-stack__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #edeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-dimple-pin-stack__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-dimple-pin-stack__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-dimple-pin-stack__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-dimple-pin-stack__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: dimple_pin_stack_status 2.18s ease-out infinite;
+}
+
+@keyframes dimple_pin_stack_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes dimple_pin_stack_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-dimple-pin-stack__a{position:absolute;left:50%;top:18%;width:4px;height:46%;background:linear-gradient(var(--accent),transparent);transform-origin:50% 0;animation:dimple_pin_stack_pend 3.12s ease-in-out infinite}
+.ease-dimple-pin-stack__b{position:absolute;left:calc(50% - 9px);top:58%;width:18px;height:18px;border-radius:50%;background:var(--accent-2);animation:dimple_pin_stack_bob 3.12s ease-in-out infinite}
+.ease-dimple-pin-stack__c{position:absolute;left:22%;right:22%;top:16%;height:2px;background:var(--accent);opacity:.35}
+.ease-dimple-pin-stack__d{position:absolute;inset:28%;border:1px dashed color-mix(in srgb,var(--accent) 40%,transparent);border-radius:50%;opacity:.5}
+@keyframes dimple_pin_stack_pend{0%{transform:rotate(-28deg)}50%{transform:rotate(28deg)}100%{transform:rotate(-28deg)}}
+@keyframes dimple_pin_stack_bob{0%{transform:translateX(-34px)}50%{transform:translateX(34px)}100%{transform:translateX(-34px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-dimple-pin-stack__a,
+  .ease-dimple-pin-stack__b,
+  .ease-dimple-pin-stack__c,
+  .ease-dimple-pin-stack__d,
+  .ease-dimple-pin-stack__meters i::after,
+  .ease-dimple-pin-stack__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-dimple-pin-stack` CSS-only demo for #77700.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Dimple pin stack reaching shear

**How does a developer use it?**

```html
<section class="ease-dimple-pin-stack">
  <div class="ease-dimple-pin-stack__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/dimple-pin-stack-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77700
