### PR TITLE
feat: add Toast Stack example (notification-toast-stack-qz9k)

### DIFF
--- a/submissions/examples/notification-toast-stack-qz9k/README.md
+++ b/submissions/examples/notification-toast-stack-qz9k/README.md
@@ -1,0 +1,44 @@
+# Toast Stack
+
+## What does this do?
+
+A stacking toast notification system: new toasts prepend to the top of the
+stack, auto-dismiss after 5 seconds, and each animates out independently
+via its own `animationend` event rather than being removed from the DOM on
+a fixed timer.
+
+## How is it used?
+
+```js
+ntsPush('Changes saved', 'success');
+ntsPush('Could not connect', 'error');
+```
+
+```html
+<div class="nts-stack" id="nts-stack" aria-live="polite"></div>
+```
+
+`ntsPush` builds a toast element, prepends it to `#nts-stack`, and schedules
+`ntsRemove` after 5 seconds. `ntsRemove` adds the `.nts-toast--leaving`
+class (which triggers the exit keyframe) and only calls `.remove()` once
+`animationend` fires — not on a JS timer guessing the animation's duration.
+
+## Why is it useful?
+
+Removing a toast from the DOM on a fixed `setTimeout` matching the CSS exit
+animation's duration works until the animation duration changes — the two
+values live in different files (JS and CSS) with no structural connection,
+so a designer adjusting `animation-duration` in the stylesheet doesn't
+know there's a matching magic number in the script that also needs
+updating. Waiting for the real `animationend` event removes that
+duplication entirely: whatever duration the CSS declares is exactly how
+long the element stays in the DOM before removal, because removal is keyed
+to the animation actually finishing, not to a guess about how long it takes.
+
+`aria-live="polite"` on the stack container means each new toast is
+announced to screen readers as it's added, without interrupting whatever
+the user is currently doing (unlike `assertive`, which would cut off
+in-progress speech). The reduced-motion branch swaps the exit animation for
+a near-instant one rather than removing it outright, since `animationend`
+still needs to fire for the removal logic to run — an animation with
+`animation: none` never fires that event at all.

--- a/submissions/examples/notification-toast-stack-qz9k/demo.html
+++ b/submissions/examples/notification-toast-stack-qz9k/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Toast Stack</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var ntsCount = 0;
+
+  function ntsPush(message, kind) {
+    var stack = document.getElementById('nts-stack');
+    var id = 'nts-toast-' + (ntsCount++);
+    var toast = document.createElement('div');
+    toast.className = 'nts-toast nts-toast--' + kind;
+    toast.id = id;
+    toast.setAttribute('role', 'status');
+    toast.innerHTML =
+      '<span class="nts-msg"></span>' +
+      '<button type="button" class="nts-dismiss" aria-label="Dismiss notification">&times;</button>';
+    toast.querySelector('.nts-msg').textContent = message;
+    toast.querySelector('.nts-dismiss').onclick = function () { ntsRemove(id); };
+
+    stack.prepend(toast);
+
+    setTimeout(function () { ntsRemove(id); }, 5000);
+  }
+
+  function ntsRemove(id) {
+    var toast = document.getElementById(id);
+    if (!toast) return;
+    toast.classList.add('nts-toast--leaving');
+    toast.addEventListener('animationend', function () { toast.remove(); }, { once: true });
+  }
+</script>
+</head>
+<body>
+<main class="nts-wrap">
+  <h1 class="nts-h1">Toast Stack</h1>
+  <p class="nts-lede">New toasts prepend to the top of the stack and auto-dismiss after 5 seconds; each also has its own exit animation independent of the others, using animationend rather than a fixed timeout to remove the element from the DOM.</p>
+
+  <div class="nts-triggers">
+    <button type="button" class="nts-btn" onclick="ntsPush('Changes saved', 'success')">Trigger success</button>
+    <button type="button" class="nts-btn" onclick="ntsPush('Could not connect', 'error')">Trigger error</button>
+  </div>
+
+  <div class="nts-stack" id="nts-stack" aria-live="polite"></div>
+</main>
+</body>
+</html>

--- a/submissions/examples/notification-toast-stack-qz9k/style.css
+++ b/submissions/examples/notification-toast-stack-qz9k/style.css
@@ -1,0 +1,106 @@
+/* Toast Stack
+   Removal waits for the CSS exit animation's animationend event rather than
+   a fixed setTimeout matching the animation duration -- so the two never
+   drift apart if the animation-duration is changed later without also
+   updating a hard-coded JS delay. */
+
+.nts-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.nts-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.nts-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.nts-triggers {
+  display: flex;
+  gap: 0.6rem;
+  margin-bottom: 1.5rem;
+}
+
+.nts-btn {
+  padding: 0.55em 1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+}
+
+.nts-btn:hover { background: #e4e9f4; }
+.nts-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.nts-stack {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(20rem, calc(100vw - 2.5rem));
+  z-index: 30;
+}
+
+.nts-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75em 0.9em;
+  border-radius: 0.6rem;
+  background: #1c2028;
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  animation: nts-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nts-toast--success { border-left: 3px solid #34a853; }
+.nts-toast--error { border-left: 3px solid #e0483f; }
+
+.nts-msg {
+  flex: 1;
+  font-size: 0.9rem;
+}
+
+.nts-dismiss {
+  flex: none;
+  border: none;
+  background: none;
+  color: #b7bdcb;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.1em 0.3em;
+}
+
+.nts-dismiss:hover { color: #fff; }
+.nts-dismiss:focus-visible { outline: 2px solid #fff; outline-offset: 1px; }
+
+.nts-toast--leaving {
+  animation: nts-exit 200ms ease forwards;
+}
+
+@keyframes nts-enter {
+  from { opacity: 0; transform: translateY(12px) scale(0.96); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes nts-exit {
+  from { opacity: 1; transform: translateX(0); max-height: 4rem; }
+  to { opacity: 0; transform: translateX(1.5rem); max-height: 0; margin: 0; padding-top: 0; padding-bottom: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nts-toast { animation: none; }
+  .nts-toast--leaving { animation: nts-exit-reduced 1ms forwards; }
+}
+
+@keyframes nts-exit-reduced {
+  to { opacity: 0; max-height: 0; margin: 0; padding: 0; }
+}
+
+@media (forced-colors: active) {
+  .nts-toast { forced-color-adjust: none; background: ButtonText; color: ButtonFace; border: 1px solid CanvasText; }
+}


### PR DESCRIPTION
Closes #79203

Stacking toast system. New toasts prepend to the top; ntsRemove adds a .nts-toast--leaving class and only calls .remove() once the CSS exit animation's real animationend event fires, not a JS setTimeout guessing the animation-duration. That removes a whole class of drift bug where a designer adjusts the CSS duration without a matching magic number in the script being updated. aria-live="polite" on the stack announces each new toast without interrupting in-progress speech.