### PR TITLE
feat: implement Hover Input Field with Retro styling #78779

### DIFF
--- a/submissions/examples/css-retro-hover-input-field/README.md
+++ b/submissions/examples/css-retro-hover-input-field/README.md
@@ -1,0 +1,13 @@
+# Hover Input Field with Retro Styling (#78779)
+
+A retro-styled neumorphic input field component featuring inset shadow depth shifts on hover, amber focus highlights, and responsive container scaling.
+
+## Features
+- **Neumorphic Inset Depth:** Smooth transition between standard inset shadow depths and intensified focus states.
+- **Retro Amber Accents:** Responsive label and text coloring triggered upon hovering and typing.
+- **Fully Responsive:** Fluid container layout scaling cleanly across all viewports.
+
+## File Hierarchy
+- `style.css` - Custom properties, neumorphic shadow tokens, hover/focus states, and media queries.
+- `demo.html` - Semantic markup demonstrating input integration with accessibility labels.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-retro-hover-input-field/demo.html
+++ b/submissions/examples/css-retro-hover-input-field/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Input Field with Retro Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="input-card" role="region" aria-label="Input field container">
+        <div class="input-group">
+            <label for="retroField" class="input-label">Username ID</label>
+            <input type="text" id="retroField" class="retro-input" placeholder="Enter operator handle..." autocomplete="off">
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-retro-hover-input-field/style.css
+++ b/submissions/examples/css-retro-hover-input-field/style.css
@@ -1,0 +1,92 @@
+/* CSS Hover Input Field with Retro Styling #78779 */
+
+:root {
+    --bg-color: #e4ebf5;
+    --shadow-light: #ffffff;
+    --shadow-dark: #c5d9e8;
+    --accent-amber: #d97706;
+    --text-main: #334155;
+    --text-sub: #64748b;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-color);
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.input-card {
+    background-color: var(--bg-color);
+    border-radius: 28px;
+    padding: 3rem;
+    box-shadow: 10px 10px 20px var(--shadow-dark), 
+                -10px -10px 20px var(--shadow-light);
+    max-width: 460px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.input-group {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.input-label {
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-sub);
+    transition: color 0.2s ease;
+}
+
+.retro-input {
+    width: 100%;
+    padding: 1rem 1.25rem;
+    background-color: var(--bg-color);
+    border: none;
+    border-radius: 14px;
+    font-size: 1rem;
+    color: var(--text-main);
+    box-shadow: inset 4px 4px 8px var(--shadow-dark), 
+                inset -4px -4px 8px var(--shadow-light);
+    outline: none;
+    transition: all 0.25s ease;
+}
+
+.retro-input::placeholder {
+    color: #94a3b8;
+}
+
+/* Hover and Focus Neumorphic Transitions */
+.retro-input:hover {
+    box-shadow: inset 5px 5px 10px var(--shadow-dark), 
+                inset -5px -5px 10px var(--shadow-light);
+}
+
+.retro-input:focus {
+    box-shadow: inset 6px 6px 12px var(--shadow-dark), 
+                inset -6px -6px 12px var(--shadow-light);
+    color: var(--accent-amber);
+}
+
+.input-group:hover .input-label {
+    color: var(--accent-amber);
+}
+
+@media (max-width: 480px) {
+    .input-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Hover Input Field with Retro styling** component (#78779).
gssoc 26

Closes #78779

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-retro-hover-input-field/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A retro neumorphic text input component featuring inset shadow depth changes on hover, amber focus highlights, and fluid container padding.

**How does it work?**
Constructed using CSS Flexbox layout, multi-layered inset box-shadow offsets, and pseudo-class selectors (`:hover`, `:focus`) for smooth interactive feedback.