### PR TITLE
feat: add css-only dark mode slider

### DIFF
--- a/submissions/examples/78514-css-dark-slider/README.md
+++ b/submissions/examples/78514-css-dark-slider/README.md
@@ -1,0 +1,44 @@
+# CSS-only Slider with Dark Mode Styling
+
+A responsive range slider component featuring neumorphic surfaces,
+gradient progress tracks, custom thumbs, keyboard interaction, and
+automatic dark-mode adaptation.
+
+## Features
+
+- CSS-only range sliders
+- Native HTML range input
+- Responsive layout
+- Automatic dark-mode support
+- Purple, cyan, and pink slider variants
+- Custom slider thumb
+- Gradient progress track
+- Neumorphic track styling
+- Tick markers
+- Keyboard accessibility through native range controls
+- Visible `:focus-visible` state
+- `prefers-reduced-motion` support
+- Pure HTML and Vanilla CSS
+- No JavaScript or external dependencies
+
+## Files
+
+- `demo.html`
+- `style.css`
+
+## Usage
+
+Open `demo.html` directly in a browser.
+
+A basic slider can be created with:
+
+```html
+<input
+  class="slider__input"
+  id="volume"
+  type="range"
+  min="0"
+  max="100"
+  value="72"
+  aria-label="Volume"
+/>

--- a/submissions/examples/78514-css-dark-slider/demo.html
+++ b/submissions/examples/78514-css-dark-slider/demo.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  />
+  <meta
+    name="description"
+    content="CSS-only responsive slider with automatic dark mode styling."
+  />
+  <title>CSS Slider with Dark Mode</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="slider-demo" aria-labelledby="page-title">
+      <div class="intro">
+        <span class="intro__eyebrow">EaseMotion Component</span>
+
+        <h1 id="page-title">CSS-Only Slider</h1>
+
+        <p>
+          A responsive range slider with smooth interaction, gradient
+          progress, accessible keyboard controls, and automatic dark-mode
+          adaptation.
+        </p>
+      </div>
+
+      <div class="slider-layout">
+        <section class="slider-card">
+          <div class="slider-card__header">
+            <div>
+              <span class="slider-card__eyebrow">Volume Control</span>
+              <h2>Master Volume</h2>
+            </div>
+
+            <output
+              class="slider-card__value"
+              id="volume-value"
+              for="volume"
+            >
+              72%
+            </output>
+          </div>
+
+          <div class="slider">
+            <input
+              class="slider__input"
+              id="volume"
+              type="range"
+              min="0"
+              max="100"
+              value="72"
+              aria-label="Master volume"
+            />
+
+            <div class="slider__decor" aria-hidden="true">
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+            </div>
+          </div>
+
+          <div class="slider__labels" aria-hidden="true">
+            <span>0</span>
+            <span>25</span>
+            <span>50</span>
+            <span>75</span>
+            <span>100</span>
+          </div>
+
+          <p class="slider-card__hint">
+            Drag the thumb or use the keyboard arrow keys.
+          </p>
+        </section>
+
+        <section class="slider-card slider-card--compact">
+          <div class="slider-card__header">
+            <div>
+              <span class="slider-card__eyebrow">Brightness</span>
+              <h2>Display</h2>
+            </div>
+
+            <output
+              class="slider-card__value slider-card__value--cyan"
+              for="brightness"
+              id="brightness-value"
+            >
+              58%
+            </output>
+          </div>
+
+          <div class="slider slider--cyan">
+            <input
+              class="slider__input"
+              id="brightness"
+              type="range"
+              min="0"
+              max="100"
+              value="58"
+              aria-label="Display brightness"
+            />
+
+            <div class="slider__decor" aria-hidden="true">
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+            </div>
+          </div>
+
+          <div class="slider__labels" aria-hidden="true">
+            <span>0</span>
+            <span>25</span>
+            <span>50</span>
+            <span>75</span>
+            <span>100</span>
+          </div>
+        </section>
+
+        <section class="slider-card slider-card--compact">
+          <div class="slider-card__header">
+            <div>
+              <span class="slider-card__eyebrow">Intensity</span>
+              <h2>Animation</h2>
+            </div>
+
+            <output
+              class="slider-card__value slider-card__value--pink"
+              for="intensity"
+              id="intensity-value"
+            >
+              86%
+            </output>
+          </div>
+
+          <div class="slider slider--pink">
+            <input
+              class="slider__input"
+              id="intensity"
+              type="range"
+              min="0"
+              max="100"
+              value="86"
+              aria-label="Animation intensity"
+            />
+
+            <div class="slider__decor" aria-hidden="true">
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+              <span class="slider__tick"></span>
+            </div>
+          </div>
+
+          <div class="slider__labels" aria-hidden="true">
+            <span>0</span>
+            <span>25</span>
+            <span>50</span>
+            <span>75</span>
+            <span>100</span>
+          </div>
+        </section>
+      </div>
+
+      <section class="feature-panel" aria-labelledby="feature-title">
+        <div>
+          <span class="feature-panel__eyebrow">Dark Mode Ready</span>
+
+          <h2 id="feature-title">
+            One component, two visual modes.
+          </h2>
+
+          <p>
+            The slider automatically adapts its surfaces, shadows, track,
+            and typography according to the user's preferred color scheme.
+          </p>
+        </div>
+
+        <div class="theme-preview" aria-hidden="true">
+          <div class="theme-preview__sun"></div>
+          <div class="theme-preview__moon"></div>
+        </div>
+      </section>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/78514-css-dark-slider/style.css
+++ b/submissions/examples/78514-css-dark-slider/style.css
@@ -1,0 +1,681 @@
+:root {
+  color-scheme: light dark;
+
+  --page-bg: #e8ecf3;
+  --surface: #e8ecf3;
+  --surface-raised: #eef1f6;
+
+  --text: #242a34;
+  --muted: #737d8d;
+
+  --accent: #7762d9;
+  --accent-dark: #5945b1;
+
+  --cyan: #32b9d2;
+  --cyan-dark: #218fa3;
+
+  --pink: #dc5e9e;
+  --pink-dark: #b34077;
+
+  --track: #dce1e9;
+  --border: rgba(255, 255, 255, 0.52);
+
+  --shadow-light: rgba(255, 255, 255, 0.92);
+  --shadow-dark: rgba(182, 188, 200, 0.62);
+
+  --transition:
+    220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg: #171b24;
+    --surface: #1b202a;
+    --surface-raised: #202631;
+
+    --text: #edf1f8;
+    --muted: #9aa4b6;
+
+    --accent: #9b89ef;
+    --accent-dark: #705ac8;
+
+    --cyan: #58d8ed;
+    --cyan-dark: #2999ad;
+
+    --pink: #f179b7;
+    --pink-dark: #c34c8e;
+
+    --track: #242b37;
+    --border: rgba(255, 255, 255, 0.08);
+
+    --shadow-light: rgba(47, 53, 65, 0.72);
+    --shadow-dark: rgba(6, 8, 12, 0.9);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 12% 10%,
+      rgba(255, 255, 255, 0.72),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at 88% 88%,
+      rgba(119, 98, 217, 0.09),
+      transparent 28%
+    ),
+    var(--page-bg);
+
+  transition:
+    color var(--transition),
+    background var(--transition);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background:
+      radial-gradient(
+        circle at 12% 10%,
+        rgba(155, 137, 239, 0.08),
+        transparent 28%
+      ),
+      radial-gradient(
+        circle at 88% 88%,
+        rgba(112, 90, 200, 0.08),
+        transparent 28%
+      ),
+      var(--page-bg);
+  }
+}
+
+input {
+  font: inherit;
+}
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 44px 18px;
+}
+
+.slider-demo {
+  width: min(1000px, 100%);
+}
+
+.intro {
+  max-width: 720px;
+
+  margin: 0 auto 36px;
+
+  text-align: center;
+}
+
+.intro__eyebrow {
+  display: inline-block;
+
+  margin-bottom: 10px;
+
+  color: var(--muted);
+
+  font-size: 0.66rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.intro h1 {
+  margin: 0;
+
+  font-size: clamp(2.4rem, 7vw, 4.7rem);
+  line-height: 0.97;
+  letter-spacing: -0.065em;
+}
+
+.intro p {
+  max-width: 650px;
+
+  margin: 17px auto 0;
+
+  color: var(--muted);
+
+  font-size: 0.9rem;
+  line-height: 1.8;
+}
+
+.slider-layout {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr 1fr;
+  gap: 18px;
+}
+
+.slider-card {
+  min-width: 0;
+
+  padding: clamp(21px, 4vw, 30px);
+
+  border: 1px solid var(--border);
+  border-radius: 23px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.58),
+      rgba(220, 225, 233, 0.72)
+    );
+
+  box-shadow:
+    13px 13px 27px var(--shadow-dark),
+    -13px -13px 27px var(--shadow-light);
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition),
+    background var(--transition);
+}
+
+.slider-card:hover {
+  transform: translateY(-4px);
+
+  box-shadow:
+    16px 16px 31px var(--shadow-dark),
+    -16px -16px 31px var(--shadow-light);
+}
+
+@media (prefers-color-scheme: dark) {
+  .slider-card {
+    background:
+      linear-gradient(
+        145deg,
+        rgba(39, 45, 57, 0.88),
+        rgba(26, 31, 41, 0.93)
+      );
+  }
+}
+
+.slider-card__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 15px;
+}
+
+.slider-card__eyebrow {
+  display: block;
+
+  margin-bottom: 6px;
+
+  color: var(--muted);
+
+  font-size: 0.59rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.slider-card h2 {
+  margin: 0;
+
+  font-size: 1.02rem;
+  letter-spacing: -0.025em;
+}
+
+.slider-card__value {
+  flex: 0 0 auto;
+
+  color: var(--accent);
+
+  font-size: 1rem;
+  font-weight: 850;
+}
+
+.slider-card__value--cyan {
+  color: var(--cyan-dark);
+}
+
+.slider-card__value--pink {
+  color: var(--pink-dark);
+}
+
+@media (prefers-color-scheme: dark) {
+  .slider-card__value--cyan {
+    color: var(--cyan);
+  }
+
+  .slider-card__value--pink {
+    color: var(--pink);
+  }
+}
+
+.slider {
+  position: relative;
+
+  margin-top: 27px;
+}
+
+.slider__input {
+  position: relative;
+  z-index: 4;
+
+  width: 100%;
+  height: 34px;
+
+  margin: 0;
+
+  appearance: none;
+  -webkit-appearance: none;
+
+  cursor: pointer;
+
+  background: transparent;
+}
+
+.slider__input::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 12px;
+
+  border-radius: 999px;
+
+  background:
+    linear-gradient(
+      90deg,
+      var(--accent) 0 72%,
+      var(--track) 72% 100%
+    );
+
+  box-shadow:
+    inset 3px 3px 7px var(--shadow-dark),
+    inset -3px -3px 7px var(--shadow-light);
+}
+
+.slider--cyan .slider__input::-webkit-slider-runnable-track {
+  background:
+    linear-gradient(
+      90deg,
+      var(--cyan) 0 58%,
+      var(--track) 58% 100%
+    );
+}
+
+.slider--pink .slider__input::-webkit-slider-runnable-track {
+  background:
+    linear-gradient(
+      90deg,
+      var(--pink) 0 86%,
+      var(--track) 86% 100%
+    );
+}
+
+.slider__input::-moz-range-track {
+  width: 100%;
+  height: 12px;
+
+  border: 0;
+  border-radius: 999px;
+
+  background: var(--track);
+
+  box-shadow:
+    inset 3px 3px 7px var(--shadow-dark),
+    inset -3px -3px 7px var(--shadow-light);
+}
+
+.slider__input::-moz-range-progress {
+  height: 12px;
+
+  border-radius: 999px;
+
+  background: var(--accent);
+}
+
+.slider--cyan .slider__input::-moz-range-progress {
+  background: var(--cyan);
+}
+
+.slider--pink .slider__input::-moz-range-progress {
+  background: var(--pink);
+}
+
+.slider__input::-webkit-slider-thumb {
+  width: 24px;
+  height: 24px;
+
+  margin-top: -6px;
+
+  appearance: none;
+  -webkit-appearance: none;
+
+  border: 3px solid var(--surface-raised);
+  border-radius: 50%;
+
+  background:
+    linear-gradient(
+      145deg,
+      #ffffff,
+      #d3d9e2
+    );
+
+  box-shadow:
+    5px 5px 11px var(--shadow-dark),
+    -4px -4px 9px var(--shadow-light),
+    0 0 0 4px rgba(119, 98, 217, 0.1);
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.slider--cyan .slider__input::-webkit-slider-thumb {
+  box-shadow:
+    5px 5px 11px var(--shadow-dark),
+    -4px -4px 9px var(--shadow-light),
+    0 0 0 4px rgba(50, 185, 210, 0.11);
+}
+
+.slider--pink .slider__input::-webkit-slider-thumb {
+  box-shadow:
+    5px 5px 11px var(--shadow-dark),
+    -4px -4px 9px var(--shadow-light),
+    0 0 0 4px rgba(220, 94, 158, 0.11);
+}
+
+.slider__input::-moz-range-thumb {
+  width: 19px;
+  height: 19px;
+
+  border: 3px solid var(--surface-raised);
+  border-radius: 50%;
+
+  background:
+    linear-gradient(
+      145deg,
+      #ffffff,
+      #d3d9e2
+    );
+
+  box-shadow:
+    5px 5px 11px var(--shadow-dark),
+    -4px -4px 9px var(--shadow-light);
+}
+
+.slider__input:hover::-webkit-slider-thumb {
+  transform: scale(1.12);
+}
+
+.slider__input:hover::-moz-range-thumb {
+  transform: scale(1.12);
+}
+
+.slider__input:focus-visible {
+  outline: 3px solid color-mix(
+    in srgb,
+    var(--accent) 34%,
+    transparent
+  );
+
+  outline-offset: 5px;
+
+  border-radius: 8px;
+}
+
+.slider__decor {
+  position: absolute;
+  z-index: 1;
+
+  left: 0;
+  right: 0;
+  top: 50%;
+
+  height: 20px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 0 6px;
+
+  pointer-events: none;
+
+  transform: translateY(-50%);
+}
+
+.slider__tick {
+  width: 3px;
+  height: 5px;
+
+  border-radius: 10px;
+
+  background: rgba(122, 131, 146, 0.35);
+}
+
+.slider__tick:nth-child(3) {
+  height: 7px;
+}
+
+.slider__labels {
+  display: flex;
+  justify-content: space-between;
+
+  margin-top: 5px;
+  padding: 0 2px;
+
+  color: var(--muted);
+
+  font-size: 0.55rem;
+  font-weight: 700;
+}
+
+.slider-card__hint {
+  margin: 18px 0 0;
+
+  color: var(--muted);
+
+  font-size: 0.66rem;
+  line-height: 1.6;
+}
+
+.feature-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 25px;
+
+  margin-top: 18px;
+  padding: 25px;
+
+  border: 1px solid var(--border);
+  border-radius: 23px;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.54),
+      rgba(220, 225, 233, 0.7)
+    );
+
+  box-shadow:
+    13px 13px 27px var(--shadow-dark),
+    -13px -13px 27px var(--shadow-light);
+}
+
+@media (prefers-color-scheme: dark) {
+  .feature-panel {
+    background:
+      linear-gradient(
+        145deg,
+        rgba(39, 45, 57, 0.86),
+        rgba(26, 31, 41, 0.92)
+      );
+  }
+}
+
+.feature-panel__eyebrow {
+  color: var(--accent);
+
+  font-size: 0.6rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.feature-panel h2 {
+  margin: 6px 0 0;
+
+  font-size: 1rem;
+  letter-spacing: -0.025em;
+}
+
+.feature-panel p {
+  max-width: 650px;
+
+  margin: 8px 0 0;
+
+  color: var(--muted);
+
+  font-size: 0.7rem;
+  line-height: 1.7;
+}
+
+.theme-preview {
+  position: relative;
+
+  width: 88px;
+  height: 48px;
+
+  flex: 0 0 auto;
+
+  border-radius: 999px;
+
+  background: var(--surface);
+
+  box-shadow:
+    inset 5px 5px 10px var(--shadow-dark),
+    inset -5px -5px 10px var(--shadow-light);
+}
+
+.theme-preview__sun,
+.theme-preview__moon {
+  position: absolute;
+
+  top: 50%;
+
+  width: 25px;
+  height: 25px;
+
+  border-radius: 50%;
+
+  transform: translateY(-50%);
+}
+
+.theme-preview__sun {
+  left: 8px;
+
+  background: #ffffff;
+
+  box-shadow:
+    0 3px 8px rgba(0, 0, 0, 0.14);
+}
+
+.theme-preview__moon {
+  right: 8px;
+
+  background: #272d39;
+
+  box-shadow:
+    0 3px 8px rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 850px) {
+  .slider-layout {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .slider-card:first-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 28px 12px;
+  }
+
+  .slider-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .slider-card:first-child {
+    grid-column: auto;
+  }
+
+  .slider-card:hover {
+    transform: none;
+  }
+
+  .feature-panel {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .theme-preview {
+    margin-top: 4px;
+  }
+}
+
+@media (max-width: 420px) {
+  .slider-card,
+  .feature-panel {
+    padding: 19px;
+    border-radius: 19px;
+  }
+
+  .slider-card__header {
+    align-items: flex-start;
+  }
+
+  .slider-card h2 {
+    font-size: 0.94rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .slider-card:hover,
+  .slider__input:hover::-webkit-slider-thumb,
+  .slider__input:hover::-moz-range-thumb {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a CSS-only Slider with Dark Mode styling for issue #78514.

It is a critical issue for expanding the EaseMotion CSS component
collection with a polished and reusable range control while maintaining
responsiveness, accessibility, dark-mode support, and lightweight
implementation.

### ✨ What's Added

- CSS-only responsive slider
- Native HTML range controls
- Custom slider thumbs
- Gradient progress tracks
- Purple, cyan, and pink variants
- Neumorphic track styling
- Tick markers
- Keyboard-accessible controls
- Visible focus states
- Automatic dark-mode support
- `prefers-reduced-motion` support
- Pure HTML and Vanilla CSS

### 📁 Files Added

- `submissions/examples/78514-css-dark-slider/demo.html`
- `submissions/examples/78514-css-dark-slider/style.css`
- `submissions/examples/78514-css-dark-slider/README.md`

### 🛠️ Technologies

- HTML5
- Vanilla CSS

No JavaScript or external dependencies are required.

### ♿ Accessibility

- Native `input[type="range"]`
- Accessible `aria-label` values
- Keyboard interaction
- Visible `:focus-visible` states
- Reduced-motion support

### 🌙 Dark Mode

The component automatically adapts using
`prefers-color-scheme: dark`.

### 📱 Responsive

The slider layout adapts from three columns to two columns and finally
to a single-column mobile layout.

### 🔗 Issue

Closes #78514