### PR TITLE
feat: add perspective hover grid example

### DIFF
--- a/submissions/examples/ease-perspective-grid/README.md
+++ b/submissions/examples/ease-perspective-grid/README.md
@@ -1,0 +1,59 @@
+# Perspective Hover Grid
+
+A photo grid where hovering a tile lifts it toward the viewer, while every
+other tile simultaneously tilts away into the background — pure CSS 3D
+physics, zero JavaScript.
+
+## How it works
+
+- `perspective: 800px` is set once on the grid container so every tile
+  shares a single vanishing point.
+- Each tile carries a `--tilt` custom property (alternating `-18deg`,
+  `0deg`, `18deg` by column) so un-hovered tiles fan outward instead of
+  rotating in one flat direction.
+- **`.perspective-grid:has(.grid-item:hover)`** — the modern `:has()`
+  pseudo-class lets the *container* detect that *some* child is hovered,
+  without any JS event listeners.
+- Combined with **`.grid-item:not(:hover)`**, this scopes the "tilt away"
+  transform to every tile except the one actually being hovered.
+- The hovered tile itself gets a simple `translateZ(60px) scale(1.05)`
+  lift via a plain `:hover` rule.
+
+```css
+.grid-item:hover {
+  transform: perspective(800px) rotateY(0deg) translateZ(60px) scale(1.05);
+}
+
+.perspective-grid:has(.grid-item:hover) .grid-item:not(:hover) {
+  transform: perspective(800px) rotateY(var(--tilt)) translateZ(-40px) scale(0.94);
+  filter: brightness(0.55) saturate(0.8);
+}
+```
+
+## Customizing
+
+- **Tilt angle:** adjust the `--tilt` values on the `nth-child` rules.
+- **Lift distance:** change `translateZ(60px)` on `.grid-item:hover`.
+- **Grid size:** update `--cols` on `.perspective-grid` (responsive
+  breakpoint included for smaller screens).
+- **Depth strength:** tweak the `perspective(800px)` value — lower =
+  more dramatic 3D distortion.
+
+## Why it fits EaseMotion CSS
+
+Fully declarative, zero JavaScript, and readable class/selector names.
+`:has()` + `:not()` replace what would normally require mouseenter/
+mouseleave listeners on every sibling — demonstrating how far modern CSS
+selectors can go without sacrificing the animation-first philosophy.
+
+## Accessibility
+
+- `prefers-reduced-motion: reduce` disables the 3D tilt/lift and falls
+  back to a simple opacity/filter change.
+- Decorative images use empty `alt=""`.
+
+## Browser support
+
+Requires `:has()` support (Chrome 105+, Safari 15.4+, Firefox 121+).
+A `@supports not selector(:has(a))` fallback provides a basic scale-up
+hover for older browsers instead of failing silently.

--- a/submissions/examples/ease-perspective-grid/demo.html
+++ b/submissions/examples/ease-perspective-grid/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Perspective Hover Grid</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="perspective-grid">
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg1/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg2/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg3/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg4/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg5/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg6/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg7/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg8/400/400" alt=""></div>
+    <div class="grid-item"><img src="https://picsum.photos/seed/pg9/400/400" alt=""></div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-perspective-grid/style.css
+++ b/submissions/examples/ease-perspective-grid/style.css
@@ -1,0 +1,103 @@
+/* ==========================================================================
+   Perspective Hover Grid
+   Zero-JS 3D grid physics using :has() + :not(:hover).
+   Hovering a tile lifts it toward the viewer while every other tile
+   tilts away into the background.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0b0f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.perspective-grid {
+  --gap: 1rem;
+  --cols: 3;
+
+  display: grid;
+  grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+  gap: var(--gap);
+  width: min(90vw, 720px);
+  padding: var(--gap);
+
+  /* Perspective lives on the container so children share one vanishing point */
+  perspective: 800px;
+}
+
+.grid-item {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  transform-style: preserve-3d;
+  transform: perspective(800px) rotateY(0deg) translateZ(0);
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+              filter 0.5s ease, box-shadow 0.5s ease;
+  will-change: transform;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+.grid-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
+/* Give each tile its own "away" rotation direction so the un-hovered
+   tiles fan outward rather than all tilting the same way. Tiles in the
+   left half tilt one direction, right half the other; middle column
+   leans on row position for variety. */
+.grid-item:nth-child(3n + 1) { --tilt: -18deg; }
+.grid-item:nth-child(3n + 2) { --tilt: 0deg; }
+.grid-item:nth-child(3n)     { --tilt: 18deg; }
+
+/* ---- The hovered tile itself: lift toward the viewer ---- */
+.grid-item:hover {
+  transform: perspective(800px) rotateY(0deg) translateZ(60px) scale(1.05);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+/* ---- Every OTHER tile: tilt away into the background ----
+   :has() on the grid detects "some tile is hovered", then
+   :not(:hover) scopes the effect to every tile except the active one. */
+.perspective-grid:has(.grid-item:hover) .grid-item:not(:hover) {
+  transform: perspective(800px) rotateY(var(--tilt)) translateZ(-40px) scale(0.94);
+  filter: brightness(0.55) saturate(0.8);
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 640px) {
+  .perspective-grid {
+    --cols: 2;
+  }
+}
+
+/* ---- Respect reduced motion: keep the lift, drop the tilt/perspective ---- */
+@media (prefers-reduced-motion: reduce) {
+  .grid-item,
+  .grid-item:hover,
+  .perspective-grid:has(.grid-item:hover) .grid-item:not(:hover) {
+    transition: filter 0.3s ease;
+    transform: none;
+  }
+}
+
+/* ---- Fallback for browsers without :has() support ----
+   Tiles still get a simple hover lift; no sibling reaction. */
+@supports not selector(:has(a)) {
+  .grid-item:hover {
+    transform: scale(1.05);
+  }
+}


### PR DESCRIPTION
closes #74744
## Pull Request Description
Adds a new example for issue #74744 — a photo grid where hovering a tile lifts it toward the viewer while every other tile tilts away into the background, using `:has()` for zero-JS 3D grid physics.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-perspective-grid/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A responsive photo grid where hovering one tile lifts it forward while the rest tilt away into the background, entirely in CSS.

**How does a developer use it?**
```html
<div class="perspective-grid">
  <div class="grid-item"><img src="..." alt=""></div>
  <div class="grid-item"><img src="..." alt=""></div>
  <div class="grid-item"><img src="..." alt=""></div>
  <!-- add as many .grid-item tiles as needed -->
</div>
```

**Why does it fit EaseMotion CSS?**
Fully declarative and JS-free — `:has(.grid-item:hover)` combined with `:not(:hover)` replaces what would normally need mouseenter/mouseleave listeners on every sibling. Readable class names, custom properties for easy tuning, and a `prefers-reduced-motion` fallback keep it in line with the animation-first, accessible-by-default philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer
Relies on `:has()` support (Chrome 105+, Safari 15.4+, Firefox 121+); added a `@supports not selector(:has(a))` fallback that degrades to a simple hover scale for older browsers instead of failing silently. Tilt direction is assigned per column via `nth-child` + a `--tilt` custom property so un-hovered tiles fan outward rather than all rotating the same way — happy to adjust the fan pattern or perspective depth if you'd prefer a different feel.