### PR TITLE
feat: add pure CSS Glassmorphism Dropdown with Dark Mode styling (#78775)

### DIFF
--- a/submissions/examples/css-dropdown-glassmorphism-dark-pure/README.md
+++ b/submissions/examples/css-dropdown-glassmorphism-dark-pure/README.md
@@ -1,0 +1,22 @@
+# Dropdown: Glassmorphism Dark Mode
+
+A pure CSS, stateful dropdown menu featuring a sleek dark mode glassmorphism aesthetic, animated backdrop blurs, and CSS-only interaction logic.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Glassmorphism in Dark Mode**: Utilizes a deep `#0f172a` base background. The glass effect is achieved using a semi-transparent dark background (`rgba(30, 41, 59, 0.4)`) combined with `backdrop-filter: blur(12px)`. Subtle white borders (`rgba(255, 255, 255, 0.1)`) create the sharp edge reflections typical of glass.
+  - **Refraction Blobs**: Includes animated, heavily blurred (`blur(80px)`) background `.blob` elements positioned behind the dropdown. As these blobs slowly drift, their colors refract through the glass UI elements, enhancing the translucent effect.
+  - **Pure CSS State Management**: The open/closed state of the dropdown is managed entirely without JavaScript using the "Checkbox Hack". 
+    - A hidden `<input type="checkbox" id="dropdown-toggle">` acts as the state container.
+    - The visible trigger button is actually a `<label for="dropdown-toggle">`. Clicking the label toggles the hidden checkbox.
+    - The General Sibling Combinator (`~`) is used to style the menu based on the checkbox state: `.dropdown-checkbox:checked ~ .dropdown-menu { opacity: 1; visibility: visible; transform: scale(1); }`.
+  - **Interaction Details**: Features a rotating chevron icon on open, subtle hover indentations on menu items, and a distinct red hover state for the "Logout" action.
+- Accessible semantic structure. Uses appropriate ARIA roles (`role="button"`, `role="listbox"`, `role="option"`) to map the checkbox hack back to standard dropdown semantics for screen readers. Honors the `prefers-reduced-motion` standard.
+
+## Usage
+Open `demo.html` in your browser. Click the "Select an option" trigger to reveal the glass dropdown menu.
+
+## Files
+- `demo.html`: The HTML structure defining the checkbox hack and the glass UI layers.
+- `style.css`: The styling, the `backdrop-filter` rules, and the `~` combinator state logic.

--- a/submissions/examples/css-dropdown-glassmorphism-dark-pure/demo.html
+++ b/submissions/examples/css-dropdown-glassmorphism-dark-pure/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dropdown: Glassmorphism Dark Mode</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="background-decor">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Glassmorphism Dropdown</h1>
+            <p>Pure CSS state management in a deep dark aesthetic.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Pure CSS Dropdown Component -->
+            <div class="glass-dropdown">
+                
+                <!-- Checkbox hack for state management -->
+                <input type="checkbox" id="dropdown-toggle" class="dropdown-checkbox" aria-hidden="true">
+                
+                <label for="dropdown-toggle" class="dropdown-trigger" role="button" aria-haspopup="listbox" aria-expanded="false">
+                    <span class="selected-text">Select an option</span>
+                    <svg class="chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                </label>
+                
+                <div class="dropdown-menu" role="listbox">
+                    <div class="dropdown-item" role="option">Dashboard</div>
+                    <div class="dropdown-item" role="option">Settings</div>
+                    <div class="dropdown-item" role="option">Analytics</div>
+                    <div class="dropdown-divider"></div>
+                    <div class="dropdown-item danger" role="option">Logout</div>
+                </div>
+
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-dropdown-glassmorphism-dark-pure/style.css
+++ b/submissions/examples/css-dropdown-glassmorphism-dark-pure/style.css
@@ -1,0 +1,229 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500&display=swap');
+
+/* =========================================
+   Theming (Dark Mode Glassmorphism)
+   ========================================= */
+:root {
+    --bg-color: #0f172a;
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    
+    /* Glass Properties */
+    --glass-bg: rgba(30, 41, 59, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --glass-highlight: rgba(255, 255, 255, 0.05);
+    
+    /* Colors */
+    --accent: #3b82f6;
+    --danger: #ef4444;
+    
+    --transition-smooth: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    font-family: 'Outfit', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
+}
+
+
+/* =========================================
+   Background Blobs for Glass Refraction
+   ========================================= */
+.background-decor {
+    position: absolute;
+    top: 0; left: 0; width: 100%; height: 100%;
+    z-index: -1;
+    overflow: hidden;
+}
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.5;
+}
+.blob-1 {
+    top: 20%;
+    left: 30%;
+    width: 300px;
+    height: 300px;
+    background: #3b82f6;
+    animation: drift 10s ease-in-out infinite alternate;
+}
+.blob-2 {
+    bottom: 20%;
+    right: 30%;
+    width: 250px;
+    height: 250px;
+    background: #8b5cf6;
+    animation: drift 12s ease-in-out infinite alternate-reverse;
+}
+
+@keyframes drift {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(40px, -40px) scale(1.1); }
+}
+
+
+/* =========================================
+   Layout
+   ========================================= */
+.container {
+    text-align: center;
+    z-index: 1;
+}
+
+.header { margin-bottom: 50px; }
+.title { font-size: 2.5rem; font-weight: 500; margin-bottom: 10px; }
+.header p { color: var(--text-secondary); font-weight: 300; }
+
+
+/* =========================================
+   [TECHNIQUE] Glassmorphism Dropdown
+   ========================================= */
+.glass-dropdown {
+    position: relative;
+    width: 260px;
+    margin: 0 auto;
+    text-align: left;
+}
+
+/* Hide the checkbox used for state management */
+.dropdown-checkbox {
+    display: none;
+}
+
+/* 
+   The Trigger Button 
+*/
+.dropdown-trigger {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border);
+    border-radius: 12px;
+    
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 400;
+    color: var(--text-primary);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    
+    transition: background var(--transition-smooth), border-color var(--transition-smooth);
+}
+
+.dropdown-trigger:hover {
+    background: rgba(30, 41, 59, 0.6);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.chevron {
+    transition: transform var(--transition-smooth);
+}
+
+/* 
+   The Menu 
+*/
+.dropdown-menu {
+    position: absolute;
+    top: calc(100% + 10px);
+    left: 0;
+    width: 100%;
+    
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 12px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+    
+    padding: 8px 0;
+    overflow: hidden;
+    
+    /* Initial Hidden State */
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px) scale(0.95);
+    transition: opacity var(--transition-smooth),
+                transform var(--transition-smooth),
+                visibility var(--transition-smooth);
+    
+    /* Ensure it sits above other content */
+    z-index: 10;
+}
+
+/* 
+   State Management (Checkbox Hack)
+   When checked, reveal the menu and rotate the chevron
+*/
+.dropdown-checkbox:checked ~ .dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+}
+
+.dropdown-checkbox:checked ~ .dropdown-trigger .chevron {
+    transform: rotate(180deg);
+}
+
+.dropdown-checkbox:checked ~ .dropdown-trigger {
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1);
+}
+
+
+/* 
+   Menu Items 
+*/
+.dropdown-item {
+    padding: 12px 20px;
+    cursor: pointer;
+    transition: background var(--transition-smooth), color var(--transition-smooth);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.dropdown-item:hover {
+    background: var(--glass-highlight);
+    padding-left: 24px; /* Subtle indent effect on hover */
+}
+
+.dropdown-divider {
+    height: 1px;
+    background: var(--glass-border);
+    margin: 8px 0;
+}
+
+.dropdown-item.danger {
+    color: var(--danger);
+}
+.dropdown-item.danger:hover {
+    background: rgba(239, 68, 68, 0.1);
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .blob {
+        animation: none !important;
+    }
+    .dropdown-menu,
+    .chevron,
+    .dropdown-item {
+        transition: none !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a pure CSS, stateful dropdown menu featuring a sleek dark mode glassmorphism aesthetic, animated backdrop blurs, and CSS-only interaction logic. Resolves issue #78775.

### Changes Made:
- Added `submissions/examples/css-dropdown-glassmorphism-dark-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the checkbox hack and the glass UI layers.
- Created `style.css` featuring the UI mechanics:
  - **Glassmorphism in Dark Mode**: Utilizes a deep `#0f172a` base background. The glass effect is achieved using a semi-transparent dark background (`rgba(30, 41, 59, 0.4)`) combined with `backdrop-filter: blur(12px)`. Subtle white borders (`rgba(255, 255, 255, 0.1)`) create the sharp edge reflections typical of glass.
  - **Refraction Blobs**: Includes animated, heavily blurred (`blur(80px)`) background `.blob` elements positioned behind the dropdown. As these blobs slowly drift, their colors refract through the glass UI elements, enhancing the translucent effect.
  - **Pure CSS State Management**: The open/closed state of the dropdown is managed entirely without JavaScript using the "Checkbox Hack". 
    - A hidden `<input type="checkbox" id="dropdown-toggle">` acts as the state container.
    - The visible trigger button is actually a `<label for="dropdown-toggle">`. Clicking the label toggles the hidden checkbox.
    - The General Sibling Combinator (`~`) is used to style the menu based on the checkbox state: `.dropdown-checkbox:checked ~ .dropdown-menu { opacity: 1; visibility: visible; transform: scale(1); }`.
  - **Interaction Details**: Features a rotating chevron icon on open, subtle hover indentations on menu items, and a distinct red hover state for the "Logout" action.
- Added `README.md` documenting usage and the technical mechanics of the state management and `backdrop-filter` rules.
- Accessible semantic structure. Uses appropriate ARIA roles (`role="button"`, `role="listbox"`, `role="option"`) to map the checkbox hack back to standard dropdown semantics for screen readers. Honors the `prefers-reduced-motion` standard.

Closes #78775
