### PR TITLE
Add Underline wave ripple link submission

### DIFF
--- a/submissions/examples/underline-wave-ripple/README.md
+++ b/submissions/examples/underline-wave-ripple/README.md
@@ -1,0 +1,21 @@
+# Underline wave ripple link
+
+A link whose underline ripples with a sine wave beneath the text on hover.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `underlinewaveripple-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Link pattern; the wave is more expressive than a flat colour line.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *warm*)
+- `README.md` — this file

--- a/submissions/examples/underline-wave-ripple/demo.html
+++ b/submissions/examples/underline-wave-ripple/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Underline wave ripple link — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Underline wave ripple link</h1>
+      <p>A link whose underline ripples with a sine wave beneath the text on hover.</p>
+    </header>
+    <section class="demo">
+      <a class="underlinewaveripple" href="#">A wave underline link</a>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/underline-wave-ripple/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/underline-wave-ripple/style.css
+++ b/submissions/examples/underline-wave-ripple/style.css
@@ -1,0 +1,58 @@
+/* Underline wave ripple link — EaseMotion CSS submission
+   Palette: warm   Folder: submissions/examples/underline-wave-ripple/   Class prefix: .underlinewaveripple
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f1115;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff6a3d;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d24;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff6a3d;
+  background: #1a1d24;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.underlinewaveripple { position: relative; color: #e6e8ec; text-decoration: none; padding-bottom: 6px; font: 16px/1.4 system-ui; }
+.underlinewaveripple::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 4px; background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 4'><path d='M0 2 Q 6 0 12 2 T 24 2' stroke='#ff6a3d' fill='none' stroke-width='1.5'/></svg>") repeat-x; background-size: 24px 4px; transform: scaleX(0); transform-origin: left; transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.underlinewaveripple:hover::after { transform: scaleX(1); animation: kf-underlinewaveripple 1.4s linear infinite; }
+@keyframes kf-underlinewaveripple { from { background-position: 0 0; } to { background-position: 24px 0; } }


### PR DESCRIPTION
Closes #79049

## What
This submission adds a new EaseMotion CSS example: `underline-wave-ripple` under `submissions/examples/`.

A link whose underline ripples with a sine wave beneath the text on hover.

## How to review
1. Open `submissions/examples/underline-wave-ripple/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/underline-wave-ripple/` and does not modify any existing file.
