### PR TITLE
feat: add Lazy Blur-Up Image example (image-lazy-blur-qz9k)

### DIFF
--- a/submissions/examples/image-lazy-blur-qz9k/README.md
+++ b/submissions/examples/image-lazy-blur-qz9k/README.md
@@ -1,0 +1,44 @@
+# Lazy Blur-Up Image
+
+## What does this do?
+
+An image that shows a blurred, scaled-up tiny placeholder immediately, then
+loads the full-resolution image only once its frame nears the viewport
+(via `IntersectionObserver`), cross-fading it in over the placeholder
+rather than popping in abruptly once loaded.
+
+## How is it used?
+
+```html
+<div class="ilb-frame" style="aspect-ratio: 4 / 3">
+  <img class="ilb-placeholder" src="tiny-8x6.jpg" alt="" aria-hidden="true" />
+  <img class="ilb-full" data-src="full-res.jpg" alt="Description of the photo" />
+</div>
+```
+
+The full-resolution image's real URL lives in `data-src`, not `src`, until
+`ilbLoad` decides to fetch it — keeping it out of `src` is what prevents the
+browser from eagerly requesting every image on the page immediately,
+which is the behaviour lazy-loading exists to avoid.
+
+## Why is it useful?
+
+A common blur-up implementation sets the full image's `src` directly once
+its frame scrolls into view and immediately toggles a "loaded" class — but
+that means the visible transition starts before the browser has actually
+finished downloading and decoding the image, so the cross-fade can begin
+against a still-blank or partially-rendered frame depending on network
+speed. This example pre-loads the full image into a throwaway, off-screen
+`Image()` object first, and only assigns `src` on the visible `<img>` (plus
+adds the `.ilb-loaded` class that starts the fade) inside that loader's own
+`onload` callback — so the fade-in is guaranteed to start with fully decoded
+image data ready to paint, not a race against an in-flight network
+request.
+
+`IntersectionObserver` with a `rootMargin: '200px'` starts the load
+slightly before the frame is actually visible, so the image has a head
+start and is more likely to be ready by the time the user scrolls it fully
+into view, rather than only beginning the fetch the instant it crosses the
+viewport edge. A feature-detection fallback loads every image immediately
+in engines without `IntersectionObserver` support, rather than leaving
+images permanently unloaded.

--- a/submissions/examples/image-lazy-blur-qz9k/demo.html
+++ b/submissions/examples/image-lazy-blur-qz9k/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lazy Blur-Up Image</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function ilbInit() {
+    var wrappers = document.querySelectorAll('.ilb-frame');
+    if (!('IntersectionObserver' in window)) {
+      wrappers.forEach(ilbLoad);
+      return;
+    }
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          ilbLoad(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '200px' });
+
+    wrappers.forEach(function (w) { observer.observe(w); });
+  }
+
+  function ilbLoad(frame) {
+    var full = frame.querySelector('.ilb-full');
+    var src = full.dataset.src;
+    var loader = new Image();
+    loader.onload = function () {
+      full.src = src;
+      frame.classList.add('ilb-loaded');
+    };
+    loader.src = src;
+  }
+
+  document.addEventListener('DOMContentLoaded', ilbInit);
+</script>
+</head>
+<body>
+<main class="ilb-wrap">
+  <h1 class="ilb-h1">Lazy Blur-Up Image</h1>
+  <p class="ilb-lede">A tiny inline placeholder shows immediately, blurred and scaled to fill the frame; the full image loads only once its frame nears the viewport, then cross-fades in over the placeholder rather than popping in abruptly.</p>
+
+  <div class="ilb-frame" style="aspect-ratio: 4 / 3">
+    <img class="ilb-placeholder" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='6'%3E%3Crect width='8' height='6' fill='%234c6ef5'/%3E%3C/svg%3E" alt="" aria-hidden="true" />
+    <img class="ilb-full" data-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300'%3E%3Crect width='400' height='300' fill='%234c6ef5'/%3E%3Ctext x='50%25' y='50%25' fill='white' font-size='24' text-anchor='middle' dy='.3em'%3EFull Image%3C/text%3E%3C/svg%3E" alt="A placeholder graphic representing the full-resolution photo" />
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/image-lazy-blur-qz9k/style.css
+++ b/submissions/examples/image-lazy-blur-qz9k/style.css
@@ -1,0 +1,67 @@
+/* Lazy Blur-Up Image
+   The full-res <img> is loaded off-screen via a throwaway Image() object
+   BEFORE its src is assigned to the visible element -- so the visible swap
+   to .ilb-loaded always coincides with the browser already having decoded
+   bytes ready to paint, rather than showing a blank frame while the real
+   request is still in flight. */
+
+.ilb-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ilb-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ilb-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.ilb-frame {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 0.7rem;
+  background: #dfe3ec;
+}
+
+.ilb-placeholder,
+.ilb-full {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ilb-placeholder {
+  filter: blur(16px);
+  transform: scale(1.15);
+  transition: opacity 400ms ease;
+}
+
+.ilb-full {
+  opacity: 0;
+  transition: opacity 400ms ease;
+}
+
+.ilb-frame.ilb-loaded .ilb-full {
+  opacity: 1;
+}
+
+.ilb-frame.ilb-loaded .ilb-placeholder {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ilb-placeholder, .ilb-full { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ilb-frame { background: Canvas; border: 1px solid CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ilb-wrap { color: #e6e9f2; }
+  .ilb-lede { color: #99a1b4; }
+  .ilb-frame { background: #2a303c; }
+}


### PR DESCRIPTION
Closes #79206

Blur-up lazy image using IntersectionObserver (200px rootMargin head start) plus a throwaway off-screen Image() object to pre-load the full-res image before assigning its src to the visible element — the cross-fade only starts once the loader's own onload fires, so it's guaranteed to begin with fully decoded data rather than racing an in-flight request. Feature-detection fallback loads immediately in engines without IntersectionObserver.