### PR TITLE
feat: create Glassmorphism Tooltip with Neumorphism styling #78877

### DIFF
--- a/submissions/examples/css-glassmorphism-tooltip-neumorphism/README.md
+++ b/submissions/examples/css-glassmorphism-tooltip-neumorphism/README.md
@@ -1,0 +1,13 @@
+# Glassmorphism Tooltip with Neumorphism styling (#78877)
+
+A hybrid UI component combining soft extruding Neumorphic surface controls with frosted Glassmorphic floating tooltips featuring accessibility linkages and CSS transitions built using pure CSS.
+
+## Features
+- **Accessible Tooltip Architecture:** Built with `role="tooltip"` linked to buttons via `aria-describedby` and full `:focus-visible` support.
+- **Hybrid Visual Aesthetic:** Blends dual Neumorphic drop shadows (`#ffffff` and `#a3b1c6`) with translucent `backdrop-filter: blur(12px)` glass popovers.
+- **Fluid Micro-Interactions:** Smooth opacity and translateY slide animations triggered via hover or keyboard focus.
+
+## File Hierarchy
+- `style.css` - CSS shadow variables, glass backdrop blur rules, caret pointing details, and hover state transitions.
+- `demo.html` - Accessible HTML structure showcasing the interactive tooltip.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-glassmorphism-tooltip-neumorphism/demo.html
+++ b/submissions/examples/css-glassmorphism-tooltip-neumorphism/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Tooltip | Neumorphism Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="neu-card" aria-label="Tooltip Interaction Showcase">
+    <h1 class="card-title">Hybrid UI Overlay</h1>
+    <p class="card-desc">Experience Neumorphic soft depth paired with a frosted Glassmorphic floating tooltip overlay.</p>
+
+    <div class="tooltip-wrapper">
+        <button type="button" class="neu-btn" aria-describedby="hybrid-tooltip">
+            Hover or Focus Me
+        </button>
+        <div id="hybrid-tooltip" class="glass-tooltip" role="tooltip">
+            Frosted glass tooltip overlay floating on soft neumorphic surfaces.
+        </div>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-glassmorphism-tooltip-neumorphism/style.css
+++ b/submissions/examples/css-glassmorphism-tooltip-neumorphism/style.css
@@ -1,0 +1,144 @@
+/* Glassmorphism Tooltip with Neumorphism Styling #78877 */
+
+:root {
+    --bg-color: #e0e5ec;
+    --neu-surface: #e0e5ec;
+    --neu-shadow-light: #ffffff;
+    --neu-shadow-dark: #a3b1c6;
+    --glass-bg: rgba(255, 255, 255, 0.45);
+    --glass-border: rgba(255, 255, 255, 0.6);
+    --text-primary: #2d3748;
+    --text-secondary: #4a5568;
+    --accent-color: #4f46e5;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    padding: 2rem;
+}
+
+/* Neumorphic Base Container Card */
+.neu-card {
+    background: var(--neu-surface);
+    border-radius: 2rem;
+    padding: 3.5rem 2.5rem;
+    width: 100%;
+    max-width: 480px;
+    text-align: center;
+    box-shadow: 9px 9px 16px var(--neu-shadow-dark), -9px -9px 16px var(--neu-shadow-light);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.card-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.card-desc {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    margin: 0 0 1rem 0;
+    line-height: 1.5;
+}
+
+/* Neumorphic Interactive Button Wrapper */
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.neu-btn {
+    appearance: none;
+    background: var(--neu-surface);
+    border: none;
+    border-radius: 1rem;
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--accent-color);
+    cursor: pointer;
+    box-shadow: 6px 6px 12px var(--neu-shadow-dark), -6px -6px 12px var(--neu-shadow-light);
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.neu-btn:hover {
+    box-shadow: 8px 8px 16px var(--neu-shadow-dark), -8px -8px 16px var(--neu-shadow-light);
+    transform: translateY(-2px);
+}
+
+.neu-btn:active {
+    box-shadow: inset 4px 4px 8px var(--neu-shadow-dark), inset -4px -4px 8px var(--neu-shadow-light);
+    transform: translateY(0);
+}
+
+.neu-btn:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Glassmorphic Tooltip Overlay */
+.glass-tooltip {
+    position: absolute;
+    bottom: calc(100% + 14px);
+    left: 50%;
+    transform: translateX(-50%) translateY(8px);
+    width: max-content;
+    max-width: 240px;
+    padding: 0.75rem 1.15rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 0.85rem;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    font-weight: 500;
+    line-height: 1.4;
+    text-align: center;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1), transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.25s;
+    z-index: 10;
+}
+
+/* Glass Tooltip Caret Pointer */
+.glass-tooltip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: rgba(255, 255, 255, 0.6) transparent transparent transparent;
+}
+
+/* Reveal Trigger States */
+.tooltip-wrapper:hover .glass-tooltip,
+.neu-btn:focus-visible + .glass-tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 480px) {
+    .neu-card {
+        padding: 2.5rem 1.5rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Glassmorphism Tooltip with Neumorphism styling** component (#78877).
gssoc 26

Closes #78877

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-glassmorphism-tooltip-neumorphism/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible with native focus handling (`:focus-visible`), `role="tooltip"`, and `aria-describedby` attributes

---

## Feature Description
**What does this add?**
A hybrid UI component featuring a soft neumorphic tactile push button that reveals a floating frosted glassmorphic tooltip with a caret pointer on hover or focus.

**How does it work?**
Constructed using semantic HTML5 elements, CSS dual box-shadow extruded depth, `backdrop-filter: blur()` floating overlays, and CSS property state transitions without JavaScript dependencies.