### PR TITLE
feat: add useKeypress hook (use-keypress-qz9k)

### DIFF
--- a/submissions/react/use-keypress-qz9k/README.md
+++ b/submissions/react/use-keypress-qz9k/README.md
@@ -1,0 +1,41 @@
+# useKeypress
+
+Calls a callback when a specific key is pressed, ignoring keystrokes typed
+into inputs, textareas, or contentEditable elements by default.
+
+## API
+
+```js
+useKeypress(key, onPress, { ignoreInputs });
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `key` | `string` | — | `KeyboardEvent.key` value to match, e.g. `'Escape'`, `'/'`. |
+| `onPress` | `(event: KeyboardEvent) => void` | — | Called on a matching, non-input keydown. |
+| `ignoreInputs` | `boolean` | `true` | Set `false` for shortcuts that should fire even while typing. |
+
+## Usage
+
+```jsx
+function CommandPalette({ onOpen }) {
+  useKeypress('/', onOpen);
+  return null;
+}
+```
+
+## Why is it useful?
+
+A global keyboard shortcut hook built without an input guard breaks the
+moment a user types the shortcut key while filling out a form — pressing
+`/` to open a command palette while typing a URL containing a slash into a
+text field is the textbook version of this bug. Checking whether
+`event.target` is an `<input>`, `<textarea>`, or `contentEditable` element
+before invoking the callback (the default, opt-out via `ignoreInputs:
+false`) means a single-character shortcut hook is safe to use globally
+without every consumer having to reimplement that guard.
+
+The listener is attached once per `key`/`onPress`/`ignoreInputs` triple via
+the effect's dependency array, so passing a stable `onPress` (e.g. wrapped
+in `useCallback` at the call site) avoids re-attaching the global listener
+on every render.

--- a/submissions/react/use-keypress-qz9k/useKeypress.jsx
+++ b/submissions/react/use-keypress-qz9k/useKeypress.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+const isTypingTarget = (el) =>
+  el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
+
+/**
+ * useKeypress
+ * Calls onPress when `key` is pressed, ignoring keystrokes that land in a
+ * text input, textarea, or contentEditable element -- a global shortcut
+ * firing while the user is typing into a field is the most common bug in
+ * hand-rolled keyboard shortcut handlers.
+ */
+export function useKeypress(key, onPress, { ignoreInputs = true } = {}) {
+  useEffect(() => {
+    function handleKeyDown(event) {
+      if (event.key !== key) return;
+      if (ignoreInputs && isTypingTarget(event.target)) return;
+      onPress(event);
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [key, onPress, ignoreInputs]);
+}
+
+export default useKeypress;


### PR DESCRIPTION
Closes #75599

React hook firing a callback on a matching keydown. Ignores input/textarea/contentEditable targets by default, since the classic bug in hand-rolled shortcut handlers is a global shortcut firing while the user types the same character into an unrelated form field.