### PR TITLE
Add Horizontal multi-bar stack submission

### DIFF
--- a/submissions/examples/horizontal-multi-bar-stack/README.md
+++ b/submissions/examples/horizontal-multi-bar-stack/README.md
@@ -1,0 +1,21 @@
+# Horizontal multi-bar stack
+
+A horizontal bar whose segments grow in width in sequence to show category composition.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `horizontalmultibarstack-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Distribution / share pattern; the staggered grow makes the segments feel distinct.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *graphite*)
+- `README.md` — this file

--- a/submissions/examples/horizontal-multi-bar-stack/demo.html
+++ b/submissions/examples/horizontal-multi-bar-stack/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Horizontal multi-bar stack — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Horizontal multi-bar stack</h1>
+      <p>A horizontal bar whose segments grow in width in sequence to show category composition.</p>
+    </header>
+    <section class="demo">
+      <div class="horizontalmultibarstack"><div class="horizontalmultibarstack-row" style="--w: 70%"><span>Design</span></div><div class="horizontalmultibarstack-row" style="--w: 50%"><span>Build</span></div><div class="horizontalmultibarstack-row" style="--w: 30%"><span>QA</span></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/horizontal-multi-bar-stack/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/horizontal-multi-bar-stack/style.css
+++ b/submissions/examples/horizontal-multi-bar-stack/style.css
@@ -1,0 +1,62 @@
+/* Horizontal multi-bar stack — EaseMotion CSS submission
+   Palette: graphite   Folder: submissions/examples/horizontal-multi-bar-stack/   Class prefix: .horizontalmultibarstack
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #101216;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #94a3b8;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d22;
+  border: 1px solid #25282e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #94a3b8;
+  background: #1a1d22;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.horizontalmultibarstack {{ display: flex; flex-direction: column; gap: 8px; max-width: 360px; }}
+.horizontalmultibarstack-row {{ height: 28px; background: #25282e; border-radius: 6px; position: relative; overflow: hidden; opacity: 0; animation: kf-horizontalmultibarstack-in 600ms ease-out forwards; }}
+.horizontalmultibarstack-row:nth-child(1) {{ animation-delay: 0.0s; }}
+.horizontalmultibarstack-row:nth-child(2) {{ animation-delay: 0.2s; }}
+.horizontalmultibarstack-row:nth-child(3) {{ animation-delay: 0.4s; }}
+.horizontalmultibarstack-row::before {{ content: ""; position: absolute; inset: 0; width: 0%; background: linear-gradient(90deg, #94a3b8, #cbd5e1); border-radius: 6px; animation: kf-horizontalmultibarstack 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards; }}
+.horizontalmultibarstack-row span {{ position: relative; z-index: 1; display: inline-block; padding: 6px 12px; color: #e6e8ec; font: 12px/1 system-ui; }}
+@keyframes kf-horizontalmultibarstack {{ from {{ width: 0%; }} to {{ width: var(--w); }} }}@keyframes kf-horizontalmultibarstack-in {{ from {{ opacity: 0; transform: translateX(-12px); }} to {{ opacity: 1; transform: translateX(0); }} }}


### PR DESCRIPTION
Closes #79140

## What
This submission adds a new EaseMotion CSS example: `horizontal-multi-bar-stack` under `submissions/examples/`.

A horizontal bar whose segments grow in width in sequence to show category composition.

## How to review
1. Open `submissions/examples/horizontal-multi-bar-stack/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/horizontal-multi-bar-stack/` and does not modify any existing file.
