### PR TITLE
Add Circular donut gauge submission

### DIFF
--- a/submissions/examples/circular-donut-gauge/README.md
+++ b/submissions/examples/circular-donut-gauge/README.md
@@ -1,0 +1,21 @@
+# Circular donut gauge
+
+An SVG donut chart whose arc fills from 0% to a target percentage with a stroke-dashoffset animation.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `circulardonutgauge-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+KPI tile pattern; the arc is a compact way to show a single value.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *cool*)
+- `README.md` — this file

--- a/submissions/examples/circular-donut-gauge/demo.html
+++ b/submissions/examples/circular-donut-gauge/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Circular donut gauge — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Circular donut gauge</h1>
+      <p>An SVG donut chart whose arc fills from 0% to a target percentage with a stroke-dashoffset animation.</p>
+    </header>
+    <section class="demo">
+      <div class="circulardonutgauge" style="--p: 75"><span>75%</span></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/circular-donut-gauge/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/circular-donut-gauge/style.css
+++ b/submissions/examples/circular-donut-gauge/style.css
@@ -1,0 +1,58 @@
+/* Circular donut gauge — EaseMotion CSS submission
+   Palette: cool   Folder: submissions/examples/circular-donut-gauge/   Class prefix: .circulardonutgauge
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0e1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #4dabf7;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #131829;
+  border: 1px solid #1d2438;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #4dabf7;
+  background: #131829;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.circulardonutgauge {{ position: relative; width: 160px; height: 160px; border-radius: 50%; background: conic-gradient(#4dabf7 calc(var(--p) * 1%), #1d2438 0); display: grid; place-items: center; }}
+.circulardonutgauge::before {{ content: ""; position: absolute; inset: 14px; border-radius: 50%; background: #131829; }}
+.circulardonutgauge span {{ position: relative; color: #e6e8ec; font: 700 24px/1 ui-monospace, monospace; z-index: 1; }}
+


### PR DESCRIPTION
Closes #79122

## What
This submission adds a new EaseMotion CSS example: `circular-donut-gauge` under `submissions/examples/`.

An SVG donut chart whose arc fills from 0% to a target percentage with a stroke-dashoffset animation.

## How to review
1. Open `submissions/examples/circular-donut-gauge/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/circular-donut-gauge/` and does not modify any existing file.
