### PR TITLE
feat: create Glowing Breadcrumb with Neon styling #78887

### DIFF
--- a/submissions/examples/css-glowing-breadcrumb-neon/README.md
+++ b/submissions/examples/css-glowing-breadcrumb-neon/README.md
@@ -1,0 +1,13 @@
+# Glowing Breadcrumb with Neon styling (#78887)
+
+A responsive breadcrumb navigation component styled with futuristic neon glow effects, luminous separators, and accessible hierarchy markup built using pure CSS.
+
+## Features
+- **Accessible Navigation:** Uses semantic `<nav>`, `<ol>`, and `aria-current="page"` attributes.
+- **Neon Luminance:** CSS `text-shadow` and `box-shadow` properties providing high-contrast glowing feedback.
+- **Responsive Overflow Support:** Horizontal scrollability on small viewports ensuring intact layout structure.
+
+## File Hierarchy
+- `style.css` - Component styling, neon glow variables, and active states.
+- `demo.html` - Accessible HTML structure showcasing breadcrumb path.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-glowing-breadcrumb-neon/demo.html
+++ b/submissions/examples/css-glowing-breadcrumb-neon/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Breadcrumb | Neon Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="breadcrumb-card">
+    <h1 class="card-title">Neon Breadcrumb Navigation</h1>
+    <p class="card-subtitle">Cyberpunk-inspired luminous hierarchy paths with neon glow states</p>
+
+    <div class="neon-breadcrumb">
+        <nav aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                <li class="breadcrumb-item">
+                    <a href="#home" class="breadcrumb-link">Home</a>
+                    <span class="breadcrumb-separator" aria-hidden="true">/</span>
+                </li>
+
+                <li class="breadcrumb-item">
+                    <a href="#network" class="breadcrumb-link">Network</a>
+                    <span class="breadcrumb-separator" aria-hidden="true">/</span>
+                </li>
+
+                <li class="breadcrumb-item">
+                    <a href="#nodes" class="breadcrumb-link">Nodes</a>
+                    <span class="breadcrumb-separator" aria-hidden="true">/</span>
+                </li>
+
+                <li class="breadcrumb-item" aria-current="page">
+                    <span class="breadcrumb-current">Cyber-Core</span>
+                </li>
+            </ol>
+        </nav>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-glowing-breadcrumb-neon/style.css
+++ b/submissions/examples/css-glowing-breadcrumb-neon/style.css
@@ -1,0 +1,115 @@
+/* Glowing Breadcrumb with Neon Styling #78887 */
+
+:root {
+    --bg-color: #080914;
+    --card-bg: #0f1123;
+    --card-border: rgba(0, 243, 255, 0.15);
+    --neon-cyan: #00f3ff;
+    --neon-cyan-glow: rgba(0, 243, 255, 0.4);
+    --neon-magenta: #ff007f;
+    --neon-magenta-glow: rgba(255, 0, 127, 0.4);
+    --text-muted: #64748b;
+    --text-active: #ffffff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-active);
+    padding: 2rem;
+}
+
+.breadcrumb-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1.25rem;
+    padding: 2.5rem 2rem;
+    width: 100%;
+    max-width: 680px;
+    box-shadow: 0 0 30px rgba(0, 243, 255, 0.05), inset 0 0 15px rgba(0, 243, 255, 0.03);
+}
+
+.card-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem 0;
+    text-shadow: 0 0 8px var(--neon-cyan-glow);
+    color: var(--neon-cyan);
+}
+
+.card-subtitle {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    margin-bottom: 2rem;
+}
+
+/* Neon Breadcrumb Navigation */
+.neon-breadcrumb nav {
+    display: flex;
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 0.75rem;
+    white-space: nowrap;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.breadcrumb-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.4rem 0.8rem;
+    border-radius: 0.5rem;
+    border: 1px solid transparent;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.breadcrumb-link:hover,
+.breadcrumb-link:focus-visible {
+    color: var(--neon-cyan);
+    border-color: rgba(0, 243, 255, 0.4);
+    background: rgba(0, 243, 255, 0.05);
+    box-shadow: 0 0 12px var(--neon-cyan-glow);
+    outline: none;
+    transform: translateY(-1px);
+}
+
+.breadcrumb-separator {
+    color: var(--neon-magenta);
+    font-weight: 800;
+    text-shadow: 0 0 8px var(--neon-magenta-glow);
+    user-select: none;
+}
+
+/* Active Page State */
+.breadcrumb-item[aria-current="page"] .breadcrumb-current {
+    color: #ffffff;
+    padding: 0.4rem 0.8rem;
+    border-radius: 0.5rem;
+    background: rgba(255, 0, 127, 0.1);
+    border: 1px solid rgba(255, 0, 127, 0.4);
+    text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 15px var(--neon-magenta-glow);
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Glowing Breadcrumb with Neon styling** component (#78887).
gssoc 26

Closes #78887

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-glowing-breadcrumb-neon/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible with proper navigation landmarks (`aria-label="Breadcrumb"`) and `aria-current="page"`

---

## Feature Description
**What does this add?**
A cyberpunk-inspired breadcrumb navigation path featuring luminous neon cyan and magenta text shadows, interactive hover glows, and responsive horizontal overflow handling.

**How does it work?**
Constructed using ordered lists (`<ol>`), CSS `text-shadow`, translucent border fills, hover glow transformations, and native horizontal scrolling for touch viewports.