### PR TITLE
Add Modal glass backdrop fade submission

### DIFF
--- a/submissions/examples/modal-backdrop-glass-fade/README.md
+++ b/submissions/examples/modal-backdrop-glass-fade/README.md
@@ -1,0 +1,21 @@
+# Modal glass backdrop fade
+
+A modal dialog whose backdrop blurs the page and fades in with a slight scale-up entrance.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `modalbackdropglassfade-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Dialog pattern; the backdrop blur signals the modal clearly without losing context.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *violet*)
+- `README.md` — this file

--- a/submissions/examples/modal-backdrop-glass-fade/demo.html
+++ b/submissions/examples/modal-backdrop-glass-fade/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modal glass backdrop fade — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Modal glass backdrop fade</h1>
+      <p>A modal dialog whose backdrop blurs the page and fades in with a slight scale-up entrance.</p>
+    </header>
+    <section class="demo">
+      <div class="modalbackdropglassfade"><div class="modalbackdropglassfade-dialog"><h3>Confirm</h3><p>Are you sure you want to proceed?</p><button>OK</button></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/modal-backdrop-glass-fade/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/modal-backdrop-glass-fade/style.css
+++ b/submissions/examples/modal-backdrop-glass-fade/style.css
@@ -1,0 +1,60 @@
+/* Modal glass backdrop fade — EaseMotion CSS submission
+   Palette: violet   Folder: submissions/examples/modal-backdrop-glass-fade/   Class prefix: .modalbackdropglassfade
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0e0a1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #a78bfa;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1329;
+  border: 1px solid #261a3a;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #a78bfa;
+  background: #1a1329;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.modalbackdropglassfade {{ position: fixed; inset: 0; background: rgba(0,0,0,0.5); backdrop-filter: blur(8px); display: grid; place-items: center; opacity: 0; animation: kf-modalbackdropglassfade 320ms ease-out forwards; }}
+.modalbackdropglassfade-dialog {{ padding: 24px; background: #1a1329; border: 1px solid #261a3a; border-radius: 16px; max-width: 360px; transform: scale(0.95); animation: kf-modalbackdropglassfade-in 320ms ease-out forwards; box-shadow: 0 24px 64px rgba(0,0,0,0.4); }}
+.modalbackdropglassfade-dialog h3 {{ margin: 0 0 8px; color: #e6e8ec; font: 600 18px/1.2 system-ui; }}
+.modalbackdropglassfade-dialog p {{ margin: 0 0 16px; color: #8b909b; font: 14px/1.5 system-ui; }}
+.modalbackdropglassfade-dialog button {{ background: #a78bfa; color: #0e0a1a; border: none; padding: 8px 20px; border-radius: 8px; font: 600 13px/1 system-ui; cursor: pointer; }}
+@keyframes kf-modalbackdropglassfade {{ to {{ opacity: 1; }} }}@keyframes kf-modalbackdropglassfade-in {{ to {{ transform: scale(1); }} }}


### PR DESCRIPTION
Closes #79194

## What
This submission adds a new EaseMotion CSS example: `modal-backdrop-glass-fade` under `submissions/examples/`.

A modal dialog whose backdrop blurs the page and fades in with a slight scale-up entrance.

## How to review
1. Open `submissions/examples/modal-backdrop-glass-fade/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/modal-backdrop-glass-fade/` and does not modify any existing file.
