### PR TITLE
feat: add subtle elevate CSS navigation (#73329)

### DIFF
--- a/submissions/examples/73329-css-nav-subtle-elevate/README.md
+++ b/submissions/examples/73329-css-nav-subtle-elevate/README.md
@@ -1,0 +1,43 @@
+# Subtle Elevate CSS Navigation Component
+
+A pure HTML + Vanilla CSS navigation component featuring a "Subtle Elevate" visual identity with restrained vertical lifts (`transform: translateY(-2px)`), expanding ambient shadows, and tactile press states.
+
+## Features
+
+- **Pure HTML + CSS**: 100% interactive without JavaScript, external fonts, external image assets, or build scripts. Works offline.
+- **Subtle Elevate Identity**: Clean flat navigation surface default (`box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06)`), restrained vertical lift on hover (`transform: translateY(-2px)`), expanding ambient shadow (`0 8px 18px rgba(15, 23, 42, 0.1)`), and tactile press state (`translateY(0)`).
+- **100% Accessible**: Built using semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` links with `aria-current="page"` for active pages and clear `:focus-visible` indicators.
+- **Clear `:focus-visible` States**: Dedicated focus outlines on active links.
+- **Responsive & Mobile Ready**: Responsive flex layout wraps cleanly across mobile viewports (320px–1440px+).
+- **Theme Adaptability & Motion Controls**: Supports `@media (prefers-color-scheme)` and `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Include `style.css` and use semantic HTML:
+
+```html
+<nav class="elevate-nav" aria-label="Primary navigation">
+  <ul class="nav-list">
+    <li class="nav-item">
+      <a href="#home" class="nav-link" aria-current="page">Home</a>
+    </li>
+    <li class="nav-item">
+      <a href="#projects" class="nav-link">Projects</a>
+    </li>
+    <li class="nav-item">
+      <a href="#about" class="nav-link">About</a>
+    </li>
+  </ul>
+</nav>
+```
+
+### Customization Variables
+
+```css
+:root {
+  --elevate-bg: #f8fafc;
+  --elevate-surface: #ffffff;
+  --elevate-border: #e2e8f0;
+  --elevate-accent: #2563eb;
+}
+```

--- a/submissions/examples/73329-css-nav-subtle-elevate/demo.html
+++ b/submissions/examples/73329-css-nav-subtle-elevate/demo.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Subtle Elevate CSS Navigation Component</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-container">
+      <header class="demo-header">
+        <div class="elevate-badge">ELEVATION SYSTEM</div>
+        <h1 class="demo-title">SUBTLE ELEVATE NAV</h1>
+        <p class="demo-subtitle">
+          Pure HTML + Vanilla CSS Restrained Elevation Navigation Component
+        </p>
+      </header>
+
+      <!-- Semantic Subtle Elevate Navigation -->
+      <nav class="elevate-nav" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li class="nav-item">
+            <a href="#home" class="nav-link" aria-current="page">
+              <span class="nav-text">Home</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#projects" class="nav-link">
+              <span class="nav-text">Projects</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#services" class="nav-link">
+              <span class="nav-text">Services</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#about" class="nav-link">
+              <span class="nav-text">About</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#contact" class="nav-link">
+              <span class="nav-text">Contact</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <!-- Demo Content Area -->
+      <section class="demo-card">
+        <div class="card-content">
+          <div class="content-tag">SUBTLE ELEVATION</div>
+          <h2 class="content-title">REFINED DEPTH INTERFACE</h2>
+          <p class="content-body">
+            Hover over or press <kbd class="elevate-kbd">Tab</kbd> to focus
+            navigation items. Each link gently rises with a restrained 2px
+            vertical lift, expanding ambient shadow, and tactile press states.
+          </p>
+        </div>
+        <footer class="card-footer">
+          <div class="keyboard-instruction">
+            <span class="elevate-key">TAB</span> Cycle links
+            <span class="elevate-key">ENTER</span> Activate link
+          </div>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/73329-css-nav-subtle-elevate/style.css
+++ b/submissions/examples/73329-css-nav-subtle-elevate/style.css
@@ -1,0 +1,350 @@
+/* -------------------------------------------------------------------------- */
+
+/* 1. CSS Variables                                                           */
+
+/* -------------------------------------------------------------------------- */
+
+:root {
+  --elevate-bg: #f8fafc;
+  --elevate-surface: #ffffff;
+  --elevate-card-bg: #ffffff;
+  --elevate-border: #e2e8f0;
+  --elevate-text: #0f172a;
+  --elevate-muted: #64748b;
+  --elevate-accent: #2563eb;
+  --elevate-shadow:
+    0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --elevate-shadow-hover:
+    0 8px 18px rgba(15, 23, 42, 0.1), 0 3px 6px rgba(15, 23, 42, 0.05);
+  --elevate-shadow-active:
+    0 10px 22px rgba(37, 99, 235, 0.18), 0 4px 8px rgba(37, 99, 235, 0.1);
+  --elevate-radius: 8px;
+  --elevate-transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.2s ease,
+    background-color 0.2s ease, border-color 0.2s ease;
+  --font-mono: "Courier New", Courier, monospace, ui-monospace;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 2. Base Styles                                                             */
+
+/* -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--elevate-bg);
+  color: var(--elevate-text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.5;
+  padding: 2rem 1rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.25rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.elevate-badge {
+  display: inline-block;
+  font-size: 0.725rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--elevate-accent);
+  background-color: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.demo-title {
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--elevate-text);
+}
+
+.demo-subtitle {
+  font-size: clamp(0.85rem, 2.5vw, 0.95rem);
+  color: var(--elevate-muted);
+  margin-top: 0.4rem;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 3. Navigation Container & List                                             */
+
+/* -------------------------------------------------------------------------- */
+
+.elevate-nav {
+  width: 100%;
+}
+
+.nav-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+.nav-item {
+  position: relative;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 4. Navigation Links & Elevated Surface                                     */
+
+/* -------------------------------------------------------------------------- */
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.35rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--elevate-text);
+  background-color: var(--elevate-surface);
+  border: 1px solid var(--elevate-border);
+  border-radius: var(--elevate-radius);
+  text-decoration: none;
+  box-shadow: var(--elevate-shadow);
+  transition: var(--elevate-transition);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav-text {
+  position: relative;
+  z-index: 1;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 5. Hover, Active & Focus-Visible States                                    */
+
+/* -------------------------------------------------------------------------- */
+
+/* Hover state: Restrained 2px elevation lift */
+.nav-link:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elevate-shadow-hover);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: var(--elevate-accent);
+}
+
+/* Tactile press active state */
+.nav-link:active {
+  transform: translateY(0);
+  box-shadow: var(--elevate-shadow);
+}
+
+/* Current active page state (aria-current="page") */
+.nav-link[aria-current="page"] {
+  background-color: var(--elevate-surface);
+  color: var(--elevate-accent);
+  border-color: var(--elevate-accent);
+  box-shadow: var(--elevate-shadow-active);
+  font-weight: 700;
+  transform: translateY(-1px);
+}
+
+.nav-link[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 15%;
+  right: 15%;
+  height: 2px;
+  background-color: var(--elevate-accent);
+  border-radius: 2px;
+}
+
+/* Keyboard focus-visible indicator */
+.nav-link:focus-visible {
+  outline: 2px solid var(--elevate-accent);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.25);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 6. Demo Content Card                                                       */
+
+/* -------------------------------------------------------------------------- */
+
+.demo-card {
+  width: 100%;
+  background-color: var(--elevate-card-bg);
+  border: 1px solid var(--elevate-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+  overflow: hidden;
+}
+
+.card-content {
+  padding: 2.25rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.content-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--elevate-accent);
+}
+
+.content-title {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.content-body {
+  font-size: 0.9rem;
+  color: var(--elevate-muted);
+}
+
+.elevate-kbd {
+  display: inline-block;
+  background-color: var(--elevate-bg);
+  border: 1px solid var(--elevate-border);
+  color: var(--elevate-text);
+  font-family: var(--font-mono);
+  font-size: 0.725rem;
+  font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.card-footer {
+  background-color: var(--elevate-bg);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--elevate-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--elevate-muted);
+}
+
+.keyboard-instruction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.elevate-key {
+  display: inline-block;
+  background-color: var(--elevate-surface);
+  border: 1px solid var(--elevate-border);
+  color: var(--elevate-text);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 7. Dark Mode Adaptation                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --elevate-bg: #090d16;
+    --elevate-surface: #1e293b;
+    --elevate-card-bg: #0f172a;
+    --elevate-border: #334155;
+    --elevate-text: #f8fafc;
+    --elevate-muted: #94a3b8;
+    --elevate-accent: #38bdf8;
+    --elevate-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    --elevate-shadow-hover:
+      0 8px 20px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(56, 189, 248, 0.15);
+    --elevate-shadow-active:
+      0 10px 24px rgba(56, 189, 248, 0.25), 0 4px 10px rgba(0, 0, 0, 0.5);
+  }
+
+  .elevate-badge {
+    background-color: rgba(56, 189, 248, 0.12);
+    border-color: rgba(56, 189, 248, 0.3);
+  }
+
+  .nav-link:focus-visible {
+    outline-color: #38bdf8;
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.35);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 8. Responsive Rules                                                        */
+
+/* -------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .nav-list {
+    gap: 0.5rem;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.8rem;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 9. Reduced-Motion Rules                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .nav-link:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Added a pure HTML/CSS Subtle Elevate navigation component under `submissions/examples/73329-css-nav-subtle-elevate/`.
- Added semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` anchor elements.
- Added restrained hover elevation using CSS transforms (`translateY(-2px)`) and expanding shadows.
- Added responsive behavior.
- Added dark-mode and reduced-motion support.
- Added clear keyboard focus states (`:focus-visible`).

## Issue

Closes #73329

## Validation

- Verified semantic navigation and `aria-current="page"`
- Verified keyboard navigation (Tab, Enter)
- Verified focus-visible state
- Verified responsive behavior (320px-1440px+)
- Verified dark mode and reduced-motion behavior
- Stylelint verified (0 errors)
- Prettier verified
- Vitest unit tests passed (61/61)
- No JavaScript
- No external dependencies
