### PR TITLE
feat: add ease-scroll-reveal-stagger-cards-sap

### DIFF
--- a/submissions/examples/ease-scroll-reveal-stagger-cards-sap/README.md
+++ b/submissions/examples/ease-scroll-reveal-stagger-cards-sap/README.md
@@ -1,0 +1,12 @@
+# ease-scroll-reveal-stagger-cards-sap
+
+A row of cards that fade/slide in with a staggered delay as they scroll into view.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.reveal-card` elements inside a flex row.
+3. Attach the `IntersectionObserver` from `demo.html`, which sets a per-card `transitionDelay` based on its index.
+
+## Notes
+- Stagger delay is set via inline `transitionDelay` computed from each card's index in the observed array, so it works with any number of cards without hardcoded CSS delays.
+- Respects `prefers-reduced-motion`: slide transform is removed, leaving only opacity fade.

--- a/submissions/examples/ease-scroll-reveal-stagger-cards-sap/demo.html
+++ b/submissions/examples/ease-scroll-reveal-stagger-cards-sap/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-reveal-stagger-cards-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f4f4f5; }
+    .spacer { height: 80vh; display: flex; align-items: center; justify-content: center; color: #94a3b8; }
+    .page { display: flex; justify-content: center; padding-bottom: 200px; }
+  </style>
+</head>
+<body>
+  <div class="spacer">Scroll down</div>
+  <div class="page">
+    <div class="stagger-cards-sap" id="cards">
+      <div class="reveal-card"></div>
+      <div class="reveal-card"></div>
+      <div class="reveal-card"></div>
+      <div class="reveal-card"></div>
+    </div>
+  </div>
+  <script>
+    const cards = [...document.querySelectorAll('.reveal-card')];
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const idx = cards.indexOf(entry.target);
+          entry.target.style.transitionDelay = `${idx * 0.1}s`;
+          entry.target.classList.add('in-view');
+        }
+      });
+    }, { threshold: 0.3 });
+    cards.forEach(c => observer.observe(c));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-stagger-cards-sap/style.css
+++ b/submissions/examples/ease-scroll-reveal-stagger-cards-sap/style.css
@@ -1,0 +1,28 @@
+.stagger-cards-sap {
+  display: flex;
+  gap: 16px;
+  font-family: system-ui, sans-serif;
+}
+
+.stagger-cards-sap .reveal-card {
+  width: 140px;
+  height: 180px;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease, transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.stagger-cards-sap .reveal-card.in-view {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stagger-cards-sap .reveal-card {
+    transition: opacity 0.2s ease;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-reveal-stagger-cards-sap`, a scroll-triggered staggered card reveal row.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-scroll-reveal-stagger-cards-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Per-card stagger delay is computed from array index via JS `transitionDelay`, scaling to any card count without hardcoded CSS.
- `prefers-reduced-motion` removes the slide transform, keeping opacity fade only.

## Feature Description

Adds a reusable scroll-triggered staggered card reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.