### PR TITLE
feat: add Sortable Table Header example (sortable-table-header-qz9k)

### DIFF
--- a/submissions/examples/sortable-table-header-qz9k/README.md
+++ b/submissions/examples/sortable-table-header-qz9k/README.md
@@ -1,0 +1,37 @@
+# Sortable Table Header
+
+## What does this do?
+
+A table whose column headers sort the rows on click, using `aria-sort` on
+each header's button as the single source of truth for both the
+accessible sort state and the visible direction arrow.
+
+## How is it used?
+
+```html
+<th><button type="button" onclick="sthSort(this, 0)">Name<span class="sth-arrow" aria-hidden="true"></span></button></th>
+```
+
+`sthSort` reads the clicked button's current `aria-sort`, clears
+`aria-sort` from every header (so exactly one is ever marked), sets the new
+direction on the clicked one, then re-sorts the row array with a
+numeric-aware comparator (falls back to `localeCompare` for non-numeric
+columns) and re-appends rows to `tbody` in the new order.
+
+## Why is it useful?
+
+`aria-sort` is the standards-defined way to expose a sortable column's
+current direction to assistive technology, but a common implementation
+tracks sort state in a separate JS variable or CSS class and only writes
+`aria-sort` as an afterthought — which risks the two falling out of sync,
+particularly once multiple columns and re-sort logic are involved. Making
+`aria-sort` itself the thing both the visual arrow (via
+`[aria-sort] .sth-arrow` attribute selectors) and the sorting logic read
+from means there's exactly one flag per header, and it's the same one a
+screen reader inspects.
+
+The comparator checks whether both cell values parse as numbers before
+falling back to string comparison, so a "Points" column sorts `9` before
+`18` before `24` — a pure string sort would order those the same way
+`"18" < "24" < "9"` sorts lexicographically, which is wrong for any numeric
+column with more than one digit-count among its values.

--- a/submissions/examples/sortable-table-header-qz9k/demo.html
+++ b/submissions/examples/sortable-table-header-qz9k/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sortable Table Header</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function sthSort(button, columnIndex) {
+    var table = button.closest('table');
+    var tbody = table.querySelector('tbody');
+    var headers = table.querySelectorAll('th button');
+    var currentDir = button.getAttribute('aria-sort') === 'ascending' ? 'descending' : 'ascending';
+
+    headers.forEach(function (h) { h.removeAttribute('aria-sort'); });
+    button.setAttribute('aria-sort', currentDir);
+
+    var rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.sort(function (a, b) {
+      var av = a.children[columnIndex].textContent.trim();
+      var bv = b.children[columnIndex].textContent.trim();
+      var an = parseFloat(av);
+      var bn = parseFloat(bv);
+      var cmp = !isNaN(an) && !isNaN(bn) ? an - bn : av.localeCompare(bv);
+      return currentDir === 'ascending' ? cmp : -cmp;
+    });
+
+    rows.forEach(function (row) { tbody.appendChild(row); });
+  }
+</script>
+</head>
+<body>
+<main class="sth-wrap">
+  <h1 class="sth-h1">Team Roster</h1>
+  <p class="sth-lede">Each header button carries aria-sort itself, cleared from every other header on click, so exactly one column is ever marked sorted -- the state lives on the semantic element a screen reader already inspects, not a separate visual-only indicator.</p>
+
+  <table class="sth-table">
+    <thead>
+      <tr>
+        <th><button type="button" class="sth-sort-btn" onclick="sthSort(this, 0)">Name<span class="sth-arrow" aria-hidden="true"></span></button></th>
+        <th><button type="button" class="sth-sort-btn" onclick="sthSort(this, 1)">Role<span class="sth-arrow" aria-hidden="true"></span></button></th>
+        <th><button type="button" class="sth-sort-btn" onclick="sthSort(this, 2)">Points<span class="sth-arrow" aria-hidden="true"></span></button></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Riley</td><td>Forward</td><td>24</td></tr>
+      <tr><td>Casey</td><td>Midfield</td><td>18</td></tr>
+      <tr><td>Jordan</td><td>Defense</td><td>9</td></tr>
+      <tr><td>Avery</td><td>Forward</td><td>31</td></tr>
+    </tbody>
+  </table>
+</main>
+</body>
+</html>

--- a/submissions/examples/sortable-table-header-qz9k/style.css
+++ b/submissions/examples/sortable-table-header-qz9k/style.css
@@ -1,0 +1,85 @@
+/* Sortable Table Header
+   The arrow glyph is drawn by .sth-arrow, whose rotation/opacity are keyed
+   off the button's OWN [aria-sort] attribute -- not a class the script also
+   has to set. One attribute update per click drives both the accessible
+   state and the visual arrow. */
+
+.sth-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.sth-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.sth-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.sth-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.sth-table th {
+  padding: 0;
+  text-align: left;
+  border-bottom: 2px solid #d3d8e2;
+}
+
+.sth-table td {
+  padding: 0.6em 0.9em;
+  border-bottom: 1px solid #eceff4;
+}
+
+.sth-sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: 100%;
+  padding: 0.6em 0.9em;
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: 700;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sth-sort-btn:hover { background: #f1f4fa; }
+.sth-sort-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: -2px; }
+
+.sth-arrow {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-bottom: 5px solid #b7bdcb;
+  opacity: 0;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.sth-sort-btn[aria-sort] .sth-arrow {
+  opacity: 1;
+  border-bottom-color: #4c6ef5;
+}
+
+.sth-sort-btn[aria-sort="descending"] .sth-arrow {
+  transform: rotate(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sth-arrow { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .sth-sort-btn[aria-sort] .sth-arrow { forced-color-adjust: none; border-bottom-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sth-wrap { color: #e6e9f2; }
+  .sth-lede { color: #99a1b4; }
+  .sth-table th { border-color: #2a303c; }
+  .sth-table td { border-color: #1e2430; }
+  .sth-sort-btn:hover { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #79205

Sortable table using aria-sort on each header button as the single source of truth for both accessible state and the visible direction arrow, cleared from every other header on click so exactly one column is ever marked sorted. The comparator checks whether both cell values parse as numbers before falling back to localeCompare, so a numeric column sorts correctly instead of lexicographically (9 before 18 before 24, not 18 before 24 before 9).