### PR TITLE
feat: add ease-cyclone-classifier-spin (#77710)

### DIFF
--- a/submissions/examples/cyclone-classifier-spin-ns/README.md
+++ b/submissions/examples/cyclone-classifier-spin-ns/README.md
@@ -1,0 +1,16 @@
+# Cyclone Classifier Spin
+
+## What does this do?
+Renders a self-contained CSS-only `ease-cyclone-classifier-spin` demo: Cyclone classifier spinning a vortex finder.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-cyclone-classifier-spin`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-cyclone-classifier-spin">
+  <div class="ease-cyclone-classifier-spin__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/cyclone-classifier-spin-ns/demo.html
+++ b/submissions/examples/cyclone-classifier-spin-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyclone Classifier Spin — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Cyclone Classifier Spin demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Cyclone Classifier Spin</h1>
+      <p class="lede">Cyclone classifier spinning a vortex finder</p>
+    </header>
+
+    <section class="ease-cyclone-classifier-spin" data-demo="cyclone-classifier-spin" aria-live="polite">
+      <div class="ease-cyclone-classifier-spin__housing">
+        <div class="ease-cyclone-classifier-spin__bezel">
+          <div class="ease-cyclone-classifier-spin__face">
+            <div class="ease-cyclone-classifier-spin__readout">
+              <span class="ease-cyclone-classifier-spin__label">Cyclone Classifier Spin</span>
+              <span class="ease-cyclone-classifier-spin__value">LIVE</span>
+            </div>
+            <div class="ease-cyclone-classifier-spin__motion" aria-hidden="true">
+              <span class="ease-cyclone-classifier-spin__a"></span>
+              <span class="ease-cyclone-classifier-spin__b"></span>
+              <span class="ease-cyclone-classifier-spin__c"></span>
+              <span class="ease-cyclone-classifier-spin__d"></span>
+            </div>
+            <div class="ease-cyclone-classifier-spin__meters">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-cyclone-classifier-spin__controls">
+          <button type="button" class="ease-cyclone-classifier-spin__btn primary">Spin</button>
+          <button type="button" class="ease-cyclone-classifier-spin__btn">Bypass</button>
+          <label class="ease-cyclone-classifier-spin__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-cyclone-classifier-spin__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/cyclone-classifier-spin-ns/style.css
+++ b/submissions/examples/cyclone-classifier-spin-ns/style.css
@@ -1,0 +1,224 @@
+/* stage: cyclone-classifier-spin */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #e9eee7;
+  font-family: "Source Serif 4", Georgia, serif;
+  background:
+    radial-gradient(ellipse at 40% 100%, color-mix(in srgb, #a058e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 80% 20%, color-mix(in srgb, #f089f0 18%, transparent), transparent 42%),
+    #0d190b;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-cyclone-classifier-spin {
+  --accent: #a058e4;
+  --accent-2: #f089f0;
+  --panel: color-mix(in srgb, #e9eee7 7%, #0d190b);
+  --line: color-mix(in srgb, #e9eee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 17px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #0d190b 75%, #000);
+}
+
+.ease-cyclone-classifier-spin__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-cyclone-classifier-spin__bezel {
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #e9eee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #0d190b 90%, #a058e4);
+}
+
+.ease-cyclone-classifier-spin__face {
+  position: relative;
+  min-height: 261px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #0d190b 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-cyclone-classifier-spin__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-cyclone-classifier-spin__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-cyclone-classifier-spin__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-cyclone-classifier-spin__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-cyclone-classifier-spin__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-cyclone-classifier-spin__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: cyclone_classifier_spin_meter 4.2s linear infinite;
+}
+
+.ease-cyclone-classifier-spin__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(6)::after { animation-delay: 0.48s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(7)::after { animation-delay: 0.56s; }
+.ease-cyclone-classifier-spin__meters i:nth-child(8)::after { animation-delay: 0.64s; }
+
+.ease-cyclone-classifier-spin__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-cyclone-classifier-spin__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #e9eee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-cyclone-classifier-spin__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-cyclone-classifier-spin__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-cyclone-classifier-spin__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-cyclone-classifier-spin__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: cyclone_classifier_spin_status 2.94s ease-out infinite;
+}
+
+@keyframes cyclone_classifier_spin_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes cyclone_classifier_spin_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-cyclone-classifier-spin__a{position:absolute;left:12%;right:12%;top:36%;height:6px;border-radius:999px;background:color-mix(in srgb,var(--accent) 25%,transparent)}
+.ease-cyclone-classifier-spin__d{position:absolute;top:33%;width:12px;height:12px;border-radius:50%;background:var(--accent);animation:cyclone_classifier_spin_track 4.2s linear infinite}
+.ease-cyclone-classifier-spin__b{position:absolute;inset:48% 22% 22%;border-radius:8px;background:radial-gradient(circle at 30% 40%,var(--accent-2),transparent 60%);animation:cyclone_classifier_spin_glow 4.2s ease-in-out infinite}
+.ease-cyclone-classifier-spin__c{position:absolute;left:16%;right:16%;bottom:14%;height:2px;background:repeating-linear-gradient(90deg,var(--accent) 0 5px,transparent 5px 11px);opacity:.4}
+@keyframes cyclone_classifier_spin_track{0%{left:12%}50%{left:78%}100%{left:12%}}
+@keyframes cyclone_classifier_spin_glow{0%,100%{opacity:.45}50%{opacity:1}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cyclone-classifier-spin__a,
+  .ease-cyclone-classifier-spin__b,
+  .ease-cyclone-classifier-spin__c,
+  .ease-cyclone-classifier-spin__d,
+  .ease-cyclone-classifier-spin__meters i::after,
+  .ease-cyclone-classifier-spin__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-cyclone-classifier-spin` CSS-only demo for #77710.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Cyclone classifier spinning a vortex finder

**How does a developer use it?**

```html
<section class="ease-cyclone-classifier-spin">
  <div class="ease-cyclone-classifier-spin__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/cyclone-classifier-spin-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77710
