### PR TITLE
Add Dropdown scale corner origin submission

### DIFF
--- a/submissions/examples/dropdown-scale-corner-origin/README.md
+++ b/submissions/examples/dropdown-scale-corner-origin/README.md
@@ -1,0 +1,21 @@
+# Dropdown scale corner origin
+
+A dropdown menu that scales in from the top-right corner of its trigger button.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `dropdownscalecornerorigin-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Toolbar / overflow pattern; the corner-origin scale tells the user where the menu came from.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *rose*)
+- `README.md` — this file

--- a/submissions/examples/dropdown-scale-corner-origin/demo.html
+++ b/submissions/examples/dropdown-scale-corner-origin/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dropdown scale corner origin — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Dropdown scale corner origin</h1>
+      <p>A dropdown menu that scales in from the top-right corner of its trigger button.</p>
+    </header>
+    <section class="demo">
+      <div class="dropdownscalecornerorigin"><button>Options</button><ul class="dropdownscalecornerorigin-menu"><li>Edit</li><li>Duplicate</li><li>Delete</li></ul></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/dropdown-scale-corner-origin/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/dropdown-scale-corner-origin/style.css
+++ b/submissions/examples/dropdown-scale-corner-origin/style.css
@@ -1,0 +1,61 @@
+/* Dropdown scale corner origin — EaseMotion CSS submission
+   Palette: rose   Folder: submissions/examples/dropdown-scale-corner-origin/   Class prefix: .dropdownscalecornerorigin
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160d12;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ff5c8a;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #26141c;
+  border: 1px solid #361b25;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ff5c8a;
+  background: #26141c;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.dropdownscalecornerorigin {{ position: relative; display: inline-block; }}
+.dropdownscalecornerorigin button {{ background: #26141c; color: #e6e8ec; border: 1px solid #361b25; padding: 8px 16px; border-radius: 8px; font: 13px/1 system-ui; cursor: pointer; }}
+.dropdownscalecornerorigin-menu {{ position: absolute; top: 100%; right: 0; margin-top: 8px; background: #26141c; border: 1px solid #361b25; border-radius: 8px; list-style: none; padding: 6px; min-width: 160px; transform-origin: top right; transform: scale(0.8); opacity: 0; transition: transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 200ms; box-shadow: 0 12px 32px rgba(0,0,0,0.3); z-index: 10; }}
+.dropdownscalecornerorigin.is-open .dropdownscalecornerorigin-menu {{ transform: scale(1); opacity: 1; }}
+.dropdownscalecornerorigin-menu li {{ padding: 8px 12px; color: #e6e8ec; border-radius: 4px; cursor: pointer; font: 13px/1 system-ui; }}
+.dropdownscalecornerorigin-menu li:hover {{ background: #ff5c8a22; color: #ff5c8a; }}
+


### PR DESCRIPTION
Closes #79253

## What
This submission adds a new EaseMotion CSS example: `dropdown-scale-corner-origin` under `submissions/examples/`.

A dropdown menu that scales in from the top-right corner of its trigger button.

## How to review
1. Open `submissions/examples/dropdown-scale-corner-origin/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/dropdown-scale-corner-origin/` and does not modify any existing file.
