### PR TITLE
CSS Sticky Side Indicators (#70161)

### DIFF
--- a/submissions/examples/sticky-side-bar/README.md
+++ b/submissions/examples/sticky-side-bar/README.md
@@ -1,0 +1,32 @@
+
+---
+
+## 🚀 Usage
+1. Clone or copy the files into your project.
+2. Open `demo.html` in your browser.
+3. Scroll through sections and use indicators to navigate.
+
+---
+
+## 🛠️ Customization
+- **Indicator size** → Adjust `width` and `height` in `.indicator`.
+- **Colors** → Modify `background` for default and active states.
+- **Position** → Change `left` or `right` in `.side-indicators`.
+
+---
+
+## 📖 Accessibility
+- Uses `role="navigation"` and `aria-label` for screen readers.
+- Active indicator marked with `aria-current="true"`.
+- Keyboard focus supported.
+
+---
+
+## 🧩 License
+MIT License — free to use and modify.
+
+---
+
+## 🙌 Credits
+Created for **EaseMotion CSS Demo Styles**.  
+Author: [SAPTARSHI-coder](https://github.com/SAPTARSHI-coder)

--- a/submissions/examples/sticky-side-bar/demo.html
+++ b/submissions/examples/sticky-side-bar/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Sticky Side Indicators</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <aside class="side-indicators" role="navigation" aria-label="Section indicators">
+    <a href="#section1" class="indicator active" aria-current="true"></a>
+    <a href="#section2" class="indicator"></a>
+    <a href="#section3" class="indicator"></a>
+    <a href="#section4" class="indicator"></a>
+  </aside>
+
+  <main>
+    <section id="section1"><h1>Section 1</h1><p>Content here...</p></section>
+    <section id="section2"><h1>Section 2</h1><p>Content here...</p></section>
+    <section id="section3"><h1>Section 3</h1><p>Content here...</p></section>
+    <section id="section4"><h1>Section 4</h1><p>Content here...</p></section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sticky-side-bar/style.css
+++ b/submissions/examples/sticky-side-bar/style.css
@@ -1,0 +1,56 @@
+/* Base setup */
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  display: flex;
+}
+
+/* Sticky side indicators */
+.side-indicators {
+  position: fixed;
+  top: 50%;
+  left: 1rem;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 1000;
+}
+
+.indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ccc;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.indicator:hover,
+.indicator:focus {
+  background: #1976d2;
+  transform: scale(1.2);
+  outline: none;
+}
+
+.indicator.active {
+  background: #1976d2;
+}
+
+/* Sections */
+main {
+  flex: 1;
+  padding: 2rem;
+}
+
+section {
+  min-height: 100vh;
+  border-bottom: 1px solid #ddd;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .side-indicators {
+    left: auto;
+    right: 1rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a new **CSS Sticky Side Indicators** component.  
It provides sticky vertical pill indicators for multi-section pages, enabling smooth navigation and clear section highlighting.  
Built entirely with **HTML + Vanilla CSS** — no external JavaScript required.
closes #70161 
---

## Type of Change

- [x] ✨ New component / example
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/css-sticky-side-indicators/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**  
Sticky vertical pill indicators for multi-section pages, styled with smooth transitions and responsive positioning.

**How does a developer use it?**
```html
<aside class="side-indicators" role="navigation" aria-label="Section indicators">
  <a href="#section1" class="indicator active" aria-current="true"></a>
  <a href="#section2" class="indicator"></a>
  <a href="#section3" class="indicator"></a>
  <a href="#section4" class="indicator"></a>
</aside>
