### PR TITLE
feat: add hover expand action chip

### DIFF
--- a/submissions/examples/hover-expand-action-chip-024/README.md
+++ b/submissions/examples/hover-expand-action-chip-024/README.md
@@ -1,0 +1,29 @@
+# Hover Expand Action Chip
+
+A compact action chip that expands its spacing and visual treatment on
+hover or keyboard focus.
+
+## What does it do?
+
+The component provides:
+
+- Smooth spacing expansion.
+- Subtle upward movement.
+- Animated arrow reveal.
+- Hover and keyboard focus states.
+- Rounded pill-shaped presentation.
+- Responsive layout.
+- Reduced-motion support.
+- No JavaScript.
+- No external libraries or assets.
+
+## How do I use it?
+
+Add the `ease-action-chip` class to an anchor or other interactive element:
+
+```html
+<a class="ease-action-chip" href="#">
+  <span>Explore</span>
+  <span class="ease-action-chip__arrow" aria-hidden="true">→</span>
+</a>
+```

--- a/submissions/examples/hover-expand-action-chip-024/demo.html
+++ b/submissions/examples/hover-expand-action-chip-024/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Hover expand action chip demo for EaseMotion CSS">
+  <title>Hover Expand Action Chip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Micro Interaction</p>
+      <h1>Compact.<br>Then Expanded.</h1>
+      <p class="hero-copy">
+        A lightweight action chip that expands its spacing and motion on
+        hover or keyboard focus.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="section-heading">
+        <span>ACTION CHIP / 01</span>
+        <h2 id="demo-title">Explore the interaction</h2>
+        <p>
+          Hover or focus the chips to reveal their expanded interaction state.
+        </p>
+      </div>
+
+      <div class="chip-grid">
+        <a class="ease-action-chip" href="#">
+          <span>Explore</span>
+          <span class="ease-action-chip__arrow" aria-hidden="true">→</span>
+        </a>
+
+        <a class="ease-action-chip" href="#">
+          <span>Learn more</span>
+          <span class="ease-action-chip__arrow" aria-hidden="true">→</span>
+        </a>
+
+        <a class="ease-action-chip" href="#">
+          <span>View projects</span>
+          <span class="ease-action-chip__arrow" aria-hidden="true">→</span>
+        </a>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Pure HTML and CSS. No JavaScript, libraries, or external assets.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-expand-action-chip-024/style.css
+++ b/submissions/examples/hover-expand-action-chip-024/style.css
@@ -1,0 +1,202 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --chip: #171d27;
+  --chip-hover: #202938;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.4);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(950px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.section-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.ease-action-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 46px;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--chip);
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    gap 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.ease-action-chip__arrow {
+  display: inline-block;
+  opacity: 0.65;
+  transform: translateX(0);
+  transition:
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms ease;
+}
+
+.ease-action-chip:hover,
+.ease-action-chip:focus-visible {
+  gap: 0.75rem;
+  padding-inline: 1.2rem;
+  border-color: var(--border-hover);
+  background: var(--chip-hover);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.22);
+}
+
+.ease-action-chip:hover .ease-action-chip__arrow,
+.ease-action-chip:focus-visible .ease-action-chip__arrow {
+  opacity: 1;
+  transform: translateX(3px);
+}
+
+.ease-action-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1rem;
+  }
+
+  .chip-grid {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .ease-action-chip {
+    width: fit-content;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .ease-action-chip,
+  .ease-action-chip__arrow {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained hover-expand action chip interaction for EaseMotion CSS.

### What's included

- Smooth spacing expansion
- Subtle lift animation
- Animated arrow reveal
- Hover and keyboard focus states
- Responsive demonstration
- `prefers-reduced-motion` support
- No JavaScript
- No external dependencies
- Offline-compatible standalone demo
- Usage documentation

### Files

- `demo.html` — action chip demonstration
- `style.css` — chip styling and animations
- `README.md` — usage and accessibility documentation

### Issue

## Closes #78012

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard interaction
- [x] Supports reduced-motion preferences
- [x] Tested locally