### PR TITLE
Add Filter tag removal submission

### DIFF
--- a/submissions/examples/filter-tag-removal-v2/README.md
+++ b/submissions/examples/filter-tag-removal-v2/README.md
@@ -1,0 +1,21 @@
+# Filter tag removal
+
+A chip tag that scales down and fades out when its close button is activated.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `filtertagremovalv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Filter / chip pattern used in search facets; the exit motion signals the action cleanly.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *violet*)
+- `README.md` — this file

--- a/submissions/examples/filter-tag-removal-v2/demo.html
+++ b/submissions/examples/filter-tag-removal-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filter tag removal — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Filter tag removal</h1>
+      <p>A chip tag that scales down and fades out when its close button is activated.</p>
+    </header>
+    <section class="demo">
+      <span class="filtertagremovalv2">design <button>×</button></span>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/filter-tag-removal-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/filter-tag-removal-v2/style.css
+++ b/submissions/examples/filter-tag-removal-v2/style.css
@@ -1,0 +1,59 @@
+/* Filter tag removal — EaseMotion CSS submission
+   Palette: violet   Folder: submissions/examples/filter-tag-removal-v2/   Class prefix: .filtertagremovalv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0e0a1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #a78bfa;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1329;
+  border: 1px solid #261a3a;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #a78bfa;
+  background: #1a1329;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.filtertagremovalv2 {{ display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; background: #1a1329; border: 1px solid #261a3a; border-radius: 999px; color: #e6e8ec; font: 13px/1 system-ui; transition: opacity 240ms, transform 240ms; }}
+.filtertagremovalv2 button {{ background: none; border: none; color: #8b909b; cursor: pointer; font-size: 16px; line-height: 1; padding: 0 2px; border-radius: 50%; transition: color 160ms; }}
+.filtertagremovalv2 button:hover {{ color: #a78bfa; }}
+.filtertagremovalv2.is-out {{ opacity: 0; transform: scale(0.6); pointer-events: none; }}
+


### PR DESCRIPTION
Closes #78962

## What
This submission adds a new EaseMotion CSS example: `filter-tag-removal-v2` under `submissions/examples/`.

A chip tag that scales down and fades out when its close button is activated.

## How to review
1. Open `submissions/examples/filter-tag-removal-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/filter-tag-removal-v2/` and does not modify any existing file.
