### PR TITLE
feat: add ease-stamp-mill-cam (#77705)

### DIFF
--- a/submissions/examples/stamp-mill-cam-ns/README.md
+++ b/submissions/examples/stamp-mill-cam-ns/README.md
@@ -1,0 +1,16 @@
+# Stamp Mill Cam
+
+## What does this do?
+Renders a self-contained CSS-only `ease-stamp-mill-cam` demo: Stamp mill cam lifting the stamp head.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-stamp-mill-cam`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-stamp-mill-cam">
+  <div class="ease-stamp-mill-cam__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/stamp-mill-cam-ns/demo.html
+++ b/submissions/examples/stamp-mill-cam-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stamp Mill Cam — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Stamp Mill Cam demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Stamp Mill Cam</h1>
+      <p class="lede">Stamp mill cam lifting the stamp head</p>
+    </header>
+
+    <section class="ease-stamp-mill-cam" data-demo="stamp-mill-cam" aria-live="polite">
+      <div class="ease-stamp-mill-cam__housing">
+        <div class="ease-stamp-mill-cam__bezel">
+          <div class="ease-stamp-mill-cam__face">
+            <div class="ease-stamp-mill-cam__readout">
+              <span class="ease-stamp-mill-cam__label">Stamp Mill Cam</span>
+              <span class="ease-stamp-mill-cam__value">LIVE</span>
+            </div>
+            <div class="ease-stamp-mill-cam__motion" aria-hidden="true">
+              <span class="ease-stamp-mill-cam__a"></span>
+              <span class="ease-stamp-mill-cam__b"></span>
+              <span class="ease-stamp-mill-cam__c"></span>
+              <span class="ease-stamp-mill-cam__d"></span>
+            </div>
+            <div class="ease-stamp-mill-cam__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-stamp-mill-cam__controls">
+          <button type="button" class="ease-stamp-mill-cam__btn primary">Lift</button>
+          <button type="button" class="ease-stamp-mill-cam__btn">Drop</button>
+          <label class="ease-stamp-mill-cam__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-stamp-mill-cam__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/stamp-mill-cam-ns/style.css
+++ b/submissions/examples/stamp-mill-cam-ns/style.css
@@ -1,0 +1,222 @@
+html { color-scheme: dark; }
+/* stamp-mill-cam */
+* { box-sizing: border-box; }
+*::before, *::after { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e7eeea;
+  font-family: "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+  background:
+    radial-gradient(ellipse at 8% 12%, color-mix(in srgb, #e458bc 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 100% 80%, color-mix(in srgb, #f08990 18%, transparent), transparent 42%),
+    #0d1c16;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-stamp-mill-cam {
+  --accent: #e458bc;
+  --accent-2: #f08990;
+  --panel: color-mix(in srgb, #e7eeea 7%, #0d1c16);
+  --line: color-mix(in srgb, #e7eeea 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 15px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d1c16 75%, #000);
+}
+
+.ease-stamp-mill-cam__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-stamp-mill-cam__bezel {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e7eeea 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d1c16 90%, #e458bc);
+}
+
+.ease-stamp-mill-cam__face {
+  position: relative;
+  min-height: 267px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d1c16 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-stamp-mill-cam__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-stamp-mill-cam__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-stamp-mill-cam__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-stamp-mill-cam__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-stamp-mill-cam__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-stamp-mill-cam__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: stamp_mill_cam_meter 3.96s linear infinite;
+}
+
+.ease-stamp-mill-cam__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-stamp-mill-cam__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-stamp-mill-cam__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-stamp-mill-cam__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-stamp-mill-cam__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+
+.ease-stamp-mill-cam__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-stamp-mill-cam__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e7eeea 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-stamp-mill-cam__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-stamp-mill-cam__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-stamp-mill-cam__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-stamp-mill-cam__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: stamp_mill_cam_status 2.77s ease-out infinite;
+}
+
+@keyframes stamp_mill_cam_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes stamp_mill_cam_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-stamp-mill-cam__a{position:absolute;left:28%;right:28%;top:28%;bottom:28%;border-radius:10px;background:var(--accent);animation:stamp_mill_cam_stamp 3.96s cubic-bezier(.2,.8,.2,1) infinite}
+.ease-stamp-mill-cam__b{position:absolute;left:22%;right:22%;bottom:16%;height:8px;border-radius:4px;background:color-mix(in srgb,var(--accent-2) 40%,transparent)}
+.ease-stamp-mill-cam__c{position:absolute;left:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent-2)}
+.ease-stamp-mill-cam__d{position:absolute;right:18%;top:18%;width:12px;height:12px;border:2px solid var(--accent)}
+@keyframes stamp_mill_cam_stamp{0%,100%{transform:scale(1) translateY(0)}40%{transform:scale(.72) translateY(18px)}55%{transform:scale(1.06) translateY(0)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stamp-mill-cam__a,
+  .ease-stamp-mill-cam__b,
+  .ease-stamp-mill-cam__c,
+  .ease-stamp-mill-cam__d,
+  .ease-stamp-mill-cam__meters i::after,
+  .ease-stamp-mill-cam__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-stamp-mill-cam` CSS-only demo for #77705.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Stamp mill cam lifting the stamp head

**How does a developer use it?**

```html
<section class="ease-stamp-mill-cam">
  <div class="ease-stamp-mill-cam__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/stamp-mill-cam-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77705
