### PR TITLE
feat: add Rating Hearts example (rating-hearts-qz9k)

### DIFF
--- a/submissions/examples/rating-hearts-qz9k/README.md
+++ b/submissions/examples/rating-hearts-qz9k/README.md
@@ -1,0 +1,39 @@
+# Rating Hearts
+
+## What does this do?
+
+A five-heart rating widget using the same radio-driven sibling-combinator
+fill technique as a star rating, with one addition: the newly selected
+heart pulses briefly, distinguishing "just selected" from "hovering."
+
+## How is it used?
+
+```html
+<div class="rht-hearts">
+  <input type="radio" id="rht-5" name="rht-rating" value="5" />
+  <label for="rht-5" class="rht-heart">♥<span class="rht-sr">5 hearts</span></label>
+  <!-- ...4 down to 1 -->
+</div>
+```
+
+Same 5→1 source order, `row-reverse` display as a star rating: sibling
+combinators only look at later-in-source elements, so the highest value has
+to come first in markup to visually appear last (rightmost after reversal).
+
+## Why is it useful?
+
+Hover-preview and "just selected" often get conflated into one visual
+treatment, but they mean different things — one is provisional, the other
+is committed. Restricting the pulse keyframe animation to `:checked` (not
+`:hover`) keeps that distinction: hovering only shifts colour, and only an
+actual selection triggers the emphasis animation, so a user scanning
+options with the mouse doesn't see the confirmation cue fire on every
+heart they pass over.
+
+The animation also needs to replay if the *same* heart is re-selected (a
+common interaction — click a value, decide, click it again to confirm) —
+browsers don't restart a CSS animation on an unrelated style recompute
+unless `animation-name` itself changes, but re-applying `:checked` after a
+brief unchecked state (radio group semantics: selecting a different button
+first) does trigger a fresh application, which this relies on rather than
+JS-driven class toggling.

--- a/submissions/examples/rating-hearts-qz9k/demo.html
+++ b/submissions/examples/rating-hearts-qz9k/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Rating Hearts</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rht-wrap">
+  <h1 class="rht-h1">Favourite Level</h1>
+  <p class="rht-lede">Same radio-driven fill technique as a star rating, but each heart also pulses briefly when it becomes the selected value, not just on hover.</p>
+
+  <fieldset class="rht-field">
+    <legend class="rht-legend">How much did you enjoy this?</legend>
+    <div class="rht-hearts">
+      <input type="radio" id="rht-5" name="rht-rating" value="5" />
+      <label for="rht-5" class="rht-heart">♥<span class="rht-sr">5 hearts</span></label>
+
+      <input type="radio" id="rht-4" name="rht-rating" value="4" checked />
+      <label for="rht-4" class="rht-heart">♥<span class="rht-sr">4 hearts</span></label>
+
+      <input type="radio" id="rht-3" name="rht-rating" value="3" />
+      <label for="rht-3" class="rht-heart">♥<span class="rht-sr">3 hearts</span></label>
+
+      <input type="radio" id="rht-2" name="rht-rating" value="2" />
+      <label for="rht-2" class="rht-heart">♥<span class="rht-sr">2 hearts</span></label>
+
+      <input type="radio" id="rht-1" name="rht-rating" value="1" />
+      <label for="rht-1" class="rht-heart">♥<span class="rht-sr">1 heart</span></label>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/rating-hearts-qz9k/style.css
+++ b/submissions/examples/rating-hearts-qz9k/style.css
@@ -1,0 +1,103 @@
+/* Rating Hearts
+   The pulse animation is scoped to :checked only (not :hover), and keyed
+   with an animation-name so re-selecting the SAME already-checked heart
+   still replays it -- browsers don't restart a running animation on a
+   style recompute unless the animation-name itself changes value. */
+
+.rht-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.rht-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.rht-lede { margin: 0 0 2rem; color: #576073; }
+
+.rht-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.rht-legend {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.rht-hearts {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+  gap: 0.2rem;
+  width: max-content;
+}
+
+.rht-hearts input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.rht-heart {
+  font-size: 2rem;
+  line-height: 1;
+  color: #d8dce6;
+  cursor: pointer;
+  display: inline-block;
+  transition: color 140ms ease;
+}
+
+.rht-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.rht-hearts input:checked ~ label.rht-heart,
+.rht-hearts input:hover ~ label.rht-heart,
+.rht-hearts label.rht-heart:hover ~ label.rht-heart {
+  color: #e0447a;
+}
+
+.rht-hearts input:checked + label.rht-heart {
+  animation: rht-pulse 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes rht-pulse {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.35); }
+  100% { transform: scale(1); }
+}
+
+.rht-hearts input:focus-visible + label.rht-heart {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+  border-radius: 0.2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rht-heart { transition: none; }
+  .rht-hearts input:checked + label.rht-heart { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .rht-heart { forced-color-adjust: none; color: CanvasText; }
+
+  .rht-hearts input:checked ~ label.rht-heart,
+  .rht-hearts input:hover ~ label.rht-heart,
+  .rht-hearts label.rht-heart:hover ~ label.rht-heart {
+    color: Highlight;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rht-wrap { color: #e6e9f2; }
+  .rht-lede { color: #99a1b4; }
+  .rht-heart { color: #3a4150; }
+}


### PR DESCRIPTION
Closes #75596

Radio-driven heart rating using the same sibling-combinator fill technique as a star rating, plus a pulse keyframe scoped to :checked only so hovering only shifts colour while an actual selection gets a distinct confirmation animation.

- prefers-reduced-motion and forced-colors support