### PR TITLE
Add OTP input grid submission

### DIFF
--- a/submissions/examples/otp-input-box-grid-v2/README.md
+++ b/submissions/examples/otp-input-box-grid-v2/README.md
@@ -1,0 +1,21 @@
+# OTP input grid
+
+A row of single-character inputs that highlights the active cell with a pulsing focus ring.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `otpinputboxgridv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Two-factor authentication pattern; the active pulse tells the user where the next digit will land.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *teal*)
+- `README.md` — this file

--- a/submissions/examples/otp-input-box-grid-v2/demo.html
+++ b/submissions/examples/otp-input-box-grid-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OTP input grid — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>OTP input grid</h1>
+      <p>A row of single-character inputs that highlights the active cell with a pulsing focus ring.</p>
+    </header>
+    <section class="demo">
+      <div class="otpinputboxgridv2"><input maxlength="1"><input maxlength="1" class="otpinputboxgridv2-active"><input maxlength="1"><input maxlength="1"></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/otp-input-box-grid-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/otp-input-box-grid-v2/style.css
+++ b/submissions/examples/otp-input-box-grid-v2/style.css
@@ -1,0 +1,59 @@
+/* OTP input grid — EaseMotion CSS submission
+   Palette: teal   Folder: submissions/examples/otp-input-box-grid-v2/   Class prefix: .otpinputboxgridv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #08161a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #14b8a6;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #0f2429;
+  border: 1px solid #163239;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #14b8a6;
+  background: #0f2429;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.otpinputboxgridv2 {{ display: inline-flex; gap: 10px; }}
+.otpinputboxgridv2 input {{ width: 44px; height: 52px; background: #0f2429; border: 2px solid #163239; border-radius: 10px; color: #e6e8ec; font: 22px/1 ui-monospace, monospace; text-align: center; transition: border-color 200ms, box-shadow 200ms; }}
+.otpinputboxgridv2 input:focus {{ outline: none; border-color: #14b8a6; box-shadow: 0 0 0 4px #14b8a622; animation: kf-otpinputboxgridv2 1.6s ease-in-out infinite; }}
+.otpinputboxgridv2-otpinputboxgridv2-active {{ border-color: #14b8a6; }}
+@keyframes kf-otpinputboxgridv2 {{ 0%, 100% {{ box-shadow: 0 0 0 0 #14b8a644; }} 50% {{ box-shadow: 0 0 0 8px #14b8a611; }} }}


### PR DESCRIPTION
Closes #78965

## What
This submission adds a new EaseMotion CSS example: `otp-input-box-grid-v2` under `submissions/examples/`.

A row of single-character inputs that highlights the active cell with a pulsing focus ring.

## How to review
1. Open `submissions/examples/otp-input-box-grid-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/otp-input-box-grid-v2/` and does not modify any existing file.
