### PR TITLE
feat: add Share / Copy Link example (share-copy-link-qz9k)

### DIFF
--- a/submissions/examples/share-copy-link-qz9k/README.md
+++ b/submissions/examples/share-copy-link-qz9k/README.md
@@ -1,0 +1,42 @@
+# Share / Copy Link
+
+## What does this do?
+
+A share control with two buttons: "Copy" always copies the URL to the
+clipboard, and "Share" opens the OS-native share sheet (`navigator.share`)
+where available, falling back to the same copy behaviour where it isn't —
+so one component covers mobile share sheets and desktop copy-link without
+any markup-level feature detection.
+
+## How is it used?
+
+```html
+<input id="scl-url" value="https://example.com/..." readonly />
+<button onclick="sclCopy(this)">
+  <span class="scl-btn-label">Copy</span>
+  <span class="scl-btn-copied" aria-hidden="true">Copied</span>
+</button>
+<button onclick="sclNativeShare(this)">Share</button>
+```
+
+`sclCopy` tries `navigator.clipboard.writeText` first and falls back to a
+`select()` + `execCommand('copy')` pair on the (temporarily writable) URL
+input for non-secure contexts. `sclNativeShare` calls `navigator.share` when
+present and otherwise just calls `sclCopy`.
+
+## Why is it useful?
+
+`navigator.share` and the async Clipboard API have non-overlapping browser
+support in different directions — share is common on mobile, absent on most
+desktop browsers; clipboard write needs a secure context. A share button
+that only calls `navigator.share` silently does nothing on unsupported
+browsers unless it also falls back to copy, and a copy button that only uses
+the async Clipboard API breaks over plain HTTP or in older WebViews unless
+it also falls back to `execCommand`. Layering both fallbacks means the
+control degrades gracefully at every tier instead of failing outright on
+any one browser/context combination.
+
+Stacking "Copy" and "Copied" label text in the same grid cell (rather than
+swapping `textContent`) keeps the button's width constant across the state
+change, so neighbouring buttons in the row don't visibly shift when the
+label's character count changes.

--- a/submissions/examples/share-copy-link-qz9k/demo.html
+++ b/submissions/examples/share-copy-link-qz9k/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Share / Copy Link</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  async function sclCopy(button) {
+    var input = document.getElementById('scl-url');
+    var status = document.getElementById('scl-status');
+    var ok = false;
+
+    if (navigator.clipboard && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(input.value);
+        ok = true;
+      } catch (err) {
+        ok = false;
+      }
+    }
+
+    if (!ok) {
+      input.removeAttribute('readonly');
+      input.select();
+      try { ok = document.execCommand('copy'); } catch (err) { ok = false; }
+      input.setAttribute('readonly', '');
+    }
+
+    button.classList.toggle('scl-btn--copied', ok);
+    status.textContent = ok ? 'Link copied to clipboard' : 'Could not copy link';
+    clearTimeout(button._sclTimer);
+    button._sclTimer = setTimeout(function () {
+      button.classList.remove('scl-btn--copied');
+      status.textContent = '';
+    }, 2000);
+  }
+
+  function sclNativeShare(button) {
+    var url = document.getElementById('scl-url').value;
+    if (navigator.share) {
+      navigator.share({ url: url, title: document.title }).catch(function () {});
+    } else {
+      sclCopy(button);
+    }
+  }
+</script>
+</head>
+<body>
+<main class="scl-wrap">
+  <h1 class="scl-h1">Share this page</h1>
+  <p class="scl-lede">The share button calls the native Web Share sheet where it's available, and falls back to copy-to-clipboard everywhere else, so one control works across mobile and desktop without feature-detecting in markup.</p>
+
+  <div class="scl-row">
+    <input id="scl-url" class="scl-url" type="text" value="https://example.com/articles/css-share-pattern" readonly aria-label="Page URL" />
+    <button type="button" class="scl-btn" onclick="sclCopy(this)">
+      <span class="scl-btn-label">Copy</span>
+      <span class="scl-btn-copied" aria-hidden="true">Copied</span>
+    </button>
+    <button type="button" class="scl-btn scl-btn--share" onclick="sclNativeShare(this)">Share</button>
+  </div>
+  <p class="scl-status" id="scl-status" role="status" aria-live="polite"></p>
+</main>
+</body>
+</html>

--- a/submissions/examples/share-copy-link-qz9k/style.css
+++ b/submissions/examples/share-copy-link-qz9k/style.css
@@ -1,0 +1,108 @@
+/* Share / Copy Link
+   .scl-btn-label and .scl-btn-copied are stacked in the same grid cell like
+   the inline-edit pattern; toggling .scl-btn--copied swaps which is visible
+   without changing the button's width, so surrounding buttons don't shift
+   when the label text changes length. */
+
+.scl-wrap {
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.scl-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.scl-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.scl-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.scl-url {
+  flex: 1;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0.6em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  color: #576073;
+  background: #f8f9fb;
+  text-overflow: ellipsis;
+}
+
+.scl-btn {
+  position: relative;
+  display: grid;
+  flex: none;
+  padding: 0.6em 1.1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.scl-btn:hover { background: #e4e9f4; }
+.scl-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.scl-btn-label,
+.scl-btn-copied {
+  grid-area: 1 / 1;
+}
+
+.scl-btn-copied {
+  visibility: hidden;
+  color: #34a853;
+}
+
+.scl-btn--copied {
+  border-color: #34a853;
+}
+
+.scl-btn--copied .scl-btn-label {
+  visibility: hidden;
+}
+
+.scl-btn--copied .scl-btn-copied {
+  visibility: visible;
+}
+
+.scl-btn--share {
+  background: #4c6ef5;
+  border-color: #4c6ef5;
+  color: #fff;
+}
+
+.scl-btn--share:hover {
+  background: #3b5be0;
+}
+
+.scl-status {
+  margin: 0.6rem 0 0;
+  font-size: 0.85rem;
+  color: #576073;
+  min-height: 1.2em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scl-btn { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .scl-url, .scl-btn { border-color: CanvasText; }
+  .scl-btn--share { forced-color-adjust: none; background: Highlight; color: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .scl-wrap { color: #e6e9f2; }
+  .scl-lede { color: #99a1b4; }
+  .scl-url { background: #171b23; border-color: #2a303c; color: #99a1b4; }
+  .scl-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+  .scl-btn:hover { background: #262e3d; }
+  .scl-status { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #78487

Share button calls navigator.share where available and falls back to copy-to-clipboard everywhere else; copy itself falls back from the async Clipboard API to execCommand for non-secure contexts.