### PR TITLE
feat: add ease-scroll-video-autoplay-fade-sap

### DIFF
--- a/submissions/examples/ease-scroll-video-autoplay-fade-sap/README.md
+++ b/submissions/examples/ease-scroll-video-autoplay-fade-sap/README.md
@@ -1,0 +1,45 @@
+# Scroll Video Autoplay Fade
+
+A background video that fades into view and only plays while scrolled into
+the viewport (pausing when scrolled away), muted by default with an
+explicit unmute control.
+
+**Level:** Advanced
+
+## Usage
+
+`IntersectionObserver` toggles `.is-visible` (fade-in) and calls
+`video.play()`/`video.pause()` based on whether `.video-frame` is at least
+40% visible. A separate toggle button controls mute state.
+
+## Accessibility
+
+- The video is `muted` by default (required for reliable autoplay in all
+  major browsers, and also the respectful default for unexpected audio) and
+  carries a descriptive `aria-label` summarizing its content, since it has
+  no captions track in this demo.
+- An explicit, labeled unmute/mute toggle button (`aria-pressed` kept in
+  sync, `aria-label` reflecting the next action) is provided — audio is
+  never turned on without explicit user action.
+- The video pauses when scrolled out of view, so it doesn't keep playing
+  (and, if unmuted, keep making sound) off-screen indefinitely.
+- `.play()` is wrapped in a `.catch(() => {})` since browsers may still
+  reject autoplay in some contexts even when muted; the code doesn't break
+  if that happens.
+- `prefers-reduced-motion` removes the fade-in transition; the video's
+  play/pause-on-scroll behavior is left as-is since it's functionally tied
+  to the video's role as content rather than being a decorative motion
+  effect — content and its play state should remain scroll-synced whether
+  or not the *entrance* is animated, though a stricter interpretation could
+  also disable autoplay entirely under reduced motion. Noted here as a
+  judgment call.
+- This demo has no captions/transcript for the video since it's decorative
+  background footage described via `aria-label`; a video conveying
+  meaningful spoken/informational content would need real captions instead.
+
+## Notes
+
+- Uses a public domain sample video from MDN's example media for the demo;
+  swap the `<source>` for real footage.
+- Play/pause-on-visibility (not just fade-in) avoids wasting bandwidth/CPU
+  on an off-screen autoplaying video.

--- a/submissions/examples/ease-scroll-video-autoplay-fade-sap/demo.html
+++ b/submissions/examples/ease-scroll-video-autoplay-fade-sap/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Video Autoplay Fade</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Video Autoplay Fade</h1><p>Scroll down — the video fades in and plays only while in view.</p></section>
+
+    <section class="video-section">
+      <div class="video-frame" id="videoFrame">
+        <video
+          id="demoVideo"
+          class="demo-video"
+          muted
+          loop
+          playsinline
+          aria-label="Muted looping background footage of city traffic at night"
+        >
+          <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
+        </video>
+        <button class="video-toggle" id="videoToggle" aria-pressed="false" aria-label="Play video with sound">
+          🔇
+        </button>
+      </div>
+    </section>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <script>
+    const frame = document.getElementById('videoFrame');
+    const video = document.getElementById('demoVideo');
+    const toggle = document.getElementById('videoToggle');
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          frame.classList.add('is-visible');
+          video.play().catch(() => {});
+        } else {
+          video.pause();
+        }
+      });
+    }, { threshold: 0.4 });
+
+    observer.observe(frame);
+
+    toggle.addEventListener('click', () => {
+      video.muted = !video.muted;
+      toggle.setAttribute('aria-pressed', String(!video.muted));
+      toggle.setAttribute('aria-label', video.muted ? 'Play video with sound' : 'Mute video');
+      toggle.textContent = video.muted ? '🔇' : '🔊';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-video-autoplay-fade-sap/style.css
+++ b/submissions/examples/ease-scroll-video-autoplay-fade-sap/style.css
@@ -1,0 +1,76 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.content { max-width: 700px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #94a3b8; }
+
+.video-section {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.video-frame {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  border-radius: 16px;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.video-frame.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.demo-video {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.video-toggle {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0,0,0,0.55);
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.video-toggle:hover { background: rgba(0,0,0,0.75); }
+
+.video-toggle:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .video-frame { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-video-autoplay-fade-sap`, a scroll-triggered fade-in video that plays only while visible.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-video-autoplay-fade-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Video is `muted` by default with an explicit, labeled unmute toggle —
  audio never turns on without direct user action — and pauses whenever
  scrolled out of view.
- README is explicit that this demo's video has no captions since it's
  decorative footage described via `aria-label`, and flags the reduced-motion
  scope-of-autoplay question as a judgment call rather than presenting the
  current behavior as unambiguously correct.

## Feature Description

Adds a reusable scroll-triggered autoplay/pause video component with mute control.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.