### PR TITLE
feat: add ease-scroll-sticky-table-header-sap

### DIFF
--- a/submissions/examples/ease-scroll-sticky-table-header-sap/README.md
+++ b/submissions/examples/ease-scroll-sticky-table-header-sap/README.md
@@ -1,0 +1,12 @@
+# ease-scroll-sticky-table-header-sap
+
+A scrollable data table whose header row stays pinned to the top of its scroll container as rows scroll beneath it.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: standard `<table>` inside a fixed-height, `overflow-y: auto` container.
+
+## Notes
+- `position: sticky` on `thead th` (not `thead` itself, since sticky positioning on `<thead>` has inconsistent browser support) is what keeps the header pinned within the scrollable container.
+- A bottom `box-shadow` on the header simulates a border that stays visible even while sticky.
+- No motion is involved in this component (pure layout behavior), so no `prefers-reduced-motion` gating is needed.

--- a/submissions/examples/ease-scroll-sticky-table-header-sap/demo.html
+++ b/submissions/examples/ease-scroll-sticky-table-header-sap/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-sticky-table-header-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="sticky-table-sap">
+    <table>
+      <thead><tr><th>Name</th><th>Role</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td>Alice Kim</td><td>Designer</td><td>Active</td></tr>
+        <tr><td>Ben Ortiz</td><td>Engineer</td><td>Active</td></tr>
+        <tr><td>Cara Lin</td><td>PM</td><td>Away</td></tr>
+        <tr><td>Dev Patel</td><td>Engineer</td><td>Active</td></tr>
+        <tr><td>Eva Ross</td><td>Designer</td><td>Away</td></tr>
+        <tr><td>Finn Cole</td><td>QA</td><td>Active</td></tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-sticky-table-header-sap/style.css
+++ b/submissions/examples/ease-scroll-sticky-table-header-sap/style.css
@@ -1,0 +1,32 @@
+.sticky-table-sap {
+  width: 360px;
+  max-height: 240px;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  font-family: system-ui, sans-serif;
+}
+
+.sticky-table-sap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.sticky-table-sap thead th {
+  position: sticky;
+  top: 0;
+  background: #f8fafc;
+  padding: 10px 14px;
+  text-align: left;
+  color: #475569;
+  font-weight: 700;
+  box-shadow: 0 1px 0 #e2e8f0;
+  z-index: 1;
+}
+
+.sticky-table-sap tbody td {
+  padding: 10px 14px;
+  color: #111;
+  border-bottom: 1px solid #f1f5f9;
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-sticky-table-header-sap`, a scrollable table with a sticky header row.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-scroll-sticky-table-header-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support (N/A — no animation)
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `position: sticky` is applied per-`th` rather than on `<thead>`, since sticky positioning on `<thead>` itself has inconsistent cross-browser support.
- A bottom box-shadow substitutes for a border that would otherwise be inconsistent while sticky.
- No motion/animation is involved, so `prefers-reduced-motion` gating isn't applicable here.

## Feature Description

Adds a reusable sticky-header scrollable data table component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.