### PR TITLE
feat: add glassmorphism blur CSS navigation (#73314)

### DIFF
--- a/submissions/examples/73314-css-nav-glassmorphism-blur/README.md
+++ b/submissions/examples/73314-css-nav-glassmorphism-blur/README.md
@@ -1,0 +1,45 @@
+# Glassmorphism Blur CSS Navigation Component
+
+A pure HTML + Vanilla CSS navigation component featuring a "Glassmorphism Blur" visual identity with translucent glass surfaces (`background: rgba(255, 255, 255, 0.08)`), backdrop blur (`backdrop-filter: blur(16px) saturate(160%)`), full fallback background for non-blur browsers, and responsive controls.
+
+## Features
+
+- **Pure HTML + CSS**: 100% interactive without JavaScript, external fonts, external image assets, or build scripts. Works offline.
+- **Glassmorphism Identity**: Translucent glass surface, 1px glass border highlight, backdrop blur (`backdrop-filter: blur(16px) saturate(160%)`), and ambient CSS background mesh elements.
+- **Robust Fallback**: Includes `@supports` fallback background (`rgba(15, 23, 42, 0.85)`) for browsers that do not support backdrop blur filters.
+- **100% Accessible**: Built using semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` links with `aria-current="page"` for active pages and clear `:focus-visible` indicators.
+- **Clear `:focus-visible` States**: Dedicated focus outlines on active links.
+- **Responsive & Mobile Ready**: Responsive flex layout wraps cleanly across mobile viewports (320px–1440px+).
+- **Theme Adaptability & Motion Controls**: Supports `@media (prefers-color-scheme)` and `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Include `style.css` and use semantic HTML:
+
+```html
+<nav class="glass-nav" aria-label="Primary navigation">
+  <ul class="nav-list">
+    <li class="nav-item">
+      <a href="#home" class="nav-link" aria-current="page">Home</a>
+    </li>
+    <li class="nav-item">
+      <a href="#projects" class="nav-link">Projects</a>
+    </li>
+    <li class="nav-item">
+      <a href="#about" class="nav-link">About</a>
+    </li>
+  </ul>
+</nav>
+```
+
+### Customization Variables
+
+```css
+:root {
+  --glass-bg: #0b1120;
+  --glass-nav-bg: rgba(255, 255, 255, 0.08);
+  --glass-nav-border: rgba(255, 255, 255, 0.18);
+  --glass-accent: #38bdf8;
+  --glass-blur: 16px;
+}
+```

--- a/submissions/examples/73314-css-nav-glassmorphism-blur/demo.html
+++ b/submissions/examples/73314-css-nav-glassmorphism-blur/demo.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glassmorphism Blur CSS Navigation Component</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Ambient CSS Mesh Orbs for Glass Transparency Demonstration -->
+    <div class="glass-orb orb-1" aria-hidden="true"></div>
+    <div class="glass-orb orb-2" aria-hidden="true"></div>
+    <div class="glass-orb orb-3" aria-hidden="true"></div>
+
+    <main class="demo-container">
+      <header class="demo-header">
+        <div class="glass-badge">GLASSMORPHISM SYSTEM</div>
+        <h1 class="demo-title">GLASSMORPHISM BLUR NAV</h1>
+        <p class="demo-subtitle">
+          Pure HTML + Vanilla CSS Translucent Backdrop-Blur Navigation Component
+        </p>
+      </header>
+
+      <!-- Semantic Glassmorphism Navigation -->
+      <nav class="glass-nav" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li class="nav-item">
+            <a href="#home" class="nav-link" aria-current="page">
+              <span class="nav-text">Home</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#projects" class="nav-link">
+              <span class="nav-text">Projects</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#services" class="nav-link">
+              <span class="nav-text">Services</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#about" class="nav-link">
+              <span class="nav-text">About</span>
+            </a>
+          </li>
+          <li class="nav-item">
+            <a href="#contact" class="nav-link">
+              <span class="nav-text">Contact</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <!-- Demo Content Area -->
+      <section class="demo-card">
+        <div class="card-content">
+          <div class="content-tag">TRANSLUCENT SURFACE</div>
+          <h2 class="content-title">GLASSMORPHISM CONTROL</h2>
+          <p class="content-body">
+            Hover over or press <kbd class="glass-kbd">Tab</kbd> to focus
+            navigation items. The component utilizes
+            <code class="glass-code">backdrop-filter: blur(16px)</code> with
+            translucent glass borders and an accessible solid color fallback for
+            non-blur browsers.
+          </p>
+        </div>
+        <footer class="card-footer">
+          <div class="keyboard-instruction">
+            <span class="glass-key">TAB</span> Cycle links
+            <span class="glass-key">ENTER</span> Activate link
+          </div>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/73314-css-nav-glassmorphism-blur/style.css
+++ b/submissions/examples/73314-css-nav-glassmorphism-blur/style.css
@@ -1,0 +1,439 @@
+/* -------------------------------------------------------------------------- */
+
+/* 1. CSS Variables                                                           */
+
+/* -------------------------------------------------------------------------- */
+
+:root {
+  --glass-bg: #0b1120;
+  --glass-nav-fallback: #1e293b;
+  --glass-nav-bg: rgba(255, 255, 255, 0.08);
+  --glass-nav-border: rgba(255, 255, 255, 0.18);
+  --glass-link-bg: rgba(255, 255, 255, 0.06);
+  --glass-link-hover: rgba(255, 255, 255, 0.16);
+  --glass-card-bg: rgba(15, 23, 42, 0.75);
+  --glass-card-fallback: #0f172a;
+  --glass-text: #f8fafc;
+  --glass-muted: #94a3b8;
+  --glass-accent: #38bdf8;
+  --glass-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  --glass-shadow-hover:
+    0 12px 36px rgba(56, 189, 248, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  --glass-radius: 14px;
+  --glass-blur: 16px;
+  --glass-transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.2s ease,
+    background-color 0.2s ease, border-color 0.2s ease;
+  --font-mono: "Courier New", Courier, monospace, ui-monospace;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 2. Base Styles & Ambient Background Mesh Orbs                              */
+
+/* -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--glass-bg);
+  color: var(--glass-text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.5;
+  padding: 2rem 1rem;
+  overflow-x: hidden;
+}
+
+/* Ambient CSS mesh gradient orbs for backdrop blur demonstration */
+.glass-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.orb-1 {
+  top: 15%;
+  left: 20%;
+  width: 280px;
+  height: 280px;
+  background: radial-gradient(circle, #38bdf8 0%, #0284c7 100%);
+}
+
+.orb-2 {
+  bottom: 20%;
+  right: 20%;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, #818cf8 0%, #4f46e5 100%);
+}
+
+.orb-3 {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle, #f43f5e 0%, #be123c 100%);
+  opacity: 0.35;
+}
+
+.demo-container {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.25rem;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.glass-badge {
+  display: inline-block;
+  font-size: 0.725rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--glass-accent);
+  background-color: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.demo-title {
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--glass-text);
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.demo-subtitle {
+  font-size: clamp(0.85rem, 2.5vw, 0.95rem);
+  color: var(--glass-muted);
+  margin-top: 0.4rem;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 3. Navigation Container & Glass Surface                                    */
+
+/* -------------------------------------------------------------------------- */
+
+.glass-nav {
+  width: 100%;
+  background-color: var(--glass-nav-fallback);
+  border: 1px solid var(--glass-nav-border);
+  border-radius: var(--glass-radius);
+  padding: 0.5rem;
+  box-shadow: var(--glass-shadow);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .glass-nav {
+    background-color: var(--glass-nav-bg);
+    backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+  }
+}
+
+.nav-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+.nav-item {
+  position: relative;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 4. Navigation Links & Translucent Glass Items                              */
+
+/* -------------------------------------------------------------------------- */
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--glass-text);
+  background-color: var(--glass-link-bg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: calc(var(--glass-radius) - 4px);
+  text-decoration: none;
+  transition: var(--glass-transition);
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .nav-link {
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+}
+
+.nav-text {
+  position: relative;
+  z-index: 1;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 5. Hover, Active & Focus-Visible States                                    */
+
+/* -------------------------------------------------------------------------- */
+
+/* Hover state: Brightened translucent surface with gentle lift */
+.nav-link:hover {
+  background-color: var(--glass-link-hover);
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  transform: translateY(-2px);
+  color: #ffffff;
+}
+
+/* Active press state */
+.nav-link:active {
+  transform: translateY(0);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+/* Current active page state (aria-current="page") */
+.nav-link[aria-current="page"] {
+  background-color: rgba(56, 189, 248, 0.2);
+  border-color: var(--glass-accent);
+  color: #ffffff;
+  box-shadow:
+    0 4px 20px rgba(56, 189, 248, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.nav-link[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 20%;
+  right: 20%;
+  height: 2px;
+  background-color: var(--glass-accent);
+  border-radius: 2px;
+}
+
+/* Keyboard focus-visible indicator */
+.nav-link:focus-visible {
+  outline: 2px solid var(--glass-accent);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.35);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 6. Demo Content Card                                                       */
+
+/* -------------------------------------------------------------------------- */
+
+.demo-card {
+  width: 100%;
+  background-color: var(--glass-card-fallback);
+  border: 1px solid var(--glass-nav-border);
+  border-radius: var(--glass-radius);
+  box-shadow: var(--glass-shadow);
+  overflow: hidden;
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .demo-card {
+    background-color: var(--glass-card-bg);
+    backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+  }
+}
+
+.card-content {
+  padding: 2.25rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.content-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--glass-accent);
+}
+
+.content-title {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.content-body {
+  font-size: 0.9rem;
+  color: var(--glass-muted);
+}
+
+.glass-code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--glass-accent);
+  background-color: rgba(56, 189, 248, 0.12);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+}
+
+.glass-kbd {
+  display: inline-block;
+  background-color: rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--glass-nav-border);
+  color: var(--glass-text);
+  font-family: var(--font-mono);
+  font-size: 0.725rem;
+  font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.card-footer {
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--glass-nav-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--glass-muted);
+}
+
+.keyboard-instruction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.glass-key {
+  display: inline-block;
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--glass-nav-border);
+  color: var(--glass-text);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 7. Dark Mode Adaptation                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --glass-bg: #e2e8f0;
+    --glass-nav-fallback: #ffffff;
+    --glass-nav-bg: rgba(255, 255, 255, 0.55);
+    --glass-nav-border: rgba(255, 255, 255, 0.6);
+    --glass-link-bg: rgba(255, 255, 255, 0.4);
+    --glass-link-hover: rgba(255, 255, 255, 0.75);
+    --glass-card-bg: rgba(255, 255, 255, 0.6);
+    --glass-card-fallback: #ffffff;
+    --glass-text: #0f172a;
+    --glass-muted: #475569;
+    --glass-accent: #0284c7;
+    --glass-shadow:
+      0 8px 32px rgba(15, 23, 42, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+
+  .orb-1 {
+    background: radial-gradient(circle, #38bdf8 0%, #bae6fd 100%);
+  }
+
+  .orb-2 {
+    background: radial-gradient(circle, #a5b4fc 0%, #c7d2fe 100%);
+  }
+
+  .glass-code {
+    background-color: rgba(2, 132, 199, 0.1);
+  }
+
+  .glass-kbd {
+    background-color: #f1f5f9;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 8. Responsive Rules                                                        */
+
+/* -------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .nav-list {
+    gap: 0.4rem;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.8rem;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 9. Reduced-Motion Rules                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .nav-link:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Added a pure HTML/CSS Glassmorphism Blur navigation component under `submissions/examples/73314-css-nav-glassmorphism-blur/`.
- Added semantic `<nav>`, `<ul>`, `<li>`, and real `<a>` anchor elements.
- Added translucent glass surfaces with backdrop blur (`backdrop-filter: blur(16px)`).
- Added a fallback background for browsers without backdrop-filter support.
- Added responsive behavior.
- Added dark-mode and reduced-motion support.
- Added clear keyboard focus states (`:focus-visible`).

## Issue

Closes #73314

## Validation

- Verified semantic navigation and `aria-current="page"`
- Verified keyboard navigation (Tab, Enter)
- Verified focus-visible state
- Verified responsive behavior (320px-1440px+)
- Verified dark mode and reduced-motion behavior
- Verified backdrop-filter fallback
- Stylelint verified (0 errors)
- Prettier verified
- Vitest unit tests passed (61/61)
- No JavaScript
- No external dependencies
