### PR TITLE
feat: add ease-animated-breadcrumb-trail-sap

### DIFF
--- a/submissions/examples/ease-animated-breadcrumb-trail-sap/README.md
+++ b/submissions/examples/ease-animated-breadcrumb-trail-sap/README.md
@@ -1,0 +1,12 @@
+# ease-animated-breadcrumb-trail-sap
+
+A breadcrumb navigation trail where each link gets an animated underline on hover, and the final crumb is styled as the non-interactive current page.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `<a>` links separated by `.crumb-sep`, ending in a `.crumb-current` span for the active page.
+
+## Notes
+- Underline grows via `scaleX()` from `transform-origin: left`, same lightweight technique as the standalone underline-nav component.
+- The final crumb uses a plain `<span>` (not `<a>`), correctly signaling it's the current page and not a clickable link.
+- Respects `prefers-reduced-motion`: underline scale transition is removed, color change remains.

--- a/submissions/examples/ease-animated-breadcrumb-trail-sap/demo.html
+++ b/submissions/examples/ease-animated-breadcrumb-trail-sap/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-animated-breadcrumb-trail-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <nav class="breadcrumb-sap">
+    <a href="#">Home</a><span class="crumb-sep">/</span>
+    <a href="#">Products</a><span class="crumb-sep">/</span>
+    <a href="#">Electronics</a><span class="crumb-sep">/</span>
+    <span class="crumb-current">Headphones</span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/ease-animated-breadcrumb-trail-sap/style.css
+++ b/submissions/examples/ease-animated-breadcrumb-trail-sap/style.css
@@ -1,0 +1,53 @@
+.breadcrumb-sap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: system-ui, sans-serif;
+  font-size: 13px;
+}
+
+.breadcrumb-sap a {
+  color: #64748b;
+  text-decoration: none;
+  position: relative;
+  padding: 2px 4px;
+  transition: color 0.2s ease;
+}
+
+.breadcrumb-sap a:hover {
+  color: #2563eb;
+}
+
+.breadcrumb-sap a::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  bottom: 0;
+  height: 2px;
+  background: #2563eb;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+}
+
+.breadcrumb-sap a:hover::after {
+  transform: scaleX(1);
+}
+
+.breadcrumb-sap .crumb-sep {
+  color: #cbd5e1;
+}
+
+.breadcrumb-sap .crumb-current {
+  color: #111;
+  font-weight: 600;
+  padding: 2px 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb-sap a,
+  .breadcrumb-sap a::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-breadcrumb-trail-sap`, an animated breadcrumb navigation trail.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-animated-breadcrumb-trail-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Underline uses the `scaleX()` technique for lightweight hover animation.
- Final crumb is a plain `<span>`, not a link, correctly marking it as the current non-navigable page.
- `prefers-reduced-motion` removes the underline scale transition.

## Feature Description

Adds a reusable animated breadcrumb navigation component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.