### PR TITLE
feat: create Hover Toggle with Material Design styling #78842

### DIFF
--- a/submissions/examples/css-hover-toggle-material/README.md
+++ b/submissions/examples/css-hover-toggle-material/README.md
@@ -1,0 +1,14 @@
+# Hover Toggle with Material Design styling (#78842)
+
+A responsive, zero-JavaScript toggle switch component built using Material Design 3 (M3) design tokens, interactive hover state layers, smooth thumb scaling, and explicit focus indicators.
+
+## Features
+- **Material 3 Design Tokens:** Employs M3 surface containers (`#f3edf7`), primary accents (`#6750a4`), and standard cubic-bezier motion curves.
+- **Hover State Layer (Ripple Halo):** Uses a CSS `::after` pseudo-element layer that expands smoothly on hover or focus to mimic Material touch feedback.
+- **Smooth Morphing Thumb:** Thumb scales up smoothly from 16px to 22px when transitioning to the active checked state (`translateX(20px)`).
+- **Fully Accessible:** Native `<input type="checkbox">` mechanics with keyboard focus indicators (`:focus-visible`) and semantic screen reader support.
+
+## File Hierarchy
+- `submissions/examples/css-hover-toggle-material/style.css` - Material 3 color tokens, ripple animations, thumb scaling logic, and media query breakpoints.
+- `submissions/examples/css-hover-toggle-material/demo.html` - Semantic HTML5 demo displaying interactive Material toggles.
+- `submissions/examples/css-hover-toggle-material/README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-hover-toggle-material/demo.html
+++ b/submissions/examples/css-hover-toggle-material/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Toggle | Material Design Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="md-toggle-card" aria-label="Material Design Hover Toggle Showcase">
+    <header class="card-header">
+        <h1 class="card-title">Material 3 Toggles</h1>
+        <p class="card-subtitle">Interactive switches featuring M3 state layers, dynamic track transitions, and hover ripple halos.</p>
+    </header>
+
+    <div class="toggle-group">
+        <!-- Toggle Item 1 -->
+        <label class="toggle-item" for="toggle-notifications">
+            <div class="toggle-label-text">
+                <span class="toggle-title">Push Notifications</span>
+                <span class="toggle-desc">Receive real-time system alerts</span>
+            </div>
+            <div class="toggle-switch-wrapper">
+                <input type="checkbox" id="toggle-notifications" checked aria-label="Push Notifications Switch">
+                <span class="switch-track"></span>
+            </div>
+        </label>
+
+        <!-- Toggle Item 2 -->
+        <label class="toggle-item" for="toggle-dark-theme">
+            <div class="toggle-label-text">
+                <span class="toggle-title">Dark Theme</span>
+                <span class="toggle-desc">Adjust UI contrast for low light</span>
+            </div>
+            <div class="toggle-switch-wrapper">
+                <input type="checkbox" id="toggle-dark-theme" aria-label="Dark Theme Switch">
+                <span class="switch-track"></span>
+            </div>
+        </label>
+
+        <!-- Toggle Item 3 -->
+        <label class="toggle-item" for="toggle-auto-sync">
+            <div class="toggle-label-text">
+                <span class="toggle-title">Background Sync</span>
+                <span class="toggle-desc">Keep data updated automatically</span>
+            </div>
+            <div class="toggle-switch-wrapper">
+                <input type="checkbox" id="toggle-auto-sync" checked aria-label="Background Sync Switch">
+                <span class="switch-track"></span>
+            </div>
+        </label>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-hover-toggle-material/style.css
+++ b/submissions/examples/css-hover-toggle-material/style.css
@@ -1,0 +1,210 @@
+/* Hover Toggle with Material Design Styling #78842 */
+
+:root {
+    /* Material 3 Color Tokens */
+    --md-surface: #fef7ff;
+    --md-surface-container: #f3edf7;
+    --md-surface-container-high: #e6e0e9;
+    --md-primary: #6750a4;
+    --md-on-primary: #ffffff;
+    --md-primary-container: #eaddff;
+    --md-on-primary-container: #21005d;
+    --md-outline: #79747e;
+    --md-outline-variant: #c4c7c5;
+    --md-on-surface: #1d1b20;
+    --md-on-surface-variant: #49454f;
+
+    /* Material Elevation & Ripple Shadows */
+    --md-elevation-1: 0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+    --md-elevation-2: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+    --md-state-hover: rgba(103, 80, 164, 0.12);
+
+    /* Material Expressive Motion Easing */
+    --md-easing-standard: cubic-bezier(0.2, 0.0, 0.0, 1.0);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: Roboto, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background-color: var(--md-surface);
+    color: var(--md-on-surface);
+    padding: 2rem 1rem;
+}
+
+/* Material Showcase Container Card */
+.md-toggle-card {
+    background-color: var(--md-surface-container);
+    border-radius: 28px;
+    padding: 3rem 2.5rem;
+    width: 100%;
+    max-width: 480px;
+    box-shadow: var(--md-elevation-1);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.card-header {
+    text-align: center;
+}
+
+.card-title {
+    font-size: 1.6rem;
+    font-weight: 500;
+    color: var(--md-on-surface);
+    letter-spacing: -0.01em;
+}
+
+.card-subtitle {
+    font-size: 0.925rem;
+    color: var(--md-on-surface-variant);
+    margin-top: 0.5rem;
+    line-height: 1.5;
+}
+
+/* Toggle List Group */
+.toggle-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+/* Material Switch Row Component */
+.toggle-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    background-color: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    transition: background-color 0.2s ease;
+}
+
+.toggle-label-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.toggle-title {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--md-on-surface);
+}
+
+.toggle-desc {
+    font-size: 0.8rem;
+    color: var(--md-on-surface-variant);
+}
+
+/* Hide Checkbox Control */
+.toggle-switch-wrapper {
+    position: relative;
+    display: inline-block;
+    width: 52px;
+    height: 32px;
+}
+
+.toggle-switch-wrapper input[type="checkbox"] {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+/* Switch Track */
+.switch-track {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--md-surface-container-high);
+    border: 2px solid var(--md-outline);
+    border-radius: 100px;
+    transition: all 0.3s var(--md-easing-standard);
+}
+
+/* Switch Thumb Container */
+.switch-track::before {
+    content: "";
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 6px;
+    bottom: 6px;
+    background-color: var(--md-outline);
+    border-radius: 50%;
+    transition: all 0.3s var(--md-easing-standard);
+}
+
+/* Material Ripple State Layer Halo */
+.switch-track::after {
+    content: "";
+    position: absolute;
+    height: 40px;
+    width: 40px;
+    left: -6px;
+    bottom: -6px;
+    border-radius: 50%;
+    background-color: var(--md-primary);
+    opacity: 0;
+    transform: scale(0.6);
+    transition: transform 0.2s ease, opacity 0.2s ease;
+    pointer-events: none;
+}
+
+/* Hover Ripple Effect */
+.toggle-switch-wrapper:hover .switch-track::after,
+.toggle-switch-wrapper input:focus-visible ~ .switch-track::after {
+    opacity: 0.12;
+    transform: scale(1);
+}
+
+.toggle-switch-wrapper:hover .switch-track {
+    border-color: var(--md-on-surface-variant);
+}
+
+/* Checked State Styles */
+.toggle-switch-wrapper input:checked ~ .switch-track {
+    background-color: var(--md-primary);
+    border-color: var(--md-primary);
+}
+
+.toggle-switch-wrapper input:checked ~ .switch-track::before {
+    transform: translateX(20px) scale(1.375);
+    background-color: var(--md-on-primary);
+}
+
+.toggle-switch-wrapper input:checked ~ .switch-track::after {
+    left: 14px;
+    background-color: var(--md-primary);
+}
+
+/* Focus Visible State */
+.toggle-switch-wrapper input:focus-visible ~ .switch-track {
+    outline: 2px solid var(--md-primary);
+    outline-offset: 3px;
+}
+
+@media (max-width: 480px) {
+    .md-toggle-card {
+        padding: 2rem 1.25rem;
+        border-radius: 20px;
+    }
+
+    .toggle-item {
+        padding: 0.85rem 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Hover Toggle with Material Design styling** component (#78842).
gssoc 26

Closes #78842

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] All submission files created strictly inside `submissions/examples/css-hover-toggle-material/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all display viewports
- [x] Built using Material Design 3 state layers, morphing thumb transitions, and accessible focus outlines

---

## Feature Description
**What does this add?**
A set of Material Design 3 interactive toggle switches with smooth state-layer ripple halos on hover, dynamic track color shifting, and thumb expansion.

**How does it work?**
Built using semantic HTML checkbox controls wrapped in custom tracks. Hover and focus states trigger smooth scale and opacity transitions via CSS pseudo-elements (`::after`) utilizing standard Material motion curves (`cubic-bezier(0.2, 0.0, 0.0, 1.0)`).