### PR TITLE
feat: add useKeySequence hook (use-key-sequence-qz9k)

### DIFF
--- a/submissions/react/use-key-sequence-qz9k/README.md
+++ b/submissions/react/use-key-sequence-qz9k/README.md
@@ -1,0 +1,43 @@
+# useKeySequence
+
+Calls a callback when an ordered sequence of keys is pressed within a
+timing window — a "g then i" go-to-inbox shortcut, or a Konami-code style
+easter egg.
+
+## API
+
+```js
+useKeySequence(sequence, onMatch, timeout);
+```
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `sequence` | `string[]` | — | Ordered `KeyboardEvent.key` values, e.g. `['g', 'i']`. |
+| `onMatch` | `(event: KeyboardEvent) => void` | — | Called when the full sequence completes in time. |
+| `timeout` | `number` | `1000` | Max ms allowed between consecutive keys before progress resets. |
+
+## Usage
+
+```jsx
+function InboxShortcut({ goToInbox }) {
+  useKeySequence(['g', 'i'], goToInbox);
+  return null;
+}
+```
+
+## Why is it useful?
+
+Multi-key shortcuts ("g then i", rather than a single modifier combo) need
+to track partial progress through the sequence and reset it both on a
+non-matching key and on a pause exceeding the timing window — without the
+timeout reset, pressing "g" then walking away and coming back an hour later
+to type an unrelated "i" would incorrectly fire the shortcut. Progress is
+tracked in a `ref`, not `useState`, deliberately: a fast two-key sequence
+completing in under 300ms shouldn't trigger an intermediate re-render for
+the "first key matched" state, since nothing needs to be rendered until the
+whole sequence resolves.
+
+A wrong key mid-sequence doesn't always reset all the way to zero — it
+restarts at position 1 if the wrong key happens to also be the sequence's
+first key (typing "g" then "g" then "i" still matches `['g', 'i']`), which
+matches how users actually mistype a repeated first character.

--- a/submissions/react/use-key-sequence-qz9k/useKeySequence.jsx
+++ b/submissions/react/use-key-sequence-qz9k/useKeySequence.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * useKeySequence
+ * Calls onMatch when the given ordered sequence of keys is pressed within
+ * `timeout` ms of each other (e.g. a Konami-code style easter egg, or a
+ * "g then i" go-to-inbox shortcut). Tracks progress with a ref, not state,
+ * so a fast sequence never triggers intermediate re-renders.
+ */
+export function useKeySequence(sequence, onMatch, timeout = 1000) {
+  const progressRef = useRef(0);
+  const lastTimeRef = useRef(0);
+
+  useEffect(() => {
+    function handleKeyDown(event) {
+      const now = Date.now();
+      if (now - lastTimeRef.current > timeout) progressRef.current = 0;
+      lastTimeRef.current = now;
+
+      const expected = sequence[progressRef.current];
+      if (event.key.toLowerCase() === expected.toLowerCase()) {
+        progressRef.current += 1;
+        if (progressRef.current === sequence.length) {
+          progressRef.current = 0;
+          onMatch(event);
+        }
+      } else {
+        progressRef.current = event.key.toLowerCase() === sequence[0].toLowerCase() ? 1 : 0;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sequence.join(','), onMatch, timeout]);
+}
+
+export default useKeySequence;


### PR DESCRIPTION
Closes #75601

React hook matching an ordered key sequence within a timing window. Progress lives in a ref, not state, so a fast sequence causes no intermediate re-renders; the timeout resets progress so an old partial match can't combine with an unrelated keystroke later.