### PR TITLE
feat: add floating tooltip reveal

### DIFF
--- a/submissions/examples/floating-tooltip-reveal-014/README.md
+++ b/submissions/examples/floating-tooltip-reveal-014/README.md
@@ -1,0 +1,42 @@
+# Floating Tooltip Reveal
+
+A lightweight tooltip interaction that smoothly reveals contextual
+information when an interactive element is hovered or focused.
+
+## What does it do?
+
+The component provides:
+
+- Smooth fade-in and upward reveal.
+- Pointer hover support.
+- Keyboard focus support.
+- `role="tooltip"` semantics.
+- `aria-describedby` association.
+- Subtle trigger elevation.
+- Responsive tooltip sizing.
+- Reduced-motion support.
+- No JavaScript.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create an interactive element with the `floating-tooltip` class and associate
+the tooltip content with `aria-describedby`:
+
+```html
+<button
+  class="floating-tooltip"
+  type="button"
+  aria-describedby="tooltip-example"
+>
+  <span>More information</span>
+
+  <span
+    class="floating-tooltip__content"
+    id="tooltip-example"
+    role="tooltip"
+  >
+    Additional contextual information.
+  </span>
+</button>
+```

--- a/submissions/examples/floating-tooltip-reveal-014/demo.html
+++ b/submissions/examples/floating-tooltip-reveal-014/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Floating tooltip reveal demo for EaseMotion CSS"
+  >
+  <title>Floating Tooltip Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Contextual Feedback</p>
+      <h1>Reveal More on Demand</h1>
+      <p class="hero-copy">
+        Hover or focus an interactive control to reveal a compact floating
+        tooltip with a smooth fade and upward motion.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-label="Floating tooltip examples">
+      <div class="demo-heading">
+        <span>TOOLTIP / 01</span>
+        <h2>Context without clutter</h2>
+        <p>
+          Try hovering over each control or navigating to it with the keyboard.
+        </p>
+      </div>
+
+      <div class="tooltip-grid">
+        <button
+          class="floating-tooltip"
+          type="button"
+          aria-describedby="tooltip-one"
+        >
+          <span class="tooltip-icon" aria-hidden="true">?</span>
+          <span>What is EaseMotion?</span>
+          <span
+            class="floating-tooltip__content"
+            id="tooltip-one"
+            role="tooltip"
+          >
+            A lightweight CSS animation system focused on expressive motion.
+          </span>
+        </button>
+
+        <button
+          class="floating-tooltip"
+          type="button"
+          aria-describedby="tooltip-two"
+        >
+          <span class="tooltip-icon" aria-hidden="true">i</span>
+          <span>More information</span>
+          <span
+            class="floating-tooltip__content"
+            id="tooltip-two"
+            role="tooltip"
+          >
+            Helpful context appears only when the control is being explored.
+          </span>
+        </button>
+
+        <button
+          class="floating-tooltip"
+          type="button"
+          aria-describedby="tooltip-three"
+        >
+          <span class="tooltip-icon" aria-hidden="true">✦</span>
+          <span>Motion details</span>
+          <span
+            class="floating-tooltip__content"
+            id="tooltip-three"
+            role="tooltip"
+          >
+            The reveal combines opacity and translation for a soft entrance.
+          </span>
+        </button>
+      </div>
+
+      <p class="interaction-hint">
+        Hover with a pointer or use Tab to focus a control.
+      </p>
+    </section>
+
+    <footer class="footer">
+      <p>Contextual information without permanent interface clutter.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/floating-tooltip-reveal-014/style.css
+++ b/submissions/examples/floating-tooltip-reveal-014/style.css
@@ -1,0 +1,261 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.4);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+  --tooltip-background: #e9eef7;
+  --tooltip-text: #10141c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1050px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.75rem, 5vw, 4rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.demo-heading {
+  max-width: 650px;
+  margin-bottom: 4rem;
+}
+
+.demo-heading > span {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.demo-heading h2 {
+  margin: 1rem 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.demo-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tooltip-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.floating-tooltip {
+  position: relative;
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--surface-hover);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 200ms ease,
+    border-color 200ms ease,
+    background 200ms ease;
+}
+
+.floating-tooltip:hover,
+.floating-tooltip:focus-visible {
+  border-color: var(--border-hover);
+  background: #1a202b;
+  transform: translateY(-2px);
+}
+
+.floating-tooltip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.tooltip-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--accent);
+  font-size: 0.8rem;
+}
+
+.floating-tooltip__content {
+  position: absolute;
+  z-index: 10;
+  bottom: calc(100% + 0.9rem);
+  left: 50%;
+  width: min(280px, calc(100vw - 3rem));
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(138, 180, 255, 0.25);
+  border-radius: 0.8rem;
+  background: var(--tooltip-background);
+  color: var(--tooltip-text);
+  box-shadow: 0 16px 35px rgba(0, 0, 0, 0.3);
+  font-size: 0.78rem;
+  font-weight: 550;
+  line-height: 1.55;
+  text-align: left;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transform: translate(-50%, 10px);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease,
+    visibility 200ms ease;
+}
+
+.floating-tooltip__content::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -6px;
+  width: 11px;
+  height: 11px;
+  border-right: 1px solid rgba(138, 180, 255, 0.25);
+  border-bottom: 1px solid rgba(138, 180, 255, 0.25);
+  background: var(--tooltip-background);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.floating-tooltip:hover .floating-tooltip__content,
+.floating-tooltip:focus-visible .floating-tooltip__content {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.interaction-hint {
+  margin: 2.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 800px) {
+  .tooltip-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .floating-tooltip {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1.5rem;
+  }
+
+  .floating-tooltip__content {
+    bottom: calc(100% + 0.75rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-tooltip,
+  .floating-tooltip__content {
+    transition: none;
+  }
+
+  .floating-tooltip:hover,
+  .floating-tooltip:focus-visible {
+    transform: none;
+  }
+
+  .floating-tooltip:hover .floating-tooltip__content,
+  .floating-tooltip:focus-visible .floating-tooltip__content {
+    transform: translate(-50%, 0);
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained floating tooltip reveal interaction for EaseMotion CSS.

### What's included

- Smooth tooltip fade and slide animation
- Mouse hover support
- Keyboard focus support
- `role="tooltip"` semantics
- `aria-describedby` association
- Responsive tooltip sizing
- `prefers-reduced-motion` support
- No JavaScript or external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive tooltip demonstration
- `style.css` — tooltip styling and reveal animation
- `README.md` — usage and accessibility documentation

### Issue

Closes #77984

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard focus
- [x] Supports reduced-motion preferences
- [x] Tested the interaction locally