### PR TITLE
feat: add useDrag hook (use-drag-qz9k)

### DIFF
--- a/submissions/react/use-drag-qz9k/README.md
+++ b/submissions/react/use-drag-qz9k/README.md
@@ -1,0 +1,63 @@
+# useDrag
+
+Tracks pointer-drag delta from the drag's starting point, using the Pointer
+Events API so the same code handles mouse, touch, and pen input.
+
+## API
+
+```js
+const { dragging, delta, handlers } = useDrag(onDragEnd);
+```
+
+| Return | Type | Description |
+|---|---|---|
+| `dragging` | `boolean` | Whether a drag is currently in progress. |
+| `delta` | `{ x: number, y: number }` | Offset from the drag's start point. |
+| `handlers` | `object` | Spread onto the draggable element. |
+
+`onDragEnd(delta)` is called once when the drag ends.
+
+## Usage
+
+```jsx
+function DraggableCard() {
+  const { dragging, delta, handlers } = useDrag((finalDelta) => {
+    console.log('dropped at offset', finalDelta);
+  });
+
+  return (
+    <div
+      {...handlers}
+      style={{
+        transform: `translate(${delta.x}px, ${delta.y}px)`,
+        cursor: dragging ? 'grabbing' : 'grab',
+        touchAction: 'none',
+      }}
+    >
+      Drag me
+    </div>
+  );
+}
+```
+
+## Why is it useful?
+
+Implementing drag tracking with separate `mousedown`/`mousemove`/`mouseup`
+and `touchstart`/`touchmove`/`touchend` listeners means writing and
+maintaining two parallel code paths for what's conceptually one gesture.
+Pointer Events unify mouse, touch, and pen input behind a single event
+model, so `onPointerDown`/`onPointerMove`/`onPointerUp` alone cover every
+input type this hook needs to support.
+
+`setPointerCapture`/`releasePointerCapture` matter specifically for fast
+drags: without pointer capture, a drag that moves the cursor off the
+original element mid-gesture (easy to do with a fast flick) stops
+delivering move events to that element, silently truncating the drag.
+Capturing the pointer on `pointerdown` guarantees the same element keeps
+receiving `pointermove`/`pointerup` for that pointer regardless of where the
+cursor physically travels, until the drag genuinely ends.
+
+Consumers still need `touch-action: none` in their own CSS on the draggable
+element — without it, a touchscreen browser can claim the gesture for
+native scrolling before Pointer Events ever see it, which this hook can't
+prevent from JS alone.

--- a/submissions/react/use-drag-qz9k/useDrag.jsx
+++ b/submissions/react/use-drag-qz9k/useDrag.jsx
@@ -1,0 +1,51 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * useDrag
+ * Tracks pointer-drag delta (dx, dy) from where the drag started, and
+ * whether a drag is currently active. Uses the Pointer Events API (not
+ * mouse/touch separately) so the same handlers work for mouse, touch, and
+ * pen input without duplicated logic, and captures the pointer so drag
+ * continues correctly even if the cursor leaves the element mid-drag.
+ */
+export function useDrag(onDragEnd) {
+  const [dragging, setDragging] = useState(false);
+  const [delta, setDelta] = useState({ x: 0, y: 0 });
+  const startRef = useRef({ x: 0, y: 0 });
+
+  const onPointerDown = useCallback((event) => {
+    event.currentTarget.setPointerCapture(event.pointerId);
+    startRef.current = { x: event.clientX, y: event.clientY };
+    setDragging(true);
+    setDelta({ x: 0, y: 0 });
+  }, []);
+
+  const onPointerMove = useCallback(
+    (event) => {
+      if (!dragging) return;
+      setDelta({
+        x: event.clientX - startRef.current.x,
+        y: event.clientY - startRef.current.y,
+      });
+    },
+    [dragging]
+  );
+
+  const onPointerUp = useCallback(
+    (event) => {
+      if (!dragging) return;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      setDragging(false);
+      onDragEnd?.(delta);
+    },
+    [dragging, delta, onDragEnd]
+  );
+
+  return {
+    dragging,
+    delta,
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel: onPointerUp },
+  };
+}
+
+export default useDrag;


### PR DESCRIPTION
Closes #79152

React hook tracking pointer-drag delta via the Pointer Events API, unifying mouse/touch/pen input behind one set of handlers instead of two parallel mouse/touch code paths. Uses setPointerCapture/releasePointerCapture so a fast drag that moves the cursor off the element mid-gesture keeps receiving move events for that pointer rather than silently truncating the drag.