### PR TITLE
feat: create Floating Carousel with Retro styling #78891

### DIFF
--- a/submissions/examples/css-floating-carousel-retro/README.md
+++ b/submissions/examples/css-floating-carousel-retro/README.md
@@ -1,0 +1,13 @@
+# Floating Carousel with Retro styling (#78891)
+
+A responsive floating card carousel component featuring retro neo-brutalist aesthetics, hard shadows, and native CSS scroll-snapping built entirely with pure CSS.
+
+## Features
+- **Semantic Structure:** Uses accessible `<main>` and `<article>` landmark elements with focusable cards.
+- **Retro Aesthetics:** High-contrast borders, solid offset box shadows, and arcade color accents.
+- **Responsive Scroll Snap:** Horizontal touch and trackbar scrolling with CSS `scroll-snap-type`.
+
+## File Hierarchy
+- `style.css` - Component variables, hard box-shadows, and layout styles.
+- `demo.html` - Semantic structure and accessibility attributes.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-floating-carousel-retro/demo.html
+++ b/submissions/examples/css-floating-carousel-retro/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Carousel | Retro Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="carousel-container" tabindex="0" aria-label="Retro Floating Carousel Showcase">
+    <h1 class="carousel-title">Retro Carousel</h1>
+    <p class="carousel-subtitle">Vintage brutalist floating card slider</p>
+
+    <div class="carousel-track" role="region" aria-label="Card gallery">
+        <article class="carousel-card" tabindex="0">
+            <span class="card-badge">ITEM #01</span>
+            <h2 class="card-heading">Hard Shadows</h2>
+            <p class="card-desc">Bold offset borders and high-contrast shadows deliver a classic retro pixel feel.</p>
+        </article>
+
+        <article class="carousel-card" tabindex="0">
+            <span class="card-badge">ITEM #02</span>
+            <h2 class="card-heading">Arcade Colors</h2>
+            <p class="card-desc">Pop color accents with monospaced typography inspired by classic arcade UI interfaces.</p>
+        </article>
+
+        <article class="carousel-card" tabindex="0">
+            <span class="card-badge">ITEM #03</span>
+            <h2 class="card-heading">Snap Scroll</h2>
+            <p class="card-desc">Native CSS horizontal scroll snapping provides fluid interaction across viewports.</p>
+        </article>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-floating-carousel-retro/style.css
+++ b/submissions/examples/css-floating-carousel-retro/style.css
@@ -1,0 +1,119 @@
+/* CSS Floating Carousel with Retro Styling #78891 */
+
+:root {
+    --bg-color: #fef08a;
+    --card-bg: #fffba1;
+    --card-border: #18181b;
+    --accent-yellow: #facc15;
+    --accent-orange: #fb923c;
+    --accent-pink: #f472b6;
+    --text-main: #18181b;
+    --shadow-hard: 6px 6px 0px #18181b;
+    --shadow-hover: 10px 10px 0px #18181b;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Courier New', Courier, monospace, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.carousel-container {
+    width: 100%;
+    max-width: 750px;
+    text-align: center;
+}
+
+.carousel-title {
+    font-size: 2.25rem;
+    font-weight: 900;
+    margin: 0 0 0.5rem 0;
+    text-transform: uppercase;
+    letter-spacing: -0.05em;
+    text-shadow: 2px 2px 0px #ffffff;
+}
+
+.carousel-subtitle {
+    color: var(--text-main);
+    font-size: 1rem;
+    font-weight: 700;
+    margin-bottom: 2.5rem;
+}
+
+/* Retro Brutalist Scroll Track */
+.carousel-track {
+    display: flex;
+    gap: 1.5rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding: 1rem 0.5rem 2.5rem 0.5rem;
+    scrollbar-width: auto;
+    scrollbar-color: var(--text-main) transparent;
+}
+
+.carousel-card {
+    flex: 0 0 280px;
+    scroll-snap-align: center;
+    background-color: var(--card-bg);
+    border: 3px solid var(--card-border);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    text-align: left;
+    box-shadow: var(--shadow-hard);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.carousel-card:hover,
+.carousel-card:focus-within {
+    transform: translate(-4px, -4px);
+    box-shadow: var(--shadow-hover);
+    outline: none;
+}
+
+.carousel-card:nth-child(1) .card-badge {
+    background-color: var(--accent-orange);
+}
+
+.carousel-card:nth-child(2) .card-badge {
+    background-color: var(--accent-pink);
+}
+
+.carousel-card:nth-child(3) .card-badge {
+    background-color: var(--accent-yellow);
+}
+
+.card-badge {
+    display: inline-block;
+    border: 2px solid var(--card-border);
+    color: var(--text-main);
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+    box-shadow: 2px 2px 0px #18181b;
+}
+
+.card-heading {
+    font-size: 1.35rem;
+    font-weight: 800;
+    margin: 0 0 0.75rem 0;
+    text-transform: uppercase;
+}
+
+.card-desc {
+    color: var(--text-main);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    font-weight: 600;
+    margin: 0;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Floating Carousel with Retro styling** component (#78891).
gssoc 26

Closes #78891

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-floating-carousel-retro/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible with proper ARIA landmark roles and keyboard focus support

---

## Feature Description
**What does this add?**
Retro/neo-brutalist floating card carousel featuring bold offset box-shadows, arcade pop colors, monospaced typography, and smooth CSS scroll-snapping.

**How does it work?**
Constructed using flexbox overflow tracks, `scroll-snap-type: x mandatory`, and CSS transform translate hover transitions without JavaScript dependencies.