### PR TITLE
feat: add useRenderCount and useWhyDidYouUpdate dev hooks (use-render-count-qz9k)

### DIFF
--- a/submissions/react/use-render-count-qz9k/README.md
+++ b/submissions/react/use-render-count-qz9k/README.md
@@ -1,0 +1,87 @@
+# useRenderCount
+
+Two small development-time debugging hooks: `useRenderCount` reports how
+many times the calling component has rendered, and `useWhyDidYouUpdate`
+logs which named props changed identity since the previous render.
+
+## API
+
+```js
+const renders = useRenderCount();
+useWhyDidYouUpdate('MyComponent', props);
+```
+
+## Usage
+
+```jsx
+function ExpensiveChart(props) {
+  useWhyDidYouUpdate('ExpensiveChart', props);
+  const renders = useRenderCount();
+  return <div data-render-count={renders}><Chart {...props} /></div>;
+}
+```
+
+## Why is it useful?
+
+"Why does this component re-render so often" is a question that's
+surprisingly tedious to answer by inspection alone, especially once a
+component takes half a dozen props and only one of them is actually
+changing on each parent re-render. `useWhyDidYouUpdate` does the diffing
+work directly: it keeps the previous render's props in a ref, and on every
+subsequent render, logs exactly which prop keys hold a different reference
+now versus last time — which reliably surfaces the common cause of an inline
+object or arrow function literal passed as a prop, since those get a new
+reference on every parent render even when their contents are identical.
+
+`useRenderCount` is the simpler companion: a raw count is often enough to
+confirm *whether* excessive re-rendering is even happening before reaching
+for the heavier prop-diffing tool. Both are meant for temporary use while
+debugging performance, not for shipping in application logic — they exist
+to answer a question during development, not to feed a decision at runtime.
+
+## Reading a suspiciously high render count
+
+A render count alone can't say *why* a component re-rendered, but a rapidly
+climbing number relative to user interaction is usually enough to confirm
+there's a problem worth investigating with `useWhyDidYouUpdate`:
+
+```jsx
+function ProductCard({ product, onAddToCart }) {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    console.log('ProductCard render #', useRenderCount());
+  }
+  return (
+    <div className="card">
+      <h3>{product.name}</h3>
+      <button onClick={() => onAddToCart(product.id)}>Add to cart</button>
+    </div>
+  );
+}
+```
+
+If that count climbs on every keystroke in an unrelated search box
+elsewhere on the page, `useWhyDidYouUpdate('ProductCard', { product,
+onAddToCart })` is the next step — it will usually point at `onAddToCart`
+being a new inline arrow function on every parent render, which is fixable
+with `useCallback` at the definition site.
+
+## A note on the conditional hook call above
+
+Calling `useRenderCount()` inside an `if` block violates the Rules of
+Hooks in the general case, since hook call order must stay identical
+across renders. It's safe here specifically because
+`process.env.NODE_ENV` is a build-time constant that never changes between
+renders of the same bundle — the branch is resolved once at build time, not
+per-render, so the hook's call order is actually stable across the
+component's lifetime. This is a narrow, well-understood exception, not a
+general pattern for conditional hook calls.
+
+## Removing debug instrumentation before shipping
+
+Because both hooks are development aids, it's worth stripping calls to
+them (or gating them behind `NODE_ENV` checks as shown above) before
+shipping to production — `useWhyDidYouUpdate`'s `console.log` calls in
+particular have a real, if small, runtime cost from the prop-diffing work
+on every render, which is a class of cost application code has no reason to
+pay outside of active debugging.

--- a/submissions/react/use-render-count-qz9k/useRenderCount.jsx
+++ b/submissions/react/use-render-count-qz9k/useRenderCount.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * useRenderCount
+ * Returns how many times the calling component has rendered, including the
+ * current render. Intended for development-time debugging of unexpected
+ * re-render frequency, not as a value consumed in application logic.
+ */
+export function useRenderCount() {
+  const countRef = useRef(0);
+  countRef.current += 1;
+  return countRef.current;
+}
+
+/**
+ * useWhyDidYouUpdate
+ * Logs which named props changed identity since the previous render, to
+ * help track down a re-render caused by a prop that "looks the same" but
+ * is a new object/array/function reference each time.
+ */
+export function useWhyDidYouUpdate(name, props) {
+  const previousRef = useRef();
+
+  useEffect(() => {
+    if (previousRef.current) {
+      const changed = {};
+      Object.keys({ ...previousRef.current, ...props }).forEach((key) => {
+        if (previousRef.current[key] !== props[key]) {
+          changed[key] = { from: previousRef.current[key], to: props[key] };
+        }
+      });
+      if (Object.keys(changed).length) {
+        // eslint-disable-next-line no-console
+        console.log('[why-did-you-update]', name, changed);
+      }
+    }
+    previousRef.current = props;
+  });
+}
+
+export default useRenderCount;


### PR DESCRIPTION
Closes #78492

Debugging aids: a raw per-component render counter, plus a prop-diffing hook that logs which named props changed identity since the previous render, surfacing inline-object/function props as an unstable reference cause.