### PR TITLE
feat: add pure CSS Animated Carousel with Gradient styling (#78833)

### DIFF
--- a/submissions/examples/css-animated-carousel-gradient-pure/README.md
+++ b/submissions/examples/css-animated-carousel-gradient-pure/README.md
@@ -1,0 +1,19 @@
+# Animated Carousel: Gradient
+
+A smooth, CSS-only infinite scrolling marquee featuring vibrant, interactive gradient cards.
+
+## Features
+- Pure CSS and HTML implementation. Absolutely no JavaScript required for the infinite scrolling loop.
+- **Component Architecture & Styling Mechanics**: 
+  - **The Infinite Loop Technique**: The HTML contains two identical sets of 5 cards side-by-side inside `.carousel-track`. The CSS animation (`scroll-left`) translates the track to the left. The magic happens by translating the track exactly the distance of *one set* of cards (`--scroll-distance = 5 * (width + gap)`). When the animation reaches 100%, the track is instantly reset to 0%, but because the second set of cards looks identical to the first, the user perceives a seamless, infinite loop.
+  - **Vibrant Gradient Cards**: Each card uses a distinct CSS `linear-gradient`. On hover, the cards pop out using `transform: translateY(-10px) scale(1.05)` with a bouncy `cubic-bezier` timing function, and their `filter: brightness()` is slightly increased.
+  - **Interactive Pausing**: The continuous animation is automatically paused (`animation-play-state: paused`) when the user hovers over the carousel with a mouse, or focuses inside it with a keyboard, allowing them to read the cards or interact with them.
+  - **Seamless Edges**: `.fade-overlay` elements are positioned absolutely on the left and right sides of the carousel wrapper. They use `linear-gradient` to blend from the background color (`#0f172a`) to `transparent`. `pointer-events: none` is used so they don't block clicks on the cards underneath.
+- Fully accessible semantic structure. The wrapper uses `role="region"` and an `aria-label`. The duplicated set of cards is hidden from screen readers using `aria-hidden="true"` so that content isn't read twice. Honors the `prefers-reduced-motion` accessibility standard by disabling the marquee animation and instead rendering a static, wrapping flex grid of the first set of cards.
+
+## Usage
+Open `demo.html` in your browser. You will see a continuous row of brightly colored gradient cards scrolling from right to left. Hover over any card to pause the carousel and see the bouncy hover interaction.
+
+## Files
+- `demo.html`: The HTML structure defining the track, the duplicated sets of cards, and the edge fade overlays.
+- `style.css`: The styling, the vibrant `linear-gradient` definitions, and the specific `@keyframes` math required to pull off the CSS-only infinite loop.

--- a/submissions/examples/css-animated-carousel-gradient-pure/demo.html
+++ b/submissions/examples/css-animated-carousel-gradient-pure/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Carousel: Gradient</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        
+        <header class="header">
+            <h1 class="title">Gradient Infinite Carousel</h1>
+            <p>A pure CSS infinite scrolling marquee featuring vibrant gradient cards.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- The Carousel Wrapper -->
+            <div class="carousel-wrapper" aria-label="Gradient Feature Showcase" role="region">
+                
+                <!-- The scrolling track -->
+                <div class="carousel-track">
+                    
+                    <!-- Original Set of Cards -->
+                    <div class="card grad-1"><h2>Dynamic</h2></div>
+                    <div class="card grad-2"><h2>Fluid</h2></div>
+                    <div class="card grad-3"><h2>Vibrant</h2></div>
+                    <div class="card grad-4"><h2>Seamless</h2></div>
+                    <div class="card grad-5"><h2>CSS Only</h2></div>
+                    
+                    <!-- Duplicated Set for Infinite Loop -->
+                    <div class="card grad-1" aria-hidden="true"><h2>Dynamic</h2></div>
+                    <div class="card grad-2" aria-hidden="true"><h2>Fluid</h2></div>
+                    <div class="card grad-3" aria-hidden="true"><h2>Vibrant</h2></div>
+                    <div class="card grad-4" aria-hidden="true"><h2>Seamless</h2></div>
+                    <div class="card grad-5" aria-hidden="true"><h2>CSS Only</h2></div>
+                    
+                </div>
+                
+                <!-- Gradient overlays for smooth fading edges -->
+                <div class="fade-overlay left"></div>
+                <div class="fade-overlay right"></div>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-animated-carousel-gradient-pure/style.css
+++ b/submissions/examples/css-animated-carousel-gradient-pure/style.css
@@ -1,0 +1,157 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap');
+
+/* =========================================
+   Theming (Gradients & Carousel config)
+   ========================================= */
+:root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    
+    /* Carousel Dimensions */
+    --card-width: 250px;
+    --card-height: 150px;
+    --card-gap: 30px;
+    --total-cards: 5; /* Important for calculating animation distance */
+    
+    /* Calculate the total distance one set of cards takes up */
+    --scroll-distance: calc((var(--card-width) + var(--card-gap)) * var(--total-cards));
+    
+    --animation-duration: 20s;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: 'Poppins', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 100%;
+    max-width: 1200px;
+    padding: 20px;
+}
+.header { text-align: center; margin-bottom: 60px; }
+.title { font-size: 2.5rem; margin-bottom: 10px; }
+.header p { color: #94a3b8; font-size: 1.1rem; }
+
+
+/* =========================================
+   [TECHNIQUE 1] Infinite Carousel Track
+   ========================================= */
+.carousel-wrapper {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    padding: 20px 0;
+}
+
+.carousel-track {
+    display: flex;
+    gap: var(--card-gap);
+    width: max-content;
+    
+    /* The infinite animation */
+    animation: scroll-left var(--animation-duration) linear infinite;
+}
+
+/* Pause the animation when the user interacts */
+.carousel-wrapper:hover .carousel-track,
+.carousel-wrapper:focus-within .carousel-track {
+    animation-play-state: paused;
+}
+
+@keyframes scroll-left {
+    0% { transform: translateX(0); }
+    /* Translate exactly one set's width so it loops seamlessly to the second set */
+    100% { transform: translateX(calc(-1 * var(--scroll-distance))); }
+}
+
+
+/* =========================================
+   [TECHNIQUE 2] Gradient Cards
+   ========================================= */
+.card {
+    width: var(--card-width);
+    height: var(--card-height);
+    border-radius: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 10px 20px -5px rgba(0,0,0,0.5);
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), filter 0.3s ease;
+    cursor: pointer;
+    flex-shrink: 0; /* Prevent cards from squishing */
+}
+
+.card h2 {
+    font-size: 1.5rem;
+    color: white;
+    text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    margin: 0;
+}
+
+/* Hover effects */
+.card:hover {
+    transform: translateY(-10px) scale(1.05);
+    filter: brightness(1.1);
+}
+
+/* Vibrant Gradient Variations */
+.grad-1 { background: linear-gradient(135deg, #f12711 0%, #f5af19 100%); }
+.grad-2 { background: linear-gradient(135deg, #00c6ff 0%, #0072ff 100%); }
+.grad-3 { background: linear-gradient(135deg, #8E2DE2 0%, #4A00E0 100%); }
+.grad-4 { background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%); }
+.grad-5 { background: linear-gradient(135deg, #ff0844 0%, #ffb199 100%); }
+
+
+/* =========================================
+   Fade Overlays (Seamless Edges)
+   ========================================= */
+.fade-overlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 15%;
+    z-index: 2;
+    pointer-events: none; /* Let clicks pass through to cards */
+}
+
+.fade-overlay.left {
+    left: 0;
+    background: linear-gradient(to right, var(--bg-color) 0%, transparent 100%);
+}
+
+.fade-overlay.right {
+    right: 0;
+    background: linear-gradient(to left, var(--bg-color) 0%, transparent 100%);
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .carousel-track {
+        animation: none !important;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+    
+    .carousel-wrapper {
+        overflow: visible;
+    }
+    
+    .fade-overlay {
+        display: none;
+    }
+    
+    /* Hide the duplicated set so they don't stack up visually */
+    .card[aria-hidden="true"] {
+        display: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a smooth, CSS-only infinite scrolling marquee featuring vibrant, interactive gradient cards. Resolves issue #78833.

### Changes Made:
- Added `submissions/examples/css-animated-carousel-gradient-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the track, the duplicated sets of cards required for the illusion, and the edge fade overlays.
- Created `style.css` featuring the UI mechanics:
  - **The Infinite Loop Technique**: The HTML contains two identical sets of 5 cards side-by-side inside `.carousel-track`. The CSS animation (`scroll-left`) translates the track to the left. The magic happens by translating the track exactly the distance of *one set* of cards (`--scroll-distance = 5 * (width + gap)`). When the animation reaches 100%, the track is instantly reset to 0%, but because the second set of cards looks identical to the first, the user perceives a seamless, infinite loop.
  - **Vibrant Gradient Cards**: Each card uses a distinct CSS `linear-gradient`. On hover, the cards pop out using `transform: translateY(-10px) scale(1.05)` with a bouncy `cubic-bezier` timing function, and their `filter: brightness()` is slightly increased.
  - **Interactive Pausing**: The continuous animation is automatically paused (`animation-play-state: paused`) when the user hovers over the carousel with a mouse, or focuses inside it with a keyboard, allowing them to read the cards or interact with them.
  - **Seamless Edges**: `.fade-overlay` elements are positioned absolutely on the left and right sides of the carousel wrapper. They use `linear-gradient` to blend from the background color (`#0f172a`) to `transparent`. `pointer-events: none` is used so they don't block clicks on the cards underneath.
- Added `README.md` documenting usage and the technical mechanics of the infinite loop `@keyframes` math.
- Fully accessible semantic structure. The wrapper uses `role="region"` and an `aria-label`. The duplicated set of cards is hidden from screen readers using `aria-hidden="true"` so that content isn't read twice. Honors the `prefers-reduced-motion` accessibility standard by disabling the marquee animation and instead rendering a static, wrapping flex grid of the first set of cards.

Closes #78833
