### PR TITLE
Add Hover sibling dim blur submission

### DIFF
--- a/submissions/examples/hover-sibling-dim-blur-v2/README.md
+++ b/submissions/examples/hover-sibling-dim-blur-v2/README.md
@@ -1,0 +1,21 @@
+# Hover sibling dim blur
+
+A gallery grid where hovering one tile dims and blurs the surrounding siblings.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `hoversiblingdimblurv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Gallery / showcase pattern; the dimming focuses the user on the active tile.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *violet*)
+- `README.md` — this file

--- a/submissions/examples/hover-sibling-dim-blur-v2/demo.html
+++ b/submissions/examples/hover-sibling-dim-blur-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover sibling dim blur — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Hover sibling dim blur</h1>
+      <p>A gallery grid where hovering one tile dims and blurs the surrounding siblings.</p>
+    </header>
+    <section class="demo">
+      <div class="hoversiblingdimblurv2"><div class="hoversiblingdimblurv2-item">A</div><div class="hoversiblingdimblurv2-item">B</div><div class="hoversiblingdimblurv2-item">C</div><div class="hoversiblingdimblurv2-item">D</div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/hover-sibling-dim-blur-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/hover-sibling-dim-blur-v2/style.css
+++ b/submissions/examples/hover-sibling-dim-blur-v2/style.css
@@ -1,0 +1,59 @@
+/* Hover sibling dim blur — EaseMotion CSS submission
+   Palette: violet   Folder: submissions/examples/hover-sibling-dim-blur-v2/   Class prefix: .hoversiblingdimblurv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0e0a1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #a78bfa;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1329;
+  border: 1px solid #261a3a;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #a78bfa;
+  background: #1a1329;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.hoversiblingdimblurv2 {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }}
+.hoversiblingdimblurv2-item {{ aspect-ratio: 1; background: #1a1329; border-radius: 12px; transition: filter 320ms, transform 320ms, opacity 320ms; display: grid; place-items: center; color: #8b909b; font: 14px/1 system-ui; }}
+.hoversiblingdimblurv2:hover .hoversiblingdimblurv2-item {{ filter: blur(2px); opacity: 0.6; }}
+.hoversiblingdimblurv2-item:hover {{ filter: blur(0); opacity: 1; transform: scale(1.05); box-shadow: 0 8px 24px #a78bfa33; background: #a78bfa22; color: #e6e8ec; }}
+


### PR DESCRIPTION
Closes #79097

## What
This submission adds a new EaseMotion CSS example: `hover-sibling-dim-blur-v2` under `submissions/examples/`.

A gallery grid where hovering one tile dims and blurs the surrounding siblings.

## How to review
1. Open `submissions/examples/hover-sibling-dim-blur-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/hover-sibling-dim-blur-v2/` and does not modify any existing file.
