### PR TITLE
feat: add pure CSS Dynamic Card with Minimalist styling (#78827)

### DIFF
--- a/submissions/examples/css-dynamic-card-minimalist-pure/README.md
+++ b/submissions/examples/css-dynamic-card-minimalist-pure/README.md
@@ -1,0 +1,18 @@
+# Dynamic Card: Minimalist
+
+A clean, typography-driven CSS card component inspired by Swiss design principles. It leverages generous whitespace and dynamically reveals extra content on interaction using modern CSS Grid techniques.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Minimalist / Swiss Aesthetics**: Focuses on strict alignment, high contrast (black on white/light gray), and strong typography (`Helvetica Neue` / `Inter`). Borders are sharp with a very subtle `4px` radius, and shadows are kept to an absolute minimum (`0.02` opacity) until interacted with.
+  - **Dynamic CSS Grid Reveal**: The core feature of this card is the smooth expansion of the hidden content (`.card-reveal-area`). Traditionally, animating from `height: 0` to `height: auto` is impossible in CSS without JavaScript. This component solves that by using CSS Grid. The hidden content is wrapped in a container with `display: grid; grid-template-rows: 0fr`. On hover/focus, it transitions to `grid-template-rows: 1fr`, allowing the browser to smoothly calculate and animate the intrinsic height of the content.
+  - **Morphing Visuals**: The `.geometric-shape` in the header acts as an abstract visual anchor. On hover, it smoothly morphs from a circle to a square while rotating and scaling up.
+- Fully accessible semantic structure. The entire card uses `<article>` and `tabindex="0"` so it can be focused via keyboard navigation. A strong focus ring is applied on `:focus-visible`. Honors the `prefers-reduced-motion` accessibility standard by disabling the morphing and grid expansion animations if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. You will see a compact, clean card. Hover over the card with your mouse (or tab to it with your keyboard) to see the card lift, the geometric shape morph, and the hidden paragraph and link smoothly expand from below the title.
+
+## Files
+- `demo.html`: The HTML structure defining the semantic `<article>` and the `.card-reveal-area` wrapper.
+- `style.css`: The styling, the minimalist typography variables, and the CSS Grid `1fr` to `0fr` animation hack.

--- a/submissions/examples/css-dynamic-card-minimalist-pure/demo.html
+++ b/submissions/examples/css-dynamic-card-minimalist-pure/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Card: Minimalist</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        
+        <header class="header">
+            <h1 class="title">Minimalist Dynamic Card</h1>
+            <p>A clean, typography-driven card that dynamically reveals content on interaction.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- The Dynamic Card -->
+            <article class="min-card" tabindex="0" aria-labelledby="card-title">
+                
+                <div class="card-visual">
+                    <!-- Minimalist geometric visual -->
+                    <div class="geometric-shape"></div>
+                </div>
+
+                <div class="card-content">
+                    <span class="card-meta">Design Systems</span>
+                    <h2 id="card-title" class="card-title">The Power of Whitespace</h2>
+                    
+                    <!-- Content that is dynamically revealed -->
+                    <div class="card-reveal-area">
+                        <p class="card-description">
+                            Embracing emptiness in your layouts isn't about wasting screen real estate; it's about giving your typography and core content room to breathe, establishing visual hierarchy, and creating a sense of premium elegance.
+                        </p>
+                        <a href="#" class="card-link" aria-label="Read more about whitespace">Read Article <span class="arrow">&rarr;</span></a>
+                    </div>
+                </div>
+                
+            </article>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-dynamic-card-minimalist-pure/style.css
+++ b/submissions/examples/css-dynamic-card-minimalist-pure/style.css
@@ -1,0 +1,201 @@
+@import url('https://fonts.googleapis.com/css2?family=Helvetica+Neue:wght@400;700&family=Inter:wght@400;600&display=swap');
+
+/* =========================================
+   Theming (Minimalist / Swiss Design)
+   ========================================= */
+:root {
+    --bg-color: #f7f7f7;
+    --card-bg: #ffffff;
+    --text-primary: #111111;
+    --text-secondary: #666666;
+    --accent: #0055ff;
+    
+    --border-color: #e0e0e0;
+    
+    /* Animation Timing */
+    --transition-snappy: 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    /* Classic Swiss Typography stack */
+    font-family: 'Helvetica Neue', 'Inter', Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    padding: 40px 20px;
+    width: 100%;
+    max-width: 600px;
+}
+.header { margin-bottom: 60px; text-align: center; }
+.title { font-size: 2rem; font-weight: 700; letter-spacing: -0.03em; margin-bottom: 8px; }
+.header p { color: var(--text-secondary); font-size: 1.05rem; }
+
+
+/* =========================================
+   [TECHNIQUE] Minimalist Dynamic Card
+   ========================================= */
+.min-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 4px; /* Very subtle radius */
+    overflow: hidden;
+    position: relative;
+    cursor: pointer;
+    outline: none;
+    
+    /* Subtle initial shadow */
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.02);
+    
+    /* Transition for the entire card lifting */
+    transition: transform var(--transition-snappy),
+                box-shadow var(--transition-snappy),
+                border-color var(--transition-snappy);
+}
+
+/* =========================================
+   Visual Header area
+   ========================================= */
+.card-visual {
+    height: 140px;
+    background-color: #f0f0f0;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Abstract geometric shape for minimalist aesthetic */
+.geometric-shape {
+    width: 60px;
+    height: 60px;
+    background-color: var(--text-primary);
+    border-radius: 50%;
+    transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+
+/* =========================================
+   Content Area & Typography
+   ========================================= */
+.card-content {
+    padding: 30px;
+}
+
+.card-meta {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.card-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0;
+    line-height: 1.2;
+    transition: color var(--transition-snappy);
+}
+
+
+/* =========================================
+   [TECHNIQUE] Dynamic CSS Grid Reveal
+   ========================================= */
+/* 
+   We hide the description initially by collapsing a grid row to 0fr.
+   This allows for a smooth height animation without hardcoding pixels.
+*/
+.card-reveal-area {
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 0;
+    transition: grid-template-rows var(--transition-snappy),
+                opacity var(--transition-snappy),
+                margin-top var(--transition-snappy);
+    margin-top: 0;
+}
+
+/* The inner wrapper that gets clipped */
+.card-reveal-area > * {
+    overflow: hidden;
+}
+
+.card-description {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0;
+    /* Added padding inside the grid item so it reveals smoothly */
+    padding-bottom: 24px; 
+}
+
+.card-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+.arrow {
+    margin-left: 6px;
+    transition: transform 0.3s ease;
+}
+.card-link:hover .arrow {
+    transform: translateX(4px);
+}
+
+
+/* =========================================
+   Interaction States (Hover / Focus)
+   ========================================= */
+.min-card:hover,
+.min-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.06);
+    border-color: #d0d0d0;
+}
+
+.min-card:hover .geometric-shape,
+.min-card:focus-visible .geometric-shape {
+    transform: scale(1.5) rotate(45deg);
+    border-radius: 4px; /* Morphs from circle to square */
+}
+
+/* Trigger the CSS Grid reveal */
+.min-card:hover .card-reveal-area,
+.min-card:focus-visible .card-reveal-area {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    margin-top: 20px; /* Push down from title */
+}
+
+.min-card:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 4px;
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .min-card,
+    .geometric-shape,
+    .card-reveal-area,
+    .arrow {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a clean, typography-driven CSS card component inspired by Swiss design principles. It leverages generous whitespace and dynamically reveals extra content on interaction using modern CSS Grid techniques. Resolves issue #78827.

### Changes Made:
- Added `submissions/examples/css-dynamic-card-minimalist-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the semantic `<article>` and the `.card-reveal-area` wrapper.
- Created `style.css` featuring the UI mechanics:
  - **Minimalist / Swiss Aesthetics**: Focuses on strict alignment, high contrast (black on white/light gray), and strong typography (`Helvetica Neue` / `Inter`). Borders are sharp with a very subtle `4px` radius, and shadows are kept to an absolute minimum (`0.02` opacity) until interacted with.
  - **Dynamic CSS Grid Reveal**: The core feature of this card is the smooth expansion of the hidden content (`.card-reveal-area`). Traditionally, animating from `height: 0` to `height: auto` is impossible in CSS without JavaScript. This component solves that by using CSS Grid. The hidden content is wrapped in a container with `display: grid; grid-template-rows: 0fr`. On hover/focus, it transitions to `grid-template-rows: 1fr`, allowing the browser to smoothly calculate and animate the intrinsic height of the content.
  - **Morphing Visuals**: The `.geometric-shape` in the header acts as an abstract visual anchor. On hover, it smoothly morphs from a circle to a square while rotating and scaling up.
- Added `README.md` documenting usage and the technical mechanics of the CSS Grid `1fr` to `0fr` animation hack.
- Fully accessible semantic structure. The entire card uses `<article>` and `tabindex="0"` so it can be focused via keyboard navigation. A strong focus ring is applied on `:focus-visible`. Honors the `prefers-reduced-motion` accessibility standard by disabling the morphing and grid expansion animations if requested by the OS.

Closes #78827
