### PR TITLE
feat: add slide-up reveal badge

### DIFF
--- a/submissions/examples/slide-up-reveal-badge-023/demo.html
+++ b/submissions/examples/slide-up-reveal-badge-023/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Slide-up reveal badge demo for EaseMotion CSS">
+  <title>Slide-Up Reveal Badge</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Micro Interaction</p>
+      <h1>Small Details.<br>Clear Motion.</h1>
+      <p class="hero-copy">
+        A lightweight badge that enters with a subtle slide-up and fade
+        transition for status, category, and contextual labels.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="section-heading">
+        <span>BADGE / 01</span>
+        <h2 id="demo-title">Reveal the details</h2>
+        <p>
+          Each badge demonstrates a slightly different use case while
+          sharing the same entrance motion.
+        </p>
+      </div>
+
+      <div class="badge-grid">
+        <article class="badge-card">
+          <span class="ease-reveal-badge">New</span>
+          <h3>Fresh content</h3>
+          <p>
+            Use a reveal badge to highlight recently added content.
+          </p>
+        </article>
+
+        <article class="badge-card">
+          <span class="ease-reveal-badge">Featured</span>
+          <h3>Selected item</h3>
+          <p>
+            Draw attention to an item without relying on heavy visual effects.
+          </p>
+        </article>
+
+        <article class="badge-card">
+          <span class="ease-reveal-badge">Live</span>
+          <h3>Active status</h3>
+          <p>
+            Communicate an active state with a compact animated label.
+          </p>
+        </article>
+
+        <article class="badge-card">
+          <span class="ease-reveal-badge">Updated</span>
+          <h3>Recent change</h3>
+          <p>
+            Indicate that existing content has recently been modified.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Pure HTML and CSS. No JavaScript, libraries, or external assets.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/slide-up-reveal-badge-023/style.css
+++ b/submissions/examples/slide-up-reveal-badge-023/style.css
@@ -1,0 +1,208 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --card: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.35);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+  --badge-background: rgba(138, 180, 255, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(950px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.section-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.badge-card {
+  min-height: 190px;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+
+.badge-card:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-3px);
+}
+
+.ease-reveal-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid rgba(138, 180, 255, 0.25);
+  border-radius: 999px;
+  background: var(--badge-background);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  animation: badge-reveal 450ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.badge-card:nth-child(2) .ease-reveal-badge {
+  animation-delay: 100ms;
+}
+
+.badge-card:nth-child(3) .ease-reveal-badge {
+  animation-delay: 200ms;
+}
+
+.badge-card:nth-child(4) .ease-reveal-badge {
+  animation-delay: 300ms;
+}
+
+.badge-card h3 {
+  margin: 1.5rem 0 0.6rem;
+  font-size: 1.05rem;
+}
+
+.badge-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.7;
+}
+
+@keyframes badge-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 650px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1rem;
+  }
+
+  .badge-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-reveal-badge {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .badge-card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained slide-up reveal badge animation for EaseMotion CSS.

### What's included

- Slide-up and fade entrance animation
- Staggered badge timing
- Responsive demonstration
- `prefers-reduced-motion` support
- No JavaScript
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — badge demonstration
- `style.css` — badge styling and animation
- `README.md` — usage and accessibility documentation

### Issue

## Closes #78011

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports reduced-motion preferences
- [x] Tested locally