### PR TITLE
feat: implement CSS-only Tab Bar with Dark Mode styling #78797

### DIFF
--- a/submissions/examples/css-dark-mode-tab-bar/README.md
+++ b/submissions/examples/css-dark-mode-tab-bar/README.md
@@ -1,0 +1,13 @@
+# CSS-only Tab Bar with Dark Mode Styling (#78797)
+
+A zero-JavaScript CSS-only tab bar component featuring dark mode aesthetics, smooth fade-in panel transitions, and glowing indigo active states.
+
+## Features
+- **Zero JavaScript:** Pure CSS state management leveraging hidden radio inputs and sibling combinators (`~`).
+- **Dark Mode Aesthetics:** Deep slate card container framing paired with indigo accent highlights and subtle borders.
+- **Fully Responsive:** Fluid flexbox layout adapting cleanly across desktop and mobile viewports.
+
+## File Hierarchy
+- `style.css` - Custom properties, sibling radio selectors, fade-in keyframes, and media queries.
+- `demo.html` - Semantic markup demonstrating tab bar and panel integration with ARIA roles.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-dark-mode-tab-bar/demo.html
+++ b/submissions/examples/css-dark-mode-tab-bar/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS-only Tab Bar with Dark Mode Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tab-card">
+        <!-- Hidden Radio Inputs controlling state without JS -->
+        <input type="radio" id="tab1" name="tabs" class="tab-radio" checked>
+        <input type="radio" id="tab2" name="tabs" class="tab-radio">
+        <input type="radio" id="tab3" name="tabs" class="tab-radio">
+
+        <div class="tab-container" role="tablist" aria-label="Dark Mode Navigation Tabs">
+            <label for="tab1" class="tab-label" role="tab" aria-selected="true" aria-controls="pane1">Overview</label>
+            <label for="tab2" class="tab-label" role="tab" aria-selected="false" aria-controls="pane2">Security</label>
+            <label for="tab3" class="tab-label" role="tab" aria-selected="false" aria-controls="pane3">Settings</label>
+        </div>
+
+        <div class="tab-content-container">
+            <div class="tab-pane pane-1" id="pane1" role="tabpanel">
+                <h3 class="pane-title">System Overview</h3>
+                <p>Welcome to the core telemetry dashboard. Review live system parameters, node health metrics, and active resource utilization in real-time.</p>
+            </div>
+            <div class="tab-pane pane-2" id="pane2" role="tabpanel">
+                <h3 class="pane-title">Security & Protocols</h3>
+                <p>Configure end-to-end encryption keys, firewall rule sets, and access control permission tables across distributed cluster nodes.</p>
+            </div>
+            <div class="tab-pane pane-3" id="pane3" role="tabpanel">
+                <h3 class="pane-title">Workspace Settings</h3>
+                <p>Manage environmental variables, notification preferences, API rate limits, and custom UI accent color schemes.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dark-mode-tab-bar/style.css
+++ b/submissions/examples/css-dark-mode-tab-bar/style.css
@@ -1,0 +1,128 @@
+/* CSS Tab Bar with Dark Mode Styling #78797 */
+
+:root {
+    --bg-color: #090d16;
+    --card-bg: #111827;
+    --border-color: #1f2937;
+    --accent-indigo: #6366f1;
+    --accent-glow: rgba(99, 102, 241, 0.3);
+    --text-main: #f9fafb;
+    --text-sub: #9ca3af;
+    --tab-hover-bg: rgba(255, 255, 255, 0.03);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-color);
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.tab-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 2.5rem 3rem;
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 540px;
+    width: 100%;
+}
+
+.tab-container {
+    display: flex;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    padding: 6px;
+    position: relative;
+    gap: 4px;
+}
+
+.tab-radio {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.tab-label {
+    flex: 1;
+    text-align: center;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-sub);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: color 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
+    user-select: none;
+    z-index: 1;
+}
+
+.tab-label:hover {
+    color: var(--text-main);
+    background-color: var(--tab-hover-bg);
+}
+
+/* Radio Checked State Bindings */
+#tab1:checked ~ .tab-container label[for="tab1"],
+#tab2:checked ~ .tab-container label[for="tab2"],
+#tab3:checked ~ .tab-container label[for="tab3"] {
+    color: var(--text-main);
+    background-color: var(--accent-indigo);
+    box-shadow: 0 4px 15px var(--accent-glow);
+}
+
+.tab-content-container {
+    position: relative;
+    min-height: 120px;
+    color: var(--text-sub);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.tab-pane {
+    display: none;
+    animation: fadeIn 0.3s ease;
+}
+
+#tab1:checked ~ .tab-content-container .pane-1,
+#tab2:checked ~ .tab-content-container .pane-2,
+#tab3:checked ~ .tab-content-container .pane-3 {
+    display: block;
+}
+
+.pane-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 480px) {
+    .tab-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+    .tab-container {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **CSS-only Tab Bar with Dark Mode styling** component (#78797).
gssoc 26

Closes #78797

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-dark-mode-tab-bar/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A zero-JavaScript CSS tab bar component featuring dark mode aesthetics, smooth tab content panel switching, and glowing indigo active indicators.

**How does it work?**
Constructed using hidden radio input elements combined with CSS sibling selectors (`~`) to toggle content panel visibility and active tab styling without JS.