### PR TITLE
feat: create Interactive Modal with Retro styling #78855

### DIFF
--- a/submissions/examples/css-interactive-modal-retro/README.md
+++ b/submissions/examples/css-interactive-modal-retro/README.md
@@ -1,0 +1,13 @@
+# Interactive Modal with Retro styling (#78855)
+
+A responsive 80s synthwave-inspired interactive modal window featuring CSS `:target` state toggling (zero JS required), backdrop blurring, glowing neon accents, and window title bar controls built using pure CSS.
+
+## Features
+- **Zero-JavaScript Interactivity:** Driven entirely by CSS `:target` pseudo-class URL anchor handling.
+- **Accessible Dialog Structure:** Configured with `role="dialog"`, `aria-modal="true"`, and explicit `aria-labelledby` linkages.
+- **Retro Synthwave Styling:** Hot pink, cyan glow, and neon yellow accents paired with extruded window geometry.
+
+## File Hierarchy
+- `style.css` - Component variables, overlay target triggers, backdrop blur rules, and modal spring scales.
+- `demo.html` - Accessible HTML structure showcasing the interactive modal.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-interactive-modal-retro/demo.html
+++ b/submissions/examples/css-interactive-modal-retro/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Modal | Retro Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main style="text-align: center;">
+    <a href="#retro-modal-window" class="open-modal-btn" role="button">
+        Launch Cyber Modal
+    </a>
+</main>
+
+<div id="retro-modal-window" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="modal-title-id">
+    <div class="retro-modal">
+        <div class="modal-header">
+            <h2 id="modal-title-id" class="modal-title">SYSTEM_ALERT.EXE</h2>
+            <a href="#" class="close-btn" aria-label="Close Modal">&times;</a>
+        </div>
+        <div class="modal-body">
+            <p>High-priority grid warning! Cybernetic protocol initialization requires user confirmation to proceed.</p>
+            <div class="modal-actions">
+                <a href="#" class="modal-btn-confirm">Execute</a>
+                <a href="#" class="modal-btn-cancel">Abort</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-interactive-modal-retro/style.css
+++ b/submissions/examples/css-interactive-modal-retro/style.css
@@ -1,0 +1,216 @@
+/* Interactive Modal with Retro Styling #78855 */
+
+:root {
+    --bg-color: #0d0221;
+    --modal-bg: #15072e;
+    --modal-header: #240d47;
+    --neon-pink: #ff007f;
+    --neon-cyan: #00f3ff;
+    --neon-yellow: #ffea00;
+    --text-main: #f8fafc;
+    --text-sub: #a78bfa;
+    --glow-pink: rgba(255, 0, 127, 0.4);
+    --glow-cyan: rgba(0, 243, 255, 0.3);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Courier New', Courier, system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    padding: 1.5rem;
+}
+
+/* Modal Open Trigger Button */
+.open-modal-btn {
+    appearance: none;
+    background: var(--modal-bg);
+    border: 2px solid var(--neon-cyan);
+    border-radius: 0.75rem;
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 800;
+    font-family: inherit;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--neon-cyan);
+    cursor: pointer;
+    box-shadow: 0 0 15px var(--glow-cyan), 4px 4px 0px var(--neon-pink);
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.open-modal-btn:hover {
+    color: #ffffff;
+    background: var(--neon-pink);
+    border-color: var(--neon-pink);
+    box-shadow: 0 0 25px var(--glow-pink), 6px 6px 0px var(--neon-cyan);
+    transform: translateY(-2px);
+}
+
+.open-modal-btn:focus-visible {
+    outline: 2px solid var(--neon-yellow);
+    outline-offset: 4px;
+}
+
+/* Hidden Modal State Control via CSS :target */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(13, 2, 33, 0.85);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 100;
+}
+
+.modal-overlay:target {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+/* Retro Window Modal Card */
+.retro-modal {
+    background: var(--modal-bg);
+    border: 2px solid var(--neon-cyan);
+    border-radius: 1rem;
+    width: 100%;
+    max-width: 500px;
+    box-shadow: 0 0 35px rgba(0, 243, 255, 0.3), inset 0 0 15px rgba(255, 0, 127, 0.2);
+    overflow: hidden;
+    transform: scale(0.9) translateY(20px);
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-overlay:target .retro-modal {
+    transform: scale(1) translateY(0);
+}
+
+/* Synthwave Window Header Bar */
+.modal-header {
+    background: var(--modal-header);
+    border-bottom: 2px solid var(--neon-cyan);
+    padding: 0.85rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.modal-title {
+    font-size: 1.1rem;
+    font-weight: 800;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--neon-yellow);
+    text-shadow: 1px 1px 0px var(--neon-pink);
+}
+
+.close-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 0.35rem;
+    background: var(--neon-pink);
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 900;
+    font-size: 0.9rem;
+    border: 1px solid #ffffff;
+    transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+    background: var(--neon-cyan);
+    color: var(--bg-color);
+    box-shadow: 0 0 10px var(--neon-cyan);
+}
+
+.close-btn:focus-visible {
+    outline: 2px solid var(--neon-yellow);
+    outline-offset: 2px;
+}
+
+/* Modal Body Content */
+.modal-body {
+    padding: 2rem 1.75rem;
+    text-align: center;
+}
+
+.modal-body p {
+    color: var(--text-sub);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0 0 1.75rem 0;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.modal-btn-confirm {
+    appearance: none;
+    text-decoration: none;
+    background-color: var(--neon-cyan);
+    color: var(--bg-color);
+    border: none;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 800;
+    font-family: inherit;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    box-shadow: 0 4px 0 var(--neon-pink);
+    transition: all 0.2s ease;
+}
+
+.modal-btn-confirm:hover {
+    background-color: #ffffff;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 0 var(--neon-pink);
+}
+
+.modal-btn-cancel {
+    text-decoration: none;
+    color: var(--text-sub);
+    border: 1px solid var(--text-sub);
+    border-radius: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    font-size: 0.9rem;
+    font-weight: 800;
+    font-family: inherit;
+    text-transform: uppercase;
+    transition: all 0.2s ease;
+}
+
+.modal-btn-cancel:hover {
+    color: var(--neon-pink);
+    border-color: var(--neon-pink);
+}
+
+@media (max-width: 480px) {
+    .retro-modal {
+        margin: 1rem;
+    }
+    .modal-actions {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Interactive Modal with Retro styling** component (#78855).
gssoc 26

Closes #78855

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-interactive-modal-retro/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript (uses CSS `:target`)
- [x] Fully responsive across all screen sizes
- [x] Accessible with dialog semantics (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) and keyboard focus outlines

---

## Feature Description
**What does this add?**
A synthwave retro modal window complete with a styled title bar, close trigger, glowing borders, and backdrop blur overlay that opens and closes smoothly using pure CSS.

**How does it work?**
Constructed using semantic HTML5, CSS `:target` selectors for toggling modal visibility without JavaScript, spring transition scales, and neon custom properties.