### PR TITLE
feat: add input-reset Sass mixin (input-reset-qz9k)

### DIFF
--- a/submissions/scss/input-reset-qz9k/README.md
+++ b/submissions/scss/input-reset-qz9k/README.md
@@ -1,0 +1,37 @@
+# input-reset-qz9k
+
+A Sass mixin normalizing cross-browser text input quirks — iOS zoom-on-focus,
+Chromium's autofill background, Firefox's extra inner border padding —
+without disabling `:focus-visible`.
+
+## Usage
+
+```scss
+@use 'input-reset' as *;
+
+.text-field {
+  @include input-reset;
+  border: 1px solid #ccc;
+  border-radius: 0.4rem;
+  padding: 0.6em 0.8em;
+}
+```
+
+## Why is it useful?
+
+Three specific input quirks cause disproportionate debugging time relative
+to how small their fixes are: iOS Safari zooms the entire viewport when
+focusing any input whose computed `font-size` is under 16px, which reads as
+"the page jumps" rather than an obvious font-size bug; Chromium paints
+autofilled fields with a yellow background that a plain `background: white`
+override doesn't reliably beat due to how autofill styling is applied;
+and Firefox adds focus-ring padding inside `<button>`/`<input
+type="submit">` via `::-moz-focus-inner` that shows up as a few px of
+unexplained inner padding no other browser has.
+
+The `font-size: max(1em, 16px)` line specifically prevents the iOS zoom
+without hard-coding a fixed size — a caller setting a larger `font-size`
+after including the mixin still gets their size, since `max()` only raises
+the floor, never lowers an already-larger value. None of these fixes touch
+`outline` or `:focus-visible`, so the reset doesn't have the common side
+effect of also silently removing keyboard focus indication.

--- a/submissions/scss/input-reset-qz9k/_input-reset.scss
+++ b/submissions/scss/input-reset-qz9k/_input-reset.scss
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------
+// input-reset-qz9k
+// Normalizes cross-browser text input styling (autofill background, iOS
+// zoom-on-focus, Firefox's extra inner padding) without touching
+// :focus-visible, so keyboard focus stays visible after the reset.
+// ---------------------------------------------------------------------------
+
+@mixin input-reset {
+  appearance: none;
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+
+  // iOS Safari zooms the viewport on focusing any input with a computed
+  // font-size under 16px -- this floor prevents that zoom without forcing
+  // a specific visual size everywhere the mixin is used.
+  font-size: max(1em, 16px);
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+
+  // Neutralize the yellow autofill background Chromium paints, without
+  // disabling autofill itself.
+  &:-webkit-autofill {
+    -webkit-text-fill-color: currentColor;
+    transition: background-color 999999s ease 0s;
+  }
+}
+
+.input-reset-demo {
+  @include input-reset;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.4rem;
+  padding: 0.5em 0.75em;
+}


### PR DESCRIPTION
Closes #75603

Sass mixin fixing three cross-browser input quirks: iOS zoom-on-focus (via font-size: max(1em, 16px)), Chromium's autofill background, and Firefox's ::-moz-focus-inner padding — none of which touch :focus-visible, so keyboard focus indication survives the reset.