### PR TITLE
feat: implement Neumorphic Carousel with Retro styling #78606

### DIFF
--- a/submissions/examples/css-retro-neumorphic-carousel/README.md
+++ b/submissions/examples/css-retro-neumorphic-carousel/README.md
@@ -1,0 +1,13 @@
+# Neumorphic Carousel with Retro Styling (#78606)
+
+A retro-styled neumorphic carousel component featuring zero-JavaScript slide transitions, dual-shadow soft surface extrusion, and inset control dots.
+
+## Features
+- **Zero JavaScript:** Pure CSS state management leveraging hidden radio inputs and sibling selectors (`~`).
+- **Neumorphic Aesthetics:** Dual-shadow soft UI cards paired with inset track depth containers and amber accents.
+- **Fully Responsive:** Fluid flexbox card layout scaling cleanly across all viewports.
+
+## File Hierarchy
+- `style.css` - Custom properties, neumorphic shadow tokens, slide keyframes, and media queries.
+- `demo.html` - Semantic markup demonstrating carousel slide integration with ARIA roles.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-retro-neumorphic-carousel/demo.html
+++ b/submissions/examples/css-retro-neumorphic-carousel/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Carousel with Retro Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="carousel-card">
+        <!-- Hidden Radio Inputs for Zero-JS Carousel Control -->
+        <input type="radio" id="slide1" name="carousel" class="carousel-radio" checked>
+        <input type="radio" id="slide2" name="carousel" class="carousel-radio">
+        <input type="radio" id="slide3" name="carousel" class="carousel-radio">
+
+        <div class="carousel-header">
+            <h2 class="carousel-title">Retro Archives</h2>
+        </div>
+
+        <div class="carousel-track-container" role="region" aria-label="Image and text carousel">
+            <div class="carousel-slide s1">
+                <span class="slide-tag">Module 01</span>
+                <h3 class="slide-heading">Neumorphic Soft Extrusion</h3>
+                <p class="slide-desc">Experience classic retro UI design language powered by precise dual-shadow light and dark offsets, creating organic physical depth without heavy graphics.</p>
+            </div>
+            <div class="carousel-slide s2">
+                <span class="slide-tag">Module 02</span>
+                <h3 class="slide-heading">Zero-JavaScript Architecture</h3>
+                <p class="slide-desc">All carousel state changes and navigation dot bindings are handled natively via hidden radio inputs and CSS sibling combinator selectors.</p>
+            </div>
+            <div class="carousel-slide s3">
+                <span class="slide-tag">Module 03</span>
+                <h3 class="slide-heading">Responsive Flexbox Scaling</h3>
+                <p class="slide-desc">Optimized fluid layout structures ensure immaculate retro aesthetic presentation across desktop displays, tablets, and mobile devices.</p>
+            </div>
+        </div>
+
+        <div class="carousel-nav" role="tablist" aria-label="Carousel slide navigation">
+            <label for="slide1" class="carousel-dot" role="tab" aria-selected="true" aria-label="Slide 1">1</label>
+            <label for="slide2" class="carousel-dot" role="tab" aria-selected="false" aria-label="Slide 2">2</label>
+            <label for="slide3" class="carousel-dot" role="tab" aria-selected="false" aria-label="Slide 3">3</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-retro-neumorphic-carousel/style.css
+++ b/submissions/examples/css-retro-neumorphic-carousel/style.css
@@ -1,0 +1,161 @@
+/* CSS Neumorphic Carousel with Retro Styling #78606 */
+
+:root {
+    --bg-color: #e4ebf5;
+    --shadow-light: #ffffff;
+    --shadow-dark: #c5d9e8;
+    --accent-amber: #d97706;
+    --text-main: #334155;
+    --text-sub: #64748b;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+}
+
+.carousel-card {
+    background-color: var(--bg-color);
+    border-radius: 32px;
+    padding: 3rem;
+    box-shadow: 12px 12px 24px var(--shadow-dark), 
+                -12px -12px 24px var(--shadow-light);
+    max-width: 580px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.carousel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.carousel-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.carousel-track-container {
+    position: relative;
+    overflow: hidden;
+    border-radius: 20px;
+    background-color: var(--bg-color);
+    box-shadow: inset 6px 6px 12px var(--shadow-dark), 
+                inset -6px -6px 12px var(--shadow-light);
+    padding: 2rem;
+    min-height: 200px;
+    display: flex;
+    align-items: center;
+}
+
+.carousel-slide {
+    display: none;
+    flex-direction: column;
+    gap: 0.75rem;
+    animation: fadeIn 0.4s ease;
+    width: 100%;
+}
+
+.slide-tag {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent-amber);
+}
+
+.slide-heading {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.slide-desc {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-sub);
+}
+
+/* Radio States */
+#slide1:checked ~ .carousel-track-container .s1,
+#slide2:checked ~ .carousel-track-container .s2,
+#slide3:checked ~ .carousel-track-container .s3 {
+    display: flex;
+}
+
+.carousel-nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.carousel-dot {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: var(--bg-color);
+    box-shadow: 5px 5px 10px var(--shadow-dark), 
+                -5px -5px 10px var(--shadow-light);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-sub);
+    transition: all 0.2s ease;
+    user-select: none;
+}
+
+.carousel-dot:hover {
+    color: var(--text-main);
+}
+
+.carousel-radio {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Active Dot Indicator States */
+#slide1:checked ~ .carousel-nav label[for="slide1"],
+#slide2:checked ~ .carousel-nav label[for="slide2"],
+#slide3:checked ~ .carousel-nav label[for="slide3"] {
+    background-color: var(--bg-color);
+    box-shadow: inset 3px 3px 6px var(--shadow-dark), 
+                inset -3px -3px 6px var(--shadow-light);
+    color: var(--accent-amber);
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 480px) {
+    .carousel-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Neumorphic Carousel with Retro styling** component (#78606).
gssoc 26

Closes #78606

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-retro-neumorphic-carousel/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A retro neumorphic carousel component featuring zero-JavaScript slide switching, dual-shadow soft surface extrusion, and inset navigation dots.

**How does it work?**
Constructed using hidden radio input elements combined with CSS sibling selectors (`~`) to toggle slide visibility and depressed dot states without JS.