### PR TITLE
feat: add animated text scramble reveal

### DIFF
--- a/submissions/examples/animated-text-scramble-reveal/README.md
+++ b/submissions/examples/animated-text-scramble-reveal/README.md
@@ -1,0 +1,33 @@
+# Animated Text Scramble Reveal
+
+A lightweight text animation that temporarily scrambles characters before
+progressively resolving into the original text.
+
+## What does it do?
+
+The effect replaces unrevealed characters with random characters and gradually
+reveals the final text from left to right.
+
+It can:
+
+- Trigger when text enters the viewport.
+- Reveal characters progressively.
+- Preserve spaces in the original text.
+- Be replayed through a button.
+- Work with multiple independent text elements.
+- Run without external libraries or assets.
+
+## How do I use it?
+
+Add the `text-scramble` class and provide the final text through
+`data-text`:
+
+```html
+<h1
+  class="text-scramble"
+  data-text="Move with Ease"
+  aria-label="Move with Ease"
+>
+  Move with Ease
+</h1>
+```

--- a/submissions/examples/animated-text-scramble-reveal/demo.html
+++ b/submissions/examples/animated-text-scramble-reveal/demo.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Animated text scramble reveal demo for EaseMotion CSS"
+  >
+  <title>Text Scramble Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo">
+    <section class="hero">
+      <p class="eyebrow">EaseMotion CSS · Text Animation</p>
+
+      <h1
+        class="text-scramble"
+        data-text="Move with Ease"
+        aria-label="Move with Ease"
+      >
+        Move with Ease
+      </h1>
+
+      <p class="intro">
+        A lightweight character-scramble reveal that resolves into readable
+        text from left to right.
+      </p>
+
+      <button class="replay-button" type="button">
+        Replay animation
+      </button>
+    </section>
+
+    <section class="examples" aria-label="Text scramble examples">
+      <article class="example-card">
+        <span class="example-number">01</span>
+        <h2
+          class="text-scramble example-title"
+          data-text="Create Motion"
+          aria-label="Create Motion"
+        >
+          Create Motion
+        </h2>
+        <p>
+          Use the effect for hero headings and prominent landing-page
+          typography.
+        </p>
+      </article>
+
+      <article class="example-card">
+        <span class="example-number">02</span>
+        <h2
+          class="text-scramble example-title"
+          data-text="Reveal Ideas"
+          aria-label="Reveal Ideas"
+        >
+          Reveal Ideas
+        </h2>
+        <p>
+          Short phrases can gain a subtle sense of anticipation without
+          overwhelming the interface.
+        </p>
+      </article>
+
+      <article class="example-card">
+        <span class="example-number">03</span>
+        <h2
+          class="text-scramble example-title"
+          data-text="Design Simply"
+          aria-label="Design Simply"
+        >
+          Design Simply
+        </h2>
+        <p>
+          The animation remains self-contained and requires no external
+          animation library.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%";
+    const scrambleElements = document.querySelectorAll(".text-scramble");
+    const replayButton = document.querySelector(".replay-button");
+
+    function scrambleText(element) {
+      const finalText = element.dataset.text;
+      const duration = 900;
+      const startTime = performance.now();
+
+      element.classList.add("is-revealing");
+
+      function update(now) {
+        const elapsed = now - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const revealed = Math.floor(progress * finalText.length);
+
+        let output = "";
+
+        for (let index = 0; index < finalText.length; index += 1) {
+          const character = finalText[index];
+
+          if (character === " ") {
+            output += " ";
+          } else if (index < revealed) {
+            output += character;
+          } else {
+            output += characters[
+              Math.floor(Math.random() * characters.length)
+            ];
+          }
+        }
+
+        element.textContent = output;
+
+        if (progress < 1) {
+          requestAnimationFrame(update);
+        } else {
+          element.textContent = finalText;
+          element.classList.remove("is-revealing");
+        }
+      }
+
+      requestAnimationFrame(update);
+    }
+
+    const observer = new IntersectionObserver(
+      (entries, currentObserver) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            scrambleText(entry.target);
+            currentObserver.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: 0.35
+      }
+    );
+
+    scrambleElements.forEach((element) => {
+      observer.observe(element);
+    });
+
+    replayButton.addEventListener("click", () => {
+      const heroText = document.querySelector(".hero .text-scramble");
+
+      scrambleText(heroText);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-text-scramble-reveal/style.css
+++ b/submissions/examples/animated-text-scramble-reveal/style.css
@@ -1,0 +1,209 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.16),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.demo {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.hero {
+  min-height: 72vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.text-scramble {
+  display: inline-block;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.hero .text-scramble {
+  max-width: 900px;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.intro {
+  max-width: 610px;
+  margin: 2rem 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.replay-button {
+  width: fit-content;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease;
+}
+
+.replay-button:hover {
+  transform: translateY(-2px);
+  border-color: rgba(138, 180, 255, 0.4);
+  background: rgba(138, 180, 255, 0.08);
+}
+
+.replay-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.is-revealing {
+  animation: text-scramble-focus 700ms ease both;
+}
+
+@keyframes text-scramble-focus {
+  from {
+    filter: blur(4px);
+    opacity: 0.35;
+  }
+
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+.examples {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.example-card {
+  min-height: 310px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  background: var(--surface);
+  transition:
+    transform 200ms ease,
+    background 200ms ease,
+    border-color 200ms ease;
+}
+
+.example-card:hover {
+  transform: translateY(-5px);
+  border-color: rgba(138, 180, 255, 0.2);
+  background: var(--surface-hover);
+}
+
+.example-number {
+  display: block;
+  margin-bottom: 5rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.example-title {
+  margin-bottom: 1rem;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.example-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+@media (max-width: 800px) {
+  .hero {
+    min-height: 65vh;
+  }
+
+  .examples {
+    grid-template-columns: 1fr;
+  }
+
+  .example-card {
+    min-height: 250px;
+  }
+
+  .example-number {
+    margin-bottom: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .is-revealing {
+    animation: none;
+  }
+
+  .replay-button,
+  .example-card {
+    transition: none;
+  }
+
+  .replay-button:hover,
+  .example-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained animated text scramble reveal component for EaseMotion CSS.

### What's included

- Character-by-character scramble reveal
- Automatic viewport-triggered animation
- Multiple independent text examples
- Replay control for the primary demo
- Smooth focus/reveal styling
- Responsive layout
- `prefers-reduced-motion` support
- No external libraries, CDNs, frameworks, or assets
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive demonstration
- `style.css` — animation and responsive styling
- `README.md` — usage and implementation documentation

### Issue

## Closes #77949


### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the animation locally