### PR TITLE
Add Fullscreen search curtain submission

### DIFF
--- a/submissions/examples/fullscreen-search-curtain/README.md
+++ b/submissions/examples/fullscreen-search-curtain/README.md
@@ -1,0 +1,21 @@
+# Fullscreen search curtain
+
+A search overlay that expands outward from the search button in a circular clip-path wipe.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `fullscreensearchcurtain-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Hero / app shell pattern; the curtain is dramatic and discoverable.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *cool*)
+- `README.md` — this file

--- a/submissions/examples/fullscreen-search-curtain/demo.html
+++ b/submissions/examples/fullscreen-search-curtain/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fullscreen search curtain — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Fullscreen search curtain</h1>
+      <p>A search overlay that expands outward from the search button in a circular clip-path wipe.</p>
+    </header>
+    <section class="demo">
+      <button class="fullscreensearchcurtain">🔍</button><div class="fullscreensearchcurtain-overlay"><input placeholder="Type to search…"></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/fullscreen-search-curtain/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fullscreen-search-curtain/style.css
+++ b/submissions/examples/fullscreen-search-curtain/style.css
@@ -1,0 +1,59 @@
+/* Fullscreen search curtain — EaseMotion CSS submission
+   Palette: cool   Folder: submissions/examples/fullscreen-search-curtain/   Class prefix: .fullscreensearchcurtain
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0e1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #4dabf7;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #131829;
+  border: 1px solid #1d2438;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #4dabf7;
+  background: #131829;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.fullscreensearchcurtain {{ background: #131829; color: #4dabf7; border: 1px solid #1d2438; border-radius: 50%; width: 48px; height: 48px; font-size: 18px; cursor: pointer; }}
+.fullscreensearchcurtain-overlay {{ position: fixed; inset: 0; background: #0a0e1a; display: grid; place-items: center; clip-path: circle(0% at calc(100% - 56px) 36px); transition: clip-path 480ms cubic-bezier(0.4, 0, 0.2, 1); }}
+.fullscreensearchcurtain-overlay.is-open {{ clip-path: circle(150% at calc(100% - 56px) 36px); }}
+.fullscreensearchcurtain-overlay input {{ background: transparent; border: none; border-bottom: 2px solid #4dabf7; color: #e6e8ec; font: 32px/1 system-ui; padding: 12px 24px; width: 60%; max-width: 600px; outline: none; }}
+


### PR DESCRIPTION
Closes #79247

## What
This submission adds a new EaseMotion CSS example: `fullscreen-search-curtain` under `submissions/examples/`.

A search overlay that expands outward from the search button in a circular clip-path wipe.

## How to review
1. Open `submissions/examples/fullscreen-search-curtain/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/fullscreen-search-curtain/` and does not modify any existing file.
