### PR TITLE
feat: add scroll progress edge indicator

### DIFF
--- a/submissions/examples/scroll-progress-edge-indicator/README.md
+++ b/submissions/examples/scroll-progress-edge-indicator/README.md
@@ -1,0 +1,68 @@
+# Scroll Progress Edge Indicator
+
+A lightweight scroll progress utility that displays the user's reading
+progress along the edge of the viewport.
+
+## What does it do?
+
+The indicator fills vertically as the user moves through the document.
+
+It:
+
+- Tracks the current document scroll position.
+- Updates as the user scrolls up or down.
+- Uses a fixed edge position so it remains visible.
+- Requires no external libraries or assets.
+- Respects `prefers-reduced-motion`.
+
+## How do I use it?
+
+Add the indicator markup:
+
+```html
+<div class="scroll-progress" aria-hidden="true">
+  <span class="scroll-progress__bar"></span>
+</div>
+```
+The progress element can then be styled with:
+
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 5px;
+  height: 100vh;
+}
+
+.scroll-progress__bar {
+  display: block;
+  width: 100%;
+  height: 0;
+}
+
+A small JavaScript handler calculates the percentage of the document that has
+been scrolled:
+
+const scrollableHeight =
+  document.documentElement.scrollHeight - window.innerHeight;
+
+const progress =
+  scrollableHeight > 0
+    ? (window.scrollY / scrollableHeight) * 100
+    : 0;
+
+progressBar.style.height = `${progress}%`;
+Why use it?
+
+The utility is useful for:
+
+Long-form articles
+Documentation pages
+Portfolios
+Tutorials
+Product pages
+Landing pages
+
+The demo is completely self-contained and works by opening demo.html
+directly in a browser.
+

--- a/submissions/examples/scroll-progress-edge-indicator/demo.html
+++ b/submissions/examples/scroll-progress-edge-indicator/demo.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Scroll progress edge indicator demo for EaseMotion CSS">
+  <title>Scroll Progress Edge Indicator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="scroll-progress" aria-hidden="true">
+    <span class="scroll-progress__bar"></span>
+  </div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS · Scroll Utility</p>
+    <h1>Scroll Progress</h1>
+    <p>
+      Scroll through the page and watch the edge indicator track your reading
+      progress.
+    </p>
+    <a class="scroll-hint" href="#content">Start exploring ↓</a>
+  </header>
+
+  <main id="content">
+    <section class="content-section">
+      <span class="section-number">01</span>
+      <div>
+        <h2>Visual feedback</h2>
+        <p>
+          Long-form pages can make it difficult to understand how much content
+          remains. A compact edge indicator gives users immediate visual
+          feedback without taking attention away from the content.
+        </p>
+        <p>
+          The progress bar begins at the top of the viewport and grows as the
+          document is consumed. Scrolling upward reverses the progress
+          naturally.
+        </p>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <span class="section-number">02</span>
+      <div>
+        <h2>Lightweight interaction</h2>
+        <p>
+          The component uses a single element for the indicator and a small
+          amount of JavaScript to calculate document progress. No libraries,
+          frameworks, external assets, or network requests are required.
+        </p>
+        <p>
+          The visual treatment is handled entirely by CSS, making the utility
+          easy to adapt to different themes and layouts.
+        </p>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <span class="section-number">03</span>
+      <div>
+        <h2>Composable by design</h2>
+        <p>
+          The indicator can sit alongside articles, documentation, portfolios,
+          product pages, and other experiences where users move through
+          vertically structured content.
+        </p>
+        <p>
+          Its fixed edge position keeps the indicator visible while allowing
+          the main interface to remain uncluttered.
+        </p>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <span class="section-number">04</span>
+      <div>
+        <h2>Keep moving</h2>
+        <p>
+          Continue scrolling to see the indicator reach the end of the page.
+          Try scrolling back upward to see the progress reverse smoothly.
+        </p>
+        <p>
+          The demo also respects the user's reduced-motion preference by
+          removing unnecessary transitions.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="demo-footer">
+    <p>End of demonstration</p>
+  </footer>
+
+  <script>
+    const progressBar = document.querySelector(".scroll-progress__bar");
+
+    function updateScrollProgress() {
+      const scrollableHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+
+      const progress =
+        scrollableHeight > 0
+          ? (window.scrollY / scrollableHeight) * 100
+          : 0;
+
+      progressBar.style.height = `${progress}%`;
+    }
+
+    let ticking = false;
+
+    window.addEventListener(
+      "scroll",
+      () => {
+        if (!ticking) {
+          window.requestAnimationFrame(() => {
+            updateScrollProgress();
+            ticking = false;
+          });
+
+          ticking = true;
+        }
+      },
+      { passive: true }
+    );
+
+    window.addEventListener("resize", updateScrollProgress);
+
+    updateScrollProgress();
+  </script>
+</body>
+</html>

--- a/submissions/examples/scroll-progress-edge-indicator/style.css
+++ b/submissions/examples/scroll-progress-edge-indicator/style.css
@@ -1,0 +1,193 @@
+:root {
+  --background: #080a0f;
+  --surface: #10141c;
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #f3f6fa;
+  --muted: #98a3b3;
+  --accent: #8ab4ff;
+  --progress-track: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(80, 112, 180, 0.14),
+      transparent 32rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.7;
+}
+
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1000;
+  width: 5px;
+  height: 100vh;
+  background: var(--progress-track);
+}
+
+.scroll-progress__bar {
+  display: block;
+  width: 100%;
+  height: 0;
+  border-radius: 0 0 0 4px;
+  background: var(--accent);
+  box-shadow: 0 0 16px rgba(138, 180, 255, 0.45);
+  transition: height 120ms linear;
+}
+
+.hero {
+  display: flex;
+  min-height: 82vh;
+  width: min(1000px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 7rem 0 5rem;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 800px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero > p:not(.eyebrow) {
+  max-width: 600px;
+  margin: 2rem 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
+.scroll-hint {
+  width: fit-content;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.03);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.scroll-hint:hover {
+  transform: translateY(-2px);
+  border-color: rgba(138, 180, 255, 0.35);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+main {
+  width: min(1000px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.content-section {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 680px);
+  gap: 2rem;
+  min-height: 75vh;
+  padding: 7rem 0;
+  border-top: 1px solid var(--border);
+  align-items: start;
+}
+
+.section-number {
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.content-section h2 {
+  margin: 0 0 1.5rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.content-section p {
+  margin: 0 0 1.25rem;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.demo-footer {
+  width: min(1000px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+}
+
+@media (max-width: 700px) {
+  .scroll-progress {
+    width: 3px;
+  }
+
+  .hero {
+    min-height: 75vh;
+    padding: 5rem 0 4rem;
+  }
+
+  .content-section {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    min-height: auto;
+    padding: 5rem 0;
+  }
+
+  .section-number {
+    order: -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .scroll-progress__bar,
+  .scroll-hint {
+    transition: none;
+  }
+
+  .scroll-hint:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a lightweight scroll progress indicator that tracks the user's reading progress along the edge of the viewport.

### What's included

- Fixed edge progress indicator
- Smooth progress updates while scrolling
- Progress reverses naturally when scrolling upward
- Responsive standalone demonstration
- `prefers-reduced-motion` support
- No external libraries, CDNs, frameworks, or assets
- Self-contained offline demo
- Usage documentation

### Files

- `demo.html` — interactive scroll progress demonstration
- `style.css` — indicator and demo styling
- `README.md` — usage and implementation documentation

### Issue

Closes #77947 

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the scrolling interaction locally