### PR TITLE
feat: add Breadcrumb Trail example (breadcrumb-trail-qz9k)

### DIFF
--- a/submissions/examples/breadcrumb-trail-qz9k/README.md
+++ b/submissions/examples/breadcrumb-trail-qz9k/README.md
@@ -1,0 +1,42 @@
+# Breadcrumb Trail
+
+## What does this do?
+
+A breadcrumb navigation trail using a real `<nav>`/`<ol>` structure, where
+each separator chevron is generated content attached to the crumb before
+it rather than a standalone element sitting between two links.
+
+## How is it used?
+
+```html
+<nav class="brt-nav" aria-label="Breadcrumb">
+  <ol class="brt-list">
+    <li class="brt-item"><a class="brt-link" href="/">Home</a></li>
+    <li class="brt-item"><a class="brt-link" href="/electronics">Electronics</a></li>
+    <li class="brt-item"><span class="brt-current" aria-current="page">Laptops</span></li>
+  </ol>
+</nav>
+```
+
+The final crumb is a `<span aria-current="page">`, not a link — it
+represents the current page, which shouldn't be a clickable link to itself.
+
+## Why is it useful?
+
+A breadcrumb trail with separator text/icons as their own `<li>` or inline
+element between crumbs needs that separator count kept in sync by hand:
+adding, removing, or conditionally hiding a crumb (e.g. collapsing a long
+trail on mobile) also means adding or removing a matching separator, and
+it's easy to end up with a dangling separator at either end or a doubled
+one in the middle. Drawing the separator as `::after` on `.brt-item`, and
+suppressing it specifically on `:last-child`, ties the separator count
+structurally to the crumb count — there's no second element that has to be
+kept in sync, so removing a crumb in markup (or via JS for a
+dynamically-truncated trail) automatically removes exactly the right
+separator with it.
+
+Using `<nav aria-label="Breadcrumb">` around a real `<ol>` (not a `<div>` of
+loose links) means the trail is announced as a distinct, ordered navigation
+landmark by assistive technology, and `aria-current="page"` on the final
+crumb identifies it as the current location without a link that would
+otherwise reload the same page.

--- a/submissions/examples/breadcrumb-trail-qz9k/demo.html
+++ b/submissions/examples/breadcrumb-trail-qz9k/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Breadcrumb Trail</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="brt-wrap">
+  <h1 class="brt-h1">Breadcrumb Trail</h1>
+  <p class="brt-lede">The separator chevrons are generated content on each link, not a separate DOM element between links, so removing or reordering crumbs never leaves a stray separator behind.</p>
+
+  <nav class="brt-nav" aria-label="Breadcrumb">
+    <ol class="brt-list">
+      <li class="brt-item"><a class="brt-link" href="#">Home</a></li>
+      <li class="brt-item"><a class="brt-link" href="#">Electronics</a></li>
+      <li class="brt-item"><a class="brt-link" href="#">Laptops</a></li>
+      <li class="brt-item"><span class="brt-current" aria-current="page">14-inch Ultrabook</span></li>
+    </ol>
+  </nav>
+</main>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-trail-qz9k/style.css
+++ b/submissions/examples/breadcrumb-trail-qz9k/style.css
@@ -1,0 +1,77 @@
+/* Breadcrumb Trail
+   ::after on .brt-item draws the separator, suppressed on :last-child --
+   so the separator count is always exactly (crumb count - 1) with no
+   dependency on a sibling combinator or a manually-placed separator span. */
+
+.brt-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.brt-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.brt-lede { margin: 0 0 2rem; color: #576073; }
+
+.brt-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.9rem;
+}
+
+.brt-item {
+  display: flex;
+  align-items: center;
+}
+
+.brt-item:not(:last-child)::after {
+  content: "";
+  width: 0.4rem;
+  height: 0.4rem;
+  margin: 0 0.55rem;
+  border-top: 1.5px solid #a8adba;
+  border-right: 1.5px solid #a8adba;
+  transform: rotate(45deg);
+  flex: none;
+}
+
+.brt-link {
+  color: #576073;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  padding: 0.15em 0.2em;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.brt-link:hover {
+  color: #4c6ef5;
+  background: #f1f4fa;
+}
+
+.brt-link:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 1px;
+}
+
+.brt-current {
+  color: #1c2028;
+  font-weight: 600;
+}
+
+@media (forced-colors: active) {
+  .brt-item::after { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .brt-wrap { color: #e6e9f2; }
+  .brt-lede { color: #99a1b4; }
+  .brt-item::after { border-color: #4a5266; }
+  .brt-link { color: #99a1b4; }
+  .brt-link:hover { color: #e6e9f2; background: #1e2430; }
+  .brt-current { color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #79147

Breadcrumb nav with a real <nav>/<ol> structure. Separator chevrons are ::after content on .brt-item, suppressed on :last-child, so the separator count is tied structurally to the crumb count — no standalone separator element to add/remove/reorder in sync when crumbs change. Final crumb is a <span aria-current="page">, not a self-linking anchor.