### PR TITLE
feat: add custom-checkbox Sass mixin (custom-checkbox-qz9k)

### DIFF
--- a/submissions/scss/custom-checkbox-qz9k/README.md
+++ b/submissions/scss/custom-checkbox-qz9k/README.md
@@ -1,0 +1,46 @@
+# custom-checkbox-qz9k
+
+A Sass mixin styling a real `<input type="checkbox">` directly via
+`appearance: none` plus a generated checkmark, instead of the common
+hide-the-input-and-style-a-sibling-span approach.
+
+## Usage
+
+```scss
+@use 'custom-checkbox' as *;
+
+input[type="checkbox"] {
+  @include custom-checkbox($checked-bg: #34a853);
+}
+```
+
+```html
+<input type="checkbox" />
+<input type="checkbox" indeterminate />
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$size` | `1.15rem` | Box dimensions. |
+| `$border` | `#b7bdcb` | Unchecked border colour. |
+| `$checked-bg` | `#4c6ef5` | Checked/indeterminate fill colour. |
+| `$radius` | `0.3rem` | Corner radius. |
+
+## Why is it useful?
+
+The common custom-checkbox pattern visually hides the real input (`opacity:
+0` or a clip-based visually-hidden technique) and styles an adjacent
+`<span>` to represent checked/unchecked state via a sibling combinator —
+which works, but doubles the markup per checkbox and requires manually
+keeping the span in sync with `:checked`/`:indeterminate`/`:disabled` via
+CSS combinators for every state. `appearance: none` lets the real input
+itself become the visual box directly: `:checked`, `:indeterminate`,
+`:disabled`, and `:focus-visible` all apply straight to the one element
+already carrying that state, with no combinator indirection and no second
+element to keep synchronized.
+
+`:indeterminate` gets its own distinct treatment (a dash, not a checkmark)
+since it's a real, separately-styleable pseudo-class — typically set via
+JS for a "select all" checkbox representing a partially-selected group —
+and conflating it visually with `:checked` would misrepresent that state to
+the user.

--- a/submissions/scss/custom-checkbox-qz9k/_custom-checkbox.scss
+++ b/submissions/scss/custom-checkbox-qz9k/_custom-checkbox.scss
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// custom-checkbox-qz9k
+// Styles a real <input type="checkbox"> directly via appearance:none plus a
+// generated checkmark, rather than hiding it and styling a sibling <span> --
+// keeping the real input visible-but-restyled preserves native form
+// behaviour (validity, autofill, browser extensions) with less markup.
+// ---------------------------------------------------------------------------
+
+@mixin custom-checkbox(
+  $size: 1.15rem,
+  $border: #b7bdcb,
+  $checked-bg: #4c6ef5,
+  $radius: 0.3rem
+) {
+  appearance: none;
+  margin: 0;
+  width: $size;
+  height: $size;
+  border: 2px solid $border;
+  border-radius: $radius;
+  display: inline-grid;
+  place-content: center;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
+
+  &::before {
+    content: "";
+    width: 0.65em;
+    height: 0.65em;
+    transform: scale(0);
+    transition: transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+    box-shadow: inset 1em 1em white;
+    clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+  }
+
+  &:checked {
+    border-color: $checked-bg;
+    background: $checked-bg;
+  }
+
+  &:checked::before {
+    transform: scale(1);
+  }
+
+  &:indeterminate {
+    border-color: $checked-bg;
+    background: $checked-bg;
+  }
+
+  &:indeterminate::before {
+    transform: scale(1);
+    clip-path: none;
+    width: 0.6em;
+    height: 2px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $checked-bg;
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.custom-checkbox-demo {
+  @include custom-checkbox;
+}


### PR DESCRIPTION
Closes #78495

Styles the real <input type=checkbox> via appearance:none plus generated content instead of hiding it and styling a sibling span, so :checked/:indeterminate/:disabled/:focus-visible apply directly with no combinator indirection.