### PR TITLE
feat: create Parallax Breadcrumb with Dark Mode styling #78829

### DIFF
--- a/submissions/examples/css-parallax-breadcrumb-dark-mode/README.md
+++ b/submissions/examples/css-parallax-breadcrumb-dark-mode/README.md
@@ -1,0 +1,14 @@
+# Parallax Breadcrumb with Dark Mode styling (#78829)
+
+A responsive, zero-JavaScript breadcrumb header component featuring a dark mode aesthetic, glassmorphic container pill, ambient aura parallax depth transitions, and accessible navigation markup.
+
+## Features
+- **Dark Mode Aesthetic:** Dark theme tokens (`#0a0d14`, `#121824`), high-contrast text ratios, and cyan/indigo glow highlights.
+- **Pure CSS Parallax Depth:** Interactive multi-layered parallax feel created using CSS transforms on hover without JavaScript.
+- **Glassmorphic Navigation Pill:** Backdrop blur filter (`backdrop-filter: blur(12px)`) with semi-transparent border borders.
+- **Accessible & Responsive:** Uses semantic HTML `<nav>` and `<ol>` hierarchy with explicit `aria-current="page"` declarations.
+
+## File Hierarchy
+- `submissions/examples/css-parallax-breadcrumb-dark-mode/style.css` - Dark mode tokens, glassmorphic rules, parallax depth transforms, and media breakpoints.
+- `submissions/examples/css-parallax-breadcrumb-dark-mode/demo.html` - Semantic HTML5 markup displaying the parallax breadcrumb component.
+- `submissions/examples/css-parallax-breadcrumb-dark-mode/README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-parallax-breadcrumb-dark-mode/demo.html
+++ b/submissions/examples/css-parallax-breadcrumb-dark-mode/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parallax Breadcrumb | Dark Mode Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="parallax-breadcrumb-card" aria-label="Parallax Breadcrumb Showcase Header">
+    <!-- Ambient Depth Background Parallax Layer -->
+    <div class="parallax-bg-layer" aria-hidden="true"></div>
+
+    <!-- Parallax Breadcrumb Navigation -->
+    <nav class="breadcrumb-nav" aria-label="Breadcrumb">
+        <ol class="breadcrumb-list">
+            <li class="breadcrumb-item">
+                <a href="#" class="breadcrumb-link">
+                    <svg class="breadcrumb-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                        <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                    </svg>
+                    <span>Home</span>
+                </a>
+            </li>
+            
+            <svg class="breadcrumb-separator" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+
+            <li class="breadcrumb-item">
+                <a href="#" class="breadcrumb-link">
+                    <svg class="breadcrumb-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+                        <line x1="8" y1="21" x2="16" y2="21"></line>
+                        <line x1="12" y1="17" x2="12" y2="21"></line>
+                    </svg>
+                    <span>Infrastructure</span>
+                </a>
+            </li>
+
+            <svg class="breadcrumb-separator" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+
+            <li class="breadcrumb-item active" aria-current="page">
+                <span>Clusters</span>
+            </li>
+        </ol>
+    </nav>
+
+    <!-- Page Context Title -->
+    <header class="page-header">
+        <h1 class="page-title">Global Database Clusters</h1>
+        <p class="page-description">Manage cross-region database replication, latency routing metrics, and active node health across active edge zones.</p>
+    </header>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-parallax-breadcrumb-dark-mode/style.css
+++ b/submissions/examples/css-parallax-breadcrumb-dark-mode/style.css
@@ -1,0 +1,196 @@
+/* Parallax Breadcrumb with Dark Mode Styling #78829 */
+
+:root {
+    --bg-dark: #0a0d14;
+    --surface-dark: #121824;
+    --border-color: rgba(255, 255, 255, 0.08);
+    --text-primary: #f3f4f6;
+    --text-muted: #9ca3af;
+    
+    /* Dark Mode Glow & Accent Tokens */
+    --accent-cyan: #06b6d4;
+    --accent-indigo: #6366f1;
+    --accent-glow: rgba(6, 182, 212, 0.15);
+    
+    --ease-parallax: cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+
+/* Parallax Showcase Hero Container */
+.parallax-breadcrumb-card {
+    position: relative;
+    width: 100%;
+    max-width: 720px;
+    background: var(--surface-dark);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 3rem 2.5rem;
+    overflow: hidden;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+}
+
+/* Multi-layered CSS Parallax Background Aura */
+.parallax-bg-layer {
+    position: absolute;
+    inset: -20px;
+    background: 
+        radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.15) 0%, transparent 40%),
+        radial-gradient(circle at 80% 80%, rgba(6, 182, 212, 0.15) 0%, transparent 40%);
+    filter: blur(30px);
+    pointer-events: none;
+    transition: transform 0.6s var(--ease-parallax);
+}
+
+.parallax-breadcrumb-card:hover .parallax-bg-layer {
+    transform: scale(1.08) translate(-10px, -5px);
+}
+
+/* Breadcrumb Navigation Bar */
+.breadcrumb-nav {
+    position: relative;
+    z-index: 10;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.6rem 1.25rem;
+    background: rgba(255, 255, 255, 0.03);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--border-color);
+    border-radius: 100px;
+    transition: transform 0.4s var(--ease-parallax), border-color 0.3s ease;
+}
+
+.parallax-breadcrumb-card:hover .breadcrumb-nav {
+    transform: translateY(-2px);
+    border-color: rgba(6, 182, 212, 0.3);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    list-style: none;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.breadcrumb-link {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.65rem;
+    border-radius: 100px;
+    transition: all 0.3s var(--ease-parallax);
+}
+
+.breadcrumb-icon {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    transition: transform 0.3s ease;
+}
+
+.breadcrumb-link:hover,
+.breadcrumb-link:focus-visible {
+    color: var(--text-primary);
+    background: var(--accent-glow);
+    outline: none;
+}
+
+.breadcrumb-link:hover .breadcrumb-icon {
+    transform: scale(1.15);
+    stroke: var(--accent-cyan);
+}
+
+.breadcrumb-item.active {
+    color: var(--accent-cyan);
+    font-weight: 600;
+}
+
+.breadcrumb-separator {
+    width: 14px;
+    height: 14px;
+    stroke: var(--text-muted);
+    opacity: 0.4;
+}
+
+/* Page Context Heading Frame */
+.page-header {
+    position: relative;
+    z-index: 10;
+    margin-top: 2rem;
+    transition: transform 0.5s var(--ease-parallax);
+}
+
+.parallax-breadcrumb-card:hover .page-header {
+    transform: translateY(-4px);
+}
+
+.page-title {
+    font-size: 2.25rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    background: linear-gradient(135deg, #ffffff 40%, var(--text-muted));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.page-description {
+    font-size: 1rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin-top: 0.75rem;
+}
+
+@media (max-width: 600px) {
+    .parallax-breadcrumb-card {
+        padding: 2rem 1.25rem;
+        border-radius: 18px;
+    }
+
+    .breadcrumb-nav {
+        padding: 0.5rem 0.85rem;
+    }
+
+    .breadcrumb-list {
+        gap: 0.4rem;
+    }
+
+    .breadcrumb-item {
+        gap: 0.4rem;
+        font-size: 0.8rem;
+    }
+
+    .page-title {
+        font-size: 1.65rem;
+    }
+
+    .page-description {
+        font-size: 0.875rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Parallax Breadcrumb with Dark Mode styling** component (#78829).
gssoc 26

Closes #78829

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] All submission files created strictly inside `submissions/examples/css-parallax-breadcrumb-dark-mode/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all display viewports
- [x] Features dark mode aesthetics, glassmorphic navigation pills, multi-layer depth transforms, and semantic breadcrumb accessibility

---

## Feature Description
**What does this add?**
A dark-mode header breadcrumb component featuring a glassmorphic pill bar, ambient glowing background layers, and multi-tier CSS parallax elevation transforms on interaction.

**How does it work?**
Constructed using semantic HTML5 `<nav>` and `<ol>` elements, CSS `backdrop-filter`, cubic-bezier transform easing functions, and hover-triggered multi-layer scaling without external dependencies.