### PR TITLE
feat: add ease-kibble-bucket-rise (#77712)

### DIFF
--- a/submissions/examples/kibble-bucket-rise-ns/README.md
+++ b/submissions/examples/kibble-bucket-rise-ns/README.md
@@ -1,0 +1,16 @@
+# Kibble Bucket Rise
+
+## What does this do?
+Renders a self-contained CSS-only `ease-kibble-bucket-rise` demo: Kibble bucket rising the shaft.
+
+## How is it used?
+Open `demo.html` in a browser. Motion uses classes under `ease-kibble-bucket-rise`. No build step or JavaScript is required for the effect.
+
+```html
+<section class="ease-kibble-bucket-rise">
+  <div class="ease-kibble-bucket-rise__housing">...</div>
+</section>
+```
+
+## Why is it useful?
+It packs a recognizable real-world motion metaphor into three submission files, fitting EaseMotion's curated CSS-first model and giving maintainers a concrete effect to standardize into `ease-*` utilities.

--- a/submissions/examples/kibble-bucket-rise-ns/demo.html
+++ b/submissions/examples/kibble-bucket-rise-ns/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kibble Bucket Rise — EaseMotion</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="stage" aria-label="Kibble Bucket Rise demo">
+    <header class="stage-head">
+      <p class="eyebrow">EaseMotion submission</p>
+      <h1>Kibble Bucket Rise</h1>
+      <p class="lede">Kibble bucket rising the shaft</p>
+    </header>
+
+    <section class="ease-kibble-bucket-rise" data-demo="kibble-bucket-rise" aria-live="polite">
+      <div class="ease-kibble-bucket-rise__housing">
+        <div class="ease-kibble-bucket-rise__bezel">
+          <div class="ease-kibble-bucket-rise__face">
+            <div class="ease-kibble-bucket-rise__readout">
+              <span class="ease-kibble-bucket-rise__label">Kibble Bucket Rise</span>
+              <span class="ease-kibble-bucket-rise__value">LIVE</span>
+            </div>
+            <div class="ease-kibble-bucket-rise__motion" aria-hidden="true">
+              <span class="ease-kibble-bucket-rise__a"></span>
+              <span class="ease-kibble-bucket-rise__b"></span>
+              <span class="ease-kibble-bucket-rise__c"></span>
+              <span class="ease-kibble-bucket-rise__d"></span>
+            </div>
+            <div class="ease-kibble-bucket-rise__meters">
+              <i></i><i></i><i></i><i></i><i></i>
+            </div>
+          </div>
+        </div>
+        <div class="ease-kibble-bucket-rise__controls">
+          <button type="button" class="ease-kibble-bucket-rise__btn primary">Raise</button>
+          <button type="button" class="ease-kibble-bucket-rise__btn">Dump</button>
+          <label class="ease-kibble-bucket-rise__switch">
+            <input type="checkbox" checked>
+            <span>Live</span>
+          </label>
+        </div>
+      </div>
+      <footer class="ease-kibble-bucket-rise__status">
+        <span class="dot"></span>
+        CSS-only motion — no JavaScript required for the effect
+      </footer>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/kibble-bucket-rise-ns/style.css
+++ b/submissions/examples/kibble-bucket-rise-ns/style.css
@@ -1,0 +1,222 @@
+/* stage: kibble-bucket-rise */
+*, *::before, *::after { box-sizing: border-box; }
+html { color-scheme: dark; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #edeee7;
+  font-family: "Gill Sans", "Gill Sans MT", sans-serif;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in srgb, #6258e4 22%, transparent), transparent 48%),
+    radial-gradient(ellipse at 90% 100%, color-mix(in srgb, #d189f0 18%, transparent), transparent 42%),
+    #1b2310;
+}
+
+.stage {
+  width: min(680px, 100%);
+}
+
+.stage-head {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  opacity: 0.7;
+}
+
+.stage-head h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+}
+
+.lede {
+  margin: 0.55rem 0 0;
+  max-width: 46ch;
+  line-height: 1.45;
+  opacity: 0.85;
+  font-size: 0.98rem;
+}
+
+.ease-kibble-bucket-rise {
+  --accent: #6258e4;
+  --accent-2: #d189f0;
+  --panel: color-mix(in srgb, #edeee7 7%, #1b2310);
+  --line: color-mix(in srgb, #edeee7 16%, transparent);
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: 0 18px 50px color-mix(in srgb, #1b2310 75%, #000);
+}
+
+.ease-kibble-bucket-rise__housing {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.ease-kibble-bucket-rise__bezel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #edeee7 5%, transparent), transparent 40%),
+    color-mix(in srgb, #1b2310 90%, #6258e4);
+}
+
+.ease-kibble-bucket-rise__face {
+  position: relative;
+  min-height: 234px;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 70% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 45%),
+    color-mix(in srgb, #1b2310 70%, #000);
+  border: 1px solid var(--line);
+}
+
+.ease-kibble-bucket-rise__readout {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ease-kibble-bucket-rise__value {
+  color: var(--accent-2);
+  font-weight: 700;
+}
+
+.ease-kibble-bucket-rise__motion {
+  position: absolute;
+  inset: 0;
+}
+
+.ease-kibble-bucket-rise__meters {
+  position: absolute;
+  left: 0.8rem;
+  right: 0.8rem;
+  bottom: 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.35rem;
+}
+
+.ease-kibble-bucket-rise__meters i {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  overflow: hidden;
+}
+
+.ease-kibble-bucket-rise__meters i::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: var(--accent);
+  animation: kibble_bucket_rise_meter 4.08s linear infinite;
+}
+
+.ease-kibble-bucket-rise__meters i:nth-child(2)::after { animation-delay: 0.16s; }
+.ease-kibble-bucket-rise__meters i:nth-child(3)::after { animation-delay: 0.24s; }
+.ease-kibble-bucket-rise__meters i:nth-child(4)::after { animation-delay: 0.32s; }
+.ease-kibble-bucket-rise__meters i:nth-child(5)::after { animation-delay: 0.40s; }
+
+.ease-kibble-bucket-rise__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.ease-kibble-bucket-rise__btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, #edeee7 6%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.ease-kibble-bucket-rise__btn.primary {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.ease-kibble-bucket-rise__switch {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-left: auto;
+  font-size: 0.86rem;
+  opacity: 0.9;
+}
+
+.ease-kibble-bucket-rise__status {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.ease-kibble-bucket-rise__status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: kibble_bucket_rise_status 2.86s ease-out infinite;
+}
+
+@keyframes kibble_bucket_rise_meter {
+  0% { transform: translateX(0); opacity: 0.55; }
+  100% { transform: translateX(40%); opacity: 1; }
+}
+
+@keyframes kibble_bucket_rise_status {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); }
+  100% { box-shadow: 0 0 0 12px transparent; }
+}
+
+.ease-kibble-bucket-rise__a{position:absolute;left:46%;top:14%;bottom:18%;width:8px;border-radius:4px;background:color-mix(in srgb,var(--accent) 30%,transparent);overflow:hidden}
+.ease-kibble-bucket-rise__a::after{content:"";position:absolute;left:0;right:0;height:22%;background:var(--accent);animation:kibble_bucket_rise_hoist 4.08s ease-in-out infinite}
+.ease-kibble-bucket-rise__b{position:absolute;left:22%;top:16%;width:12px;height:12px;border:2px solid var(--accent-2);animation:kibble_bucket_rise_sheave 4.08s linear infinite}
+.ease-kibble-bucket-rise__c{position:absolute;right:20%;top:16%;width:12px;height:12px;border:2px solid var(--accent);animation:kibble_bucket_rise_sheave 4.08s linear infinite reverse}
+.ease-kibble-bucket-rise__d{position:absolute;left:18%;right:18%;bottom:14%;height:3px;background:repeating-linear-gradient(90deg,var(--accent) 0 8px,transparent 8px 16px);opacity:.45}
+@keyframes kibble_bucket_rise_hoist{0%{transform:translateY(0)}50%{transform:translateY(280%)}100%{transform:translateY(0)}}
+@keyframes kibble_bucket_rise_sheave{to{transform:rotate(360deg)}}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-kibble-bucket-rise__a,
+  .ease-kibble-bucket-rise__b,
+  .ease-kibble-bucket-rise__c,
+  .ease-kibble-bucket-rise__d,
+  .ease-kibble-bucket-rise__meters i::after,
+  .ease-kibble-bucket-rise__status .dot {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-kibble-bucket-rise` CSS-only demo for #77712.

---

## Type of Change

- [x] New animation / hover effect
- [ ] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

Kibble bucket rising the shaft

**How does a developer use it?**

```html
<section class="ease-kibble-bucket-rise">
  <div class="ease-kibble-bucket-rise__housing">...</div>
</section>
```

**Why does it fit EaseMotion CSS?**

Self-contained CSS motion metaphor under `submissions/examples/kibble-bucket-rise-ns/` with reduced-motion support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Closes #77712
