### PR TITLE
Add Popover arrow pointer pop submission

### DIFF
--- a/submissions/examples/popover-arrow-pointer-pop/README.md
+++ b/submissions/examples/popover-arrow-pointer-pop/README.md
@@ -1,0 +1,21 @@
+# Popover arrow pointer pop
+
+A popover that appears above its trigger with a small rotated square that mimics an arrow pointer.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `popoverarrowpointerpop-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Info / hint pattern; the arrow makes the popover feel anchored.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *ruby*)
+- `README.md` — this file

--- a/submissions/examples/popover-arrow-pointer-pop/demo.html
+++ b/submissions/examples/popover-arrow-pointer-pop/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Popover arrow pointer pop — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Popover arrow pointer pop</h1>
+      <p>A popover that appears above its trigger with a small rotated square that mimics an arrow pointer.</p>
+    </header>
+    <section class="demo">
+      <div class="popoverarrowpointerpop"><button>Hover me</button><div class="popoverarrowpointerpop-tip">Tooltip text</div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/popover-arrow-pointer-pop/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/popover-arrow-pointer-pop/style.css
+++ b/submissions/examples/popover-arrow-pointer-pop/style.css
@@ -1,0 +1,60 @@
+/* Popover arrow pointer pop — EaseMotion CSS submission
+   Palette: ruby   Folder: submissions/examples/popover-arrow-pointer-pop/   Class prefix: .popoverarrowpointerpop
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #160a0d;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #ef4444;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #261418;
+  border: 1px solid #36191e;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #ef4444;
+  background: #261418;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.popoverarrowpointerpop {{ position: relative; display: inline-block; }}
+.popoverarrowpointerpop button {{ background: #261418; color: #e6e8ec; border: 1px solid #36191e; padding: 8px 16px; border-radius: 8px; cursor: pointer; }}
+.popoverarrowpointerpop-tip {{ position: absolute; bottom: calc(100% + 12px); left: 50%; transform: translateX(-50%) translateY(4px); background: #261418; color: #e6e8ec; border: 1px solid #36191e; border-radius: 8px; padding: 8px 12px; font: 12px/1.4 system-ui; white-space: nowrap; opacity: 0; transition: opacity 200ms, transform 200ms; pointer-events: none; box-shadow: 0 8px 24px rgba(0,0,0,0.3); }}
+.popoverarrowpointerpop-tip::after {{ content: ""; position: absolute; top: 100%; left: 50%; transform: translateX(-50%) rotate(45deg); width: 8px; height: 8px; background: #261418; border-right: 1px solid #36191e; border-bottom: 1px solid #36191e; margin-top: -4px; }}
+.popoverarrowpointerpop:hover .popoverarrowpointerpop-tip, .popoverarrowpointerpop:focus-within .popoverarrowpointerpop-tip {{ opacity: 1; transform: translateX(-50%) translateY(0); }}
+


### PR DESCRIPTION
Closes #79280

## What
This submission adds a new EaseMotion CSS example: `popover-arrow-pointer-pop` under `submissions/examples/`.

A popover that appears above its trigger with a small rotated square that mimics an arrow pointer.

## How to review
1. Open `submissions/examples/popover-arrow-pointer-pop/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/popover-arrow-pointer-pop/` and does not modify any existing file.
