### PR TITLE
Add Curved image unclip submission

### DIFF
--- a/submissions/examples/curved-image-unclip/README.md
+++ b/submissions/examples/curved-image-unclip/README.md
@@ -1,0 +1,21 @@
+# Curved image unclip
+
+An image that transitions from a fully rounded capsule to a softer rectangle on hover.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `curvedimageunclip-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Profile / card pattern; the shape shift adds motion without a layout jump.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *rose*)
+- `README.md` — this file

--- a/submissions/examples/curved-image-unclip/demo.html
+++ b/submissions/examples/curved-image-unclip/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Curved image unclip — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Curved image unclip</h1>
+      <p>An image that transitions from a fully rounded capsule to a softer rectangle on hover.</p>
+    </header>
+    <section class="demo">
+      <div class="curvedimageunclip"></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/curved-image-unclip/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/curved-image-unclip/style.css
+++ b/submissions/examples/curved-image-unclip/style.css
@@ -1,0 +1,57 @@
+/* Curved image unclip — EaseMotion CSS submission
+   Palette: rose   Folder: submissions/examples/curved-image-unclip/   Class prefix: .curvedimageunclip
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160d12;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff5c8a;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #26141c;
+  border: 1px solid #361b25;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff5c8a;
+  background: #26141c;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.curvedimageunclip { width: 200px; height: 200px; border-radius: 999px; background: linear-gradient(135deg, #ff5c8a, #ffb4d2); box-shadow: 0 12px 32px #ff5c8a33; transition: border-radius 480ms cubic-bezier(0.4, 0, 0.2, 1), transform 480ms; cursor: pointer; }
+.curvedimageunclip:hover { border-radius: 16px; transform: scale(1.05); }
+


### PR DESCRIPTION
Closes #79058

## What
This submission adds a new EaseMotion CSS example: `curved-image-unclip` under `submissions/examples/`.

An image that transitions from a fully rounded capsule to a softer rectangle on hover.

## How to review
1. Open `submissions/examples/curved-image-unclip/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/curved-image-unclip/` and does not modify any existing file.
