### PR TITLE
feat: add Tab Panel Fade example (tab-panel-fade-qz9k)

### DIFF
--- a/submissions/examples/tab-panel-fade-qz9k/README.md
+++ b/submissions/examples/tab-panel-fade-qz9k/README.md
@@ -1,0 +1,40 @@
+# Tab Panel Fade
+
+## What does this do?
+
+A tabbed panel interface (settings page style) implementing the full
+WAI-ARIA Tabs pattern — arrow-key navigation, `Home`/`End`, roving
+`tabindex` — where switching panels cross-fades the newly shown panel in,
+even when re-selecting the already-active tab.
+
+## How is it used?
+
+```html
+<div class="tpf-tablist" role="tablist" onkeydown="tpfKeydown(event)">
+  <button role="tab" id="tab-profile" aria-controls="panel-profile" aria-selected="true" tabindex="0" onclick="tpfActivate(this)">Profile</button>
+  <!-- ... -->
+</div>
+<div class="tpf-panel" id="panel-profile" role="tabpanel" aria-labelledby="tab-profile" tabindex="0">...</div>
+```
+
+`tpfActivate` toggles `aria-selected`, roving `tabindex` (only the active
+tab is in the Tab order — arrow keys move between tabs), and each panel's
+`hidden` attribute; `tpfKeydown` implements `ArrowLeft`/`ArrowRight`/`Home`/
+`End` per the ARIA Tabs authoring practice.
+
+## Why is it useful?
+
+The fade only works reliably because it's a CSS *animation*, not a
+*transition*: a transition only fires on a property value change, so
+toggling `hidden` off on a panel whose opacity was already `1` before it was
+hidden produces no visible transition at all — the browser has nothing to
+interpolate from. An `animation` re-applied via `:not([hidden])` always
+starts from its declared `0%` keyframe regardless of the element's prior
+state, so the fade-in plays correctly on every activation, first switch or
+the hundredth.
+
+Implementing the full keyboard pattern (not just click-to-switch) matters
+because tabs are one of the ARIA patterns screen reader and keyboard users
+specifically expect arrow-key behaviour from — a mouse-only tab
+implementation is a common and easy-to-miss accessibility gap that looks
+completely correct in a visual review.

--- a/submissions/examples/tab-panel-fade-qz9k/demo.html
+++ b/submissions/examples/tab-panel-fade-qz9k/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Tab Panel Fade</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function tpfActivate(tab) {
+    var list = tab.closest('.tpf-tablist');
+    var tabs = list.querySelectorAll('[role="tab"]');
+    var panels = document.querySelectorAll('.tpf-panel');
+
+    tabs.forEach(function (t) {
+      var selected = t === tab;
+      t.setAttribute('aria-selected', String(selected));
+      t.tabIndex = selected ? 0 : -1;
+    });
+
+    panels.forEach(function (panel) {
+      panel.hidden = panel.id !== tab.getAttribute('aria-controls');
+    });
+
+    tab.focus();
+  }
+
+  function tpfKeydown(event) {
+    var tabs = Array.from(event.currentTarget.querySelectorAll('[role="tab"]'));
+    var index = tabs.indexOf(event.target);
+    if (index === -1) return;
+
+    var next = null;
+    if (event.key === 'ArrowRight') next = tabs[(index + 1) % tabs.length];
+    if (event.key === 'ArrowLeft') next = tabs[(index - 1 + tabs.length) % tabs.length];
+    if (event.key === 'Home') next = tabs[0];
+    if (event.key === 'End') next = tabs[tabs.length - 1];
+
+    if (next) {
+      event.preventDefault();
+      tpfActivate(next);
+    }
+  }
+</script>
+</head>
+<body>
+<main class="tpf-wrap">
+  <h1 class="tpf-h1">Account Settings</h1>
+  <p class="tpf-lede">Switching tabs cross-fades panels via an animation keyed to each panel's own id, so re-selecting an already-active tab still replays the fade instead of doing nothing.</p>
+
+  <div class="tpf-tablist" role="tablist" aria-label="Settings sections" onkeydown="tpfKeydown(event)">
+    <button type="button" role="tab" id="tpf-tab-profile" aria-controls="tpf-panel-profile" aria-selected="true" tabindex="0" class="tpf-tab" onclick="tpfActivate(this)">Profile</button>
+    <button type="button" role="tab" id="tpf-tab-billing" aria-controls="tpf-panel-billing" aria-selected="false" tabindex="-1" class="tpf-tab" onclick="tpfActivate(this)">Billing</button>
+    <button type="button" role="tab" id="tpf-tab-security" aria-controls="tpf-panel-security" aria-selected="false" tabindex="-1" class="tpf-tab" onclick="tpfActivate(this)">Security</button>
+  </div>
+
+  <div class="tpf-panel" id="tpf-panel-profile" role="tabpanel" aria-labelledby="tpf-tab-profile" tabindex="0">
+    <p>Update your name, avatar, and public profile details.</p>
+  </div>
+  <div class="tpf-panel" id="tpf-panel-billing" role="tabpanel" aria-labelledby="tpf-tab-billing" tabindex="0" hidden>
+    <p>Manage your plan, payment method, and invoices.</p>
+  </div>
+  <div class="tpf-panel" id="tpf-panel-security" role="tabpanel" aria-labelledby="tpf-tab-security" tabindex="0" hidden>
+    <p>Change your password and review active sessions.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/tab-panel-fade-qz9k/style.css
+++ b/submissions/examples/tab-panel-fade-qz9k/style.css
@@ -1,0 +1,85 @@
+/* Tab Panel Fade
+   The fade is a keyframe animation applied via the panel's own :not([hidden])
+   state, not a transition -- transitions don't replay on an element that was
+   just unhidden with the same end state, but a freshly-applied animation
+   always plays from its 0% frame. */
+
+.tpf-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.tpf-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.tpf-lede { margin: 0 0 2rem; color: #576073; }
+
+.tpf-tablist {
+  display: flex;
+  gap: 0.3rem;
+  border-bottom: 1px solid #dfe3ec;
+  margin-bottom: 1.25rem;
+}
+
+.tpf-tab {
+  padding: 0.6em 1em;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  color: #576073;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.tpf-tab:hover {
+  color: #1c2028;
+}
+
+.tpf-tab[aria-selected="true"] {
+  color: #4c6ef5;
+  border-color: #4c6ef5;
+}
+
+.tpf-tab:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.tpf-panel {
+  padding: 0.5rem 0.1rem;
+}
+
+.tpf-panel:not([hidden]) {
+  animation: tpf-fade-in 220ms ease;
+}
+
+.tpf-panel p {
+  margin: 0;
+  color: #576073;
+}
+
+@keyframes tpf-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tpf-tab { transition: none; }
+  .tpf-panel:not([hidden]) { animation: none; }
+}
+
+@media (forced-colors: active) {
+  .tpf-tab[aria-selected="true"] { forced-color-adjust: none; color: Highlight; border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .tpf-wrap { color: #e6e9f2; }
+  .tpf-lede { color: #99a1b4; }
+  .tpf-tablist { border-color: #2a303c; }
+  .tpf-tab { color: #99a1b4; }
+  .tpf-tab:hover { color: #e6e9f2; }
+  .tpf-panel p { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #78486

Full WAI-ARIA Tabs pattern (arrow-key nav, roving tabindex) whose panel switch cross-fades via a CSS animation keyed to :not([hidden]), which replays correctly even on re-selecting the already-active tab, unlike a transition would.