### PR TITLE
feat: add card content slide reveal

### DIFF
--- a/submissions/examples/card-content-slide-reveal-035/README.md
+++ b/submissions/examples/card-content-slide-reveal-035/README.md
@@ -1,0 +1,36 @@
+# Card Content Slide Reveal
+
+A reusable card interaction where secondary content smoothly slides upward
+into view when the card is hovered or receives keyboard focus.
+
+## What does it do?
+
+The component provides:
+
+- Secondary content reveal.
+- Smooth upward slide.
+- Subtle card lift.
+- Hover interaction.
+- Keyboard focus interaction.
+- Responsive layout.
+- Reduced-motion support.
+- No JavaScript.
+- No external libraries or assets.
+
+## How do I use it?
+
+Create a card with a primary content section and a details section:
+
+```html
+<article class="ease-slide-card">
+  <div class="ease-slide-card__main">
+    <h3>Project Alpha</h3>
+    <p>Short project description.</p>
+  </div>
+
+  <div class="ease-slide-card__details">
+    <p>Additional project information.</p>
+    <a href="#">Explore project</a>
+  </div>
+</article>
+```

--- a/submissions/examples/card-content-slide-reveal-035/demo.html
+++ b/submissions/examples/card-content-slide-reveal-035/demo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Card content slide reveal demo for EaseMotion CSS"
+  >
+  <title>Card Content Slide Reveal</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EaseMotion CSS · Card Interaction</p>
+      <h1>Reveal<br>What Matters.</h1>
+      <p class="hero-copy">
+        A reusable card interaction where secondary content smoothly slides
+        upward into view when the card is hovered or focused.
+      </p>
+    </header>
+
+    <section class="demo-panel" aria-labelledby="demo-title">
+      <div class="section-heading">
+        <span>CARD / 01</span>
+        <h2 id="demo-title">Content on demand</h2>
+        <p>
+          Hover or focus a card to reveal its supporting information and
+          action.
+        </p>
+      </div>
+
+      <div class="card-grid">
+        <article class="ease-slide-card">
+          <span class="ease-slide-card__number">01</span>
+
+          <div class="ease-slide-card__main">
+            <p class="ease-slide-card__category">Design system</p>
+            <h3>Motion patterns</h3>
+            <p class="ease-slide-card__summary">
+              Build expressive interactions with lightweight CSS.
+            </p>
+          </div>
+
+          <div class="ease-slide-card__details">
+            <p>
+              Explore reusable transitions and micro-interactions designed
+              for modern interfaces.
+            </p>
+            <a href="#motion-patterns">
+              Explore pattern
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </article>
+
+        <article class="ease-slide-card">
+          <span class="ease-slide-card__number">02</span>
+
+          <div class="ease-slide-card__main">
+            <p class="ease-slide-card__category">Components</p>
+            <h3>Interactive cards</h3>
+            <p class="ease-slide-card__summary">
+              Keep secondary information hidden until it is needed.
+            </p>
+          </div>
+
+          <div class="ease-slide-card__details">
+            <p>
+              Use the reveal pattern for projects, products, portfolios, and
+              feature collections.
+            </p>
+            <a href="#interactive-cards">
+              View component
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </article>
+
+        <article class="ease-slide-card">
+          <span class="ease-slide-card__number">03</span>
+
+          <div class="ease-slide-card__main">
+            <p class="ease-slide-card__category">Experience</p>
+            <h3>Focused motion</h3>
+            <p class="ease-slide-card__summary">
+              Add movement without overwhelming the interface.
+            </p>
+          </div>
+
+          <div class="ease-slide-card__details">
+            <p>
+              A restrained vertical reveal keeps the interaction clear and
+              purposeful.
+            </p>
+            <a href="#focused-motion">
+              Learn more
+              <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <p>Pure HTML and CSS. No JavaScript, libraries, or external assets.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/card-content-slide-reveal-035/style.css
+++ b/submissions/examples/card-content-slide-reveal-035/style.css
@@ -1,0 +1,305 @@
+:root {
+  --background: #080a0f;
+  --surface: #11151d;
+  --card: #171d27;
+  --card-hover: #1b222e;
+  --border: rgba(255, 255, 255, 0.1);
+  --border-hover: rgba(138, 180, 255, 0.4);
+  --text: #f4f7fb;
+  --muted: #98a4b5;
+  --accent: #8ab4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 50% 0,
+      rgba(91, 122, 190, 0.15),
+      transparent 34rem
+    ),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1050px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 6rem;
+}
+
+.hero {
+  min-height: 58vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.section-heading > span {
+  margin: 0 0 1rem;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(3.5rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.065em;
+}
+
+.hero-copy {
+  max-width: 650px;
+  margin: 2rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-panel {
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  background: var(--surface);
+}
+
+.section-heading {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ease-slide-card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 360px;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background:
+    radial-gradient(
+      circle at 85% 10%,
+      rgba(138, 180, 255, 0.12),
+      transparent 9rem
+    ),
+    var(--card);
+  color: var(--text);
+  text-decoration: none;
+  transition:
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 220ms ease,
+    background 220ms ease;
+}
+
+.ease-slide-card::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background:
+    linear-gradient(
+      to top,
+      rgba(138, 180, 255, 0.08),
+      transparent 55%
+    );
+  opacity: 0;
+  transition: opacity 240ms ease;
+}
+
+.ease-slide-card:hover,
+.ease-slide-card:focus-within {
+  transform: translateY(-5px);
+  border-color: var(--border-hover);
+  background:
+    radial-gradient(
+      circle at 85% 10%,
+      rgba(138, 180, 255, 0.16),
+      transparent 10rem
+    ),
+    var(--card-hover);
+}
+
+.ease-slide-card:hover::before,
+.ease-slide-card:focus-within::before {
+  opacity: 1;
+}
+
+.ease-slide-card__number {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.ease-slide-card__main {
+  transition:
+    transform 300ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 260ms ease;
+}
+
+.ease-slide-card__category {
+  margin: 0 0 0.7rem;
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.ease-slide-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: -0.03em;
+}
+
+.ease-slide-card__summary {
+  margin: 0.7rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.ease-slide-card__details {
+  position: absolute;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  opacity: 0;
+  transform: translateY(28px);
+  transition:
+    opacity 260ms ease,
+    transform 340ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ease-slide-card__details p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.ease-slide-card__details a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1.1rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.ease-slide-card__details a span {
+  transition: transform 200ms ease;
+}
+
+.ease-slide-card__details a:hover span,
+.ease-slide-card__details a:focus-visible span {
+  transform: translateX(4px);
+}
+
+.ease-slide-card__details a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.ease-slide-card:hover .ease-slide-card__main,
+.ease-slide-card:focus-within .ease-slide-card__main {
+  opacity: 0.25;
+  transform: translateY(-24px);
+}
+
+.ease-slide-card:hover .ease-slide-card__details,
+.ease-slide-card:focus-within .ease-slide-card__details {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.footer {
+  margin-top: 5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 850px) {
+  .page {
+    padding-top: 3.5rem;
+  }
+
+  .demo-panel {
+    padding: 1rem;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ease-slide-card {
+    min-height: 320px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-slide-card,
+  .ease-slide-card::before,
+  .ease-slide-card__main,
+  .ease-slide-card__details,
+  .ease-slide-card__details a span {
+    transition: none;
+  }
+
+  .ease-slide-card:hover,
+  .ease-slide-card:focus-within {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds a self-contained card content slide reveal interaction for EaseMotion CSS.

### What's included

- Secondary content reveal
- Smooth upward slide animation
- Subtle card lift
- Hover and keyboard focus states
- Responsive demonstration
- `prefers-reduced-motion` support
- No JavaScript
- No external dependencies
- Offline-compatible standalone demo
- Usage and accessibility documentation

### Files

- `demo.html` — card reveal demonstration
- `style.css` — card styling and animation
- `README.md` — usage and accessibility documentation

### Issue

Closes #79385

### Checklist

- [x] Added only files under `submissions/examples/`
- [x] Included `demo.html`, `style.css`, and `README.md`
- [x] No external dependencies
- [x] Works by opening `demo.html` directly
- [x] Supports keyboard interaction
- [x] Supports reduced-motion preferences
- [x] Tested locally