### PR TITLE
feat: add magnetic physics button example

### DIFF
--- a/submissions/examples/ease-magnetic-button-aaniya22/README.md
+++ b/submissions/examples/ease-magnetic-button-aaniya22/README.md
@@ -1,0 +1,57 @@
+# Magnetic Physics Button
+
+A premium button that physically "pulls" toward the user's cursor as it
+enters a magnetic field radius around it — a spring-like tactile effect
+with no physics engine (no GSAP, no Framer Motion) required.
+
+## How it works
+
+- On `pointermove`, we compute the **geometric distance** between the
+  cursor and the button's exact center: `Math.sqrt(dx*dx + dy*dy)`.
+- If the cursor is within the button's `data-radius`, its
+  `transform: translate()` is set proportionally to the offset, scaled
+  by `data-strength` (0–1) — closer to center moves less, further out
+  (but still inside the radius) pulls more.
+- The "physics" feel isn't a JS spring simulation — it comes from a
+  **CSS `cubic-bezier` overshoot easing**
+  (`cubic-bezier(0.34, 1.56, 0.64, 1)`) on the `transform` transition,
+  which settles like a real spring after each pointer move.
+- While actively pulled (`.is-pulled`), the transition tightens to
+  `0.15s` so the button tracks the cursor responsively; on pointer leave
+  it eases back to center with the bouncier curve.
+
+## Usage
+
+```html
+<button class="magnetic-button" data-radius="90" data-strength="0.4">
+  <span class="magnetic-button-label">Get Started</span>
+</button>
+```
+
+| Data attribute   | Default | Description                                        |
+|-------------------|---------|----------------------------------------------------|
+| `data-radius`     | `90`    | px radius of the magnetic field around the button   |
+| `data-strength`   | `0.4`   | 0–1, how far the button travels relative to cursor offset |
+
+The tiny inline script in `demo.html` wires this up for any element with
+the `.magnetic-button` class — just add the class and data attributes.
+
+## Why it fits EaseMotion CSS
+
+The animation itself is 100% native CSS transition/easing — JS here only
+supplies the cursor-distance math (which can't be done in pure CSS
+without a pointer listener), keeping the actual motion declarative,
+GPU-accelerated (`transform`-only), and dependency-free.
+
+## Accessibility
+
+- Uses a semantic `<button>`.
+- `:focus-visible` gets a clear outline independent of the magnetic
+  effect, so keyboard users get a visible focus state.
+- `prefers-reduced-motion: reduce` disables the pull transform entirely
+  while keeping the button fully clickable.
+
+## Browser support
+
+Uses `PointerEvent` (all modern evergreen browsers) and standard CSS
+transitions — no experimental APIs.

--- a/submissions/examples/ease-magnetic-button-aaniya22/demo.html
+++ b/submissions/examples/ease-magnetic-button-aaniya22/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Magnetic Physics Button</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-page">
+    <h1>Magnetic Physics Button</h1>
+    <p>Move your cursor near the buttons below.</p>
+
+    <div class="demo-row">
+      <button class="magnetic-button" data-radius="90" data-strength="0.4">
+        <span class="magnetic-button-label">Get Started</span>
+      </button>
+
+      <button class="magnetic-button secondary" data-radius="120" data-strength="0.5">
+        <span class="magnetic-button-label">Learn More</span>
+      </button>
+    </div>
+  </main>
+
+  <script>
+    // Magnetic pull: track cursor distance from each button's center,
+    // translate proportionally within a configurable radius, and let
+    // CSS cubic-bezier easing supply the spring "settle" feel.
+    document.querySelectorAll('.magnetic-button').forEach((btn) => {
+      const radius = parseFloat(btn.dataset.radius) || 90;
+      const strength = parseFloat(btn.dataset.strength) || 0.4;
+
+      const reset = () => {
+        btn.style.transform = 'translate(0px, 0px)';
+        btn.classList.remove('is-pulled');
+      };
+
+      window.addEventListener('pointermove', (e) => {
+        const rect = btn.getBoundingClientRect();
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+
+        const dx = e.clientX - centerX;
+        const dy = e.clientY - centerY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance < radius) {
+          btn.style.transform = `translate(${dx * strength}px, ${dy * strength}px)`;
+          btn.classList.add('is-pulled');
+        } else if (btn.classList.contains('is-pulled')) {
+          reset();
+        }
+      });
+
+      btn.addEventListener('pointerleave', reset);
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/ease-magnetic-button-aaniya22/style.css
+++ b/submissions/examples/ease-magnetic-button-aaniya22/style.css
@@ -1,0 +1,97 @@
+/* ==========================================================================
+   Magnetic Physics Button
+   Spring-like pull driven by transform + cubic-bezier easing.
+   The "physics" feel comes from a bouncy easing curve reacting to
+   distance-proportional translate values set via JS.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.demo-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: #0b0b0f;
+  color: #fff;
+  text-align: center;
+}
+
+.demo-page p {
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 1rem;
+}
+
+.demo-row {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+.magnetic-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 2rem;
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0b0b0f;
+  background: #fff;
+  cursor: pointer;
+  isolation: isolate;
+
+  /* Spring easing: overshoot slightly then settle, like a real magnet */
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1),
+              box-shadow 0.3s ease;
+  will-change: transform;
+}
+
+.magnetic-button-label {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* While actively being pulled, snap the transition tighter so it tracks
+   the cursor responsively instead of lagging behind it */
+.magnetic-button.is-pulled {
+  transition: transform 0.15s cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 0.3s ease;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+}
+
+.magnetic-button:active {
+  transform: scale(0.96) !important;
+}
+
+.magnetic-button:focus-visible {
+  outline: 2px solid #6ec6ff;
+  outline-offset: 3px;
+}
+
+.magnetic-button.secondary {
+  background: transparent;
+  color: #fff;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+}
+
+/* Respect reduced motion: keep the button usable, drop the pull */
+@media (prefers-reduced-motion: reduce) {
+  .magnetic-button,
+  .magnetic-button.is-pulled {
+    transition: box-shadow 0.2s ease;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
closes #74593
## Pull Request Description
Adds a new example for issue #74593 — a button that physically "pulls" toward the user's cursor within a magnetic field radius, giving a spring-like tactile hover effect.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-magnetic-button-aaniya22/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A magnetic-pull button that translates toward the cursor as it enters a configurable radius, then springs back on pointer leave.

**How does a developer use it?**
```html
<button class="magnetic-button" data-radius="90" data-strength="0.4">
  <span class="magnetic-button-label">Get Started</span>
</button>
```

**Why does it fit EaseMotion CSS?**
The animation itself is 100% native CSS transition/easing — a small script only supplies the cursor-distance math (which pure CSS can't do without a pointer listener). The actual motion stays declarative, GPU-accelerated (`transform`-only), and dependency-free, matching the animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer
Named the folder `ease-magnetic-button-aaniya22` since `ease-magnetic-button` already exists in the repo (a separate framework-dependent component under `submissions/examples/`) — happy to rename if you'd prefer a different disambiguation. Spring feel comes purely from a `cubic-bezier` overshoot easing on `transform`, not a JS physics loop; open to tuning the default `radius`/`strength` values if you want a stronger or subtler pull.