### PR TITLE
Add Volume equalizer slider submission

### DIFF
--- a/submissions/examples/volume-equalizer-slider/README.md
+++ b/submissions/examples/volume-equalizer-slider/README.md
@@ -1,0 +1,21 @@
+# Volume equalizer slider
+
+A volume slider whose thumb and track morph into a vertical bar-spectrum equalizer while dragging.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `volumeequalizerslider-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Drag-to-reveal visualisation gives the slider more presence than a plain range input.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *warm*)
+- `README.md` — this file

--- a/submissions/examples/volume-equalizer-slider/demo.html
+++ b/submissions/examples/volume-equalizer-slider/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Volume equalizer slider — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Volume equalizer slider</h1>
+      <p>A volume slider whose thumb and track morph into a vertical bar-spectrum equalizer while dragging.</p>
+    </header>
+    <section class="demo">
+      <div class="volumeequalizerslider-wrap"><input type="range" class="volumeequalizerslider" min="0" max="100" value="50"><div class="volumeequalizerslider-bars"><span></span><span></span><span></span><span></span><span></span></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/volume-equalizer-slider/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/volume-equalizer-slider/style.css
+++ b/submissions/examples/volume-equalizer-slider/style.css
@@ -1,0 +1,66 @@
+/* Volume equalizer slider — EaseMotion CSS submission
+   Palette: warm   Folder: submissions/examples/volume-equalizer-slider/   Class prefix: .volumeequalizerslider
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f1115;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff6a3d;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d24;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff6a3d;
+  background: #1a1d24;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.volumeequalizerslider-wrap { display: flex; align-items: center; gap: 16px; }
+.volumeequalizerslider { appearance: none; width: 240px; height: 8px; border-radius: 999px; background: linear-gradient(to right, #ff6a3d 0%, #ff6a3d var(--v, 50%), #262a33 var(--v, 50%), #262a33 100%); outline: none; }
+.volumeequalizerslider::-webkit-slider-thumb { appearance: none; width: 22px; height: 22px; border-radius: 50%; background: #ffd166; box-shadow: 0 0 0 4px #ff6a3d33; cursor: grab; transition: box-shadow 200ms; }
+.volumeequalizerslider:active::-webkit-slider-thumb { box-shadow: 0 0 0 8px #ff6a3d55; }
+.volumeequalizerslider-bars { display: flex; align-items: center; gap: 4px; height: 36px; padding: 0 8px; background: #1a1d24; border-radius: 8px; }
+.volumeequalizerslider-bars span { width: 4px; height: 100%; background: #ff6a3d; border-radius: 2px; transform-origin: bottom; transform: scaleY(0.25); }
+.volumeequalizerslider:active ~ .volumeequalizerslider-bars span { animation: kf-volumeequalizerslider 0.7s ease-in-out infinite; }
+.volumeequalizerslider-bars span:nth-child(2) { animation-delay: 0.1s !important; }
+.volumeequalizerslider-bars span:nth-child(3) { animation-delay: 0.2s !important; }
+.volumeequalizerslider-bars span:nth-child(4) { animation-delay: 0.3s !important; }
+.volumeequalizerslider-bars span:nth-child(5) { animation-delay: 0.4s !important; }
+@keyframes kf-volumeequalizerslider { 0%, 100% { transform: scaleY(0.2); } 50% { transform: scaleY(1); } }


### PR DESCRIPTION
Closes #78927

## What
This submission adds a new EaseMotion CSS example: `volume-equalizer-slider` under `submissions/examples/`.

A volume slider whose thumb and track morph into a vertical bar-spectrum equalizer while dragging.

## How to review
1. Open `submissions/examples/volume-equalizer-slider/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/volume-equalizer-slider/` and does not modify any existing file.
