### PR TITLE
Add Diagonal colour split fill submission

### DIFF
--- a/submissions/examples/diagonal-color-split-fill/README.md
+++ b/submissions/examples/diagonal-color-split-fill/README.md
@@ -1,0 +1,21 @@
+# Diagonal colour split fill
+
+A button whose background fills in diagonally from bottom-left to top-right on hover.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `diagonalcolorsplitfill-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+CTA / category pattern; the diagonal sweep is more dynamic than a flat fill.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *teal*)
+- `README.md` — this file

--- a/submissions/examples/diagonal-color-split-fill/demo.html
+++ b/submissions/examples/diagonal-color-split-fill/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diagonal colour split fill — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Diagonal colour split fill</h1>
+      <p>A button whose background fills in diagonally from bottom-left to top-right on hover.</p>
+    </header>
+    <section class="demo">
+      <button class="diagonalcolorsplitfill">Click me</button>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/diagonal-color-split-fill/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/diagonal-color-split-fill/style.css
+++ b/submissions/examples/diagonal-color-split-fill/style.css
@@ -1,0 +1,59 @@
+/* Diagonal colour split fill — EaseMotion CSS submission
+   Palette: teal   Folder: submissions/examples/diagonal-color-split-fill/   Class prefix: .diagonalcolorsplitfill
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #08161a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #14b8a6;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #0f2429;
+  border: 1px solid #163239;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #14b8a6;
+  background: #0f2429;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.diagonalcolorsplitfill { position: relative; padding: 14px 32px; background: #0f2429; color: #e6e8ec; border: 1px solid #163239; border-radius: 8px; font: 14px/1 system-ui; cursor: pointer; overflow: hidden; z-index: 1; transition: color 320ms; }
+.diagonalcolorsplitfill::before { content: ""; position: absolute; inset: 0; background: #14b8a6; transform: skewX(-20deg) translateX(-110%); transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1); z-index: -1; }
+.diagonalcolorsplitfill:hover { color: #08161a; border-color: #14b8a6; }
+.diagonalcolorsplitfill:hover::before { transform: skewX(-20deg) translateX(0); }
+


### PR DESCRIPTION
Closes #79070

## What
This submission adds a new EaseMotion CSS example: `diagonal-color-split-fill` under `submissions/examples/`.

A button whose background fills in diagonally from bottom-left to top-right on hover.

## How to review
1. Open `submissions/examples/diagonal-color-split-fill/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/diagonal-color-split-fill/` and does not modify any existing file.
