### PR TITLE
feat: add minimalist outline CSS form (#73356)

### DIFF
--- a/submissions/examples/73356-css-form-minimalist-outline/README.md
+++ b/submissions/examples/73356-css-form-minimalist-outline/README.md
@@ -1,0 +1,52 @@
+# Minimalist Outline CSS Form Component
+
+A pure HTML + Vanilla CSS form component featuring a clean, modern, lightweight "Minimalist Outline" visual identity with thin borders, restrained typography, native validation states, and subtle focus transitions.
+
+## Features
+
+- **Pure HTML + CSS**: 100% interactive without JavaScript, external fonts, external image assets, or build scripts. Works offline.
+- **Minimalist Outline Identity**: Crisp 1px borders (`border: 1px solid var(--form-border)`), restrained border radius (`6px`), generous whitespace, and understated typography.
+- **Semantic & Accessible**: Complete `<form>` structure with associated `<label for="...">` elements, text inputs, email inputs, selects, textareas, custom outlined checkboxes, and submit buttons.
+- **Native HTML Validation**: Built-in support for `:user-invalid` / `:invalid:not(:placeholder-shown)` with clear error outlines (`--form-error`).
+- **Clear `:focus-visible` States**: High-contrast focus outlines on active controls (`:focus-visible`).
+- **Responsive & Dark Mode**: Fully responsive layout adapts seamlessly across mobile viewports (320px–1440px+), `@media (prefers-color-scheme)`, and `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Include `style.css` and use semantic HTML:
+
+```html
+<form class="minimal-form">
+  <div class="form-field">
+    <label for="name" class="field-label">Full Name</label>
+    <input type="text" id="name" name="name" class="minimal-input" required />
+  </div>
+
+  <div class="form-field">
+    <label for="email" class="field-label">Email Address</label>
+    <input
+      type="email"
+      id="email"
+      name="email"
+      class="minimal-input"
+      required
+    />
+  </div>
+
+  <button type="submit" class="minimal-btn">Send Message</button>
+</form>
+```
+
+### Customization Variables
+
+```css
+:root {
+  --form-bg: #f8fafc;
+  --form-surface: #ffffff;
+  --form-border: #cbd5e1;
+  --form-text: #0f172a;
+  --form-accent: #0f172a;
+  --form-accent-focus: #2563eb;
+  --form-error: #dc2626;
+}
+```

--- a/submissions/examples/73356-css-form-minimalist-outline/demo.html
+++ b/submissions/examples/73356-css-form-minimalist-outline/demo.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Minimalist Outline CSS Form Component</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-container">
+      <header class="demo-header">
+        <div class="minimal-badge">DESIGN SYSTEM</div>
+        <h1 class="demo-title">MINIMALIST OUTLINE FORM</h1>
+        <p class="demo-subtitle">
+          Pure HTML + Vanilla CSS Lightweight Outlined Interface
+        </p>
+      </header>
+
+      <section class="minimal-card">
+        <form class="minimal-form">
+          <div class="form-grid">
+            <!-- Full Name -->
+            <div class="form-field">
+              <label for="name" class="field-label">Full Name</label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                class="minimal-input"
+                placeholder="e.g. Alex Morgan"
+                autocomplete="name"
+                required
+              />
+            </div>
+
+            <!-- Email Address -->
+            <div class="form-field">
+              <label for="email" class="field-label">Email Address</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                class="minimal-input"
+                placeholder="alex@example.com"
+                autocomplete="email"
+                required
+              />
+            </div>
+          </div>
+
+          <!-- Inquiry Type -->
+          <div class="form-field">
+            <label for="inquiry" class="field-label">Inquiry Category</label>
+            <div class="select-wrapper">
+              <select
+                id="inquiry"
+                name="inquiry"
+                class="minimal-select"
+                required
+              >
+                <option value="" disabled selected>
+                  Select an inquiry topic...
+                </option>
+                <option value="general">General Support</option>
+                <option value="feedback">Feedback &amp; Suggestions</option>
+                <option value="partnership">Partnership &amp; Press</option>
+                <option value="other">Other Inquiry</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Message Textarea -->
+          <div class="form-field">
+            <label for="message" class="field-label">Message</label>
+            <textarea
+              id="message"
+              name="message"
+              class="minimal-textarea"
+              rows="4"
+              placeholder="Write your message here..."
+              required
+            ></textarea>
+          </div>
+
+          <!-- Consent Checkbox -->
+          <div class="form-field field-checkbox">
+            <label for="consent" class="checkbox-label">
+              <input
+                type="checkbox"
+                id="consent"
+                name="consent"
+                class="minimal-checkbox"
+                required
+              />
+              <span class="custom-checkbox" aria-hidden="true"></span>
+              <span class="checkbox-text"
+                >I agree to the privacy policy and terms of service.</span
+              >
+            </label>
+          </div>
+
+          <!-- Form Actions -->
+          <div class="form-actions">
+            <button type="submit" class="minimal-btn">
+              <span>Send Message</span>
+              <span class="btn-arrow" aria-hidden="true">&rarr;</span>
+            </button>
+          </div>
+        </form>
+
+        <footer class="form-footer">
+          <div class="keyboard-instruction">
+            <span class="minimal-key">TAB</span> Navigate fields
+            <span class="minimal-key">SPACE</span> Toggle checkbox
+            <span class="minimal-key">ENTER</span> Submit form
+          </div>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/73356-css-form-minimalist-outline/style.css
+++ b/submissions/examples/73356-css-form-minimalist-outline/style.css
@@ -1,0 +1,470 @@
+/* -------------------------------------------------------------------------- */
+
+/* 1. CSS Variables                                                           */
+
+/* -------------------------------------------------------------------------- */
+
+:root {
+  --form-bg: #f8fafc;
+  --form-surface: #ffffff;
+  --form-card-bg: #ffffff;
+  --form-border: #cbd5e1;
+  --form-border-hover: #64748b;
+  --form-text: #0f172a;
+  --form-muted: #64748b;
+  --form-accent: #0f172a;
+  --form-accent-focus: #2563eb;
+  --form-error: #dc2626;
+  --form-error-bg: #fef2f2;
+  --form-radius: 6px;
+  --form-transition:
+    border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease,
+    color 0.18s ease;
+  --font-mono: "Courier New", Courier, monospace, ui-monospace;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 2. Base Styles                                                             */
+
+/* -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--form-bg);
+  color: var(--form-text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.5;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.25rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.minimal-badge {
+  display: inline-block;
+  font-size: 0.725rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--form-accent);
+  background-color: rgba(15, 23, 42, 0.05);
+  border: 1px solid var(--form-border);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.demo-title {
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--form-text);
+}
+
+.demo-subtitle {
+  font-size: clamp(0.85rem, 2.5vw, 0.95rem);
+  color: var(--form-muted);
+  margin-top: 0.4rem;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 3. Form Card & Container                                                   */
+
+/* -------------------------------------------------------------------------- */
+
+.minimal-card {
+  width: 100%;
+  background-color: var(--form-card-bg);
+  border: 1px solid var(--form-border);
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(15, 23, 42, 0.04);
+  overflow: hidden;
+}
+
+.minimal-form {
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 4. Form Fields & Labels                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.field-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--form-text);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 5. Minimalist Outlined Controls                                            */
+
+/* -------------------------------------------------------------------------- */
+
+.minimal-input,
+.minimal-select,
+.minimal-textarea {
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--form-text);
+  background-color: var(--form-surface);
+  border: 1px solid var(--form-border);
+  border-radius: var(--form-radius);
+  outline: none;
+  transition: var(--form-transition);
+  appearance: none;
+}
+
+.minimal-input::placeholder,
+.minimal-textarea::placeholder {
+  color: #94a3b8;
+}
+
+.minimal-input:hover,
+.minimal-select:hover,
+.minimal-textarea:hover {
+  border-color: var(--form-border-hover);
+}
+
+.minimal-input:focus,
+.minimal-select:focus,
+.minimal-textarea:focus {
+  border-color: var(--form-accent-focus);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.minimal-textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+/* Select wrapper arrow icon */
+.select-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.select-wrapper::after {
+  content: "";
+  position: absolute;
+  right: 1rem;
+  width: 7px;
+  height: 7px;
+  border-right: 2px solid var(--form-muted);
+  border-bottom: 2px solid var(--form-muted);
+  transform: rotate(45deg);
+  pointer-events: none;
+  margin-top: -3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 6. Outlined Checkbox Styling                                              */
+
+/* -------------------------------------------------------------------------- */
+
+.field-checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.minimal-checkbox {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.custom-checkbox {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--form-border);
+  border-radius: 4px;
+  background-color: var(--form-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--form-transition);
+  flex-shrink: 0;
+}
+
+.custom-checkbox::after {
+  content: "";
+  width: 5px;
+  height: 9px;
+  border: solid #ffffff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  margin-top: -1px;
+}
+
+.checkbox-label:hover .custom-checkbox {
+  border-color: var(--form-border-hover);
+}
+
+.minimal-checkbox:checked + .custom-checkbox {
+  background-color: var(--form-accent);
+  border-color: var(--form-accent);
+}
+
+.minimal-checkbox:checked + .custom-checkbox::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.minimal-checkbox:focus-visible + .custom-checkbox {
+  outline: 2px solid var(--form-accent-focus);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.checkbox-text {
+  font-size: 0.8125rem;
+  color: var(--form-muted);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 7. Validation & Focus-Visible States                                       */
+
+/* -------------------------------------------------------------------------- */
+
+.minimal-input:user-invalid,
+.minimal-select:user-invalid,
+.minimal-textarea:user-invalid,
+.minimal-input:invalid:not(:placeholder-shown),
+.minimal-textarea:invalid:not(:placeholder-shown) {
+  border-color: var(--form-error);
+  background-color: var(--form-error-bg);
+}
+
+.minimal-input:user-invalid:focus,
+.minimal-select:user-invalid:focus,
+.minimal-textarea:user-invalid:focus {
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 8. Minimalist Outlined Button                                              */
+
+/* -------------------------------------------------------------------------- */
+
+.form-actions {
+  margin-top: 0.5rem;
+}
+
+.minimal-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--form-accent);
+  background-color: transparent;
+  border: 1px solid var(--form-accent);
+  border-radius: var(--form-radius);
+  cursor: pointer;
+  transition: var(--form-transition);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.minimal-btn:hover {
+  background-color: var(--form-accent);
+  color: #ffffff;
+}
+
+.minimal-btn:hover .btn-arrow {
+  transform: translateX(4px);
+}
+
+.minimal-btn:active {
+  transform: scale(0.98);
+}
+
+.minimal-btn:focus-visible {
+  outline: 2px solid var(--form-accent-focus);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.btn-arrow {
+  transition: transform 0.18s ease;
+}
+
+.form-footer {
+  background-color: var(--form-bg);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--form-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--form-muted);
+}
+
+.keyboard-instruction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.minimal-key {
+  display: inline-block;
+  background-color: var(--form-surface);
+  border: 1px solid var(--form-border);
+  color: var(--form-text);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 9. Dark Mode Adaptation                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --form-bg: #090d16;
+    --form-surface: #0f172a;
+    --form-card-bg: #0f172a;
+    --form-border: #334155;
+    --form-border-hover: #64748b;
+    --form-text: #f8fafc;
+    --form-muted: #94a3b8;
+    --form-accent: #f8fafc;
+    --form-accent-focus: #38bdf8;
+    --form-error: #ef4444;
+    --form-error-bg: rgba(239, 68, 68, 0.1);
+  }
+
+  .minimal-badge {
+    background-color: rgba(248, 250, 252, 0.05);
+  }
+
+  .minimal-btn {
+    color: #f8fafc;
+    border-color: #f8fafc;
+  }
+
+  .minimal-btn:hover {
+    background-color: #f8fafc;
+    color: #090d16;
+  }
+
+  .minimal-checkbox:checked + .custom-checkbox {
+    background-color: #f8fafc;
+    border-color: #f8fafc;
+  }
+
+  .minimal-checkbox:checked + .custom-checkbox::after {
+    border-color: #090d16;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 10. Responsive Rules                                                       */
+
+/* -------------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .minimal-form {
+    padding: 1.5rem 1.25rem;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 11. Reduced-Motion Rules                                                   */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .minimal-btn:hover .btn-arrow {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
 ## Summary

- Added a pure HTML/CSS Minimalist Outline form under `submissions/examples/73356-css-form-minimalist-outline/`.
- Added semantic form controls and accessible `<label for="...">` associations.
- Added responsive, dark-mode, and reduced-motion support.
- Added native validation (`:user-invalid`) and clear focus-visible states.
- Added subtle CSS transitions on crisp 1px borders.

## Issue

Closes #73356

## Validation

- Verified semantic form controls and label associations
- Verified keyboard navigation (Tab, Space, Enter)
- Verified focus-visible states
- Verified native validation behavior
- Verified responsive behavior (320px-1440px+)
- Verified dark mode and reduced-motion behavior
- Stylelint verified (0 errors)
- Prettier verified
- Vitest unit tests passed (61/61)
- No JavaScript
- No external dependencies
