### PR TITLE
feat: add scroll triggered number counter

### DIFF
--- a/submissions/examples/scroll-triggered-number-counter/README.md
+++ b/submissions/examples/scroll-triggered-number-counter/README.md
@@ -1,0 +1,35 @@
+# Scroll-Triggered Number Counter
+
+A lightweight animated number counter that begins counting when its metric
+enters the viewport.
+
+## What does it do?
+
+The component progressively changes a numeric value from zero to its target
+value when the counter becomes visible.
+
+It supports:
+
+- Scroll-triggered animation.
+- Configurable target values.
+- Configurable animation duration.
+- Integer and decimal values.
+- Optional suffixes such as `%`, `+`, and `s`.
+- One-time animation.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a counter with a target value:
+
+```html
+<div class="counter">
+  <strong
+    class="counter__value"
+    data-target="98"
+  >0</strong>
+
+  <span class="counter__suffix">%</span>
+</div>
+```

--- a/submissions/examples/scroll-triggered-number-counter/demo.html
+++ b/submissions/examples/scroll-triggered-number-counter/demo.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Scroll-triggered number counter demo for EaseMotion CSS"
+  >
+  <title>Scroll-Triggered Number Counter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Metrics</p>
+      <h1>Numbers in Motion</h1>
+      <p class="hero-copy">
+        Scroll down and watch each metric count smoothly toward its target
+        value when it enters the viewport.
+      </p>
+    </header>
+
+    <section class="spacer" aria-hidden="true">
+      <span>Scroll to reveal metrics ↓</span>
+    </section>
+
+    <section class="counter-grid" aria-label="Key metrics">
+      <article class="counter">
+        <span class="counter__label">Customer satisfaction</span>
+        <div class="counter__number">
+          <strong
+            class="counter__value"
+            data-target="98"
+            data-duration="1400"
+          >0</strong>
+          <span class="counter__suffix">%</span>
+        </div>
+        <p>
+          A clear animated percentage for highlighting an important metric.
+        </p>
+      </article>
+
+      <article class="counter">
+        <span class="counter__label">Projects delivered</span>
+        <div class="counter__number">
+          <strong
+            class="counter__value"
+            data-target="240"
+            data-duration="1700"
+          >0</strong>
+          <span class="counter__suffix">+</span>
+        </div>
+        <p>
+          Whole-number counters work naturally for totals and achievements.
+        </p>
+      </article>
+
+      <article class="counter">
+        <span class="counter__label">Active contributors</span>
+        <div class="counter__number">
+          <strong
+            class="counter__value"
+            data-target="64"
+            data-duration="1200"
+          >0</strong>
+          <span class="counter__suffix">+</span>
+        </div>
+        <p>
+          Use compact counters to give supporting statistics more visual
+          emphasis.
+        </p>
+      </article>
+
+      <article class="counter">
+        <span class="counter__label">Response time</span>
+        <div class="counter__number">
+          <strong
+            class="counter__value"
+            data-target="1.8"
+            data-decimals="1"
+            data-duration="1500"
+          >0.0</strong>
+          <span class="counter__suffix">s</span>
+        </div>
+        <p>
+          Decimal values can also be animated for measurements and rates.
+        </p>
+      </article>
+    </section>
+
+    <footer class="footer">
+      <p>End of demonstration</p>
+    </footer>
+  </main>
+
+  <script>
+    const counters = document.querySelectorAll(".counter");
+
+    function easeOutCubic(progress) {
+      return 1 - Math.pow(1 - progress, 3);
+    }
+
+    function animateCounter(counter) {
+      const valueElement = counter.querySelector(".counter__value");
+      const target = Number(valueElement.dataset.target);
+      const decimals = Number(valueElement.dataset.decimals || 0);
+      const duration = Number(valueElement.dataset.duration || 1400);
+      const start = performance.now();
+
+      counter.classList.add("is-visible");
+
+      function update(now) {
+        const elapsed = now - start;
+        const progress = Math.min(elapsed / duration, 1);
+        const easedProgress = easeOutCubic(progress);
+        const currentValue = target * easedProgress;
+
+        valueElement.textContent = currentValue.toFixed(decimals);
+
+        if (progress < 1) {
+          requestAnimationFrame(update);
+        } else {
+          valueElement.textContent = target.toFixed(decimals);
+        }
+      }
+
+      requestAnimationFrame(update);
+    }
+
+    const observer = new IntersectionObserver(
+      (entries, currentObserver) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+
+          animateCounter(entry.target);
+          currentObserver.unobserve(entry.target);
+        });
+      },
+      {
+        threshold: 0.3
+      }
+    );
+
+    counters.forEach((counter) => {
+      observer.observe(counter);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/scroll-triggered-number-counter/style.css
+++ b/submissions/examples/scroll-triggered-number-counter/style.css
@@ -1,0 +1,212 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.hero {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.spacer {
+  display: flex;
+  min-height: 42vh;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.counter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.counter {
+  min-height: 330px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  background: var(--surface);
+  transition:
+    border-color 200ms ease,
+    background 200ms ease,
+    transform 200ms ease;
+}
+
+.counter:hover {
+  border-color: rgba(138, 180, 255, 0.22);
+  background: var(--surface-hover);
+  transform: translateY(-4px);
+}
+
+.counter__label {
+  display: block;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
+
+.counter__number {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin: 4rem 0 1.5rem;
+}
+
+.counter__value {
+  display: inline-block;
+  font-size: clamp(3.5rem, 8vw, 6rem);
+  line-height: 0.9;
+  letter-spacing: -0.06em;
+  font-variant-numeric: tabular-nums;
+}
+
+.counter__suffix {
+  color: var(--accent);
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-weight: 700;
+}
+
+.counter__value,
+.counter__suffix {
+  opacity: 0.45;
+}
+
+.counter.is-visible .counter__value,
+.counter.is-visible .counter__suffix {
+  opacity: 1;
+  animation: counter-focus 500ms ease both;
+}
+
+.counter p {
+  max-width: 480px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+@keyframes counter-focus {
+  from {
+    opacity: 0.4;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.footer {
+  margin-top: 6rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+}
+
+@media (max-width: 650px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .counter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .counter {
+    min-height: 280px;
+  }
+
+  .counter__number {
+    margin-top: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .counter,
+  .counter.is-visible .counter__value,
+  .counter.is-visible .counter__suffix {
+    transition: none;
+    animation: none;
+  }
+
+  .counter:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained scroll-triggered number counter component for EaseMotion CSS.

### What's included

- Viewport-triggered counting animation
- Configurable target values
- Configurable animation duration
- Integer and decimal number support
- Optional metric suffixes
- One-time animation
- `IntersectionObserver` implementation
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive counter demonstration
- `style.css` — counter styling and animation
- `README.md` — usage and implementation documentation

### Issue

Closes #77962

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the counter interaction locally