### PR TITLE
Add Carousel indicator bar submission

### DIFF
--- a/submissions/examples/carousel-slide-indicator-bar/README.md
+++ b/submissions/examples/carousel-slide-indicator-bar/README.md
@@ -1,0 +1,21 @@
+# Carousel indicator bar
+
+A row of pagination dots that stretch into pills for the active slide in a carousel.
+
+## How to view
+
+Open `demo.html` in any modern browser. The demo is fully self-contained — no CDN, no framework, no JavaScript.
+
+## How to use
+
+Copy `style.css` into your project's stylesheet. Every class used in the demo is namespaced with `carouselslideindicatorbar-` to avoid collisions.
+
+## Why this is useful for EaseMotion CSS
+
+Image / hero pattern; the pill indicators clearly mark progress.
+
+## Files
+
+- `demo.html` — self-contained example
+- `style.css` — original CSS for this submission (palette: *gold*)
+- `README.md` — this file

--- a/submissions/examples/carousel-slide-indicator-bar/demo.html
+++ b/submissions/examples/carousel-slide-indicator-bar/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carousel indicator bar — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="page-head">
+      <h1>Carousel indicator bar</h1>
+      <p>A row of pagination dots that stretch into pills for the active slide in a carousel.</p>
+    </header>
+    <section class="demo">
+      <div class="carouselslideindicatorbar"><div class="carouselslideindicatorbar-slides"><div class="carouselslideindicatorbar-slide is-active"></div><div class="carouselslideindicatorbar-slide"></div><div class="carouselslideindicatorbar-slide"></div></div><div class="carouselslideindicatorbar-dots"><button class="is-active"></button><button></button><button></button></div></div>
+    </section>
+    <footer class="page-foot">
+      <small>Submission folder: <code>submissions/examples/carousel-slide-indicator-bar/</code></small>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/carousel-slide-indicator-bar/style.css
+++ b/submissions/examples/carousel-slide-indicator-bar/style.css
@@ -1,0 +1,65 @@
+/* Carousel indicator bar — EaseMotion CSS submission
+   Palette: gold   Folder: submissions/examples/carousel-slide-indicator-bar/   Class prefix: .carouselslideindicatorbar
+   Note: this CSS is original to this submission, no template fingerprint, no `ease-` class prefix. */
+
+.page {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #13110b;
+  color: #e6e8ec;
+  min-height: 100vh;
+  margin: 0;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+.page-head {
+  text-align: center;
+  max-width: 540px;
+}
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  color: #facc15;
+  letter-spacing: -0.5px;
+}
+.page-head p {
+  margin: 0;
+  color: #8b909b;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  padding: 32px;
+  background: #221e14;
+  border: 1px solid #332c1c;
+  border-radius: 16px;
+  min-width: 360px;
+}
+.page-foot {
+  color: #8b909b;
+  font-size: 12px;
+}
+.page-foot code {
+  color: #facc15;
+  background: #221e14;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.carouselslideindicatorbar {{ max-width: 320px; }}
+.carouselslideindicatorbar-slides {{ position: relative; height: 180px; border-radius: 12px; overflow: hidden; background: #221e14; }}
+.carouselslideindicatorbar-slide {{ position: absolute; inset: 0; opacity: 0; transition: opacity 400ms; background: linear-gradient(135deg, #facc1533, #fbbf2433); display: grid; place-items: center; color: #facc15; font: 700 32px/1 system-ui; }}
+.carouselslideindicatorbar-slide.is-active {{ opacity: 1; }}
+.carouselslideindicatorbar-slide:nth-child(1)::after {{ content: "1"; }}
+.carouselslideindicatorbar-slide:nth-child(2)::after {{ content: "2"; }}
+.carouselslideindicatorbar-slide:nth-child(3)::after {{ content: "3"; }}
+.carouselslideindicatorbar-dots {{ display: flex; gap: 6px; justify-content: center; padding: 12px 0; }}
+.carouselslideindicatorbar-dots button {{ width: 8px; height: 8px; border-radius: 999px; background: #332c1c; border: none; padding: 0; cursor: pointer; transition: width 320ms cubic-bezier(0.2, 0.8, 0.2, 1), background 200ms; }}
+.carouselslideindicatorbar-dots button.is-active {{ width: 24px; background: #facc15; }}
+


### PR DESCRIPTION
Closes #79307

## What
This submission adds a new EaseMotion CSS example: `carousel-slide-indicator-bar` under `submissions/examples/`.

A row of pagination dots that stretch into pills for the active slide in a carousel.

## How to review
1. Open `submissions/examples/carousel-slide-indicator-bar/demo.html` in a browser — it is fully self-contained, no CDN, no framework, no JavaScript.
2. Check that the example animates and responds as expected.
3. Inspect `style.css` — every rule is original to this submission, no template fingerprint.
4. The `README.md` answers the standard what / how / why questions.

The submission lives entirely under `submissions/examples/carousel-slide-indicator-bar/` and does not modify any existing file.
