### PR TITLE
feat: add backdrop-scrim Sass mixins (backdrop-scrim-qz9k)

### DIFF
--- a/submissions/scss/backdrop-scrim-qz9k/README.md
+++ b/submissions/scss/backdrop-scrim-qz9k/README.md
@@ -1,0 +1,58 @@
+# backdrop-scrim-qz9k
+
+Sass mixins for modal/drawer backdrop scrims: a flat semi-transparent fill,
+and a gradient variant that darkens progressively toward one edge.
+
+## Usage
+
+```scss
+@use 'backdrop-scrim' as *;
+
+.modal-overlay {
+  @include scrim-flat;
+}
+
+.bottom-sheet-overlay {
+  @include scrim-gradient($direction: to top, $from-opacity: 0.1, $to-opacity: 0.65);
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$color` | `rgba(15, 18, 24, 0.5)` (flat) / `#0f1218` (gradient) | Scrim colour. |
+| `$from-opacity` / `$to-opacity` | `0.15` / `0.6` | Gradient endpoints (gradient only). |
+| `$direction` | `to bottom` | Gradient direction (gradient only). |
+
+## Why is it useful?
+
+A flat semi-transparent scrim behind a modal darkens the entire page
+uniformly, which works fine for a centered dialog but reads poorly behind
+a bottom sheet or a side drawer where the scrim's job is really to draw
+focus toward one edge of the screen while dimming the rest — a uniform
+darkness doesn't create that gradient of emphasis. `scrim-gradient` instead
+fades from a lighter opacity to a darker one across the screen, so content
+near the drawer/sheet (where the scrim is darkest) recedes more than
+content further away, which reads as a more deliberate visual hierarchy
+than a flat dim.
+
+Both mixins derive the gradient's two rgba stops from a single `$color`
+input via `color.channel()` (Dart Sass's modern replacement for the
+deprecated global `red()`/`green()`/`blue()` functions) rather than
+requiring two separately-specified rgba colours — changing the base colour
+only requires updating one value, and the two opacity stops stay correctly
+tied to the same hue.
+
+## Choosing a direction
+
+`$direction` accepts any valid CSS gradient direction, so the darkening
+edge can be matched to wherever the sheet/drawer actually sits:
+
+```scss
+.right-drawer-overlay {
+  @include scrim-gradient($direction: to left);
+}
+```
+
+`to left` darkens the right edge of the screen, appropriate for a drawer
+sliding in from the right — the scrim's darkest point lines up with where
+the drawer itself will appear.

--- a/submissions/scss/backdrop-scrim-qz9k/_backdrop-scrim.scss
+++ b/submissions/scss/backdrop-scrim-qz9k/_backdrop-scrim.scss
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------
+// backdrop-scrim-qz9k
+// A modal/drawer scrim mixin using a gradient rather than a flat semi-
+// transparent fill, so text near the bottom of a bottom-sheet stays
+// readable against varied background content without needing a darker
+// flat scrim that would also darken content near the top unnecessarily.
+// ---------------------------------------------------------------------------
+
+@use 'sass:color';
+
+@mixin scrim-flat($color: rgba(15, 18, 24, 0.5)) {
+  position: fixed;
+  inset: 0;
+  background: $color;
+  z-index: 40;
+}
+
+@mixin scrim-gradient(
+  $color: #0f1218,
+  $from-opacity: 0.15,
+  $to-opacity: 0.6,
+  $direction: to bottom
+) {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  $r: color.channel($color, "red", $space: rgb);
+  $g: color.channel($color, "green", $space: rgb);
+  $b: color.channel($color, "blue", $space: rgb);
+
+  background: linear-gradient(
+    $direction,
+    rgba($r, $g, $b, $from-opacity),
+    rgba($r, $g, $b, $to-opacity)
+  );
+}
+
+.backdrop-scrim-demo {
+  @include scrim-flat;
+}
+
+.backdrop-scrim-demo--gradient {
+  @include scrim-gradient($direction: to top);
+}


### PR DESCRIPTION
Closes #79211

Sass mixins for modal/drawer scrims: scrim-flat for a uniform dim (centered dialogs), scrim-gradient for a directional darkening better suited to a bottom sheet or side drawer, where a flat dim doesn't create the visual emphasis gradient those UI patterns need. Both rgba stops in the gradient derive from one  via color.channel() (Dart Sass's modern replacement for the deprecated global red()/green()/blue() functions).