### PR TITLE
feat: add hover reveal image caption

### DIFF
--- a/submissions/examples/hover-reveal-image-caption-018/README.md
+++ b/submissions/examples/hover-reveal-image-caption-018/README.md
@@ -1,0 +1,40 @@
+# Hover Reveal Image Caption
+
+A lightweight image-card interaction that reveals contextual information
+from the bottom of the visual when hovered or focused.
+
+## What does it do?
+
+The component provides:
+
+- Bottom-to-top caption reveal.
+- Smooth opacity transition.
+- Mouse hover support.
+- Keyboard focus support.
+- Subtle background visual movement.
+- Responsive card layout.
+- Reduced-motion support.
+- No JavaScript.
+- No external assets or libraries.
+
+## How do I use it?
+
+Create a card with a media element and caption:
+
+```html
+<figure class="hover-caption-card">
+  <div
+    class="hover-caption-card__media"
+    role="img"
+    aria-label="Example image"
+    tabindex="0"
+  >
+    Visual
+  </div>
+
+  <figcaption class="hover-caption-card__caption">
+    <strong>Featured Work</strong>
+    <span>A smooth caption reveal interaction.</span>
+  </figcaption>
+</figure>
+```

--- a/submissions/examples/hover-reveal-image-caption-018/demo.html
+++ b/submissions/examples/hover-reveal-image-caption-018/demo.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Hover reveal image caption demo for EaseMotion CSS">
+  <title>Hover Reveal Image Caption</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Image Interaction</p>
+      <h1>Let the<br>Details Appear.</h1>
+      <p class="hero-copy">
+        Hover or focus each visual to reveal its contextual caption with a
+        smooth bottom-up motion.
+      </p>
+    </header>
+
+    <section class="gallery" aria-labelledby="gallery-title">
+      <div class="section-heading">
+        <span>GALLERY / 01</span>
+        <h2 id="gallery-title">Reveal on interaction</h2>
+      </div>
+
+      <div class="gallery-grid">
+        <figure class="hover-caption-card">
+          <div
+            class="hover-caption-card__media hover-caption-card__media--blue"
+            role="img"
+            aria-label="Abstract blue geometric composition"
+            tabindex="0"
+          >
+            <span class="visual-number">01</span>
+            <span class="visual-shape visual-shape--one"></span>
+            <span class="visual-shape visual-shape--two"></span>
+          </div>
+
+          <figcaption class="hover-caption-card__caption">
+            <strong>Blue Geometry</strong>
+            <span>Structured forms with a quiet sense of movement.</span>
+          </figcaption>
+        </figure>
+
+        <figure class="hover-caption-card">
+          <div
+            class="hover-caption-card__media hover-caption-card__media--violet"
+            role="img"
+            aria-label="Abstract violet layered composition"
+            tabindex="0"
+          >
+            <span class="visual-number">02</span>
+            <span class="visual-shape visual-shape--three"></span>
+            <span class="visual-shape visual-shape--four"></span>
+          </div>
+
+          <figcaption class="hover-caption-card__caption">
+            <strong>Violet Layers</strong>
+            <span>Overlapping surfaces create depth within the frame.</span>
+          </figcaption>
+        </figure>
+
+        <figure class="hover-caption-card">
+          <div
+            class="hover-caption-card__media hover-caption-card__media--warm"
+            role="img"
+            aria-label="Abstract warm gradient composition"
+            tabindex="0"
+          >
+            <span class="visual-number">03</span>
+            <span class="visual-shape visual-shape--five"></span>
+            <span class="visual-shape visual-shape--six"></span>
+          </div>
+
+          <figcaption class="hover-caption-card__caption">
+            <strong>Warm Horizon</strong>
+            <span>A soft visual field paired with contextual information.</span>
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Pure HTML and CSS. No external images, libraries, or assets.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-reveal-image-caption-018/style.css
+++ b/submissions/examples/hover-reveal-image-caption-018/style.css
@@ -1,0 +1,319 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+  --caption: rgba(8, 10, 15, 0.9);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 8rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.section-heading {
+  margin-bottom: 2rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.hover-caption-card {
+  position: relative;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.hover-caption-card__media {
+  position: relative;
+  min-height: 430px;
+  overflow: hidden;
+  isolation: isolate;
+  cursor: pointer;
+  outline: none;
+}
+
+.hover-caption-card__media:focus-visible {
+  box-shadow: inset 0 0 0 3px var(--accent);
+}
+
+.hover-caption-card__media::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  background: var(--surface);
+}
+
+.hover-caption-card__media--blue {
+  background:
+    radial-gradient(circle at 30% 30%, #8ab4ff 0, transparent 28%),
+    linear-gradient(145deg, #101a2b, #263e64);
+}
+
+.hover-caption-card__media--violet {
+  background:
+    radial-gradient(circle at 70% 35%, #c084fc 0, transparent 30%),
+    linear-gradient(145deg, #171026, #49306a);
+}
+
+.hover-caption-card__media--warm {
+  background:
+    radial-gradient(circle at 35% 65%, #f5c77b 0, transparent 30%),
+    linear-gradient(145deg, #211810, #60482c);
+}
+
+.visual-number {
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.visual-shape {
+  position: absolute;
+  display: block;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  transition: transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.visual-shape--one {
+  width: 220px;
+  height: 220px;
+  right: -70px;
+  bottom: 30px;
+  border-radius: 50%;
+  background: rgba(138, 180, 255, 0.2);
+}
+
+.visual-shape--two {
+  width: 150px;
+  height: 150px;
+  left: 20%;
+  bottom: 80px;
+  border-radius: 2rem;
+  transform: rotate(35deg);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.visual-shape--three {
+  width: 230px;
+  height: 230px;
+  right: -80px;
+  top: 70px;
+  border-radius: 50%;
+  background: rgba(192, 132, 252, 0.2);
+}
+
+.visual-shape--four {
+  width: 160px;
+  height: 160px;
+  left: -40px;
+  bottom: 80px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.visual-shape--five {
+  width: 260px;
+  height: 150px;
+  right: -70px;
+  bottom: 50px;
+  border-radius: 50%;
+  transform: rotate(-25deg);
+  background: rgba(245, 199, 123, 0.22);
+}
+
+.visual-shape--six {
+  width: 130px;
+  height: 260px;
+  left: 25%;
+  top: 80px;
+  border-radius: 5rem;
+  transform: rotate(30deg);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.hover-caption-card__caption {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1.4rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--caption);
+  backdrop-filter: blur(12px);
+  opacity: 0;
+  transform: translateY(100%);
+  transition:
+    opacity 260ms ease,
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.hover-caption-card__caption strong {
+  font-size: 1rem;
+}
+
+.hover-caption-card__caption span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.hover-caption-card:hover .hover-caption-card__caption,
+.hover-caption-card:focus-within .hover-caption-card__caption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hover-caption-card:hover .visual-shape--one,
+.hover-caption-card:focus-within .visual-shape--one {
+  transform: translate(-12px, -10px);
+}
+
+.hover-caption-card:hover .visual-shape--two,
+.hover-caption-card:focus-within .visual-shape--two {
+  transform: rotate(48deg) translateY(-8px);
+}
+
+.hover-caption-card:hover .visual-shape--three,
+.hover-caption-card:focus-within .visual-shape--three {
+  transform: translate(-12px, 8px);
+}
+
+.hover-caption-card:hover .visual-shape--four,
+.hover-caption-card:focus-within .visual-shape--four {
+  transform: translate(10px, -8px);
+}
+
+.hover-caption-card:hover .visual-shape--five,
+.hover-caption-card:focus-within .visual-shape--five {
+  transform: rotate(-18deg) translate(-8px, -10px);
+}
+
+.hover-caption-card:hover .visual-shape--six,
+.hover-caption-card:focus-within .visual-shape--six {
+  transform: rotate(42deg) translateY(-10px);
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 850px) {
+  .gallery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hover-caption-card__media {
+    min-height: 380px;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .hover-caption-card__media {
+    min-height: 330px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hover-caption-card__caption,
+  .visual-shape {
+    transition: none;
+  }
+
+  .hover-caption-card:hover .visual-shape,
+  .hover-caption-card:focus-within .visual-shape {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained hover reveal image caption interaction for EaseMotion CSS.

### What's included

- Bottom-up caption reveal
- Smooth opacity and transform animation
- Mouse hover support
- Keyboard focus support
- Subtle visual movement
- Responsive layout
- `prefers-reduced-motion` support
- No JavaScript or external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — interactive image caption demonstration
- `style.css` — card styling and reveal animation
- `README.md` — usage and accessibility documentation

### Issue

## Closes #77999

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard focus
- [x] Supports reduced-motion preferences
- [x] Tested locally