### PR TITLE
feat: add pure CSS Spinner with Neumorphism styling (#78826)

### DIFF
--- a/submissions/examples/css-spinner-neumorphism-pure/README.md
+++ b/submissions/examples/css-spinner-neumorphism-pure/README.md
@@ -1,0 +1,19 @@
+# Spinner: Neumorphism
+
+A pure CSS loading indicator featuring a soft, extruded aesthetic utilizing Neumorphic design principles and multi-layered CSS box shadows.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript, SVGs, or external libraries required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Neumorphic Base**: The core of Neumorphism is setting the background color of the element to exactly match the background color of its container (`--base-color: #e0e5ec;`). The shape is entirely defined by manipulating shadows.
+  - **The Outset Base**: The outer `.neumorphic-spinner` wrapper uses a dual `box-shadow` (one dark shadow on the bottom right, one light shadow on the top left) to create the illusion of a raised, extruded circular button.
+  - **The Inset Core**: The inner `.spinner-inner` uses a dual `inset box-shadow` to create the illusion of a carved-out hole in the center of the raised button, resulting in a physical-looking ring.
+  - **The Animated Indicator**: Sandwiched between the outset base and the inset core (managed via `z-index`) is the `.spinner-indicator`. This layer utilizes a `conic-gradient` with a sharp blue accent color that sweeps into transparency. Because the inset core is layered on top, the conic gradient is masked, turning it into a spinning track. An `::after` pseudo-element provides a bright, glowing, rounded cap to the leading edge of the spin.
+- Fully accessible semantic structure. The wrapper uses `aria-busy="true"` and `aria-label="Loading data"` to properly notify screen readers. Honors the `prefers-reduced-motion` accessibility standard by disabling the high-speed rotation and instead rendering a static blue ring if requested by the OS.
+
+## Usage
+Open `demo.html` in your browser. You will see a soft, clay-like loading spinner tracking smoothly within its track.
+
+## Files
+- `demo.html`: The HTML structure defining the layers required to achieve the neumorphic sandwich effect.
+- `style.css`: The styling, the critical `box-shadow` configurations, and the `z-index` layering logic.

--- a/submissions/examples/css-spinner-neumorphism-pure/demo.html
+++ b/submissions/examples/css-spinner-neumorphism-pure/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spinner: Neumorphism</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        
+        <header class="header">
+            <h1 class="title">Neumorphic Spinner</h1>
+            <p>A soft, extruded loading indicator utilizing CSS box-shadow manipulation.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- The Neumorphic Spinner -->
+            <div class="spinner-container" aria-busy="true" aria-label="Loading data">
+                
+                <div class="neumorphic-spinner">
+                    <!-- The inner carved out section -->
+                    <div class="spinner-inner"></div>
+                    <!-- The rotating indicator -->
+                    <div class="spinner-indicator"></div>
+                </div>
+
+            </div>
+            
+            <div class="status-text">Fetching...</div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-spinner-neumorphism-pure/style.css
+++ b/submissions/examples/css-spinner-neumorphism-pure/style.css
@@ -1,0 +1,150 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming (Neumorphism / Soft UI)
+   ========================================= */
+:root {
+    /* The critical neumorphic base color */
+    --base-color: #e0e5ec;
+    
+    /* Shadows calculated based on base color */
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    
+    --text-color: #4a5568;
+    
+    --spinner-size: 120px;
+    --ring-thickness: 16px;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--base-color);
+    color: var(--text-color);
+    font-family: 'Nunito', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    text-align: center;
+    padding: 40px;
+    /* Apply a soft container shadow */
+    border-radius: 30px;
+    box-shadow: 10px 10px 20px var(--shadow-dark), 
+               -10px -10px 20px var(--shadow-light);
+}
+
+.header { margin-bottom: 50px; }
+.title { font-size: 2rem; font-weight: 700; margin-bottom: 10px; color: #2d3748; }
+.header p { font-size: 1rem; color: #718096; }
+
+
+/* =========================================
+   [TECHNIQUE] Neumorphic Spinner
+   ========================================= */
+.spinner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0 auto;
+}
+
+.neumorphic-spinner {
+    position: relative;
+    width: var(--spinner-size);
+    height: var(--spinner-size);
+    border-radius: 50%;
+    
+    /* The Outset shadow (makes it look like a raised button) */
+    background-color: var(--base-color);
+    box-shadow: 8px 8px 16px var(--shadow-dark), 
+               -8px -8px 16px var(--shadow-light);
+               
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* The inner ring (carved in) */
+.spinner-inner {
+    position: absolute;
+    width: calc(var(--spinner-size) - (var(--ring-thickness) * 2));
+    height: calc(var(--spinner-size) - (var(--ring-thickness) * 2));
+    border-radius: 50%;
+    background-color: var(--base-color);
+    
+    /* The Inset shadow (makes it look carved into the surface) */
+    box-shadow: inset 6px 6px 10px var(--shadow-dark), 
+                inset -6px -6px 10px var(--shadow-light);
+    z-index: 2;
+}
+
+/* 
+   The spinning indicator block. 
+   It's placed behind the inner ring, so only the outer edge is visible.
+*/
+.spinner-indicator {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    
+    /* A bright, contrasting accent color for the loading progress */
+    background: conic-gradient(from 0deg, transparent 0%, transparent 60%, #4299e1 100%);
+    
+    animation: spin 1.2s cubic-bezier(0.5, 0.1, 0.15, 1) infinite;
+    z-index: 1;
+}
+
+/* Soft rounded cap on the spinning indicator */
+.spinner-indicator::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: calc(50% - (var(--ring-thickness) / 2));
+    width: var(--ring-thickness);
+    height: var(--ring-thickness);
+    background-color: #4299e1;
+    border-radius: 50%;
+    box-shadow: 0 0 8px rgba(66, 153, 225, 0.8);
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* =========================================
+   Status Text
+   ========================================= */
+.status-text {
+    margin-top: 40px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #718096;
+    letter-spacing: 1px;
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .spinner-indicator {
+        animation: none !important;
+        background: #4299e1; /* Static full ring fallback */
+    }
+    .status-text {
+        animation: none !important;
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS loading indicator featuring a soft, extruded aesthetic utilizing Neumorphic design principles and multi-layered CSS box shadows. Resolves issue #78826.

### Changes Made:
- Added `submissions/examples/css-spinner-neumorphism-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the layers required to achieve the neumorphic sandwich effect.
- Created `style.css` featuring the UI mechanics:
  - **Neumorphic Base**: The core of Neumorphism is setting the background color of the element to exactly match the background color of its container (`--base-color: #e0e5ec;`). The shape is entirely defined by manipulating shadows.
  - **The Outset Base**: The outer `.neumorphic-spinner` wrapper uses a dual `box-shadow` (one dark shadow on the bottom right, one light shadow on the top left) to create the illusion of a raised, extruded circular button.
  - **The Inset Core**: The inner `.spinner-inner` uses a dual `inset box-shadow` to create the illusion of a carved-out hole in the center of the raised button, resulting in a physical-looking ring.
  - **The Animated Indicator**: Sandwiched between the outset base and the inset core (managed via `z-index`) is the `.spinner-indicator`. This layer utilizes a `conic-gradient` with a sharp blue accent color that sweeps into transparency. Because the inset core is layered on top, the conic gradient is masked, turning it into a spinning track. An `::after` pseudo-element provides a bright, glowing, rounded cap to the leading edge of the spin.
- Added `README.md` documenting usage and the technical mechanics of the critical `box-shadow` configurations, and the `z-index` layering logic.
- Fully accessible semantic structure. The wrapper uses `aria-busy="true"` and `aria-label="Loading data"` to properly notify screen readers. Honors the `prefers-reduced-motion` accessibility standard by disabling the high-speed rotation and instead rendering a static blue ring if requested by the OS.

Closes #78826
