### PR TITLE
feat: create Glowing Slider with Dark Mode styling #78848

### DIFF
--- a/submissions/examples/css-glowing-slider-dark-mode/README.md
+++ b/submissions/examples/css-glowing-slider-dark-mode/README.md
@@ -1,0 +1,13 @@
+# Glowing Slider with Dark Mode styling (#78848)
+
+A responsive custom-styled `<input type="range">` control featuring cyan ambient thumb illumination, smooth scaling interaction states, and dark mode aesthetics built using pure CSS.
+
+## Features
+- **Cross-Browser Compatibility:** Styled range thumbs for WebKit/Blink and Gecko (Firefox) engines.
+- **Accessible Inputs:** Semantic `<label>` association, keyboard `:focus-visible` ring outlines, and `aria-value*` bindings.
+- **Glowing Micro-Interactions:** Continuous drop-shadow cyan illumination with spring hover transformations.
+
+## File Hierarchy
+- `style.css` - Custom range input variables, WebKit/Firefox pseudo-element rules, and glow shadow dynamics.
+- `demo.html` - Semantic HTML structure showcasing range input controls.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-glowing-slider-dark-mode/demo.html
+++ b/submissions/examples/css-glowing-slider-dark-mode/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Slider | Dark Mode Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="slider-card" aria-label="Glowing Slider Control Showcase">
+    <h1 class="card-title">Glowing Slider</h1>
+    <p class="card-desc">Custom styled range slider control featuring glowing thumb illumination and high-contrast dark mode palette.</p>
+
+    <div class="slider-container">
+        <div class="slider-label-group">
+            <label for="intensity-range" class="slider-label">Light Intensity</label>
+            <span class="slider-value">75%</span>
+        </div>
+        <input 
+            type="range" 
+            id="intensity-range" 
+            class="glowing-slider" 
+            min="0" 
+            max="100" 
+            value="75"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="75"
+            aria-label="Light Intensity"
+        >
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-glowing-slider-dark-mode/style.css
+++ b/submissions/examples/css-glowing-slider-dark-mode/style.css
@@ -1,0 +1,146 @@
+/* Glowing Slider with Dark Mode Styling #78848 */
+
+:root {
+    --bg-color: #090d16;
+    --card-bg: #111827;
+    --card-border: #1f2937;
+    --text-primary: #f9fafb;
+    --text-secondary: #9ca3af;
+    --accent-cyan: #00f3ff;
+    --accent-glow: rgba(0, 243, 255, 0.4);
+    --track-bg: #1f2937;
+    --shadow-card: 0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    padding: 2rem;
+}
+
+/* Slider Showcase Container Card */
+.slider-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1.5rem;
+    padding: 3.5rem 2.5rem;
+    width: 100%;
+    max-width: 480px;
+    text-align: center;
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.75rem;
+}
+
+.card-title {
+    font-size: 1.65rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.card-desc {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    margin: -0.5rem 0 0.5rem 0;
+    line-height: 1.6;
+}
+
+/* Slider Wrapper */
+.slider-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.slider-label-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.slider-label {
+    color: var(--text-secondary);
+}
+
+.slider-value {
+    color: var(--accent-cyan);
+    font-family: monospace;
+    font-size: 1rem;
+    text-shadow: 0 0 8px var(--accent-glow);
+}
+
+/* Custom Range Input Styling */
+.glowing-slider {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: var(--track-bg);
+    border-radius: 9999px;
+    outline: none;
+    cursor: pointer;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.5);
+    transition: all 0.3s ease;
+}
+
+/* WebKit Thumb */
+.glowing-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--accent-cyan);
+    border: 3px solid var(--card-bg);
+    box-shadow: 0 0 15px var(--accent-cyan), 0 0 25px var(--accent-glow);
+    cursor: pointer;
+    transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+}
+
+.glowing-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+    box-shadow: 0 0 20px var(--accent-cyan), 0 0 35px var(--accent-cyan);
+}
+
+/* Firefox Thumb */
+.glowing-slider::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--accent-cyan);
+    border: 3px solid var(--card-bg);
+    box-shadow: 0 0 15px var(--accent-cyan), 0 0 25px var(--accent-glow);
+    cursor: pointer;
+    transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+}
+
+.glowing-slider::-moz-range-thumb:hover {
+    transform: scale(1.2);
+    box-shadow: 0 0 20px var(--accent-cyan), 0 0 35px var(--accent-cyan);
+}
+
+.glowing-slider:focus-visible {
+    outline: 2px solid var(--accent-cyan);
+    outline-offset: 4px;
+}
+
+@media (max-width: 480px) {
+    .slider-card {
+        padding: 2.5rem 1.5rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Glowing Slider with Dark Mode styling** component (#78848).
gssoc 26

Closes #78848

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-glowing-slider-dark-mode/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all screen sizes
- [x] Accessible range controls (`<label>` linkage, `aria-label`, focus rings)

---

## Feature Description
**What does this add?**
A sleek dark mode custom range slider featuring cyan neon glowing thumb indicators and spring scale micro-interactions on drag or hover.

**How does it work?**
Constructed using semantic HTML5 `<input type="range">`, vendor-prefixed thumb pseudo-elements (`::-webkit-slider-thumb` and `::-moz-range-thumb`), and CSS drop-shadow glows without external dependencies.