### PR TITLE
feat: add pure CSS Glassmorphism Slider with Cyberpunk styling (#78838)

### DIFF
--- a/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/README.md
+++ b/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/README.md
@@ -1,0 +1,21 @@
+# Glassmorphism Slider: Cyberpunk
+
+A highly stylized, JavaScript-free range slider component featuring a unique blend of Glassmorphism mechanics and aggressive Cyberpunk neon aesthetics.
+
+## Features
+- Pure CSS and HTML implementation. Customizes the native `<input type="range">` element.
+- **Component Architecture & Styling Mechanics**: 
+  - **Cyberpunk Aesthetics**: Features a dark theme with vibrant neon pink (`#f72585`) and cyan (`#4cc9f0`) colors. Includes a CSS-only animated glitch text effect using `::before` and `::after` pseudo-elements with `clip` and `text-shadow`. A rotating perspective grid background completes the environment.
+  - **Glassmorphism Container**: The slider is housed within a `.glass-panel` that utilizes `backdrop-filter: blur(12px)` over a dark, translucent background (`rgba(20, 20, 25, 0.4)`). This creates a smoked glass effect that blurs the moving neon background elements beneath it. Sharp, glowing corner accents (created with pseudo-elements) replace traditional rounded corners to fit the sci-fi theme.
+  - **Custom Range Input**: The native browser slider is entirely visually overhauled:
+    - `-webkit-appearance: none;` is used to strip native styles.
+    - The **track** (`::-webkit-slider-runnable-track`) is styled as a hollow, glowing wireframe bar with an inset cyan shadow.
+    - The **thumb** (`::-webkit-slider-thumb`) is transformed into a vertical, glowing pink rectangular handle. On `:active` (click/drag), the thumb scales up and intensifies its glow, providing tactile feedback.
+- fully accessible semantic structure. Uses the native `<input type="range">` allowing for standard keyboard navigation (arrows to slide). Includes a highly visible dashed yellow outline on `:focus-visible`. Honors the `prefers-reduced-motion` accessibility standard by disabling the background grid movement and glitch text animations if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. You will see an animated, perspective neon grid background with floating glowing orbs. In the center, a smoked glass panel blurs the background behind it. Use your mouse to drag (or keyboard to slide) the glowing pink slider thumb along the cyan track.
+
+## Files
+- `demo.html`: The HTML structure defining the background matrix environment, glitch text, and the custom range input.
+- `style.css`: The styling, the custom `::-webkit-slider-thumb` / `::-webkit-slider-runnable-track` cross-browser configurations, the `backdrop-filter` glass properties, and the `@keyframes` logic for the glitch text and moving grid.

--- a/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/demo.html
+++ b/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Slider: Cyberpunk</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="background-matrix">
+        <!-- Abstract background elements to show off the glass blur -->
+        <div class="neon-grid"></div>
+        <div class="glow-orb orb-1"></div>
+        <div class="glow-orb orb-2"></div>
+        
+        <header class="header">
+            <h1 class="glitch-text" data-text="CYBER_SLIDER">CYBER_SLIDER</h1>
+            <p>Adjust the neon output frequency.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Cyberpunk Glassmorphism Container -->
+            <div class="glass-panel">
+                
+                <div class="slider-header">
+                    <span class="slider-label">OVERDRIVE_LEVEL</span>
+                    <span class="slider-value">85%</span>
+                </div>
+                
+                <!-- The Custom Range Slider -->
+                <div class="cyber-slider-wrapper">
+                    <input type="range" min="0" max="100" value="85" class="cyber-slider" aria-label="Overdrive Level">
+                    
+                    <!-- Decorative HUD elements -->
+                    <div class="hud-line top-left"></div>
+                    <div class="hud-line bottom-right"></div>
+                </div>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/style.css
+++ b/submissions/examples/css-glassmorphism-slider-cyberpunk-pure/style.css
@@ -1,0 +1,292 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+/* =========================================
+   Theming (Cyberpunk + Glassmorphism)
+   ========================================= */
+:root {
+    /* Cyberpunk Colors */
+    --neon-pink: #f72585;
+    --neon-cyan: #4cc9f0;
+    --neon-yellow: #fce205;
+    --dark-bg: #09090b;
+    --text-color: #e0e0e0;
+    
+    /* Glassmorphism Variables */
+    --glass-bg: rgba(20, 20, 25, 0.4);
+    --glass-border: rgba(76, 201, 240, 0.3);
+    --glass-blur: 12px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--dark-bg);
+    color: var(--text-color);
+    font-family: 'Share Tech Mono', monospace;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* =========================================
+   Cyberpunk Background Environment
+   ========================================= */
+.background-matrix {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    padding: 20px;
+    box-sizing: border-box;
+    background-color: var(--dark-bg);
+}
+
+.neon-grid {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-image: 
+        linear-gradient(rgba(76, 201, 240, 0.1) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(76, 201, 240, 0.1) 1px, transparent 1px);
+    background-size: 30px 30px;
+    z-index: 0;
+    transform: perspective(500px) rotateX(60deg) translateY(-100px) scale(3);
+    opacity: 0.4;
+    animation: gridMove 20s linear infinite;
+}
+@keyframes gridMove {
+    0% { transform: perspective(500px) rotateX(60deg) translateY(0) scale(3); }
+    100% { transform: perspective(500px) rotateX(60deg) translateY(60px) scale(3); }
+}
+
+.glow-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    z-index: 0;
+    opacity: 0.5;
+}
+.orb-1 {
+    width: 300px; height: 300px;
+    background-color: var(--neon-pink);
+    top: 20%; left: 30%;
+}
+.orb-2 {
+    width: 250px; height: 250px;
+    background-color: var(--neon-cyan);
+    bottom: 20%; right: 30%;
+}
+
+.header, .content-area {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    width: 100%;
+    max-width: 600px;
+}
+.header p { color: var(--neon-cyan); letter-spacing: 2px; text-transform: uppercase; margin-bottom: 50px;}
+
+
+/* =========================================
+   Glitch Text Effect
+   ========================================= */
+.glitch-text {
+    font-size: 3rem;
+    font-weight: bold;
+    color: #fff;
+    position: relative;
+    text-shadow: 0 0 10px var(--neon-pink), 0 0 20px var(--neon-cyan);
+    margin-bottom: 10px;
+    letter-spacing: 4px;
+}
+.glitch-text::before,
+.glitch-text::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+}
+.glitch-text::before {
+    left: 2px;
+    text-shadow: -2px 0 var(--neon-pink);
+    clip: rect(24px, 550px, 90px, 0);
+    animation: glitch-anim 3s infinite linear alternate-reverse;
+}
+.glitch-text::after {
+    left: -2px;
+    text-shadow: -2px 0 var(--neon-cyan);
+    clip: rect(85px, 550px, 140px, 0);
+    animation: glitch-anim 2.5s infinite linear alternate-reverse;
+}
+@keyframes glitch-anim {
+    0% { clip: rect(70px, 9999px, 76px, 0); }
+    20% { clip: rect(29px, 9999px, 16px, 0); }
+    40% { clip: rect(76px, 9999px, 3px, 0); }
+    60% { clip: rect(42px, 9999px, 78px, 0); }
+    80% { clip: rect(15px, 9999px, 13px, 0); }
+    100% { clip: rect(53px, 9999px, 5px, 0); }
+}
+
+
+/* =========================================
+   [TECHNIQUE 1] Glassmorphism Panel
+   ========================================= */
+.glass-panel {
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--glass-border);
+    border-radius: 4px; /* Sharp corners for cyberpunk */
+    padding: 40px;
+    box-shadow: 
+        0 8px 32px 0 rgba(0, 0, 0, 0.5),
+        inset 0 0 15px rgba(76, 201, 240, 0.1);
+    position: relative;
+    overflow: hidden;
+}
+/* Cyberpunk corner cuts on the glass panel */
+.glass-panel::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0;
+    width: 20px; height: 2px;
+    background: var(--neon-pink);
+    box-shadow: 0 0 10px var(--neon-pink);
+}
+.glass-panel::after {
+    content: '';
+    position: absolute;
+    bottom: 0; right: 0;
+    width: 20px; height: 2px;
+    background: var(--neon-cyan);
+    box-shadow: 0 0 10px var(--neon-cyan);
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 25px;
+    font-size: 1.2rem;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 5px rgba(76, 201, 240, 0.5);
+}
+.slider-value {
+    color: var(--neon-pink);
+    text-shadow: 0 0 5px rgba(247, 37, 133, 0.5);
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Custom Input Range
+   ========================================= */
+.cyber-slider-wrapper {
+    position: relative;
+    padding: 10px 0;
+}
+
+.cyber-slider {
+    -webkit-appearance: none;
+    width: 100%;
+    background: transparent;
+    cursor: crosshair;
+    position: relative;
+    z-index: 2;
+}
+
+.cyber-slider:focus {
+    outline: none;
+}
+
+/* Range Track */
+.cyber-slider::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 8px;
+    cursor: crosshair;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 0;
+    border: 1px solid var(--neon-cyan);
+    box-shadow: inset 0 0 5px rgba(76, 201, 240, 0.5);
+}
+.cyber-slider::-moz-range-track {
+    width: 100%;
+    height: 8px;
+    cursor: crosshair;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 0;
+    border: 1px solid var(--neon-cyan);
+    box-shadow: inset 0 0 5px rgba(76, 201, 240, 0.5);
+}
+
+/* Range Thumb (The Draggable Handle) */
+.cyber-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    height: 24px;
+    width: 12px;
+    border-radius: 0;
+    background: var(--neon-pink);
+    border: 2px solid #fff;
+    cursor: ew-resize;
+    margin-top: -9px; /* center on track */
+    box-shadow: 0 0 15px var(--neon-pink), inset 0 0 5px rgba(0,0,0,0.5);
+    transition: transform 0.1s;
+}
+.cyber-slider::-moz-range-thumb {
+    height: 24px;
+    width: 12px;
+    border-radius: 0;
+    background: var(--neon-pink);
+    border: 2px solid #fff;
+    cursor: ew-resize;
+    box-shadow: 0 0 15px var(--neon-pink), inset 0 0 5px rgba(0,0,0,0.5);
+    transition: transform 0.1s;
+}
+
+/* Thumb Hover/Active state */
+.cyber-slider:active::-webkit-slider-thumb {
+    transform: scale(1.2);
+    box-shadow: 0 0 25px var(--neon-pink), inset 0 0 5px rgba(0,0,0,0.5);
+}
+.cyber-slider:active::-moz-range-thumb {
+    transform: scale(1.2);
+    box-shadow: 0 0 25px var(--neon-pink), inset 0 0 5px rgba(0,0,0,0.5);
+}
+
+/* Focus state for accessibility (Cyberpunk style) */
+.cyber-slider:focus-visible::-webkit-slider-thumb {
+    outline: 2px dashed var(--neon-yellow);
+    outline-offset: 4px;
+}
+
+
+/* HUD Decorative Lines */
+.hud-line {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border: 1px solid var(--neon-cyan);
+    opacity: 0.5;
+    pointer-events: none;
+    z-index: 1;
+}
+.top-left {
+    top: -5px; left: -10px;
+    border-right: none; border-bottom: none;
+}
+.bottom-right {
+    bottom: -5px; right: -10px;
+    border-left: none; border-top: none;
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .neon-grid,
+    .glitch-text::before,
+    .glitch-text::after {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a highly stylized, JavaScript-free range slider component featuring a unique blend of Glassmorphism mechanics and aggressive Cyberpunk neon aesthetics. Resolves issue #78838.

### Changes Made:
- Added `submissions/examples/css-glassmorphism-slider-cyberpunk-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the background matrix environment, glitch text, and the custom range input wrapped in a glass HUD.
- Created `style.css` featuring the UI mechanics:
  - **Cyberpunk Aesthetics**: Features a dark theme with vibrant neon pink (`#f72585`) and cyan (`#4cc9f0`) colors. Includes a CSS-only animated glitch text effect using `::before` and `::after` pseudo-elements with `clip` and `text-shadow`. A rotating perspective grid background completes the environment.
  - **Glassmorphism Container**: The slider is housed within a `.glass-panel` that utilizes `backdrop-filter: blur(12px)` over a dark, translucent background (`rgba(20, 20, 25, 0.4)`). This creates a smoked glass effect that blurs the moving neon background elements beneath it. Sharp, glowing corner accents (created with pseudo-elements) replace traditional rounded corners to fit the sci-fi theme.
  - **Custom Range Input**: The native browser slider is entirely visually overhauled:
    - `-webkit-appearance: none;` is used to strip native styles.
    - The **track** (`::-webkit-slider-runnable-track`) is styled as a hollow, glowing wireframe bar with an inset cyan shadow.
    - The **thumb** (`::-webkit-slider-thumb`) is transformed into a vertical, glowing pink rectangular handle. On `:active` (click/drag), the thumb scales up and intensifies its glow, providing tactile feedback.
- Added `README.md` documenting usage and the technical mechanics of the custom cross-browser slider pseudo-elements, the `backdrop-filter` glass properties, and the `@keyframes` logic for the glitch text.
- Fully accessible semantic structure. Uses the native `<input type="range">` allowing for standard keyboard navigation (arrows to slide). Includes a highly visible dashed yellow outline on `:focus-visible`. Honors the `prefers-reduced-motion` accessibility standard by disabling the background grid movement and glitch text animations if requested by the OS.

Closes #78838
