### PR TITLE
feat: add Timeline example (timeline-branch-qz9k)

### DIFF
--- a/submissions/examples/timeline-branch-qz9k/README.md
+++ b/submissions/examples/timeline-branch-qz9k/README.md
@@ -1,0 +1,44 @@
+# Timeline
+
+## What does this do?
+
+A vertical event timeline where each item draws its own connector line
+reaching up to the previous item's dot, using a fixed-length `::before` per
+item rather than one continuous line spanning the whole list.
+
+## How is it used?
+
+```html
+<ol class="tlb-list">
+  <li class="tlb-item">
+    <span class="tlb-dot" aria-hidden="true"></span>
+    <div class="tlb-body">
+      <p class="tlb-date">v2.4.0 — Aug 2026</p>
+      <p class="tlb-desc">Added dark mode.</p>
+    </div>
+  </li>
+  <!-- ... -->
+</ol>
+```
+
+Every item except the first gets a connector (`:not(:first-child)::before`)
+of a fixed height matching the gap between dots
+(`padding-bottom` on `.tlb-item`), so the line always exactly bridges to the
+dot above regardless of how much text each item's description contains.
+
+## Why is it useful?
+
+The common way to build this is one absolutely-positioned line spanning the
+full height of the list (`top: 0; bottom: 0`) sitting behind all the dots —
+which requires the line to start and end exactly at the first and last dot,
+awkward with `padding`/`margin` at the list edges, and requires z-index
+management to keep dots above the line. Drawing the connector per-item
+instead ties each segment's length directly to that item's own fixed
+vertical rhythm (dot spacing), so adding, removing, or reordering items
+never requires recalculating a single shared line's length — each item is
+fully self-contained.
+
+The dots are `aria-hidden` since they're purely decorative; the real
+event data (date, description) is ordinary text in a real `<ol>`, so a
+screen reader gets the timeline as a plain ordered list of entries with no
+extra markup to parse.

--- a/submissions/examples/timeline-branch-qz9k/demo.html
+++ b/submissions/examples/timeline-branch-qz9k/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Timeline</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tlb-wrap">
+  <h1 class="tlb-h1">Release Timeline</h1>
+  <p class="tlb-lede">A vertical timeline whose connecting line is drawn per-item as a ::before reaching up to the previous dot, so the line length never has to be measured or hard-coded.</p>
+
+  <ol class="tlb-list">
+    <li class="tlb-item">
+      <span class="tlb-dot" aria-hidden="true"></span>
+      <div class="tlb-body">
+        <p class="tlb-date">v2.4.0 — Aug 2026</p>
+        <p class="tlb-desc">Added dark mode and the new component library.</p>
+      </div>
+    </li>
+    <li class="tlb-item">
+      <span class="tlb-dot" aria-hidden="true"></span>
+      <div class="tlb-body">
+        <p class="tlb-date">v2.3.0 — Jun 2026</p>
+        <p class="tlb-desc">Performance pass: 40% smaller bundle.</p>
+      </div>
+    </li>
+    <li class="tlb-item">
+      <span class="tlb-dot" aria-hidden="true"></span>
+      <div class="tlb-body">
+        <p class="tlb-date">v2.2.0 — Mar 2026</p>
+        <p class="tlb-desc">Initial public release.</p>
+      </div>
+    </li>
+  </ol>
+</main>
+</body>
+</html>

--- a/submissions/examples/timeline-branch-qz9k/style.css
+++ b/submissions/examples/timeline-branch-qz9k/style.css
@@ -1,0 +1,75 @@
+/* Timeline
+   Each item's connector is a ::before extending UPWARD from its own dot to
+   the previous item's dot (negative top, positive height via calc), so no
+   item needs to know the previous item's height -- only its own position
+   relative to the fixed dot column. */
+
+.tlb-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.tlb-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.tlb-lede { margin: 0 0 2rem; color: #576073; }
+
+.tlb-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tlb-item {
+  position: relative;
+  padding-left: 1.75rem;
+  padding-bottom: 1.75rem;
+}
+
+.tlb-item:last-child {
+  padding-bottom: 0;
+}
+
+.tlb-dot {
+  position: absolute;
+  top: 0.3rem;
+  left: 0;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: #4c6ef5;
+}
+
+.tlb-item:not(:first-child)::before {
+  content: "";
+  position: absolute;
+  top: -1.45rem;
+  left: 0.3rem;
+  width: 2px;
+  height: 1.75rem;
+  background: #d3d8e2;
+}
+
+.tlb-date {
+  margin: 0 0 0.2em;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.tlb-desc {
+  margin: 0;
+  color: #576073;
+  font-size: 0.92rem;
+}
+
+@media (forced-colors: active) {
+  .tlb-dot { forced-color-adjust: none; background: Highlight; }
+  .tlb-item::before { background: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tlb-wrap { color: #e6e9f2; }
+  .tlb-lede, .tlb-desc { color: #99a1b4; }
+  .tlb-item::before { background: #2a303c; }
+}


### PR DESCRIPTION
Closes #75597

Vertical event timeline. Each item draws its own fixed-length connector reaching up to the previous dot rather than one shared line spanning the full list height, so items can be added, removed, or reordered with no recalculation.

- Real <ol>, decorative dots marked aria-hidden