### PR TITLE
Add Toast alert stack top submission

### DIFF
--- a/submissions/examples/toast-alert-stack-top/README.md
+++ b/submissions/examples/toast-alert-stack-top/README.md
@@ -1,0 +1,21 @@
+# Toast alert stack top
+
+A toast notification that slides down from the top of the viewport with a shrinking dismiss bar.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `toastalertstacktop-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Notification pattern; the top-of-screen toast is non-blocking.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *gold*)
+- `README.md` — this file

--- a/submissions/examples/toast-alert-stack-top/demo.html
+++ b/submissions/examples/toast-alert-stack-top/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toast alert stack top — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Toast alert stack top</h1>
+      <p>A toast notification that slides down from the top of the viewport with a shrinking dismiss bar.</p>
+    </header>
+    <section class="demo">
+      <div class="toastalertstacktop"><div class="toastalertstacktop-icon">✓</div><div class="toastalertstacktop-text">Saved successfully</div><div class="toastalertstacktop-bar"></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/toast-alert-stack-top/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/toast-alert-stack-top/style.css
+++ b/submissions/examples/toast-alert-stack-top/style.css
@@ -1,0 +1,59 @@
+/* Toast alert stack top — EaseMotion CSS submission
+   Palette: gold   Folder: submissions/examples/toast-alert-stack-top/   Class prefix: .toastalertstacktop
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #13110b;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #facc15;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #221e14;
+  border: 1px solid #332c1c;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #facc15;
+  background: #221e14;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.toastalertstacktop {{ display: flex; align-items: center; gap: 12px; padding: 14px 18px; background: #221e14; border: 1px solid #332c1c; border-radius: 12px; box-shadow: 0 12px 32px rgba(0,0,0,0.3); max-width: 320px; position: relative; overflow: hidden; transform: translateY(-120%); animation: kf-toastalertstacktop 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards; }}
+.toastalertstacktop-icon {{ width: 28px; height: 28px; border-radius: 50%; background: #facc15; color: #13110b; display: grid; place-items: center; font: 600 14px/1 system-ui; flex-shrink: 0; }}
+.toastalertstacktop-text {{ color: #e6e8ec; font: 13px/1.4 system-ui; }}
+.toastalertstacktop-bar {{ position: absolute; left: 0; right: 0; bottom: 0; height: 2px; background: #facc15; transform-origin: left; animation: kf-toastalertstacktop-bar 4s linear forwards; }}
+@keyframes kf-toastalertstacktop {{ to {{ transform: translateY(0); }} }}@keyframes kf-toastalertstacktop-bar {{ from {{ transform: scaleX(1); }} to {{ transform: scaleX(0); }} }}


### PR DESCRIPTION
Closes #79229

## What
This submission adds a new EaseMotion CSS example: `toast-alert-stack-top` under `submissions/examples/`.

A toast notification that slides down from the top of the viewport with a shrinking dismiss bar.

## How to review
1. Open `submissions/examples/toast-alert-stack-top/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/toast-alert-stack-top/` and does not modify any existing file.
