### PR TITLE
feat: add metallic sheen CSS navigation (#73330)

### DIFF
--- a/submissions/examples/73330-css-nav-metallic-sheen/README.md
+++ b/submissions/examples/73330-css-nav-metallic-sheen/README.md
@@ -1,0 +1,43 @@
+# Metallic Sheen CSS Navigation Component
+
+A pure HTML + Vanilla CSS navigation component featuring a "Metallic Sheen" visual identity with brushed metal surface gradients, inset bevel highlights, and a sliding reflective sheen band pseudo-element (`::before`).
+
+## Features
+
+- **Pure HTML + CSS**: 100% interactive without JavaScript, external fonts, external image assets, or build scripts. Works offline.
+- **Metallic Sheen Identity**: Multi-layer brushed metal surface gradients (`linear-gradient(180deg, #334155 0%, #1e293b 50%, #0f172a 100%)`), inset highlight bevels (`box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25)`), and a reflective sheen band (`::before`) sliding across the control (`transform: translateX(-150%)` &rarr; `translateX(150%)`).
+- **100% Accessible**: Built using semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` links with `aria-current="page"` for active pages and clear `:focus-visible` indicators.
+- **Clear `:focus-visible` States**: Dedicated focus outlines on active links.
+- **Responsive & Mobile Ready**: Responsive flex layout wraps cleanly across mobile viewports (320px–1440px+).
+- **Theme Adaptability & Motion Controls**: Supports `@media (prefers-color-scheme)` and `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Include `style.css` and use semantic HTML:
+
+```html
+<nav class="metallic-nav" aria-label="Primary navigation">
+  <ul class="nav-list">
+    <li class="nav-item">
+      <a href="#home" class="nav-link" aria-current="page">Home</a>
+    </li>
+    <li class="nav-item">
+      <a href="#projects" class="nav-link">Projects</a>
+    </li>
+    <li class="nav-item">
+      <a href="#about" class="nav-link">About</a>
+    </li>
+  </ul>
+</nav>
+```
+
+### Customization Variables
+
+```css
+:root {
+  --metal-bg: #0f172a;
+  --metal-card-bg: #1e293b;
+  --metal-border: rgba(255, 255, 255, 0.15);
+  --metal-accent: #38bdf8;
+}
+```

--- a/submissions/examples/73330-css-nav-metallic-sheen/demo.html
+++ b/submissions/examples/73330-css-nav-metallic-sheen/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Metallic Sheen CSS Navigation Component</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-container">
+      <header class="demo-header">
+        <div class="metal-badge">POLISHED METAL SYSTEM</div>
+        <h1 class="demo-title">METALLIC SHEEN NAV</h1>
+        <p class="demo-subtitle">
+          Pure HTML + Vanilla CSS Brushed Metal Reflective Navigation Component
+        </p>
+      </header>
+
+      <!-- Semantic Metallic Navigation -->
+      <nav class="metallic-nav" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li class="nav-item">
+            <a href="#home" class="nav-link" aria-current="page">
+              <span class="nav-text">Home</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#projects" class="nav-link">
+              <span class="nav-text">Projects</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#services" class="nav-link">
+              <span class="nav-text">Services</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#about" class="nav-link">
+              <span class="nav-text">About</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#contact" class="nav-link">
+              <span class="nav-text">Contact</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <!-- Demo Content Area -->
+      <section class="demo-card">
+        <div class="card-content">
+          <div class="content-tag">CONTROL PANEL</div>
+          <h2 class="content-title">POLISHED METALLIC INTERFACE</h2>
+          <p class="content-body">
+            Hover over or press <kbd class="metal-kbd">Tab</kbd> to focus
+            navigation items. Each button features brushed metal gradient
+            layers, bevel highlights, and a sliding reflective sheen band.
+          </p>
+        </div>
+        <footer class="card-footer">
+          <div class="keyboard-instruction">
+            <span class="metal-key">TAB</span> Cycle links
+            <span class="metal-key">ENTER</span> Activate link
+          </div>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/73330-css-nav-metallic-sheen/style.css
+++ b/submissions/examples/73330-css-nav-metallic-sheen/style.css
@@ -1,0 +1,402 @@
+/* -------------------------------------------------------------------------- */
+
+/* 1. CSS Variables                                                           */
+
+/* -------------------------------------------------------------------------- */
+
+:root {
+  --metal-bg: #0f172a;
+  --metal-surface: linear-gradient(
+    180deg,
+    #334155 0%,
+    #1e293b 50%,
+    #0f172a 100%
+  );
+  --metal-surface-hover: linear-gradient(
+    180deg,
+    #475569 0%,
+    #334155 50%,
+    #1e293b 100%
+  );
+  --metal-surface-active: linear-gradient(
+    180deg,
+    #0284c7 0%,
+    #0369a1 50%,
+    #075985 100%
+  );
+  --metal-card-bg: #1e293b;
+  --metal-border: rgba(255, 255, 255, 0.15);
+  --metal-text: #f8fafc;
+  --metal-muted: #94a3b8;
+  --metal-accent: #38bdf8;
+  --metal-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  --metal-shadow-hover:
+    0 8px 20px rgba(56, 189, 248, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  --metal-radius: 6px;
+  --metal-transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.2s ease,
+    border-color 0.2s ease, background 0.2s ease;
+  --font-mono: "Courier New", Courier, monospace, ui-monospace;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 2. Base Styles                                                             */
+
+/* -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--metal-bg);
+  color: var(--metal-text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.5;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.25rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.metal-badge {
+  display: inline-block;
+  font-size: 0.725rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--metal-accent);
+  background-color: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.demo-title {
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--metal-text);
+}
+
+.demo-subtitle {
+  font-size: clamp(0.85rem, 2.5vw, 0.95rem);
+  color: var(--metal-muted);
+  margin-top: 0.4rem;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 3. Navigation Container & List                                             */
+
+/* -------------------------------------------------------------------------- */
+
+.metallic-nav {
+  width: 100%;
+}
+
+.nav-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+.nav-item {
+  position: relative;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 4. Navigation Links & Metallic Surface                                     */
+
+/* -------------------------------------------------------------------------- */
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.35rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--metal-text);
+  background: var(--metal-surface);
+  border: 1px solid var(--metal-border);
+  border-radius: var(--metal-radius);
+  text-decoration: none;
+  box-shadow: var(--metal-shadow);
+  transition: var(--metal-transition);
+  overflow: hidden;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Reflective Sheen Band pseudo-element */
+.nav-link::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.35) 50%,
+    transparent 70%
+  );
+  transform: translateX(-150%);
+  transition: transform 0.5s ease;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.nav-text {
+  position: relative;
+  z-index: 2;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 5. Hover, Active & Focus-Visible States                                    */
+
+/* -------------------------------------------------------------------------- */
+
+/* Hover state: Metallic sheen slides across item */
+.nav-link:hover {
+  background: var(--metal-surface-hover);
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: var(--metal-shadow-hover);
+  transform: translateY(-2px);
+  color: #ffffff;
+}
+
+.nav-link:hover::before {
+  transform: translateX(150%);
+}
+
+/* Active press state */
+.nav-link:active {
+  transform: translateY(0);
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.6),
+    0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+/* Current active page state (aria-current="page") */
+.nav-link[aria-current="page"] {
+  background: var(--metal-surface-active);
+  border-color: var(--metal-accent);
+  color: #ffffff;
+  box-shadow:
+    0 4px 16px rgba(56, 189, 248, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.nav-link[aria-current="page"]::before {
+  transform: translateX(150%);
+}
+
+/* Keyboard focus-visible indicator */
+.nav-link:focus-visible {
+  outline: 2px solid var(--metal-accent);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.35);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 6. Demo Content Card                                                       */
+
+/* -------------------------------------------------------------------------- */
+
+.demo-card {
+  width: 100%;
+  background-color: var(--metal-card-bg);
+  border: 1px solid var(--metal-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.card-content {
+  padding: 2.25rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.content-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--metal-accent);
+}
+
+.content-title {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.content-body {
+  font-size: 0.9rem;
+  color: var(--metal-muted);
+}
+
+.metal-kbd {
+  display: inline-block;
+  background-color: #0f172a;
+  border: 1px solid var(--metal-border);
+  color: var(--metal-text);
+  font-family: var(--font-mono);
+  font-size: 0.725rem;
+  font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.card-footer {
+  background-color: #0f172a;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--metal-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--metal-muted);
+}
+
+.keyboard-instruction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.metal-key {
+  display: inline-block;
+  background-color: var(--metal-card-bg);
+  border: 1px solid var(--metal-border);
+  color: var(--metal-text);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 7. Dark Mode Adaptation                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --metal-bg: #f8fafc;
+    --metal-surface: linear-gradient(
+      180deg,
+      #ffffff 0%,
+      #e2e8f0 50%,
+      #cbd5e1 100%
+    );
+    --metal-surface-hover: linear-gradient(
+      180deg,
+      #ffffff 0%,
+      #cbd5e1 50%,
+      #94a3b8 100%
+    );
+    --metal-card-bg: #ffffff;
+    --metal-border: #cbd5e1;
+    --metal-text: #0f172a;
+    --metal-muted: #64748b;
+    --metal-accent: #0284c7;
+    --metal-shadow:
+      0 2px 8px rgba(15, 23, 42, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  .demo-card {
+    box-shadow: 0 4px 20px rgba(15, 23, 42, 0.05);
+  }
+
+  .nav-text {
+    text-shadow: none;
+  }
+
+  .metal-kbd,
+  .card-footer {
+    background-color: #f8fafc;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 8. Responsive Rules                                                        */
+
+/* -------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .nav-list {
+    gap: 0.5rem;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.8rem;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 9. Reduced-Motion Rules                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .nav-link::before {
+    display: none !important;
+  }
+
+  .nav-link:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Added a pure HTML/CSS Metallic Sheen navigation component under `submissions/examples/73330-css-nav-metallic-sheen/`.
- Added semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` anchor elements.
- Added brushed metal surface gradients, inset bevel highlights, and a sliding reflective sheen band (`::before`).
- Added responsive behavior.
- Added dark-mode and reduced-motion support.
- Added clear keyboard focus states (`:focus-visible`).

## Issue

Closes #73330

## Validation

- Verified semantic navigation and `aria-current="page"`
- Verified keyboard navigation (Tab, Enter)
- Verified focus-visible state
- Verified responsive behavior (320px-1440px+)
- Verified dark mode and reduced-motion behavior
- Stylelint verified (0 errors)
- Prettier verified
- Vitest unit tests passed (61/61)
- No JavaScript
- No external dependencies
