### PR TITLE
feat: add pure CSS Responsive Breadcrumb with Dark Mode styling (#78276)

### DIFF
--- a/submissions/examples/css-responsive-breadcrumb-dark-pure/README.md
+++ b/submissions/examples/css-responsive-breadcrumb-dark-pure/README.md
@@ -1,0 +1,18 @@
+# Responsive Breadcrumb: Dark Mode
+
+A highly polished, JavaScript-free breadcrumb navigation component featuring a premium dark mode aesthetic, pure CSS chevron separators, and horizontal scroll responsiveness.
+
+## Features
+- Pure CSS and HTML implementation. Responsiveness is handled elegantly through native scrolling rather than complex media query collapsing.
+- **Component Architecture & Styling Mechanics**: 
+  - **Responsive Scrolling**: On mobile devices, long breadcrumb trails often break layouts or wrap awkwardly. This component utilizes `white-space: nowrap;` on the list items combined with `overflow-x: auto;` on the container. This allows users on smaller screens to simply swipe horizontally to see the full path. Custom Webkit scrollbar styling is included to keep the scrollbar minimal and on-theme.
+  - **CSS Chevron Separators**: Instead of using background images, icon fonts, or polluting the HTML with SVG separators, the chevrons (`>`) between links are generated entirely with CSS. The `::after` pseudo-element draws a small square with only top and right borders (`border-top`, `border-right`), which is then rotated 45 degrees (`transform: rotate(45deg)`) to create a perfectly crisp, resolution-independent chevron.
+- **Theming**: Configured via CSS Custom Properties. The palette features a sophisticated "Slate" dark theme (Slate 900 background, Slate 800 nav container) with a vibrant Light Blue (`#38bdf8`) hover state. The active/current page features a subtle white text-shadow to make it glow slightly. Because the component is specifically designed as a "Dark Mode" breadcrumb, the dark styling is hardcoded into the root variables.
+- Fully accessible semantic structure. Uses `<nav aria-label="Breadcrumb">`, an ordered list `<ol>`, and `aria-current="page"` for proper screen reader context. Includes high-contrast `:focus-visible` outlines for keyboard navigation.
+
+## Usage
+Open `demo.html` in your browser. Hover over the links to see the smooth background highlight. To test responsiveness, resize your browser window to a narrow width (e.g., mobile size) and observe how the breadcrumb gracefully handles overflow by allowing horizontal scrolling instead of wrapping or breaking.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic breadcrumb list and the SVG home icon.
+- `style.css`: The styling, the `overflow-x` responsiveness logic, the CSS-drawn chevrons, and the dark slate theme variables.

--- a/submissions/examples/css-responsive-breadcrumb-dark-pure/demo.html
+++ b/submissions/examples/css-responsive-breadcrumb-dark-pure/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Breadcrumb: Dark Mode</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Dark Mode Breadcrumbs</h1>
+            <p>Responsive, horizontally scrollable breadcrumbs with a sleek dark aesthetic.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Breadcrumb Navigation -->
+            <nav aria-label="Breadcrumb" class="dark-breadcrumb-nav">
+                <ol class="dark-breadcrumb">
+                    
+                    <li class="breadcrumb-item">
+                        <a href="#" class="breadcrumb-link">
+                            <!-- Home Icon -->
+                            <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
+                        </a>
+                    </li>
+                    
+                    <li class="breadcrumb-item">
+                        <a href="#" class="breadcrumb-link">Settings</a>
+                    </li>
+                    
+                    <li class="breadcrumb-item">
+                        <a href="#" class="breadcrumb-link">Account Preferences</a>
+                    </li>
+                    
+                    <li class="breadcrumb-item">
+                        <a href="#" class="breadcrumb-link">Security Center</a>
+                    </li>
+                    
+                    <li class="breadcrumb-item" aria-current="page">
+                        <span class="breadcrumb-current">Two-Factor Auth</span>
+                    </li>
+                    
+                </ol>
+            </nav>
+
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-responsive-breadcrumb-dark-pure/style.css
+++ b/submissions/examples/css-responsive-breadcrumb-dark-pure/style.css
@@ -1,0 +1,173 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+/* =========================================
+   Theming (Dark Mode Enforced)
+   ========================================= */
+:root {
+    --bg-base: #0f172a; /* Slate 900 */
+    --text-primary: #f8fafc; /* Slate 50 */
+    --text-muted: #64748b; /* Slate 500 */
+    
+    /* Breadcrumb Palette */
+    --nav-bg: #1e293b; /* Slate 800 */
+    --nav-border: #334155; /* Slate 700 */
+    --link-color: #94a3b8; /* Slate 400 */
+    --link-hover: #38bdf8; /* Light Blue */
+    --link-bg-hover: rgba(56, 189, 248, 0.1);
+    
+    --transition-speed: 0.2s;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-base);
+    color: var(--text-primary);
+    font-family: 'Inter', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px 20px;
+    box-sizing: border-box;
+}
+
+.container {
+    width: 100%;
+    max-width: 800px;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 50px;
+}
+.title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 10px 0;
+    letter-spacing: -0.5px;
+}
+.header p {
+    color: var(--text-muted);
+    font-size: 1rem;
+    margin: 0;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Responsive Scroll Container
+   ========================================= */
+.dark-breadcrumb-nav {
+    background: var(--nav-bg);
+    border: 1px solid var(--nav-border);
+    border-radius: 12px;
+    padding: 12px 16px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+    
+    /* Enable horizontal scrolling on small screens */
+    overflow-x: auto;
+    /* Smooth scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+    
+    /* Fade out the right edge if scrolling is possible */
+    /* This requires a wrapper ideally, but for pure CSS we rely on the scrollbar */
+    /* Custom Scrollbar for Webkit */
+    scrollbar-width: thin;
+    scrollbar-color: var(--nav-border) transparent;
+}
+
+/* Custom Scrollbar Webkit */
+.dark-breadcrumb-nav::-webkit-scrollbar {
+    height: 6px;
+}
+.dark-breadcrumb-nav::-webkit-scrollbar-track {
+    background: transparent; 
+}
+.dark-breadcrumb-nav::-webkit-scrollbar-thumb {
+    background-color: var(--nav-border); 
+    border-radius: 10px;
+}
+
+
+/* =========================================
+   Breadcrumb List
+   ========================================= */
+.dark-breadcrumb {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    /* Prevent links from wrapping, forcing horizontal scroll */
+    white-space: nowrap;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+    font-size: 0.95rem;
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] CSS Chevron Separators
+   ========================================= */
+.breadcrumb-item:not(:last-child)::after {
+    content: '';
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    margin: 0 12px;
+    /* Create a chevron using borders and rotation */
+    border-top: 2px solid var(--text-muted);
+    border-right: 2px solid var(--text-muted);
+    transform: rotate(45deg);
+    opacity: 0.6;
+}
+
+
+/* =========================================
+   Links & Hover States
+   ========================================= */
+.breadcrumb-link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: var(--link-color);
+    font-weight: 500;
+    padding: 6px 10px;
+    border-radius: 6px;
+    transition: all var(--transition-speed) ease;
+}
+
+.breadcrumb-link:hover,
+.breadcrumb-link:focus-visible {
+    color: var(--link-hover);
+    background: var(--link-bg-hover);
+    outline: none;
+}
+
+.breadcrumb-link:focus-visible {
+    box-shadow: 0 0 0 2px var(--link-hover);
+}
+
+
+/* =========================================
+   Active (Current Page) State
+   ========================================= */
+.breadcrumb-current {
+    color: var(--text-primary);
+    font-weight: 600;
+    padding: 6px 10px;
+    /* Subtle glow for the active item */
+    text-shadow: 0 0 10px rgba(248, 250, 252, 0.3);
+}
+
+
+/* Dark Mode is enforced stylistically, but keeping media query for completeness */
+@media (prefers-color-scheme: light) {
+    body {
+        background-color: #0f172a;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly polished, JavaScript-free breadcrumb navigation component featuring a premium dark mode aesthetic, pure CSS chevron separators, and horizontal scroll responsiveness. Resolves issue #78276.

### Changes Made:
- Added `submissions/examples/css-responsive-breadcrumb-dark-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic breadcrumb list and the SVG home icon.
- Created `style.css` featuring the UI mechanics:
  - **Responsive Scrolling**: On mobile devices, long breadcrumb trails often break layouts or wrap awkwardly. This component utilizes `white-space: nowrap;` on the list items combined with `overflow-x: auto;` on the container. This allows users on smaller screens to simply swipe horizontally to see the full path. Custom Webkit scrollbar styling is included to keep the scrollbar minimal and on-theme.
  - **CSS Chevron Separators**: Instead of using background images, icon fonts, or polluting the HTML with SVG separators, the chevrons (`>`) between links are generated entirely with CSS. The `::after` pseudo-element draws a small square with only top and right borders (`border-top`, `border-right`), which is then rotated 45 degrees (`transform: rotate(45deg)`) to create a perfectly crisp, resolution-independent chevron.
  - **Theming Supported**: Configured via CSS Custom Properties. The palette features a sophisticated "Slate" dark theme (Slate 900 background, Slate 800 nav container) with a vibrant Light Blue (`#38bdf8`) hover state. The active/current page features a subtle white text-shadow to make it glow slightly. Because the component is specifically designed as a "Dark Mode" breadcrumb, the dark styling is hardcoded into the root variables.
- Added `README.md` documenting usage and the technical mechanics of the `overflow-x` responsiveness logic, the CSS-drawn chevrons, and the dark slate theme variables.
- Fully accessible semantic structure. Uses `<nav aria-label="Breadcrumb">`, an ordered list `<ol>`, and `aria-current="page"` for proper screen reader context. Includes high-contrast `:focus-visible` outlines for keyboard navigation.

Closes #78276
