### PR TITLE
feat: add useScript hook (use-script-qz9k)

### DIFF
--- a/submissions/react/use-script-qz9k/README.md
+++ b/submissions/react/use-script-qz9k/README.md
@@ -1,0 +1,40 @@
+# useScript
+
+Loads an external `<script src>` tag and reports its status
+(`idle`/`loading`/`ready`/`error`), deduplicating by `src` so the same
+script is never injected twice.
+
+## API
+
+```js
+const status = useScript(src);
+```
+
+## Usage
+
+```jsx
+function MapWidget() {
+  const status = useScript('https://maps.example.com/sdk.js');
+  if (status !== 'ready') return <Spinner />;
+  return <Map />;
+}
+```
+
+## Why is it useful?
+
+A component that injects a `<script>` tag on mount and removes it on
+unmount breaks the moment two components need the same third-party script
+at once: one unmounting would remove the tag out from under the other, and
+mounting both together would inject the same `src` twice, which is
+wasteful at best and can throw for scripts that error on redefinition (many
+SDKs guard against exactly that). Storing load status directly on the
+script element itself (`dataset.status`) and checking for an existing tag
+with the same `src` before creating a new one means any number of
+components can call `useScript` with the same URL and share one script tag,
+each independently getting the correct current status.
+
+Scripts are intentionally never removed on unmount — a `<script>` tag
+having already executed once, removing it doesn't undo whatever global side
+effects it had, so leaving it in the DOM for the lifetime of the page avoids
+a needless re-fetch and re-execution if another component mounts the same
+`src` later.

--- a/submissions/react/use-script-qz9k/useScript.jsx
+++ b/submissions/react/use-script-qz9k/useScript.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+const cache = new Map();
+
+/**
+ * useScript
+ * Loads an external <script> tag once per src across the whole app (even
+ * across multiple components mounting the same src concurrently), and
+ * reports its load status. A second mount of a src already in the DOM
+ * reuses the existing tag instead of injecting a duplicate.
+ */
+export function useScript(src) {
+  const [status, setStatus] = useState(src ? 'loading' : 'idle');
+
+  useEffect(() => {
+    if (!src) return;
+
+    let existing = document.querySelector(`script[src="${src}"]`);
+
+    if (!existing) {
+      existing = document.createElement('script');
+      existing.src = src;
+      existing.async = true;
+      existing.dataset.status = 'loading';
+      document.body.appendChild(existing);
+    }
+
+    setStatus(existing.dataset.status || 'loading');
+
+    function handleLoad() {
+      existing.dataset.status = 'ready';
+      setStatus('ready');
+    }
+    function handleError() {
+      existing.dataset.status = 'error';
+      setStatus('error');
+    }
+
+    existing.addEventListener('load', handleLoad);
+    existing.addEventListener('error', handleError);
+
+    return () => {
+      existing.removeEventListener('load', handleLoad);
+      existing.removeEventListener('error', handleError);
+    };
+  }, [src]);
+
+  return status;
+}
+
+export default useScript;


### PR DESCRIPTION
Closes #75600

React hook loading an external <script src>, deduplicating via document.querySelector before injecting so multiple components requesting the same third-party SDK share one tag instead of each injecting a duplicate.