### PR TITLE
Add KPI metric arrow bounce submission

### DIFF
--- a/submissions/examples/kpi-metric-arrow-bounce/README.md
+++ b/submissions/examples/kpi-metric-arrow-bounce/README.md
@@ -1,0 +1,21 @@
+# KPI metric arrow bounce
+
+A small arrow next to a KPI number that bounces up or down depending on the trend direction.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `kpimetricarrowbounce-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Dashboard tile pattern; the bounce reinforces the trend.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *ruby*)
+- `README.md` — this file

--- a/submissions/examples/kpi-metric-arrow-bounce/demo.html
+++ b/submissions/examples/kpi-metric-arrow-bounce/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KPI metric arrow bounce — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>KPI metric arrow bounce</h1>
+      <p>A small arrow next to a KPI number that bounces up or down depending on the trend direction.</p>
+    </header>
+    <section class="demo">
+      <div class="kpimetricarrowbounce"><span class="kpimetricarrowbounce-num">$12.4k</span><span class="kpimetricarrowbounce-arrow kpimetricarrowbounce-up">↑ +8%</span></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/kpi-metric-arrow-bounce/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/kpi-metric-arrow-bounce/style.css
+++ b/submissions/examples/kpi-metric-arrow-bounce/style.css
@@ -1,0 +1,60 @@
+/* KPI metric arrow bounce — EaseMotion CSS submission
+   Palette: ruby   Folder: submissions/examples/kpi-metric-arrow-bounce/   Class prefix: .kpimetricarrowbounce
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160a0d;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ef4444;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261418;
+  border: 1px solid #36191e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ef4444;
+  background: #261418;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.kpimetricarrowbounce {{ display: inline-flex; align-items: baseline; gap: 8px; padding: 8px 14px; background: #261418; border-radius: 8px; }}
+.kpimetricarrowbounce-num {{ color: #e6e8ec; font: 700 22px/1 ui-monospace, monospace; }}
+.kpimetricarrowbounce-arrow {{ font: 600 13px/1 system-ui; padding: 3px 8px; border-radius: 999px; display: inline-flex; align-items: center; gap: 2px; }}
+.kpimetricarrowbounce-up {{ color: #ef4444; background: #ef444422; animation: kf-kpimetricarrowbounce 2.4s ease-in-out infinite; }}
+.kpimetricarrowbounce-down {{ color: #ff5c5c; background: #ff5c5c22; }}
+@keyframes kf-kpimetricarrowbounce {{ 0%, 100% {{ transform: translateY(0); }} 50% {{ transform: translateY(-3px); }} }}


### PR DESCRIPTION
Closes #79137

## What
This submission adds a new EaseMotion CSS example: `kpi-metric-arrow-bounce` under `submissions/examples/`.

A small arrow next to a KPI number that bounces up or down depending on the trend direction.

## How to review
1. Open `submissions/examples/kpi-metric-arrow-bounce/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/kpi-metric-arrow-bounce/` and does not modify any existing file.
