### PR TITLE
Add Radar skill chart polygon submission

### DIFF
--- a/submissions/examples/radar-skill-chart-polygon/README.md
+++ b/submissions/examples/radar-skill-chart-polygon/README.md
@@ -1,0 +1,21 @@
+# Radar skill chart polygon
+
+A radar chart whose polygon vertices expand from the centre outward on first paint.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `radarskillchartpolygon-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Skill / assessment pattern; the polygon encodes multiple values compactly.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *teal*)
+- `README.md` — this file

--- a/submissions/examples/radar-skill-chart-polygon/demo.html
+++ b/submissions/examples/radar-skill-chart-polygon/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Radar skill chart polygon — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Radar skill chart polygon</h1>
+      <p>A radar chart whose polygon vertices expand from the centre outward on first paint.</p>
+    </header>
+    <section class="demo">
+      <svg class="radarskillchartpolygon" viewBox="0 0 200 200"><polygon class="radarskillchartpolygon-shape" points="100,30 165,75 145,155 55,155 35,75"/></svg>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/radar-skill-chart-polygon/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/radar-skill-chart-polygon/style.css
+++ b/submissions/examples/radar-skill-chart-polygon/style.css
@@ -1,0 +1,57 @@
+/* Radar skill chart polygon — EaseMotion CSS submission
+   Palette: teal   Folder: submissions/examples/radar-skill-chart-polygon/   Class prefix: .radarskillchartpolygon
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #08161a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #14b8a6;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #0f2429;
+  border: 1px solid #163239;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #14b8a6;
+  background: #0f2429;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.radarskillchartpolygon {{ width: 200px; height: 200px; }}
+.radarskillchartpolygon-shape {{ fill: #14b8a633; stroke: #14b8a6; stroke-width: 2; stroke-linejoin: round; transform-origin: 100px 100px; transform: scale(0); animation: kf-radarskillchartpolygon 1.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards; }}
+@keyframes kf-radarskillchartpolygon {{ to {{ transform: scale(1); }} }}


### PR DESCRIPTION
Closes #79134

## What
This submission adds a new EaseMotion CSS example: `radar-skill-chart-polygon` under `submissions/examples/`.

A radar chart whose polygon vertices expand from the centre outward on first paint.

## How to review
1. Open `submissions/examples/radar-skill-chart-polygon/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/radar-skill-chart-polygon/` and does not modify any existing file.
