### PR TITLE
feat: add pure CSS Hover Badge with Neumorphism styling (#78845)

### DIFF
--- a/submissions/examples/css-hover-badge-neumorphism-pure/README.md
+++ b/submissions/examples/css-hover-badge-neumorphism-pure/README.md
@@ -1,0 +1,21 @@
+# Hover Badge: Neumorphism
+
+A highly tactile, pure CSS UI component featuring Soft UI (Neumorphism) styling. The component demonstrates interactive buttons that reveal notification badges with a bouncy animation upon hover or focus.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript is required for the hover states or animations.
+- **Component Architecture & Styling Mechanics**: 
+  - **Neumorphic Base Effect**: The core aesthetic of Neumorphism (Soft UI) is achieved by matching the element's background color exactly to the page's background color (`#e0e5ec`). Depth is then created using a complex, dual-layered `box-shadow`: a dark shadow (`rgba(163, 177, 198, 0.6)`) applied to the bottom-right, and a light shadow (`rgba(255, 255, 255, 0.5)`) applied to the top-left.
+  - **Interactive States**: To make the component feel tactile and physical:
+    - On `:hover` / `:focus`, the outer shadows are slightly reduced, making the button appear to depress slightly.
+    - On `:active` (click), the shadows instantly switch to `inset`, creating a realistic pushed-button effect.
+  - **Bouncy Hover Badge**: The badge element is hidden by default using `opacity: 0` and `transform: scale(0) translateY(10px)`. When the parent element is hovered or focused, the badge reveals itself using a snappy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` timing function, causing it to overshoot its final scale and bounce into place.
+- **Theming**: Configured via CSS Custom Properties. The variables `--bg-color`, `--shadow-light`, and `--shadow-dark` are critical to maintaining the Neumorphic illusion. Accent colors for the icons and badges are also easily configurable.
+- Fully accessible semantic structure. Uses `<button>` for interactive elements and `tabindex="0"` for non-native interactive elements. Includes `aria-label` for screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the bouncy animations and relying on instant display toggling if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. You will see a notification bell and a user avatar, both styled as physical, extruded surfaces from the background. Hover over (or keyboard tab to) either element to watch the badges pop out with a playful animation. Click the elements to see the neumorphic inset shadow "pressed" state.
+
+## Files
+- `demo.html`: The HTML structure defining the wrappers, SVGs, and the nested `.hover-badge` elements.
+- `style.css`: The styling, the critical `box-shadow` configurations for Neumorphism, and the `cubic-bezier` animation logic for the badge reveal.

--- a/submissions/examples/css-hover-badge-neumorphism-pure/demo.html
+++ b/submissions/examples/css-hover-badge-neumorphism-pure/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Badge: Neumorphism</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        
+        <header class="header">
+            <h1 class="title">Neumorphic Badge</h1>
+            <p>Hover or focus the elements below to see the soft UI transitions.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Neumorphic Notification Button -->
+            <div class="neumorphic-wrapper">
+                
+                <button class="neumorphic-btn" aria-label="Notifications">
+                    <!-- Bell Icon -->
+                    <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                        <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+                    </svg>
+                    
+                    <!-- The Hover Badge -->
+                    <span class="hover-badge">3</span>
+                </button>
+                
+                <span class="label-text">Messages</span>
+                
+            </div>
+            
+            <!-- Secondary Example (Avatar with Status Badge) -->
+            <div class="neumorphic-wrapper">
+                
+                <div class="neumorphic-avatar" tabindex="0" aria-label="User Profile">
+                    <svg viewBox="0 0 24 24" width="28" height="28" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                        <circle cx="12" cy="7" r="4"></circle>
+                    </svg>
+                    
+                    <!-- The Hover Status Badge -->
+                    <span class="hover-badge status-badge"></span>
+                </div>
+                
+                <span class="label-text">Profile</span>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-hover-badge-neumorphism-pure/style.css
+++ b/submissions/examples/css-hover-badge-neumorphism-pure/style.css
@@ -1,0 +1,218 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@600;700&display=swap');
+
+/* =========================================
+   Theming (Neumorphism / Soft UI)
+   ========================================= */
+:root {
+    /* Background must be a solid, slightly off-white color for the shadows to work */
+    --bg-color: #e0e5ec;
+    
+    /* Neumorphic Shadows */
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    
+    /* Primary Accent Color */
+    --accent-color: #ff4757; /* Vibrant Red for Badges */
+    --accent-color-alt: #2ed573; /* Green for Status */
+    
+    --text-color: #4a5568;
+    
+    --transition-speed: 0.3s;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Nunito', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    text-align: center;
+    padding: 20px;
+}
+
+.header {
+    margin-bottom: 60px;
+}
+.title {
+    font-size: 2.2rem;
+    color: var(--text-color);
+    margin-bottom: 10px;
+    letter-spacing: 1px;
+    /* Soft embossed text effect */
+    text-shadow: 2px 2px 4px var(--shadow-dark), -2px -2px 4px var(--shadow-light);
+}
+
+
+/* =========================================
+   Layout Containers
+   ========================================= */
+.content-area {
+    display: flex;
+    justify-content: center;
+    gap: 60px;
+    flex-wrap: wrap;
+}
+
+.neumorphic-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.label-text {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-color);
+    opacity: 0.7;
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Neumorphic Base Elements
+   ========================================= */
+.neumorphic-btn,
+.neumorphic-avatar {
+    position: relative;
+    width: 80px;
+    height: 80px;
+    background-color: var(--bg-color);
+    border: none;
+    border-radius: 50%; /* Circle shape */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--text-color);
+    cursor: pointer;
+    
+    /* The core Neumorphic shadow: 
+       Bottom-right dark shadow + Top-left light shadow */
+    box-shadow: 
+        9px 9px 16px rgba(163, 177, 198, 0.6), 
+       -9px -9px 16px rgba(255, 255, 255, 0.5);
+       
+    transition: all var(--transition-speed) ease;
+    outline: none;
+}
+
+.neumorphic-btn svg,
+.neumorphic-avatar svg {
+    transition: transform var(--transition-speed) ease, color var(--transition-speed) ease;
+}
+
+
+/* Interactive States for Neumorphic Elements */
+.neumorphic-btn:hover,
+.neumorphic-avatar:hover,
+.neumorphic-btn:focus-visible,
+.neumorphic-avatar:focus-visible {
+    /* Slightly inset the shadow on hover */
+    box-shadow: 
+        5px 5px 10px rgba(163, 177, 198, 0.5), 
+       -5px -5px 10px rgba(255, 255, 255, 0.4);
+}
+
+.neumorphic-btn:active,
+.neumorphic-avatar:active {
+    /* Fully inset the shadow on click (pressed state) */
+    box-shadow: 
+        inset 6px 6px 10px rgba(163, 177, 198, 0.5), 
+        inset -6px -6px 10px rgba(255, 255, 255, 0.5);
+}
+
+.neumorphic-btn:hover svg,
+.neumorphic-btn:focus-visible svg {
+    color: var(--accent-color);
+    transform: scale(1.1);
+}
+
+.neumorphic-avatar:hover svg,
+.neumorphic-avatar:focus-visible svg {
+    color: var(--accent-color-alt);
+    transform: scale(1.1);
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] The Hover Badge
+   ========================================= */
+.hover-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    
+    /* Base Badge Styling */
+    min-width: 24px;
+    height: 24px;
+    padding: 0 6px;
+    box-sizing: border-box;
+    background-color: var(--accent-color);
+    color: #fff;
+    font-size: 0.85rem;
+    font-weight: 700;
+    border-radius: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    /* Neumorphic shadow matching the background */
+    border: 3px solid var(--bg-color);
+    
+    /* Hidden Initial State */
+    opacity: 0;
+    transform: scale(0) translateY(10px);
+    transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); /* Bouncy pop */
+    
+    pointer-events: none; /* Don't interfere with clicks */
+}
+
+/* Status Badge Variation (Just a dot) */
+.status-badge {
+    min-width: 16px;
+    height: 16px;
+    padding: 0;
+    background-color: var(--accent-color-alt);
+    top: 5px;
+    right: 5px;
+}
+
+
+/* Triggering the Badge on Hover/Focus of Parent */
+.neumorphic-btn:hover .hover-badge,
+.neumorphic-btn:focus-visible .hover-badge,
+.neumorphic-avatar:hover .hover-badge,
+.neumorphic-avatar:focus-visible .hover-badge {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .neumorphic-btn,
+    .neumorphic-avatar,
+    .hover-badge,
+    .neumorphic-btn svg,
+    .neumorphic-avatar svg {
+        transition: none !important;
+    }
+    
+    .hover-badge {
+        /* Fallback for reduced motion */
+        transform: scale(1) translateY(0) !important;
+        display: none;
+    }
+    
+    .neumorphic-btn:hover .hover-badge,
+    .neumorphic-avatar:hover .hover-badge {
+        display: flex;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly tactile, pure CSS UI component featuring Soft UI (Neumorphism) styling. The component demonstrates interactive buttons that reveal notification badges with a bouncy animation upon hover or focus. Resolves issue #78845.

### Changes Made:
- Added `submissions/examples/css-hover-badge-neumorphism-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the wrappers, SVGs, and the nested `.hover-badge` elements for both a notification bell and a user avatar.
- Created `style.css` featuring the UI mechanics:
  - **Neumorphic Base Effect**: The core aesthetic of Neumorphism (Soft UI) is achieved by matching the element's background color exactly to the page's background color (`#e0e5ec`). Depth is then created using a complex, dual-layered `box-shadow`: a dark shadow (`rgba(163, 177, 198, 0.6)`) applied to the bottom-right, and a light shadow (`rgba(255, 255, 255, 0.5)`) applied to the top-left.
  - **Interactive States**: To make the component feel tactile and physical:
    - On `:hover` / `:focus-visible`, the outer shadows are slightly reduced, making the button appear to depress slightly.
    - On `:active` (click), the shadows instantly switch to `inset`, creating a realistic pushed-button effect.
  - **Bouncy Hover Badge**: The badge element is hidden by default using `opacity: 0` and `transform: scale(0) translateY(10px)`. When the parent element is hovered or focused, the badge reveals itself using a snappy `cubic-bezier(0.175, 0.885, 0.32, 1.275)` timing function, causing it to overshoot its final scale and bounce into place.
  - **Theming Supported**: Configured via CSS Custom Properties. The variables `--bg-color`, `--shadow-light`, and `--shadow-dark` are critical to maintaining the Neumorphic illusion. Accent colors for the icons and badges are also easily configurable.
- Added `README.md` documenting usage and the technical mechanics of the critical `box-shadow` configurations for Neumorphism, and the `cubic-bezier` animation logic for the badge reveal.
- Fully accessible semantic structure. Uses `<button>` for interactive elements and `tabindex="0"` for non-native interactive elements. Includes `aria-label` for screen reader context. Honors the `prefers-reduced-motion` accessibility standard by disabling the bouncy animations and relying on instant display toggling if requested by the OS.

Closes #78845
