### PR TITLE
feat: create Hover Badge with Neumorphism styling #78845

### DIFF
--- a/submissions/examples/css-hover-badge-neumorphism/README.md
+++ b/submissions/examples/css-hover-badge-neumorphism/README.md
@@ -1,0 +1,13 @@
+# Hover Badge with Neumorphism styling (#78845)
+
+A responsive, zero-JavaScript badge component featuring soft neumorphic double drop-shadows, inset counter pills, interactive depth transitions, and accessible focus states.
+
+## Features
+- **Neumorphic Soft Aesthetics:** Uses dual light (`#ffffff`) and dark (`#b8bec5`) soft shadows over an `#e0e5ec` background.
+- **Interactive Depth Elevation:** Smoothly transitions between flat extrusions, hover elevations, and active inset depth states (`box-shadow`).
+- **Responsive & Accessible:** Fully adaptive flexbox grid, focus-visible indicators, and semantic HTML structure.
+
+## File Hierarchy
+- `submissions/examples/css-hover-badge-neumorphism/style.css` - Neumorphic shadow variables, transitions, button depth logic, and responsive breakpoints.
+- `submissions/examples/css-hover-badge-neumorphism/demo.html` - Semantic HTML5 demo displaying interactive neumorphic badges.
+- `submissions/examples/css-hover-badge-neumorphism/README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-hover-badge-neumorphism/demo.html
+++ b/submissions/examples/css-hover-badge-neumorphism/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Badge | Neumorphism Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="neu-card" aria-label="Neumorphic Hover Badge Showcase">
+    <h1 class="card-title">Neumorphic Badges</h1>
+    <p class="card-desc">Soft extruded shadows, smooth depth transitions, and inset counter badges using pure HTML and CSS.</p>
+
+    <div class="badge-container">
+        <!-- Interactive Badge 1 -->
+        <a href="#" class="neu-badge" aria-label="Pro Status Badge">
+            <svg class="badge-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+            </svg>
+            <span>Pro Member</span>
+            <span class="badge-count">v2.4</span>
+        </a>
+
+        <!-- Interactive Badge 2 -->
+        <a href="#" class="neu-badge" aria-label="Active Notifications Badge">
+            <svg class="badge-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+            </svg>
+            <span>Updates</span>
+            <span class="badge-count">12</span>
+        </a>
+
+        <!-- Inset Variant Badge -->
+        <a href="#" class="neu-badge neu-badge-inset" aria-label="Verified Status Inset Badge">
+            <svg class="badge-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+                <polyline points="22 4 12 14.01 9 11.01"></polyline>
+            </svg>
+            <span>Verified</span>
+        </a>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-hover-badge-neumorphism/style.css
+++ b/submissions/examples/css-hover-badge-neumorphism/style.css
@@ -1,0 +1,156 @@
+/* Hover Badge with Neumorphism Styling #78845 */
+
+:root {
+    --neu-bg: #e0e5ec;
+    --neu-text-primary: #3d4852;
+    --neu-text-secondary: #64748b;
+    --neu-accent: #4f46e5;
+    --neu-accent-light: #818cf8;
+    
+    /* Neumorphic Soft Dual Shadows */
+    --shadow-flat: 8px 8px 16px #b8bec5, -8px -8px 16px #ffffff;
+    --shadow-hover: 12px 12px 24px #b3b9c1, -12px -12px 24px #ffffff;
+    --shadow-pressed: inset 5px 5px 10px #b8bec5, inset -5px -5px 10px #ffffff;
+    
+    --ease-soft: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--neu-bg);
+    color: var(--neu-text-primary);
+    padding: 2rem 1rem;
+}
+
+/* Main Neumorphic Showcase Card */
+.neu-card {
+    background: var(--neu-bg);
+    padding: 3rem 2.5rem;
+    border-radius: 32px;
+    box-shadow: var(--shadow-flat);
+    width: 100%;
+    max-width: 480px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+}
+
+.card-title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--neu-text-primary);
+    letter-spacing: -0.02em;
+}
+
+.card-desc {
+    font-size: 0.95rem;
+    color: var(--neu-text-secondary);
+    line-height: 1.6;
+    margin-top: -1rem;
+}
+
+/* Badge Grid Layout */
+.badge-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.25rem;
+    width: 100%;
+}
+
+/* Base Neumorphic Hover Badge */
+.neu-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.4rem;
+    background: var(--neu-bg);
+    border-radius: 100px;
+    border: none;
+    color: var(--neu-text-primary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    box-shadow: var(--shadow-flat);
+    transition: all 0.3s var(--ease-soft);
+    user-select: none;
+}
+
+.badge-icon {
+    width: 18px;
+    height: 18px;
+    stroke: var(--neu-accent);
+    transition: transform 0.3s var(--ease-soft);
+}
+
+.badge-count {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.6rem;
+    border-radius: 50px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    background: var(--neu-bg);
+    box-shadow: var(--shadow-pressed);
+    color: var(--neu-accent);
+}
+
+/* Neumorphic Hover States */
+.neu-badge:hover,
+.neu-badge:focus-visible {
+    box-shadow: var(--shadow-hover);
+    transform: translateY(-2px);
+    color: var(--neu-accent);
+    outline: none;
+}
+
+.neu-badge:hover .badge-icon {
+    transform: scale(1.15) rotate(5deg);
+}
+
+/* Active Pressed State */
+.neu-badge:active,
+.neu-badge.pressed {
+    box-shadow: var(--shadow-pressed);
+    transform: translateY(0);
+}
+
+/* Inset Badge Variant */
+.neu-badge-inset {
+    box-shadow: var(--shadow-pressed);
+    color: var(--neu-accent);
+}
+
+.neu-badge-inset:hover {
+    box-shadow: var(--shadow-flat);
+}
+
+@media (max-width: 480px) {
+    .neu-card {
+        padding: 2rem 1.25rem;
+        border-radius: 24px;
+    }
+
+    .badge-container {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .neu-badge {
+        justify-content: center;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Hover Badge with Neumorphism styling** component (#78845).
gssoc 26

Closes #78845

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] All submission files created strictly inside `submissions/examples/css-hover-badge-neumorphism/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all display viewports
- [x] Features soft dual neumorphic drop-shadows, inset counter elements, and hover depth elevation

---

## Feature Description
**What does this add?**
A sleek set of neumorphic badges featuring soft dual-shadow extrusions, inset pill counters, animated SVG icons, and hover depth transformations.

**How does it work?**
Constructed using pure HTML/CSS, CSS custom properties for neumorphic light/dark shadow pairs, `:hover` and `:active` shadow depth transforms, and responsive Flexbox positioning.