### PR TITLE
feat: add Foucault Pendulum Swing CSS navigation (#73335)

### DIFF
--- a/submissions/examples/73335-css-nav-foucault-pendulum/README.md
+++ b/submissions/examples/73335-css-nav-foucault-pendulum/README.md
@@ -1,0 +1,47 @@
+# Foucault Pendulum Swing CSS Navigation Component
+
+A pure HTML + Vanilla CSS navigation component featuring a "Foucault Pendulum Swing" visual identity with a suspended CSS cable & bob (`.pendulum-cable`, `.pendulum-bob`), smooth physics-inspired swinging keyframes (`@keyframes pendulum-swing`), circular floor track guides (`.pendulum-track`), and pointer-safe decorative layers (`pointer-events: none; aria-hidden="true"`).
+
+## Features
+
+- **Pure HTML + CSS**: 100% interactive without JavaScript, external fonts, external image assets, or build scripts. Works offline.
+- **Foucault Pendulum Identity**: Suspended CSS cable & brass/cyan bob (`.pendulum`), orbital floor track rings (`.pendulum-track`), realistic swinging keyframes (`@keyframes pendulum-swing`), and pointer-safe decorative layers (`pointer-events: none`).
+- **100% Accessible**: Built using semantic `<header>`, `<nav aria-label="Primary navigation">`, `<ul class="nav-links">`, real `<a>` navigation links with `aria-current="page"`, and clear `:focus-visible` indicators.
+- **Clear `:focus-visible` States**: Dedicated focus outlines on active navigation links with radiant cyan glow.
+- **Responsive & Mobile Ready**: Layout wraps cleanly across mobile viewports (320px–1440px+).
+- **Theme Adaptability & Motion Controls**: Supports `@media (prefers-color-scheme)` and `@media (prefers-reduced-motion: reduce)`.
+
+## Usage
+
+Include `style.css` and use semantic HTML:
+
+```html
+<header class="site-header">
+  <nav class="pendulum-nav" aria-label="Primary navigation">
+    <a class="brand" href="#">EASEMOTION</a>
+
+    <ul class="nav-links">
+      <li><a href="#home" aria-current="page">Home</a></li>
+      <li><a href="#about">About</a></li>
+    </ul>
+
+    <div class="pendulum-decoration" aria-hidden="true">
+      <div class="pendulum-arm">
+        <span class="pendulum-cable"></span>
+        <span class="pendulum-bob"></span>
+      </div>
+    </div>
+  </nav>
+</header>
+```
+
+### Customization Variables
+
+```css
+:root {
+  --pendulum-bg: #0b1020;
+  --pendulum-surface: #121a2d;
+  --pendulum-accent: #63e6ff;
+  --pendulum-accent-2: #a78bfa;
+}
+```

--- a/submissions/examples/73335-css-nav-foucault-pendulum/demo.html
+++ b/submissions/examples/73335-css-nav-foucault-pendulum/demo.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Foucault Pendulum Swing CSS Navigation Component</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="pendulum-nav" aria-label="Primary navigation">
+        <a class="brand" href="#">
+          <span class="brand-icon"></span>
+          <span class="brand-text">EASEMOTION</span>
+        </a>
+
+        <ul class="nav-links">
+          <li><a href="#home" aria-current="page">Home</a></li>
+          <li><a href="#observatory">Observatory</a></li>
+          <li><a href="#components">Components</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+
+        <!-- Decorative Foucault Pendulum Element -->
+        <div class="pendulum-decoration" aria-hidden="true">
+          <div class="pendulum-track">
+            <span class="track-ring ring-inner"></span>
+            <span class="track-ring ring-outer"></span>
+            <span class="track-ticks"></span>
+          </div>
+          <div class="pendulum-arm">
+            <span class="pendulum-cable"></span>
+            <span class="pendulum-bob"></span>
+            <span class="pendulum-shadow"></span>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <main class="demo-container">
+      <header class="demo-hero">
+        <div class="pendulum-badge">OBSERVATORY PRECISION SYSTEM</div>
+        <h1 class="demo-title">FOUCAULT PENDULUM NAVIGATION</h1>
+        <p class="demo-subtitle">
+          Pure HTML + Vanilla CSS Precision Astronomical Instrument Navigation
+          Component
+        </p>
+      </header>
+
+      <section class="demo-card">
+        <div class="card-content">
+          <div class="content-tag">ASTRONOMICAL INSTRUMENTATION</div>
+          <h2 class="content-title">ROTATIONAL PHYSICS & PRECISION SWING</h2>
+          <p class="content-body">
+            Observe the suspended Foucault pendulum swinging smoothly over the
+            circular compass track. Built using semantic
+            <code class="pendulum-code">&lt;nav&gt;</code> and
+            <code class="pendulum-code">&lt;a&gt;</code> elements, CSS swinging
+            keyframe physics, and pointer-safe decorative layers (<code
+              class="pendulum-code"
+              >aria-hidden="true"</code
+            >).
+          </p>
+        </div>
+        <footer class="card-footer">
+          <div class="keyboard-instruction">
+            <span class="pendulum-key">TAB</span> Navigate links
+            <span class="pendulum-key">ENTER</span> Activate link
+          </div>
+        </footer>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/73335-css-nav-foucault-pendulum/style.css
+++ b/submissions/examples/73335-css-nav-foucault-pendulum/style.css
@@ -1,0 +1,450 @@
+/* -------------------------------------------------------------------------- */
+
+/* 1. CSS Variables                                                           */
+
+/* -------------------------------------------------------------------------- */
+
+:root {
+  --pendulum-bg: #0b1020;
+  --pendulum-surface: #121a2d;
+  --pendulum-card-bg: #121a2d;
+  --pendulum-border: rgba(99, 230, 255, 0.3);
+  --pendulum-text: #f5f7ff;
+  --pendulum-muted: #aab4ca;
+  --pendulum-accent: #63e6ff;
+  --pendulum-accent-2: #a78bfa;
+  --pendulum-focus: #67e8f9;
+  --pendulum-glow: 0 0 16px rgba(99, 230, 255, 0.3);
+  --pendulum-radius: 8px;
+  --pendulum-transition: 180ms ease;
+  --font-mono: "Courier New", Courier, monospace, ui-monospace;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 2. Base Styles                                                             */
+
+/* -------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--pendulum-bg);
+  color: var(--pendulum-text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  line-height: 1.5;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 3. Navigation Container & Header                                           */
+
+/* -------------------------------------------------------------------------- */
+
+.site-header {
+  position: relative;
+  z-index: 10;
+  width: 100%;
+  background-color: var(--pendulum-surface);
+  border-bottom: 1px solid var(--pendulum-border);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+.pendulum-nav {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.25rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 80px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--pendulum-text);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  font-size: 1.1rem;
+  z-index: 2;
+  transition: color var(--pendulum-transition);
+}
+
+.brand-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--pendulum-accent);
+  box-shadow: 0 0 10px var(--pendulum-accent);
+}
+
+.brand:hover {
+  color: var(--pendulum-accent);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+  z-index: 2;
+}
+
+.nav-links a {
+  position: relative;
+  text-decoration: none;
+  color: var(--pendulum-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 0.5rem 0.25rem;
+  transition: color var(--pendulum-transition);
+}
+
+.nav-links a:hover {
+  color: var(--pendulum-accent);
+}
+
+/* Active page navigation indicator */
+.nav-links a[aria-current="page"] {
+  color: var(--pendulum-text);
+  font-weight: 700;
+}
+
+.nav-links a[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background-color: var(--pendulum-accent);
+  box-shadow: 0 0 8px var(--pendulum-accent);
+  border-radius: 2px;
+}
+
+/* Keyboard focus-visible state */
+.brand:focus-visible,
+.nav-links a:focus-visible {
+  outline: 2px solid var(--pendulum-focus);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 4. Decorative Foucault Pendulum Construction & Physics                     */
+
+/* -------------------------------------------------------------------------- */
+
+.pendulum-decoration {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 140px;
+  height: 70px;
+  pointer-events: none;
+  user-select: none;
+  z-index: 1;
+  opacity: 0.85;
+}
+
+/* Circular floor track & compass ring */
+.pendulum-track {
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%) rotateX(65deg);
+  width: 120px;
+  height: 120px;
+  border: 1px dashed rgba(99, 230, 255, 0.35);
+  border-radius: 50%;
+  box-shadow: inset 0 0 12px rgba(99, 230, 255, 0.15);
+}
+
+.track-ring {
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 50%;
+}
+
+/* Suspended Pendulum Arm & Cable */
+.pendulum-arm {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  width: 2px;
+  height: 75px;
+  transform-origin: top center;
+  animation: pendulum-swing 3.2s infinite ease-in-out;
+}
+
+.pendulum-cable {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 100%;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.8) 0%,
+    var(--pendulum-accent) 100%
+  );
+  box-shadow: 0 0 4px var(--pendulum-accent);
+}
+
+/* Brass & Cyan Pendulum Bob */
+.pendulum-bob {
+  position: absolute;
+  bottom: -6px;
+  left: -5px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 35%,
+    #ffffff 0%,
+    var(--pendulum-accent) 40%,
+    var(--pendulum-accent-2) 100%
+  );
+  box-shadow:
+    0 0 10px var(--pendulum-accent),
+    0 0 16px var(--pendulum-accent-2);
+}
+
+/* Pendulum Shadow on Floor Track */
+.pendulum-shadow {
+  position: absolute;
+  bottom: -12px;
+  left: -8px;
+  width: 18px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.5);
+  filter: blur(2px);
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 5. Keyframe Animations                                                     */
+
+/* -------------------------------------------------------------------------- */
+
+@keyframes pendulum-swing {
+  0% {
+    transform: rotate(-22deg);
+  }
+
+  50% {
+    transform: rotate(22deg);
+  }
+
+  100% {
+    transform: rotate(-22deg);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 6. Demo Content Card                                                       */
+
+/* -------------------------------------------------------------------------- */
+
+.demo-container {
+  max-width: 680px;
+  margin: 3rem auto;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.demo-hero {
+  text-align: center;
+}
+
+.pendulum-badge {
+  display: inline-block;
+  font-size: 0.725rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--pendulum-accent);
+  background-color: rgba(99, 230, 255, 0.12);
+  border: 1px solid rgba(99, 230, 255, 0.3);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.demo-title {
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--pendulum-text);
+  text-shadow: 0 0 14px rgba(99, 230, 255, 0.4);
+}
+
+.demo-subtitle {
+  font-size: clamp(0.85rem, 2.5vw, 0.95rem);
+  color: var(--pendulum-muted);
+  margin-top: 0.4rem;
+}
+
+.demo-card {
+  width: 100%;
+  background-color: var(--pendulum-card-bg);
+  border: 1px solid var(--pendulum-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.card-content {
+  padding: 2.25rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.content-tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--pendulum-accent-2);
+}
+
+.content-title {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.content-body {
+  font-size: 0.9rem;
+  color: var(--pendulum-muted);
+}
+
+.pendulum-code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--pendulum-accent);
+  background-color: rgba(99, 230, 255, 0.1);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+}
+
+.card-footer {
+  background-color: #0b1020;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--pendulum-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--pendulum-muted);
+}
+
+.keyboard-instruction {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pendulum-key {
+  display: inline-block;
+  background-color: var(--pendulum-surface);
+  border: 1px solid var(--pendulum-border);
+  color: var(--pendulum-accent);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 3px;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 7. Dark Mode Adaptation                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --pendulum-bg: #f8fafc;
+    --pendulum-surface: #ffffff;
+    --pendulum-card-bg: #ffffff;
+    --pendulum-border: #cbd5e1;
+    --pendulum-text: #0f172a;
+    --pendulum-muted: #64748b;
+    --pendulum-accent: #0284c7;
+    --pendulum-accent-2: #7c3aed;
+  }
+
+  .site-header {
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  .card-footer {
+    background-color: #f8fafc;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 8. Responsive Rules                                                        */
+
+/* -------------------------------------------------------------------------- */
+
+@media (max-width: 768px) {
+  .pendulum-nav {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .pendulum-decoration {
+    display: none;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* 9. Reduced-Motion Rules                                                    */
+
+/* -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .pendulum-arm {
+    transform: rotate(0deg) !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Added a pure HTML/CSS Foucault Pendulum Swing navigation component under `submissions/examples/73335-css-nav-foucault-pendulum/`.
- Added semantic `<header>`, `<nav aria-label="Primary navigation">`, `<ul class="nav-links">`, and real `<a>` navigation links.
- Added CSS-only suspended pendulum cable & bob construction with realistic swinging physics keyframes (`@keyframes pendulum-swing`).
- Added circular floor track rings (`.pendulum-track`) with pointer-safe decorative layers (`pointer-events: none; aria-hidden="true"`).
- Added active page styling (`aria-current="page"`).
- Added responsive behavior.
- Added dark-mode compatibility.
- Added reduced-motion support.
- Added clear keyboard focus states (`:focus-visible`).

## Issue

Closes #73335

## Validation

- Verified semantic navigation and link structure
- Verified keyboard navigation
- Verified focus-visible state
- Verified hover/active states
- Verified responsive behavior (320px-1440px+)
- Verified dark mode and reduced-motion behavior
- Stylelint verified (0 errors)
- Prettier verified
- Vitest unit tests passed (61/61)
- No JavaScript
- No external dependencies
