### PR TITLE
feat: add volumetric glass sidebar example

### DIFF
--- a/submissions/examples/ease-volumetric-glass/README.md
+++ b/submissions/examples/ease-volumetric-glass/README.md
@@ -1,0 +1,67 @@
+# Volumetric Glass Sidebar (macOS Style)
+
+A premium, translucent sidebar with real volumetric depth and edge-lighting
+— not just a flat `blur()` tint. Built to mimic thick acrylic glass like
+macOS Big Sur+ sidebars, purely in CSS.
+
+## How it works
+
+Depth comes from **layering four separate techniques**, not one blur:
+
+1. **Core glass** — `backdrop-filter: blur(40px) saturate(150%)` on a
+   low-opacity white background. The saturation boost is what keeps
+   colors behind the glass vivid instead of muddy grey.
+2. **Refracted border** — a `border-image` linear-gradient that's bright
+   on the top-left and fades elsewhere, simulating light bending through
+   an acrylic edge rather than a uniform stroke.
+3. **Embedded noise grain** — an inline SVG `feTurbulence` filter applied
+   via `::before` at very low opacity with `mix-blend-mode: overlay`,
+   which breaks up the "flat frosted rectangle" look real blur alone
+   produces.
+4. **Glowing top edge + inner light bloom** — `box-shadow: inset 0 1px 0
+   rgba(255,255,255,.5)` for the crisp top highlight, plus a soft
+   `::after` gradient bloom near the top and an outer cast shadow for
+   volume against the page.
+
+```css
+.glass-sidebar {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(40px) saturate(150%);
+  border-image: linear-gradient(160deg, rgba(255,255,255,.65), rgba(255,255,255,.04)) 1;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.5), 8px 0 40px rgba(0,0,0,.35);
+}
+```
+
+## Customizing
+
+- **Blur strength:** adjust `blur(40px)` — lower = sharper background,
+  higher = more frosted.
+- **Tint color:** change the `rgba(255,255,255,...)` background to any
+  hue for a colored glass effect.
+- **Edge glow angle:** rotate the `border-image` gradient's `160deg` to
+  reposition where the "light source" appears to hit the glass.
+- **Grain intensity:** tweak the `opacity` on `.glass-sidebar::before`.
+
+## Why it fits EaseMotion CSS
+
+No images, no JS, no canvas — every part of the depth illusion (blur,
+noise, light bloom, refracted border) is achieved with layered native CSS
+properties. Class names describe intent (`glass-sidebar`, `nav-item`,
+`sidebar-footer`) and the whole effect is copy-paste portable into any
+layout.
+
+## Accessibility
+
+- Text contrast is kept above the glass with solid white/near-white type
+  rather than relying on the backdrop for readability.
+- Interactive nav items get a visible `:hover`/`.active` state independent
+  of the glass effect (background + inset highlight), so functionality
+  doesn't depend on perceiving translucency.
+
+## Browser support
+
+`backdrop-filter` is supported in all modern evergreen browsers (Safari
+needs no prefix as of 9+, but `-webkit-backdrop-filter` is included for
+broader Safari coverage). A `@supports not (backdrop-filter: blur(1px))`
+fallback swaps in a solid dark background so the sidebar stays fully
+legible on unsupported browsers.

--- a/submissions/examples/ease-volumetric-glass/demo.html
+++ b/submissions/examples/ease-volumetric-glass/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Volumetric Glass Sidebar (macOS Style)</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="page">
+
+    <!-- Colorful backdrop so the glass has something to refract -->
+    <div class="backdrop"></div>
+
+    <aside class="glass-sidebar">
+      <div class="sidebar-brand">
+        <span class="brand-dot"></span>
+        <span class="brand-name">Aurora</span>
+      </div>
+
+      <nav class="sidebar-nav">
+        <a href="#" class="nav-item active">
+          <span class="nav-icon">◈</span> Dashboard
+        </a>
+        <a href="#" class="nav-item">
+          <span class="nav-icon">◇</span> Projects
+        </a>
+        <a href="#" class="nav-item">
+          <span class="nav-icon">◆</span> Messages
+        </a>
+        <a href="#" class="nav-item">
+          <span class="nav-icon">○</span> Calendar
+        </a>
+        <a href="#" class="nav-item">
+          <span class="nav-icon">△</span> Settings
+        </a>
+      </nav>
+
+      <div class="sidebar-footer">
+        <div class="avatar"></div>
+        <div class="footer-text">
+          <span class="footer-name">Aahana</span>
+          <span class="footer-role">Contributor</span>
+        </div>
+      </div>
+    </aside>
+
+    <main class="content">
+      <h1>Volumetric Glass Sidebar</h1>
+      <p>
+        Hover the nav items to see the acrylic edge-light respond.
+        The sidebar uses layered <code>backdrop-filter</code>,
+        an embedded SVG noise pattern, and inset shadows to fake
+        real depth &mdash; no images, no JS.
+      </p>
+    </main>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-volumetric-glass/style.css
+++ b/submissions/examples/ease-volumetric-glass/style.css
@@ -1,0 +1,247 @@
+/* ==========================================================================
+   Volumetric Glass Sidebar (macOS Style)
+   Premium translucent sidebar with real depth: layered backdrop-filter,
+   embedded SVG noise grain, glowing top-edge, and refracted border light.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #fff;
+}
+
+.page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  overflow: hidden;
+}
+
+/* ---- Colorful backdrop so the glass has something to refract ---- */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at 15% 20%, #ff6ec7 0%, transparent 45%),
+    radial-gradient(circle at 80% 15%, #6ec6ff 0%, transparent 45%),
+    radial-gradient(circle at 60% 80%, #a06bff 0%, transparent 50%),
+    radial-gradient(circle at 20% 85%, #ffd66e 0%, transparent 45%),
+    #0b0b12;
+  filter: saturate(1.3);
+}
+
+/* ==========================================================================
+   The glass sidebar
+   ========================================================================== */
+
+.glass-sidebar {
+  position: relative;
+  width: 260px;
+  min-height: 100vh;
+  padding: 1.75rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  /* Core volumetric glass: blur + saturation boost, not a flat tint */
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(40px) saturate(150%);
+  -webkit-backdrop-filter: blur(40px) saturate(150%);
+
+  /* Translucent border that reads as light refracting through acrylic:
+     bright on top-left, fading elsewhere */
+  border: 1px solid transparent;
+  border-image: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.65) 0%,
+      rgba(255, 255, 255, 0.12) 35%,
+      rgba(255, 255, 255, 0.04) 60%,
+      rgba(255, 255, 255, 0.18) 100%
+    )
+    1;
+
+  /* Glowing top edge + soft outer cast + inner depth */
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    inset 0 0 40px rgba(255, 255, 255, 0.04),
+    8px 0 40px rgba(0, 0, 0, 0.35);
+}
+
+/* Embedded noise grain, layered above the blur to sell "thick acrylic"
+   rather than a flat frosted rectangle */
+.glass-sidebar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* Soft interior light bloom near the top, like light catching the glass edge */
+.glass-sidebar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 140px;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.16) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+/* ---- Brand row ---- */
+.sidebar-brand {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.brand-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff6ec7, #a06bff);
+  box-shadow: 0 0 12px rgba(160, 107, 255, 0.7);
+}
+
+/* ---- Nav ---- */
+.sidebar-nav {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.6rem;
+  color: rgba(255, 255, 255, 0.75);
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background 0.25s ease, color 0.25s ease,
+              box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.nav-icon {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.nav-item:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  transform: translateX(2px);
+}
+
+.nav-item.active {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    inset 0 0 12px rgba(255, 255, 255, 0.08);
+}
+
+/* ---- Footer ---- */
+.sidebar-footer {
+  position: relative;
+  z-index: 1;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6ec6ff, #a06bff);
+  flex-shrink: 0;
+}
+
+.footer-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.footer-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.footer-role {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* ==========================================================================
+   Page content (just enough to show the sidebar in context)
+   ========================================================================== */
+
+.content {
+  flex: 1;
+  padding: 3rem 3rem;
+  max-width: 640px;
+}
+
+.content h1 {
+  font-size: 1.9rem;
+  margin: 0 0 0.75rem;
+}
+
+.content p {
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.6;
+}
+
+.content code {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.3rem;
+  font-size: 0.9em;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 720px) {
+  .page {
+    flex-direction: column;
+  }
+  .glass-sidebar {
+    width: 100%;
+    min-height: auto;
+  }
+  .content {
+    padding: 2rem 1.5rem;
+  }
+}
+
+/* ---- Fallback for browsers without backdrop-filter support ---- */
+@supports not (backdrop-filter: blur(1px)) {
+  .glass-sidebar {
+    background: rgba(20, 20, 28, 0.92);
+  }
+}


### PR DESCRIPTION
closes #74647
## Pull Request Description
Adds a new example for issue #74647 — a premium, translucent macOS-style sidebar with real volumetric depth and edge-lighting, not just a flat blur.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-volumetric-glass/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A frosted, acrylic-style sidebar that layers backdrop-filter blur, saturation boost, embedded SVG noise grain, a refracted-light border, and a glowing top edge to simulate real glass depth.

**How does a developer use it?**
```html
<aside class="glass-sidebar">
  <div class="sidebar-brand">...</div>
  <nav class="sidebar-nav">
    <a href="#" class="nav-item active">...</a>
    <a href="#" class="nav-item">...</a>
  </nav>
  <div class="sidebar-footer">...</div>
</aside>
```

**Why does it fit EaseMotion CSS?**
No images, canvas, or JS — every part of the depth illusion (blur, grain, light bloom, refracted border) comes from layered native CSS properties with descriptive, copy-paste-portable class names, in line with the animation-first, declarative philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer
Used `border-image` with a directional gradient (instead of a plain border) to simulate light hitting one corner of the glass — open to adjusting the angle/opacity if you want a stronger or subtler refraction. Included a `@supports not (backdrop-filter: blur(1px))` fallback that swaps in a solid dark background for browsers without blur support, so text stays legible either way.