### PR TITLE
feat: add pure CSS Interactive Spinner with Neumorphism styling (#78774)

### DIFF
--- a/submissions/examples/css-interactive-spinner-neumorphism-pure/README.md
+++ b/submissions/examples/css-interactive-spinner-neumorphism-pure/README.md
@@ -1,0 +1,22 @@
+# Interactive Spinner: Neumorphism
+
+A pure CSS loading spinner wrapped in a Neumorphic (soft UI) button shell, featuring stateful CSS animations that react to hover and click interactions.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Neumorphism Aesthetics**: Built on a solid `#e0e5ec` base color. The visual extrusion is achieved by applying two opposing box shadows: a light shadow on the top-left (`-9px -9px 16px rgba(255,255,255, 0.5)`) and a dark shadow on the bottom-right (`9px 9px 16px rgb(163,177,198,0.6)`).
+  - **Masked Conic Gradient**: The actual spinning element (`.spinner-ring`) is created using a `conic-gradient()` that sweeps from transparent to an accent blue. Instead of layering a solid circle over it, we use CSS masks (`mask-image: radial-gradient(transparent 55%, black 56%)`) to hollow out the center, creating a true ring.
+  - **Interactive State Transitions**:
+    - **Hover**: The `.spinner-trigger:hover` state accelerates the `animation-duration` of the ring from 2s to 0.8s and applies a CSS `filter: drop-shadow()` to make the accent color glow.
+    - **Active (Click)**: The `.spinner-trigger:active` state reverses the shadow logic. It changes the outer track's `box-shadow` from external to `inset`, simulating the physical button being pressed down into the surface. Concurrently, it switches the spin animation to run in reverse.
+- Accessible semantic structure. Uses a native `<button>` with an `aria-label` to ensure the interaction is accessible. Honors the `prefers-reduced-motion` standard by removing the spin animation entirely and defaulting to a solid static ring for users who request reduced motion.
+
+## Usage
+Open `demo.html` in your browser. You will see a soft, extruded circular button with a slowly rotating blue ring. 
+- **Hover** over the button to see the spinner accelerate and glow.
+- **Click and hold** the button to see the neumorphic shadows invert (deboss) and the spinner reverse direction.
+
+## Files
+- `demo.html`: The HTML structure defining the nested layers (trigger > track > ring > hub).
+- `style.css`: The styling, the neumorphic shadow logic, and the interactive keyframe animations.

--- a/submissions/examples/css-interactive-spinner-neumorphism-pure/demo.html
+++ b/submissions/examples/css-interactive-spinner-neumorphism-pure/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Spinner: Neumorphism</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Interactive Spinner</h1>
+            <p>Soft UI mechanics. Hover to accelerate, click to invert.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Neumorphic Interactive Spinner Component -->
+            <div class="neumorphic-container">
+                
+                <!-- The interactive wrapper -->
+                <button class="spinner-trigger" aria-label="Loading indicator (interactive)">
+                    
+                    <!-- The outer track (embossed) -->
+                    <div class="spinner-track">
+                        
+                        <!-- The spinning inner element -->
+                        <div class="spinner-ring"></div>
+                        
+                        <!-- The central hub (debossed on click) -->
+                        <div class="spinner-hub">
+                            <svg class="icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>
+                                <path d="M21 3v5h-5"></path>
+                            </svg>
+                        </div>
+                        
+                    </div>
+                    
+                </button>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-interactive-spinner-neumorphism-pure/style.css
+++ b/submissions/examples/css-interactive-spinner-neumorphism-pure/style.css
@@ -1,0 +1,195 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600&display=swap');
+
+/* =========================================
+   Theming (Neumorphism / Soft UI)
+   ========================================= */
+:root {
+    /* Soft UI Base Color */
+    --base-color: #e0e5ec;
+    --text-primary: #4a5568;
+    --text-secondary: #a0aec0;
+    
+    /* Shadows for extrusion (outward) */
+    --shadow-light: 9px 9px 16px rgb(163,177,198,0.6), -9px -9px 16px rgba(255,255,255, 0.5);
+    /* Shadows for intrusion (inward/pressed) */
+    --shadow-inset: inset 6px 6px 10px 0 rgba(163,177,198, 0.7), inset -6px -6px 10px 0 rgba(255,255,255, 0.8);
+    
+    --accent: #667eea;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--base-color);
+    color: var(--text-primary);
+    font-family: 'Nunito', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+
+/* =========================================
+   Layout
+   ========================================= */
+.container {
+    text-align: center;
+}
+
+.header { margin-bottom: 60px; }
+.title { font-size: 2.2rem; font-weight: 600; margin-bottom: 8px; color: var(--text-primary); }
+.header p { color: var(--text-secondary); font-weight: 400; }
+
+.neumorphic-container {
+    display: flex;
+    justify-content: center;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Neumorphic Interactive Spinner
+   ========================================= */
+   
+/* 
+   The outer invisible button wrapper to capture interactions 
+*/
+.spinner-trigger {
+    background: transparent;
+    border: none;
+    padding: 20px;
+    cursor: pointer;
+    outline: none;
+    border-radius: 50%;
+    /* Subtle transition on the wrapper itself */
+    transition: transform 0.2s ease;
+}
+.spinner-trigger:focus-visible {
+    border: 2px dashed var(--accent);
+}
+
+/* 
+   The Outer Track (Embossed Base) 
+*/
+.spinner-track {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background-color: var(--base-color);
+    box-shadow: var(--shadow-light);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: box-shadow 0.3s ease;
+}
+
+/* 
+   The Spinning Ring (The actual loader)
+*/
+.spinner-ring {
+    position: absolute;
+    top: 5px; left: 5px; right: 5px; bottom: 5px;
+    border-radius: 50%;
+    /* Conic gradient to create the swoosh effect */
+    background: conic-gradient(from 0deg, transparent 0%, transparent 60%, var(--accent) 100%);
+    /* Mask the center to create a ring instead of a full circle */
+    -webkit-mask-image: radial-gradient(transparent 55%, black 56%);
+    mask-image: radial-gradient(transparent 55%, black 56%);
+    
+    /* Default spin animation */
+    animation: spin 2s linear infinite;
+    /* Smooth transition for when we change the animation speed on hover */
+    transition: filter 0.3s ease;
+}
+
+/* 
+   The Central Hub (Solid center)
+*/
+.spinner-hub {
+    position: relative;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background-color: var(--base-color);
+    /* Initially slightly extruded to match the track */
+    box-shadow: 4px 4px 8px rgb(163,177,198,0.4), -4px -4px 8px rgba(255,255,255, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--text-secondary);
+    transition: box-shadow 0.3s ease, color 0.3s ease;
+    z-index: 2; /* Keep above the spinning ring */
+}
+
+.icon {
+    /* Subtle pulsing to indicate it's active */
+    animation: pulse 2s ease-in-out infinite;
+}
+
+
+/* =========================================
+   Interactive States
+   ========================================= */
+
+/* 1. Hover State: Accelerate and Glow */
+.spinner-trigger:hover .spinner-ring {
+    /* Accelerate the spin */
+    animation: spin 0.8s linear infinite;
+    /* Add a subtle glow */
+    filter: drop-shadow(0 0 4px var(--accent));
+}
+.spinner-trigger:hover .spinner-hub {
+    color: var(--accent);
+}
+
+/* 2. Active/Click State: Invert Shadows (Deboss) */
+.spinner-trigger:active {
+    transform: scale(0.97);
+}
+.spinner-trigger:active .spinner-track {
+    /* Invert the track shadow to look pressed in */
+    box-shadow: var(--shadow-inset);
+}
+.spinner-trigger:active .spinner-hub {
+    /* Invert the hub shadow to match */
+    box-shadow: inset 3px 3px 6px 0 rgba(163,177,198, 0.6), inset -3px -3px 6px 0 rgba(255,255,255, 0.6);
+}
+.spinner-trigger:active .spinner-ring {
+    /* Reverse direction on click */
+    animation: spin-reverse 0.6s linear infinite;
+}
+
+
+/* =========================================
+   Keyframes
+   ========================================= */
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+@keyframes spin-reverse {
+    0% { transform: rotate(360deg); }
+    100% { transform: rotate(0deg); }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.6; transform: scale(0.95); }
+    50% { opacity: 1; transform: scale(1.05); }
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .spinner-ring,
+    .icon {
+        animation: none !important;
+    }
+    .spinner-trigger:hover .spinner-ring {
+        animation: none !important;
+        /* Fallback: just show the full ring without spinning */
+        background: conic-gradient(from 0deg, var(--accent) 0%, var(--accent) 100%);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS loading spinner wrapped in a Neumorphic (soft UI) button shell, featuring stateful CSS animations that react to hover and click interactions. Resolves issue #78774.

### Changes Made:
- Added `submissions/examples/css-interactive-spinner-neumorphism-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the nested layers (trigger > track > ring > hub).
- Created `style.css` featuring the UI mechanics:
  - **Neumorphism Aesthetics**: Built on a solid `#e0e5ec` base color. The visual extrusion is achieved by applying two opposing box shadows: a light shadow on the top-left (`-9px -9px 16px rgba(255,255,255, 0.5)`) and a dark shadow on the bottom-right (`9px 9px 16px rgb(163,177,198,0.6)`).
  - **Masked Conic Gradient**: The actual spinning element (`.spinner-ring`) is created using a `conic-gradient()` that sweeps from transparent to an accent blue. Instead of layering a solid circle over it, we use CSS masks (`mask-image: radial-gradient(transparent 55%, black 56%)`) to hollow out the center, creating a true ring.
  - **Interactive State Transitions**:
    - **Hover**: The `.spinner-trigger:hover` state accelerates the `animation-duration` of the ring from 2s to 0.8s and applies a CSS `filter: drop-shadow()` to make the accent color glow.
    - **Active (Click)**: The `.spinner-trigger:active` state reverses the shadow logic. It changes the outer track's `box-shadow` from external to `inset`, simulating the physical button being pressed down into the surface. Concurrently, it switches the spin animation to run in reverse.
- Added `README.md` documenting usage and the technical mechanics of the neumorphic shadow logic and interactive keyframe animations.
- Accessible semantic structure. Uses a native `<button>` with an `aria-label` to ensure the interaction is accessible. Honors the `prefers-reduced-motion` standard by removing the spin animation entirely and defaulting to a solid static ring for users who request reduced motion.

Closes #78774
