### PR TITLE
feat: add Form Progress Hint example (form-progress-hint-qz9k)

### DIFF
--- a/submissions/examples/form-progress-hint-qz9k/README.md
+++ b/submissions/examples/form-progress-hint-qz9k/README.md
@@ -1,0 +1,42 @@
+# Form Progress Hint
+
+## What does this do?
+
+A form completion indicator that tracks only the `required` fields —
+optional fields don't count toward or against the percentage — updating
+live via `oninput` on the form, with a status line announced through
+`aria-live` alongside the visual bar.
+
+## How is it used?
+
+```html
+<form class="fph-form" oninput="fphUpdate(this)">
+  <div class="fph-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+    <div class="fph-progress-fill" id="fph-bar"></div>
+  </div>
+  <label for="fph-name">Full name <span class="fph-req">*</span></label>
+  <input class="fph-field" id="fph-name" required />
+  <!-- an optional field with no `required`, contributing nothing to the count -->
+</form>
+```
+
+`fphUpdate` selects only `.fph-field[required]`, counts how many currently
+have a non-empty trimmed value, and writes both the bar's inline `width`
+and the `aria-valuenow`/status text from that ratio.
+
+## Why is it useful?
+
+A progress indicator based on "fields filled out of total fields" over-
+counts completion whenever a form mixes required and optional fields — a
+user who has filled every required field but skipped an optional "Company"
+field sees a bar that never reaches 100%, which reads as an error state
+even though the form is actually submittable. Scoping the count to
+`[required]` specifically means the bar's 100% state corresponds exactly to
+"this form can be submitted," not to an arbitrary field count that includes
+fields the user is free to leave blank.
+
+The bar's width changes are instant script writes (`style.width = pct +
+'%'`), but the visible smooth fill comes entirely from the CSS
+`transition: width` on `.fph-progress-fill` — the script never animates
+anything itself, keeping the animation declarative and controllable
+independently of the counting logic.

--- a/submissions/examples/form-progress-hint-qz9k/demo.html
+++ b/submissions/examples/form-progress-hint-qz9k/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Form Progress Hint</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function fphUpdate(form) {
+    var fields = form.querySelectorAll('.fph-field[required]');
+    var filled = 0;
+    fields.forEach(function (field) {
+      if (field.value.trim()) filled++;
+    });
+    var pct = fields.length ? Math.round((filled / fields.length) * 100) : 0;
+    var bar = document.getElementById('fph-bar');
+    var label = document.getElementById('fph-label');
+    bar.style.width = pct + '%';
+    bar.parentElement.setAttribute('aria-valuenow', String(pct));
+    label.textContent = filled === fields.length
+      ? 'All required fields complete'
+      : filled + ' of ' + fields.length + ' required fields complete';
+  }
+</script>
+</head>
+<body>
+<main class="fph-wrap">
+  <h1 class="fph-h1">Create Profile</h1>
+  <p class="fph-lede">A completion bar tracks only the required fields, updating live as each is filled, so the percentage always reflects genuine remaining work rather than a step count that ignores which fields are optional.</p>
+
+  <form class="fph-form" oninput="fphUpdate(this)">
+    <div class="fph-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Form completion">
+      <div class="fph-progress-fill" id="fph-bar"></div>
+    </div>
+    <p class="fph-status" id="fph-label" aria-live="polite">0 of 3 required fields complete</p>
+
+    <label class="fph-label" for="fph-name">Full name <span class="fph-req">*</span></label>
+    <input class="fph-field" id="fph-name" type="text" required />
+
+    <label class="fph-label" for="fph-email">Email <span class="fph-req">*</span></label>
+    <input class="fph-field" id="fph-email" type="email" required />
+
+    <label class="fph-label" for="fph-company">Company (optional)</label>
+    <input class="fph-field" id="fph-company" type="text" />
+
+    <label class="fph-label" for="fph-role">Role <span class="fph-req">*</span></label>
+    <input class="fph-field" id="fph-role" type="text" required />
+  </form>
+</main>
+</body>
+</html>

--- a/submissions/examples/form-progress-hint-qz9k/style.css
+++ b/submissions/examples/form-progress-hint-qz9k/style.css
@@ -1,0 +1,90 @@
+/* Form Progress Hint
+   .fph-progress-fill's width is set inline by the script per input, and the
+   transition here is what turns each discrete jump into a smooth animated
+   fill -- the script only ever writes a target percentage, never animates
+   it directly. */
+
+.fph-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.fph-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.fph-lede { margin: 0 0 1.75rem; color: #576073; }
+
+.fph-progress {
+  height: 0.5rem;
+  border-radius: 999px;
+  background: #e4e7ef;
+  overflow: hidden;
+  margin-bottom: 0.4rem;
+}
+
+.fph-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: #4c6ef5;
+  border-radius: inherit;
+  transition: width 260ms ease;
+}
+
+.fph-status {
+  margin: 0 0 1.5rem;
+  font-size: 0.85rem;
+  color: #576073;
+}
+
+.fph-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.fph-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  margin-top: 0.6rem;
+}
+
+.fph-req {
+  color: #e0483f;
+}
+
+.fph-field {
+  box-sizing: border-box;
+  padding: 0.55em 0.75em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  transition: border-color 160ms ease;
+}
+
+.fph-field:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.fph-field:required:valid {
+  border-color: #34a853;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fph-progress-fill, .fph-field { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .fph-progress { forced-color-adjust: none; background: Canvas; border: 1px solid CanvasText; }
+  .fph-progress-fill { background: Highlight; }
+  .fph-field { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fph-wrap { color: #e6e9f2; }
+  .fph-lede, .fph-status { color: #99a1b4; }
+  .fph-progress { background: #2a303c; }
+  .fph-field { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #78488

Completion bar scoped to only [required] fields, so an optional field left blank never prevents the bar from reaching 100% the way an all-fields count would.