### PR TITLE
feat: add basic schedule slot row demo

### DIFF
--- a/submissions/examples/basic-schedule-slot-row-kk/README.md
+++ b/submissions/examples/basic-schedule-slot-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Schedule Slot Row
+
+## What it does
+
+This submission adds a simple CSS-only schedule slot row for agendas, meeting lists, daily plans, event schedules, and planning cards.
+
+It aligns a time block, event title, helper text, and a small status label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a time, event copy, and optional status:
+
+```html
+<div class="basic-schedule-slot-row">
+  <time datetime="09:30">09:30</time>
+  <div class="slot-copy">
+    <strong>Design sync</strong>
+    <p>Review layout notes and open UI tasks.</p>
+  </div>
+  <span class="slot-label is-live">Live</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across dashboards, agenda cards, event sections, planning panels, and calendar-inspired layouts. It uses semantic HTML and CSS only.
+
+## Included features
+
+- Time block, event copy, and status label layout
+- Live, planned, and done examples
+- Semantic `time` element usage
+- Divider support between rows
+- Responsive stacked layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the schedule slot row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-schedule-slot-row-kk/demo.html
+++ b/submissions/examples/basic-schedule-slot-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Schedule Slot Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Schedule Slot Row</p>
+          <h1>Readable agenda rows for meetings, events, and daily plans.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a time block, event copy, and a small
+            status label for compact schedules, agendas, and planning cards.
+          </p>
+        </header>
+
+        <section class="schedule-panel" aria-label="Schedule slot row examples">
+          <div class="basic-schedule-slot-row">
+            <time datetime="09:30">09:30</time>
+            <div class="slot-copy">
+              <strong>Design sync</strong>
+              <p>Review layout notes and open UI tasks.</p>
+            </div>
+            <span class="slot-label is-live">Live</span>
+          </div>
+
+          <div class="basic-schedule-slot-row">
+            <time datetime="11:00">11:00</time>
+            <div class="slot-copy">
+              <strong>Code review</strong>
+              <p>Check pending frontend submissions.</p>
+            </div>
+            <span class="slot-label">Planned</span>
+          </div>
+
+          <div class="basic-schedule-slot-row">
+            <time datetime="15:45">15:45</time>
+            <div class="slot-copy">
+              <strong>Release notes</strong>
+              <p>Summarize completed improvements.</p>
+            </div>
+            <span class="slot-label is-done">Done</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-schedule-slot-row"&gt;
+  &lt;time datetime="09:30"&gt;09:30&lt;/time&gt;
+  &lt;div class="slot-copy"&gt;
+    &lt;strong&gt;Design sync&lt;/strong&gt;
+    &lt;p&gt;Review layout notes and open UI tasks.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="slot-label is-live"&gt;Live&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-schedule-slot-row-kk/style.css
+++ b/submissions/examples/basic-schedule-slot-row-kk/style.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #93c5fd;
+  --accent-soft: rgba(147, 197, 253, 0.14);
+  --success: #86efac;
+  --live: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(147, 197, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(252, 165, 165, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.schedule-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-schedule-slot-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-schedule-slot-row + .basic-schedule-slot-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-schedule-slot-row time {
+  min-width: 4.1rem;
+  border-radius: 0.85rem;
+  padding: 0.55rem 0.65rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.slot-copy {
+  min-width: 0;
+}
+
+.slot-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.slot-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slot-label {
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.slot-label.is-live {
+  color: var(--live);
+  background: rgba(252, 165, 165, 0.13);
+}
+
+.slot-label.is-done {
+  color: var(--success);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-schedule-slot-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .slot-label {
+    grid-column: 2;
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Schedule Slot Row demo inside `submissions/examples/basic-schedule-slot-row-kk/`. This submission introduces a compact CSS-only row pattern for agendas, meeting lists, daily plans, event schedules, and planning cards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only schedule slot row for showing a time block, event title, helper text, and small status label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-schedule-slot-row">
  <time datetime="09:30">09:30</time>
  <div class="slot-copy">
    <strong>Design sync</strong>
    <p>Review layout notes and open UI tasks.</p>
  </div>
  <span class="slot-label is-live">Live</span>
</div>