### PR TITLE
Add Neumorphic press down submission

### DIFF
--- a/submissions/examples/neumorphic-press-down-v2/README.md
+++ b/submissions/examples/neumorphic-press-down-v2/README.md
@@ -1,0 +1,21 @@
+# Neumorphic press down
+
+A button whose dual shadows invert to suggest a physical press while the mouse is held.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `neumorphicpressdownv2-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Hardware-style pattern; the shadow inversion sells the press.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *graphite*)
+- `README.md` — this file

--- a/submissions/examples/neumorphic-press-down-v2/demo.html
+++ b/submissions/examples/neumorphic-press-down-v2/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic press down — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Neumorphic press down</h1>
+      <p>A button whose dual shadows invert to suggest a physical press while the mouse is held.</p>
+    </header>
+    <section class="demo">
+      <button class="neumorphicpressdownv2">Press me</button>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/neumorphic-press-down-v2/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/neumorphic-press-down-v2/style.css
+++ b/submissions/examples/neumorphic-press-down-v2/style.css
@@ -1,0 +1,58 @@
+/* Neumorphic press down — EaseMotion CSS submission
+   Palette: graphite   Folder: submissions/examples/neumorphic-press-down-v2/   Class prefix: .neumorphicpressdownv2
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #101216;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #94a3b8;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d22;
+  border: 1px solid #25282e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #94a3b8;
+  background: #1a1d22;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.neumorphicpressdownv2 {{ padding: 16px 32px; background: #1a1d22; color: #e6e8ec; border: none; border-radius: 12px; font: 14px/1 system-ui; font-weight: 600; cursor: pointer; box-shadow: 6px 6px 12px #00000044, -6px -6px 12px #ffffff10; transition: box-shadow 160ms, transform 80ms; }}
+.neumorphicpressdownv2:hover {{ box-shadow: 4px 4px 8px #00000044, -4px -4px 8px #ffffff10; }}
+.neumorphicpressdownv2:active {{ transform: translateY(2px); box-shadow: inset 4px 4px 8px #00000055, inset -4px -4px 8px #ffffff10; }}
+


### PR DESCRIPTION
Closes #79106

## What
This submission adds a new EaseMotion CSS example: `neumorphic-press-down-v2` under `submissions/examples/`.

A button whose dual shadows invert to suggest a physical press while the mouse is held.

## How to review
1. Open `submissions/examples/neumorphic-press-down-v2/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/neumorphic-press-down-v2/` and does not modify any existing file.
