### PR TITLE
feat: add slide-in action panel

### DIFF
--- a/submissions/examples/slide-in-action-panel-016/README.md
+++ b/submissions/examples/slide-in-action-panel-016/README.md
@@ -1,0 +1,38 @@
+# Slide-In Action Panel
+
+A reusable contextual action panel that slides into view from the side of
+the interface.
+
+## What does it do?
+
+The component provides:
+
+- Smooth side-to-side panel entrance.
+- Subtle backdrop transition.
+- Close button.
+- Escape-key dismissal.
+- Keyboard focus support.
+- Responsive mobile layout.
+- Reduced-motion support.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create an action panel with the `slide-action-panel` class:
+
+```html
+<aside class="slide-action-panel">
+  <span class="slide-action-panel__label">QUICK ACTIONS</span>
+
+  <h2>Choose an action</h2>
+
+  <p>
+    Access frequently used controls without leaving the current view.
+  </p>
+
+  <div class="slide-action-panel__actions">
+    <button type="button">Save changes</button>
+    <button type="button">Duplicate</button>
+  </div>
+</aside>
+```

--- a/submissions/examples/slide-in-action-panel-016/demo.html
+++ b/submissions/examples/slide-in-action-panel-016/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Slide-in action panel demo for EaseMotion CSS">
+  <title>Slide-In Action Panel</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Contextual Actions</p>
+      <h1>Actions,<br>Within Reach.</h1>
+      <p class="hero-copy">
+        Open a compact action panel from the side and access secondary
+        controls without leaving the current interface.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="demo-heading">
+        <span>PANEL / 01</span>
+        <h2 id="demo-title">Slide-in interaction</h2>
+        <p>
+          Choose a trigger to reveal the contextual action panel.
+        </p>
+      </div>
+
+      <button class="open-panel" type="button" aria-controls="action-panel">
+        Open action panel
+        <span aria-hidden="true">→</span>
+      </button>
+    </section>
+  </main>
+
+  <div class="panel-backdrop" aria-hidden="true"></div>
+
+  <aside
+    class="slide-action-panel"
+    id="action-panel"
+    aria-labelledby="panel-title"
+    aria-hidden="true"
+  >
+    <div class="slide-action-panel__top">
+      <span class="slide-action-panel__label">QUICK ACTIONS</span>
+
+      <button
+        class="slide-action-panel__close"
+        type="button"
+        aria-label="Close action panel"
+      >
+        ×
+      </button>
+    </div>
+
+    <div class="slide-action-panel__body">
+      <h2 id="panel-title">Choose an action</h2>
+      <p>
+        Access frequently used controls without leaving the current view.
+      </p>
+
+      <div class="slide-action-panel__actions">
+        <button type="button" class="panel-action panel-action--primary">
+          Save changes
+        </button>
+
+        <button type="button" class="panel-action">
+          Duplicate
+        </button>
+
+        <button type="button" class="panel-action">
+          Share
+        </button>
+      </div>
+    </div>
+
+    <p class="slide-action-panel__hint">
+      Press Escape or use the close button to dismiss.
+    </p>
+  </aside>
+
+  <script>
+    const openButton = document.querySelector(".open-panel");
+    const closeButton = document.querySelector(".slide-action-panel__close");
+    const panel = document.querySelector(".slide-action-panel");
+    const backdrop = document.querySelector(".panel-backdrop");
+
+    function openPanel() {
+      panel.classList.add("is-open");
+      panel.setAttribute("aria-hidden", "false");
+      backdrop.classList.add("is-visible");
+      closeButton.focus();
+    }
+
+    function closePanel() {
+      panel.classList.remove("is-open");
+      panel.setAttribute("aria-hidden", "true");
+      backdrop.classList.remove("is-visible");
+      openButton.focus();
+    }
+
+    openButton.addEventListener("click", openPanel);
+    closeButton.addEventListener("click", closePanel);
+    backdrop.addEventListener("click", closePanel);
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && panel.classList.contains("is-open")) {
+        closePanel();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/slide-in-action-panel-016/style.css
+++ b/submissions/examples/slide-in-action-panel-016/style.css
@@ -1,0 +1,325 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --surface-hover: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.35);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1050px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.75rem, 5vw, 4rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.demo-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.demo-heading > span {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.demo-heading h2 {
+  margin: 1rem 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.demo-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.open-panel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 52px;
+  padding: 0.8rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-hover);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.open-panel span {
+  color: var(--accent);
+  transition: transform 180ms ease;
+}
+
+.open-panel:hover {
+  border-color: var(--border-hover);
+  background: #1b222d;
+  transform: translateY(-2px);
+}
+
+.open-panel:hover span {
+  transform: translateX(4px);
+}
+
+.open-panel:focus-visible,
+.panel-action:focus-visible,
+.slide-action-panel__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.panel-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 260ms ease,
+    visibility 260ms ease;
+}
+
+.panel-backdrop.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.slide-action-panel {
+  position: fixed;
+  z-index: 100;
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  width: min(420px, calc(100vw - 2rem));
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: rgba(17, 21, 29, 0.98);
+  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(18px);
+  transform: translateX(calc(100% + 2rem));
+  visibility: hidden;
+  transition:
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 420ms ease;
+}
+
+.slide-action-panel.is-open {
+  transform: translateX(0);
+  visibility: visible;
+}
+
+.slide-action-panel__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.slide-action-panel__label {
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+}
+
+.slide-action-panel__close {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 1.4rem;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+
+.slide-action-panel__close:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text);
+}
+
+.slide-action-panel__body {
+  margin: auto 0;
+}
+
+.slide-action-panel__body h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.slide-action-panel__body > p {
+  max-width: 330px;
+  margin: 0 0 2rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.slide-action-panel__actions {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.panel-action {
+  width: 100%;
+  min-height: 50px;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: var(--surface-hover);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.panel-action:hover {
+  border-color: var(--border-hover);
+  background: #1b222d;
+  transform: translateX(4px);
+}
+
+.panel-action--primary {
+  border-color: rgba(138, 180, 255, 0.3);
+  background: rgba(138, 180, 255, 0.1);
+  color: var(--accent);
+}
+
+.slide-action-panel__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .slide-action-panel {
+    top: 0.5rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    width: calc(100vw - 1rem);
+    border-radius: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .open-panel,
+  .open-panel span,
+  .panel-backdrop,
+  .slide-action-panel,
+  .slide-action-panel__close,
+  .panel-action {
+    transition: none;
+  }
+
+  .open-panel:hover,
+  .panel-action:hover {
+    transform: none;
+  }
+
+  .open-panel:hover span {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained slide-in action panel interaction for EaseMotion CSS.

### What's included

- Smooth side-panel entrance animation
- Backdrop transition
- Close button
- Escape-key dismissal
- Keyboard focus support
- Responsive layout
- `prefers-reduced-motion` support
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive action panel demonstration
- `style.css` — panel styling and motion
- `README.md` — usage and accessibility documentation

### Issue

## Closes #77991

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard interaction
- [x] Supports reduced-motion preferences
- [x] Tested locally