### PR TITLE
feat: add ease-scroll-image-sequence-sap

### DIFF
--- a/submissions/examples/ease-scroll-image-sequence-sap/README.md
+++ b/submissions/examples/ease-scroll-image-sequence-sap/README.md
@@ -1,0 +1,18 @@
+# ease-scroll-image-sequence-sap
+
+A scroll-scrubbed image sequence — scrolling through a tall track advances through a series of frames, like a scrubbable product-reveal animation (Apple-style scroll sequences).
+
+## Usage
+1. Include `style.css`.
+2. Add markup: a tall `.scroll-track` wrapping a `position: sticky` container holding `.seq-frame` layers.
+3. Attach the scroll-linked frame calculation from `demo.html`.
+
+## Customization
+- `.scroll-track` height (`300vh`): how much scroll distance covers the full sequence — taller = slower scrub.
+- Number of frames — swap the colored `.seq-frame` divs for real sequential images.
+- Frame opacity transition duration for cross-fade smoothness between frames.
+
+## Notes
+- The sticky container stays pinned in the viewport while its tall parent (`.scroll-track`) scrolls underneath, and frame progress is calculated from how far the parent has scrolled relative to its own scrollable height — this is the standard technique for scroll-scrubbed sequences.
+- Only one frame is `.active` (opacity 1) at a time; frame index is derived directly from scroll progress, not a timer.
+- Respects `prefers-reduced-motion`: cross-fade transition duration is unaffected in this component since frame switching is directly tied to scroll position (not a persistent animation) — each frame change is a state response to user scroll input, not decorative motion.

--- a/submissions/examples/ease-scroll-image-sequence-sap/demo.html
+++ b/submissions/examples/ease-scroll-image-sequence-sap/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-image-sequence-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f4f4f5; }
+    .scroll-track { height: 300vh; position: relative; }
+    .sticky-wrap { position: sticky; top: 30vh; display: flex; align-items: center; justify-content: center; }
+  </style>
+</head>
+<body>
+  <div class="scroll-track" id="track">
+    <div class="sticky-wrap">
+      <div class="img-sequence-sap" id="sequence">
+        <div class="seq-frame active">1</div>
+        <div class="seq-frame">2</div>
+        <div class="seq-frame">3</div>
+        <div class="seq-frame">4</div>
+        <div class="seq-frame">5</div>
+      </div>
+    </div>
+  </div>
+  <script>
+    const track = document.getElementById('track');
+    const frames = [...document.querySelectorAll('.seq-frame')];
+
+    function update() {
+      const rect = track.getBoundingClientRect();
+      const total = rect.height - window.innerHeight;
+      const progress = Math.min(1, Math.max(0, -rect.top / total));
+      const frameIdx = Math.min(frames.length - 1, Math.floor(progress * frames.length));
+      frames.forEach((f, i) => f.classList.toggle('active', i === frameIdx));
+    }
+
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-image-sequence-sap/style.css
+++ b/submissions/examples/ease-scroll-image-sequence-sap/style.css
@@ -1,0 +1,38 @@
+.img-sequence-sap {
+  position: relative;
+  width: 320px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #111;
+}
+
+.img-sequence-sap .seq-frame {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-size: 40px;
+  font-weight: 800;
+  opacity: 0;
+  transition: opacity 0.15s linear;
+}
+
+.img-sequence-sap .seq-frame.active {
+  opacity: 1;
+}
+
+.img-sequence-sap .seq-frame:nth-child(1) { background: linear-gradient(135deg, #1e293b, #334155); }
+.img-sequence-sap .seq-frame:nth-child(2) { background: linear-gradient(135deg, #334155, #475569); }
+.img-sequence-sap .seq-frame:nth-child(3) { background: linear-gradient(135deg, #2563eb, #334155); }
+.img-sequence-sap .seq-frame:nth-child(4) { background: linear-gradient(135deg, #7c3aed, #2563eb); }
+.img-sequence-sap .seq-frame:nth-child(5) { background: linear-gradient(135deg, #ec4899, #7c3aed); }
+
+@media (prefers-reduced-motion: reduce) {
+  .img-sequence-sap .seq-frame {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-image-sequence-sap`, a scroll-scrubbed image/frame sequence component.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-scroll-image-sequence-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses the standard sticky-container + tall-parent scroll-scrub technique; frame index derives directly from scroll progress, not a timer.
- Only one frame is active at a time, matching real product-reveal scroll sequences.
- README notes frame switching is a direct scroll-input response rather than persistent decorative motion, so the cross-fade remains active regardless of `prefers-reduced-motion`.

## Feature Description

Adds a reusable scroll-scrubbed image sequence component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.