### PR TITLE
feat: create CSS-only Slider with Retro styling (#78262)

### DIFF
--- a/submissions/examples/css-slider-retro-pure/README.md
+++ b/submissions/examples/css-slider-retro-pure/README.md
@@ -1,0 +1,22 @@
+# Retro CSS Slider
+
+A highly stylized, JavaScript-free custom `<input type="range">` featuring chunky 8-bit pixel aesthetics, tactile press states, and cross-browser support.
+
+## Features
+- Pure CSS and HTML implementation. No images, SVGs, or JavaScript required to achieve the pixelated look.
+- **Component Architecture & Styling Mechanics**: 
+  - **Resetting Native Styles**: Relies on `-webkit-appearance: none;` on the native range input to strip away default OS styling, allowing for complete CSS redesign via pseudo-elements.
+  - **Cross-Browser Pseudo-Elements**: The styling targets `::-webkit-slider-runnable-track` and `::-webkit-slider-thumb` for Chrome/Safari/Edge, and duplicates styles for `::-moz-range-track` and `::-moz-range-thumb` for Firefox compatibility.
+  - **CSS Pixel Borders (Box-Shadow)**: The jagged, blocky 3D borders characteristic of 8-bit graphics and early 90s OS interfaces (like Windows 95) are achieved using layered `box-shadow` techniques.
+    - **Outset Bevel (Thumb)**: `inset 4px 4px 0 light-color, inset -4px -4px 0 dark-color` creates a button that looks raised.
+    - **Inset Bevel (Track)**: The colors are inverted on the track to make it look like a recessed groove.
+  - **Tactile Feedback**: On the `:active` state (when the user clicks and drags), the thumb's inset shadows are inverted, and it is physically translated downwards (`transform: translateY(4px)`). This perfectly simulates the mechanical action of pressing a chunky plastic button.
+- **Theming**: The palette utilizes classic console grey, arcade red, and pitch-black shadows. The font is `'Press Start 2P'` from Google Fonts. Due to the strict nature of retro themes, it ignores OS light/dark modes for the component itself, maintaining its distinct 8-bit aesthetic globally.
+- Fully accessible semantic structure. Because it relies on a real `<input type="range">`, it is perfectly accessible to screen readers, keyboards (using arrow keys), and touch devices. Includes a chunky dashed outline for `:focus-visible`.
+
+## Usage
+Open `demo.html` in your browser. Click and drag the red slider thumb. Notice how the thumb physically presses down into the groove, changing its highlight/shadow bevels to simulate a physical mechanical press.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic range input wrapped in a retro console container.
+- `style.css`: The styling, the complex `box-shadow` layering for pixel borders, the cross-browser pseudo-selectors, and the active state "press" mechanics.

--- a/submissions/examples/css-slider-retro-pure/demo.html
+++ b/submissions/examples/css-slider-retro-pure/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro CSS Slider</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="retro-container">
+        <header class="header">
+            <h1 class="pixel-title">8-BIT SLIDER</h1>
+            <p>A purely CSS styled range input with chunky retro aesthetics.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <div class="slider-wrapper">
+                
+                <div class="slider-group">
+                    <label for="retro-slider" class="retro-label">MUSIC VOL</label>
+                    
+                    <div class="slider-container">
+                        <input type="range" id="retro-slider" class="retro-slider" min="0" max="100" value="80">
+                    </div>
+                </div>
+
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-slider-retro-pure/style.css
+++ b/submissions/examples/css-slider-retro-pure/style.css
@@ -1,0 +1,214 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+/* =========================================
+   Theming
+   ========================================= */
+:root {
+    --bg-base: #2b2b2b;
+    --text-primary: #ffffff;
+    --text-accent: #fcee0a; /* Arcade Yellow */
+    
+    /* Pixel Track Variables */
+    --track-bg: #111111;
+    --track-border-light: #555555;
+    --track-border-dark: #000000;
+    
+    /* Pixel Thumb Variables */
+    --thumb-size: 24px;
+    --thumb-color: #ff003c; /* Arcade Red/Pink */
+    --thumb-border-light: #ff7799;
+    --thumb-border-dark: #880022;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Press Start 2P', cursive;
+    -webkit-font-smoothing: none; /* Crucial for pixel fonts */
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.retro-container {
+    width: 100%;
+    max-width: 500px;
+    background: #c0c0c0; /* Classic Windows 95 / Console Grey */
+    padding: 30px;
+    
+    /* Chunky Pixel Box Shadow Border */
+    box-shadow: 
+        inset 4px 4px 0 #ffffff, 
+        inset -4px -4px 0 #555555,
+        0 8px 0 #000000;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 40px;
+    /* Inset pixel box */
+    background: #000;
+    padding: 20px;
+    box-shadow: inset 4px 4px 0 #555555, inset -4px -4px 0 #ffffff;
+}
+
+.pixel-title {
+    font-size: 1.5rem;
+    margin: 0 0 15px 0;
+    color: var(--text-accent);
+    line-height: 1.4;
+}
+
+.header p { 
+    color: #aaaaaa; 
+    font-size: 0.7rem; 
+    margin: 0;
+    line-height: 1.6;
+}
+
+
+/* =========================================
+   Slider Container
+   ========================================= */
+.slider-group {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.retro-label {
+    font-size: 0.8rem;
+    color: #000000;
+    text-shadow: 2px 2px 0 #ffffff;
+}
+
+.slider-container {
+    padding: 10px 0; 
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Reset Native Input Styles
+   ========================================= */
+.retro-slider {
+    -webkit-appearance: none;
+    width: 100%;
+    background: transparent;
+    margin: 0;
+    position: relative;
+}
+
+.retro-slider:focus {
+    outline: none;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Styling the Track (Pixel Groove)
+   ========================================= */
+   
+/* WebKit */
+.retro-slider::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 16px;
+    cursor: pointer;
+    background: var(--track-bg);
+    /* Pixel Inset Box Shadow */
+    box-shadow: 
+        inset 4px 4px 0 var(--track-border-dark),
+        inset -4px -4px 0 var(--track-border-light);
+}
+
+/* Firefox */
+.retro-slider::-moz-range-track {
+    width: 100%;
+    height: 16px;
+    cursor: pointer;
+    background: var(--track-bg);
+    box-shadow: 
+        inset 4px 4px 0 var(--track-border-dark),
+        inset -4px -4px 0 var(--track-border-light);
+}
+
+
+/* =========================================
+   [TECHNIQUE 3] Styling the Thumb (Chunky Block)
+   ========================================= */
+   
+/* WebKit */
+.retro-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    height: 32px;
+    width: 24px;
+    background: var(--thumb-color);
+    cursor: grab;
+    margin-top: -8px; /* (16/2) - (32/2) */
+    
+    /* Outset Pixel Box Shadow */
+    box-shadow: 
+        inset 4px 4px 0 var(--thumb-border-light),
+        inset -4px -4px 0 var(--thumb-border-dark),
+        0 4px 0 rgba(0,0,0,0.5); /* Drop shadow on the track */
+}
+
+/* Firefox */
+.retro-slider::-moz-range-thumb {
+    height: 32px;
+    width: 24px;
+    background: var(--thumb-color);
+    cursor: grab;
+    border: none;
+    border-radius: 0; /* Remove FF default radius */
+    
+    box-shadow: 
+        inset 4px 4px 0 var(--thumb-border-light),
+        inset -4px -4px 0 var(--thumb-border-dark),
+        0 4px 0 rgba(0,0,0,0.5);
+}
+
+
+/* =========================================
+   Interaction States
+   ========================================= */
+
+/* Active (Dragging) state on Thumb */
+.retro-slider:active::-webkit-slider-thumb {
+    cursor: grabbing;
+    /* Invert the inset shadow to look "pressed" */
+    box-shadow: 
+        inset 4px 4px 0 var(--thumb-border-dark),
+        inset -4px -4px 0 var(--thumb-border-light),
+        0 0 0 rgba(0,0,0,0); /* Remove drop shadow */
+    transform: translateY(4px); /* Physically move down */
+}
+
+.retro-slider:active::-moz-range-thumb {
+    cursor: grabbing;
+    box-shadow: 
+        inset 4px 4px 0 var(--thumb-border-dark),
+        inset -4px -4px 0 var(--thumb-border-light),
+        0 0 0 rgba(0,0,0,0);
+    transform: translateY(4px);
+}
+
+/* Keyboard Focus */
+.retro-slider:focus-visible::-webkit-slider-thumb {
+    outline: 4px dashed var(--text-accent);
+    outline-offset: 4px;
+}
+.retro-slider:focus-visible::-moz-range-thumb {
+    outline: 4px dashed var(--text-accent);
+    outline-offset: 4px;
+}
+
+/* Dark Mode handling - Retro usually dictates its own colors, but we can darken the background */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #1a1a1a;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly stylized, JavaScript-free custom `<input type="range">` featuring chunky 8-bit pixel aesthetics, tactile press states, and cross-browser support. Resolves issue #78262.

### Changes Made:
- Added `submissions/examples/css-slider-retro-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic range input wrapped in a retro console container.
- Created `style.css` featuring the UI mechanics:
  - **Resetting Native Styles**: Relies on `-webkit-appearance: none;` on the native range input to strip away default OS styling, allowing for complete CSS redesign via pseudo-elements.
  - **Cross-Browser Pseudo-Elements**: The styling targets `::-webkit-slider-runnable-track` and `::-webkit-slider-thumb` for Chrome/Safari/Edge, and duplicates styles for `::-moz-range-track` and `::-moz-range-thumb` for Firefox compatibility.
  - **CSS Pixel Borders (Box-Shadow)**: The jagged, blocky 3D borders characteristic of 8-bit graphics and early 90s OS interfaces (like Windows 95) are achieved using layered `box-shadow` techniques.
    - **Outset Bevel (Thumb)**: `inset 4px 4px 0 light-color, inset -4px -4px 0 dark-color` creates a button that looks raised.
    - **Inset Bevel (Track)**: The colors are inverted on the track to make it look like a recessed groove.
  - **Tactile Feedback**: On the `:active` state (when the user clicks and drags), the thumb's inset shadows are inverted, and it is physically translated downwards (`transform: translateY(4px)`). This perfectly simulates the mechanical action of pressing a chunky plastic button.
  - **Theming Supported**: The palette utilizes classic console grey, arcade red, and pitch-black shadows. The font is `'Press Start 2P'` from Google Fonts. Due to the strict nature of retro themes, it ignores OS light/dark modes for the component itself, maintaining its distinct 8-bit aesthetic globally.
- Added `README.md` documenting usage and the technical mechanics of the complex `box-shadow` layering for pixel borders, the cross-browser pseudo-selectors, and the active state "press" mechanics.
- Fully accessible semantic structure. Because it relies on a real `<input type="range">`, it is perfectly accessible to screen readers, keyboards (using arrow keys), and touch devices. Includes a chunky dashed outline for `:focus-visible`.

Closes #78262
