### PR TITLE
feat: add Skeleton Card Loader example (skeleton-card-loader-qz9k)

### DIFF
--- a/submissions/examples/skeleton-card-loader-qz9k/README.md
+++ b/submissions/examples/skeleton-card-loader-qz9k/README.md
@@ -1,0 +1,47 @@
+# Skeleton Card Loader
+
+## What does this do?
+
+A card component whose skeleton (shimmer placeholders) and loaded content
+live in the same markup from the start, toggled by a single
+`.scl-loaded` class, so real content replacing the skeleton never shifts
+the card's layout.
+
+## How is it used?
+
+```html
+<article class="scl-card" aria-busy="true">
+  <div class="scl-thumb" aria-hidden="true"></div>
+  <img class="scl-real-thumb" src="..." alt="..." />
+  <div class="scl-line scl-line-title" aria-hidden="true"></div>
+  <h2 class="scl-real-title">Mountain Trail Map</h2>
+</article>
+```
+
+```js
+card.classList.add('scl-loaded'); // once real data has arrived
+card.removeAttribute('aria-busy');
+```
+
+Each real element (`.scl-real-thumb`, `.scl-real-title`, ...) sits directly
+alongside its skeleton counterpart with matching dimensions; `.scl-loaded`
+simply flips which set is `display: none`.
+
+## Why is it useful?
+
+Skeleton loaders are often built as a separate component swapped out
+entirely for the real content once data arrives, which risks a layout
+shift the instant the swap happens if the skeleton's dimensions don't
+exactly match the real content's — a title placeholder sized generically
+rather than matching the actual heading's line-height, for instance. Because
+both states are written in the *same* card with matched box models
+(thumbnail aspect-ratio, line heights, margins), the toggle changes only
+which content paints, never the card's measured height — so there's no
+"page jumps as content loads" flicker regardless of how the real content's
+actual length compares to the placeholder.
+
+`aria-busy="true"` on the card while skeleton content is showing tells
+assistive technology the region is still loading, and the skeleton pieces
+themselves are `aria-hidden` since shimmering grey bars carry no
+information worth announcing — only the real content, once loaded, is
+meant to be read.

--- a/submissions/examples/skeleton-card-loader-qz9k/demo.html
+++ b/submissions/examples/skeleton-card-loader-qz9k/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Skeleton Card Loader</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function sclSwap() {
+    document.querySelectorAll('.scl-card').forEach(function (card) {
+      card.classList.toggle('scl-loaded');
+    });
+  }
+</script>
+</head>
+<body>
+<main class="scl-wrap">
+  <h1 class="scl-h1">Skeleton Loader</h1>
+  <p class="scl-lede">Skeleton and loaded content occupy the same card markup, toggled by one class, so the shimmer never causes a layout jump when real content arrives -- the skeleton's dimensions are the real content's dimensions.</p>
+
+  <button type="button" class="scl-btn" onclick="sclSwap()">Toggle loaded state</button>
+
+  <div class="scl-grid">
+    <article class="scl-card" aria-busy="true">
+      <div class="scl-thumb" aria-hidden="true"></div>
+      <img class="scl-real-thumb" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180'%3E%3Crect width='320' height='180' fill='%234c6ef5'/%3E%3C/svg%3E" alt="" />
+      <div class="scl-line scl-line-title" aria-hidden="true"></div>
+      <h2 class="scl-real-title">Mountain Trail Map</h2>
+      <div class="scl-line scl-line-text" aria-hidden="true"></div>
+      <p class="scl-real-text">A curated route through the northern ridge, with elevation notes.</p>
+    </article>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/skeleton-card-loader-qz9k/style.css
+++ b/submissions/examples/skeleton-card-loader-qz9k/style.css
@@ -1,0 +1,115 @@
+/* Skeleton Card Loader
+   Skeleton and real elements share the same box model (same padding/margin
+   context) so swapping their visibility via .scl-loaded never changes the
+   card's total height -- the two states are laid out identically, only
+   their content and paint differ. */
+
+.scl-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.scl-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.scl-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.scl-btn {
+  padding: 0.55em 1.1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+  margin-bottom: 1.5rem;
+}
+
+.scl-btn:hover { background: #e4e9f4; }
+.scl-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.scl-card {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.7rem;
+  padding: 1rem;
+  background: #fbfcfe;
+}
+
+.scl-thumb,
+.scl-line {
+  border-radius: 0.4rem;
+  background: linear-gradient(90deg, #e4e7ef 25%, #eef0f5 37%, #e4e7ef 63%);
+  background-size: 400% 100%;
+  animation: scl-shimmer 1.4s ease infinite;
+}
+
+.scl-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin-bottom: 0.85rem;
+}
+
+.scl-line {
+  height: 0.9em;
+  margin-bottom: 0.5rem;
+}
+
+.scl-line-title { width: 70%; height: 1.15em; }
+.scl-line-text { width: 100%; }
+
+.scl-real-thumb,
+.scl-real-title,
+.scl-real-text {
+  display: none;
+}
+
+.scl-real-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.4rem;
+  margin-bottom: 0.85rem;
+}
+
+.scl-real-title {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+}
+
+.scl-real-text {
+  margin: 0;
+  color: #576073;
+  font-size: 0.92rem;
+}
+
+.scl-card.scl-loaded .scl-thumb,
+.scl-card.scl-loaded .scl-line {
+  display: none;
+}
+
+.scl-card.scl-loaded .scl-real-thumb,
+.scl-card.scl-loaded .scl-real-title,
+.scl-card.scl-loaded .scl-real-text {
+  display: block;
+}
+
+@keyframes scl-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scl-thumb, .scl-line { animation: none; background: #e4e7ef; }
+}
+
+@media (forced-colors: active) {
+  .scl-thumb, .scl-line { forced-color-adjust: none; background: ButtonFace; border: 1px solid CanvasText; animation: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .scl-wrap { color: #e6e9f2; }
+  .scl-lede { color: #99a1b4; }
+  .scl-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+  .scl-card { background: #171b23; border-color: #2a303c; }
+  .scl-thumb, .scl-line { background: linear-gradient(90deg, #262e3d 25%, #2e3648 37%, #262e3d 63%); background-size: 400% 100%; }
+  .scl-real-text { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #79148

Skeleton and real content live in the same card markup from the start, with matched box models (thumbnail aspect-ratio, line heights, margins), toggled by a single .scl-loaded class. Because both states share identical dimensions, the swap changes only what paints, never the card's measured height — no layout shift when real content arrives regardless of its actual length. aria-busy on the card while loading, skeleton pieces marked aria-hidden.