### PR TITLE
feat: add Countdown example (countdown-flip-qz9k)

### DIFF
--- a/submissions/examples/countdown-flip-qz9k/README.md
+++ b/submissions/examples/countdown-flip-qz9k/README.md
@@ -1,0 +1,36 @@
+# Countdown
+
+## What does this do?
+
+An hours:minutes:seconds countdown where each digit's text is generated CSS
+content, read from a per-unit custom property (`--cd-content`) that the
+script updates once per tick.
+
+## How is it used?
+
+```html
+<span class="cd-unit" id="cd-h"><span class="cd-num"></span><span class="cd-label">hrs</span></span>
+```
+
+```js
+el.style.setProperty('--cd-content', '"' + text + '"');
+```
+
+`.cd-num::before { content: var(--cd-content, "00"); }` renders the digits;
+the script never sets `textContent` on the unit — only the custom property.
+
+## Why is it useful?
+
+A countdown ticking every second is a sustained, repeating DOM write; doing
+that via `textContent` on a real text node works fine, but every popular
+"animated flip" variant of a countdown tends to rebuild inner markup
+(nested spans for old/new digit) on every tick, which means new DOM nodes
+created and discarded once per second for as long as the countdown runs.
+Routing the digit through a CSS custom property read by generated content
+means each tick is a single `style.setProperty` call — no nodes created,
+no `innerHTML` parsing, just the browser's cheapest possible content update.
+
+The `cdSet` helper also bails out early if the formatted value hasn't
+actually changed (`data-value` compared before writing), so a tick where
+the number is unchanged (impossible for seconds, but relevant if this
+pattern is reused for a slower-ticking unit) touches nothing at all.

--- a/submissions/examples/countdown-flip-qz9k/demo.html
+++ b/submissions/examples/countdown-flip-qz9k/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Countdown</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function cdSet(el, value) {
+    var text = String(value).padStart(2, '0');
+    if (el.dataset.value === text) return;
+    el.dataset.value = text;
+    el.style.setProperty('--cd-content', '"' + text + '"');
+  }
+
+  function cdTick() {
+    var now = new Date();
+    var end = new Date();
+    end.setHours(24, 0, 0, 0);
+    var diff = Math.max(0, end - now);
+    var h = Math.floor(diff / 3600000);
+    var m = Math.floor((diff % 3600000) / 60000);
+    var s = Math.floor((diff % 60000) / 1000);
+    cdSet(document.getElementById('cd-h'), h);
+    cdSet(document.getElementById('cd-m'), m);
+    cdSet(document.getElementById('cd-s'), s);
+  }
+
+  cdTick();
+  setInterval(cdTick, 1000);
+</script>
+</head>
+<body>
+<main class="cd-wrap">
+  <h1 class="cd-h1">Offer Ends In</h1>
+  <p class="cd-lede">Each unit's digits live in a CSS custom property read by content, so updating the count is one style write per tick with no innerHTML churn or extra DOM nodes.</p>
+
+  <div class="cd-display">
+    <span class="cd-unit" id="cd-h" data-value="00"><span class="cd-num"></span><span class="cd-label">hrs</span></span>
+    <span class="cd-sep">:</span>
+    <span class="cd-unit" id="cd-m" data-value="00"><span class="cd-num"></span><span class="cd-label">min</span></span>
+    <span class="cd-sep">:</span>
+    <span class="cd-unit" id="cd-s" data-value="00"><span class="cd-num"></span><span class="cd-label">sec</span></span>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/countdown-flip-qz9k/style.css
+++ b/submissions/examples/countdown-flip-qz9k/style.css
@@ -1,0 +1,74 @@
+/* Countdown
+   The digit text is painted by .cd-num::before reading the --cd-content
+   custom property, set once per tick via inline style -- the script never
+   touches textContent/innerHTML, so there's no DOM node churn on a
+   once-per-second timer. */
+
+.cd-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  text-align: center;
+}
+
+.cd-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.cd-lede { margin: 0 0 2rem; color: #576073; text-align: left; }
+
+.cd-display {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.cd-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+
+  --cd-content: "00";
+}
+
+.cd-num {
+  display: inline-block;
+  min-width: 2.4ch;
+  padding: 0.4em 0.3em;
+  border-radius: 0.5rem;
+  background: #1c2028;
+  color: #fff;
+  font-size: 1.8rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.cd-num::before {
+  content: var(--cd-content, "00");
+}
+
+.cd-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8b93a3;
+}
+
+.cd-sep {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #8b93a3;
+  align-self: flex-start;
+  margin-top: 0.35em;
+}
+
+@media (forced-colors: active) {
+  .cd-num { forced-color-adjust: none; background: ButtonText; color: ButtonFace; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cd-wrap { color: #e6e9f2; }
+  .cd-lede { color: #99a1b4; }
+  .cd-num { background: #2a303c; }
+}


### PR DESCRIPTION
Closes #75598

HH:MM:SS countdown. Each digit is generated content reading a per-unit CSS custom property, updated once per tick via style.setProperty — no textContent/innerHTML writes and no DOM node churn on a once-per-second timer.