### PR TITLE
Add Breadcrumb arrow shift submission

### DIFF
--- a/submissions/examples/breadcrumb-segment-arrow-shift/README.md
+++ b/submissions/examples/breadcrumb-segment-arrow-shift/README.md
@@ -1,0 +1,21 @@
+# Breadcrumb arrow shift
+
+A breadcrumb whose chevron separators shift right on the hovered segment.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `breadcrumbsegmentarrowshift-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Page nav pattern; the chevron shift signals which link is the active one.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *forest*)
+- `README.md` — this file

--- a/submissions/examples/breadcrumb-segment-arrow-shift/demo.html
+++ b/submissions/examples/breadcrumb-segment-arrow-shift/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Breadcrumb arrow shift — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Breadcrumb arrow shift</h1>
+      <p>A breadcrumb whose chevron separators shift right on the hovered segment.</p>
+    </header>
+    <section class="demo">
+      <nav class="breadcrumbsegmentarrowshift"><a>Home</a><span>›</span><a>Docs</a><span>›</span><a class="breadcrumbsegmentarrowshift-active">API</a></nav>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/breadcrumb-segment-arrow-shift/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-segment-arrow-shift/style.css
+++ b/submissions/examples/breadcrumb-segment-arrow-shift/style.css
@@ -1,0 +1,61 @@
+/* Breadcrumb arrow shift — EaseMotion CSS submission
+   Palette: forest   Folder: submissions/examples/breadcrumb-segment-arrow-shift/   Class prefix: .breadcrumbsegmentarrowshift
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0d1612;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #2ecc71;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #152721;
+  border: 1px solid #1f3530;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #2ecc71;
+  background: #152721;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.breadcrumbsegmentarrowshift {{ display: inline-flex; align-items: center; gap: 6px; color: #8b909b; font: 13px/1 system-ui; }}
+.breadcrumbsegmentarrowshift a {{ color: #8b909b; text-decoration: none; padding: 4px 8px; border-radius: 4px; transition: color 160ms, background 160ms; cursor: pointer; }}
+.breadcrumbsegmentarrowshift a:hover {{ color: #2ecc71; background: #2ecc7111; }}
+.breadcrumbsegmentarrowshift span {{ transition: transform 200ms, color 200ms; color: #1f3530; }}
+.breadcrumbsegmentarrowshift a:hover + span {{ transform: translateX(4px); color: #2ecc71; }}
+.breadcrumbsegmentarrowshift-breadcrumbsegmentarrowshift-active {{ color: #e6e8ec; font-weight: 600; }}
+


### PR DESCRIPTION
Closes #79251

## What
This submission adds a new EaseMotion CSS example: `breadcrumb-segment-arrow-shift` under `submissions/examples/`.

A breadcrumb whose chevron separators shift right on the hovered segment.

## How to review
1. Open `submissions/examples/breadcrumb-segment-arrow-shift/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/breadcrumb-segment-arrow-shift/` and does not modify any existing file.
