### PR TITLE
feat: add fade-in tooltip

### DIFF
--- a/submissions/examples/fade-in-tooltip-034/README.md
+++ b/submissions/examples/fade-in-tooltip-034/README.md
@@ -1,0 +1,42 @@
+# Fade-In Tooltip
+
+A lightweight tooltip that smoothly fades and moves upward into view when
+its trigger is hovered or receives keyboard focus.
+
+## What does it do?
+
+The component provides:
+
+- Fade-in animation.
+- Subtle upward reveal.
+- Hover interaction.
+- Keyboard focus interaction.
+- Tooltip pointer styling.
+- Responsive layout.
+- Reduced-motion support.
+- No JavaScript.
+- No external libraries or assets.
+
+## How do I use it?
+
+Wrap a trigger and tooltip content inside the `ease-tooltip` class:
+
+```html
+<div class="ease-tooltip">
+  <button
+    class="ease-tooltip__trigger"
+    type="button"
+    aria-describedby="tooltip"
+  >
+    More information
+  </button>
+
+  <span
+    class="ease-tooltip__content"
+    id="tooltip"
+    role="tooltip"
+  >
+    Additional information appears here.
+  </span>
+</div>
+```

--- a/submissions/examples/fade-in-tooltip-034/demo.html
+++ b/submissions/examples/fade-in-tooltip-034/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Fade-in tooltip demo for EaseMotion CSS">
+  <title>Fade-In Tooltip</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Tooltip Interaction</p>
+      <h1>Reveal<br>the Context.</h1>
+      <p class="hero-copy">
+        A compact tooltip that smoothly fades and rises into view when its
+        trigger is hovered or focused.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="section-heading">
+        <span>TOOLTIP / 01</span>
+        <h2 id="demo-title">Context on demand</h2>
+        <p>
+          Hover or focus each trigger to reveal additional information.
+        </p>
+      </div>
+
+      <div class="tooltip-grid">
+        <div class="ease-tooltip">
+          <button
+            class="ease-tooltip__trigger"
+            type="button"
+            aria-describedby="tooltip-one"
+          >
+            <span aria-hidden="true">?</span>
+            <span>What is EaseMotion?</span>
+          </button>
+
+          <span
+            class="ease-tooltip__content"
+            id="tooltip-one"
+            role="tooltip"
+          >
+            A lightweight CSS motion system for expressive interfaces.
+          </span>
+        </div>
+
+        <div class="ease-tooltip">
+          <button
+            class="ease-tooltip__trigger"
+            type="button"
+            aria-describedby="tooltip-two"
+          >
+            <span aria-hidden="true">i</span>
+            <span>Interaction details</span>
+          </button>
+
+          <span
+            class="ease-tooltip__content"
+            id="tooltip-two"
+            role="tooltip"
+          >
+            The reveal combines opacity and a small vertical movement.
+          </span>
+        </div>
+
+        <div class="ease-tooltip">
+          <button
+            class="ease-tooltip__trigger"
+            type="button"
+            aria-describedby="tooltip-three"
+          >
+            <span aria-hidden="true">+</span>
+            <span>Learn more</span>
+          </button>
+
+          <span
+            class="ease-tooltip__content"
+            id="tooltip-three"
+            role="tooltip"
+          >
+            Hover and keyboard focus both activate the tooltip transition.
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Pure HTML and CSS. No JavaScript, libraries, or external assets.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/fade-in-tooltip-034/style.css
+++ b/submissions/examples/fade-in-tooltip-034/style.css
@@ -1,0 +1,235 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --card: #171d27;
+  --tooltip: #202938;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.4);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(950px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.section-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tooltip-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ease-tooltip {
+  position: relative;
+}
+
+.ease-tooltip__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 64px;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: var(--card);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 750;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 200ms ease,
+    background 200ms ease,
+    transform 200ms ease;
+}
+
+.ease-tooltip__trigger > span:first-child {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--accent);
+  font-size: 0.75rem;
+}
+
+.ease-tooltip__trigger:hover,
+.ease-tooltip__trigger:focus-visible {
+  border-color: var(--border-hover);
+  background: #1b222e;
+  transform: translateY(-2px);
+}
+
+.ease-tooltip__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.ease-tooltip__content {
+  position: absolute;
+  z-index: 5;
+  right: 0;
+  bottom: calc(100% + 0.75rem);
+  left: 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border-hover);
+  border-radius: 0.75rem;
+  background: var(--tooltip);
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.6;
+  box-shadow: 0 14px 35px rgba(0, 0, 0, 0.28);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ease-tooltip__content::after {
+  content: "";
+  position: absolute;
+  right: 1.25rem;
+  bottom: -6px;
+  width: 10px;
+  height: 10px;
+  border-right: 1px solid var(--border-hover);
+  border-bottom: 1px solid var(--border-hover);
+  background: var(--tooltip);
+  transform: rotate(45deg);
+}
+
+.ease-tooltip:hover .ease-tooltip__content,
+.ease-tooltip:focus-within .ease-tooltip__content {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 750px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1rem;
+  }
+
+  .tooltip-grid {
+    grid-template-columns: 1fr;
+    gap: 3.5rem;
+  }
+
+  .ease-tooltip__content {
+    bottom: calc(100% + 0.6rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip__trigger,
+  .ease-tooltip__content {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained fade-in tooltip interaction for EaseMotion CSS.

### What's included

- Fade-in and upward reveal animation
- Hover and keyboard focus states
- Native button trigger
- `aria-describedby` and tooltip semantics
- Responsive demonstration
- `prefers-reduced-motion` support
- No JavaScript
- No external dependencies
- Offline-compatible standalone demo
- Usage and accessibility documentation

### Files

- `demo.html` — tooltip demonstration
- `style.css` — tooltip styling and animation
- `README.md` — usage and accessibility documentation

### Issue

Closes #79384

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard interaction
- [x] Supports reduced-motion preferences
- [x] Tested locally