### PR TITLE
feat: add pure CSS 3D Slider with Gradient component (#78256)

### DIFF
--- a/submissions/examples/css-3d-slider-gradient-pure/README.md
+++ b/submissions/examples/css-3d-slider-gradient-pure/README.md
@@ -1,0 +1,22 @@
+# CSS 3D Slider with Gradient
+
+A hardware-accelerated, JavaScript-free custom `<input type="range">` featuring tactile 3D depth, vibrant gradients, and cross-browser styling support.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript is required for the styling, hover interactions, or active/dragging states.
+- **Component Architecture & Styling Mechanics**: 
+  - **Resetting Native Styles**: The foundation relies on `-webkit-appearance: none;` on the `.slider-3d` input. This strips away the browser's default OS styling for the slider, allowing us to build it from scratch using pseudo-elements.
+  - **Cross-Browser Pseudo-Elements**: Because browsers implement the shadow DOM for inputs differently, the styling is duplicated across vendor-specific selectors: `::-webkit-slider-runnable-track` (for Chrome/Safari/Edge) and `::-moz-range-track` (for Firefox), as well as their respective `-thumb` counterparts.
+  - **3D Depth Construction**: 
+    - The *track* uses deep `inset` box-shadows (`inset 0 3px 6px rgba(...)`) to make it look like a physical groove carved into the background.
+    - The *thumb* uses a complex stack of standard and `inset` box-shadows. The standard outer shadow (`0 4px 6px ...`) lifts it off the track, while the inset shadows (`inset 0 2px 0 rgba(255,255,255,1), inset 0 -2px 0 rgba(0,0,0,0.1)`) create a bevel effect that mimics light hitting the top edge and shadow on the bottom edge of a physical dial.
+  - **Tactile Feedback**: On `:active` (when the user clicks and drags), the thumb scales down slightly (`transform: scale(0.95)`) and its drop-shadow reduces, perfectly simulating the physical action of pressing a button down into the track.
+- **Theming**: Configured via CSS Custom Properties. The palette features a vibrant, multi-stop linear gradient for the track. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, which swaps the gradients to a darker, more metallic aesthetic.
+- Fully accessible semantic structure. Because it relies on a real `<input type="range">`, it is perfectly accessible to screen readers, keyboards (using arrow keys to adjust value), and touch devices. It also includes `:focus-visible` styling for keyboard navigation outlines.
+
+## Usage
+Open `demo.html` in your browser. Click and drag the thumb on the slider. Notice the inset shadows on the track that give it depth, the 3D bevel on the thumb, and the satisfying "squish" animation when you press down on it to adjust the value. Toggle Dark Mode to see the metallic theme.
+
+## Files
+- `demo.html`: The HTML structure defining the range input and its container.
+- `style.css`: The styling, the complex `box-shadow` layering, the cross-browser pseudo-selectors, and the active/hover state transitions.

--- a/submissions/examples/css-3d-slider-gradient-pure/demo.html
+++ b/submissions/examples/css-3d-slider-gradient-pure/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Slider with Gradient Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">3D Gradient Slider</h1>
+            <p>A beautifully styled pure CSS input range with 3D depth and gradients.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <div class="slider-wrapper">
+                
+                <div class="slider-group">
+                    <label for="volume-slider" class="slider-label">Volume Level</label>
+                    
+                    <!-- The 3D Slider Container -->
+                    <div class="slider-container">
+                        <!-- Custom styled range input -->
+                        <input type="range" id="volume-slider" class="slider-3d" min="0" max="100" value="75">
+                        
+                        <!-- 
+                          Optional: A pure CSS trick using an adjacent element to fake the "fill" of the track before the thumb. 
+                          Since styling the fill before the thumb purely in CSS cross-browser is tricky without JS, 
+                          we rely on the native track styling or a gradient that covers the whole track.
+                        -->
+                    </div>
+                </div>
+
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-3d-slider-gradient-pure/style.css
+++ b/submissions/examples/css-3d-slider-gradient-pure/style.css
@@ -1,0 +1,257 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #e2e8f0;
+    --text-primary: #1e293b;
+    --text-secondary: #64748b;
+    
+    /* 3D Track Variables */
+    --track-bg: #cbd5e1;
+    --track-inner-shadow: inset 0 3px 6px rgba(0,0,0,0.15), inset 0 -3px 6px rgba(255,255,255,0.7);
+    --track-gradient: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+    
+    /* 3D Thumb Variables */
+    --thumb-size: 32px;
+    --thumb-color: #f8fafc;
+    --thumb-gradient: linear-gradient(135deg, #ffffff 0%, #e2e8f0 100%);
+    --thumb-shadow: 
+        0 4px 6px rgba(0,0,0,0.2), 
+        0 2px 4px rgba(0,0,0,0.1), 
+        inset 0 2px 0 rgba(255,255,255,1), 
+        inset 0 -2px 0 rgba(0,0,0,0.1);
+        
+    --thumb-hover-glow: 0 0 15px rgba(139, 92, 246, 0.4);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Montserrat', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.container {
+    width: 100%;
+    max-width: 500px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 10px 0;
+    letter-spacing: -0.5px;
+}
+
+.header p { 
+    color: var(--text-secondary); 
+    font-size: 1rem; 
+    margin: 0;
+}
+
+
+/* =========================================
+   Slider Container
+   ========================================= */
+.slider-wrapper {
+    background: #ffffff;
+    padding: 40px;
+    border-radius: 24px;
+    box-shadow: 
+        0 20px 40px rgba(0,0,0,0.05),
+        inset 0 2px 0 rgba(255,255,255,1);
+}
+
+.slider-group {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.slider-label {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.slider-container {
+    position: relative;
+    padding: 10px 0; /* Room for thumb overhang */
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Reset Native Input Styles
+   ========================================= */
+.slider-3d {
+    -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+    width: 100%; /* Specific width is required for Firefox. */
+    background: transparent; /* Otherwise white in Chrome */
+    margin: 0;
+}
+
+.slider-3d:focus {
+    outline: none; /* Removes the blue border. You should probably do some kind of focus styling for accessibility reasons though. */
+}
+
+/* Accessible focus styling */
+.slider-3d:focus-visible::-webkit-slider-thumb {
+    outline: 2px solid #3b82f6;
+    outline-offset: 4px;
+}
+.slider-3d:focus-visible::-moz-range-thumb {
+    outline: 2px solid #3b82f6;
+    outline-offset: 4px;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Styling the Track (3D + Gradient)
+   ========================================= */
+   
+/* WebKit (Chrome, Safari, Edge) */
+.slider-3d::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 16px;
+    cursor: pointer;
+    background: var(--track-gradient);
+    border-radius: 99px;
+    box-shadow: var(--track-inner-shadow);
+    /* Soft border to define the edge */
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+/* Firefox */
+.slider-3d::-moz-range-track {
+    width: 100%;
+    height: 16px;
+    cursor: pointer;
+    background: var(--track-gradient);
+    border-radius: 99px;
+    box-shadow: var(--track-inner-shadow);
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+
+/* =========================================
+   [TECHNIQUE 3] Styling the Thumb (3D Button)
+   ========================================= */
+   
+/* WebKit (Chrome, Safari, Edge) */
+.slider-3d::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    height: var(--thumb-size);
+    width: var(--thumb-size);
+    border-radius: 50%;
+    background: var(--thumb-gradient);
+    cursor: grab;
+    /* 
+       The top margin calculation:
+       (track height / 2) - (thumb height / 2)
+       (16px / 2) - (32px / 2) = 8 - 16 = -8px
+    */
+    margin-top: -9px; 
+    box-shadow: var(--thumb-shadow);
+    transition: transform 0.1s ease, box-shadow 0.2s ease;
+    border: 1px solid rgba(0,0,0,0.05);
+}
+
+/* Firefox */
+.slider-3d::-moz-range-thumb {
+    height: var(--thumb-size);
+    width: var(--thumb-size);
+    border-radius: 50%;
+    background: var(--thumb-gradient);
+    cursor: grab;
+    box-shadow: var(--thumb-shadow);
+    transition: transform 0.1s ease, box-shadow 0.2s ease;
+    border: 1px solid rgba(0,0,0,0.05);
+}
+
+
+/* =========================================
+   Interaction States (Hover & Active)
+   ========================================= */
+
+/* Hover state on Thumb */
+.slider-3d:hover::-webkit-slider-thumb {
+    box-shadow: var(--thumb-shadow), var(--thumb-hover-glow);
+}
+.slider-3d:hover::-moz-range-thumb {
+    box-shadow: var(--thumb-shadow), var(--thumb-hover-glow);
+}
+
+/* Active (Dragging) state on Thumb */
+.slider-3d:active::-webkit-slider-thumb {
+    cursor: grabbing;
+    transform: scale(0.95); /* Squish down slightly when pressed */
+    /* Reduce the shadow to simulate pressing in */
+    box-shadow: 
+        0 2px 3px rgba(0,0,0,0.2), 
+        inset 0 2px 0 rgba(255,255,255,1), 
+        inset 0 -2px 0 rgba(0,0,0,0.1);
+}
+
+.slider-3d:active::-moz-range-thumb {
+    cursor: grabbing;
+    transform: scale(0.95);
+    box-shadow: 
+        0 2px 3px rgba(0,0,0,0.2), 
+        inset 0 2px 0 rgba(255,255,255,1), 
+        inset 0 -2px 0 rgba(0,0,0,0.1);
+}
+
+
+/* Dark Mode Compatibility */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #0f172a;
+        --text-primary: #f8fafc;
+        --text-secondary: #94a3b8;
+        
+        --track-inner-shadow: inset 0 3px 6px rgba(0,0,0,0.6), inset 0 -1px 3px rgba(255,255,255,0.1);
+        /* Darker gradient for night mode */
+        --track-gradient: linear-gradient(90deg, #1e3a8a 0%, #5b21b6 50%, #be185d 100%);
+        
+        /* Metallic Dark Thumb */
+        --thumb-gradient: linear-gradient(135deg, #475569 0%, #1e293b 100%);
+        --thumb-shadow: 
+            0 4px 6px rgba(0,0,0,0.6), 
+            0 2px 4px rgba(0,0,0,0.5), 
+            inset 0 2px 0 rgba(255,255,255,0.2), 
+            inset 0 -2px 0 rgba(0,0,0,0.4);
+    }
+    
+    .slider-wrapper {
+        background: #1e293b;
+        box-shadow: 
+            0 20px 40px rgba(0,0,0,0.4),
+            inset 0 1px 0 rgba(255,255,255,0.05);
+    }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .slider-3d::-webkit-slider-thumb,
+    .slider-3d::-moz-range-thumb {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a hardware-accelerated, JavaScript-free custom `<input type="range">` featuring tactile 3D depth, vibrant gradients, and cross-browser styling support. Resolves issue #78256.

### Changes Made:
- Added `submissions/examples/css-3d-slider-gradient-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic `range` input and its container.
- Created `style.css` featuring the UI mechanics:
  - **Resetting Native Styles**: The foundation relies on `-webkit-appearance: none;` on the `.slider-3d` input. This strips away the browser's default OS styling for the slider, allowing us to build it from scratch using pseudo-elements.
  - **Cross-Browser Pseudo-Elements**: Because browsers implement the shadow DOM for inputs differently, the styling is duplicated across vendor-specific selectors: `::-webkit-slider-runnable-track` (for Chrome/Safari/Edge) and `::-moz-range-track` (for Firefox), as well as their respective `-thumb` counterparts.
  - **3D Depth Construction**: 
    - The *track* uses deep `inset` box-shadows (`inset 0 3px 6px rgba(...)`) to make it look like a physical groove carved into the background.
    - The *thumb* uses a complex stack of standard and `inset` box-shadows. The standard outer shadow (`0 4px 6px ...`) lifts it off the track, while the inset shadows (`inset 0 2px 0 rgba(255,255,255,1), inset 0 -2px 0 rgba(0,0,0,0.1)`) create a bevel effect that mimics light hitting the top edge and shadow on the bottom edge of a physical dial.
  - **Tactile Feedback**: On `:active` (when the user clicks and drags), the thumb scales down slightly (`transform: scale(0.95)`) and its drop-shadow reduces, perfectly simulating the physical action of pressing a button down into the track.
  - **Theming Supported**: Configured via CSS Custom Properties. The palette features a vibrant, multi-stop linear gradient for the track. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, which swaps the gradients to a darker, more metallic aesthetic.
- Added `README.md` documenting usage and the technical mechanics of the complex `box-shadow` layering, the cross-browser pseudo-selectors, and the active/hover state transitions.
- Fully accessible semantic structure. Because it relies on a real `<input type="range">`, it is perfectly accessible to screen readers, keyboards (using arrow keys to adjust value), and touch devices. It also includes `:focus-visible` styling for keyboard navigation outlines.

Closes #78256
