### PR TITLE
Add Off-canvas drawer slide submission

### DIFF
--- a/submissions/examples/offcanvas-drawer-slide-right/README.md
+++ b/submissions/examples/offcanvas-drawer-slide-right/README.md
@@ -1,0 +1,21 @@
+# Off-canvas drawer slide
+
+A navigation drawer that slides in from the right edge of the screen with a soft easing.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `offcanvasdrawerslideright-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Mobile / settings pattern; the slide is a familiar gesture.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *teal*)
+- `README.md` — this file

--- a/submissions/examples/offcanvas-drawer-slide-right/demo.html
+++ b/submissions/examples/offcanvas-drawer-slide-right/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Off-canvas drawer slide — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Off-canvas drawer slide</h1>
+      <p>A navigation drawer that slides in from the right edge of the screen with a soft easing.</p>
+    </header>
+    <section class="demo">
+      <aside class="offcanvasdrawerslideright"><h3>Menu</h3><ul><li>Home</li><li>Settings</li><li>Profile</li></ul></aside>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/offcanvas-drawer-slide-right/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/offcanvas-drawer-slide-right/style.css
+++ b/submissions/examples/offcanvas-drawer-slide-right/style.css
@@ -1,0 +1,61 @@
+/* Off-canvas drawer slide — EaseMotion CSS submission
+   Palette: teal   Folder: submissions/examples/offcanvas-drawer-slide-right/   Class prefix: .offcanvasdrawerslideright
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #08161a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #14b8a6;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #0f2429;
+  border: 1px solid #163239;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #14b8a6;
+  background: #0f2429;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.offcanvasdrawerslideright {{ position: fixed; top: 0; right: 0; bottom: 0; width: 280px; background: #0f2429; border-left: 1px solid #163239; padding: 24px; transform: translateX(100%); transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1); box-shadow: -12px 0 32px rgba(0,0,0,0.3); }}
+.offcanvasdrawerslideright.is-open {{ transform: translateX(0); }}
+.offcanvasdrawerslideright h3 {{ margin: 0 0 16px; color: #e6e8ec; font: 600 18px/1 system-ui; }}
+.offcanvasdrawerslideright ul {{ list-style: none; padding: 0; margin: 0; }}
+.offcanvasdrawerslideright li {{ padding: 12px 8px; color: #8b909b; border-bottom: 1px solid #163239; cursor: pointer; transition: color 160ms; }}
+.offcanvasdrawerslideright li:hover {{ color: #14b8a6; }}
+


### PR DESCRIPTION
Closes #79197

## What
This submission adds a new EaseMotion CSS example: `offcanvas-drawer-slide-right` under `submissions/examples/`.

A navigation drawer that slides in from the right edge of the screen with a soft easing.

## How to review
1. Open `submissions/examples/offcanvas-drawer-slide-right/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/offcanvas-drawer-slide-right/` and does not modify any existing file.
