### PR TITLE
feat: implement Hover Slider with Pastel styling #78800

### DIFF
--- a/submissions/examples/css-pastel-hover-slider/README.md
+++ b/submissions/examples/css-pastel-hover-slider/README.md
@@ -1,0 +1,13 @@
+# Hover Slider with Pastel Styling (#78800)
+
+A soft pastel-themed range slider component featuring gradient thumb styling, hover scale transformations, and clean light-mode card aesthetics.
+
+## Features
+- **Pastel Aesthetics:** Clean soft gray-white backgrounds paired with pink-to-purple gradient slider thumbs.
+- **Hover Scale Interaction:** Dynamic thumb expansion and soft shadow enhancement on mouse hover.
+- **Fully Responsive:** Centered card layout scaling cleanly across all mobile and desktop viewports.
+
+## File Hierarchy
+- `style.css` - Custom properties, range input styling overrides, thumb animations, and media queries.
+- `demo.html` - Semantic markup demonstrating slider card integration with ARIA accessibility roles.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-pastel-hover-slider/demo.html
+++ b/submissions/examples/css-pastel-hover-slider/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Slider with Pastel Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="slider-card" role="region" aria-label="Pastel Range Slider Component">
+        <div class="slider-header">
+            <h3 class="slider-title">Color Intensity</h3>
+            <span class="slider-value" aria-label="Current value 75 percent">75%</span>
+        </div>
+        <input type="range" min="0" max="100" value="75" class="pastel-slider" aria-label="Color Intensity Slider">
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pastel-hover-slider/style.css
+++ b/submissions/examples/css-pastel-hover-slider/style.css
@@ -1,0 +1,110 @@
+/* CSS Hover Slider with Pastel Styling #78800 */
+
+:root {
+    --bg-color: #f8fafc;
+    --card-bg: #ffffff;
+    --border-color: #e2e8f0;
+    --pastel-pink: #f472b6;
+    --pastel-purple: #c084fc;
+    --slider-track: #e2e8f0;
+    --text-main: #1e293b;
+    --text-sub: #64748b;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-color);
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.slider-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 3rem 3.5rem;
+    box-shadow: 0 20px 40px -15px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 420px;
+    width: 100%;
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.slider-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+
+.slider-value {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--pastel-pink);
+    background: rgba(244, 114, 182, 0.1);
+    padding: 0.25rem 0.75rem;
+    border-radius: 50px;
+}
+
+.pastel-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 8px;
+    background: var(--slider-track);
+    border-radius: 4px;
+    outline: none;
+    transition: background 0.3s ease;
+}
+
+.pastel-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--pastel-pink), var(--pastel-purple));
+    cursor: pointer;
+    box-shadow: 0 4px 10px rgba(244, 114, 182, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pastel-slider::-moz-range-thumb {
+    width: 22px;
+    height: 22px;
+    border: none;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--pastel-pink), var(--pastel-purple));
+    cursor: pointer;
+    box-shadow: 0 4px 10px rgba(244, 114, 182, 0.4);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pastel-slider:hover::-webkit-slider-thumb {
+    transform: scale(1.15);
+    box-shadow: 0 6px 16px rgba(244, 114, 182, 0.6);
+}
+
+.pastel-slider:hover::-moz-range-thumb {
+    transform: scale(1.15);
+    box-shadow: 0 6px 16px rgba(244, 114, 182, 0.6);
+}
+
+@media (max-width: 480px) {
+    .slider-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Hover Slider with Pastel styling** component (#78800).
gssoc 26

Closes #78800

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-pastel-hover-slider/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A soft pastel-themed range input component featuring pink-purple gradient thumbs, hover scale animations, and light-mode card framing.

**How does it work?**
Constructed using custom range input pseudo-elements (`::-webkit-slider-thumb`), flexbox header alignment, and smooth transition scaling.