### PR TITLE
feat: create Glassmorphism Badge with Pastel styling #78868

### DIFF
--- a/submissions/examples/css-glassmorphism-badge-pastel/README.md
+++ b/submissions/examples/css-glassmorphism-badge-pastel/README.md
@@ -1,0 +1,13 @@
+# Glassmorphism Badge with Pastel styling (#78868)
+
+A collection of responsive frosted glassmorphism status badges with soft pastel glowing accents and backdrop blur styling built entirely with pure CSS.
+
+## Features
+- **Semantic & Accessible Markup:** Includes focus states, ARIA roles, and decorative dot indicators.
+- **Glassmorphism Aesthetic:** Translucent backgrounds combined with native `backdrop-filter: blur()`.
+- **Soft Pastel Glow:** Subtle hover scaling effects with pastel box-shadow aura highlights.
+
+## File Hierarchy
+- `style.css` - Component styling, backdrop blur properties, and color variations.
+- `demo.html` - Accessible HTML structure showcasing badge variations.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-glassmorphism-badge-pastel/demo.html
+++ b/submissions/examples/css-glassmorphism-badge-pastel/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Badge | Pastel Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="badge-card" tabindex="0" aria-label="Glassmorphism Badge Showcase">
+    <h1 class="badge-title">Pastel Glass Badges</h1>
+    <p class="badge-subtitle">Frosted glassmorphic status badges with soft glow accents</p>
+
+    <div class="badge-group" role="region" aria-label="Badge status collection">
+        <span class="glass-badge mint" tabindex="0">
+            <span class="badge-dot" aria-hidden="true"></span>
+            System Operational
+        </span>
+
+        <span class="glass-badge purple" tabindex="0">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Pro Member
+        </span>
+
+        <span class="glass-badge pink" tabindex="0">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Featured
+        </span>
+
+        <span class="glass-badge cyan" tabindex="0">
+            <span class="badge-dot" aria-hidden="true"></span>
+            Beta v2.4
+        </span>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-glassmorphism-badge-pastel/style.css
+++ b/submissions/examples/css-glassmorphism-badge-pastel/style.css
@@ -1,0 +1,131 @@
+/* Glassmorphism Badge with Pastel Styling #78868 */
+
+:root {
+    --bg-color: #121020;
+    --card-bg: rgba(255, 255, 255, 0.03);
+    --card-border: rgba(255, 255, 255, 0.08);
+    --pastel-purple: #c084fc;
+    --pastel-pink: #f472b6;
+    --pastel-cyan: #38bdf8;
+    --pastel-mint: #6ee7b7;
+    --text-main: #f3e8ff;
+    --text-sub: #a78bfa;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 2rem;
+}
+
+.badge-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-radius: 1.5rem;
+    padding: 3rem 2.5rem;
+    width: 100%;
+    max-width: 520px;
+    text-align: center;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.badge-title {
+    font-size: 1.6rem;
+    font-weight: 800;
+    margin: 0 0 0.25rem 0;
+}
+
+.badge-subtitle {
+    color: var(--text-sub);
+    font-size: 0.9rem;
+    margin-bottom: 2.5rem;
+}
+
+/* Glassmorphism Badge Grid */
+.badge-group {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.glass-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    cursor: default;
+}
+
+.glass-badge:hover,
+.glass-badge:focus-visible {
+    transform: translateY(-3px) scale(1.03);
+    outline: none;
+}
+
+/* Badge Color Variants */
+.glass-badge.purple {
+    background: rgba(192, 132, 252, 0.12);
+    color: var(--pastel-purple);
+    border-color: rgba(192, 132, 252, 0.3);
+}
+
+.glass-badge.purple:hover {
+    box-shadow: 0 0 20px rgba(192, 132, 252, 0.4);
+}
+
+.glass-badge.pink {
+    background: rgba(244, 114, 182, 0.12);
+    color: var(--pastel-pink);
+    border-color: rgba(244, 114, 182, 0.3);
+}
+
+.glass-badge.pink:hover {
+    box-shadow: 0 0 20px rgba(244, 114, 182, 0.4);
+}
+
+.glass-badge.cyan {
+    background: rgba(56, 189, 248, 0.12);
+    color: var(--pastel-cyan);
+    border-color: rgba(56, 189, 248, 0.3);
+}
+
+.glass-badge.cyan:hover {
+    box-shadow: 0 0 20px rgba(56, 189, 248, 0.4);
+}
+
+.glass-badge.mint {
+    background: rgba(110, 231, 183, 0.12);
+    color: var(--pastel-mint);
+    border-color: rgba(110, 231, 183, 0.3);
+}
+
+.glass-badge.mint:hover {
+    box-shadow: 0 0 20px rgba(110, 231, 183, 0.4);
+}
+
+.badge-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: currentColor;
+    box-shadow: 0 0 8px currentColor;
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Glassmorphism Badge with Pastel styling** component (#78868).
gssoc 26

Closes #78868

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-glassmorphism-badge-pastel/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible with proper keyboard focus support and ARIA landmark roles

---

## Feature Description
**What does this add?**
Frosted glassmorphism status badges featuring soft pastel color themes, backdrop blur effects, active glowing shadows, and elevation transitions.

**How does it work?**
Constructed using CSS flexbox, translucent RGBA background fills, `backdrop-filter: blur()`, and custom hover state keyframe elevations without JavaScript dependencies.