### PR TITLE
feat: add sliding tab indicator

### DIFF
--- a/submissions/examples/sliding-tab-indicator/README.md
+++ b/submissions/examples/sliding-tab-indicator/README.md
@@ -1,0 +1,46 @@
+# Sliding Tab Indicator
+
+A reusable tab navigation pattern with a smooth sliding indicator that follows
+the active tab.
+
+## What does it do?
+
+The component provides:
+
+- Multiple selectable tabs.
+- A sliding active-state indicator.
+- Dynamic indicator width based on the selected tab.
+- Animated content-panel switching.
+- Keyboard navigation with left and right arrow keys.
+- Responsive horizontal tab scrolling.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a tab navigation:
+
+```html
+<nav class="tabs" aria-label="Content sections">
+  <button
+    class="tabs__trigger is-active"
+    type="button"
+    aria-selected="true"
+    data-panel="panel-overview"
+  >
+    Overview
+  </button>
+
+  <button
+    class="tabs__trigger"
+    type="button"
+    aria-selected="false"
+    data-panel="panel-activity"
+  >
+    Activity
+  </button>
+
+  <span class="tabs__indicator" aria-hidden="true"></span>
+</nav>
+```
+

--- a/submissions/examples/sliding-tab-indicator/demo.html
+++ b/submissions/examples/sliding-tab-indicator/demo.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Sliding tab indicator demo for EaseMotion CSS"
+  >
+  <title>Sliding Tab Indicator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Navigation</p>
+      <h1>Sliding Tabs</h1>
+      <p>
+        Switch between sections and watch the active indicator glide into
+        position.
+      </p>
+    </header>
+
+    <section class="demo-card">
+      <nav class="tabs" aria-label="Content sections">
+        <button
+          class="tabs__trigger is-active"
+          type="button"
+          aria-selected="true"
+          aria-controls="panel-overview"
+          data-panel="panel-overview"
+        >
+          Overview
+        </button>
+
+        <button
+          class="tabs__trigger"
+          type="button"
+          aria-selected="false"
+          aria-controls="panel-activity"
+          data-panel="panel-activity"
+        >
+          Activity
+        </button>
+
+        <button
+          class="tabs__trigger"
+          type="button"
+          aria-selected="false"
+          aria-controls="panel-settings"
+          data-panel="panel-settings"
+        >
+          Settings
+        </button>
+
+        <span class="tabs__indicator" aria-hidden="true"></span>
+      </nav>
+
+      <div class="tab-panels">
+        <article
+          class="tab-panel is-active"
+          id="panel-overview"
+          role="tabpanel"
+        >
+          <span class="panel-number">01</span>
+          <h2>Overview</h2>
+          <p>
+            A sliding indicator makes the selected navigation state immediately
+            visible while adding a subtle sense of continuity between tabs.
+          </p>
+        </article>
+
+        <article
+          class="tab-panel"
+          id="panel-activity"
+          role="tabpanel"
+          hidden
+        >
+          <span class="panel-number">02</span>
+          <h2>Activity</h2>
+          <p>
+            Tab transitions work particularly well for dashboards and
+            interfaces where related information needs to share the same
+            visual space.
+          </p>
+        </article>
+
+        <article
+          class="tab-panel"
+          id="panel-settings"
+          role="tabpanel"
+          hidden
+        >
+          <span class="panel-number">03</span>
+          <h2>Settings</h2>
+          <p>
+            The indicator position is calculated from the active trigger, so
+            the same pattern can adapt to different tab labels and layouts.
+          </p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const tabs = document.querySelector(".tabs");
+    const triggers = [...document.querySelectorAll(".tabs__trigger")];
+    const panels = [...document.querySelectorAll(".tab-panel")];
+    const indicator = document.querySelector(".tabs__indicator");
+
+    function moveIndicator(trigger) {
+      const tabsRect = tabs.getBoundingClientRect();
+      const triggerRect = trigger.getBoundingClientRect();
+
+      indicator.style.setProperty(
+        "--indicator-width",
+        `${triggerRect.width}px`
+      );
+
+      indicator.style.setProperty(
+        "--indicator-x",
+        `${triggerRect.left - tabsRect.left}px`
+      );
+    }
+
+    function activateTab(trigger) {
+      triggers.forEach((item) => {
+        const active = item === trigger;
+
+        item.classList.toggle("is-active", active);
+        item.setAttribute("aria-selected", String(active));
+      });
+
+      panels.forEach((panel) => {
+        const active = panel.id === trigger.dataset.panel;
+
+        panel.classList.toggle("is-active", active);
+        panel.hidden = !active;
+      });
+
+      moveIndicator(trigger);
+    }
+
+    triggers.forEach((trigger) => {
+      trigger.addEventListener("click", () => {
+        activateTab(trigger);
+      });
+
+      trigger.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+          return;
+        }
+
+        event.preventDefault();
+
+        const currentIndex = triggers.indexOf(trigger);
+        const direction = event.key === "ArrowRight" ? 1 : -1;
+        const nextIndex =
+          (currentIndex + direction + triggers.length) % triggers.length;
+
+        triggers[nextIndex].focus();
+        activateTab(triggers[nextIndex]);
+      });
+    });
+
+    window.addEventListener("resize", () => {
+      const activeTrigger = document.querySelector(".tabs__trigger.is-active");
+      moveIndicator(activeTrigger);
+    });
+
+    moveIndicator(document.querySelector(".tabs__trigger.is-active"));
+  </script>
+</body>
+</html>

--- a/submissions/examples/sliding-tab-indicator/style.css
+++ b/submissions/examples/sliding-tab-indicator/style.css
@@ -1,0 +1,214 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-soft: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(900px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.hero {
+  max-width: 700px;
+  margin-bottom: 3rem;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: 0.92;
+  letter-spacing: -0.06em;
+}
+
+.hero p:last-child {
+  max-width: 600px;
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.demo-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.tabs {
+  --indicator-width: 0px;
+  --indicator-x: 0px;
+
+  position: relative;
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tabs__trigger {
+  position: relative;
+  z-index: 1;
+  min-width: 120px;
+  padding: 0.9rem 1rem;
+  border: 0;
+  border-radius: 0.75rem;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 650;
+  cursor: pointer;
+  transition: color 180ms ease;
+}
+
+.tabs__trigger:hover,
+.tabs__trigger.is-active {
+  color: var(--text);
+}
+
+.tabs__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.tabs__indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  width: var(--indicator-width);
+  height: 2px;
+  transform: translateX(var(--indicator-x));
+  transform-origin: left;
+  border-radius: 999px 999px 0 0;
+  background: var(--accent);
+  box-shadow: 0 0 14px rgba(138, 180, 255, 0.5);
+  transition:
+    transform 300ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 300ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+}
+
+.tab-panels {
+  min-height: 340px;
+}
+
+.tab-panel {
+  padding: 3rem;
+  animation: panel-enter 260ms ease both;
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
+
+.panel-number {
+  display: block;
+  margin-bottom: 4rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.tab-panel h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.tab-panel p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+@keyframes panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 3.5rem 0 5rem;
+  }
+
+  .tabs__trigger {
+    min-width: 105px;
+    padding: 0.8rem;
+  }
+
+  .tab-panel {
+    min-height: 320px;
+    padding: 2rem 1.5rem;
+  }
+
+  .panel-number {
+    margin-bottom: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__indicator,
+  .tabs__trigger,
+  .tab-panel {
+    transition: none;
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained sliding tab navigation component for EaseMotion CSS.

### What's included

- Animated active-tab indicator
- Dynamic indicator width and position
- Functional tab content switching
- Keyboard arrow navigation
- Responsive tab layout
- Focus-visible accessibility state
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive tab demonstration
- `style.css` — component styling and animations
- `README.md` — usage and implementation documentation

### Issue

## Closes #77953


### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the tab interaction locally