### PR TITLE
feat: add ease-hover-card-flip-preview-sap

### DIFF
--- a/submissions/examples/ease-hover-card-flip-preview-sap/README.md
+++ b/submissions/examples/ease-hover-card-flip-preview-sap/README.md
@@ -1,0 +1,33 @@
+# Hover Card Flip Preview
+
+A card that flips to reveal a detail preview on hover or keyboard focus,
+similar in mechanism to the pricing flip card but styled for a
+person/profile preview use case.
+
+**Level:** Intermediate
+
+## Usage
+
+`.preview-card` is a focusable `perspective` container; `.preview-inner`
+rotates on `:hover`/`:focus-visible` to reveal `.preview-back`.
+
+## Accessibility
+
+- Card is focusable (`tabindex="0"`) and the flip triggers on
+  `:focus-visible` as well as `:hover`, so keyboard users can preview the
+  back content without needing a pointer.
+- `:focus-visible` also shows a distinct box-shadow ring around the whole
+  card, independent of the flip state itself.
+- Both faces' text content exists in the DOM at all times (not injected on
+  flip), so it's available to assistive tech and text search regardless of
+  visual flip state.
+- `prefers-reduced-motion` removes the rotate transition; hover/focus still
+  reveals the back face, just as an instant switch.
+
+## Notes
+
+- This is a hover/focus preview effect — there's no click-to-pin/toggle
+  behavior in this demo, so the back content is only visible while
+  hovering or focused. If a persistent (click-to-flip-and-stay) variant is
+  needed, see the toggle-based approach in `ease-card-flip-pricing-sap`
+  instead, which uses a click handler rather than pure `:hover`/`:focus-visible`.

--- a/submissions/examples/ease-hover-card-flip-preview-sap/demo.html
+++ b/submissions/examples/ease-hover-card-flip-preview-sap/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Card Flip Preview</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Card Flip Preview</h1>
+
+    <div class="preview-grid">
+      <div class="preview-card" tabindex="0">
+        <div class="preview-inner">
+          <div class="preview-face preview-front">
+            <h2>Team Member</h2>
+            <p>Hover to preview</p>
+          </div>
+          <div class="preview-face preview-back">
+            <h3>Priya Shah</h3>
+            <p>Senior Engineer, 5 yrs on the platform team.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-hover-card-flip-preview-sap/style.css
+++ b/submissions/examples/ease-hover-card-flip-preview-sap/style.css
@@ -1,0 +1,78 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.preview-card {
+  width: 240px;
+  height: 160px;
+  perspective: 1000px;
+  outline: none;
+}
+
+.preview-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.5s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.preview-card:hover .preview-inner,
+.preview-card:focus-visible .preview-inner {
+  transform: rotateY(180deg);
+}
+
+.preview-card:focus-visible {
+  box-shadow: 0 0 0 3px #6366f1;
+  border-radius: 14px;
+}
+
+.preview-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.08);
+}
+
+.preview-front {
+  background: white;
+  border: 1px solid #e2e8f0;
+}
+
+.preview-front h2 { margin: 0 0 0.3rem; font-size: 1rem; }
+.preview-front p { margin: 0; font-size: 0.8rem; color: #94a3b8; }
+
+.preview-back {
+  background: #4338ca;
+  color: white;
+  transform: rotateY(180deg);
+}
+
+.preview-back h3 { margin: 0 0 0.4rem; font-size: 1.05rem; }
+.preview-back p { margin: 0; font-size: 0.8rem; color: #c7d2fe; }
+
+@media (prefers-reduced-motion: reduce) {
+  .preview-inner { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-card-flip-preview-sap`, a hover/focus-triggered flip card for detail previews.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-card-flip-preview-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Flip triggers on `:focus-visible` as well as `:hover`, giving keyboard
  users the same preview access as mouse users, with a distinct focus ring.
- README distinguishes this hover-only preview pattern from the click-toggle
  flip card elsewhere in the set, pointing to the right component depending
  on whether a persistent flip is needed.

## Feature Description

Adds a reusable hover/focus flip-card preview component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.