### PR TITLE
feat: add aspect-cover Sass mixins (aspect-cover-qz9k)

### DIFF
--- a/submissions/scss/aspect-cover-qz9k/README.md
+++ b/submissions/scss/aspect-cover-qz9k/README.md
@@ -1,0 +1,100 @@
+# aspect-cover-qz9k
+
+Sass mixins for cropping images/video to a fixed aspect ratio via
+`aspect-ratio` + `object-fit: cover`, with `object-position` exposed as a
+first-class parameter.
+
+## Usage
+
+```scss
+@use 'aspect-cover' as *;
+
+.thumbnail {
+  @include aspect-cover(4, 3, top);
+}
+
+.hero-media-container {
+  @include aspect-cover-container(21, 9);
+}
+```
+
+```html
+<img class="thumbnail" src="portrait.jpg" alt="..." />
+
+<div class="hero-media-container">
+  <iframe src="https://maps.example.com/embed" title="Location map"></iframe>
+</div>
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$width` / `$height` | `16` / `9` | Target ratio. |
+| `$position` | `center` | `object-position` value (aspect-cover only) — which part of the source survives the crop. |
+
+## Why is it useful?
+
+`aspect-ratio` plus `object-fit: cover` is the standard fixed-ratio crop
+recipe, but most copies of it hard-code `object-position: center`, which
+crops symmetrically from all sides — for a portrait photo used as a wide
+thumbnail, that usually crops off the top of someone's head. Exposing
+`$position` as a real parameter (`top`, `20% 80%`, etc.) lets each usage
+choose which part of the source image should survive the crop, without
+needing a separate override rule bolted on after including the mixin.
+
+`aspect-cover-container` exists because `object-fit`/`object-position` only
+apply to *replaced elements* (`img`, `video`, `canvas`, `iframe` in some
+engines) — a ratio-locked box wrapping arbitrary content (a map embed
+that doesn't behave as a replaced element consistently, a chart canvas)
+needs the ratio on the wrapper instead, with the child stretched to fill it
+via `width: 100%; height: 100%`. Keeping both variants in one file makes the
+choice between them explicit rather than reaching for the wrong one and
+discovering the ratio silently doesn't apply.
+
+## Choosing between the two variants
+
+```scss
+// Direct <img>/<video> -- use aspect-cover.
+.product-photo {
+  @include aspect-cover(1, 1);
+}
+
+// Anything else (embeds, canvases, custom elements) -- use
+// aspect-cover-container, since object-fit won't apply to the child directly.
+.chart-frame {
+  @include aspect-cover-container(3, 2);
+}
+```
+
+A quick rule of thumb: if the element in markup is literally `<img>`,
+`<video>`, or `<canvas>`, reach for `aspect-cover` directly on that
+element. For anything else — a `<div>` wrapping a third-party embed, a
+custom component that renders its own internal markup — reach for
+`aspect-cover-container` on the wrapper instead, since `object-fit`
+silently does nothing on a non-replaced element and the ratio would
+otherwise need a completely different technique (the padding-top hack) to
+enforce.
+
+## Responsive art direction with object-position
+
+Because `object-position` is a real CSS property, it can be combined with
+media queries to change which part of an image is emphasized at different
+viewport widths — useful when the same photo is used as both a wide
+banner and a narrow card thumbnail:
+
+```scss
+.banner-photo {
+  @include aspect-cover(21, 9, center);
+
+  @media (max-width: 640px) {
+    // On narrow viewports the same photo crops to a taller ratio via a
+    // separate rule; re-centering the crop keeps the subject in frame
+    // rather than relying on the wide-crop's center point.
+    aspect-ratio: 4 / 3;
+    object-position: 30% center;
+  }
+}
+```
+
+This keeps the responsive behaviour declared entirely in CSS, with no
+JavaScript needed to swap image sources or recompute a crop region per
+breakpoint.

--- a/submissions/scss/aspect-cover-qz9k/_aspect-cover.scss
+++ b/submissions/scss/aspect-cover-qz9k/_aspect-cover.scss
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// aspect-cover-qz9k
+// A fixed-ratio image/video crop mixin combining aspect-ratio with
+// object-fit: cover, plus an object-position parameter -- because "crop to
+// a ratio" and "which part of the image survives the crop" are two
+// separate decisions that get conflated if object-position isn't exposed.
+// ---------------------------------------------------------------------------
+
+@mixin aspect-cover(
+  $width: 16,
+  $height: 9,
+  $position: center
+) {
+  aspect-ratio: #{$width} / #{$height};
+  width: 100%;
+  object-fit: cover;
+  object-position: $position;
+  display: block;
+}
+
+// Container variant for when the ratio needs to apply to a wrapper around
+// non-replaced content (a map embed, a chart canvas) rather than directly
+// to an <img>/<video>.
+@mixin aspect-cover-container($width: 16, $height: 9) {
+  aspect-ratio: #{$width} / #{$height};
+  overflow: hidden;
+
+  > * {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.aspect-cover-demo {
+  @include aspect-cover(4, 3, top);
+}
+
+.aspect-cover-demo--container {
+  @include aspect-cover-container(21, 9);
+}


### PR DESCRIPTION
Closes #79153

Sass mixins for fixed-ratio image/video crops via aspect-ratio + object-fit:cover. Exposes object-position as a real parameter rather than hard-coding center, since a symmetric center crop on a portrait photo used as a wide thumbnail typically crops off the subject. aspect-cover-container covers non-replaced content (embeds, canvases) that object-fit can't apply to directly.