### PR TITLE
feat: add native css scroll-snapping carousel example

### DIFF
--- a/submissions/examples/ease-scroll-snap-carousel/README.md
+++ b/submissions/examples/ease-scroll-snap-carousel/README.md
@@ -1,0 +1,81 @@
+# Native CSS Scroll-Snapping Carousel
+
+A horizontal image carousel with drag/swipe momentum and snapping —
+built entirely with native CSS `scroll-snap` APIs, no JavaScript, no
+30KB+ swipe library like Swiper.js.
+
+## How it works
+
+- `.snap-carousel` is a flex container with `overflow-x: auto` and
+  **`scroll-snap-type: x mandatory`** — this tells the browser every
+  scroll gesture must come to rest on a snap point along the x axis.
+- Each `.snap-item` sets **`scroll-snap-align: center`**, defining that
+  snap point as its own center, plus `scroll-snap-stop: always` so fast
+  swipes can't skip past a slide.
+- `scroll-behavior: smooth` makes any programmatic or keyboard-driven
+  scroll (e.g. an anchor link or arrow key) animate smoothly instead of
+  jumping.
+- Momentum and physics come **entirely from the OS/browser's native
+  touch scrolling** — no `touchstart`/`touchmove` math, no requestAnimationFrame
+  loop, so it runs at native frame rate.
+- The scrollbar is hidden (`scrollbar-width: none` / `::-webkit-scrollbar
+  { display: none }`) while scroll functionality is fully preserved.
+
+```css
+.snap-carousel {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+}
+
+.snap-item {
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+}
+```
+
+## Usage
+
+```html
+<div class="snap-carousel">
+  <div class="snap-item"><img src="..." alt=""></div>
+  <div class="snap-item"><img src="..." alt=""></div>
+  <div class="snap-item"><img src="..." alt=""></div>
+</div>
+```
+
+Add as many `.snap-item` children as needed — the carousel scales
+automatically. Item width is controlled via `flex-basis` on `.snap-item`
+and adjusts at two breakpoints to reveal more neighboring slides on
+larger screens.
+
+## Customizing
+
+- **Slide width:** change `flex-basis` on `.snap-item` (or the
+  responsive breakpoint values).
+- **Snap point:** switch `scroll-snap-align` to `start` or `end` instead
+  of `center` for edge-aligned snapping.
+- **Gap:** adjust `gap` on `.snap-carousel`.
+
+## Why it fits EaseMotion CSS
+
+Fully declarative, zero dependencies, zero JavaScript — the entire
+interaction (drag, momentum, snap, smooth-scroll) is handled by native
+browser APIs. Class names are self-explanatory and the whole block is
+copy-paste portable into any layout.
+
+## Accessibility
+
+- Carousel remains keyboard-scrollable (arrow keys / Tab + native focus
+  scrolling) since it's a plain scrollable container, not a custom
+  widget intercepting input.
+- Images use empty `alt=""` as decorative placeholders — replace with
+  descriptive `alt` text for real content.
+
+## Browser support
+
+`scroll-snap-type` and `scroll-snap-align` are supported in all modern
+evergreen browsers (Chrome 69+, Firefox 68+, Safari 11+, Edge 79+).
+Browsers without support simply fall back to normal free scrolling with
+no error.

--- a/submissions/examples/ease-scroll-snap-carousel/demo.html
+++ b/submissions/examples/ease-scroll-snap-carousel/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Native CSS Scroll-Snapping Carousel</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <h1>Native CSS Scroll-Snapping Carousel</h1>
+    <p>Swipe or drag horizontally &mdash; zero JavaScript, native momentum &amp; snap.</p>
+
+    <div class="snap-carousel">
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc1/600/400" alt=""></div>
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc2/600/400" alt=""></div>
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc3/600/400" alt=""></div>
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc4/600/400" alt=""></div>
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc5/600/400" alt=""></div>
+      <div class="snap-item"><img src="https://picsum.photos/seed/sc6/600/400" alt=""></div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/ease-scroll-snap-carousel/style.css
+++ b/submissions/examples/ease-scroll-snap-carousel/style.css
@@ -1,0 +1,84 @@
+/* ==========================================================================
+   Native CSS Scroll-Snapping Carousel
+   Zero-JS horizontal carousel using scroll-snap-type + scroll-behavior.
+   Native momentum, native snap, native OS frame rate.
+   ========================================================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0b0b0f;
+  color: #fff;
+}
+
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.page h1 {
+  font-size: 1.9rem;
+  margin: 0 0 0.5rem;
+}
+
+.page p {
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0 0 2rem;
+}
+
+/* ---- The carousel track ---- */
+.snap-carousel {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+
+  /* The core of the effect: mandatory snapping on the x axis,
+     plus smooth programmatic/keyboard scroll fallback */
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+
+  /* Hide the scrollbar without hiding scroll functionality */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* old Edge/IE */
+}
+
+.snap-carousel::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, new Edge */
+}
+
+.snap-item {
+  flex: 0 0 80%;
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.snap-item img {
+  display: block;
+  width: 100%;
+  height: 260px;
+  object-fit: cover;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* ---- Responsive: show more of the neighboring slides on wider screens ---- */
+@media (min-width: 640px) {
+  .snap-item {
+    flex-basis: 55%;
+  }
+}
+
+@media (min-width: 960px) {
+  .snap-item {
+    flex-basis: 38%;
+  }
+}


### PR DESCRIPTION
closes #74160 
## Pull Request Description
Adds a new example for issue #74160 — a horizontal image carousel with native drag/swipe momentum and snapping, no JS swipe library needed.

---

## Type of Change
- [x] ✨ New animation / hover effect

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-scroll-snap-carousel/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A zero-JS horizontal carousel using native `scroll-snap-type: x mandatory` and `scroll-behavior: smooth` for OS-native drag momentum and snapping.

**How does a developer use it?**
```html
<div class="snap-carousel">
  <div class="snap-item"><img src="..." alt=""></div>
  <div class="snap-item"><img src="..." alt=""></div>
  <div class="snap-item"><img src="..." alt=""></div>
</div>
```

**Why does it fit EaseMotion CSS?**
Fully declarative, zero dependencies, zero JavaScript — drag, momentum, and snap are all handled by native browser scroll-snap APIs, running at native OS frame rate instead of a JS-driven physics loop. Self-explanatory class names keep it copy-paste portable, in line with the animation-first philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [x] Edge
- [ ] Firefox
- [ ] Safari

---

## Notes for Maintainer
Slide width uses `flex-basis` with two responsive breakpoints (55% at 640px, 38% at 960px) so neighboring slides peek in on larger screens — happy to adjust those values or the snap alignment (`center` vs `start`) if you'd prefer a different feel. Scrollbar is hidden cross-browser while scroll functionality (including keyboard scrolling) stays fully intact.