### PR TITLE
feat: add ease-drag-photo-reorder-grid-sap

### DIFF
--- a/submissions/examples/ease-drag-photo-reorder-grid-sap/README.md
+++ b/submissions/examples/ease-drag-photo-reorder-grid-sap/README.md
@@ -1,0 +1,11 @@
+# ease-drag-photo-reorder-grid-sap
+
+A photo grid where tiles can be dragged and dropped to reorder, using native HTML5 drag and drop with a placeholder-swap technique.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.photo-tile draggable="true"` elements with `background-image` inside `.photo-reorder-sap`.
+
+## Notes
+- Reordering swaps DOM positions using a temporary placeholder node, avoiding directly manipulating `innerHTML` (which would lose event listeners).
+- Respects `prefers-reduced-motion`: drag-feedback scale/opacity transitions are disabled.

--- a/submissions/examples/ease-drag-photo-reorder-grid-sap/demo.html
+++ b/submissions/examples/ease-drag-photo-reorder-grid-sap/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-photo-reorder-grid-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="photo-reorder-sap" id="grid">
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=200)"></div>
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=200)"></div>
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1519681393784-d120267933ba?w=200)"></div>
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1449824913935-59a10b8d2000?w=200)"></div>
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=200)"></div>
+    <div class="photo-tile" draggable="true" style="background-image:url(https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=200)"></div>
+  </div>
+  <script>
+    const grid = document.getElementById('grid');
+    let dragged = null;
+    grid.querySelectorAll('.photo-tile').forEach(tile => {
+      tile.addEventListener('dragstart', () => { dragged = tile; tile.classList.add('dragging'); });
+      tile.addEventListener('dragend', () => tile.classList.remove('dragging'));
+      tile.addEventListener('dragover', (e) => { e.preventDefault(); tile.classList.add('drag-over'); });
+      tile.addEventListener('dragleave', () => tile.classList.remove('drag-over'));
+      tile.addEventListener('drop', (e) => {
+        e.preventDefault();
+        tile.classList.remove('drag-over');
+        if (dragged && dragged !== tile) {
+          const temp = document.createElement('div');
+          dragged.before(temp);
+          tile.before(dragged);
+          temp.replaceWith(tile === dragged ? tile : tile);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-photo-reorder-grid-sap/style.css
+++ b/submissions/examples/ease-drag-photo-reorder-grid-sap/style.css
@@ -1,0 +1,31 @@
+.photo-reorder-sap {
+  display: grid;
+  grid-template-columns: repeat(3, 80px);
+  gap: 8px;
+}
+
+.photo-reorder-sap .photo-tile {
+  width: 80px;
+  height: 80px;
+  border-radius: 10px;
+  background-size: cover;
+  background-position: center;
+  cursor: grab;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.photo-reorder-sap .photo-tile.dragging {
+  opacity: 0.4;
+  transform: scale(0.92);
+}
+
+.photo-reorder-sap .photo-tile.drag-over {
+  outline: 2px dashed #2563eb;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .photo-reorder-sap .photo-tile {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-photo-reorder-grid-sap`, a draggable reorderable photo grid.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-photo-reorder-grid-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Swap uses a temporary placeholder DOM node rather than `innerHTML` rewriting, preserving each tile's own drag event listeners.
- `prefers-reduced-motion` disables the drag scale/opacity feedback transition.

## Feature Description

Adds a reusable draggable photo reorder grid component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.