### PR TITLE
feat: add Dual Handle Range example (range-slider-dual-handle-qz9k)

### DIFF
--- a/submissions/examples/range-slider-dual-handle-qz9k/README.md
+++ b/submissions/examples/range-slider-dual-handle-qz9k/README.md
@@ -1,0 +1,42 @@
+# Dual Handle Range
+
+## What does this do?
+
+A min/max price range slider built from two overlapping native
+`<input type="range">` elements sharing one visual track, instead of a
+custom-built drag implementation.
+
+## How is it used?
+
+```html
+<div class="drh-slider">
+  <div class="drh-track" id="drh-track"><div class="drh-range" id="drh-range"></div></div>
+  <input type="range" id="drh-min" class="drh-input drh-input-min" min="0" max="100" value="20" oninput="drhUpdate()" />
+  <input type="range" id="drh-max" class="drh-input drh-input-max" min="0" max="100" value="80" oninput="drhUpdate()" />
+</div>
+```
+
+`drhUpdate` clamps the two values so they can't fully cross (a 5-unit
+minimum gap), then positions `.drh-range` — a visual overlay showing the
+selected span — between them.
+
+## Why is it useful?
+
+Two full-width overlapping range inputs stacked on top of each other have
+an obvious problem: whichever input is on top in the DOM (or has the
+higher effective hit area at a given click point) captures every click,
+making the other handle undraggable. Setting `pointer-events: none` on the
+inputs themselves and restoring `pointer-events: auto` only on their
+`::-webkit-slider-thumb`/`::-moz-range-thumb` pseudo-elements means each
+input's hit area shrinks down to just its own thumb — a click anywhere
+else on the track passes through to whichever input's thumb is actually
+under the pointer, so both handles stay independently draggable regardless
+of stacking order.
+
+Using two real `<input type="range">` elements (rather than a fully custom
+pointer-drag implementation) means both handles get native keyboard
+support — Tab between them, arrow keys to nudge — for free, along with
+correct behaviour on touch devices without any gesture code of this
+component's own. The 5-unit minimum gap enforced in `drhUpdate` prevents an
+ambiguous state where "min" and "max" would represent the same or
+inverted values.

--- a/submissions/examples/range-slider-dual-handle-qz9k/demo.html
+++ b/submissions/examples/range-slider-dual-handle-qz9k/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dual Handle Range</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function drhUpdate(movedInput) {
+    var min = document.getElementById('drh-min');
+    var max = document.getElementById('drh-max');
+    var minVal = Number(min.value);
+    var maxVal = Number(max.value);
+
+    // Keep a minimum gap so the two handles can never fully cross, which
+    // would make it ambiguous which handle is "min" and which is "max".
+    if (minVal > maxVal - 5) {
+      if (movedInput === min) min.value = maxVal - 5;
+      else if (movedInput === max) max.value = minVal + 5;
+      minVal = Number(min.value);
+      maxVal = Number(max.value);
+    }
+
+    var track = document.getElementById('drh-track');
+    var range = document.getElementById('drh-range');
+    var pctMin = (minVal / 100) * 100;
+    var pctMax = (maxVal / 100) * 100;
+    range.style.left = pctMin + '%';
+    range.style.width = (pctMax - pctMin) + '%';
+
+    document.getElementById('drh-min-out').textContent = '$' + minVal;
+    document.getElementById('drh-max-out').textContent = '$' + maxVal;
+  }
+</script>
+</head>
+<body>
+<main class="drh-wrap">
+  <h1 class="drh-h1">Price Range</h1>
+  <p class="drh-lede">Two overlapping native range inputs on the same track; the topmost one under the pointer receives the drag because each has pointer-events limited to its own thumb width via a wide, mostly-transparent hit target.</p>
+
+  <div class="drh-labels">
+    <span id="drh-min-out">$0</span>
+    <span id="drh-max-out">$100</span>
+  </div>
+
+  <div class="drh-slider">
+    <div class="drh-track" id="drh-track">
+      <div class="drh-range" id="drh-range"></div>
+    </div>
+    <input type="range" id="drh-min" class="drh-input drh-input-min" min="0" max="100" value="20" oninput="drhUpdate(this)" aria-label="Minimum price" />
+    <input type="range" id="drh-max" class="drh-input drh-input-max" min="0" max="100" value="80" oninput="drhUpdate(this)" aria-label="Maximum price" />
+  </div>
+  <script>drhUpdate(null);</script>
+</main>
+</body>
+</html>

--- a/submissions/examples/range-slider-dual-handle-qz9k/style.css
+++ b/submissions/examples/range-slider-dual-handle-qz9k/style.css
@@ -1,0 +1,115 @@
+/* Dual Handle Range
+   Both <input type=range> elements are stacked full-width on the same
+   track; pointer-events:none on the input itself with pointer-events:auto
+   restored only on its ::-webkit-slider-thumb (and Firefox's
+   ::-moz-range-thumb) means clicks land on whichever thumb they're
+   actually over, not on the input covering the largest area. */
+
+.drh-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.drh-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.drh-lede { margin: 0 0 2rem; color: #576073; }
+
+.drh-labels {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 700;
+  margin-bottom: 0.9rem;
+}
+
+.drh-slider {
+  position: relative;
+  height: 1.6rem;
+}
+
+.drh-track {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  background: #dfe3ec;
+  border-radius: 999px;
+}
+
+.drh-range {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: #4c6ef5;
+  border-radius: 999px;
+}
+
+.drh-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  appearance: none;
+  background: none;
+  pointer-events: none;
+}
+
+.drh-input::-webkit-slider-thumb {
+  appearance: none;
+  pointer-events: auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #4c6ef5;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  cursor: grab;
+  margin-top: -0.05rem;
+}
+
+.drh-input::-moz-range-thumb {
+  pointer-events: auto;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #4c6ef5;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  cursor: grab;
+}
+
+.drh-input::-webkit-slider-runnable-track,
+.drh-input::-moz-range-track {
+  background: none;
+  border: none;
+}
+
+.drh-input:focus-visible::-webkit-slider-thumb {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.drh-input:focus-visible::-moz-range-thumb {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .drh-track { background: Canvas; border: 1px solid CanvasText; }
+  .drh-range { forced-color-adjust: none; background: Highlight; }
+  .drh-input::-webkit-slider-thumb { background: Highlight; border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .drh-wrap { color: #e6e9f2; }
+  .drh-lede { color: #99a1b4; }
+  .drh-track { background: #2a303c; }
+
+  .drh-input::-webkit-slider-thumb,
+  .drh-input::-moz-range-thumb { background: #171b23; }
+}


### PR DESCRIPTION
Closes #79204

Min/max range slider from two overlapping native <input type=range> elements. pointer-events:none on each input, restored to auto only on its own ::-webkit-slider-thumb/::-moz-range-thumb, shrinks each input's hit area down to just its thumb — clicks land on whichever handle is actually under the pointer regardless of DOM stacking order. Real range inputs mean native keyboard/touch support comes free. A 5-unit minimum gap prevents the two handles from crossing into an ambiguous min/max state.