### PR TITLE
feat: add ease-drag-slider-timeline-scrub-sap

### DIFF
--- a/submissions/examples/ease-drag-slider-timeline-scrub-sap/README.md
+++ b/submissions/examples/ease-drag-slider-timeline-scrub-sap/README.md
@@ -1,0 +1,38 @@
+# Drag Slider Timeline Scrub
+
+A media-player-style scrub bar for seeking through a timeline, draggable
+via pointer with the handle growing on hover, and full keyboard seek support.
+
+**Level:** Advanced
+
+## Usage
+
+`.scrub-track` is a `role="slider"` div. Dragging or clicking anywhere on
+the track calls `setTime()` based on pointer X position; ArrowLeft/Right
+seek ±5 seconds, Home/End jump to start/end.
+
+## Accessibility
+
+- Implements the ARIA slider pattern: `role="slider"`, `aria-valuemin`/
+  `aria-valuemax`/`aria-valuenow` (in seconds), and `aria-valuetext` giving
+  a human-readable "0:42 of 3:00" format — since raw seconds alone aren't
+  very meaningful when announced.
+- Fully keyboard-operable independent of dragging: ArrowLeft/Right step by
+  5 seconds, Home/End jump to the extremes, matching common media-player
+  keyboard conventions.
+- Current time is also shown as visible text next to the track
+  (`#currentTime`), not conveyed by handle position alone.
+- `:focus-visible` outline shown on the track.
+- `prefers-reduced-motion` removes the handle's hover-scale transition;
+  seeking itself is a direct, non-animated value change regardless.
+
+## Notes
+
+- `aria-valuetext` is recalculated on every `setTime()` call (drag,
+  keyboard, or click), so it always reflects the current formatted time
+  rather than only being set once at initial render.
+- This is a slider-only scrub bar; it doesn't include actual audio/video
+  playback wiring in this demo — pair `setTime()`'s output with a real
+  media element's `currentTime` property in production usage.
+- Clicking directly on the track (not just dragging the handle) also seeks,
+  matching standard media player scrub-bar behavior.

--- a/submissions/examples/ease-drag-slider-timeline-scrub-sap/demo.html
+++ b/submissions/examples/ease-drag-slider-timeline-scrub-sap/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Slider Timeline Scrub</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Slider Timeline Scrub</h1>
+
+    <div class="player">
+      <div
+        class="scrub-track"
+        id="scrubTrack"
+        role="slider"
+        tabindex="0"
+        aria-label="Seek"
+        aria-valuemin="0"
+        aria-valuemax="180"
+        aria-valuenow="42"
+        aria-valuetext="0:42 of 3:00"
+      >
+        <div class="scrub-fill" id="scrubFill" style="width: 23.3%;"></div>
+        <div class="scrub-handle" id="scrubHandle" style="left: 23.3%;"></div>
+      </div>
+      <div class="time-row">
+        <span id="currentTime">0:42</span>
+        <span id="totalTime">3:00</span>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const track = document.getElementById('scrubTrack');
+    const fill = document.getElementById('scrubFill');
+    const handle = document.getElementById('scrubHandle');
+    const currentTimeEl = document.getElementById('currentTime');
+    const DURATION = 180;
+    let dragging = false;
+
+    function fmt(sec) {
+      const m = Math.floor(sec / 60);
+      const s = Math.floor(sec % 60).toString().padStart(2, '0');
+      return `${m}:${s}`;
+    }
+
+    function setTime(sec) {
+      sec = Math.min(Math.max(sec, 0), DURATION);
+      const pct = (sec / DURATION) * 100;
+      fill.style.width = pct + '%';
+      handle.style.left = pct + '%';
+      track.setAttribute('aria-valuenow', Math.round(sec));
+      track.setAttribute('aria-valuetext', `${fmt(sec)} of ${fmt(DURATION)}`);
+      currentTimeEl.textContent = fmt(sec);
+    }
+
+    function timeFromEvent(e) {
+      const rect = track.getBoundingClientRect();
+      const pct = (e.clientX - rect.left) / rect.width;
+      return pct * DURATION;
+    }
+
+    track.addEventListener('pointerdown', (e) => {
+      dragging = true;
+      track.setPointerCapture(e.pointerId);
+      setTime(timeFromEvent(e));
+    });
+
+    track.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      setTime(timeFromEvent(e));
+    });
+
+    track.addEventListener('pointerup', () => { dragging = false; });
+
+    track.addEventListener('keydown', (e) => {
+      const current = parseFloat(track.getAttribute('aria-valuenow'));
+      if (e.key === 'ArrowRight') { e.preventDefault(); setTime(current + 5); }
+      if (e.key === 'ArrowLeft') { e.preventDefault(); setTime(current - 5); }
+      if (e.key === 'Home') { e.preventDefault(); setTime(0); }
+      if (e.key === 'End') { e.preventDefault(); setTime(DURATION); }
+    });
+
+    setTime(42);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-slider-timeline-scrub-sap/style.css
+++ b/submissions/examples/ease-drag-slider-timeline-scrub-sap/style.css
@@ -1,0 +1,73 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.75rem;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.player { width: min(360px, 90vw); }
+
+.scrub-track {
+  position: relative;
+  height: 5px;
+  border-radius: 999px;
+  background: #334155;
+  cursor: pointer;
+  touch-action: none;
+  margin: 0 8px;
+}
+
+.scrub-fill {
+  position: absolute;
+  height: 100%;
+  border-radius: 999px;
+  background: #6366f1;
+}
+
+.scrub-handle {
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  transition: transform 0.15s ease;
+}
+
+.scrub-track:hover .scrub-handle {
+  transform: translate(-50%, -50%) scale(1.3);
+}
+
+.scrub-track:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 4px;
+}
+
+.time-row {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrub-handle { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-slider-timeline-scrub-sap`, a draggable media-timeline scrub bar with full keyboard support.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-slider-timeline-scrub-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Implements the ARIA slider pattern with `aria-valuetext` giving a
  human-readable time format, recalculated on every seek regardless of input method.
- ArrowLeft/Right/Home/End keyboard seeking works fully independent of
  pointer dragging, matching standard media-player conventions.
- README notes this is a slider-only scrub bar without actual media
  playback wiring, to be paired with a real media element in production.

## Feature Description

Adds a reusable draggable media-timeline scrub bar component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.