### PR TITLE
Add Audio mute wave toggle submission

### DIFF
--- a/submissions/examples/audio-mute-wave-toggle/README.md
+++ b/submissions/examples/audio-mute-wave-toggle/README.md
@@ -1,0 +1,21 @@
+# Audio mute wave toggle
+
+A speaker icon whose soundwave arcs expand outward while the audio is unmuted and collapse when muted.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `audiomutewavetoggle-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Audio control pattern; the wave arcs give a live visual cue tied to the on/off state.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *warm*)
+- `README.md` — this file

--- a/submissions/examples/audio-mute-wave-toggle/demo.html
+++ b/submissions/examples/audio-mute-wave-toggle/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Audio mute wave toggle — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Audio mute wave toggle</h1>
+      <p>A speaker icon whose soundwave arcs expand outward while the audio is unmuted and collapse when muted.</p>
+    </header>
+    <section class="demo">
+      <button class="audiomutewavetoggle" aria-label="mute"><svg viewBox="0 0 24 24" width="32" height="32"><path d="M3 9v6h4l5 4V5L7 9H3z" fill="currentColor"/><g class="audiomutewavetoggle-waves" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"><path d="M16 8c2 2 2 6 0 8"/><path d="M19 5c4 4 4 10 0 14"/></g></svg></button>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/audio-mute-wave-toggle/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/audio-mute-wave-toggle/style.css
+++ b/submissions/examples/audio-mute-wave-toggle/style.css
@@ -1,0 +1,61 @@
+/* Audio mute wave toggle — EaseMotion CSS submission
+   Palette: warm   Folder: submissions/examples/audio-mute-wave-toggle/   Class prefix: .audiomutewavetoggle
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f1115;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff6a3d;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d24;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff6a3d;
+  background: #1a1d24;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.audiomutewavetoggle { background: #1a1d24; border: 1px solid #262a33; border-radius: 50%; width: 56px; height: 56px; color: #8b909b; cursor: pointer; display: grid; place-items: center; transition: color 200ms, transform 200ms; }
+.audiomutewavetoggle:hover { color: #ff6a3d; transform: scale(1.05); }
+.audiomutewavetoggle.is-on { color: #ff6a3d; }
+.audiomutewavetoggle.is-on .audiomutewavetoggle-waves path { animation: kf-audiomutewavetoggle 1.4s ease-in-out infinite; }
+.audiomutewavetoggle.is-on .audiomutewavetoggle-waves path:nth-child(2) { animation-delay: 0.2s; }
+.audiomutewavetoggle.is-on .audiomutewavetoggle-waves path { transform-origin: 18px 12px; }
+@keyframes kf-audiomutewavetoggle { 0%, 100% { opacity: 0.3; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.1); } }


### PR DESCRIPTION
Closes #78981

## What
This submission adds a new EaseMotion CSS example: `audio-mute-wave-toggle` under `submissions/examples/`.

A speaker icon whose soundwave arcs expand outward while the audio is unmuted and collapse when muted.

## How to review
1. Open `submissions/examples/audio-mute-wave-toggle/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/audio-mute-wave-toggle/` and does not modify any existing file.
