### PR TITLE
feat: add floating elevation tooltip example

### DIFF
--- a/submissions/examples/css-tooltip-floating-elevation-73483/README.md
+++ b/submissions/examples/css-tooltip-floating-elevation-73483/README.md
@@ -1,0 +1,70 @@
+# Floating Elevation Tooltip
+
+A pure-CSS tooltip that rises into view on a soft **elevation arc**: the bubble
+slides up with a `translateY`, its drop-shadow deepens as if it lifts off the
+surface, and a gentle vertical bob continues while it stays revealed. Zero
+JavaScript.
+
+## Overview
+
+This contribution implements the **Floating Elevation** tooltip variation
+(#235) for the EaseMotion CSS library, following the existing tooltip example
+conventions (`demo.html` + `style.css` + `README.md`).
+
+## Features
+
+- **Elevation arc on reveal**: the bubble starts offset toward the trigger and
+  animates to its resting position while `box-shadow` grows from a tight
+  `0 2px 6px` to a deep `0 18px 40px` shadow, reading as the bubble lifting off
+  the surface.
+- **Gentle bob loop**: while revealed, a `float-bob` keyframe nudges the bubble
+  up ~6px and back on a 3.2s ease-in-out loop using the `translate` property
+  (so it composites cleanly with the reveal `transform`).
+- **Four directions**: top, right, bottom, left modifiers.
+- **Keyboard accessible**: triggers carry `tabindex="0"` and reveal on
+  `:focus-visible`, not just `:hover`.
+- **Hardware-accelerated**: reveal animates `transform` / `opacity` /
+  `box-shadow` (paint-friendly, no layout); bob uses the standalone `translate`
+  property to avoid clobbering the reveal `transform`.
+- **Dark mode**: the demo page is dark; the bubble itself is a light surface
+  for contrast, driven by CSS custom properties so it can be re-themed.
+- **Reduced motion**: `prefers-reduced-motion: reduce` halts the bob loop and
+  collapses the reveal transition so the bubble appears instantly, static.
+- **Zero JavaScript**.
+
+## Usage
+
+```html
+<span
+  class="float-tip float-tip--top"
+  tabindex="0"
+  data-tooltip="Rises with a translateY arc and a deepening shadow."
+  >Hover / focus</span
+>
+```
+
+## CSS Custom Properties
+
+```css
+--accent: #7dd3fc;
+--tip-bg: #ffffff;
+--tip-fg: #1a1f2e;
+--dur: 0.45s;  /* reveal transition */
+--bob: 3.2s;    /* idle bob loop    */
+```
+
+## Accessibility Notes
+
+- The trigger is a real focusable element (`tabindex="0"`) and reveals on
+  `:focus-visible`.
+- `prefers-reduced-motion: reduce` halts the bob `animation` and collapses
+  the reveal `transition` to `0.01ms`, so motion-sensitive users get an
+  instant, static tooltip.
+- The bob uses the standalone `translate` property (not `transform`), so it
+  composites independently from the directional reveal `transform` and does not
+  fight the entrance arc.
+
+## Related Issue
+
+Addresses Issue #73483 in the EaseMotion CSS repository (CSS Tooltip: Floating
+Elevation Variation #235).

--- a/submissions/examples/css-tooltip-floating-elevation-73483/demo.html
+++ b/submissions/examples/css-tooltip-floating-elevation-73483/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Tooltip: Floating Elevation | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__head">
+        <p class="eyebrow">Tooltips &amp; Popovers &middot; Variation #235</p>
+        <h1>Floating Elevation Tooltip</h1>
+        <p class="lead">
+          A pure-CSS tooltip that rises into view on a soft elevation arc,
+          casting a growing drop-shadow as if lifting off the surface. No JS.
+        </p>
+      </header>
+
+      <section class="demo" aria-label="Floating elevation tooltip variants">
+        <div class="demo__grid">
+          <span
+            class="float-tip float-tip--top"
+            tabindex="0"
+            data-tooltip="Rises with a translateY arc and a deepening shadow."
+            >Hover / focus &uarr;</span
+          >
+          <span
+            class="float-tip float-tip--right"
+            tabindex="0"
+            data-tooltip="Shadow grows as the bubble elevates."
+            >Right &rarr;</span
+          >
+          <span
+            class="float-tip float-tip--bottom"
+            tabindex="0"
+            data-tooltip="A gentle bob continues after the reveal."
+            >&darr; Bottom</span
+          >
+          <span
+            class="float-tip float-tip--left"
+            tabindex="0"
+            data-tooltip="Pure transform + box-shadow, GPU-friendly."
+            >&larr; Left</span
+          >
+        </div>
+        <p class="hint">
+          Keyboard: <kbd>Tab</kbd> to focus a trigger; the bubble floats up.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-tooltip-floating-elevation-73483/style.css
+++ b/submissions/examples/css-tooltip-floating-elevation-73483/style.css
@@ -1,0 +1,212 @@
+/* =========================================================================
+   Floating Elevation Tooltip - pure CSS, no JS
+   The bubble rises into view with an arc'd translateY, a deepening drop
+   shadow, and a gentle bob loop while revealed. Reveal on :hover /
+   :focus-visible. prefers-reduced-motion halts the bob.
+   ========================================================================= */
+
+:root {
+  --bg: #0a0c12;
+  --fg: #eef1f7;
+  --muted: #83899a;
+  --accent: #7dd3fc;
+  --tip-bg: #ffffff;
+  --tip-fg: #1a1f2e;
+  --dur: 0.45s;
+  --bob: 3.2s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background:
+    radial-gradient(700px 450px at 50% 0%, rgba(125, 211, 252, 0.1), transparent 60%),
+    var(--bg);
+  color: var(--fg);
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: clamp(24px, 6vw, 64px) 20px;
+}
+
+.page__head {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  color: var(--accent);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+  margin: 0 0 10px;
+}
+
+.page__head h1 {
+  margin: 0 0 10px;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  letter-spacing: -0.02em;
+  color: var(--accent);
+}
+
+.lead {
+  max-width: 58ch;
+  margin: 0 auto;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* ---------- demo layout ---------- */
+.demo__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 28px;
+  justify-items: center;
+  padding: 30px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+  border-radius: 18px;
+}
+
+.hint {
+  margin: 22px 0 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+kbd {
+  background: #14171f;
+  border: 1px solid #262a35;
+  border-radius: 6px;
+  padding: 1px 7px;
+  font-size: 0.8em;
+}
+
+/* ---------- the trigger ---------- */
+.float-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--fg);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  outline: none;
+  transition: border-color var(--dur), box-shadow var(--dur),
+    background var(--dur);
+}
+
+.float-tip:hover,
+.float-tip:focus-visible {
+  border-color: rgba(125, 211, 252, 0.8);
+  box-shadow: 0 0 18px rgba(125, 211, 252, 0.25);
+  background: rgba(125, 211, 252, 0.1);
+}
+
+/* ---------- the tooltip surface ---------- */
+.float-tip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  width: max-content;
+  max-width: 240px;
+  padding: 10px 14px;
+  background: var(--tip-bg);
+  color: var(--tip-fg);
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  z-index: 20;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  transition: opacity var(--dur) ease, transform var(--dur) ease,
+    box-shadow var(--dur) ease;
+}
+
+/* ---------- reveal + bob loop ---------- */
+.float-tip:hover::after,
+.float-tip:focus-visible::after {
+  opacity: 1;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5), 0 8px 18px rgba(0, 0, 0, 0.35);
+  animation: float-bob var(--bob) ease-in-out infinite;
+}
+
+@keyframes float-bob {
+  0%, 100% { translate: 0 0; }
+  50%      { translate: 0 -6px; }
+}
+
+/* ---------- positions ---------- */
+/* default: top - rises from below the gap up to resting spot */
+.float-tip--top::after {
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(14px);
+}
+.float-tip--top:hover::after,
+.float-tip--top:focus-visible::after {
+  transform: translateX(-50%) translateY(0);
+}
+
+.float-tip--right::after {
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translateY(-50%) translateX(-14px);
+}
+.float-tip--right:hover::after,
+.float-tip--right:focus-visible::after {
+  transform: translateY(-50%) translateX(0);
+}
+
+.float-tip--bottom::after {
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(-14px);
+}
+.float-tip--bottom:hover::after,
+.float-tip--bottom:focus-visible::after {
+  transform: translateX(-50%) translateY(0);
+}
+
+.float-tip--left::after {
+  top: 50%;
+  right: calc(100% + 12px);
+  transform: translateY(-50%) translateX(14px);
+}
+.float-tip--left:hover::after,
+.float-tip--left:focus-visible::after {
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ---------- accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .float-tip,
+  .float-tip::after,
+  .float-tip:hover::after,
+  .float-tip:focus-visible::after {
+    transition-duration: 0.01ms !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
Adds a pure-CSS floating elevation tooltip example under `submissions/examples/css-tooltip-floating-elevation-73483/` (`demo.html` + `style.css` + `README.md`), following the repo's existing tooltip example conventions.

## What
- A tooltip that reveals with a gentle floating/elevation effect (translateY bob + soft drop-shadow growth), pure CSS, no JS.
- Uses the established `[data-tooltip]` pattern with `::after` content, four direction modifiers (top/right/bottom/left), `:hover` / `:focus-visible` reveal, `tabindex=0` for keyboard access.
- `prefers-reduced-motion: reduce` halts the bob and shows the bubble statically.

## Files
- `submissions/examples/css-tooltip-floating-elevation-73483/demo.html`
- `submissions/examples/css-tooltip-floating-elevation-73483/style.css`
- `submissions/examples/css-tooltip-floating-elevation-73483/README.md`

Closes #73483

---

_This pull request was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
