### PR TITLE
feat: add Password Visibility Toggle example (password-toggle-visibility-qz9k)

### DIFF
--- a/submissions/examples/password-toggle-visibility-qz9k/README.md
+++ b/submissions/examples/password-toggle-visibility-qz9k/README.md
@@ -1,0 +1,41 @@
+# Password Visibility Toggle
+
+## What does this do?
+
+A password field with a show/hide button that swaps the input's `type`
+between `password` and `text`, keeping focus and caret position through the
+swap, and driving its own eye/eye-off icon from `aria-pressed` rather than a
+separate class.
+
+## How is it used?
+
+```html
+<input id="ptv-input" class="ptv-input" type="password" />
+<button type="button" class="ptv-toggle" onclick="ptvToggle(this)" aria-pressed="false" aria-label="Show password">
+  <svg class="ptv-icon ptv-icon-eye">...</svg>
+  <svg class="ptv-icon ptv-icon-eye-off">...</svg>
+</button>
+```
+
+`ptvToggle` flips `input.type`, updates `aria-pressed` and `aria-label` on
+the button to match, and re-focuses the input with the caret restored to
+where it was — changing an input's `type` attribute can silently drop focus
+in some browsers, which this explicitly guards against.
+
+## Why is it useful?
+
+Toggling `input.type` between `password` and `text` is simple, but two
+details are easy to miss: focus can be lost the moment the type changes
+(the field visually stays in place, but keyboard focus silently moves to
+`<body>`), and the caret resets to position 0 instead of staying where the
+user was typing — both are jarring if the user is mid-edit when they toggle
+visibility. Re-calling `.focus()` and `.setSelectionRange()` after the type
+swap fixes both.
+
+Driving the icon swap from `aria-pressed` (an attribute the button already
+needs for accessibility, since a toggle button should expose its pressed
+state) rather than a separate visual-only class means the accessible state
+and the visual state are structurally the same value — there's no second
+place for them to fall out of sync. `aria-label` also updates each time, so
+a screen reader announces "Show password" or "Hide password" correctly
+rather than a static label that stops matching the button's actual effect.

--- a/submissions/examples/password-toggle-visibility-qz9k/demo.html
+++ b/submissions/examples/password-toggle-visibility-qz9k/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Password Visibility Toggle</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function ptvToggle(button) {
+    var input = document.getElementById('ptv-input');
+    var showing = input.type === 'text';
+    input.type = showing ? 'password' : 'text';
+    button.setAttribute('aria-pressed', String(!showing));
+    button.setAttribute('aria-label', showing ? 'Show password' : 'Hide password');
+    // Keep the caret at the end after the type swap, which some browsers
+    // otherwise reset to the start of the field.
+    var pos = input.value.length;
+    input.focus();
+    input.setSelectionRange(pos, pos);
+  }
+</script>
+</head>
+<body>
+<main class="ptv-wrap">
+  <h1 class="ptv-h1">Sign in</h1>
+  <p class="ptv-lede">Toggling visibility swaps the input's type between password and text without losing focus, caret position, or the value itself, using aria-pressed so the button's own state (not just the field's) is exposed to assistive tech.</p>
+
+  <label class="ptv-field-label" for="ptv-input">Password</label>
+  <div class="ptv-field">
+    <input
+      id="ptv-input"
+      class="ptv-input"
+      type="password"
+      autocomplete="current-password"
+      value="correct-horse-battery"
+    />
+    <button
+      type="button"
+      class="ptv-toggle"
+      onclick="ptvToggle(this)"
+      aria-pressed="false"
+      aria-label="Show password"
+    >
+      <svg class="ptv-icon ptv-icon-eye" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+      <svg class="ptv-icon ptv-icon-eye-off" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z" />
+        <circle cx="12" cy="12" r="3" />
+        <line x1="3" y1="3" x2="21" y2="21" />
+      </svg>
+    </button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/password-toggle-visibility-qz9k/style.css
+++ b/submissions/examples/password-toggle-visibility-qz9k/style.css
@@ -1,0 +1,98 @@
+/* Password Visibility Toggle
+   Both eye icons are always in the DOM; aria-pressed on the button (not a
+   class on the wrapper) drives which one shows via an attribute selector,
+   so the button's accessible state and its visual state can never drift
+   apart from each other. */
+
+.ptv-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ptv-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ptv-lede { margin: 0 0 2rem; color: #576073; }
+
+.ptv-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.ptv-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.ptv-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 2.6em 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  letter-spacing: 0.02em;
+  transition: border-color 160ms ease;
+}
+
+.ptv-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.ptv-toggle {
+  position: absolute;
+  right: 0.4rem;
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 0.4rem;
+  background: none;
+  color: #6b7386;
+  cursor: pointer;
+}
+
+.ptv-toggle:hover { background: #f1f4fa; color: #1c2028; }
+.ptv-toggle:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 1px; }
+
+.ptv-icon {
+  grid-area: 1 / 1;
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.ptv-icon-eye-off {
+  display: none;
+}
+
+.ptv-toggle[aria-pressed="true"] .ptv-icon-eye {
+  display: none;
+}
+
+.ptv-toggle[aria-pressed="true"] .ptv-icon-eye-off {
+  display: block;
+}
+
+@media (forced-colors: active) {
+  .ptv-input { border-color: CanvasText; }
+  .ptv-toggle:hover { forced-color-adjust: none; background: ButtonFace; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ptv-wrap { color: #e6e9f2; }
+  .ptv-lede { color: #99a1b4; }
+  .ptv-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .ptv-toggle { color: #99a1b4; }
+  .ptv-toggle:hover { background: #1e2430; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #79146

Password field with a show/hide toggle. Changing input.type can silently drop focus and reset the caret to position 0 in some browsers — this re-focuses the field and restores the caret position after the type swap. The eye/eye-off icon is driven by aria-pressed via an attribute selector rather than a separate visual class, so the button's accessible state and visual state are structurally the same value and can't drift apart.