### PR TITLE
feat: add ease-drag-crop-rotate-image-sap

### DIFF
--- a/submissions/examples/ease-drag-crop-rotate-image-sap/README.md
+++ b/submissions/examples/ease-drag-crop-rotate-image-sap/README.md
@@ -1,0 +1,18 @@
+# ease-drag-crop-rotate-image-sap
+
+An image crop preview frame — drag the image to reposition it within the fixed crop bounds, plus a rotate button, common in avatar/profile upload UIs.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.crop-frame` (fixed size, `overflow: hidden`) containing the draggable `<img>`.
+3. Attach the drag + rotate/reset logic from `demo.html`.
+
+## Customization
+- Frame dimensions/border-radius (circular for avatar-style crop, or square/rectangular).
+- Rotation increment (`90°` per click) — reduce for finer control.
+- Image starting size/zoom level.
+
+## Notes
+- Position and rotation are both stored as CSS custom properties (`--tx`, `--ty`, `--rot`) combined in a single `transform`, so dragging and rotating compose correctly instead of overwriting each other.
+- `overflow: hidden` on the frame is what creates the actual "crop" — the image extends beyond the frame and only the visible portion counts as the crop result.
+- Respects `prefers-reduced-motion`: the smoothing transition on the image transform is removed; live drag remains 1:1 direct input regardless, and the rotate button's transform change becomes an instant snap rather than eased.

--- a/submissions/examples/ease-drag-crop-rotate-image-sap/demo.html
+++ b/submissions/examples/ease-drag-crop-rotate-image-sap/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-crop-rotate-image-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="crop-rotate-sap">
+    <div class="crop-frame" id="frame">
+      <img id="img" src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=500" alt="Crop preview">
+    </div>
+    <div class="crop-controls">
+      <button id="rotateBtn">Rotate 90°</button>
+      <button id="resetBtn">Reset</button>
+    </div>
+  </div>
+  <script>
+    const frame = document.getElementById('frame');
+    const img = document.getElementById('img');
+    let tx = 0, ty = 0, rot = 0;
+    let dragging = false, startX = 0, startY = 0;
+
+    function applyTransform() {
+      img.style.setProperty('--tx', tx + 'px');
+      img.style.setProperty('--ty', ty + 'px');
+      img.style.setProperty('--rot', rot + 'deg');
+    }
+
+    function onDown(x, y) {
+      dragging = true;
+      startX = x - tx;
+      startY = y - ty;
+      frame.classList.add('dragging');
+    }
+
+    function onMove(x, y) {
+      if (!dragging) return;
+      tx = x - startX;
+      ty = y - startY;
+      applyTransform();
+    }
+
+    function onUp() {
+      dragging = false;
+      frame.classList.remove('dragging');
+    }
+
+    frame.addEventListener('mousedown', (e) => onDown(e.clientX, e.clientY));
+    window.addEventListener('mousemove', (e) => onMove(e.clientX, e.clientY));
+    window.addEventListener('mouseup', onUp);
+    frame.addEventListener('touchstart', (e) => onDown(e.touches[0].clientX, e.touches[0].clientY), { passive: true });
+    frame.addEventListener('touchmove', (e) => onMove(e.touches[0].clientX, e.touches[0].clientY), { passive: true });
+    frame.addEventListener('touchend', onUp);
+
+    document.getElementById('rotateBtn').addEventListener('click', () => {
+      rot = (rot + 90) % 360;
+      applyTransform();
+    });
+
+    document.getElementById('resetBtn').addEventListener('click', () => {
+      tx = 0; ty = 0; rot = 0;
+      applyTransform();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-crop-rotate-image-sap/style.css
+++ b/submissions/examples/ease-drag-crop-rotate-image-sap/style.css
@@ -1,0 +1,58 @@
+.crop-rotate-sap {
+  width: 300px;
+  font-family: system-ui, sans-serif;
+}
+
+.crop-rotate-sap .crop-frame {
+  position: relative;
+  width: 100%;
+  height: 240px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #111;
+  cursor: grab;
+}
+
+.crop-rotate-sap .crop-frame.dragging {
+  cursor: grabbing;
+}
+
+.crop-rotate-sap .crop-frame img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  max-width: none;
+  width: 340px;
+  transform: translate(-50%, -50%) translate(var(--tx, 0px), var(--ty, 0px)) rotate(var(--rot, 0deg));
+  transition: transform 0.15s ease-out;
+  user-select: none;
+  pointer-events: none;
+}
+
+.crop-rotate-sap .crop-frame.dragging img {
+  transition: none;
+}
+
+.crop-rotate-sap .crop-controls {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.crop-rotate-sap .crop-controls button {
+  flex: 1;
+  padding: 9px;
+  border: none;
+  border-radius: 8px;
+  background: #111;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crop-rotate-sap .crop-frame img {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-crop-rotate-image-sap`, a draggable image crop/rotate preview frame.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-crop-rotate-image-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Position and rotation are separate CSS custom properties combined in one `transform`, so drag and rotate compose correctly rather than overwriting each other.
- `overflow: hidden` on the frame is what produces the actual crop effect on the oversized draggable image.
- `prefers-reduced-motion` removes the transform's smoothing transition; the rotate button's change becomes an instant snap, while live drag remains unaffected as direct input.

## Feature Description

Adds a reusable draggable image crop/rotate preview component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.