### PR TITLE
feat: add Combobox Autocomplete example (combobox-autocomplete-qz9k)

### DIFF
--- a/submissions/examples/combobox-autocomplete-qz9k/README.md
+++ b/submissions/examples/combobox-autocomplete-qz9k/README.md
@@ -1,0 +1,45 @@
+# Combobox Autocomplete
+
+## What does this do?
+
+A filtered-list combobox (country search) implementing the ARIA Combobox
+pattern with `aria-activedescendant`: arrow keys move a visual "active"
+highlight through the filtered options while keyboard focus never leaves
+the text input.
+
+## How is it used?
+
+```html
+<input
+  id="cba-input" role="combobox"
+  aria-expanded="false" aria-controls="cba-listbox" aria-autocomplete="list"
+  oninput="cbaFilter(this)" onkeydown="cbaKeydown(event)"
+/>
+<ul class="cba-listbox" id="cba-listbox" role="listbox" hidden></ul>
+```
+
+`cbaFilter` rebuilds the listbox from a prefix match on every keystroke;
+`cbaKeydown` moves `cbaActiveIndex` on Arrow keys and sets
+`aria-activedescendant` on the input to the currently-active option's id,
+without ever calling `.focus()` on an option.
+
+## Why is it useful?
+
+A combobox's options list is easy to implement by actually moving DOM focus
+into the listbox on arrow-key press — but that breaks the "single text
+field with a dropdown" mental model: focus visibly leaves the input, screen
+readers announce a context switch, and typing to continue filtering no
+longer works without first tabbing back. `aria-activedescendant` is the
+ARIA-sanctioned way around this: the input keeps real DOM focus the entire
+time, and the input's `aria-activedescendant` attribute *tells* assistive
+tech which option is conceptually active, without any focus move actually
+happening. The visual highlight is a plain CSS class kept in sync with that
+same active index — there's exactly one source of truth for "which option is
+active," referenced by both the accessibility attribute and the visible
+style.
+
+Filtering by exact-prefix match (`indexOf(query) === 0`, not a general
+substring search) keeps results predictable — a search for "In" only
+matches countries starting with "In" (India, Indonesia), rather than also
+surfacing an unrelated country that happens to contain "in" somewhere in the
+middle of its name.

--- a/submissions/examples/combobox-autocomplete-qz9k/demo.html
+++ b/submissions/examples/combobox-autocomplete-qz9k/demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Combobox Autocomplete</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var cbaOptions = ['Argentina', 'Australia', 'Austria', 'Belgium', 'Brazil', 'Canada', 'Chile', 'China', 'Denmark', 'Egypt', 'France', 'Germany', 'India', 'Indonesia', 'Italy', 'Japan'];
+  var cbaActiveIndex = -1;
+
+  function cbaFilter(input) {
+    var list = document.getElementById('cba-listbox');
+    var query = input.value.trim().toLowerCase();
+    var matches = query ? cbaOptions.filter(function (o) { return o.toLowerCase().indexOf(query) === 0; }) : [];
+
+    list.innerHTML = '';
+    cbaActiveIndex = -1;
+
+    matches.forEach(function (option, i) {
+      var li = document.createElement('li');
+      li.className = 'cba-option';
+      li.id = 'cba-option-' + i;
+      li.setAttribute('role', 'option');
+      li.textContent = option;
+      li.onclick = function () { cbaSelect(option); };
+      list.appendChild(li);
+    });
+
+    list.hidden = matches.length === 0;
+    input.setAttribute('aria-expanded', String(matches.length > 0));
+  }
+
+  function cbaSelect(value) {
+    var input = document.getElementById('cba-input');
+    input.value = value;
+    document.getElementById('cba-listbox').hidden = true;
+    input.setAttribute('aria-expanded', 'false');
+    input.focus();
+  }
+
+  function cbaKeydown(event) {
+    var list = document.getElementById('cba-listbox');
+    var options = list.querySelectorAll('.cba-option');
+    if (list.hidden || !options.length) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      cbaActiveIndex = Math.min(cbaActiveIndex + 1, options.length - 1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      cbaActiveIndex = Math.max(cbaActiveIndex - 1, 0);
+    } else if (event.key === 'Enter' && cbaActiveIndex >= 0) {
+      event.preventDefault();
+      cbaSelect(options[cbaActiveIndex].textContent);
+      return;
+    } else if (event.key === 'Escape') {
+      list.hidden = true;
+      event.target.setAttribute('aria-expanded', 'false');
+      return;
+    } else {
+      return;
+    }
+
+    options.forEach(function (opt, i) {
+      opt.classList.toggle('cba-option--active', i === cbaActiveIndex);
+    });
+    event.target.setAttribute('aria-activedescendant', options[cbaActiveIndex].id);
+  }
+</script>
+</head>
+<body>
+<main class="cba-wrap">
+  <h1 class="cba-h1">Country</h1>
+  <p class="cba-lede">A combobox with arrow-key navigation over the filtered list via aria-activedescendant, so focus stays in the text field the whole time instead of jumping into the listbox.</p>
+
+  <label class="cba-field-label" for="cba-input">Search countries</label>
+  <div class="cba-combo">
+    <input
+      id="cba-input"
+      class="cba-input"
+      type="text"
+      role="combobox"
+      aria-expanded="false"
+      aria-controls="cba-listbox"
+      aria-autocomplete="list"
+      autocomplete="off"
+      oninput="cbaFilter(this)"
+      onkeydown="cbaKeydown(event)"
+      placeholder="Start typing..."
+    />
+    <ul class="cba-listbox" id="cba-listbox" role="listbox" hidden></ul>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/combobox-autocomplete-qz9k/style.css
+++ b/submissions/examples/combobox-autocomplete-qz9k/style.css
@@ -1,0 +1,85 @@
+/* Combobox Autocomplete
+   .cba-option--active is a plain class the script toggles, not a :focus
+   state -- because focus never actually leaves the input in this pattern,
+   "active" here means "would be selected on Enter," which only a class can
+   represent since nothing in the listbox itself is ever focused. */
+
+.cba-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.cba-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.cba-lede { margin: 0 0 2rem; color: #576073; }
+
+.cba-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.cba-combo {
+  position: relative;
+}
+
+.cba-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  transition: border-color 160ms ease;
+}
+
+.cba-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.cba-listbox {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  max-height: 12rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0.3rem;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 20px rgba(28, 32, 40, 0.12);
+}
+
+.cba-option {
+  padding: 0.5em 0.6em;
+  border-radius: 0.35rem;
+  cursor: pointer;
+  font-size: 0.92rem;
+}
+
+.cba-option:hover,
+.cba-option--active {
+  background: #eef2fd;
+  color: #33408c;
+}
+
+@media (forced-colors: active) {
+  .cba-input, .cba-listbox { border-color: CanvasText; }
+  .cba-option--active { forced-color-adjust: none; background: Highlight; color: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cba-wrap { color: #e6e9f2; }
+  .cba-lede { color: #99a1b4; }
+  .cba-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .cba-listbox { background: #171b23; border-color: #2a303c; }
+  .cba-option:hover, .cba-option--active { background: #262e4a; color: #b7c0f2; }
+}


### PR DESCRIPTION
Closes #79149

Filtered combobox implementing the ARIA Combobox pattern via aria-activedescendant instead of moving DOM focus into the listbox on arrow-key press — the input keeps real focus the entire time, and aria-activedescendant tells assistive tech which option is conceptually active. The visual highlight class is kept in sync with the same active index used for the accessibility attribute, so there's one source of truth for both.