### PR TITLE
feat: add glowing focus input

### DIFF
--- a/submissions/examples/glowing-focus-input/README.md
+++ b/submissions/examples/glowing-focus-input/README.md
@@ -1,0 +1,31 @@
+# Glowing Focus Input
+
+A lightweight input-field interaction that uses a subtle animated glow to
+clearly identify the currently focused form control.
+
+## What does it do?
+
+The component enhances the native focus state with:
+
+- Animated border transition.
+- Soft outer glow.
+- Subtle focus elevation.
+- `:focus-within` label feedback.
+- Keyboard-accessible focus indicators.
+- Responsive form layout.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Wrap an input with the `glow-field` class:
+
+```html
+<label class="glow-field">
+  <span>Email address</span>
+  <input
+    type="email"
+    placeholder="you@example.com"
+  >
+</label>
+```

--- a/submissions/examples/glowing-focus-input/demo.html
+++ b/submissions/examples/glowing-focus-input/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Glowing focus input demo for EaseMotion CSS"
+  >
+  <title>Glowing Focus Input</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Form Interaction</p>
+      <h1>Focus the Field</h1>
+      <p class="hero-copy">
+        Select any input to see a restrained animated glow clearly identify
+        the active form control.
+      </p>
+    </header>
+
+    <section class="form-panel" aria-label="Glowing input examples">
+      <div class="form-heading">
+        <span class="form-index">FORM / 01</span>
+        <h2>Tell us about yourself</h2>
+        <p>
+          Focus each field to reveal the interaction.
+        </p>
+      </div>
+
+      <form class="glow-form">
+        <label class="glow-field">
+          <span>Full name</span>
+          <input
+            type="text"
+            name="name"
+            placeholder="Alex Morgan"
+            autocomplete="name"
+          >
+        </label>
+
+        <label class="glow-field">
+          <span>Email address</span>
+          <input
+            type="email"
+            name="email"
+            placeholder="alex@example.com"
+            autocomplete="email"
+          >
+        </label>
+
+        <label class="glow-field">
+          <span>Website</span>
+          <input
+            type="url"
+            name="website"
+            placeholder="https://example.com"
+            autocomplete="url"
+          >
+        </label>
+
+        <label class="glow-field glow-field--wide">
+          <span>Message</span>
+          <textarea
+            name="message"
+            rows="5"
+            placeholder="Write something..."
+          ></textarea>
+        </label>
+
+        <button class="submit-button" type="submit">
+          Continue
+          <span aria-hidden="true">→</span>
+        </button>
+      </form>
+    </section>
+
+    <footer class="footer">
+      <p>Focus states should be visible, clear, and intentional.</p>
+    </footer>
+  </main>
+
+  <script>
+    const form = document.querySelector(".glow-form");
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/glowing-focus-input/style.css
+++ b/submissions/examples/glowing-focus-input/style.css
@@ -1,0 +1,270 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-focus: rgba(138, 180, 255, 0.65);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+  --input-background: #0c1017;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1050px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 55vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 620px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.form-panel {
+  padding: clamp(1.5rem, 5vw, 4rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.form-heading {
+  max-width: 650px;
+  margin-bottom: 3rem;
+}
+
+.form-index {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.form-heading h2 {
+  margin: 1rem 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.form-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.glow-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.glow-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.glow-field--wide {
+  grid-column: 1 / -1;
+}
+
+.glow-field span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.glow-field input,
+.glow-field textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: var(--input-background);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  outline: none;
+  resize: vertical;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    background 220ms ease,
+    transform 220ms ease;
+}
+
+.glow-field input {
+  min-height: 56px;
+  padding: 0 1rem;
+}
+
+.glow-field textarea {
+  min-height: 140px;
+  padding: 1rem;
+}
+
+.glow-field input::placeholder,
+.glow-field textarea::placeholder {
+  color: rgba(152, 164, 181, 0.55);
+}
+
+.glow-field input:hover,
+.glow-field textarea:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.glow-field input:focus,
+.glow-field textarea:focus {
+  border-color: var(--border-focus);
+  background: var(--surface-hover);
+  box-shadow:
+    0 0 0 3px rgba(138, 180, 255, 0.08),
+    0 0 24px rgba(138, 180, 255, 0.14);
+  transform: translateY(-1px);
+}
+
+.glow-field:focus-within span {
+  color: var(--accent);
+}
+
+.submit-button {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  margin-top: 0.5rem;
+  border: 1px solid rgba(138, 180, 255, 0.4);
+  border-radius: 999px;
+  background: var(--accent);
+  color: #080a0f;
+  font: inherit;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.submit-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+.submit-button:active {
+  transform: translateY(0);
+}
+
+.submit-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.submit-button span {
+  transition: transform 180ms ease;
+}
+
+.submit-button:hover span {
+  transform: translateX(4px);
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 650px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .glow-form {
+    grid-template-columns: 1fr;
+  }
+
+  .glow-field--wide,
+  .submit-button {
+    grid-column: auto;
+  }
+
+  .form-panel {
+    padding: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glow-field input,
+  .glow-field textarea,
+  .submit-button,
+  .submit-button span {
+    transition: none;
+  }
+
+  .glow-field input:focus,
+  .glow-field textarea:focus,
+  .submit-button:hover,
+  .submit-button:active {
+    transform: none;
+  }
+
+  .submit-button:hover span {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained glowing focus input interaction for EaseMotion CSS.

### What's included

- Animated focus border
- Soft focus glow
- Subtle input elevation
- `:focus-within` label feedback
- Keyboard-accessible focus states
- Responsive form layout
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive form demonstration
- `style.css` — input styling and focus animation
- `README.md` — usage and implementation documentation

### Issue

## Closes #77971

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested keyboard and pointer focus states locally