### PR TITLE
Add Accordion smooth grid expand submission

### DIFF
--- a/submissions/examples/accordion-smooth-grid-expand/README.md
+++ b/submissions/examples/accordion-smooth-grid-expand/README.md
@@ -1,0 +1,21 @@
+# Accordion smooth grid expand
+
+An accordion whose panels open and close with a smooth height transition using the CSS grid trick.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `accordionsmoothgridexpand-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+FAQ / settings pattern; the smooth expand avoids the snap of a fixed-height panel.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *ruby*)
+- `README.md` — this file

--- a/submissions/examples/accordion-smooth-grid-expand/demo.html
+++ b/submissions/examples/accordion-smooth-grid-expand/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accordion smooth grid expand — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Accordion smooth grid expand</h1>
+      <p>An accordion whose panels open and close with a smooth height transition using the CSS grid trick.</p>
+    </header>
+    <section class="demo">
+      <div class="accordionsmoothgridexpand"><details open><summary>What is EaseMotion CSS?</summary><p>A library of motion and micro-interaction examples for the web.</p></details><details><summary>How do I use it?</summary><p>Copy a submission folder and import its CSS into your project.</p></details></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/accordion-smooth-grid-expand/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/accordion-smooth-grid-expand/style.css
+++ b/submissions/examples/accordion-smooth-grid-expand/style.css
@@ -1,0 +1,62 @@
+/* Accordion smooth grid expand — EaseMotion CSS submission
+   Palette: ruby   Folder: submissions/examples/accordion-smooth-grid-expand/   Class prefix: .accordionsmoothgridexpand
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160a0d;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ef4444;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261418;
+  border: 1px solid #36191e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ef4444;
+  background: #261418;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.accordionsmoothgridexpand {{ display: flex; flex-direction: column; gap: 8px; max-width: 480px; }}
+.accordionsmoothgridexpand details {{ background: #261418; border: 1px solid #36191e; border-radius: 10px; overflow: hidden; }}
+.accordionsmoothgridexpand summary {{ padding: 14px 18px; color: #e6e8ec; font: 600 14px/1 system-ui; cursor: pointer; list-style: none; display: flex; justify-content: space-between; align-items: center; transition: background 160ms; }}
+.accordionsmoothgridexpand summary::after {{ content: "+"; color: #8b909b; font: 600 18px/1 system-ui; transition: transform 240ms; }}
+.accordionsmoothgridexpand details[open] summary::after {{ transform: rotate(45deg); color: #ef4444; }}
+.accordionsmoothgridexpand summary:hover {{ background: #36191e; }}
+.accordionsmoothgridexpand p {{ margin: 0; padding: 0 18px 16px; color: #8b909b; font: 13px/1.5 system-ui; }}
+


### PR DESCRIPTION
Closes #79201

## What
This submission adds a new EaseMotion CSS example: `accordion-smooth-grid-expand` under `submissions/examples/`.

An accordion whose panels open and close with a smooth height transition using the CSS grid trick.

## How to review
1. Open `submissions/examples/accordion-smooth-grid-expand/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/accordion-smooth-grid-expand/` and does not modify any existing file.
