### PR TITLE
feat: add Modal Dialog Focus Trap example (modal-dialog-focus-qz9k)

### DIFF
--- a/submissions/examples/modal-dialog-focus-qz9k/README.md
+++ b/submissions/examples/modal-dialog-focus-qz9k/README.md
@@ -1,0 +1,42 @@
+# Modal Dialog Focus Trap
+
+## What does this do?
+
+A confirmation dialog with a real keyboard focus trap: opening it remembers
+what element had focus beforehand and restores it on close, and Tab/Shift+Tab
+wrap between the dialog's first and last focusable elements instead of
+escaping into the page underneath.
+
+## How is it used?
+
+```html
+<button onclick="mdfOpen()">Open dialog</button>
+<div class="mdf-overlay" id="mdf-overlay" hidden onclick="if (event.target === this) mdfClose()"></div>
+<div class="mdf-dialog" id="mdf-dialog" role="dialog" aria-modal="true" aria-labelledby="mdf-title" hidden>
+  <h2 id="mdf-title">Delete item?</h2>
+  <button class="mdf-close" onclick="mdfClose()">Cancel</button>
+  <button class="mdf-confirm" onclick="mdfClose()">Delete</button>
+</div>
+```
+
+`mdfOpen` records `document.activeElement` before showing the dialog and
+moving focus to its first control; `mdfKeydown` intercepts `Tab` to keep
+focus cycling only through the dialog's own focusable elements, and
+`Escape` to close.
+
+## Why is it useful?
+
+A modal without a real focus trap is a common but serious accessibility
+failure: a keyboard or screen-reader user can Tab straight through the
+dialog's own buttons and land back on content behind the overlay, which is
+supposed to be inert while the dialog is open — they end up interacting
+with a page they can't currently see the relevant part of. Cycling focus
+strictly between the dialog's first and last focusable elements (rather
+than only trapping *forward* Tab, a common incomplete implementation)
+keeps keyboard navigation contained in both directions.
+
+Restoring focus to whatever was focused *before* the dialog opened —
+rather than to `document.body` or nothing — matters just as much on close:
+without it, a keyboard user who opened the dialog from a specific button in
+a long list loses their place entirely and has to re-navigate from the top
+of the page to get back to where they were.

--- a/submissions/examples/modal-dialog-focus-qz9k/demo.html
+++ b/submissions/examples/modal-dialog-focus-qz9k/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Modal Dialog Focus Trap</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var mdfLastFocused = null;
+
+  function mdfOpen() {
+    mdfLastFocused = document.activeElement;
+    var dialog = document.getElementById('mdf-dialog');
+    dialog.hidden = false;
+    document.getElementById('mdf-overlay').hidden = false;
+    dialog.querySelector('.mdf-close').focus();
+    document.addEventListener('keydown', mdfKeydown);
+  }
+
+  function mdfClose() {
+    document.getElementById('mdf-dialog').hidden = true;
+    document.getElementById('mdf-overlay').hidden = true;
+    document.removeEventListener('keydown', mdfKeydown);
+    if (mdfLastFocused) mdfLastFocused.focus();
+  }
+
+  function mdfKeydown(event) {
+    if (event.key === 'Escape') {
+      mdfClose();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    var dialog = document.getElementById('mdf-dialog');
+    var focusable = dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+</script>
+</head>
+<body>
+<main class="mdf-wrap">
+  <h1 class="mdf-h1">Modal Focus Trap</h1>
+  <p class="mdf-lede">Opening the dialog remembers what was focused beforehand and restores it on close; Tab and Shift+Tab wrap within the dialog instead of escaping into the page behind it.</p>
+
+  <button type="button" class="mdf-open-btn" onclick="mdfOpen()">Open dialog</button>
+
+  <div class="mdf-overlay" id="mdf-overlay" hidden onclick="if (event.target === this) mdfClose()"></div>
+  <div class="mdf-dialog" id="mdf-dialog" role="dialog" aria-modal="true" aria-labelledby="mdf-title" hidden>
+    <h2 class="mdf-title" id="mdf-title">Delete item?</h2>
+    <p class="mdf-body">This action cannot be undone.</p>
+    <div class="mdf-actions">
+      <button type="button" class="mdf-close" onclick="mdfClose()">Cancel</button>
+      <button type="button" class="mdf-confirm" onclick="mdfClose()">Delete</button>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/modal-dialog-focus-qz9k/style.css
+++ b/submissions/examples/modal-dialog-focus-qz9k/style.css
@@ -1,0 +1,111 @@
+/* Modal Dialog Focus Trap
+   The dialog and overlay are separate elements at the same stacking level,
+   not overlay-as-dialog-background, so the dialog's own box-shadow and
+   border-radius aren't clipped by an overlay that would otherwise need
+   overflow:hidden to mask the scrim's own corners. */
+
+.mdf-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.mdf-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.mdf-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.mdf-open-btn {
+  padding: 0.6em 1.2em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+}
+
+.mdf-open-btn:hover { background: #e4e9f4; }
+.mdf-open-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.mdf-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 18, 24, 0.45);
+  z-index: 20;
+}
+
+.mdf-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 21;
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 1.5rem;
+  border-radius: 0.8rem;
+  background: #fff;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+.mdf-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.mdf-body {
+  margin: 0 0 1.4rem;
+  color: #576073;
+  font-size: 0.94rem;
+}
+
+.mdf-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.mdf-close,
+.mdf-confirm {
+  padding: 0.55em 1.1em;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mdf-close {
+  border: 1px solid #d3d8e2;
+  background: #fff;
+}
+
+.mdf-close:hover { background: #f1f4fa; }
+
+.mdf-confirm {
+  border: 1px solid #e0483f;
+  background: #e0483f;
+  color: #fff;
+}
+
+.mdf-confirm:hover { background: #c73c34; }
+
+.mdf-close:focus-visible,
+.mdf-confirm:focus-visible,
+.mdf-open-btn:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .mdf-dialog { border: 1px solid CanvasText; }
+  .mdf-close { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .mdf-wrap { color: #e6e9f2; }
+  .mdf-lede { color: #99a1b4; }
+  .mdf-open-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+  .mdf-dialog { background: #171b23; }
+  .mdf-body { color: #99a1b4; }
+  .mdf-close { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .mdf-close:hover { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #79150

Confirmation dialog with a genuine keyboard focus trap. mdfOpen records document.activeElement before showing the dialog; mdfKeydown intercepts Tab to cycle focus strictly between the dialog's first and last focusable elements in both directions (not just forward Tab, a common incomplete implementation), and Escape closes. Focus is restored to whatever was focused before the dialog opened on close, so a keyboard user doesn't lose their place in a long list behind it.