### PR TITLE
feat: add pure CSS Hover Toggle with Material Design styling (#78842)

### DIFF
--- a/submissions/examples/css-hover-toggle-material-pure/README.md
+++ b/submissions/examples/css-hover-toggle-material-pure/README.md
@@ -1,0 +1,20 @@
+# Hover Toggle: Material Design
+
+A unique, JavaScript-free toggle switch that activates purely on hover, featuring strict adherence to Google's Material Design 3 (MD3) styling, elevation, and motion systems.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript or even a `<input type="checkbox">` is required, as the state is entirely driven by the CSS `:hover` pseudo-class.
+- **Component Architecture & Styling Mechanics**: 
+  - **Material 3 Specifications**: The toggle adheres to MD3 sizing and color tokens. The track uses a thick outline (`--outline: #79747e`) and a small thumb (`16px`) when off. When activated (hovered), the outline disappears, the background fills with the primary color (`--primary: #6750a4`), and the thumb expands to `24px` while sliding to the right.
+  - **State Layers (Ripples)**: Material Design relies heavily on "State Layers" for tactile feedback. This is implemented via a `.state-layer` div nested inside the thumb. On `:focus-visible`, it becomes slightly opaque (`0.12`). On `:hover`, it provides a subtle primary-colored halo (`0.08 opacity`). On `:active` (click), it darkens, mimicking the classic Material ripple.
+  - **Hover-Driven Activation**: Instead of binding the `checked` state to a hidden checkbox, the `.material-hover-toggle:hover` selector directly transforms the `.toggle-track` and `.toggle-thumb`, making the interaction instant and fluid.
+  - **Tactile Morphing**: When the user clicks the toggle (`:active`), the thumb morphs slightly larger (`28px`), providing physical feedback. The CSS `calc()` function dynamically adjusts the `transform: translateX` value to ensure the thumb remains perfectly aligned with the track boundary during this stretch.
+- **Motion System**: Utilizes the official MD3 easing curve (`cubic-bezier(0.2, 0.0, 0, 1.0)`) and duration tokens (`150ms` for state layers, `250ms` for structural changes) to guarantee an authentic Material feel.
+- Fully accessible semantic structure. The wrapper uses `role="switch"` and `tabindex="0"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the morphing and sliding animations if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse cursor over the toggle wrapper. You will instantly see the switch slide to the "On" position, expanding the thumb and filling the track with the primary color. Click down on the toggle to see the thumb stretch and the state layer (ripple) darken.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic wrapper, the track, the thumb, and the nested `.state-layer`.
+- `style.css`: The styling, the Material Design 3 color and motion tokens, and the `:hover` driven interaction logic.

--- a/submissions/examples/css-hover-toggle-material-pure/demo.html
+++ b/submissions/examples/css-hover-toggle-material-pure/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Toggle: Material Design</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        
+        <header class="header">
+            <h1 class="title">Hover Toggle (Material)</h1>
+            <p>A CSS-only toggle switch that activates on hover. Features Material Design elevation and state layers.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- The Hover Toggle Component -->
+            <div class="material-hover-toggle" tabindex="0" role="switch" aria-checked="false" aria-label="Toggle Feature on Hover">
+                
+                <span class="toggle-label">Sync Data</span>
+                
+                <div class="toggle-track">
+                    <!-- The thumb with Material state layer (hover ripple) -->
+                    <div class="toggle-thumb">
+                        <div class="state-layer"></div>
+                    </div>
+                </div>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-hover-toggle-material-pure/style.css
+++ b/submissions/examples/css-hover-toggle-material-pure/style.css
@@ -1,0 +1,177 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
+
+/* =========================================
+   Theming (Material Design 3)
+   ========================================= */
+:root {
+    /* Colors */
+    --surface-color: #f8f9fa;
+    --on-surface: #1f1f1f;
+    --outline: #79747e;
+    
+    --primary: #6750a4; /* MD3 Purple */
+    --on-primary: #ffffff;
+    
+    --surface-variant: #e7e0ec;
+    --on-surface-variant: #49454f;
+    
+    /* Animation Timing (Material Standard Easing) */
+    --md-sys-motion-easing-standard: cubic-bezier(0.2, 0.0, 0, 1.0);
+    --md-sys-motion-duration-short: 150ms;
+    --md-sys-motion-duration-medium: 250ms;
+    
+    /* Toggle Dimensions */
+    --track-width: 52px;
+    --track-height: 32px;
+    --thumb-size-off: 16px;
+    --thumb-size-on: 24px;
+    --thumb-size-active: 28px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--surface-color);
+    color: var(--on-surface);
+    font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    text-align: center;
+    padding: 20px;
+}
+.header { margin-bottom: 60px; }
+.title { font-size: 2.2rem; font-weight: 500; margin-bottom: 10px; }
+.header p { color: var(--on-surface-variant); }
+
+
+/* =========================================
+   [TECHNIQUE] Hover Toggle (Material)
+   ========================================= */
+.material-hover-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 16px;
+    cursor: pointer;
+    padding: 12px 16px;
+    border-radius: 8px;
+    transition: background-color var(--md-sys-motion-duration-short) linear;
+    -webkit-tap-highlight-color: transparent;
+    outline: none;
+}
+
+.toggle-label {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--on-surface);
+}
+
+/* The Track (Unchecked State) */
+.toggle-track {
+    position: relative;
+    width: var(--track-width);
+    height: var(--track-height);
+    background-color: var(--surface-variant);
+    border: 2px solid var(--outline);
+    border-radius: 16px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 0 4px;
+    
+    transition: background-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                border-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+}
+
+/* The Thumb (Unchecked State) */
+.toggle-thumb {
+    position: relative;
+    width: var(--thumb-size-off);
+    height: var(--thumb-size-off);
+    background-color: var(--outline);
+    border-radius: 50%;
+    
+    /* Material Elevation Level 1 */
+    box-shadow: 0px 1px 2px 0px rgba(0,0,0,0.3), 0px 1px 3px 1px rgba(0,0,0,0.15);
+    
+    transform: translateX(0);
+    transition: transform var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                width var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                height var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard),
+                background-color var(--md-sys-motion-duration-medium) var(--md-sys-motion-easing-standard);
+    
+    /* Center the thumb vertically */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Material State Layer (The ripple/halo effect on hover) */
+.state-layer {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--on-surface);
+    opacity: 0;
+    transition: opacity var(--md-sys-motion-duration-short) linear;
+    pointer-events: none;
+}
+
+
+/* =========================================
+   State Changes (Hover = Checked)
+   ========================================= */
+
+/* Reveal state layer slightly when focused or hovered (before fully activating) */
+.material-hover-toggle:focus-visible .state-layer {
+    opacity: 0.12;
+}
+
+/* HOVER TRIGGERS THE TOGGLE */
+.material-hover-toggle:hover .toggle-track {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+.material-hover-toggle:hover .toggle-thumb {
+    background-color: var(--on-primary);
+    width: var(--thumb-size-on);
+    height: var(--thumb-size-on);
+    /* Calculate translation: track width - borders - padding*2 - new thumb size */
+    transform: translateX(calc(var(--track-width) - 4px - 8px - var(--thumb-size-on)));
+}
+
+/* Change state layer color when "on" */
+.material-hover-toggle:hover .state-layer {
+    background-color: var(--primary);
+    opacity: 0.08; /* Suble hover halo */
+}
+
+/* Press state (Tactile morphing) */
+.material-hover-toggle:active .toggle-thumb {
+    width: var(--thumb-size-active);
+    height: var(--thumb-size-active);
+}
+.material-hover-toggle:active .state-layer {
+    opacity: 0.12; /* Darker halo on press */
+}
+/* Adjust translation when thumb is larger during press */
+.material-hover-toggle:hover:active .toggle-thumb {
+    transform: translateX(calc(var(--track-width) - 4px - 8px - var(--thumb-size-active)));
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .toggle-track,
+    .toggle-thumb,
+    .state-layer {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a unique, JavaScript-free toggle switch that activates purely on hover, featuring strict adherence to Google's Material Design 3 (MD3) styling, elevation, and motion systems. Resolves issue #78842.

### Changes Made:
- Added `submissions/examples/css-hover-toggle-material-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic wrapper, the track, the thumb, and the nested `.state-layer` for hover ripples.
- Created `style.css` featuring the UI mechanics:
  - **Material 3 Specifications**: The toggle adheres to MD3 sizing and color tokens. The track uses a thick outline (`--outline: #79747e`) and a small thumb (`16px`) when off. When activated (hovered), the outline disappears, the background fills with the primary color (`--primary: #6750a4`), and the thumb expands to `24px` while sliding to the right.
  - **State Layers (Ripples)**: Material Design relies heavily on "State Layers" for tactile feedback. This is implemented via a `.state-layer` div nested inside the thumb. On `:focus-visible`, it becomes slightly opaque (`0.12`). On `:hover`, it provides a subtle primary-colored halo (`0.08 opacity`). On `:active` (click), it darkens, mimicking the classic Material ripple.
  - **Hover-Driven Activation**: Instead of binding the `checked` state to a hidden checkbox, the `.material-hover-toggle:hover` selector directly transforms the `.toggle-track` and `.toggle-thumb`, making the interaction instant and fluid.
  - **Tactile Morphing**: When the user clicks the toggle (`:active`), the thumb morphs slightly larger (`28px`), providing physical feedback. The CSS `calc()` function dynamically adjusts the `transform: translateX` value to ensure the thumb remains perfectly aligned with the track boundary during this stretch.
  - **Motion System**: Utilizes the official MD3 easing curve (`cubic-bezier(0.2, 0.0, 0, 1.0)`) and duration tokens (`150ms` for state layers, `250ms` for structural changes) to guarantee an authentic Material feel.
- Added `README.md` documenting usage and the technical mechanics of the MD3 motion system and hover-driven CSS logic.
- Fully accessible semantic structure. The wrapper uses `role="switch"` and `tabindex="0"`. Honors the `prefers-reduced-motion` accessibility standard by disabling the morphing and sliding animations if requested by the OS.

Closes #78842
