### PR TITLE
Add Text glitch cyber shift submission

### DIFF
--- a/submissions/examples/text-glitch-cyber-shift/README.md
+++ b/submissions/examples/text-glitch-cyber-shift/README.md
@@ -1,0 +1,21 @@
+# Text glitch cyber shift
+
+A headline whose RGB layers briefly split and re-combine on hover for a digital glitch effect.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `textglitchcybershift-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Hero / error-state pattern; the glitch reads as 'system' or 'live data'.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *gold*)
+- `README.md` — this file

--- a/submissions/examples/text-glitch-cyber-shift/demo.html
+++ b/submissions/examples/text-glitch-cyber-shift/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text glitch cyber shift — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Text glitch cyber shift</h1>
+      <p>A headline whose RGB layers briefly split and re-combine on hover for a digital glitch effect.</p>
+    </header>
+    <section class="demo">
+      <h2 class="textglitchcybershift" data-text="SYSTEM">SYSTEM</h2>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/text-glitch-cyber-shift/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/text-glitch-cyber-shift/style.css
+++ b/submissions/examples/text-glitch-cyber-shift/style.css
@@ -1,0 +1,61 @@
+/* Text glitch cyber shift — EaseMotion CSS submission
+   Palette: gold   Folder: submissions/examples/text-glitch-cyber-shift/   Class prefix: .textglitchcybershift
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #13110b;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #facc15;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #221e14;
+  border: 1px solid #332c1c;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #facc15;
+  background: #221e14;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.textglitchcybershift { position: relative; font: 700 36px/1 system-ui; color: #e6e8ec; letter-spacing: 2px; text-transform: uppercase; cursor: default; }
+.textglitchcybershift::before, .textglitchcybershift::after { content: attr(data-text); position: absolute; inset: 0; pointer-events: none; }
+.textglitchcybershift::before { color: #facc15; clip-path: polygon(0 0, 100% 0, 100% 40%, 0 40%); transform: translate(0, 0); transition: transform 100ms; }
+.textglitchcybershift::after { color: #fbbf24; clip-path: polygon(0 60%, 100% 60%, 100% 100%, 0 100%); transform: translate(0, 0); transition: transform 100ms; }
+.textglitchcybershift:hover::before { animation: kf-textglitchcybershift 320ms steps(2) infinite; }
+.textglitchcybershift:hover::after { animation: kf-textglitchcybershift-2 320ms steps(2) infinite; }
+@keyframes kf-textglitchcybershift { 0% { transform: translate(-3px, -1px); } 50% { transform: translate(3px, 1px); } 100% { transform: translate(-2px, 0); } }@keyframes kf-textglitchcybershift-2 { 0% { transform: translate(2px, 1px); } 50% { transform: translate(-2px, -1px); } 100% { transform: translate(1px, 0); } }


### PR DESCRIPTION
Closes #79008

## What
This submission adds a new EaseMotion CSS example: `text-glitch-cyber-shift` under `submissions/examples/`.

A headline whose RGB layers briefly split and re-combine on hover for a digital glitch effect.

## How to review
1. Open `submissions/examples/text-glitch-cyber-shift/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/text-glitch-cyber-shift/` and does not modify any existing file.
