### PR TITLE
Add Stat comparison pill slide submission

### DIFF
--- a/submissions/examples/stat-comparison-pill-slide/README.md
+++ b/submissions/examples/stat-comparison-pill-slide/README.md
@@ -1,0 +1,21 @@
+# Stat comparison pill slide
+
+A stat card that toggles between two metrics (weekly vs monthly) with a horizontal slide.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `statcomparisonpillslide-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Dashboard filter pattern; the slide keeps both values feeling related.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *amber*)
+- `README.md` — this file

--- a/submissions/examples/stat-comparison-pill-slide/demo.html
+++ b/submissions/examples/stat-comparison-pill-slide/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Stat comparison pill slide — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Stat comparison pill slide</h1>
+      <p>A stat card that toggles between two metrics (weekly vs monthly) with a horizontal slide.</p>
+    </header>
+    <section class="demo">
+      <div class="statcomparisonpillslide"><button class="statcomparisonpillslide-toggle">Weekly</button><div class="statcomparisonpillslide-track"><div class="statcomparisonpillslide-pane"><strong>1,284</strong><small>this week</small></div><div class="statcomparisonpillslide-pane"><strong>5,612</strong><small>this month</small></div></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/stat-comparison-pill-slide/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/stat-comparison-pill-slide/style.css
+++ b/submissions/examples/stat-comparison-pill-slide/style.css
@@ -1,0 +1,62 @@
+/* Stat comparison pill slide — EaseMotion CSS submission
+   Palette: amber   Folder: submissions/examples/stat-comparison-pill-slide/   Class prefix: .statcomparisonpillslide
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #161208;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ffb13b;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261d10;
+  border: 1px solid #352817;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ffb13b;
+  background: #261d10;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.statcomparisonpillslide {{ position: relative; display: inline-block; padding: 16px 20px; background: #261d10; border-radius: 12px; overflow: hidden; min-width: 200px; }}
+.statcomparisonpillslide-toggle {{ background: #352817; color: #e6e8ec; border: none; padding: 4px 10px; border-radius: 999px; font: 11px/1 system-ui; cursor: pointer; margin-bottom: 12px; }}
+.statcomparisonpillslide-track {{ display: flex; transition: transform 400ms cubic-bezier(0.2, 0.8, 0.2, 1); }}
+.statcomparisonpillslide-pane {{ flex: 0 0 100%; display: flex; flex-direction: column; gap: 4px; }}
+.statcomparisonpillslide-pane strong {{ color: #ffb13b; font: 700 20px/1 ui-monospace, monospace; }}
+.statcomparisonpillslide-pane small {{ color: #8b909b; font: 11px/1 system-ui; }}
+.statcomparisonpillslide.is-month .statcomparisonpillslide-track {{ transform: translateX(-100%); }}
+


### PR DESCRIPTION
Closes #79129

## What
This submission adds a new EaseMotion CSS example: `stat-comparison-pill-slide` under `submissions/examples/`.

A stat card that toggles between two metrics (weekly vs monthly) with a horizontal slide.

## How to review
1. Open `submissions/examples/stat-comparison-pill-slide/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/stat-comparison-pill-slide/` and does not modify any existing file.
