### PR TITLE
Add Megamenu multi-column submission

### DIFF
--- a/submissions/examples/megamenu-multicolumn-dropdown/README.md
+++ b/submissions/examples/megamenu-multicolumn-dropdown/README.md
@@ -1,0 +1,21 @@
+# Megamenu multi-column
+
+A wide mega menu that slides down with multiple columns of links, each column fading in in sequence.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `megamenumulticolumndropdown-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+E-commerce / product nav pattern; the multi-column keeps many links accessible.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *violet*)
+- `README.md` — this file

--- a/submissions/examples/megamenu-multicolumn-dropdown/demo.html
+++ b/submissions/examples/megamenu-multicolumn-dropdown/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Megamenu multi-column — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Megamenu multi-column</h1>
+      <p>A wide mega menu that slides down with multiple columns of links, each column fading in in sequence.</p>
+    </header>
+    <section class="demo">
+      <nav class="megamenumulticolumndropdown"><button>Products</button><div class="megamenumulticolumndropdown-panel"><div><h4>Apps</h4><a>Mobile</a><a>Web</a><a>Desktop</a></div><div><h4>Tools</h4><a>Editor</a><a>Console</a><a>CLI</a></div><div><h4>Resources</h4><a>Docs</a><a>Blog</a><a>Support</a></div></div></nav>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/megamenu-multicolumn-dropdown/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/megamenu-multicolumn-dropdown/style.css
+++ b/submissions/examples/megamenu-multicolumn-dropdown/style.css
@@ -1,0 +1,62 @@
+/* Megamenu multi-column — EaseMotion CSS submission
+   Palette: violet   Folder: submissions/examples/megamenu-multicolumn-dropdown/   Class prefix: .megamenumulticolumndropdown
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0e0a1a;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #a78bfa;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #1a1329;
+  border: 1px solid #261a3a;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #a78bfa;
+  background: #1a1329;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.megamenumulticolumndropdown {{ position: relative; display: inline-block; }}
+.megamenumulticolumndropdown button {{ background: #1a1329; color: #e6e8ec; border: 1px solid #261a3a; padding: 10px 20px; border-radius: 8px; font: 14px/1 system-ui; cursor: pointer; }}
+.megamenumulticolumndropdown-panel {{ position: absolute; top: 100%; left: 0; margin-top: 8px; background: #1a1329; border: 1px solid #261a3a; border-radius: 12px; padding: 24px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; min-width: 480px; box-shadow: 0 12px 32px rgba(0,0,0,0.3); opacity: 0; transform: translateY(-8px); transition: opacity 200ms, transform 200ms; z-index: 10; pointer-events: none; }}
+.megamenumulticolumndropdown.is-open .megamenumulticolumndropdown-panel {{ opacity: 1; transform: translateY(0); pointer-events: auto; }}
+.megamenumulticolumndropdown-panel h4 {{ margin: 0 0 12px; color: #a78bfa; font: 600 12px/1 system-ui; text-transform: uppercase; letter-spacing: 1px; }}
+.megamenumulticolumndropdown-panel a {{ display: block; color: #8b909b; text-decoration: none; padding: 4px 0; font: 13px/1.4 system-ui; transition: color 160ms; }}
+.megamenumulticolumndropdown-panel a:hover {{ color: #e6e8ec; }}
+


### PR DESCRIPTION
Closes #79261

## What
This submission adds a new EaseMotion CSS example: `megamenu-multicolumn-dropdown` under `submissions/examples/`.

A wide mega menu that slides down with multiple columns of links, each column fading in in sequence.

## How to review
1. Open `submissions/examples/megamenu-multicolumn-dropdown/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/megamenu-multicolumn-dropdown/` and does not modify any existing file.
