### PR TITLE
feat: add scroll reveal staggered cards

### DIFF
--- a/submissions/examples/scroll-reveal-staggered-cards/README.md
+++ b/submissions/examples/scroll-reveal-staggered-cards/README.md
@@ -1,0 +1,42 @@
+# Scroll-Reveal Staggered Cards
+
+A reusable scroll-reveal pattern that progressively brings a group of cards
+into view with a subtle staggered animation.
+
+## What does it do?
+
+The component combines opacity and vertical movement to reveal cards one after
+another when their container enters the viewport.
+
+It provides:
+
+- Viewport-triggered reveal.
+- Sequential card timing.
+- Responsive card layouts.
+- Subtle opacity and vertical movement.
+- One-time animation for each card group.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a card group with the `stagger-grid` class:
+
+```html
+<div class="stagger-grid">
+  <article class="stagger-card">
+    <h2>Discover</h2>
+    <p>Card content.</p>
+  </article>
+
+  <article class="stagger-card">
+    <h2>Explore</h2>
+    <p>Card content.</p>
+  </article>
+
+  <article class="stagger-card">
+    <h2>Create</h2>
+    <p>Card content.</p>
+  </article>
+</div>
+```

--- a/submissions/examples/scroll-reveal-staggered-cards/demo.html
+++ b/submissions/examples/scroll-reveal-staggered-cards/demo.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Scroll-reveal staggered cards demo for EaseMotion CSS"
+  >
+  <title>Scroll-Reveal Staggered Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Scroll Animation</p>
+      <h1>Staggered Reveal</h1>
+      <p class="hero-copy">
+        Scroll through the page and watch each card enter the viewport with a
+        subtle, sequential motion.
+      </p>
+    </header>
+
+    <section class="intro-space" aria-hidden="true">
+      <span>Keep scrolling ↓</span>
+    </section>
+
+    <section
+      class="stagger-grid"
+      aria-label="Staggered feature cards"
+    >
+      <article class="stagger-card">
+        <span class="card-number">01</span>
+        <h2>Discover</h2>
+        <p>
+          Cards reveal progressively to establish a natural visual rhythm and
+          guide attention through related content.
+        </p>
+      </article>
+
+      <article class="stagger-card">
+        <span class="card-number">02</span>
+        <h2>Explore</h2>
+        <p>
+          The staggered timing creates separation between elements without
+          requiring heavy animation or external libraries.
+        </p>
+      </article>
+
+      <article class="stagger-card">
+        <span class="card-number">03</span>
+        <h2>Create</h2>
+        <p>
+          Use the pattern for portfolios, product features, dashboards,
+          articles, and modern landing pages.
+        </p>
+      </article>
+
+      <article class="stagger-card">
+        <span class="card-number">04</span>
+        <h2>Compose</h2>
+        <p>
+          The same reveal pattern can work with different numbers of cards and
+          responsive layouts.
+        </p>
+      </article>
+
+      <article class="stagger-card">
+        <span class="card-number">05</span>
+        <h2>Refine</h2>
+        <p>
+          A small vertical movement combined with opacity keeps the entrance
+          subtle and readable.
+        </p>
+      </article>
+
+      <article class="stagger-card">
+        <span class="card-number">06</span>
+        <h2>Deliver</h2>
+        <p>
+          Once visible, the cards remain in place so users can comfortably
+          continue exploring the content.
+        </p>
+      </article>
+    </section>
+
+    <footer class="footer">
+      <p>End of demonstration</p>
+    </footer>
+  </main>
+
+  <script>
+    const grids = document.querySelectorAll(".stagger-grid");
+
+    const observer = new IntersectionObserver(
+      (entries, currentObserver) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+
+          entry.target.classList.add("is-visible");
+          currentObserver.unobserve(entry.target);
+        });
+      },
+      {
+        threshold: 0.18
+      }
+    );
+
+    grids.forEach((grid) => {
+      observer.observe(grid);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/scroll-reveal-staggered-cards/style.css
+++ b/submissions/examples/scroll-reveal-staggered-cards/style.css
@@ -1,0 +1,213 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.hero {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.intro-space {
+  display: flex;
+  min-height: 45vh;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.stagger-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.stagger-card {
+  min-height: 330px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  background: var(--surface);
+  opacity: 0;
+  transform: translateY(28px);
+  transition:
+    opacity 550ms ease,
+    transform 550ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 200ms ease,
+    background 200ms ease;
+}
+
+.stagger-grid.is-visible .stagger-card {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.stagger-grid.is-visible .stagger-card:nth-child(2) {
+  transition-delay: 100ms;
+}
+
+.stagger-grid.is-visible .stagger-card:nth-child(3) {
+  transition-delay: 200ms;
+}
+
+.stagger-grid.is-visible .stagger-card:nth-child(4) {
+  transition-delay: 300ms;
+}
+
+.stagger-grid.is-visible .stagger-card:nth-child(5) {
+  transition-delay: 400ms;
+}
+
+.stagger-grid.is-visible .stagger-card:nth-child(6) {
+  transition-delay: 500ms;
+}
+
+.stagger-card:hover {
+  border-color: rgba(138, 180, 255, 0.22);
+  background: var(--surface-hover);
+  transform: translateY(-5px);
+}
+
+.stagger-grid.is-visible .stagger-card:hover {
+  transform: translateY(-5px);
+}
+
+.card-number {
+  display: block;
+  margin-bottom: 5rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.stagger-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.8rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.stagger-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.footer {
+  margin-top: 6rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+}
+
+@media (max-width: 800px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .stagger-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .stagger-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stagger-card {
+    min-height: 260px;
+  }
+
+  .card-number {
+    margin-bottom: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .stagger-card,
+  .stagger-grid.is-visible .stagger-card {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .stagger-grid.is-visible .stagger-card:nth-child(n) {
+    transition-delay: 0s;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained scroll-reveal staggered card component for EaseMotion CSS.

### What's included

- Viewport-triggered card reveal
- Sequential stagger timing
- Opacity and vertical entrance animation
- Responsive card grid
- `IntersectionObserver` implementation
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive demonstration
- `style.css` — card styling and animations
- `README.md` — usage and implementation documentation

### Issue

## Closes #77959

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the scroll interaction locally