### PR TITLE
feat: create Responsive Toggle with Minimalist styling (#78270)

### DIFF
--- a/submissions/examples/css-responsive-toggle-minimalist-pure/README.md
+++ b/submissions/examples/css-responsive-toggle-minimalist-pure/README.md
@@ -1,0 +1,21 @@
+# Responsive Toggle: Minimalist
+
+A highly polished, JavaScript-free toggle switch component featuring a clean monochrome aesthetic and mathematically responsive scaling.
+
+## Features
+- Pure CSS and HTML implementation. The interactive state is managed entirely through the "Checkbox Hack".
+- **Component Architecture & Styling Mechanics**: 
+  - **The Checkbox Hack**: The toggle relies on a visually hidden `<input type="checkbox">` wrapped inside a `<label>`. Clicking anywhere on the label toggles the checkbox state. The CSS uses the adjacent sibling combinator (`.toggle-input:checked + .toggle-track`) to animate the background color and move the thumb.
+  - **Mathematical Responsiveness**: Instead of hardcoding translation values, the thumb's movement is calculated dynamically using CSS `calc()` based on custom properties:
+    `transform: translateX(calc(var(--toggle-width) - var(--thumb-size) - (var(--thumb-margin) * 2)));`
+    This means you can resize the entire toggle perfectly just by overriding the `--toggle-width` and `--toggle-height` variables in a media query, without needing to manually adjust the animation distances.
+  - **Minimalist Aesthetic**: The design avoids heavy shadows or gradients, relying on crisp borders, flat colors (stark black and white), and a smooth `cubic-bezier` timing function for a premium, lightweight feel.
+- **Theming**: Configured via CSS Custom Properties. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, intelligently swapping the monochrome palette while maintaining the minimalist aesthetic.
+- Fully accessible semantic structure. Because it uses a real `<input type="checkbox">`, it is perfectly accessible to screen readers (with `aria-label`) and keyboards. Includes `:focus-visible` styling to draw a high-contrast outline when navigated via the Tab key. Honors the `prefers-reduced-motion` accessibility standard by disabling the translation animations if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. Click the toggles to see the smooth sliding animation. Resize your browser window to below 400px wide to observe how the toggle seamlessly scales down its dimensions and travel distance using CSS variable overrides.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox hack and accessibility attributes.
+- `style.css`: The styling, the `calc()` geometry for responsive scaling, and the clean monochrome theme logic.

--- a/submissions/examples/css-responsive-toggle-minimalist-pure/demo.html
+++ b/submissions/examples/css-responsive-toggle-minimalist-pure/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Toggle: Minimalist</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Minimalist Toggle</h1>
+            <p>Pure CSS responsive toggle switch with clean, monochrome aesthetics.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <div class="toggle-group">
+                <span class="toggle-label-text">Enable Notifications</span>
+                
+                <!-- The Minimalist Toggle -->
+                <label class="minimal-toggle" aria-label="Toggle Notifications">
+                    <input type="checkbox" class="toggle-input" checked>
+                    <span class="toggle-track">
+                        <span class="toggle-thumb"></span>
+                    </span>
+                </label>
+            </div>
+            
+            <div class="toggle-group">
+                <span class="toggle-label-text">Dark Theme</span>
+                
+                <!-- The Minimalist Toggle (Off state) -->
+                <label class="minimal-toggle" aria-label="Toggle Theme">
+                    <input type="checkbox" class="toggle-input">
+                    <span class="toggle-track">
+                        <span class="toggle-thumb"></span>
+                    </span>
+                </label>
+            </div>
+
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-responsive-toggle-minimalist-pure/style.css
+++ b/submissions/examples/css-responsive-toggle-minimalist-pure/style.css
@@ -1,0 +1,213 @@
+@import url('https://fonts.googleapis.com/css2?family=Helvetica+Neue:wght@400;500&display=swap');
+
+/* =========================================
+   Theming & Geometry Variables
+   ========================================= */
+:root {
+    --bg-base: #f9fafb;
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    
+    /* Toggle Dimensions - Responsive Base */
+    --toggle-width: 48px;
+    --toggle-height: 24px;
+    --thumb-size: 20px;
+    --thumb-margin: 2px;
+    
+    /* Colors - Minimalist Monochrome */
+    --track-off: #e5e7eb;
+    --track-on: #111827; /* Solid black/dark grey for 'On' */
+    --thumb-color: #ffffff;
+    --track-border: #d1d5db;
+    
+    --transition-speed: 0.3s;
+    --transition-curve: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.container {
+    width: 100%;
+    max-width: 400px;
+    background: #ffffff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+    border: 1px solid #f3f4f6;
+}
+
+.header {
+    margin-bottom: 35px;
+}
+.title { 
+    margin: 0 0 8px 0; 
+    font-size: 1.5rem; 
+    font-weight: 500;
+    letter-spacing: -0.5px;
+}
+.header p { 
+    margin: 0; 
+    color: var(--text-secondary); 
+    font-size: 0.95rem; 
+}
+
+
+/* =========================================
+   Toggle Layout
+   ========================================= */
+.toggle-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 0;
+    border-bottom: 1px solid #f3f4f6;
+}
+.toggle-group:last-child {
+    border-bottom: none;
+}
+
+.toggle-label-text {
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Responsive Checkbox Hack
+   ========================================= */
+.minimal-toggle {
+    position: relative;
+    display: inline-flex;
+    cursor: pointer;
+    /* Prevent text selection when clicking rapidly */
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* Hide the native checkbox visually but keep it accessible */
+.toggle-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* The Track */
+.toggle-track {
+    display: block;
+    width: var(--toggle-width);
+    height: var(--toggle-height);
+    background-color: var(--track-off);
+    border-radius: 999px; /* Pill shape */
+    box-shadow: inset 0 0 0 1px var(--track-border);
+    transition: background-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+    position: relative;
+}
+
+/* The Thumb */
+.toggle-thumb {
+    position: absolute;
+    top: var(--thumb-margin);
+    left: var(--thumb-margin);
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    background-color: var(--thumb-color);
+    border-radius: 50%;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    transition: transform var(--transition-speed) var(--transition-curve);
+}
+
+
+/* =========================================
+   State Changes
+   ========================================= */
+   
+/* Active (Checked) State */
+.toggle-input:checked + .toggle-track {
+    background-color: var(--track-on);
+    box-shadow: inset 0 0 0 1px var(--track-on);
+}
+
+/* 
+   Calculate the translation distance responsively:
+   Total width - Thumb size - (Margin * 2)
+*/
+.toggle-input:checked + .toggle-track .toggle-thumb {
+    transform: translateX(calc(var(--toggle-width) - var(--thumb-size) - (var(--thumb-margin) * 2)));
+}
+
+/* Keyboard Focus */
+.toggle-input:focus-visible + .toggle-track {
+    outline: 2px solid var(--track-on);
+    outline-offset: 2px;
+}
+
+/* Hover effect on thumb */
+.minimal-toggle:hover .toggle-thumb {
+    box-shadow: 0 3px 6px rgba(0,0,0,0.15);
+}
+
+
+/* =========================================
+   Responsive Scaling
+   ========================================= */
+/* On smaller screens, seamlessly scale the toggle down by redefining variables */
+@media (max-width: 400px) {
+    :root {
+        --toggle-width: 40px;
+        --toggle-height: 20px;
+        --thumb-size: 16px;
+    }
+}
+
+
+/* Dark Mode Compatibility */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-base: #111827;
+        --text-primary: #f9fafb;
+        --text-secondary: #9ca3af;
+        
+        --track-off: #374151;
+        --track-on: #ffffff;
+        --thumb-color: #111827;
+        --track-border: #4b5563;
+    }
+    
+    .container {
+        background: #1f2937;
+        border-color: #374151;
+    }
+    
+    .toggle-group {
+        border-color: #374151;
+    }
+    
+    .toggle-thumb {
+        background-color: #ffffff;
+    }
+    .toggle-input:checked + .toggle-track .toggle-thumb {
+        background-color: var(--thumb-color);
+    }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .toggle-track,
+    .toggle-thumb {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly polished, JavaScript-free toggle switch component featuring a clean monochrome aesthetic and mathematically responsive scaling. Resolves issue #78270.

### Changes Made:
- Added `submissions/examples/css-responsive-toggle-minimalist-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox hack and accessibility attributes.
- Created `style.css` featuring the UI mechanics:
  - **The Checkbox Hack**: The toggle relies on a visually hidden `<input type="checkbox">` wrapped inside a `<label>`. Clicking anywhere on the label toggles the checkbox state. The CSS uses the adjacent sibling combinator (`.toggle-input:checked + .toggle-track`) to animate the background color and move the thumb.
  - **Mathematical Responsiveness**: Instead of hardcoding translation values, the thumb's movement is calculated dynamically using CSS `calc()` based on custom properties (`transform: translateX(calc(var(--toggle-width) - var(--thumb-size) - (var(--thumb-margin) * 2)));`). This allows the toggle to be resized perfectly just by overriding the `--toggle-width` and `--toggle-height` variables in a media query.
  - **Minimalist Aesthetic**: The design avoids heavy shadows or gradients, relying on crisp borders, flat colors (stark black and white), and a smooth `cubic-bezier` timing function for a premium, lightweight feel.
  - **Theming Supported**: Configured via CSS Custom Properties. Fully supports automatic OS-level Dark Mode via `@media (prefers-color-scheme: dark)`, intelligently swapping the monochrome palette while maintaining the minimalist aesthetic.
- Added `README.md` documenting usage and the technical mechanics of the `calc()` geometry for responsive scaling and the clean monochrome theme logic.
- Fully accessible semantic structure. Because it uses a real `<input type="checkbox">`, it is perfectly accessible to screen readers (with `aria-label`) and keyboards. Includes `:focus-visible` styling to draw a high-contrast outline when navigated via the Tab key. Honors the `prefers-reduced-motion` accessibility standard by disabling the translation animations if requested by the OS.

Closes #78270
