### PR TITLE
feat: add ease-drag-kanban-column-sap

### DIFF
--- a/submissions/examples/ease-drag-kanban-column-sap/README.md
+++ b/submissions/examples/ease-drag-kanban-column-sap/README.md
@@ -1,0 +1,11 @@
+# ease-drag-kanban-column-sap
+
+Draggable kanban columns that can be reordered horizontally via native HTML5 drag and drop.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.col-sap draggable="true"` columns inside `.kanban-col-sap`.
+
+## Notes
+- Reordering compares DOM index of dragged vs target column to decide whether to insert before or after, keeping the swap direction correct regardless of drag direction.
+- `prefers-reduced-motion` disables the drag/scale visual feedback transition; drag mechanics remain functional.

--- a/submissions/examples/ease-drag-kanban-column-sap/demo.html
+++ b/submissions/examples/ease-drag-kanban-column-sap/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-kanban-column-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="kanban-col-sap" id="board">
+    <div class="col-sap" draggable="true"><div class="col-header">To Do</div></div>
+    <div class="col-sap" draggable="true"><div class="col-header">In Progress</div></div>
+    <div class="col-sap" draggable="true"><div class="col-header">Done</div></div>
+  </div>
+  <script>
+    const board = document.getElementById('board');
+    let dragged = null;
+    board.querySelectorAll('.col-sap').forEach(col => {
+      col.addEventListener('dragstart', () => { dragged = col; col.classList.add('dragging'); });
+      col.addEventListener('dragend', () => col.classList.remove('dragging'));
+      col.addEventListener('dragover', (e) => { e.preventDefault(); col.classList.add('drag-over'); });
+      col.addEventListener('dragleave', () => col.classList.remove('drag-over'));
+      col.addEventListener('drop', (e) => {
+        e.preventDefault();
+        col.classList.remove('drag-over');
+        if (dragged && dragged !== col) {
+          const all = [...board.children];
+          const draggedIdx = all.indexOf(dragged);
+          const targetIdx = all.indexOf(col);
+          if (draggedIdx < targetIdx) col.after(dragged); else col.before(dragged);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-kanban-column-sap/style.css
+++ b/submissions/examples/ease-drag-kanban-column-sap/style.css
@@ -1,0 +1,36 @@
+.kanban-col-sap {
+  display: flex;
+  gap: 14px;
+  font-family: system-ui, sans-serif;
+}
+
+.kanban-col-sap .col-sap {
+  width: 160px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f1f5f9;
+  transition: transform 0.25s ease;
+}
+
+.kanban-col-sap .col-sap.dragging {
+  opacity: 0.5;
+  transform: scale(0.96);
+}
+
+.kanban-col-sap .col-sap.drag-over {
+  outline: 2px dashed #2563eb;
+}
+
+.kanban-col-sap .col-header {
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+  margin-bottom: 8px;
+  cursor: grab;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kanban-col-sap .col-sap {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-kanban-column-sap`, draggable reorderable kanban columns.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-kanban-column-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Column reorder logic compares DOM index of dragged vs drop target to insert on the correct side regardless of drag direction.
- `prefers-reduced-motion` disables the scale/opacity drag feedback transition.

## Feature Description

Adds a reusable draggable reorderable kanban column set component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.

