### PR TITLE
feat: add laser ray trace tooltip example

### DIFF
--- a/submissions/examples/css-tooltip-laser-ray-trace-73485/README.md
+++ b/submissions/examples/css-tooltip-laser-ray-trace-73485/README.md
@@ -1,0 +1,78 @@
+# Laser Ray Trace Tooltip
+
+A pure-CSS tooltip that fires a **laser beam** line from the trigger to the
+bubble, which then snaps open with a `clip-path` tracing sweep — like a ray
+being traced and then a hologram panel powering on along it. Neon-green glow
+throughout. Zero JavaScript.
+
+## Overview
+
+This contribution implements the **Laser Ray Trace** tooltip variation (#237)
+for the EaseMotion CSS library, following the existing tooltip example
+conventions (`demo.html` + `style.css` + `README.md`).
+
+## Features
+
+- **Two-stage reveal**: a thin glowing beam (`::before`) scales out from the
+  trigger toward the bubble over `0.16s`, then the bubble (`::after`) sweeps
+  open via `clip-path: inset(...)` over `0.42s` with the start delayed by the
+  beam duration. The eye reads it as: beam fires → panel powers open.
+- **Directional beams**: the beam is a vertical bar for top/bottom
+  (`scaleY` from the trigger edge) and a horizontal bar for left/right
+  (`scaleX` from the trigger edge); `transform-origin` is anchored to the
+  trigger side so the beam grows outward from the source.
+- **Directional clip sweep**: top/bottom/left reveal with
+  `clip-path: inset(0 100% 0 0)` → `inset(0)`, right reveals with
+  `inset(0 0 0 100%)` → `inset(0)`, so the panel always opens along the beam
+  direction.
+- **Neon glow**: layered `box-shadow` (tight 8px + soft 16px) on both the beam
+  and the bubble border, plus a `text-shadow` on the message for a coherent
+  emissive look.
+- **Four directions**: top, right, bottom, left modifiers.
+- **Keyboard accessible**: triggers carry `tabindex="0"` and reveal on
+  `:focus-visible`, not just `:hover`.
+- **Hardware-accelerated**: beam animates `transform` (`scaleX/Y`); bubble
+  animates `clip-path` + `opacity` (paint-only, no layout).
+- **Dark mode**: dark by default; the laser palette is driven by CSS custom
+  properties so it can be re-themed.
+- **Reduced motion**: `prefers-reduced-motion: reduce` halts the beam-grow
+  and the clip sweep; beam and bubble appear instantly at their resting
+  transforms (beam fully scaled, bubble fully open with `clip-path: none`).
+- **Zero JavaScript**.
+
+## Usage
+
+```html
+<span
+  class="laser-tip laser-tip--top"
+  tabindex="0"
+  data-tooltip="Beam fires first, then the bubble sweeps open."
+  >Hover / focus</span
+>
+```
+
+## CSS Custom Properties
+
+```css
+--laser: #00ff9d;
+--laser-soft: rgba(0, 255, 157, 0.5);
+--dur: 0.42s;       /* bubble clip sweep */
+--beam-dur: 0.16s;  /* beam grow + bubble start delay */
+```
+
+## Accessibility Notes
+
+- The trigger is a real focusable element (`tabindex="0"`) and reveals on
+  `:focus-visible`.
+- `prefers-reduced-motion: reduce` removes the staged timing entirely:
+  `transition-duration` collapses to `0.01ms`, `transition-delay` is zeroed,
+  and the bubble's `clip-path` is set to `none` so it is fully visible. The
+  beam and bubble are placed at their correct resting transforms immediately,
+  so motion-sensitive users get a clean, static tooltip.
+- The decorative beam carries no text; the readable message lives entirely in
+  the bubble's `::after` content for unambiguous screen-reader access.
+
+## Related Issue
+
+Addresses Issue #73485 in the EaseMotion CSS repository (CSS Tooltip: Laser Ray
+Trace Variation #237).

--- a/submissions/examples/css-tooltip-laser-ray-trace-73485/demo.html
+++ b/submissions/examples/css-tooltip-laser-ray-trace-73485/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Tooltip: Laser Ray Trace | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__head">
+        <p class="eyebrow">Tooltips &amp; Popovers &middot; Variation #237</p>
+        <h1>Laser Ray Trace Tooltip</h1>
+        <p class="lead">
+          A pure-CSS tooltip that fires a laser beam line from the trigger to
+          the bubble, which then snaps open with a tracing sweep. No JS.
+        </p>
+      </header>
+
+      <section class="demo" aria-label="Laser ray tooltip variants">
+        <div class="demo__grid">
+          <span
+            class="laser-tip laser-tip--top"
+            tabindex="0"
+            data-tooltip="Beam fires first, then the bubble sweeps open."
+            >Hover / focus &uarr;</span
+          >
+          <span
+            class="laser-tip laser-tip--right"
+            tabindex="0"
+            data-tooltip="Beam grows via scaleX/scaleY from the trigger."
+            >Right &rarr;</span
+          >
+          <span
+            class="laser-tip laser-tip--bottom"
+            tabindex="0"
+            data-tooltip="Bubble clips open with a clip-path sweep."
+            >&darr; Bottom</span
+          >
+          <span
+            class="laser-tip laser-tip--left"
+            tabindex="0"
+            data-tooltip="Neon glow via layered text-shadow + box-shadow."
+            >&larr; Left</span
+          >
+        </div>
+        <p class="hint">
+          Keyboard: <kbd>Tab</kbd> to focus a trigger; the beam fires.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-tooltip-laser-ray-trace-73485/style.css
+++ b/submissions/examples/css-tooltip-laser-ray-trace-73485/style.css
@@ -1,0 +1,317 @@
+/* =========================================================================
+   Laser Ray Trace Tooltip - pure CSS, no JS
+   Two pseudo-elements:
+     ::before = the laser beam (a thin bar that scales out from the trigger)
+     ::after  = the bubble (clips open via clip-path inset, neon glow)
+   Reveal on :hover / :focus-visible. prefers-reduced-motion shows them
+   instantly with no beam-grow or clip sweep.
+   ========================================================================= */
+
+:root {
+  --bg: #04060a;
+  --fg: #d6fff0;
+  --muted: #5e6b66;
+  --laser: #00ff9d;
+  --laser-soft: rgba(0, 255, 157, 0.5);
+  --tip-bg: rgba(6, 16, 12, 0.95);
+  --tip-fg: #e6fff4;
+  --dur: 0.42s;
+  --beam-dur: 0.16s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background:
+    radial-gradient(700px 450px at 50% 0%, rgba(0, 255, 157, 0.08), transparent 60%),
+    var(--bg);
+  color: var(--fg);
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: clamp(24px, 6vw, 64px) 20px;
+}
+
+.page__head {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  color: var(--laser);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+  margin: 0 0 10px;
+}
+
+.page__head h1 {
+  margin: 0 0 10px;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  letter-spacing: -0.02em;
+  color: var(--laser);
+  text-shadow: 0 0 12px var(--laser-soft);
+}
+
+.lead {
+  max-width: 58ch;
+  margin: 0 auto;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* ---------- demo layout ---------- */
+.demo__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 28px;
+  justify-items: center;
+  padding: 30px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(0, 255, 157, 0.12);
+  border-radius: 18px;
+}
+
+.hint {
+  margin: 22px 0 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+kbd {
+  background: #0a1410;
+  border: 1px solid #163024;
+  border-radius: 6px;
+  padding: 1px 7px;
+  font-size: 0.8em;
+}
+
+/* ---------- the trigger ---------- */
+.laser-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--fg);
+  background: rgba(0, 255, 157, 0.05);
+  border: 1px solid rgba(0, 255, 157, 0.4);
+  outline: none;
+  transition: border-color var(--dur), box-shadow var(--dur),
+    background var(--dur);
+}
+
+.laser-tip:hover,
+.laser-tip:focus-visible {
+  border-color: var(--laser);
+  box-shadow: 0 0 18px var(--laser-soft);
+  background: rgba(0, 255, 157, 0.1);
+}
+
+/* ---------- shared pseudo base ---------- */
+.laser-tip::before,
+.laser-tip::after {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 20;
+}
+
+/* ---------- the bubble (::after) ---------- */
+.laser-tip::after {
+  content: attr(data-tooltip);
+  width: max-content;
+  max-width: 240px;
+  padding: 9px 13px;
+  background: var(--tip-bg);
+  color: var(--tip-fg);
+  border: 1px solid var(--laser);
+  border-radius: 6px;
+  box-shadow: 0 0 16px var(--laser-soft), 0 8px 24px rgba(0, 0, 0, 0.6);
+  text-shadow: 0 0 6px var(--laser-soft);
+  font-weight: 500;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  /* start fully clipped so it can sweep open */
+  clip-path: inset(0 100% 0 0);
+}
+
+/* ---------- the beam (::before) ---------- */
+/* thin glowing bar; transform-origin at the trigger side; grows on reveal */
+.laser-tip::before {
+  content: "";
+  background: linear-gradient(var(--laser), var(--laser));
+  box-shadow: 0 0 8px var(--laser), 0 0 16px var(--laser-soft);
+  border-radius: 2px;
+}
+
+/* ===== TOP ===== */
+/* beam: vertical, grows upward from trigger top edge to bubble bottom */
+.laser-tip--top::before {
+  bottom: 100%;
+  left: 50%;
+  width: 2px;
+  height: 12px;
+  transform: translateX(-50%) scaleY(0);
+  transform-origin: bottom center;
+}
+.laser-tip--top::after {
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+.laser-tip--top:hover::before,
+.laser-tip--top:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) scaleY(1);
+  transition: opacity var(--beam-dur) ease,
+    transform var(--beam-dur) ease;
+  transition-delay: 0s;
+}
+.laser-tip--top:hover::after,
+.laser-tip--top:focus-visible::after {
+  opacity: 1;
+  clip-path: inset(0 0 0 0);
+  transition: opacity 0.01s linear var(--beam-dur),
+    clip-path var(--dur) ease var(--beam-dur);
+}
+
+/* ===== RIGHT ===== */
+.laser-tip--right::before {
+  top: 50%;
+  left: 100%;
+  width: 12px;
+  height: 2px;
+  transform: translateY(-50%) scaleX(0);
+  transform-origin: left center;
+}
+.laser-tip--right::after {
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translateY(-50%);
+  clip-path: inset(0 0 0 100%); /* sweep L->R */
+}
+.laser-tip--right:hover::before,
+.laser-tip--right:focus-visible::before {
+  opacity: 1;
+  transform: translateY(-50%) scaleX(1);
+  transition: opacity var(--beam-dur) ease,
+    transform var(--beam-dur) ease;
+}
+.laser-tip--right:hover::after,
+.laser-tip--right:focus-visible::after {
+  opacity: 1;
+  clip-path: inset(0 0 0 0);
+  transition: opacity 0.01s linear var(--beam-dur),
+    clip-path var(--dur) ease var(--beam-dur);
+}
+
+/* ===== BOTTOM ===== */
+.laser-tip--bottom::before {
+  top: 100%;
+  left: 50%;
+  width: 2px;
+  height: 12px;
+  transform: translateX(-50%) scaleY(0);
+  transform-origin: top center;
+}
+.laser-tip--bottom::after {
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+.laser-tip--bottom:hover::before,
+.laser-tip--bottom:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) scaleY(1);
+  transition: opacity var(--beam-dur) ease,
+    transform var(--beam-dur) ease;
+}
+.laser-tip--bottom:hover::after,
+.laser-tip--bottom:focus-visible::after {
+  opacity: 1;
+  clip-path: inset(0 0 0 0);
+  transition: opacity 0.01s linear var(--beam-dur),
+    clip-path var(--dur) ease var(--beam-dur);
+}
+
+/* ===== LEFT ===== */
+.laser-tip--left::before {
+  top: 50%;
+  right: 100%;
+  width: 12px;
+  height: 2px;
+  transform: translateY(-50%) scaleX(0);
+  transform-origin: right center;
+}
+.laser-tip--left::after {
+  top: 50%;
+  right: calc(100% + 12px);
+  transform: translateY(-50%);
+  clip-path: inset(0 100% 0 0); /* sweep R->L */
+}
+.laser-tip--left:hover::before,
+.laser-tip--left:focus-visible::before {
+  opacity: 1;
+  transform: translateY(-50%) scaleX(1);
+  transition: opacity var(--beam-dur) ease,
+    transform var(--beam-dur) ease;
+}
+.laser-tip--left:hover::after,
+.laser-tip--left:focus-visible::after {
+  opacity: 1;
+  clip-path: inset(0 0 0 0);
+  transition: opacity 0.01s linear var(--beam-dur),
+    clip-path var(--dur) ease var(--beam-dur);
+}
+
+/* ---------- accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .laser-tip::before,
+  .laser-tip::after,
+  .laser-tip:hover::before,
+  .laser-tip:hover::after,
+  .laser-tip:focus-visible::before,
+  .laser-tip:focus-visible::after {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+    animation: none !important;
+    clip-path: none !important;
+  }
+  .laser-tip::before,
+  .laser-tip::after { opacity: 0; }
+  .laser-tip:hover::before,
+  .laser-tip:hover::after,
+  .laser-tip:focus-visible::before,
+  .laser-tip:focus-visible::after { opacity: 1; }
+
+  /* static rest transforms so beam + bubble are positioned correctly */
+  .laser-tip--top::before,
+  .laser-tip--bottom::before { transform: translateX(-50%) scaleY(1); }
+  .laser-tip--right::before,
+  .laser-tip--left::before   { transform: translateY(-50%) scaleX(1); }
+  .laser-tip--top::after,
+  .laser-tip--bottom::after { transform: translateX(-50%); }
+  .laser-tip--right::after,
+  .laser-tip--left::after   { transform: translateY(-50%); }
+}


### PR DESCRIPTION
Adds a pure-CSS laser ray trace tooltip example under `submissions/examples/css-tooltip-laser-ray-trace-73485/` (`demo.html` + `style.css` + `README.md`), following the repo's existing tooltip example conventions.

## What
- A tooltip that fires a laser beam line (`::before`, a thin bar that scales out from the trigger via `scaleX`/`scaleY` with `transform-origin` anchored to the trigger side) over 0.16s, then the bubble (`::after`) sweeps open via `clip-path: inset(...)` over 0.42s with the start delayed by the beam duration. Pure CSS, no JS.
- Directional beams (vertical for top/bottom, horizontal for left/right) and directional clip sweeps so the panel opens along the beam. Neon layered `box-shadow` + glow `text-shadow`.
- Uses the established `[data-tooltip]` pattern, four direction modifiers (top/right/bottom/left), `:hover` / `:focus-visible` reveal, `tabindex=0` for keyboard access.
- `prefers-reduced-motion: reduce` halts beam-grow + clip sweep (beam fully scaled, bubble `clip-path: none`, both shown instantly at rest).

## Files
- `submissions/examples/css-tooltip-laser-ray-trace-73485/demo.html`
- `submissions/examples/css-tooltip-laser-ray-trace-73485/style.css`
- `submissions/examples/css-tooltip-laser-ray-trace-73485/README.md`

Closes #73485

---

_This pull request was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
