### PR TITLE
feat: add image zoom hover frame

### DIFF
--- a/submissions/examples/image-zoom-hover-frame-031/README.md
+++ b/submissions/examples/image-zoom-hover-frame-031/README.md
@@ -1,0 +1,28 @@
+# Image Zoom Hover Frame
+
+A reusable image frame that smoothly zooms its image content during hover
+or keyboard focus.
+
+## What does it do?
+
+The component provides:
+
+- Smooth image zoom.
+- Clipped image boundaries.
+- Subtle frame lift.
+- Hover interaction.
+- Keyboard focus interaction.
+- Responsive layout.
+- Reduced-motion support.
+- No JavaScript.
+- No external libraries.
+
+## How do I use it?
+
+Wrap an image with the `ease-image-zoom` class:
+
+```html
+<a class="ease-image-zoom" href="#">
+  <img src="image.jpg" alt="Example image">
+</a>
+```

--- a/submissions/examples/image-zoom-hover-frame-031/demo.html
+++ b/submissions/examples/image-zoom-hover-frame-031/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Image zoom hover frame demo for EaseMotion CSS"
+  >
+  <title>Image Zoom Hover Frame</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Image Interaction</p>
+      <h1>Look<br>Closer.</h1>
+      <p class="hero-copy">
+        A lightweight image frame that smoothly zooms its content on hover
+        and keyboard focus.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="section-heading">
+        <span>IMAGE / 01</span>
+        <h2 id="demo-title">Zoom into detail</h2>
+        <p>
+          Hover or focus an image frame to reveal its subtle zoom interaction.
+        </p>
+      </div>
+
+      <div class="image-grid">
+        <a class="ease-image-zoom" href="#image-one">
+          <img
+            src="https://images.unsplash.com/photo-1519608487953-e999c86e7455?auto=format&fit=crop&w=1200&q=80"
+            alt="Mountain landscape under a star-filled night sky"
+          >
+          <span class="image-label">Night landscape</span>
+        </a>
+
+        <a class="ease-image-zoom" href="#image-two">
+          <img
+            src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80"
+            alt="Open road surrounded by mountains"
+          >
+          <span class="image-label">Open road</span>
+        </a>
+
+        <a class="ease-image-zoom" href="#image-three">
+          <img
+            src="https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=1200&q=80"
+            alt="Mountain lake surrounded by green hills"
+          >
+          <span class="image-label">Mountain lake</span>
+        </a>
+      </div>
+
+      <p class="demo-note">
+        The interaction is CSS-based. The demo images use remote sources only
+        for visual demonstration.
+      </p>
+    </section>
+
+    <footer class="footer">
+      <p>Pure interaction CSS. No JavaScript or external libraries.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/image-zoom-hover-frame-031/style.css
+++ b/submissions/examples/image-zoom-hover-frame-031/style.css
@@ -1,0 +1,218 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --card: #171d27;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.4);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1050px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.section-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ease-image-zoom {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  color: var(--text);
+  text-decoration: none;
+  transition:
+    border-color 220ms ease,
+    transform 220ms ease;
+}
+
+.ease-image-zoom::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.65),
+    transparent 55%
+  );
+  pointer-events: none;
+}
+
+.ease-image-zoom img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1);
+  transition:
+    transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ease-image-zoom:hover,
+.ease-image-zoom:focus-visible {
+  border-color: var(--border-hover);
+  transform: translateY(-4px);
+}
+
+.ease-image-zoom:hover img,
+.ease-image-zoom:focus-visible img {
+  transform: scale(1.08);
+}
+
+.ease-image-zoom:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.image-label {
+  position: absolute;
+  z-index: 1;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.demo-note {
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 800px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1rem;
+  }
+
+  .image-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ease-image-zoom {
+    aspect-ratio: 16 / 10;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-image-zoom,
+  .ease-image-zoom img {
+    transition: none;
+  }
+
+  .ease-image-zoom:hover,
+  .ease-image-zoom:focus-visible {
+    transform: none;
+  }
+
+  .ease-image-zoom:hover img,
+  .ease-image-zoom:focus-visible img {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained image zoom hover frame interaction for EaseMotion CSS.

### What's included

- Smooth image zoom
- Clipped image boundaries
- Subtle frame lift
- Hover and keyboard focus states
- Responsive demonstration
- `prefers-reduced-motion` support
- No JavaScript
- No external libraries
- Usage documentation

### Files

- `demo.html` — image zoom demonstration
- `style.css` — image frame styling and animation
- `README.md` — usage and accessibility documentation

### Issue

Closes #79373

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No JavaScript
- [x] No external libraries
- [x] Supports keyboard interaction
- [x] Supports reduced-motion preferences
- [x] Tested locally