### PR TITLE
feat: Floating Modal with SaaS Modern styling (#78892)

### DIFF
--- a/submissions/examples/floating-saas-modal-sb/README.md
+++ b/submissions/examples/floating-saas-modal-sb/README.md
@@ -1,0 +1,67 @@
+# Floating Modal (SaaS Modern)
+
+A pure-CSS modal component that floats above the page with a soft backdrop blur and a
+smooth scale-and-fade entrance. It opens and closes entirely through hash navigation
+(`:target`) — no JavaScript required.
+
+## What does this do?
+
+It renders a responsive, accessible dialog overlay with a SaaS-modern look (clean white
+surface, layered shadow, accent gradient, blurred backdrop) that animates into view when
+its trigger link is clicked and animates out when the backdrop or close control is used.
+
+## How is it used?
+
+Link the trigger to the overlay's `id`, and link the close/backdrop controls to `#`:
+
+```html
+<a class="fsm-trigger" href="#fsm-modal">Open modal</a>
+
+<div class="fsm-overlay" id="fsm-modal" role="presentation">
+  <a class="fsm-backdrop" href="#" aria-label="Close modal"></a>
+  <section class="fsm-panel" role="dialog" aria-modal="true"
+           aria-labelledby="fsm-panel-title" aria-describedby="fsm-panel-desc">
+    <header class="fsm-panel-header">
+      <div>
+        <h2 id="fsm-panel-title">Title</h2>
+        <p class="fsm-panel-subtitle">Subtitle</p>
+      </div>
+      <a class="fsm-close" href="#" aria-label="Close modal">&times;</a>
+    </header>
+    <div class="fsm-body" id="fsm-panel-desc">Body content</div>
+    <footer class="fsm-actions">
+      <a class="fsm-btn fsm-btn-secondary" href="#">Cancel</a>
+      <a class="fsm-btn fsm-btn-primary" href="#">Confirm</a>
+    </footer>
+  </section>
+</div>
+```
+
+### Configurable tokens
+
+Override these on `.floating-saas-modal-demo` (or `:root`) to retune the animation:
+
+```css
+.floating-saas-modal-demo {
+  --fsm-duration: 240ms;                       /* entrance duration */
+  --fsm-easing: cubic-bezier(0.22, 1, 0.36, 1); /* entrance easing */
+  --fsm-radius: 1.25rem;                        /* panel corner radius */
+  --fsm-accent: #6c63ff;                        /* primary accent */
+  --fsm-surface: #ffffff;                       /* panel background */
+}
+```
+
+## Why is it useful?
+
+It demonstrates EaseMotion's philosophy of declarative, dependency-free motion: the
+entrance is driven by the `:target` pseudo-class and CSS transitions, so it works by
+opening the HTML file directly with no server, framework, or JavaScript. It is fully
+responsive (the plan grid and actions stack on narrow screens), honors
+`prefers-reduced-motion`, and exposes visible focus outlines for keyboard users — making
+it a clean, reusable pattern for dashboards, onboarding flows, and upgrade prompts.
+
+## Files
+
+- `demo.html` — self-contained standalone preview.
+- `style.css` — scoped styles with configurable custom properties.
+- `README.md` — usage and rationale.

--- a/submissions/examples/floating-saas-modal-sb/demo.html
+++ b/submissions/examples/floating-saas-modal-sb/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Floating Modal (SaaS Modern)</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <main class="floating-saas-modal-demo">
+    <section class="fsm-hero" aria-labelledby="fsm-hero-title">
+      <span class="fsm-eyebrow">Pure CSS component</span>
+      <h1 id="fsm-hero-title">Floating modal with SaaS modern styling</h1>
+      <p class="fsm-copy">
+        A responsive dialog pattern that floats above the page with a soft backdrop blur,
+        smooth scale-and-fade motion, and configurable timing tokens. Opens and closes
+        with no JavaScript using hash navigation.
+      </p>
+      <a class="fsm-trigger" href="#fsm-modal">Open modal</a>
+    </section>
+
+    <div class="fsm-overlay" id="fsm-modal" role="presentation">
+      <a class="fsm-backdrop" href="#" aria-label="Close modal"></a>
+      <section
+        class="fsm-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="fsm-panel-title"
+        aria-describedby="fsm-panel-desc"
+      >
+        <header class="fsm-panel-header">
+          <div>
+            <h2 id="fsm-panel-title">Upgrade your workspace</h2>
+            <p class="fsm-panel-subtitle">Pick the plan that fits your team</p>
+          </div>
+          <a class="fsm-close" href="#" aria-label="Close modal">&times;</a>
+        </header>
+
+        <div class="fsm-body" id="fsm-panel-desc">
+          <p>
+            This panel floats above the page with a layered shadow and a blurred backdrop.
+            Tune the entrance with the CSS custom properties on the wrapper.
+          </p>
+
+          <div class="fsm-plan-grid" aria-label="Available plans">
+            <span class="fsm-plan"><span class="fsm-plan-dot"></span>Starter</span>
+            <span class="fsm-plan"><span class="fsm-plan-dot"></span>Pro</span>
+            <span class="fsm-plan"><span class="fsm-plan-dot"></span>Business</span>
+            <span class="fsm-plan"><span class="fsm-plan-dot"></span>Enterprise</span>
+          </div>
+        </div>
+
+        <footer class="fsm-actions">
+          <a class="fsm-btn fsm-btn-secondary" href="#">Maybe later</a>
+          <a class="fsm-btn fsm-btn-primary" href="#">Upgrade now</a>
+        </footer>
+      </section>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/floating-saas-modal-sb/style.css
+++ b/submissions/examples/floating-saas-modal-sb/style.css
@@ -1,0 +1,327 @@
+@import "../../../core/variables.css";
+@import "../../../core/utilities.css";
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --fsm-bg: #f6f7fb;
+  --fsm-surface: #ffffff;
+  --fsm-text: #0f172a;
+  --fsm-muted: #64748b;
+  --fsm-border: #e7e9f3;
+  --fsm-accent: var(--ease-color-primary, #6c63ff);
+  --fsm-accent-soft: rgba(108, 99, 255, 0.10);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: var(--ease-font-sans, "Inter", system-ui, -apple-system, sans-serif);
+  color: var(--fsm-text);
+  background:
+    radial-gradient(circle at 12% 14%, rgba(108, 99, 255, 0.12), transparent 28rem),
+    radial-gradient(circle at 88% 10%, rgba(139, 92, 246, 0.10), transparent 24rem),
+    linear-gradient(180deg, #fbfbff 0%, var(--fsm-bg) 100%);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Demo scaffold ─────────────────────────────────────────────────────── */
+.floating-saas-modal-demo {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.25rem, 5vw, 4rem);
+}
+
+.fsm-hero {
+  width: min(100%, 44rem);
+  text-align: center;
+}
+
+.fsm-eyebrow {
+  display: inline-block;
+  margin: 0 0 1rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: var(--fsm-accent-soft);
+  color: var(--fsm-accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.fsm-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.fsm-copy {
+  width: min(100%, 34rem);
+  margin: 1.1rem auto 1.8rem;
+  color: var(--fsm-muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+/* ── Floating trigger button ──────────────────────────────────────────── */
+.fsm-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 3rem;
+  padding: 0 1.4rem;
+  border: 0;
+  border-radius: 0.85rem;
+  background: var(--fsm-accent);
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow:
+    0 10px 24px rgba(108, 99, 255, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+              box-shadow 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.fsm-trigger:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 16px 32px rgba(108, 99, 255, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.fsm-trigger:active {
+  transform: translateY(0);
+}
+
+/* ── Modal overlay ─────────────────────────────────────────────────────── */
+.fsm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 5vw, 2rem);
+  background: rgba(15, 23, 42, 0.42);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--fsm-duration, 240ms) var(--fsm-easing, cubic-bezier(0.22, 1, 0.36, 1)),
+    visibility var(--fsm-duration, 240ms) var(--fsm-easing, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+/* Backdrop click target (anchor to #) closes the modal */
+.fsm-backdrop {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+/* ── Modal panel ───────────────────────────────────────────────────────── */
+.fsm-panel {
+  position: relative;
+  width: min(100%, 30rem);
+  max-height: min(86vh, 46rem);
+  overflow: auto;
+  padding: clamp(1.5rem, 5vw, 2rem);
+  border-radius: var(--fsm-radius, 1.25rem);
+  background: var(--fsm-surface);
+  border: 1px solid var(--fsm-border);
+  box-shadow:
+    0 32px 80px rgba(15, 23, 42, 0.24),
+    0 8px 18px rgba(15, 23, 42, 0.12);
+  transform: translateY(1.2rem) scale(0.97);
+  opacity: 0;
+  transition:
+    transform var(--fsm-duration, 240ms) var(--fsm-easing, cubic-bezier(0.22, 1, 0.36, 1)),
+    opacity var(--fsm-duration, 240ms) var(--fsm-easing, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+/* Open state via :target (hash navigation, no JS) */
+.fsm-overlay:target {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.fsm-overlay:target .fsm-panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+/* ── Panel internals ───────────────────────────────────────────────────── */
+.fsm-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+}
+
+.fsm-panel-title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.fsm-panel-subtitle {
+  margin: 0.3rem 0 0;
+  color: var(--fsm-muted);
+  font-size: 0.9rem;
+}
+
+.fsm-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  border: 1px solid var(--fsm-border);
+  border-radius: 0.65rem;
+  background: var(--fsm-bg);
+  color: var(--fsm-muted);
+  font-size: 1.05rem;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.fsm-close:hover {
+  background: var(--fsm-accent-soft);
+  color: var(--fsm-accent);
+  border-color: transparent;
+}
+
+.fsm-body {
+  color: var(--fsm-text);
+  font-size: 0.96rem;
+  line-height: 1.65;
+}
+
+.fsm-body p {
+  margin: 0 0 1rem;
+}
+
+.fsm-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0 0 1.4rem;
+}
+
+.fsm-plan {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--fsm-border);
+  border-radius: 0.8rem;
+  background: var(--fsm-bg);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--fsm-text);
+}
+
+.fsm-plan-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: var(--fsm-accent);
+  box-shadow: 0 0 0 4px var(--fsm-accent-soft);
+}
+
+/* ── Action footer ─────────────────────────────────────────────────────── */
+.fsm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.7rem;
+  margin-top: 1.5rem;
+}
+
+.fsm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0 1.2rem;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease,
+              transform 160ms ease;
+}
+
+.fsm-btn-primary {
+  background: var(--fsm-accent);
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(108, 99, 255, 0.28);
+}
+
+.fsm-btn-primary:hover {
+  transform: translateY(-1px);
+}
+
+.fsm-btn-secondary {
+  background: var(--fsm-surface);
+  color: var(--fsm-text);
+  border-color: var(--fsm-border);
+}
+
+.fsm-btn-secondary:hover {
+  background: var(--fsm-bg);
+}
+
+/* ── Focus + a11y ─────────────────────────────────────────────────────── */
+.fsm-trigger:focus-visible,
+.fsm-btn:focus-visible,
+.fsm-close:focus-visible {
+  outline: 3px solid var(--fsm-accent);
+  outline-offset: 3px;
+}
+
+/* ── Responsive ────────────────────────────────────────────────────────── */
+@media (max-width: 540px) {
+  .fsm-plan-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fsm-actions {
+    flex-direction: column-reverse;
+  }
+
+  .fsm-btn {
+    width: 100%;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .fsm-trigger,
+  .fsm-overlay,
+  .fsm-panel,
+  .fsm-btn,
+  .fsm-close {
+    transition: none;
+  }
+
+  .fsm-panel {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Floating Modal with SaaS Modern styling

Resolves #78892

### What this adds

A new pure-CSS modal component contribution under `submissions/examples/floating-saas-modal-sb/`.

### Files

- `demo.html` — self-contained standalone preview (no server/CDN/JS).
- `style.css` — scoped styles with configurable CSS custom properties.
- `README.md` — usage, tokens, and rationale.

### Implementation details

- **No JavaScript:** opens/closes via the `:target` pseudo-class (hash navigation). The trigger links to `#fsm-modal`; the backdrop and close control link to `#` to dismiss.
- **SaaS Modern look:** clean white surface, layered shadow, accent gradient, blurred backdrop.
- **Responsive:** the plan grid and the action footer stack into a single column on narrow screens (`max-width: 540px`); action buttons go full-width.
- **Accessible:** `role="dialog"` / `aria-modal="true"`, `aria-labelledby` + `aria-describedby`, visible `:focus-visible` outlines, and respects `prefers-reduced-motion` (disables transitions and the entrance transform).
- **Configurable tokens** (override on `.floating-saas-modal-demo` or `:root`): `--fsm-duration`, `--fsm-easing`, `--fsm-radius`, `--fsm-accent`, `--fsm-surface`.

### Checklist

- [x] Placed under `submissions/examples/` with a unique suffix (`-sb`)
- [x] Contains exactly `demo.html`, `style.css`, `README.md`
- [x] `demo.html` works by opening directly in a browser (no server/CDN/framework)
- [x] Fully responsive
- [x] Honors `prefers-reduced-motion`
- [x] Clean single conventional commit

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
