### PR TITLE
feat: create Glowing Sidebar with Cyberpunk styling #78831

### DIFF
--- a/submissions/examples/css-glowing-sidebar-cyberpunk/README.md
+++ b/submissions/examples/css-glowing-sidebar-cyberpunk/README.md
@@ -1,0 +1,14 @@
+# Glowing Sidebar with Cyberpunk styling (#78831)
+
+A responsive, zero-JavaScript navigation sidebar component featuring a futuristic cyberpunk aesthetic with glowing neon accents, glassmorphic backdrop filters, custom polygon clip-paths, and a pure CSS mobile drawer mechanism.
+
+## Features
+- **Cyberpunk Neon Palette:** Uses high-contrast neon cyan (`#00f0ff`), neon pink (`#ff007f`), and yellow (`#ffe600`) tokens.
+- **Glowing Edge Glows:** Border glows and active states using `box-shadow`, `text-shadow`, and linear-gradient border overlays.
+- **Glassmorphism Backdrop:** Translucent dark container (`rgba(10, 10, 20, 0.85)`) coupled with `backdrop-filter: blur(16px)`.
+- **Pure CSS Mobile Drawer:** Toggleable off-canvas menu for mobile viewports using a hidden `<input type="checkbox">` control.
+
+## File Hierarchy
+- `submissions/examples/css-glowing-sidebar-cyberpunk/style.css` - Cyberpunk theme variables, glassmorphic rules, hover glow effects, and responsive mobile breakpoints.
+- `submissions/examples/css-glowing-sidebar-cyberpunk/demo.html` - Semantic HTML5 markup showcasing the glowing sidebar navigation.
+- `submissions/examples/css-glowing-sidebar-cyberpunk/README.md` - Technical overview and component description.

--- a/submissions/examples/css-glowing-sidebar-cyberpunk/demo.html
+++ b/submissions/examples/css-glowing-sidebar-cyberpunk/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Sidebar | Cyberpunk Styling</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<!-- Checkbox Controller for Responsive Mobile Toggle -->
+<input type="checkbox" id="sidebar-toggle" aria-label="Toggle navigation menu">
+
+<label for="sidebar-toggle" class="toggle-btn" title="Toggle Menu">
+    &#9776; MENU
+</label>
+
+<!-- Cyberpunk Sidebar Container -->
+<aside class="cyber-sidebar" aria-label="Cyberpunk Sidebar Navigation">
+    <div class="sidebar-header">
+        <div class="brand-icon" aria-hidden="true"></div>
+        <span class="brand-title">NEXUS//OS</span>
+    </div>
+
+    <nav>
+        <ul class="nav-list">
+            <li class="nav-item active">
+                <a href="#" class="nav-link">
+                    <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="3" width="7" height="7"></rect>
+                        <rect x="14" y="3" width="7" height="7"></rect>
+                        <rect x="14" y="14" width="7" height="7"></rect>
+                        <rect x="3" y="14" width="7" height="7"></rect>
+                    </svg>
+                    <span>Dashboard</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#" class="nav-link">
+                    <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+                    </svg>
+                    <span>Security</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#" class="nav-link">
+                    <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+                    </svg>
+                    <span>Telemetry</span>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="#" class="nav-link">
+                    <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="3"></circle>
+                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                    </svg>
+                    <span>Settings</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+
+    <div class="sidebar-footer">
+        <div class="system-status">
+            <span class="status-indicator"></span>
+            <span>SYSTEM ONLINE // 99.9%</span>
+        </div>
+    </div>
+</aside>
+
+<!-- Demo Content Area -->
+<main class="main-content">
+    <div class="content-card">
+        <h1 class="content-title">CYBERPUNK SIDEBAR SHOWCASE</h1>
+        <p class="content-desc">This component features continuous neon edge lighting, glassmorphism backdrop blurs, futuristic polygon clip-paths, and zero-JavaScript mobile responsiveness using CSS checkbox input hacks.</p>
+    </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/css-glowing-sidebar-cyberpunk/style.css
+++ b/submissions/examples/css-glowing-sidebar-cyberpunk/style.css
@@ -1,0 +1,270 @@
+/* Glowing Sidebar with Cyberpunk Styling #78831 */
+
+:root {
+    --bg-dark: #05050a;
+    --sidebar-bg: rgba(10, 10, 20, 0.85);
+    --surface-dark: #0d0e1a;
+    --border-cyber: rgba(0, 240, 255, 0.2);
+    --border-cyber-active: #00f0ff;
+    
+    /* Cyberpunk Neon Palette */
+    --neon-cyan: #00f0ff;
+    --neon-pink: #ff007f;
+    --neon-yellow: #ffe600;
+    --text-primary: #e2e8f0;
+    --text-muted: #64748b;
+
+    --ease-cyber: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    min-height: 100vh;
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    font-family: 'Courier New', Courier, system-ui, -apple-system, sans-serif;
+    display: flex;
+    overflow-x: hidden;
+}
+
+/* Cyberpunk Grid Background Overlay */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: 
+        linear-gradient(rgba(0, 240, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 240, 255, 0.03) 1px, transparent 1px);
+    background-size: 30px 30px;
+    pointer-events: none;
+    z-index: 0;
+}
+
+/* Sidebar Toggle Input Switch */
+#sidebar-toggle {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Toggle Hamburger Button for Mobile */
+.toggle-btn {
+    display: none;
+    position: fixed;
+    top: 1.25rem;
+    left: 1.25rem;
+    z-index: 100;
+    padding: 0.6rem 0.85rem;
+    background: var(--surface-dark);
+    border: 1px solid var(--neon-cyan);
+    color: var(--neon-cyan);
+    border-radius: 4px;
+    cursor: pointer;
+    box-shadow: 0 0 10px rgba(0, 240, 255, 0.3);
+}
+
+/* Glowing Cyberpunk Sidebar Container */
+.cyber-sidebar {
+    position: relative;
+    z-index: 50;
+    width: 280px;
+    min-height: 100vh;
+    background: var(--sidebar-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-right: 1px solid var(--border-cyber);
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 1.25rem;
+    transition: transform 0.4s var(--ease-cyber);
+    box-shadow: 5px 0 25px rgba(0, 240, 255, 0.15);
+}
+
+/* Ambient Neon Edge Glow */
+.cyber-sidebar::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: -1px;
+    width: 2px;
+    height: 100%;
+    background: linear-gradient(180deg, var(--neon-cyan), var(--neon-pink), var(--neon-yellow), var(--neon-cyan));
+    box-shadow: 0 0 12px var(--neon-cyan);
+}
+
+/* Sidebar Brand Header */
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px dashed rgba(0, 240, 255, 0.2);
+    margin-bottom: 2rem;
+}
+
+.brand-icon {
+    width: 32px;
+    height: 32px;
+    background: var(--neon-pink);
+    clip-path: polygon(20% 0%, 100% 0%, 80% 100%, 0% 100%);
+    box-shadow: 0 0 10px var(--neon-pink);
+}
+
+.brand-title {
+    font-size: 1.1rem;
+    font-weight: 900;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: #fff;
+    text-shadow: 0 0 8px var(--neon-cyan);
+}
+
+/* Navigation List & Links */
+.nav-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.nav-item {
+    position: relative;
+}
+
+.nav-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    transition: all 0.3s var(--ease-cyber);
+    clip-path: polygon(0 0, 92% 0, 100% 30%, 100% 100%, 0 100%);
+}
+
+.nav-icon {
+    width: 18px;
+    height: 18px;
+    stroke: currentColor;
+    transition: transform 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+    color: var(--neon-cyan);
+    background: rgba(0, 240, 255, 0.08);
+    border-color: var(--border-cyber);
+    box-shadow: inset 0 0 15px rgba(0, 240, 255, 0.2);
+    outline: none;
+    transform: translateX(4px);
+}
+
+.nav-link:hover .nav-icon {
+    transform: scale(1.15);
+    stroke: var(--neon-cyan);
+}
+
+/* Active Navigation Item Styling */
+.nav-item.active .nav-link {
+    color: #ffffff;
+    background: rgba(255, 0, 127, 0.12);
+    border-color: var(--neon-pink);
+    box-shadow: 0 0 15px rgba(255, 0, 127, 0.3), inset 0 0 10px rgba(255, 0, 127, 0.2);
+}
+
+.nav-item.active .nav-link .nav-icon {
+    stroke: var(--neon-pink);
+    filter: drop-shadow(0 0 5px var(--neon-pink));
+}
+
+/* Status Widget Footer */
+.sidebar-footer {
+    margin-top: auto;
+    padding-top: 1.5rem;
+    border-top: 1px dashed rgba(0, 240, 255, 0.2);
+}
+
+.system-status {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.75rem;
+    color: var(--neon-yellow);
+    letter-spacing: 0.05em;
+}
+
+.status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--neon-yellow);
+    box-shadow: 0 0 8px var(--neon-yellow);
+    animation: statusPulse 1.8s infinite alternate;
+}
+
+@keyframes statusPulse {
+    0% { opacity: 0.4; }
+    100% { opacity: 1; }
+}
+
+/* Main Content Area Demo */
+.main-content {
+    flex: 1;
+    padding: 3rem 2rem;
+    position: relative;
+    z-index: 10;
+}
+
+.content-card {
+    background: var(--surface-dark);
+    border: 1px solid var(--border-cyber);
+    border-radius: 8px;
+    padding: 2.5rem;
+    max-width: 650px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+.content-title {
+    font-size: 1.75rem;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 240, 255, 0.4);
+    margin-bottom: 1rem;
+}
+
+.content-desc {
+    color: var(--text-muted);
+    line-height: 1.6;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+    .toggle-btn {
+        display: block;
+    }
+
+    .cyber-sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        transform: translateX(-100%);
+    }
+
+    #sidebar-toggle:checked ~ .cyber-sidebar {
+        transform: translateX(0);
+    }
+
+    .main-content {
+        padding: 5rem 1.25rem 2rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Glowing Sidebar with Cyberpunk styling** component (#78831).
gssoc 26

Closes #78831

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] All submission files created strictly inside `submissions/examples/css-glowing-sidebar-cyberpunk/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive across all display viewports
- [x] Features cyberpunk neon styling, glassmorphic backdrop filters, custom polygon clip-paths, and responsive off-canvas mobile navigation

---

## Feature Description
**What does this add?**
A cyberpunk-inspired dark navigation sidebar featuring glowing neon accents, glassmorphic blur, polygon clipped button states, and an off-canvas drawer pattern on mobile viewports.

**How does it work?**
Built using semantic HTML5 navigation markup, custom CSS properties for neon glow effects, CSS transform transitions, backdrop filters, and a pure CSS checkbox controller for mobile sidebar toggling.