### PR TITLE
feat: add ripple click button

### DIFF
--- a/submissions/examples/ripple-click-button/README.md
+++ b/submissions/examples/ripple-click-button/README.md
@@ -1,0 +1,27 @@
+# Ripple Click Button
+
+A lightweight click-feedback interaction that creates an expanding ripple from
+the exact pointer position inside a button.
+
+## What does it do?
+
+The component provides:
+
+- Pointer-position ripple origin.
+- Smooth expanding animation.
+- Automatic ripple cleanup.
+- Multiple button variants.
+- Keyboard focus support.
+- Responsive layout.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a button with the `ripple-button` class:
+
+```html
+<button class="ripple-button" type="button">
+  <span>Click me</span>
+</button>
+```

--- a/submissions/examples/ripple-click-button/demo.html
+++ b/submissions/examples/ripple-click-button/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Ripple click button demo for EaseMotion CSS"
+  >
+  <title>Ripple Click Button</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Click Interaction</p>
+      <h1>Ripple Feedback</h1>
+      <p class="hero-copy">
+        Click anywhere on the buttons and watch the ripple originate exactly
+        from the point of interaction.
+      </p>
+    </header>
+
+    <section class="demo" aria-label="Ripple button examples">
+      <div class="button-group">
+        <button class="ripple-button ripple-button--primary" type="button">
+          <span>Get started</span>
+        </button>
+
+        <button class="ripple-button ripple-button--secondary" type="button">
+          <span>Explore more</span>
+        </button>
+
+        <button class="ripple-button ripple-button--compact" type="button">
+          <span>Learn more</span>
+        </button>
+      </div>
+
+      <p class="hint">
+        Try clicking different positions inside each button.
+      </p>
+    </section>
+
+    <footer class="footer">
+      <p>Click position determines the ripple origin.</p>
+    </footer>
+  </main>
+
+  <script>
+    const buttons = document.querySelectorAll(".ripple-button");
+
+    buttons.forEach((button) => {
+      button.addEventListener("pointerdown", (event) => {
+        if (event.pointerType === "touch") {
+          return;
+        }
+
+        const rect = button.getBoundingClientRect();
+        const ripple = document.createElement("span");
+
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+
+        const radius = Math.max(
+          Math.hypot(x, y),
+          Math.hypot(rect.width - x, y),
+          Math.hypot(x, rect.height - y),
+          Math.hypot(rect.width - x, rect.height - y)
+        );
+
+        ripple.className = "ripple";
+        ripple.style.width = `${radius * 2}px`;
+        ripple.style.height = `${radius * 2}px`;
+        ripple.style.left = `${x - radius}px`;
+        ripple.style.top = `${y - radius}px`;
+
+        button.appendChild(ripple);
+
+        ripple.addEventListener("animationend", () => {
+          ripple.remove();
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ripple-click-button/style.css
+++ b/submissions/examples/ripple-click-button/style.css
@@ -1,0 +1,226 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1000px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo {
+  min-height: 45vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.ripple-button {
+  position: relative;
+  overflow: hidden;
+  min-width: 170px;
+  min-height: 58px;
+  padding: 1rem 1.5rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  isolation: isolate;
+  touch-action: manipulation;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+}
+
+.ripple-button span:not(.ripple) {
+  position: relative;
+  z-index: 2;
+}
+
+.ripple-button--primary {
+  border-color: rgba(138, 180, 255, 0.4);
+  background: var(--accent);
+  color: #080a0f;
+}
+
+.ripple-button--secondary {
+  border-color: var(--border);
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.ripple-button--compact {
+  min-width: 130px;
+  min-height: 50px;
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.ripple-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+.ripple-button:active {
+  transform: translateY(0);
+}
+
+.ripple-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.ripple {
+  position: absolute;
+  z-index: 1;
+  display: block;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.28);
+  transform: scale(0);
+  pointer-events: none;
+  animation: ripple-expand 600ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ripple-button--secondary .ripple,
+.ripple-button--compact .ripple {
+  background: rgba(138, 180, 255, 0.2);
+}
+
+@keyframes ripple-expand {
+  0% {
+    opacity: 0.8;
+    transform: scale(0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1);
+  }
+}
+
+.hint {
+  margin: 2.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .button-group {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .ripple-button {
+    width: min(100%, 280px);
+  }
+
+  .demo {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ripple-button {
+    transition: none;
+  }
+
+  .ripple {
+    animation-duration: 1ms;
+  }
+
+  .ripple-button:hover,
+  .ripple-button:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained ripple click interaction for EaseMotion CSS.

### What's included

- Pointer-position ripple origin
- Smooth expanding ripple animation
- Automatic ripple cleanup
- Multiple button variants
- Keyboard focus support
- Responsive layout
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive ripple button demonstration
- `style.css` — button styling and ripple animation
- `README.md` — usage and implementation documentation

### Issue

Closes #77968

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested the click interaction locally