### PR TITLE
feat: add CSS CLI command snippet

### DIFF
--- a/submissions/examples/cli-command-snippet-ks-70137/README.md
+++ b/submissions/examples/cli-command-snippet-ks-70137/README.md
@@ -1,0 +1,79 @@
+# CLI Command Snippet
+
+## Overview
+
+A lightweight, modern terminal-style command component built entirely with HTML and CSS. It provides a polished presentation for CLI commands commonly used in developer documentation, including a visual structure for a copy button.
+
+## Features
+
+- Pure HTML/CSS
+- Terminal-style design with macOS-inspired window controls
+- Responsive (flex-wraps the copy button on mobile devices)
+- Accessible (semantic markup, visible focus, aria-hidden decorators)
+- Keyboard-friendly
+- Hover/focus states
+- Reduced-motion support
+- CSS custom properties
+- No external dependencies
+
+## Usage
+
+```html
+<div class="command-snippet">
+    <div class="terminal-header">
+        <div class="terminal-dots" aria-hidden="true">
+            <span class="dot dot-close"></span>
+            <span class="dot dot-minimize"></span>
+            <span class="dot dot-expand"></span>
+        </div>
+        <span class="terminal-title">bash</span>
+    </div>
+
+    <div class="command-body">
+        <div class="command-text-container">
+            <span class="prompt" aria-hidden="true">$</span>
+            <code>npm install easemotion</code>
+        </div>
+
+        <button type="button" class="copy-button" aria-label="Copy command">
+            Copy
+        </button>
+    </div>
+</div>
+```
+
+To replace the command, simply change the text inside the `<code>` element.
+
+## Copy Button Limitation
+
+**IMPORTANT:**
+This showcase intentionally uses CSS/HTML only. The Copy button is a visual UI element and does not access the clipboard. Actual clipboard copying requires JavaScript using the Clipboard API.
+
+## CSS Custom Properties
+
+| Variable | Purpose |
+|----------|---------|
+| `--page-bg` | Page background color |
+| `--terminal-bg` | Terminal main background |
+| `--terminal-border` | Terminal container border |
+| `--terminal-text` | Command text color |
+| `--terminal-muted` | Secondary text (title, eyebrow) |
+| `--terminal-accent` | Accent color (focus ring) |
+| `--button-bg` | Copy button resting background |
+| `--button-text` | Copy button text color |
+| `--prompt-color` | Color of the $ prompt symbol |
+| `--radius` | Component border radius |
+| `--shadow` | Component box shadow |
+| `--transition` | Standard transition timing |
+
+## Accessibility
+
+- **Semantic Markup**: Structural elements like `<button>` and `<code>` are used correctly.
+- **Visible Focus**: Interactive elements show a clear high-contrast outline when navigated via keyboard.
+- **Keyboard Accessibility**: The copy button can be focused and activated natively.
+- **Color Contrast**: Chosen colors exceed WCAG minimums against the dark backgrounds.
+- **Reduced-Motion Support**: Disables hover translations and entrance animations for users who prefer reduced motion.
+
+## Responsive Behavior
+
+The component uses Flexbox layout. On desktop and tablet, the command and copy button sit on the same line. On mobile devices (`< 600px`), the copy button naturally drops below the command text and expands to full width to maximize tap-target size, ensuring it remains fully usable and preventing horizontal page overflow.

--- a/submissions/examples/cli-command-snippet-ks-70137/demo.html
+++ b/submissions/examples/cli-command-snippet-ks-70137/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CLI Command Snippet</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="page">
+        <section class="showcase">
+            <header class="showcase-header">
+                <p class="eyebrow">EaseMotion CSS</p>
+                <h1>CLI Command Snippet</h1>
+                <p>
+                    A lightweight terminal-style command component
+                    built entirely with HTML and CSS.
+                </p>
+            </header>
+
+            <div class="command-snippet">
+                <div class="terminal-header">
+                    <div class="terminal-dots" aria-hidden="true">
+                        <span class="dot dot-close"></span>
+                        <span class="dot dot-minimize"></span>
+                        <span class="dot dot-expand"></span>
+                    </div>
+                    <span class="terminal-title">bash</span>
+                </div>
+
+                <div class="command-body">
+                    <div class="command-text-container">
+                        <span class="prompt" aria-hidden="true">$</span>
+                        <code>npm install easemotion</code>
+                    </div>
+
+                    <button
+                        type="button"
+                        class="copy-button"
+                        aria-label="Copy command"
+                    >
+                        Copy
+                    </button>
+                </div>
+            </div>
+            
+            <!-- Secondary Example -->
+            <div class="command-snippet secondary-example">
+                <div class="terminal-header">
+                    <div class="terminal-dots" aria-hidden="true">
+                        <span class="dot dot-close"></span>
+                        <span class="dot dot-minimize"></span>
+                        <span class="dot dot-expand"></span>
+                    </div>
+                    <span class="terminal-title">bash</span>
+                </div>
+
+                <div class="command-body">
+                    <div class="command-text-container">
+                        <span class="prompt" aria-hidden="true">$</span>
+                        <code>npx create-easemotion-app@latest</code>
+                    </div>
+
+                    <button
+                        type="button"
+                        class="copy-button"
+                        aria-label="Copy command"
+                    >
+                        Copy
+                    </button>
+                </div>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/submissions/examples/cli-command-snippet-ks-70137/style.css
+++ b/submissions/examples/cli-command-snippet-ks-70137/style.css
@@ -1,0 +1,251 @@
+:root {
+    --page-bg: #0d1117;
+    --terminal-bg: #161b22;
+    --terminal-border: #30363d;
+    --terminal-header-bg: #21262d;
+    --terminal-text: #e6edf3;
+    --terminal-muted: #8b949e;
+    --terminal-accent: #2f81f7;
+    --button-bg: rgba(255, 255, 255, 0.1);
+    --button-bg-hover: rgba(255, 255, 255, 0.15);
+    --button-text: #c9d1d9;
+    --prompt-color: #3fb950;
+    --radius: 8px;
+    --shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    --transition: 180ms ease;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    background-color: var(--page-bg);
+    color: var(--terminal-text);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1rem;
+}
+
+.page {
+    width: 100%;
+    max-width: 700px;
+}
+
+.showcase {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.showcase-header {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.eyebrow {
+    color: var(--terminal-muted);
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.showcase-header h1 {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    margin-bottom: 1rem;
+    color: #fff;
+    letter-spacing: -0.02em;
+}
+
+.showcase-header p {
+    color: var(--terminal-muted);
+    font-size: 1.125rem;
+    line-height: 1.6;
+    max-width: 500px;
+    margin-inline: auto;
+}
+
+/* Command Snippet Component */
+.command-snippet {
+    background-color: var(--terminal-bg);
+    border: 1px solid var(--terminal-border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    transition: transform var(--transition), box-shadow var(--transition);
+    animation: command-enter 0.5s ease backwards;
+}
+
+.secondary-example {
+    animation-delay: 0.15s;
+}
+
+.command-snippet:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+
+.terminal-header {
+    background-color: var(--terminal-header-bg);
+    border-bottom: 1px solid var(--terminal-border);
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+.terminal-dots {
+    display: flex;
+    gap: 6px;
+    position: absolute;
+    left: 1rem;
+}
+
+.dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+
+.dot-close { background-color: #ff5f56; }
+.dot-minimize { background-color: #ffbd2e; }
+.dot-expand { background-color: #27c93f; }
+
+.terminal-title {
+    color: var(--terminal-muted);
+    font-size: 0.75rem;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    width: 100%;
+    text-align: center;
+    user-select: none;
+}
+
+.command-body {
+    padding: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.command-text-container {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    overflow-x: auto;
+    white-space: nowrap;
+    /* Hide scrollbar for a cleaner look */
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+.command-text-container::-webkit-scrollbar {
+    display: none;
+}
+
+.prompt {
+    color: var(--prompt-color);
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-weight: 600;
+    user-select: none;
+}
+
+code {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.875rem;
+    color: var(--terminal-text);
+}
+
+/* Copy Button */
+.copy-button {
+    background-color: var(--button-bg);
+    color: var(--button-text);
+    border: 1px solid var(--terminal-border);
+    border-radius: 6px;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.75rem;
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.copy-button:hover {
+    background-color: var(--button-bg-hover);
+    color: #fff;
+    border-color: var(--terminal-muted);
+}
+
+.copy-button:active {
+    transform: scale(0.96);
+}
+
+.copy-button:focus-visible {
+    outline: 2px solid var(--terminal-accent);
+    outline-offset: 2px;
+}
+
+/* Entrance Animation */
+@keyframes command-enter {
+    from {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .command-body {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.25rem;
+    }
+
+    .copy-button {
+        width: 100%;
+        padding: 0.6rem;
+    }
+    
+    .command-text-container {
+        width: 100%;
+    }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+    
+    .command-snippet {
+        animation: none;
+    }
+    
+    .command-snippet:hover {
+        transform: none;
+    }
+    
+    .copy-button:active {
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Description

Implements #70137 by adding a reusable CSS/HTML CLI Command Snippet component for the EaseMotion CSS showcase.

## Features

- Terminal-style command snippet
- npm/CLI command presentation
- CSS-only implementation
- Visual Copy button
- No JavaScript
- Responsive layout
- Hover and focus interactions
- Keyboard accessibility
- `prefers-reduced-motion` support
- CSS custom properties
- No external dependencies
- Documentation included

## Important Note

The Copy button is intentionally a visual UI element because this issue requires a pure CSS/HTML implementation. Actual clipboard functionality would require JavaScript and the Clipboard API.

## Files Added

- `submissions/examples/cli-command-snippet-ks-70137/demo.html`
- `submissions/examples/cli-command-snippet-ks-70137/style.css`
- `submissions/examples/cli-command-snippet-ks-70137/README.md`

## Checklist

- [x] Pure HTML/CSS
- [x] No JavaScript
- [x] CLI command snippet
- [x] Copy button UI
- [x] Responsive
- [x] Accessible
- [x] Keyboard focus support
- [x] Reduced-motion support
- [x] CSS custom properties
- [x] Documentation added
- [x] No external dependencies
- [x] No unrelated files modified

Closes #70137
