### PR TITLE
Add Tab underline tracking bar submission

### DIFF
--- a/submissions/examples/tab-underline-tracking-bar/README.md
+++ b/submissions/examples/tab-underline-tracking-bar/README.md
@@ -1,0 +1,21 @@
+# Tab underline tracking bar
+
+A row of tabs whose underline indicator slides between the active tab and the previously active tab.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `tabunderlinetrackingbar-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Settings / page nav pattern; the sliding underline is a familiar cue.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *warm*)
+- `README.md` — this file

--- a/submissions/examples/tab-underline-tracking-bar/demo.html
+++ b/submissions/examples/tab-underline-tracking-bar/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab underline tracking bar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Tab underline tracking bar</h1>
+      <p>A row of tabs whose underline indicator slides between the active tab and the previously active tab.</p>
+    </header>
+    <section class="demo">
+      <nav class="tabunderlinetrackingbar"><button class="tabunderlinetrackingbar-tab is-active">Profile</button><button class="tabunderlinetrackingbar-tab">Settings</button><button class="tabunderlinetrackingbar-tab">Activity</button><span class="tabunderlinetrackingbar-bar"></span></nav>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/tab-underline-tracking-bar/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/tab-underline-tracking-bar/style.css
+++ b/submissions/examples/tab-underline-tracking-bar/style.css
@@ -1,0 +1,62 @@
+/* Tab underline tracking bar — EaseMotion CSS submission
+   Palette: warm   Folder: submissions/examples/tab-underline-tracking-bar/   Class prefix: .tabunderlinetrackingbar
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0f1115;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff6a3d;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1d24;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff6a3d;
+  background: #1a1d24;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.tabunderlinetrackingbar {{ position: relative; display: inline-flex; background: #1a1d24; border-radius: 10px; padding: 4px; gap: 4px; }}
+.tabunderlinetrackingbar-tab {{ position: relative; z-index: 1; padding: 8px 18px; background: none; border: none; color: #8b909b; font: 13px/1 system-ui; cursor: pointer; border-radius: 6px; transition: color 200ms; }}
+.tabunderlinetrackingbar-tab.is-active {{ color: #0f1115; }}
+.tabunderlinetrackingbar-bar {{ position: absolute; top: 4px; bottom: 4px; left: 4px; width: 0; background: #ff6a3d; border-radius: 6px; transition: transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1), width 320ms cubic-bezier(0.2, 0.8, 0.2, 1); z-index: 0; box-shadow: 0 2px 8px #ff6a3d44; }}
+.tabunderlinetrackingbar-tab:nth-child(1).is-active ~ .tabunderlinetrackingbar-bar {{ transform: translateX(0); width: calc(33.33% - 4px); }}
+.tabunderlinetrackingbar-tab:nth-child(2).is-active ~ .tabunderlinetrackingbar-bar {{ transform: translateX(100%); width: calc(33.33% - 4px); }}
+.tabunderlinetrackingbar-tab:nth-child(3).is-active ~ .tabunderlinetrackingbar-bar {{ transform: translateX(200%); width: calc(33.33% - 4px); }}
+


### PR DESCRIPTION
Closes #79244

## What
This submission adds a new EaseMotion CSS example: `tab-underline-tracking-bar` under `submissions/examples/`.

A row of tabs whose underline indicator slides between the active tab and the previously active tab.

## How to review
1. Open `submissions/examples/tab-underline-tracking-bar/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/tab-underline-tracking-bar/` and does not modify any existing file.
