### PR TITLE
feat: add ease-wilfley-table-riffle (#77709)

### DIFF
--- a/submissions/examples/wilfley-table-riffle-ns/README.md
+++ b/submissions/examples/wilfley-table-riffle-ns/README.md
@@ -1,0 +1,16 @@
+# Wilfley Table Riffle
+
+## What does this do?
+Renders a self-contained CSS-only `ease-wilfley-table-riffle` demo: Wilfley table riffles walking concentrate.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-wilfley-table-riffle`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-wilfley-table-riffle">
+  <div class="ease-wilfley-table-riffle__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/wilfley-table-riffle-ns/demo.html
+++ b/submissions/examples/wilfley-table-riffle-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wilfley Table Riffle — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Wilfley Table Riffle demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Wilfley Table Riffle</h1>
+      <p class="lede">Wilfley table riffles walking concentrate</p>
+    </header>
+
+    <section class="ease-wilfley-table-riffle" data-demo="wilfley-table-riffle" aria-live="polite">
+      <div class="ease-wilfley-table-riffle__housing">
+        <div class="ease-wilfley-table-riffle__bezel">
+          <div class="ease-wilfley-table-riffle__face">
+            <div class="ease-wilfley-table-riffle__readout">
+              <span class="ease-wilfley-table-riffle__label">Wilfley Table Riffle</span>
+              <span class="ease-wilfley-table-riffle__value">LIVE</span>
+            </div>
+            <div class="ease-wilfley-table-riffle__motion" aria-hidden="true">
+              <span class="ease-wilfley-table-riffle__a"></span>
+              <span class="ease-wilfley-table-riffle__b"></span>
+              <span class="ease-wilfley-table-riffle__c"></span>
+              <span class="ease-wilfley-table-riffle__d"></span>
+            </div>
+            <div class="ease-wilfley-table-riffle__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-wilfley-table-riffle__controls">
+          <button type="button" class="ease-wilfley-table-riffle__btn primary">Stroke</button>
+          <button type="button" class="ease-wilfley-table-riffle__btn">Stop</button>
+          <label class="ease-wilfley-table-riffle__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-wilfley-table-riffle__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/wilfley-table-riffle-ns/style.css
+++ b/submissions/examples/wilfley-table-riffle-ns/style.css
@@ -1,0 +1,226 @@
+/* Wilfley Table Riffle motion stage */
+html { color-scheme: dark; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #eee8e7;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #58e4e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #89c0f0 18%, transparent), transparent 42%),
+    #150d09;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-wilfley-table-riffle {
+  --accent: #58e4e4;
+  --accent-2: #89c0f0;
+  --panel: color-mix(in srgb, #eee8e7 7%, #150d09);
+  --line: color-mix(in srgb, #eee8e7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #150d09 75%, #000);
+}
+
+.ease-wilfley-table-riffle__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-wilfley-table-riffle__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #eee8e7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #150d09 90%, #58e4e4);
+}
+
+.ease-wilfley-table-riffle__face {
+  position: relative;
+  min-height: 250px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #150d09 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-wilfley-table-riffle__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-wilfley-table-riffle__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-wilfley-table-riffle__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-wilfley-table-riffle__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-wilfley-table-riffle__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-wilfley-table-riffle__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: wilfley_table_riffle_meter 4.56s linear infinite;
+}
+
+.ease-wilfley-table-riffle__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-wilfley-table-riffle__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-wilfley-table-riffle__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-wilfley-table-riffle__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-wilfley-table-riffle__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-wilfley-table-riffle__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #eee8e7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-wilfley-table-riffle__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-wilfley-table-riffle__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-wilfley-table-riffle__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-wilfley-table-riffle__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: wilfley_table_riffle_status 3.19s ease-out infinite;
+}
+
+@keyframes wilfley_table_riffle_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes wilfley_table_riffle_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-wilfley-table-riffle__a{position:absolute;inset:16%;border-radius:50%;border:2px solid color-mix(in srgb,var(--accent) 55%,transparent);animation:wilfley_table_riffle_ring 4.56s ease-out infinite}
+.ease-wilfley-table-riffle__b{position:absolute;inset:26%;border-radius:50%;background:radial-gradient(circle,var(--accent-2),transparent 68%);animation:wilfley_table_riffle_core 4.56s ease-in-out infinite}
+.ease-wilfley-table-riffle__c{position:absolute;left:16%;right:16%;top:50%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 7px,transparent 7px 14px);opacity:.45}
+.ease-wilfley-table-riffle__d{position:absolute;left:50%;top:16%;width:8px;height:8px;border-radius:50%;background:var(--accent);animation:wilfley_table_riffle_spark 4.56s linear infinite}
+@keyframes wilfley_table_riffle_ring{0%{transform:scale(.82);opacity:.95}100%{transform:scale(1.28);opacity:0}}
+@keyframes wilfley_table_riffle_core{0%,100%{transform:scale(.88);opacity:.5}50%{transform:scale(1.12);opacity:1}}
+@keyframes wilfley_table_riffle_spark{0%{transform:rotate(0deg) translateX(0)}100%{transform:rotate(360deg) translateX(42px)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-wilfley-table-riffle__a,
+  .ease-wilfley-table-riffle__b,
+  .ease-wilfley-table-riffle__c,
+  .ease-wilfley-table-riffle__d,
+  .ease-wilfley-table-riffle__meters i::after,
+  .ease-wilfley-table-riffle__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-wilfley-table-riffle` CSS-only demo for #77709.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Wilfley table riffles walking concentrate

**How does a developer use it?**

```html
<section class="ease-wilfley-table-riffle">
  <div class="ease-wilfley-table-riffle__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/wilfley-table-riffle-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77709
