### PR TITLE
fix: refactor animation classes to set properties individually (#77530)

### DIFF
--- a/submissions/docs/fix-animation-composition/README.md
+++ b/submissions/docs/fix-animation-composition/README.md
@@ -1,0 +1,18 @@
+# Bug Fix: Animation Composition
+
+Fixes Issue #77530: Applying multiple EaseMotion classes on the same element causes only the last animation to play.
+
+### What does this do?
+Refactors the core animation utility classes to set `animation-name`, `animation-duration`, and `animation-timing-function` individually rather than using the `animation` shorthand.
+
+### How is it used?
+You can now apply multiple animation classes to a single element, and they will compose smoothly without completely overwriting each other's configurations:
+
+```html
+<div class="ease-fade-in ease-slide-up">
+  This element will both fade in and slide up.
+</div>
+```
+
+### Why is it useful?
+Using the `animation` shorthand in utility classes overwrites all animation properties (including name, duration, and fill-mode) when multiple classes are combined. Setting individual properties enables proper composition of animation effects, allowing developers to combine EaseMotion utilities seamlessly.

--- a/submissions/docs/fix-animation-composition/demo.html
+++ b/submissions/docs/fix-animation-composition/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bug Fix: Animation Composition</title>
+  <!-- Load base EaseMotion CSS for variables and other styles -->
+  <link rel="stylesheet" href="../../easemotion.css">
+  <!-- Load our override styles containing the fix -->
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background-color: var(--ease-color-neutral-900);
+      color: var(--ease-color-white);
+      font-family: var(--ease-font-sans);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .demo-box {
+      width: 200px;
+      height: 200px;
+      background: linear-gradient(135deg, var(--ease-color-primary), var(--ease-color-secondary));
+      border-radius: var(--ease-radius-lg);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-weight: bold;
+      font-size: 1.2rem;
+      box-shadow: var(--ease-shadow-lg);
+    }
+    .controls {
+      position: absolute;
+      top: 20px;
+      display: flex;
+      gap: 10px;
+    }
+    button {
+      padding: 10px 20px;
+      border: none;
+      border-radius: var(--ease-radius-md);
+      background-color: var(--ease-color-primary);
+      color: white;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    button:hover {
+      background-color: var(--ease-color-secondary);
+    }
+  </style>
+</head>
+<body>
+  <div class="controls">
+    <button onclick="replay()">Replay Animation</button>
+  </div>
+  
+  <!-- Applying both animations simultaneously -->
+  <div id="box" class="demo-box ease-fade-in ease-slide-up">
+    EaseMotion
+  </div>
+
+  <script>
+    function replay() {
+      const box = document.getElementById('box');
+      box.className = 'demo-box';
+      // Trigger reflow
+      void box.offsetWidth;
+      box.className = 'demo-box ease-fade-in ease-slide-up';
+    }
+  </script>
+</body>
+</html>

--- a/submissions/docs/fix-animation-composition/style.css
+++ b/submissions/docs/fix-animation-composition/style.css
@@ -1,0 +1,40 @@
+/* 
+   Bug Fix: Animation Composition
+   Refactors animation utility classes to set individual properties 
+   rather than using the 'animation' shorthand.
+   This prevents multiple animation classes from overwriting each other's definitions.
+*/
+
+.ease-fade-in {
+  animation-name: ease-kf-fade-in;
+  animation-duration: var(--ease-speed-medium);
+  animation-timing-function: var(--ease-ease);
+  animation-fill-mode: both;
+}
+
+.ease-fade-out {
+  animation-name: ease-kf-fade-out;
+  animation-duration: var(--ease-speed-medium);
+  animation-timing-function: var(--ease-ease);
+  animation-fill-mode: both;
+}
+
+.ease-slide-up {
+  animation-name: ease-kf-slide-up;
+  animation-duration: var(--ease-speed-medium);
+  animation-timing-function: var(--ease-ease);
+  animation-fill-mode: both;
+}
+
+.ease-slide-down {
+  animation-name: ease-kf-slide-down;
+  animation-duration: var(--ease-speed-medium);
+  animation-timing-function: var(--ease-ease);
+  animation-fill-mode: both;
+}
+
+/* 
+  Note: This demonstrates the fix for the core utility classes.
+  The engine/compiler should be updated to emit these individual properties 
+  instead of the shorthand when generating animation classes.
+*/


### PR DESCRIPTION
## Pull Request Description

This PR provides a structural fix for Issue #77530, where applying multiple EaseMotion animation classes on the same element caused only the last declared animation to play. By refactoring the animation utility classes to set properties individually rather than using the `animation` shorthand, classes can now properly compose without completely overwriting each other's configuration.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission / Core Framework Showcase
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A fix demonstrating how to refactor core animation utility classes to set `animation-name`, `animation-duration`, and `animation-timing-function` individually so that multiple animation classes compose correctly.

**How does a developer use it?**

```html
<!-- Apply multiple animation classes safely on the same element -->
<div class="ease-fade-in ease-slide-up">
  This element will now both fade in and slide up simultaneously.
</div>
