### PR TITLE
Add Funnel conversion step submission

### DIFF
--- a/submissions/examples/funnel-conversion-step/README.md
+++ b/submissions/examples/funnel-conversion-step/README.md
@@ -1,0 +1,21 @@
+# Funnel conversion step
+
+A funnel chart whose stages highlight on hover with a subtle trapezoid clip-path.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `funnelconversionstep-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Sales / conversion pattern; the highlight shows which step is being inspected.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *warm*)
+- `README.md` — this file

--- a/submissions/examples/funnel-conversion-step/demo.html
+++ b/submissions/examples/funnel-conversion-step/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Funnel conversion step — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Funnel conversion step</h1>
+      <p>A funnel chart whose stages highlight on hover with a subtle trapezoid clip-path.</p>
+    </header>
+    <section class="demo">
+      <div class="funnelconversionstep"><div class="funnelconversionstep-step" style="--w: 100%">Visitors 10,000</div><div class="funnelconversionstep-step" style="--w: 75%">Sign-ups 7,500</div><div class="funnelconversionstep-step" style="--w: 50%">Activated 5,000</div><div class="funnelconversionstep-step" style="--w: 30%">Paid 3,000</div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/funnel-conversion-step/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/funnel-conversion-step/style.css
+++ b/submissions/examples/funnel-conversion-step/style.css
@@ -1,0 +1,58 @@
+/* Funnel conversion step — EaseMotion CSS submission
+   Palette: warm   Folder: submissions/examples/funnel-conversion-step/   Class prefix: .funnelconversionstep
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f1115;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff6a3d;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d24;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff6a3d;
+  background: #1a1d24;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.funnelconversionstep {{ display: flex; flex-direction: column; gap: 6px; max-width: 360px; }}
+.funnelconversionstep-step {{ height: 36px; background: linear-gradient(90deg, #ff6a3d, color-mix(in srgb, #ff6a3d 40%, transparent)); clip-path: polygon(0 0, 100% 0, calc(100% - 16px) 100%, 0 100%); padding: 0 16px; display: flex; align-items: center; color: #0f1115; font: 600 12px/1 system-ui; transition: filter 200ms, transform 200ms; cursor: pointer; width: var(--w); }}
+.funnelconversionstep-step:hover {{ filter: brightness(1.2); transform: translateX(4px); }}
+


### PR DESCRIPTION
Closes #79176

## What
This submission adds a new EaseMotion CSS example: `funnel-conversion-step` under `submissions/examples/`.

A funnel chart whose stages highlight on hover with a subtle trapezoid clip-path.

## How to review
1. Open `submissions/examples/funnel-conversion-step/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/funnel-conversion-step/` and does not modify any existing file.
