### PR TITLE
feat: add bouncing spring tooltip example

### DIFF
--- a/submissions/examples/css-tooltip-bouncing-spring-73484/README.md
+++ b/submissions/examples/css-tooltip-bouncing-spring-73484/README.md
@@ -1,0 +1,71 @@
+# Bouncing Spring Tooltip
+
+A pure-CSS tooltip that pops in with an **overshoot spring**: the bubble
+travels past its resting point and settles back, driven by a single-pass
+keyframe animation using the overshoot easing
+`cubic-bezier(0.34, 1.56, 0.64, 1)`. Like it is attached to the trigger by a
+rubber band. Zero JavaScript.
+
+## Overview
+
+This contribution implements the **Bouncing Spring** tooltip variation (#236)
+for the EaseMotion CSS library, following the existing tooltip example
+conventions (`demo.html` + `style.css` + `README.md`).
+
+## Features
+
+- **Overshoot spring**: the reveal is a `forwards` keyframe animation using
+  `cubic-bezier(0.34, 1.56, 0.64, 1)` — the y2 value `1.56` pushes the value
+  past `1` then settles, producing the characteristic bounce-back.
+- **Directional overshoot**: each direction (top/right/bottom/left) has its
+  own keyframe so the overshoot always points *away* from the trigger, reading
+  as the bubble springing out from its source.
+- **Scale + slide + fade**: the bubble enters at `scale(0.6)` with low
+  opacity, springs to full size and opacity in one pass — no layout cost.
+- **Four directions**: top, right, bottom, left modifiers.
+- **Keyboard accessible**: triggers carry `tabindex="0"` and reveal on
+  `:focus-visible`, not just `:hover`.
+- **Hardware-accelerated**: only `transform` / `opacity` animate.
+- **Dark mode**: dark by default; palette driven by CSS custom properties so
+  it can be re-themed.
+- **Reduced motion**: `prefers-reduced-motion: reduce` halts the spring
+  animation; the bubble appears instantly at its resting position (with the
+  correct per-direction centering transform applied).
+- **Zero JavaScript**.
+
+## Usage
+
+```html
+<span
+  class="spring-tip spring-tip--top"
+  tabindex="0"
+  data-tooltip="Cubic-bezier overshoot mimics a spring release."
+  >Hover / focus</span
+>
+```
+
+## CSS Custom Properties
+
+```css
+--accent: #fb7185;
+--accent2: #f59e0b;
+--dur: 0.55s;
+--spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* overshoot easing */
+```
+
+## Accessibility Notes
+
+- The trigger is a real focusable element (`tabindex="0"`) and reveals on
+  `:focus-visible`.
+- `prefers-reduced-motion: reduce` halts the spring `animation`; the bubble is
+  shown instantly at rest with the correct per-direction centering transform
+  (`translateX(-50%)` for top/bottom, `translateY(-50%)` for left/right) so it
+  stays correctly positioned for motion-sensitive users.
+- The overshoot uses a single-pass `forwards` animation (not an infinite loop),
+  so it plays once per reveal and stops — no continuous motion to tax the
+  vestibular system.
+
+## Related Issue
+
+Addresses Issue #73484 in the EaseMotion CSS repository (CSS Tooltip: Bouncing
+Spring Variation #236).

--- a/submissions/examples/css-tooltip-bouncing-spring-73484/demo.html
+++ b/submissions/examples/css-tooltip-bouncing-spring-73484/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Tooltip: Bouncing Spring | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__head">
+        <p class="eyebrow">Tooltips &amp; Popovers &middot; Variation #236</p>
+        <h1>Bouncing Spring Tooltip</h1>
+        <p class="lead">
+          A pure-CSS tooltip that pops in with an overshoot spring curve, like
+          it is attached to the trigger by a rubber band. No JavaScript.
+        </p>
+      </header>
+
+      <section class="demo" aria-label="Bouncing spring tooltip variants">
+        <div class="demo__grid">
+          <span
+            class="spring-tip spring-tip--top"
+            tabindex="0"
+            data-tooltip="Cubic-bezier overshoot mimics a spring release."
+            >Hover / focus &uarr;</span
+          >
+          <span
+            class="spring-tip spring-tip--right"
+            tabindex="0"
+            data-tooltip="It overshoots then settles back to rest."
+            >Right &rarr;</span
+          >
+          <span
+            class="spring-tip spring-tip--bottom"
+            tabindex="0"
+            data-tooltip="One keyframe pass, no layout cost."
+            >&darr; Bottom</span
+          >
+          <span
+            class="spring-tip spring-tip--left"
+            tabindex="0"
+            data-tooltip="Pure transform + opacity, GPU-friendly."
+            >&larr; Left</span
+          >
+        </div>
+        <p class="hint">
+          Keyboard: <kbd>Tab</kbd> to focus a trigger; the tooltip springs in.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-tooltip-bouncing-spring-73484/style.css
+++ b/submissions/examples/css-tooltip-bouncing-spring-73484/style.css
@@ -1,0 +1,235 @@
+/* =========================================================================
+   Bouncing Spring Tooltip - pure CSS, no JS
+   The bubble pops in with an overshoot: it travels past rest then settles
+   back, driven by a single keyframe animation with an overshoot easing.
+   Reveal on :hover / :focus-visible. prefers-reduced-motion halts it.
+   ========================================================================= */
+
+:root {
+  --bg: #0c0a0f;
+  --fg: #fbf0ff;
+  --muted: #8c8295;
+  --accent: #fb7185;
+  --accent2: #f59e0b;
+  --tip-bg: #1f1722;
+  --tip-fg: #ffe9f0;
+  --dur: 0.55s;
+  /* overshoot cubic-bezier: travels past 1 then settles */
+  --spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background:
+    radial-gradient(700px 450px at 50% 0%, rgba(251, 113, 133, 0.12), transparent 60%),
+    var(--bg);
+  color: var(--fg);
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: clamp(24px, 6vw, 64px) 20px;
+}
+
+.page__head {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  color: var(--accent);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+  margin: 0 0 10px;
+}
+
+.page__head h1 {
+  margin: 0 0 10px;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lead {
+  max-width: 58ch;
+  margin: 0 auto;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* ---------- demo layout ---------- */
+.demo__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 28px;
+  justify-items: center;
+  padding: 30px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(251, 113, 133, 0.12);
+  border-radius: 18px;
+}
+
+.hint {
+  margin: 22px 0 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+kbd {
+  background: #1a131d;
+  border: 1px solid #322636;
+  border-radius: 6px;
+  padding: 1px 7px;
+  font-size: 0.8em;
+}
+
+/* ---------- the trigger ---------- */
+.spring-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--fg);
+  background: rgba(251, 113, 133, 0.08);
+  border: 1px solid rgba(251, 113, 133, 0.4);
+  outline: none;
+  transition: border-color var(--dur), box-shadow var(--dur),
+    background var(--dur);
+}
+
+.spring-tip:hover,
+.spring-tip:focus-visible {
+  border-color: rgba(245, 158, 11, 0.8);
+  box-shadow: 0 0 18px rgba(251, 113, 133, 0.3);
+  background: rgba(251, 113, 133, 0.14);
+}
+
+/* ---------- the tooltip surface ---------- */
+.spring-tip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  width: max-content;
+  max-width: 240px;
+  padding: 10px 14px;
+  background: var(--tip-bg);
+  color: var(--tip-fg);
+  border: 1px solid rgba(251, 113, 133, 0.45);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  font-weight: 500;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  z-index: 20;
+}
+
+/* ---------- reveal with overshoot ---------- */
+.spring-tip:hover::after,
+.spring-tip:focus-visible::after {
+  animation: spring-in var(--dur) var(--spring) forwards;
+}
+
+/* The animation handles opacity + translate; per-direction keyframes below
+   carry the directional vector so the overshoot points away from the
+   trigger. We define a default (top) and override with modifiers. */
+@keyframes spring-in--top {
+  0%   { opacity: 0; transform: translateX(-50%) translateY(18px) scale(0.6); }
+  100% { opacity: 1; transform: translateX(-50%) translateY(0)   scale(1); }
+}
+@keyframes spring-in--right {
+  0%   { opacity: 0; transform: translate(-18px, -50%) scale(0.6); }
+  100% { opacity: 1; transform: translate(0, -50%)    scale(1); }
+}
+@keyframes spring-in--bottom {
+  0%   { opacity: 0; transform: translateX(-50%) translateY(-18px) scale(0.6); }
+  100% { opacity: 1; transform: translateX(-50%) translateY(0)    scale(1); }
+}
+@keyframes spring-in--left {
+  0%   { opacity: 0; transform: translate(18px, -50%) scale(0.6); }
+  100% { opacity: 1; transform: translate(0, -50%)   scale(1); }
+}
+
+/* ---------- positions + which keyframe to use ---------- */
+.spring-tip--top::after {
+  bottom: calc(100% + 12px);
+  left: 50%;
+}
+.spring-tip--top:hover::after,
+.spring-tip--top:focus-visible::after {
+  animation-name: spring-in--top;
+}
+
+.spring-tip--right::after {
+  top: 50%;
+  left: calc(100% + 12px);
+}
+.spring-tip--right:hover::after,
+.spring-tip--right:focus-visible::after {
+  animation-name: spring-in--right;
+}
+
+.spring-tip--bottom::after {
+  top: calc(100% + 12px);
+  left: 50%;
+}
+.spring-tip--bottom:hover::after,
+.spring-tip--bottom:focus-visible::after {
+  animation-name: spring-in--bottom;
+}
+
+.spring-tip--left::after {
+  top: 50%;
+  right: calc(100% + 12px);
+}
+.spring-tip--left:hover::after,
+.spring-tip--left:focus-visible::after {
+  animation-name: spring-in--left;
+}
+
+/* ---------- accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .spring-tip,
+  .spring-tip::after,
+  .spring-tip:hover::after,
+  .spring-tip:focus-visible::after {
+    transition-duration: 0.01ms !important;
+    animation: none !important;
+    opacity: 1; /* when revealed */
+  }
+  /* keep hidden until reveal, then show instantly at rest */
+  .spring-tip::after { opacity: 0; }
+  .spring-tip:hover::after,
+  .spring-tip:focus-visible::after { opacity: 1; transform: none; }
+
+  /* per-direction static rest transforms */
+  .spring-tip--top::after,
+  .spring-tip--bottom::after { transform: translateX(-50%); }
+  .spring-tip--right::after,
+  .spring-tip--left::after   { transform: translateY(-50%); }
+}


### PR DESCRIPTION
Adds a pure-CSS bouncing spring tooltip example under `submissions/examples/css-tooltip-bouncing-spring-73484/` (`demo.html` + `style.css` + `README.md`), following the repo's existing tooltip example conventions.

## What
- A tooltip that pops in with an overshoot spring: single-pass `forwards` keyframe animation using `cubic-bezier(0.34, 1.56, 0.64, 1)` overshoot easing, entering at `scale(0.6)` + low opacity and springing to rest. Pure CSS, no JS.
- Per-direction keyframes (`spring-in--top/right/bottom/left`) so the overshoot always points away from the trigger.
- Uses the established `[data-tooltip]` pattern with `::after` content, four direction modifiers (top/right/bottom/left), `:hover` / `:focus-visible` reveal, `tabindex=0` for keyboard access.
- Hardware-accelerated (transform/opacity). `prefers-reduced-motion: reduce` halts the spring (bubble shown instantly at rest with correct per-direction centering transform).

## Files
- `submissions/examples/css-tooltip-bouncing-spring-73484/demo.html`
- `submissions/examples/css-tooltip-bouncing-spring-73484/style.css`
- `submissions/examples/css-tooltip-bouncing-spring-73484/README.md`

Closes #73484

---

_This pull request was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
