### PR TITLE
feat: add PIN Code Input example (pin-code-input-qz9k)

### DIFF
--- a/submissions/examples/pin-code-input-qz9k/README.md
+++ b/submissions/examples/pin-code-input-qz9k/README.md
@@ -1,0 +1,45 @@
+# PIN Code Input
+
+## What does this do?
+
+A six-box verification code input: typing a digit auto-advances to the
+next box, Backspace on an empty box returns to the previous one, and
+pasting (or SMS autofill delivering) a full code into any box distributes
+its digits across the remaining boxes rather than discarding everything
+but the first character.
+
+## How is it used?
+
+```html
+<div class="pci-boxes" role="group" aria-label="6-digit verification code">
+  <input class="pci-box" type="text" inputmode="numeric" maxlength="1"
+    autocomplete="one-time-code" oninput="pciInput(event, 0)" onkeydown="pciKeydown(event, 0)"
+    aria-label="Digit 1" />
+  <!-- ...digits 2-6 -->
+</div>
+```
+
+Only the first box carries `autocomplete="one-time-code"` — that's the
+attribute mobile browsers use to offer autofilling an SMS-delivered code,
+and it needs to land on one field for the browser to know where to place
+the full code text, which `pciInput`'s multi-digit branch then redistributes.
+
+## Why is it useful?
+
+The naive version of this pattern only handles single-keystroke digit
+entry and breaks the moment a code arrives any other way: pasting a
+6-digit code copied from a messaging app, or a mobile browser's SMS
+autofill inserting the whole code into one field at once. Both deliver
+more than one character to a single `maxlength="1"` input in one `input`
+event, and if that's not handled explicitly, only the first digit survives
+while the rest of the typed/pasted code is silently dropped — the user
+sees just one box filled and no indication anything went wrong.
+`pciInput` checks the incoming value length and, when it's longer than
+one character, walks the extra digits into subsequent boxes starting from
+the current position.
+
+Each digit lives in a real, separately-focusable `<input>` rather than one
+input visually split into boxes via `letter-spacing` — that's what makes
+individual `aria-label`s ("Digit 1", "Digit 2", ...) and per-box Backspace
+navigation possible, giving screen reader users a clear sense of position
+within the code as they move through it.

--- a/submissions/examples/pin-code-input-qz9k/demo.html
+++ b/submissions/examples/pin-code-input-qz9k/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>PIN Code Input</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function pciInput(event, index) {
+    var inputs = document.querySelectorAll('.pci-box');
+    var value = event.target.value.replace(/\D/g, '');
+
+    if (value.length > 1) {
+      // Pasted or autofilled multiple digits into one box: distribute them
+      // across the remaining boxes starting here, instead of only keeping
+      // the first character and discarding the rest.
+      value.split('').forEach(function (digit, offset) {
+        if (inputs[index + offset]) inputs[index + offset].value = digit;
+      });
+      var last = Math.min(index + value.length, inputs.length) - 1;
+      inputs[last].focus();
+      pciCheckComplete(inputs);
+      return;
+    }
+
+    event.target.value = value;
+    if (value && inputs[index + 1]) inputs[index + 1].focus();
+    pciCheckComplete(inputs);
+  }
+
+  function pciKeydown(event, index) {
+    var inputs = document.querySelectorAll('.pci-box');
+    if (event.key === 'Backspace' && !event.target.value && inputs[index - 1]) {
+      inputs[index - 1].focus();
+    }
+  }
+
+  function pciCheckComplete(inputs) {
+    var code = Array.from(inputs).map(function (i) { return i.value; }).join('');
+    var status = document.getElementById('pci-status');
+    status.textContent = code.length === inputs.length ? 'Code complete: ' + code : '';
+  }
+</script>
+</head>
+<body>
+<main class="pci-wrap">
+  <h1 class="pci-h1">Enter verification code</h1>
+  <p class="pci-lede">Typing a digit advances to the next box; Backspace on an empty box returns to the previous one. Pasting a full code into any box distributes its digits across the remaining boxes instead of only keeping the first digit.</p>
+
+  <div class="pci-boxes" role="group" aria-label="6-digit verification code">
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" oninput="pciInput(event, 0)" onkeydown="pciKeydown(event, 0)" aria-label="Digit 1" />
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" oninput="pciInput(event, 1)" onkeydown="pciKeydown(event, 1)" aria-label="Digit 2" />
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" oninput="pciInput(event, 2)" onkeydown="pciKeydown(event, 2)" aria-label="Digit 3" />
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" oninput="pciInput(event, 3)" onkeydown="pciKeydown(event, 3)" aria-label="Digit 4" />
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" oninput="pciInput(event, 4)" onkeydown="pciKeydown(event, 4)" aria-label="Digit 5" />
+    <input class="pci-box" type="text" inputmode="numeric" maxlength="1" oninput="pciInput(event, 5)" onkeydown="pciKeydown(event, 5)" aria-label="Digit 6" />
+  </div>
+  <p class="pci-status" id="pci-status" role="status" aria-live="polite"></p>
+</main>
+</body>
+</html>

--- a/submissions/examples/pin-code-input-qz9k/style.css
+++ b/submissions/examples/pin-code-input-qz9k/style.css
@@ -1,0 +1,58 @@
+/* PIN Code Input
+   Each box is a genuinely separate <input>, not one input styled to look
+   like six boxes via letter-spacing -- separate inputs are what makes
+   per-digit focus, individual aria-labels, and Backspace-to-previous-box
+   navigation possible without any div-contenteditable trickery. */
+
+.pci-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.pci-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.pci-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.pci-boxes {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.pci-box {
+  width: 2.4rem;
+  height: 2.8rem;
+  text-align: center;
+  font: inherit;
+  font-size: 1.3rem;
+  font-weight: 700;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.pci-box:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.pci-status {
+  margin: 0.9rem 0 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #34a853;
+  min-height: 1.2em;
+}
+
+@media (forced-colors: active) {
+  .pci-box { border-color: CanvasText; }
+  .pci-box:focus-visible { border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .pci-wrap { color: #e6e9f2; }
+  .pci-lede { color: #99a1b4; }
+  .pci-box { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #79207

Six-box verification code input. pciInput checks the incoming value's length and, when longer than one character (a paste or SMS autofill delivering the whole code to one box), distributes the extra digits across subsequent boxes instead of only keeping the first character and dropping the rest — the most common failure mode of a naive per-digit-input implementation. Each digit is a real, separately-focusable <input> with its own aria-label, not one input styled to look like six boxes.