### PR TITLE
Add Sticky header shrink scroll submission

### DIFF
--- a/submissions/examples/sticky-header-shrink-scroll/README.md
+++ b/submissions/examples/sticky-header-shrink-scroll/README.md
@@ -1,0 +1,21 @@
+# Sticky header shrink scroll
+
+A page header that compacts its padding and reduces its logo size once the page scrolls past the hero.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `stickyheadershrinkscroll-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Marketing / docs pattern; the compact header keeps the title visible without dominating the page.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *amber*)
+- `README.md` — this file

--- a/submissions/examples/sticky-header-shrink-scroll/demo.html
+++ b/submissions/examples/sticky-header-shrink-scroll/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sticky header shrink scroll — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Sticky header shrink scroll</h1>
+      <p>A page header that compacts its padding and reduces its logo size once the page scrolls past the hero.</p>
+    </header>
+    <section class="demo">
+      <header class="stickyheadershrinkscroll"><strong>Brand</strong><nav><a>Home</a><a>About</a><a>Contact</a></nav></header>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/sticky-header-shrink-scroll/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/sticky-header-shrink-scroll/style.css
+++ b/submissions/examples/sticky-header-shrink-scroll/style.css
@@ -1,0 +1,62 @@
+/* Sticky header shrink scroll — EaseMotion CSS submission
+   Palette: amber   Folder: submissions/examples/sticky-header-shrink-scroll/   Class prefix: .stickyheadershrinkscroll
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #161208;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ffb13b;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261d10;
+  border: 1px solid #352817;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ffb13b;
+  background: #261d10;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.stickyheadershrinkscroll {{ display: flex; align-items: center; justify-content: space-between; padding: 24px 40px; background: #261d10; border-bottom: 1px solid #352817; position: sticky; top: 0; transition: padding 320ms, background 320ms, box-shadow 320ms; z-index: 10; }}
+.stickyheadershrinkscroll strong {{ color: #ffb13b; font: 700 20px/1 system-ui; transition: font-size 320ms; }}
+.stickyheadershrinkscroll nav {{ display: inline-flex; gap: 24px; }}
+.stickyheadershrinkscroll nav a {{ color: #8b909b; text-decoration: none; font: 14px/1 system-ui; transition: color 200ms; }}
+.stickyheadershrinkscroll nav a:hover {{ color: #e6e8ec; }}
+.stickyheadershrinkscroll.is-stuck {{ padding: 12px 40px; background: #161208; box-shadow: 0 4px 16px rgba(0,0,0,0.3); }}
+.stickyheadershrinkscroll.is-stuck strong {{ font-size: 16px; }}
+


### PR DESCRIPTION
Closes #79258

## What
This submission adds a new EaseMotion CSS example: `sticky-header-shrink-scroll` under `submissions/examples/`.

A page header that compacts its padding and reduces its logo size once the page scrolls past the hero.

## How to review
1. Open `submissions/examples/sticky-header-shrink-scroll/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/sticky-header-shrink-scroll/` and does not modify any existing file.
