### PR TITLE
feat: add CSS-only glitch text effect submission

### DIFF
--- a/submissions/examples/ease-glitch-text/README.md
+++ b/submissions/examples/ease-glitch-text/README.md
@@ -1,0 +1,14 @@
+# Ease Glitch Text Effect
+
+### What does this do?
+This is a purely CSS-driven cyberpunk-style glitching text effect that uses `clip-path` and RGB text-shadows to create a flawless, hardware-accelerated text glitch without requiring canvas manipulation or heavy JS libraries.
+
+### How is it used?
+Apply the `glitch-text` class to any text element and set the `data-text` attribute to match the text content:
+
+```html
+<h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+```
+
+### Why is it useful?
+It fits EaseMotion's philosophy by delivering complex, visually striking animations using lightweight, highly optimized CSS techniques, avoiding unnecessary DOM duplication and keeping rendering performant and GPU-accelerated.

--- a/submissions/examples/ease-glitch-text/demo.html
+++ b/submissions/examples/ease-glitch-text/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Only Glitch Text Effect</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: #111;
+      font-family: monospace, sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
+</body>
+</html>

--- a/submissions/examples/ease-glitch-text/style.css
+++ b/submissions/examples/ease-glitch-text/style.css
@@ -1,0 +1,89 @@
+.glitch-text {
+  position: relative;
+  font-size: 5rem;
+  font-weight: bold;
+  color: #fff;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  display: inline-block;
+  user-select: none;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
+.glitch-text::before {
+  left: 3px;
+  text-shadow: -2px 0 #ff00c1;
+  clip-path: polygon(0 0, 100% 0, 100% 33%, 0 33%);
+  animation: glitch-anim-1 2s infinite linear alternate-reverse;
+}
+
+.glitch-text::after {
+  left: -3px;
+  text-shadow: -2px 0 #00fff9;
+  clip-path: polygon(0 67%, 100% 67%, 100% 100%, 0 100%);
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim-1 {
+  0% {
+    clip-path: polygon(0 20%, 100% 20%, 100% 40%, 0 40%);
+    transform: translate(2px, -1px);
+  }
+  20% {
+    clip-path: polygon(0 10%, 100% 10%, 100% 50%, 0 50%);
+    transform: translate(-2px, 1px);
+  }
+  40% {
+    clip-path: polygon(0 60%, 100% 60%, 100% 80%, 0 80%);
+    transform: translate(2px, 0);
+  }
+  60% {
+    clip-path: polygon(0 30%, 100% 30%, 100% 70%, 0 70%);
+    transform: translate(-2px, -2px);
+  }
+  80% {
+    clip-path: polygon(0 50%, 100% 50%, 100% 90%, 0 90%);
+    transform: translate(2px, 2px);
+  }
+  100% {
+    clip-path: polygon(0 10%, 100% 10%, 100% 30%, 0 30%);
+    transform: translate(-2px, 0);
+  }
+}
+
+@keyframes glitch-anim-2 {
+  0% {
+    clip-path: polygon(0 60%, 100% 60%, 100% 90%, 0 90%);
+    transform: translate(-2px, 2px);
+  }
+  20% {
+    clip-path: polygon(0 30%, 100% 30%, 100% 80%, 0 80%);
+    transform: translate(2px, -1px);
+  }
+  40% {
+    clip-path: polygon(0 10%, 100% 10%, 100% 50%, 0 50%);
+    transform: translate(-2px, 1px);
+  }
+  60% {
+    clip-path: polygon(0 80%, 100% 80%, 100% 100%, 0 100%);
+    transform: translate(2px, 2px);
+  }
+  80% {
+    clip-path: polygon(0 40%, 100% 40%, 100% 60%, 0 60%);
+    transform: translate(-2px, -2px);
+  }
+  100% {
+    clip-path: polygon(0 20%, 100% 20%, 100% 40%, 0 40%);
+    transform: translate(2px, 0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a purely CSS-driven cyberpunk-style glitching text effect using `clip-path` and RGB text-shadows, creating a flawless, hardware-accelerated text glitch without requiring canvas manipulation or heavy JS libraries. This implements the request from issue #74110.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

This adds a highly performant, purely CSS-driven cyberpunk glitch text effect using `clip-path` and pseudo-element text-shadows.

**How does a developer use it?**

```html
<h1 class="glitch-text" data-text="CYBERPUNK">CYBERPUNK</h1>
