### PR TITLE
feat: add useGeolocation hook (use-geolocation-qz9k)

### DIFF
--- a/submissions/react/use-geolocation-qz9k/README.md
+++ b/submissions/react/use-geolocation-qz9k/README.md
@@ -1,0 +1,49 @@
+# useGeolocation
+
+Tracks the browser's current geolocation via `watchPosition`, reporting
+loading state, the latest position, and any error.
+
+## API
+
+```js
+const { loading, position, error } = useGeolocation(options);
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enableHighAccuracy` | `boolean` | `false` | Request higher-accuracy (typically slower, more power-hungry) positioning. |
+| `timeout` | `number` | `10000` | Milliseconds to wait for a position before erroring. |
+| `maximumAge` | `number` | `0` | Milliseconds a cached position may be reused for. |
+
+## Usage
+
+```jsx
+function NearbyStores() {
+  const { loading, position, error } = useGeolocation();
+
+  if (loading) return <Spinner />;
+  if (error) return <p>Couldn't get your location: {error.message}</p>;
+  return <StoreList lat={position.latitude} lng={position.longitude} />;
+}
+```
+
+## Why is it useful?
+
+`navigator.geolocation` has two APIs: `getCurrentPosition` for a one-shot
+read, and `watchPosition` for continuous updates as the device moves. A
+hook wrapping only `getCurrentPosition` is simpler but means any
+consumer that actually needs live tracking (a delivery-tracking map, a
+"find nearby" feature that should update as the user walks) has to build
+its own polling loop on top, typically re-calling `getCurrentPosition` on
+an interval — which is both less accurate (fixed polling doesn't align
+with when the device's actual position sensor updates) and unnecessarily
+battery-hungry compared to the OS-level position callbacks
+`watchPosition` receives natively.
+
+Feature-detecting `'geolocation' in navigator` before use means the hook
+degrades to a clear error state on browsers or contexts without geolocation
+support (some embedded WebViews, non-secure origins) rather than throwing
+when `navigator.geolocation` is undefined. The watch is cleared via
+`clearWatch` in the effect's cleanup, so a component tracking location
+doesn't leave a location watch running (and the associated OS-level
+location indicator active) after it unmounts.

--- a/submissions/react/use-geolocation-qz9k/useGeolocation.jsx
+++ b/submissions/react/use-geolocation-qz9k/useGeolocation.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useGeolocation
+ * Wraps navigator.geolocation.watchPosition in hook form, reporting the
+ * latest position, loading state, and any error. Watches continuously
+ * (rather than a one-shot getCurrentPosition) so a consumer tracking a
+ * moving user gets updates without re-requesting permission or re-polling
+ * manually, and cleans up the watch on unmount or option change.
+ */
+export function useGeolocation(options = {}) {
+  const { enableHighAccuracy = false, timeout = 10000, maximumAge = 0 } = options;
+  const [state, setState] = useState({
+    loading: true,
+    position: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!('geolocation' in navigator)) {
+      setState({
+        loading: false,
+        position: null,
+        error: { code: 0, message: 'Geolocation is not supported by this browser.' },
+      });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, loading: true }));
+
+    const watchId = navigator.geolocation.watchPosition(
+      (position) => {
+        setState({
+          loading: false,
+          error: null,
+          position: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            accuracy: position.coords.accuracy,
+            timestamp: position.timestamp,
+          },
+        });
+      },
+      (error) => {
+        setState({ loading: false, position: null, error });
+      },
+      { enableHighAccuracy, timeout, maximumAge }
+    );
+
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, [enableHighAccuracy, timeout, maximumAge]);
+
+  return state;
+}
+
+export default useGeolocation;


### PR DESCRIPTION
Closes #79208

React hook wrapping navigator.geolocation.watchPosition rather than the simpler one-shot getCurrentPosition, so a consumer tracking a moving device gets live OS-level position updates instead of building its own polling loop on top of repeated getCurrentPosition calls. Feature-detects navigator.geolocation before use and clears the watch on unmount.