### PR TITLE
feat: add ease-drag-calendar-event-resize-sap

### DIFF
--- a/submissions/examples/ease-drag-calendar-event-resize-sap/README.md
+++ b/submissions/examples/ease-drag-calendar-event-resize-sap/README.md
@@ -1,0 +1,18 @@
+# ease-drag-calendar-event-resize-sap
+
+A calendar event block with a bottom-edge resize handle — drag to change the event's duration, snapping to the underlying time-grid lines.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.cal-event` (with a `.resize-handle` at the bottom) inside a grid-lined calendar container.
+3. Attach the resize drag logic from `demo.html`.
+
+## Customization
+- `gridSize` (JS): snapping increment in pixels — should match the visual grid line spacing (`40px` here, e.g. representing 30-min slots).
+- `minHeight`: prevents the event from being resized smaller than a minimum duration.
+- Event color/content.
+
+## Notes
+- `e.stopPropagation()` on the handle's `mousedown` prevents the resize drag from also triggering any drag-to-move behavior on the parent event block (not implemented in this demo, but a common pairing).
+- Height snaps to `gridSize` increments via rounding, so the event always aligns to visible grid lines rather than landing at an arbitrary pixel height.
+- Respects `prefers-reduced-motion`: the event has no decorative transition to begin with (resize is 1:1 direct drag input); a defensive `transition: none` is included in case one is added later.

--- a/submissions/examples/ease-drag-calendar-event-resize-sap/demo.html
+++ b/submissions/examples/ease-drag-calendar-event-resize-sap/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-calendar-event-resize-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="cal-resize-sap">
+    <div class="cal-event" id="event">
+      Team Standup
+      <div class="resize-handle" id="handle"></div>
+    </div>
+  </div>
+  <script>
+    const event = document.getElementById('event');
+    const handle = document.getElementById('handle');
+    let resizing = false;
+    let startY = 0;
+    let startHeight = 0;
+    const minHeight = 40;
+    const gridSize = 40;
+
+    handle.addEventListener('mousedown', (e) => {
+      e.stopPropagation();
+      resizing = true;
+      startY = e.clientY;
+      startHeight = event.offsetHeight;
+      event.classList.add('resizing');
+    });
+
+    window.addEventListener('mousemove', (e) => {
+      if (!resizing) return;
+      const delta = e.clientY - startY;
+      let newHeight = Math.max(minHeight, startHeight + delta);
+      newHeight = Math.round(newHeight / gridSize) * gridSize;
+      event.style.height = newHeight + 'px';
+    });
+
+    window.addEventListener('mouseup', () => {
+      resizing = false;
+      event.classList.remove('resizing');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-calendar-event-resize-sap/style.css
+++ b/submissions/examples/ease-drag-calendar-event-resize-sap/style.css
@@ -1,0 +1,56 @@
+.cal-resize-sap {
+  position: relative;
+  width: 220px;
+  height: 400px;
+  background: repeating-linear-gradient(to bottom, #f1f5f9 0, #f1f5f9 1px, transparent 1px, transparent 40px);
+  border-radius: 12px;
+  font-family: system-ui, sans-serif;
+}
+
+.cal-resize-sap .cal-event {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 40px;
+  height: 120px;
+  background: #2563eb;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 10px;
+  box-sizing: border-box;
+  overflow: hidden;
+  cursor: grab;
+}
+
+.cal-resize-sap .cal-event.resizing {
+  cursor: ns-resize;
+}
+
+.cal-resize-sap .resize-handle {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 10px;
+  cursor: ns-resize;
+}
+
+.cal-resize-sap .resize-handle::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 3px;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(255,255,255,0.5);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cal-resize-sap .cal-event {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-calendar-event-resize-sap`, a draggable calendar event resize handle with grid snapping.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-calendar-event-resize-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `e.stopPropagation()` on the resize handle prevents conflicts with any future drag-to-move behavior on the parent event.
- Resize height snaps to `gridSize` increments, keeping events aligned to the calendar's visible time-grid lines.
- `prefers-reduced-motion`: resize is direct 1:1 drag input with no decorative transition to begin with; a defensive rule is included for future additions.

## Feature Description

Adds a reusable draggable calendar event resize component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.