### PR TITLE
Add Sparkline wave progress submission

### DIFF
--- a/submissions/examples/progress-sparkline-wave/README.md
+++ b/submissions/examples/progress-sparkline-wave/README.md
@@ -1,0 +1,21 @@
+# Sparkline wave progress
+
+A small inline trend line that draws from left to right using stroke-dashoffset.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `progresssparklinewave-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+KPI / stat tile pattern; the draw-on motion catches the eye without taking much room.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *rose*)
+- `README.md` — this file

--- a/submissions/examples/progress-sparkline-wave/demo.html
+++ b/submissions/examples/progress-sparkline-wave/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sparkline wave progress — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Sparkline wave progress</h1>
+      <p>A small inline trend line that draws from left to right using stroke-dashoffset.</p>
+    </header>
+    <section class="demo">
+      <svg class="progresssparklinewave" viewBox="0 0 200 60"><polyline points="0,40 25,30 50,35 75,15 100,25 125,10 150,20 175,5 200,15"/></svg>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/progress-sparkline-wave/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/progress-sparkline-wave/style.css
+++ b/submissions/examples/progress-sparkline-wave/style.css
@@ -1,0 +1,57 @@
+/* Sparkline wave progress — EaseMotion CSS submission
+   Palette: rose   Folder: submissions/examples/progress-sparkline-wave/   Class prefix: .progresssparklinewave
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160d12;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff5c8a;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #26141c;
+  border: 1px solid #361b25;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff5c8a;
+  background: #26141c;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.progresssparklinewave {{ width: 200px; height: 60px; }}
+.progresssparklinewave polyline {{ fill: none; stroke: #ff5c8a; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: 600; stroke-dashoffset: 600; animation: kf-progresssparklinewave 1.6s ease-out forwards; }}
+@keyframes kf-progresssparklinewave {{ to {{ stroke-dashoffset: 0; }} }}


### PR DESCRIPTION
Closes #79127

## What
This submission adds a new EaseMotion CSS example: `progress-sparkline-wave` under `submissions/examples/`.

A small inline trend line that draws from left to right using stroke-dashoffset.

## How to review
1. Open `submissions/examples/progress-sparkline-wave/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/progress-sparkline-wave/` and does not modify any existing file.
