### PR TITLE
feat: add safe-print Sass mixin (safe-print-qz9k)

### DIFF
--- a/submissions/scss/safe-print-qz9k/README.md
+++ b/submissions/scss/safe-print-qz9k/README.md
@@ -1,0 +1,39 @@
+# safe-print-qz9k
+
+A Sass mixin providing sane print-stylesheet defaults: strips dark
+backgrounds and shadows that waste ink, appends link destinations as
+visible text, and hides UI that only makes sense on screen.
+
+## Usage
+
+```scss
+@use 'safe-print';
+```
+
+Including the partial applies its `@media print` block globally — there's
+no per-element opt-in needed, since every one of its fixes is a safe
+default for any page. Opt individual elements out with `.no-print` or a
+`data-print-hide` attribute.
+
+```html
+<nav class="no-print">...</nav>
+```
+
+## Why is it useful?
+
+A page styled only for screen tends to print badly in three specific,
+recurring ways: dark-themed cards and shadows print as heavy ink blocks
+that waste toner and reduce legibility on paper, hyperlinks are
+meaningless once printed since the destination URL is invisible on the
+page, and fixed/sticky headers or floating action buttons repeat on every
+printed page, overlapping content instead of scrolling out of the way like
+they do on screen.
+
+Appending `attr(href)` after every link's text (skipping in-page anchors
+and `javascript:` pseudo-links, which have no meaningful printed
+destination) means a printed page retains the information a hyperlink
+represents even once its clickability is gone. `!important` is used
+deliberately here — a print stylesheet exists specifically to override
+whatever the screen stylesheet already decided, so it needs to reliably win
+that fight rather than depend on selector specificity matching everywhere
+the mixin is included.

--- a/submissions/scss/safe-print-qz9k/_safe-print.scss
+++ b/submissions/scss/safe-print-qz9k/_safe-print.scss
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------
+// safe-print-qz9k
+// Print-stylesheet defaults that fix the most common print regressions:
+// dark backgrounds bleeding ink, links losing their destination on paper,
+// and fixed-position UI overlapping every printed page.
+// ---------------------------------------------------------------------------
+
+@mixin safe-print {
+  @media print {
+    * {
+      background: transparent !important;
+      color: #000 !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+    }
+
+    a[href]::after {
+      content: " (" attr(href) ")";
+      font-size: 0.85em;
+      color: #444;
+    }
+
+    a[href^="#"]::after,
+    a[href^="javascript:"]::after {
+      content: "";
+    }
+
+    [data-print-hide],
+    .no-print {
+      display: none !important;
+    }
+
+    img {
+      max-width: 100% !important;
+    }
+  }
+}
+
+@include safe-print;


### PR DESCRIPTION
Closes #75604

Sass mixin with print-stylesheet defaults: strips dark backgrounds/shadows that waste ink, appends each link's href as visible text, and hides fixed/sticky UI via .no-print / [data-print-hide].