### PR TITLE
feat: add Inline Edit Field example (inline-edit-field-qz9k)

### DIFF
--- a/submissions/examples/inline-edit-field-qz9k/README.md
+++ b/submissions/examples/inline-edit-field-qz9k/README.md
@@ -1,0 +1,40 @@
+# Inline Edit Field
+
+## What does this do?
+
+A text value that becomes editable in place when clicked: Enter commits the
+change, Escape cancels, and blurring the field (clicking away) commits like
+Enter rather than silently discarding the edit.
+
+## How is it used?
+
+```html
+<div class="ief-field" id="ief-title">
+  <button type="button" class="ief-value" onclick="iefEdit(this.parentElement)">Q3 Roadmap</button>
+  <input class="ief-input" type="text"
+    onkeydown="iefKeydown(event, this.parentElement)"
+    onblur="iefCommit(this.parentElement, false)" />
+</div>
+```
+
+Both `.ief-value` and `.ief-input` occupy the same CSS grid cell
+(`grid-area: 1 / 1`); toggling `.ief-editing` swaps their `visibility`
+rather than swapping which element exists in the DOM, so the field never
+reflows or jumps in width between modes.
+
+## Why is it useful?
+
+The riskiest part of an inline-edit pattern is what happens when focus
+leaves the field unexpectedly — clicking a different part of the page,
+tabbing away, or the user simply changing their mind mid-edit without
+pressing a key. A version that only listens for Enter/Escape and does
+nothing on blur leaves the field stuck in edit mode, or worse, silently
+discards a real edit if blur is wired to cancel by default. Committing on
+blur (treating "click away" the same as pressing Enter) matches what most
+users expect: their typed value is applied, not thrown away, unless they
+explicitly pressed Escape.
+
+Keeping both elements permanently in the DOM (toggling `visibility`
+instead of conditionally rendering) means the button and input share
+identical box dimensions from the same grid cell, so there's no layout
+shift the instant a user clicks to start editing.

--- a/submissions/examples/inline-edit-field-qz9k/demo.html
+++ b/submissions/examples/inline-edit-field-qz9k/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Inline Edit Field</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function iefEdit(el) {
+    var span = el.querySelector('.ief-value');
+    var input = el.querySelector('.ief-input');
+    input.value = span.textContent;
+    el.classList.add('ief-editing');
+    input.focus();
+    input.select();
+  }
+
+  function iefCommit(el, cancel) {
+    var span = el.querySelector('.ief-value');
+    var input = el.querySelector('.ief-input');
+    if (!cancel && input.value.trim()) span.textContent = input.value.trim();
+    el.classList.remove('ief-editing');
+  }
+
+  function iefKeydown(event, el) {
+    if (event.key === 'Enter') iefCommit(el, false);
+    if (event.key === 'Escape') iefCommit(el, true);
+  }
+</script>
+</head>
+<body>
+<main class="ief-wrap">
+  <h1 class="ief-h1">Inline Edit</h1>
+  <p class="ief-lede">Click the value to edit it in place; Enter commits, Escape cancels, and blur commits like Enter so clicking away never silently discards a change.</p>
+
+  <div class="ief-field" id="ief-title">
+    <button type="button" class="ief-value" onclick="iefEdit(document.getElementById('ief-title'))">Q3 Roadmap</button>
+    <input
+      class="ief-input"
+      type="text"
+      onkeydown="iefKeydown(event, document.getElementById('ief-title'))"
+      onblur="iefCommit(document.getElementById('ief-title'), false)"
+      aria-label="Edit title"
+    />
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/inline-edit-field-qz9k/style.css
+++ b/submissions/examples/inline-edit-field-qz9k/style.css
@@ -1,0 +1,73 @@
+/* Inline Edit Field
+   .ief-value and .ief-input occupy the same grid cell (both on row/col 1),
+   and .ief-editing toggles which one is visible -- so swapping modes never
+   reflows the surrounding layout the way conditionally rendering one or the
+   other element would. */
+
+.ief-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ief-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ief-lede { margin: 0 0 2rem; color: #576073; }
+
+.ief-field {
+  display: grid;
+}
+
+.ief-value,
+.ief-input {
+  grid-area: 1 / 1;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.4em 0.6em;
+  border-radius: 0.4rem;
+}
+
+.ief-value {
+  text-align: left;
+  border: 1px solid transparent;
+  background: none;
+  cursor: text;
+  visibility: visible;
+}
+
+.ief-value:hover {
+  background: #f1f4fa;
+}
+
+.ief-value:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.ief-input {
+  border: 1px solid #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+  visibility: hidden;
+  background: #fff;
+}
+
+.ief-field.ief-editing .ief-value {
+  visibility: hidden;
+}
+
+.ief-field.ief-editing .ief-input {
+  visibility: visible;
+}
+
+@media (forced-colors: active) {
+  .ief-value:hover { forced-color-adjust: none; background: ButtonFace; }
+  .ief-input { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ief-wrap { color: #e6e9f2; }
+  .ief-lede { color: #99a1b4; }
+  .ief-value:hover { background: #1e2430; }
+  .ief-input { background: #171b23; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #75595

Click-to-edit text field. Enter and blur both commit, matching what most users expect (clicking away applies the edit, only Escape discards it). The display value and input occupy the same CSS grid cell, so toggling edit mode never reflows the surrounding layout.