### PR TITLE
Add Floating action speed dial submission

### DIFF
--- a/submissions/examples/fab-speed-dial-tm/README.md
+++ b/submissions/examples/fab-speed-dial-tm/README.md
@@ -1,0 +1,21 @@
+# Floating action speed dial
+
+A primary FAB that expands into 4 radial sub-action buttons in a fan layout on click.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `fabspeeddial-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Mobile productivity pattern; the radial fan keeps the secondary actions discoverable but tucked away.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *rose*)
+- `README.md` — this file

--- a/submissions/examples/fab-speed-dial-tm/demo.html
+++ b/submissions/examples/fab-speed-dial-tm/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Floating action speed dial — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Floating action speed dial</h1>
+      <p>A primary FAB that expands into 4 radial sub-action buttons in a fan layout on click.</p>
+    </header>
+    <section class="demo">
+      <div class="fabspeeddial"><button class="fabspeeddial-main">+</button><div class="fabspeeddial-items"><a style="--i:0">📷</a><a style="--i:1">✏️</a><a style="--i:2">📎</a><a style="--i:3">⭐</a></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/fab-speed-dial-tm/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fab-speed-dial-tm/style.css
+++ b/submissions/examples/fab-speed-dial-tm/style.css
@@ -1,0 +1,60 @@
+/* Floating action speed dial — EaseMotion CSS submission
+   Palette: rose   Folder: submissions/examples/fab-speed-dial-tm/   Class prefix: .fabspeeddial
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160d12;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff5c8a;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #26141c;
+  border: 1px solid #361b25;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff5c8a;
+  background: #26141c;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.fabspeeddial { position: relative; width: 56px; height: 56px; }
+.fabspeeddial-main { width: 56px; height: 56px; border-radius: 50%; background: #ff5c8a; color: #160d12; border: none; font: 28px/1 system-ui; cursor: pointer; box-shadow: 0 8px 24px #ff5c8a66; transition: transform 240ms; position: relative; z-index: 2; }
+.fabspeeddial-main:hover { transform: scale(1.1) rotate(45deg); }
+.fabspeeddial-items a { position: absolute; width: 40px; height: 40px; border-radius: 50%; background: #26141c; color: #e6e8ec; display: grid; place-items: center; text-decoration: none; top: 8px; left: 8px; opacity: 0; transform: scale(0.4); transition: transform 320ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 240ms; font-size: 18px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.fabspeeddial.is-open .fabspeeddial-items a { opacity: 1; transform: rotate(calc(var(--i) * 45deg)) translate(0, -80px) rotate(calc(var(--i) * -45deg)); transition-delay: calc(var(--i) * 60ms); }
+


### PR DESCRIPTION
Closes #78988

## What
This submission adds a new EaseMotion CSS example: `fab-speed-dial-tm` under `submissions/examples/`.

A primary FAB that expands into 4 radial sub-action buttons in a fan layout on click.

## How to review
1. Open `submissions/examples/fab-speed-dial-tm/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/fab-speed-dial-tm/` and does not modify any existing file.
