### PR TITLE
feat: add particle burst tooltip example

### DIFF
--- a/submissions/examples/css-tooltip-particle-burst-73486/README.md
+++ b/submissions/examples/css-tooltip-particle-burst-73486/README.md
@@ -1,0 +1,76 @@
+# Particle Burst Tooltip
+
+A pure-CSS tooltip that **bursts a spray of particles** outward from the
+trigger, then fades the message bubble in behind them. The particles are a
+single `box-shadow` list on a `0x0` `::before` element, animated from
+all-at-center to a spread ring — no JavaScript, no images, no DOM particles.
+
+## Overview
+
+This contribution implements the **Particle Burst** tooltip variation (#238)
+for the EaseMotion CSS library, following the existing tooltip example
+conventions (`demo.html` + `style.css` + `README.md`).
+
+## Features
+
+- **box-shadow particles**: the `::before` is a `0x0` box carrying an 8-entry
+  `box-shadow` list (alternating `--particle` / `--particle2` colors). At rest
+  every shadow is at `(0,0)`; the keyframe spreads them onto axes + diagonals
+  at radius `--r`, reading as a burst.
+- **Single-pass burst**: the particle keyframe runs once (`forwards`) over
+  `0.6s ease-out`, fading out at the end so the field disappears cleanly.
+- **Staged bubble**: the message bubble (`::after`) fades in with a
+  `--burst`-long delay so it appears *after* the burst, layered behind the
+  settling particles.
+- **Four directions**: top, right, bottom, left modifiers; the `::before`
+  origin is anchored to the trigger edge facing the bubble so the burst
+  emanates from the correct side.
+- **Keyboard accessible**: triggers carry `tabindex="0"` and reveal on
+  `:focus-visible`, not just `:hover`.
+- **Hardware-accelerated**: the burst animates `box-shadow` + `opacity`
+  (paint-only, no layout); the bubble animates `opacity`.
+- **Dark mode**: dark by default; the palette is driven by CSS custom
+  properties so it can be re-themed.
+- **Reduced motion**: `prefers-reduced-motion: reduce` hides the particle
+  field entirely and shows the bubble instantly (no burst, no fade), so
+  motion-sensitive users get a clean, static tooltip.
+- **Zero JavaScript**.
+
+## Usage
+
+```html
+<span
+  class="burst-tip burst-tip--top"
+  tabindex="0"
+  data-tooltip="Particles spray outward, then the bubble appears."
+  >Hover / focus</span
+>
+```
+
+## CSS Custom Properties
+
+```css
+--particle: #ffd166;
+--particle2: #ef476f;
+--dur: 0.5s;    /* bubble fade in */
+--burst: 0.6s;  /* particle burst + bubble delay */
+--r: 26px;       /* particle spread radius */
+```
+
+## Accessibility Notes
+
+- The trigger is a real focusable element (`tabindex="0"`) and reveals on
+  `:focus-visible`.
+- `prefers-reduced-motion: reduce` hides the `::before` particle field
+  entirely (`opacity: 0`) and shows the bubble instantly, so there is no burst
+  or fade for motion-sensitive users.
+- The decorative `::before` carries no text; the readable message lives
+  entirely in the bubble's `::after` content for unambiguous screen-reader
+  access.
+- The particle keyframe is single-pass (`forwards`, not `infinite`), so the
+  burst plays once per reveal and stops — no continuous motion.
+
+## Related Issue
+
+Addresses Issue #73486 in the EaseMotion CSS repository (CSS Tooltip: Particle
+Burst Variation #238).

--- a/submissions/examples/css-tooltip-particle-burst-73486/demo.html
+++ b/submissions/examples/css-tooltip-particle-burst-73486/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Tooltip: Particle Burst | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__head">
+        <p class="eyebrow">Tooltips &amp; Popovers &middot; Variation #238</p>
+        <h1>Particle Burst Tooltip</h1>
+        <p class="lead">
+          A pure-CSS tooltip that bursts a spray of particles outward from the
+          trigger, then the message bubble fades in behind them. No JavaScript.
+        </p>
+      </header>
+
+      <section class="demo" aria-label="Particle burst tooltip variants">
+        <div class="demo__grid">
+          <span
+            class="burst-tip burst-tip--top"
+            tabindex="0"
+            data-tooltip="Particles spray outward, then the bubble appears."
+            >Hover / focus &uarr;</span
+          >
+          <span
+            class="burst-tip burst-tip--right"
+            tabindex="0"
+            data-tooltip="Eight particles via layered box-shadows."
+            >Right &rarr;</span
+          >
+          <span
+            class="burst-tip burst-tip--bottom"
+            tabindex="0"
+            data-tooltip="Single-pass burst, fades and falls."
+            >&darr; Bottom</span
+          >
+          <span
+            class="burst-tip burst-tip--left"
+            tabindex="0"
+            data-tooltip="No JS, no images - pure box-shadow particles."
+            >&larr; Left</span
+          >
+        </div>
+        <p class="hint">
+          Keyboard: <kbd>Tab</kbd> to focus a trigger; the burst fires.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/css-tooltip-particle-burst-73486/style.css
+++ b/submissions/examples/css-tooltip-particle-burst-73486/style.css
@@ -1,0 +1,331 @@
+/* =========================================================================
+   Particle Burst Tooltip - pure CSS, no JS
+   ::before = a 0x0 box carrying 8 box-shadow "particles". On reveal a
+   keyframe animates the box-shadow list from all-at-center to spread-out +
+   fading, reading as a burst. ::after = the message bubble, fading in.
+   Reveal on :hover / :focus-visible. prefers-reduced-motion skips the burst.
+   ========================================================================= */
+
+:root {
+  --bg: #0a0810;
+  --fg: #f3e9ff;
+  --muted: #8a8095;
+  --particle: #ffd166;
+  --particle2: #ef476f;
+  --tip-bg: rgba(20, 14, 28, 0.95);
+  --tip-fg: #fbe9ff;
+  --dur: 0.5s;
+  --burst: 0.6s;
+  /* particle spread radius */
+  --r: 26px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background:
+    radial-gradient(700px 450px at 50% 0%, rgba(255, 209, 102, 0.08), transparent 60%),
+    var(--bg);
+  color: var(--fg);
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: clamp(24px, 6vw, 64px) 20px;
+}
+
+.page__head {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  color: var(--particle);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+  margin: 0 0 10px;
+}
+
+.page__head h1 {
+  margin: 0 0 10px;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, var(--particle), var(--particle2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lead {
+  max-width: 58ch;
+  margin: 0 auto;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+/* ---------- demo layout ---------- */
+.demo__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 28px;
+  justify-items: center;
+  padding: 30px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 209, 102, 0.12);
+  border-radius: 18px;
+}
+
+.hint {
+  margin: 22px 0 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+kbd {
+  background: #15101d;
+  border: 1px solid #2a1f3a;
+  border-radius: 6px;
+  padding: 1px 7px;
+  font-size: 0.8em;
+}
+
+/* ---------- the trigger ---------- */
+.burst-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--fg);
+  background: rgba(255, 209, 102, 0.08);
+  border: 1px solid rgba(255, 209, 102, 0.4);
+  outline: none;
+  transition: border-color var(--dur), box-shadow var(--dur),
+    background var(--dur);
+}
+
+.burst-tip:hover,
+.burst-tip:focus-visible {
+  border-color: var(--particle);
+  box-shadow: 0 0 18px rgba(255, 209, 102, 0.3);
+  background: rgba(255, 209, 102, 0.14);
+}
+
+/* ---------- shared pseudo base ---------- */
+.burst-tip::before,
+.burst-tip::after {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 20;
+}
+
+/* ---------- the particle field (::before) ----------
+   A 0x0 element whose box-shadow list forms 8 particles. The keyframe
+   animates the list from all-at-(0,0) to spread on a ring, fading out. */
+.burst-tip::before {
+  content: "";
+  width: 0;
+  height: 0;
+  /* resting (hidden) state: particles at center */
+  box-shadow:
+    0 0 0 var(--particle),
+    0 0 0 var(--particle2),
+    0 0 0 var(--particle),
+    0 0 0 var(--particle2),
+    0 0 0 var(--particle),
+    0 0 0 var(--particle2),
+    0 0 0 var(--particle),
+    0 0 0 var(--particle2);
+}
+
+/* ---------- the bubble (::after) ---------- */
+.burst-tip::after {
+  content: attr(data-tooltip);
+  width: max-content;
+  max-width: 240px;
+  padding: 9px 13px;
+  background: var(--tip-bg);
+  color: var(--tip-fg);
+  border: 1px solid rgba(255, 209, 102, 0.5);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  font-weight: 500;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  transition: opacity var(--dur) ease var(--burst);
+}
+
+/* ---------- burst keyframes (per direction: origin at trigger edge) ---------- */
+/* ring of 8 particles spread on axes + diagonals; fade out at end */
+@keyframes burst--top {
+  0% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2);
+  }
+  100% {
+    opacity: 0;
+    box-shadow:
+       0 calc(-1 * var(--r)) 0 var(--particle),
+         var(--r) calc(-1 * var(--r)) 0 var(--particle2),
+         var(--r) 0 0 var(--particle),
+         var(--r) var(--r) 0 var(--particle2),
+       0 var(--r) 0 var(--particle),
+      calc(-1 * var(--r)) var(--r) 0 var(--particle2),
+      calc(-1 * var(--r)) 0 0 var(--particle),
+      calc(-1 * var(--r)) calc(-1 * var(--r)) 0 var(--particle2);
+  }
+}
+
+/* the right/left/bottom variants reuse the same ring shape; only the
+   ::before origin differs, which is set per-modifier below. We reuse one
+   keyframe for all four by naming it generally. */
+@keyframes burst--side {
+  0% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2),
+      0 0 0 var(--particle), 0 0 0 var(--particle2);
+  }
+  100% {
+    opacity: 0;
+    box-shadow:
+       0 calc(-1 * var(--r)) 0 var(--particle),
+         var(--r) calc(-1 * var(--r)) 0 var(--particle2),
+         var(--r) 0 0 var(--particle),
+         var(--r) var(--r) 0 var(--particle2),
+       0 var(--r) 0 var(--particle),
+      calc(-1 * var(--r)) var(--r) 0 var(--particle2),
+      calc(-1 * var(--r)) 0 0 var(--particle),
+      calc(-1 * var(--r)) calc(-1 * var(--r)) 0 var(--particle2);
+  }
+}
+
+/* ---------- positions + reveal wiring ---------- */
+/* TOP: origin at top-center of trigger, burst upward into the gap */
+.burst-tip--top::before {
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.burst-tip--top::after {
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+.burst-tip--top:hover::before,
+.burst-tip--top:focus-visible::before {
+  opacity: 1;
+  animation: burst--top var(--burst) ease-out forwards;
+}
+.burst-tip--top:hover::after,
+.burst-tip--top:focus-visible::after {
+  opacity: 1;
+}
+
+/* RIGHT */
+.burst-tip--right::before {
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+}
+.burst-tip--right::after {
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translateY(-50%);
+}
+.burst-tip--right:hover::before,
+.burst-tip--right:focus-visible::before {
+  opacity: 1;
+  animation: burst--side var(--burst) ease-out forwards;
+}
+.burst-tip--right:hover::after,
+.burst-tip--right:focus-visible::after {
+  opacity: 1;
+}
+
+/* BOTTOM */
+.burst-tip--bottom::before {
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.burst-tip--bottom::after {
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+.burst-tip--bottom:hover::before,
+.burst-tip--bottom:focus-visible::before {
+  opacity: 1;
+  animation: burst--side var(--burst) ease-out forwards;
+}
+.burst-tip--bottom:hover::after,
+.burst-tip--bottom:focus-visible::after {
+  opacity: 1;
+}
+
+/* LEFT */
+.burst-tip--left::before {
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+}
+.burst-tip--left::after {
+  top: 50%;
+  right: calc(100% + 12px);
+  transform: translateY(-50%);
+}
+.burst-tip--left:hover::before,
+.burst-tip--left:focus-visible::before {
+  opacity: 1;
+  animation: burst--side var(--burst) ease-out forwards;
+}
+.burst-tip--left:hover::after,
+.burst-tip--left:focus-visible::after {
+  opacity: 1;
+}
+
+/* ---------- accessibility ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .burst-tip::before,
+  .burst-tip::after,
+  .burst-tip:hover::before,
+  .burst-tip:hover::after,
+  .burst-tip:focus-visible::before,
+  .burst-tip:focus-visible::after {
+    transition-duration: 0.01ms !important;
+    animation: none !important;
+  }
+  /* hide the particle field entirely for reduced motion; show bubble */
+  .burst-tip::before { opacity: 0 !important; }
+  .burst-tip::after { opacity: 0; }
+  .burst-tip:hover::after,
+  .burst-tip:focus-visible::after { opacity: 1; }
+}


### PR DESCRIPTION
Adds a pure-CSS particle burst tooltip example under `submissions/examples/css-tooltip-particle-burst-73486/` (`demo.html` + `style.css` + `README.md`), following the repo's existing tooltip example conventions.

## What
- A tooltip that bursts a spray of particles outward from the trigger via a `0x0` `::before` element carrying an 8-entry `box-shadow` list, animated single-pass (`forwards`) from all-at-center to a spread ring on axes + diagonals over 0.6s `ease-out`, fading at the end. The message bubble (`::after`) fades in after with a `--burst`-long delay. Pure CSS, no JS, no images, no DOM particles.
- `::before` origin anchored to the trigger edge per direction so the burst emanates from the correct side.
- Uses the established `[data-tooltip]` pattern, four direction modifiers (top/right/bottom/left), `:hover` / `:focus-visible` reveal, `tabindex=0` for keyboard access.
- `prefers-reduced-motion: reduce` hides the particle field entirely and shows the bubble instantly.

## Files
- `submissions/examples/css-tooltip-particle-burst-73486/demo.html`
- `submissions/examples/css-tooltip-particle-burst-73486/style.css`
- `submissions/examples/css-tooltip-particle-burst-73486/README.md`

Closes #73486

---

_This pull request was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
