### PR TITLE
feat: create Morphing Carousel with Gradient styling #78888

### DIFF
--- a/submissions/examples/css-morphing-carousel-gradient/README.md
+++ b/submissions/examples/css-morphing-carousel-gradient/README.md
@@ -1,0 +1,13 @@
+# Morphing Carousel with Gradient styling (#78888)
+
+A responsive fluid carousel component featuring dynamic asymmetric border-radius morphing states, vibrant top gradients, and native horizontal scroll snapping built entirely with pure CSS.
+
+## Features
+- **Semantic Structure:** Built with clean HTML5 landmark structures (`<main>`, `<article>`) and proper keyboard focus management.
+- **Morphing Border Geometry:** Asymmetric `border-radius` transitions smooth out with spring-like cubic-bezier timing curves on hover.
+- **Responsive Scroll Snap:** Fluid horizontal scrolling using native CSS `scroll-snap-type: x mandatory`.
+
+## File Hierarchy
+- `style.css` - Component styles, morphing border geometry, gradient overlays, and transitions.
+- `demo.html` - Semantic DOM markup and ARIA showcase wrapper.
+- `README.md` - Technical specification and usage guidelines.

--- a/submissions/examples/css-morphing-carousel-gradient/demo.html
+++ b/submissions/examples/css-morphing-carousel-gradient/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morphing Carousel | Gradient Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="carousel-wrapper" tabindex="0" aria-label="Morphing Gradient Carousel Showcase">
+    <h1 class="carousel-title">Morphing Carousel</h1>
+    <p class="carousel-subtitle">Fluid border-radius morphing card slider with gradients</p>
+
+    <div class="carousel-track" role="region" aria-label="Gradient card collection">
+        <article class="morph-card" tabindex="0">
+            <span class="card-number">CARD 01</span>
+            <h2 class="card-heading">Sunset Morph</h2>
+            <p class="card-desc">Asymmetric border-radius transitions seamlessly upon hover for an organic morphing motion.</p>
+        </article>
+
+        <article class="morph-card" tabindex="0">
+            <span class="card-number">CARD 02</span>
+            <h2 class="card-heading">Ocean Flow</h2>
+            <p class="card-desc">Deep cyan and blue gradient accents combined with horizontal touch scroll-snapping.</p>
+        </article>
+
+        <article class="morph-card" tabindex="0">
+            <span class="card-number">CARD 03</span>
+            <h2 class="card-heading">Emerald Shift</h2>
+            <p class="card-desc">Pure CSS keyframe spring physics behavior delivered entirely without external libraries.</p>
+        </article>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-morphing-carousel-gradient/style.css
+++ b/submissions/examples/css-morphing-carousel-gradient/style.css
@@ -1,0 +1,131 @@
+/* CSS Morphing Carousel with Gradient Styling #78888 */
+
+:root {
+    --bg-color: #0d0f17;
+    --card-bg: #161b26;
+    --card-border: rgba(255, 255, 255, 0.08);
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+    --grad-1: linear-gradient(135deg, #ec4899, #8b5cf6);
+    --grad-2: linear-gradient(135deg, #3b82f6, #06b6d4);
+    --grad-3: linear-gradient(135deg, #10b981, #f59e0b);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.carousel-wrapper {
+    width: 100%;
+    max-width: 800px;
+    text-align: center;
+}
+
+.carousel-title {
+    font-size: 2rem;
+    font-weight: 800;
+    margin: 0 0 0.25rem 0;
+    background: linear-gradient(135deg, #f8fafc, #94a3b8);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.carousel-subtitle {
+    color: var(--text-sub);
+    font-size: 0.95rem;
+    margin-bottom: 2.5rem;
+}
+
+/* Horizontal Scroll Track with Morphing Cards */
+.carousel-track {
+    display: flex;
+    gap: 1.5rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding: 1rem 0.5rem 2.5rem 0.5rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--card-border) transparent;
+}
+
+.morph-card {
+    flex: 0 0 280px;
+    scroll-snap-align: center;
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 2rem 0.75rem 2rem 0.75rem;
+    padding: 2rem;
+    text-align: left;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: 0 15px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+.morph-card:hover,
+.morph-card:focus-within {
+    border-radius: 0.75rem 2rem 0.75rem 2rem;
+    transform: translateY(-8px) scale(1.02);
+    box-shadow: 0 25px 35px -10px rgba(0, 0, 0, 0.6);
+    outline: none;
+}
+
+/* Morphing Gradient Accents */
+.morph-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 6px;
+    transition: height 0.3s ease;
+}
+
+.morph-card:nth-child(1)::before {
+    background: var(--grad-1);
+}
+
+.morph-card:nth-child(2)::before {
+    background: var(--grad-2);
+}
+
+.morph-card:nth-child(3)::before {
+    background: var(--grad-3);
+}
+
+.morph-card:hover::before {
+    height: 100%;
+    opacity: 0.05;
+}
+
+.card-number {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--text-sub);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+    display: block;
+}
+
+.card-heading {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin: 0 0 0.75rem 0;
+}
+
+.card-desc {
+    color: var(--text-sub);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    margin: 0;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Morphing Carousel with Gradient styling** component (#78888).
gssoc 26

Closes #78888

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-morphing-carousel-gradient/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible with proper ARIA landmark roles and keyboard focus support

---

## Feature Description
**What does this add?**
Morphing card carousel featuring fluid border-radius geometric transitions, gradient headers, and horizontal scroll-snapping.

**How does it work?**
Uses CSS asymmetric `border-radius` property shifts triggered on `:hover` and `:focus-within` combined with native `scroll-snap-type: x mandatory` layout tracks without JavaScript dependencies.