### PR TITLE
feat: add hover lift action cards

### DIFF
--- a/submissions/examples/hover-lift-action-cards/README.md
+++ b/submissions/examples/hover-lift-action-cards/README.md
@@ -1,0 +1,35 @@
+# Hover Lift Action Cards
+
+A lightweight card interaction that creates a subtle elevation effect when the
+pointer hovers over a card.
+
+## What does it do?
+
+The component combines a small upward translation with border, background, and
+shadow transitions.
+
+It provides:
+
+- Smooth hover elevation.
+- Subtle depth through box-shadow.
+- Border and surface transitions.
+- Responsive card layout.
+- Interactive icon and link feedback.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a card with the `lift-card` class:
+
+```html
+<article class="lift-card">
+  <span class="lift-card__number">01</span>
+
+  <h2>Explore</h2>
+
+  <p>
+    Discover a smooth interactive card experience.
+  </p>
+</article>
+```

--- a/submissions/examples/hover-lift-action-cards/demo.html
+++ b/submissions/examples/hover-lift-action-cards/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Hover lift action cards demo for EaseMotion CSS"
+  >
+  <title>Hover Lift Action Cards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Hover Interaction</p>
+      <h1>Lift Your Cards</h1>
+      <p class="hero-copy">
+        Move your pointer across the cards to create a subtle sense of depth
+        with smooth elevation and shadow transitions.
+      </p>
+    </header>
+
+    <section class="card-grid" aria-label="Interactive action cards">
+      <article class="lift-card">
+        <div class="card-top">
+          <span class="card-number">01</span>
+          <span class="card-icon" aria-hidden="true">↗</span>
+        </div>
+        <div>
+          <h2>Explore</h2>
+          <p>
+            Discover new possibilities through a lightweight interaction that
+            responds naturally to pointer movement.
+          </p>
+        </div>
+        <span class="card-link">View experience</span>
+      </article>
+
+      <article class="lift-card">
+        <div class="card-top">
+          <span class="card-number">02</span>
+          <span class="card-icon" aria-hidden="true">✦</span>
+        </div>
+        <div>
+          <h2>Create</h2>
+          <p>
+            Turn simple content blocks into engaging action surfaces with a
+            restrained elevation effect.
+          </p>
+        </div>
+        <span class="card-link">Start creating</span>
+      </article>
+
+      <article class="lift-card">
+        <div class="card-top">
+          <span class="card-number">03</span>
+          <span class="card-icon" aria-hidden="true">→</span>
+        </div>
+        <div>
+          <h2>Connect</h2>
+          <p>
+            Give users immediate visual feedback while keeping the interface
+            clean, accessible, and responsive.
+          </p>
+        </div>
+        <span class="card-link">Connect now</span>
+      </article>
+
+      <article class="lift-card">
+        <div class="card-top">
+          <span class="card-number">04</span>
+          <span class="card-icon" aria-hidden="true">⌁</span>
+        </div>
+        <div>
+          <h2>Refine</h2>
+          <p>
+            Use subtle motion to establish hierarchy without overwhelming the
+            surrounding interface.
+          </p>
+        </div>
+        <span class="card-link">Refine details</span>
+      </article>
+    </section>
+
+    <footer class="footer">
+      <p>Hover over a card to see the elevation effect.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-lift-action-cards/style.css
+++ b/submissions/examples/hover-lift-action-cards/style.css
@@ -1,0 +1,215 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.09);
+  --border-hover: rgba(138, 180, 255, 0.3);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+  --shadow: rgba(0, 0, 0, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.lift-card {
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 1.4rem;
+  background: var(--surface);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 280ms ease,
+    border-color 280ms ease,
+    background 280ms ease;
+}
+
+.lift-card:hover {
+  transform: translateY(-8px);
+  border-color: var(--border-hover);
+  background: var(--surface-hover);
+  box-shadow:
+    0 24px 50px var(--shadow),
+    0 4px 14px rgba(138, 180, 255, 0.06);
+}
+
+.card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-number {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.card-icon {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--muted);
+  font-size: 1rem;
+  transition:
+    transform 280ms ease,
+    color 280ms ease,
+    border-color 280ms ease;
+}
+
+.lift-card:hover .card-icon {
+  transform: translate(2px, -2px);
+  border-color: var(--border-hover);
+  color: var(--accent);
+}
+
+.lift-card h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.lift-card p {
+  max-width: 470px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.card-link::after {
+  content: "→";
+  color: var(--accent);
+  transition: transform 200ms ease;
+}
+
+.lift-card:hover .card-link::after {
+  transform: translateX(4px);
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 700px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lift-card {
+    min-height: 300px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lift-card,
+  .card-icon,
+  .card-link::after {
+    transition: none;
+  }
+
+  .lift-card:hover {
+    transform: none;
+  }
+
+  .lift-card:hover .card-icon {
+    transform: none;
+  }
+
+  .lift-card:hover .card-link::after {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained hover lift card interaction for EaseMotion CSS.

### What's included

- Smooth card elevation on hover
- Subtle shadow transition
- Border and background feedback
- Interactive icon and link motion
- Responsive card grid
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive card demonstration
- `style.css` — card styling and hover animation
- `README.md` — usage and implementation documentation

### Issue

Closes #77965 

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the hover interaction locally