### PR TITLE
Add Navbar floating dock bounce submission

### DIFF
--- a/submissions/examples/navbar-floating-dock-bounce/README.md
+++ b/submissions/examples/navbar-floating-dock-bounce/README.md
@@ -1,0 +1,21 @@
+# Navbar floating dock bounce
+
+A dock-style navigation bar whose icons scale up on hover, with adjacent icons scaling slightly.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `navbarfloatingdockbounce-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+macOS-style nav pattern; the cascade of scales gives a tactile feel.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *graphite*)
+- `README.md` — this file

--- a/submissions/examples/navbar-floating-dock-bounce/demo.html
+++ b/submissions/examples/navbar-floating-dock-bounce/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Navbar floating dock bounce — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Navbar floating dock bounce</h1>
+      <p>A dock-style navigation bar whose icons scale up on hover, with adjacent icons scaling slightly.</p>
+    </header>
+    <section class="demo">
+      <nav class="navbarfloatingdockbounce"><a>🏠</a><a>📷</a><a>💬</a><a>⚙️</a><a>👤</a></nav>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/navbar-floating-dock-bounce/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/navbar-floating-dock-bounce/style.css
+++ b/submissions/examples/navbar-floating-dock-bounce/style.css
@@ -1,0 +1,60 @@
+/* Navbar floating dock bounce — EaseMotion CSS submission
+   Palette: graphite   Folder: submissions/examples/navbar-floating-dock-bounce/   Class prefix: .navbarfloatingdockbounce
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #101216;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #94a3b8;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d22;
+  border: 1px solid #25282e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #94a3b8;
+  background: #1a1d22;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.navbarfloatingdockbounce {{ display: inline-flex; gap: 4px; padding: 8px; background: #1a1d22; border-radius: 16px; box-shadow: 0 12px 32px rgba(0,0,0,0.3); border: 1px solid #25282e; }}
+.navbarfloatingdockbounce a {{ display: grid; place-items: center; width: 44px; height: 44px; border-radius: 12px; font-size: 20px; text-decoration: none; transition: transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1), background 200ms; cursor: pointer; }}
+.navbarfloatingdockbounce a:hover {{ transform: scale(1.4) translateY(-8px); background: #94a3b833; z-index: 1; }}
+.navbarfloatingdockbounce a:hover + a {{ transform: scale(1.2) translateY(-2px); }}
+.navbarfloatingdockbounce a:has(+ a:hover) {{ transform: scale(1.2) translateY(-2px); }}
+


### PR DESCRIPTION
Closes #79214

## What
This submission adds a new EaseMotion CSS example: `navbar-floating-dock-bounce` under `submissions/examples/`.

A dock-style navigation bar whose icons scale up on hover, with adjacent icons scaling slightly.

## How to review
1. Open `submissions/examples/navbar-floating-dock-bounce/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/navbar-floating-dock-bounce/` and does not modify any existing file.
