### PR TITLE
Add 3D tilt displace card submission

### DIFF
--- a/submissions/examples/3d-tilt-displace-card-v2/README.md
+++ b/submissions/examples/3d-tilt-displace-card-v2/README.md
@@ -1,0 +1,21 @@
+# 3D tilt displace card
+
+A multi-layer card whose title, image, and button shift at different depths on hover for a parallax feel.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `3dtiltdisplacecardv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Product / portfolio card pattern; layered depth reads as premium.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *ruby*)
+- `README.md` — this file

--- a/submissions/examples/3d-tilt-displace-card-v2/demo.html
+++ b/submissions/examples/3d-tilt-displace-card-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D tilt displace card — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>3D tilt displace card</h1>
+      <p>A multi-layer card whose title, image, and button shift at different depths on hover for a parallax feel.</p>
+    </header>
+    <section class="demo">
+      <div class="3dtiltdisplacecardv2"><div class="3dtiltdisplacecardv2-bg"></div><div class="3dtiltdisplacecardv2-layer 3dtiltdisplacecardv2-l1">Title</div><div class="3dtiltdisplacecardv2-layer 3dtiltdisplacecardv2-l2">Image goes here</div><div class="3dtiltdisplacecardv2-layer 3dtiltdisplacecardv2-l3">View →</div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/3d-tilt-displace-card-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/3d-tilt-displace-card-v2/style.css
+++ b/submissions/examples/3d-tilt-displace-card-v2/style.css
@@ -1,0 +1,65 @@
+/* 3D tilt displace card — EaseMotion CSS submission
+   Palette: ruby   Folder: submissions/examples/3d-tilt-displace-card-v2/   Class prefix: .3dtiltdisplacecardv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160a0d;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ef4444;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261418;
+  border: 1px solid #36191e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ef4444;
+  background: #261418;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.3dtiltdisplacecardv2 {{ position: relative; width: 280px; height: 180px; border-radius: 16px; overflow: hidden; transform-style: preserve-3d; transition: transform 320ms; cursor: pointer; background: #261418; }}
+.3dtiltdisplacecardv2-bg {{ position: absolute; inset: 0; background: linear-gradient(135deg, #ef4444, #fb7185); opacity: 0.3; }}
+.3dtiltdisplacecardv2-layer {{ position: absolute; padding: 12px 16px; transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1); color: #e6e8ec; font: 14px/1 system-ui; }}
+.3dtiltdisplacecardv2-l1 {{ top: 16px; left: 16px; font-size: 18px; font-weight: 600; color: #ef4444; transform: translateZ(40px); }}
+.3dtiltdisplacecardv2-l2 {{ bottom: 60px; left: 16px; right: 16px; color: #8b909b; transform: translateZ(20px); }}
+.3dtiltdisplacecardv2-l3 {{ bottom: 16px; right: 16px; background: #ef4444; color: #160a0d; padding: 8px 16px; border-radius: 999px; transform: translateZ(60px); }}
+.3dtiltdisplacecardv2:hover {{ transform: rotateX(8deg) rotateY(-8deg); }}
+.3dtiltdisplacecardv2:hover .3dtiltdisplacecardv2-l1 {{ transform: translateZ(60px) translate(-4px, -4px); }}
+.3dtiltdisplacecardv2:hover .3dtiltdisplacecardv2-l2 {{ transform: translateZ(40px); }}
+.3dtiltdisplacecardv2:hover .3dtiltdisplacecardv2-l3 {{ transform: translateZ(80px) translate(2px, 2px); }}
+


### PR DESCRIPTION
Closes #79024

## What
This submission adds a new EaseMotion CSS example: `3d-tilt-displace-card-v2` under `submissions/examples/`.

A multi-layer card whose title, image, and button shift at different depths on hover for a parallax feel.

## How to review
1. Open `submissions/examples/3d-tilt-displace-card-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/3d-tilt-displace-card-v2/` and does not modify any existing file.
