### PR TITLE
feat: add animated accordion height reveal

### DIFF
--- a/submissions/examples/animated-accordion-height-reveal/README.md
+++ b/submissions/examples/animated-accordion-height-reveal/README.md
@@ -1,0 +1,50 @@
+# Animated Accordion Height Reveal
+
+A reusable accordion interaction with a smooth expand-and-collapse height
+transition.
+
+## What does it do?
+
+The accordion reveals and hides content using a CSS grid-row transition.
+
+The interaction provides:
+
+- Smooth content expansion.
+- Smooth content collapse.
+- Multiple accordion items.
+- One active section at a time in the demo.
+- Keyboard-accessible buttons.
+- Accessible `aria-expanded` states.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create an accordion with a button and content panel:
+
+```html
+<div class="accordion">
+  <button
+    class="accordion__trigger"
+    type="button"
+    aria-expanded="false"
+    aria-controls="accordion-panel"
+  >
+    <span>What is EaseMotion CSS?</span>
+    <span class="accordion__icon" aria-hidden="true">+</span>
+  </button>
+
+  <div
+    class="accordion__content"
+    id="accordion-panel"
+    role="region"
+    hidden
+  >
+    <div class="accordion__inner">
+      <p>
+        EaseMotion CSS is a collection of reusable motion patterns.
+      </p>
+    </div>
+  </div>
+</div>
+```

--- a/submissions/examples/animated-accordion-height-reveal/demo.html
+++ b/submissions/examples/animated-accordion-height-reveal/demo.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Animated accordion height reveal demo for EaseMotion CSS"
+  >
+  <title>Animated Accordion Height Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Interaction</p>
+      <h1>Animated Accordion</h1>
+      <p class="hero-copy">
+        Expand each section to reveal its content through a smooth,
+        lightweight height transition.
+      </p>
+    </header>
+
+    <section class="accordion-list" aria-label="Frequently asked questions">
+      <article class="accordion is-open">
+        <button
+          class="accordion__trigger"
+          type="button"
+          aria-expanded="true"
+          aria-controls="accordion-panel-1"
+        >
+          <span class="accordion__title">
+            What is EaseMotion CSS?
+          </span>
+          <span class="accordion__icon" aria-hidden="true">+</span>
+        </button>
+
+        <div
+          class="accordion__content"
+          id="accordion-panel-1"
+          role="region"
+        >
+          <div class="accordion__inner">
+            <p>
+              EaseMotion CSS is a collection of reusable motion patterns and
+              CSS-focused interaction examples designed to make interfaces
+              feel more expressive.
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <article class="accordion">
+        <button
+          class="accordion__trigger"
+          type="button"
+          aria-expanded="false"
+          aria-controls="accordion-panel-2"
+        >
+          <span class="accordion__title">
+            Why use an accordion?
+          </span>
+          <span class="accordion__icon" aria-hidden="true">+</span>
+        </button>
+
+        <div
+          class="accordion__content"
+          id="accordion-panel-2"
+          role="region"
+          hidden
+        >
+          <div class="accordion__inner">
+            <p>
+              Accordions help organize related information into compact
+              sections while allowing users to reveal only the content they
+              want to explore.
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <article class="accordion">
+        <button
+          class="accordion__trigger"
+          type="button"
+          aria-expanded="false"
+          aria-controls="accordion-panel-3"
+        >
+          <span class="accordion__title">
+            Does the animation require a library?
+          </span>
+          <span class="accordion__icon" aria-hidden="true">+</span>
+        </button>
+
+        <div
+          class="accordion__content"
+          id="accordion-panel-3"
+          role="region"
+          hidden
+        >
+          <div class="accordion__inner">
+            <p>
+              No. The height reveal is implemented with CSS grid rows and a
+              small amount of JavaScript for interaction and accessibility.
+            </p>
+          </div>
+        </div>
+      </article>
+
+      <article class="accordion">
+        <button
+          class="accordion__trigger"
+          type="button"
+          aria-expanded="false"
+          aria-controls="accordion-panel-4"
+        >
+          <span class="accordion__title">
+            Can multiple sections remain open?
+          </span>
+          <span class="accordion__icon" aria-hidden="true">+</span>
+        </button>
+
+        <div
+          class="accordion__content"
+          id="accordion-panel-4"
+          role="region"
+          hidden
+        >
+          <div class="accordion__inner">
+            <p>
+              This demo keeps the interaction focused by allowing one section
+              to remain open at a time. The pattern can also be adapted to
+              support multiple expanded sections.
+            </p>
+          </div>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    const accordions = document.querySelectorAll(".accordion");
+
+    function closeAccordion(accordion) {
+      const trigger = accordion.querySelector(".accordion__trigger");
+      const content = accordion.querySelector(".accordion__content");
+
+      accordion.classList.remove("is-open");
+      trigger.setAttribute("aria-expanded", "false");
+
+      content.style.gridTemplateRows = "0fr";
+
+      window.setTimeout(() => {
+        if (!accordion.classList.contains("is-open")) {
+          content.hidden = true;
+        }
+      }, 320);
+    }
+
+    function openAccordion(accordion) {
+      const trigger = accordion.querySelector(".accordion__trigger");
+      const content = accordion.querySelector(".accordion__content");
+
+      content.hidden = false;
+
+      requestAnimationFrame(() => {
+        accordion.classList.add("is-open");
+        trigger.setAttribute("aria-expanded", "true");
+        content.style.gridTemplateRows = "1fr";
+      });
+    }
+
+    accordions.forEach((accordion) => {
+      const trigger = accordion.querySelector(".accordion__trigger");
+
+      trigger.addEventListener("click", () => {
+        const isOpen = accordion.classList.contains("is-open");
+
+        accordions.forEach((item) => {
+          if (item !== accordion && item.classList.contains("is-open")) {
+            closeAccordion(item);
+          }
+        });
+
+        if (isOpen) {
+          closeAccordion(accordion);
+        } else {
+          openAccordion(accordion);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/animated-accordion-height-reveal/style.css
+++ b/submissions/examples/animated-accordion-height-reveal/style.css
@@ -1,0 +1,193 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --border-active: rgba(138, 180, 255, 0.28);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(900px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.hero {
+  max-width: 700px;
+  margin-bottom: 3rem;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: 0.92;
+  letter-spacing: -0.06em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.accordion-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.accordion {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.15rem;
+  background: var(--surface);
+  transition:
+    border-color 220ms ease,
+    background 220ms ease;
+}
+
+.accordion:hover {
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.accordion.is-open {
+  border-color: var(--border-active);
+  background: var(--surface-hover);
+}
+
+.accordion__trigger {
+  display: flex;
+  width: 100%;
+  min-height: 78px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.accordion__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+  border-radius: inherit;
+}
+
+.accordion__title {
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.accordion__icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 2rem;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  transition:
+    transform 300ms ease,
+    color 300ms ease,
+    border-color 300ms ease;
+}
+
+.accordion.is-open .accordion__icon {
+  transform: rotate(45deg);
+  border-color: var(--border-active);
+  color: var(--accent);
+}
+
+.accordion__content {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 320ms ease;
+}
+
+.accordion__content[hidden] {
+  display: grid;
+}
+
+.accordion.is-open .accordion__content {
+  grid-template-rows: 1fr;
+}
+
+.accordion__inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.accordion__inner p {
+  margin: 0;
+  padding: 0 1.5rem 1.5rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 3.5rem 0 5rem;
+  }
+
+  .accordion__trigger {
+    min-height: 70px;
+    padding: 1rem 1.1rem;
+  }
+
+  .accordion__inner p {
+    padding: 0 1.1rem 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .accordion,
+  .accordion__icon,
+  .accordion__content {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained animated accordion component with a smooth height reveal and collapse interaction.

### What's included

- Animated expand/collapse transition
- Multiple accordion items
- One-open-at-a-time interaction
- Accessible `aria-expanded` states
- Keyboard-accessible controls
- Animated open/close icon
- Responsive layout
- `prefers-reduced-motion` support
- No external libraries, CDNs, frameworks, or assets
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive accordion demonstration
- `style.css` — accordion styling and animations
- `README.md` — usage and implementation documentation

### Issue

## Closes #77951

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the accordion interaction locally