### PR TITLE
Add Button arrow push reveal submission

### DIFF
--- a/submissions/examples/button-arrow-push-reveal-v2/README.md
+++ b/submissions/examples/button-arrow-push-reveal-v2/README.md
@@ -1,0 +1,21 @@
+# Button arrow push reveal
+
+A button whose arrow icon pushes the label left and slides in from the right on hover.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `buttonarrowpushrevealv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+CTA pattern; the moving arrow tells the user what will happen next.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *forest*)
+- `README.md` — this file

--- a/submissions/examples/button-arrow-push-reveal-v2/demo.html
+++ b/submissions/examples/button-arrow-push-reveal-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Button arrow push reveal — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Button arrow push reveal</h1>
+      <p>A button whose arrow icon pushes the label left and slides in from the right on hover.</p>
+    </header>
+    <section class="demo">
+      <button class="buttonarrowpushrevealv2"><span class="buttonarrowpushrevealv2-text">Continue</span><span class="buttonarrowpushrevealv2-arrow">→</span></button>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/button-arrow-push-reveal-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/button-arrow-push-reveal-v2/style.css
+++ b/submissions/examples/button-arrow-push-reveal-v2/style.css
@@ -1,0 +1,59 @@
+/* Button arrow push reveal — EaseMotion CSS submission
+   Palette: forest   Folder: submissions/examples/button-arrow-push-reveal-v2/   Class prefix: .buttonarrowpushrevealv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0d1612;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #2ecc71;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #152721;
+  border: 1px solid #1f3530;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #2ecc71;
+  background: #152721;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.buttonarrowpushrevealv2 {{ position: relative; display: inline-flex; align-items: center; gap: 8px; padding: 12px 22px; background: #2ecc71; color: #0d1612; border: none; border-radius: 999px; font: 14px/1 system-ui; font-weight: 600; cursor: pointer; overflow: hidden; transition: gap 280ms cubic-bezier(0.2, 0.8, 0.2, 1); }}
+.buttonarrowpushrevealv2-arrow {{ display: inline-block; transition: transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1); }}
+.buttonarrowpushrevealv2:hover {{ gap: 14px; }}
+.buttonarrowpushrevealv2:hover .buttonarrowpushrevealv2-arrow {{ transform: translateX(4px); }}
+


### PR DESCRIPTION
Closes #79087

## What
This submission adds a new EaseMotion CSS example: `button-arrow-push-reveal-v2` under `submissions/examples/`.

A button whose arrow icon pushes the label left and slides in from the right on hover.

## How to review
1. Open `submissions/examples/button-arrow-push-reveal-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/button-arrow-push-reveal-v2/` and does not modify any existing file.
