### PR TITLE
Add Search clear cross submission

### DIFF
--- a/submissions/examples/search-clear-cross/README.md
+++ b/submissions/examples/search-clear-cross/README.md
@@ -1,0 +1,21 @@
+# Search clear cross
+
+A search field whose 'X' clear button slides in from the right whenever the field has any text.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `searchclearcross-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Search input pattern; the reveal-on-type keeps the resting state clean.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *cool*)
+- `README.md` — this file

--- a/submissions/examples/search-clear-cross/demo.html
+++ b/submissions/examples/search-clear-cross/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Search clear cross — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Search clear cross</h1>
+      <p>A search field whose 'X' clear button slides in from the right whenever the field has any text.</p>
+    </header>
+    <section class="demo">
+      <div class="searchclearcross"><input type="search" placeholder="Search…"><button>×</button></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/search-clear-cross/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/search-clear-cross/style.css
+++ b/submissions/examples/search-clear-cross/style.css
@@ -1,0 +1,61 @@
+/* Search clear cross — EaseMotion CSS submission
+   Palette: cool   Folder: submissions/examples/search-clear-cross/   Class prefix: .searchclearcross
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0e1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #4dabf7;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #131829;
+  border: 1px solid #1d2438;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #4dabf7;
+  background: #131829;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.searchclearcross { position: relative; display: inline-block; width: 260px; }
+.searchclearcross input { width: 100%; padding: 10px 36px 10px 14px; background: #131829; border: 1px solid #1d2438; border-radius: 999px; color: #e6e8ec; font: 14px/1 system-ui; outline: none; transition: border-color 200ms, box-shadow 200ms; }
+.searchclearcross input:focus { border-color: #4dabf7; box-shadow: 0 0 0 4px #4dabf722; }
+.searchclearcross button { position: absolute; right: 6px; top: 50%; transform: translate(8px, -50%) scale(0.6); width: 28px; height: 28px; border: none; border-radius: 50%; background: #1d2438; color: #e6e8ec; cursor: pointer; opacity: 0; transition: opacity 200ms, transform 200ms; }
+.searchclearcross input:not(:placeholder-shown) ~ button { opacity: 1; transform: translate(0, -50%) scale(1); }
+.searchclearcross button:hover { background: #4dabf7; color: #0a0e1a; }
+


### PR DESCRIPTION
Closes #78984

## What
This submission adds a new EaseMotion CSS example: `search-clear-cross` under `submissions/examples/`.

A search field whose 'X' clear button slides in from the right whenever the field has any text.

## How to review
1. Open `submissions/examples/search-clear-cross/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/search-clear-cross/` and does not modify any existing file.
