### PR TITLE
feat: add ease-padlock-shackle-clear (#77703)

### DIFF
--- a/submissions/examples/padlock-shackle-clear-ns/README.md
+++ b/submissions/examples/padlock-shackle-clear-ns/README.md
@@ -1,0 +1,16 @@
+# Padlock Shackle Clear
+
+## What does this do?
+Renders a self-contained CSS-only `ease-padlock-shackle-clear` demo: Padlock shackle clearing the body.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-padlock-shackle-clear`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-padlock-shackle-clear">
+  <div class="ease-padlock-shackle-clear__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/padlock-shackle-clear-ns/demo.html
+++ b/submissions/examples/padlock-shackle-clear-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Padlock Shackle Clear — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Padlock Shackle Clear demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Padlock Shackle Clear</h1>
+      <p class="lede">Padlock shackle clearing the body</p>
+    </header>
+
+    <section class="ease-padlock-shackle-clear" data-demo="padlock-shackle-clear" aria-live="polite">
+      <div class="ease-padlock-shackle-clear__housing">
+        <div class="ease-padlock-shackle-clear__bezel">
+          <div class="ease-padlock-shackle-clear__face">
+            <div class="ease-padlock-shackle-clear__readout">
+              <span class="ease-padlock-shackle-clear__label">Padlock Shackle Clear</span>
+              <span class="ease-padlock-shackle-clear__value">LIVE</span>
+            </div>
+            <div class="ease-padlock-shackle-clear__motion" aria-hidden="true">
+              <span class="ease-padlock-shackle-clear__a"></span>
+              <span class="ease-padlock-shackle-clear__b"></span>
+              <span class="ease-padlock-shackle-clear__c"></span>
+              <span class="ease-padlock-shackle-clear__d"></span>
+            </div>
+            <div class="ease-padlock-shackle-clear__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-padlock-shackle-clear__controls">
+          <button type="button" class="ease-padlock-shackle-clear__btn primary">Open</button>
+          <button type="button" class="ease-padlock-shackle-clear__btn">Snap</button>
+          <label class="ease-padlock-shackle-clear__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-padlock-shackle-clear__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/padlock-shackle-clear-ns/style.css
+++ b/submissions/examples/padlock-shackle-clear-ns/style.css
@@ -1,0 +1,223 @@
+html { color-scheme: dark; }
+/* padlock-shackle-clear */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eeece7;
+  font-family: "Franklin Gothic Medium", "Arial Narrow", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #58a0e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #9789f0 18%, transparent), transparent 42%),
+    #232010;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-padlock-shackle-clear {
+  --accent: #58a0e4;
+  --accent-2: #9789f0;
+  --panel: color-mix(in srgb, #eeece7 7%, #232010);
+  --line: color-mix(in srgb, #eeece7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 11px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #232010 75%, #000);
+}
+
+.ease-padlock-shackle-clear__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-padlock-shackle-clear__bezel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eeece7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #232010 90%, #58a0e4);
+}
+
+.ease-padlock-shackle-clear__face {
+  position: relative;
+  min-height: 239px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #232010 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-padlock-shackle-clear__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-padlock-shackle-clear__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-padlock-shackle-clear__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-padlock-shackle-clear__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-padlock-shackle-clear__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-padlock-shackle-clear__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: padlock_shackle_clear_meter 4.92s linear infinite;
+}
+
+.ease-padlock-shackle-clear__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-padlock-shackle-clear__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-padlock-shackle-clear__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-padlock-shackle-clear__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-padlock-shackle-clear__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-padlock-shackle-clear__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-padlock-shackle-clear__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eeece7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-padlock-shackle-clear__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-padlock-shackle-clear__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-padlock-shackle-clear__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-padlock-shackle-clear__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: padlock_shackle_clear_status 3.44s ease-out infinite;
+}
+
+@keyframes padlock_shackle_clear_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes padlock_shackle_clear_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-padlock-shackle-clear__a{position:absolute;inset:20%;border-radius:50%;border:2px solid var(--accent);animation:padlock_shackle_clear_cw 4.92s linear infinite}
+.ease-padlock-shackle-clear__b{position:absolute;inset:32%;border-radius:50%;border:2px dashed var(--accent-2);animation:padlock_shackle_clear_ccw 4.92s linear infinite}
+.ease-padlock-shackle-clear__c{position:absolute;inset:44%;border-radius:50%;background:var(--accent);opacity:.45}
+.ease-padlock-shackle-clear__d{position:absolute;left:49%;top:12%;width:6px;height:6px;border-radius:50%;background:var(--accent-2);animation:padlock_shackle_clear_cw 4.92s linear infinite}
+@keyframes padlock_shackle_clear_cw{to{transform:rotate(360deg)}}
+@keyframes padlock_shackle_clear_ccw{to{transform:rotate(-360deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-padlock-shackle-clear__a,
+  .ease-padlock-shackle-clear__b,
+  .ease-padlock-shackle-clear__c,
+  .ease-padlock-shackle-clear__d,
+  .ease-padlock-shackle-clear__meters i::after,
+  .ease-padlock-shackle-clear__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-padlock-shackle-clear` CSS-only demo for #77703.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Padlock shackle clearing the body

**How does a developer use it?**

```html
<section class="ease-padlock-shackle-clear">
  <div class="ease-padlock-shackle-clear__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/padlock-shackle-clear-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77703
