### PR TITLE
Add Swipeable option card submission

### DIFF
--- a/submissions/examples/swipeable-option-card/README.md
+++ b/submissions/examples/swipeable-option-card/README.md
@@ -1,0 +1,21 @@
+# Swipeable option card
+
+A list item card that slides left on hover/swipe to reveal edit and delete action buttons.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `swipeableoptioncard-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+List-item pattern; the swipe-to-reveal gives the user destructive actions without cluttering the row.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *amber*)
+- `README.md` — this file

--- a/submissions/examples/swipeable-option-card/demo.html
+++ b/submissions/examples/swipeable-option-card/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Swipeable option card — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Swipeable option card</h1>
+      <p>A list item card that slides left on hover/swipe to reveal edit and delete action buttons.</p>
+    </header>
+    <section class="demo">
+      <div class="swipeableoptioncard"><div class="swipeableoptioncard-body"><strong>Inbox item</strong><p>Swipe left to reveal actions.</p></div><div class="swipeableoptioncard-actions"><button>Edit</button><button class="swipeableoptioncard-del">Delete</button></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/swipeable-option-card/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/swipeable-option-card/style.css
+++ b/submissions/examples/swipeable-option-card/style.css
@@ -1,0 +1,61 @@
+/* Swipeable option card — EaseMotion CSS submission
+   Palette: amber   Folder: submissions/examples/swipeable-option-card/   Class prefix: .swipeableoptioncard
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #161208;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ffb13b;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261d10;
+  border: 1px solid #352817;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ffb13b;
+  background: #261d10;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.swipeableoptioncard { position: relative; overflow: hidden; border-radius: 12px; background: #261d10; max-width: 360px; }
+.swipeableoptioncard-body { padding: 16px 20px; transition: transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.swipeableoptioncard-actions { position: absolute; inset: 0; display: flex; justify-content: flex-end; align-items: center; padding: 0 16px; gap: 8px; background: linear-gradient(to left, #352817, transparent); }
+.swipeableoptioncard-actions button { background: #352817; color: #e6e8ec; border: none; padding: 6px 12px; border-radius: 6px; cursor: pointer; font: 12px/1 system-ui; }
+.swipeableoptioncard-actions .swipeableoptioncard-del { background: #ffb13b; color: #161208; }
+.swipeableoptioncard:hover .swipeableoptioncard-body { transform: translateX(-100px); }
+


### PR DESCRIPTION
Closes #78991

## What
This submission adds a new EaseMotion CSS example: `swipeable-option-card` under `submissions/examples/`.

A list item card that slides left on hover/swipe to reveal edit and delete action buttons.

## How to review
1. Open `submissions/examples/swipeable-option-card/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/swipeable-option-card/` and does not modify any existing file.
