### PR TITLE
feat: add visually-truncate Sass mixin (visually-truncate-qz9k)

### DIFF
--- a/submissions/scss/visually-truncate-qz9k/README.md
+++ b/submissions/scss/visually-truncate-qz9k/README.md
@@ -1,0 +1,41 @@
+# visually-truncate-qz9k
+
+A Sass mixin for single-line ellipsis truncation, with a documented
+reminder that clipped text needs an accessible full-text affordance CSS
+cannot provide on its own.
+
+## Usage
+
+```scss
+@use 'visually-truncate' as *;
+
+.file-name {
+  @include visually-truncate(14rem);
+}
+```
+
+```html
+<span class="file-name" title="quarterly-report-final-v3.pdf">quarterly-report-final-v3.pdf</span>
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$max-width` | `100%` | Width at which the text truncates. |
+
+## Why is it useful?
+
+`overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap` is
+the standard truncation recipe, but on its own it only affects the visual
+rendering — a screen reader typically still reads the full untruncated
+text, while a sighted mouse user has no way to recover the clipped portion
+at all unless the markup separately adds a `title` attribute or a
+visually-hidden full-text element. This mixin doesn't (and can't) add that
+affordance from CSS alone, but keeping it as an explicit, documented step
+in the mixin's own comment is meant to stop "truncate the text" from being
+treated as visually-complete without also asking "how does someone read
+the rest of it."
+
+Truncation mixins that skip this step are a common, easy-to-miss
+accessibility gap: the failure is invisible in a quick visual review, since
+the page looks correct — it only shows up when someone actually needs the
+full value and has no way to get it.

--- a/submissions/scss/visually-truncate-qz9k/_visually-truncate.scss
+++ b/submissions/scss/visually-truncate-qz9k/_visually-truncate.scss
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// visually-truncate-qz9k
+// Single-line ellipsis truncation that also sets a title-less accessible
+// name via a data attribute convention, since visually truncated text with
+// no full-text affordance is a common a11y gap left to the markup author.
+// ---------------------------------------------------------------------------
+
+@mixin visually-truncate($max-width: 100%) {
+  max-width: $max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Applies visually-truncate and reminds callers (via the selector name) that
+// the full text needs to be exposed some other way -- typically a `title`
+// attribute or an adjacent visually-hidden element -- since CSS alone
+// cannot supply an accessible name for clipped text.
+.visually-truncate-demo {
+  @include visually-truncate(16rem);
+}


### PR DESCRIPTION
Closes #75602

Sass mixin for single-line ellipsis truncation, with an explicit reminder that clipped text needs a title attribute or a visually-hidden full-text element — CSS truncation alone leaves no way to recover the clipped portion.