### PR TITLE
feat: add neon interactive slider component

### DIFF
--- a/submissions/examples/ease-neon-interactive-slider/README.md
+++ b/submissions/examples/ease-neon-interactive-slider/README.md
@@ -1,0 +1,36 @@
+@'
+# Ease Neon Interactive Slider
+
+## Description
+A range slider styled with a glowing neon aesthetic - animated fill track, glowing thumb, and hover/active glow intensification. Includes pink and lime tinted variants alongside the default cyan.
+
+## Usage
+```html
+<div class="ease-neon-slider">
+  <div class="slider-label-row">
+    <span class="slider-name">Brightness</span>
+    <span class="slider-value" data-value>50%</span>
+  </div>
+  <input type="range" min="0" max="100" value="50" style="--slider-percent: 50%;" />
+</div>
+<script>
+  // update --slider-percent and the label text on input, see demo.html
+</script>
+```
+
+## Customization (CSS custom properties)
+- --slider-fill-color: #00f0ff
+- --slider-glow: rgba(0, 240, 255, 0.6)
+- --slider-thumb-size: 22px
+- --slider-height: 8px
+
+Add tint-pink or tint-lime classes for alternate color schemes.
+
+## Accessibility
+Built on a native input type="range", so keyboard arrow-key control works out of the box. Respects prefers-reduced-motion.
+
+## Files
+- demo.html
+- style.css
+- README.md
+'@ | Set-Content -Path submissions\examples\ease-neon-interactive-slider\README.md

--- a/submissions/examples/ease-neon-interactive-slider/demo.html
+++ b/submissions/examples/ease-neon-interactive-slider/demo.html
@@ -1,0 +1,54 @@
+@'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ease Neon Interactive Slider - Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+body { margin: 0; min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 34px; background: #05050a; padding: 40px; box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div class="ease-neon-slider">
+  <div class="slider-label-row">
+    <span class="slider-name">Brightness</span>
+    <span class="slider-value" data-value>50%</span>
+  </div>
+  <div class="slider-track-wrap">
+    <input type="range" min="0" max="100" value="50" style="--slider-percent: 50%;" />
+  </div>
+</div>
+<div class="ease-neon-slider tint-pink">
+  <div class="slider-label-row">
+    <span class="slider-name">Volume</span>
+    <span class="slider-value" data-value>70%</span>
+  </div>
+  <div class="slider-track-wrap">
+    <input type="range" min="0" max="100" value="70" style="--slider-percent: 70%;" />
+  </div>
+</div>
+<div class="ease-neon-slider tint-lime">
+  <div class="slider-label-row">
+    <span class="slider-name">Speed</span>
+    <span class="slider-value" data-value>30%</span>
+  </div>
+  <div class="slider-track-wrap">
+    <input type="range" min="0" max="100" value="30" style="--slider-percent: 30%;" />
+  </div>
+</div>
+
+<script>
+  document.querySelectorAll(".ease-neon-slider").forEach(function (widget) {
+    var input = widget.querySelector("input[type=range]");
+    var label = widget.querySelector("[data-value]");
+    input.addEventListener("input", function () {
+      label.textContent = input.value + "%";
+      input.style.setProperty("--slider-percent", input.value + "%");
+    });
+  });
+</script>
+</body>
+</html>
+'@ | Set-Content -Path submissions\examples\ease-neon-interactive-slider\demo.html

--- a/submissions/examples/ease-neon-interactive-slider/style.css
+++ b/submissions/examples/ease-neon-interactive-slider/style.css
@@ -1,0 +1,87 @@
+.ease-neon-slider {
+  --slider-track-bg: #1a1a2e;
+  --slider-fill-color: #00f0ff;
+  --slider-fill-color-2: #ff00c8;
+  --slider-thumb-color: #ffffff;
+  --slider-glow: rgba(0, 240, 255, 0.6);
+  --slider-height: 8px;
+  --slider-thumb-size: 22px;
+  --slider-duration: 0.2s;
+  width: min(320px, 90vw);
+  font-family: system-ui, sans-serif;
+}
+.ease-neon-slider .slider-label-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  font-size: 0.8rem;
+}
+.ease-neon-slider .slider-name {
+  color: #f5f7fa;
+  font-weight: 600;
+}
+.ease-neon-slider .slider-value {
+  color: var(--slider-fill-color);
+  font-weight: 700;
+  text-shadow: 0 0 8px var(--slider-glow);
+}
+.ease-neon-slider .slider-track-wrap {
+  position: relative;
+}
+.ease-neon-slider input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: var(--slider-height);
+  border-radius: 999px;
+  background: linear-gradient(to right, var(--slider-fill-color) 0%, var(--slider-fill-color) var(--slider-percent, 50%), var(--slider-track-bg) var(--slider-percent, 50%), var(--slider-track-bg) 100%);
+  outline: none;
+  cursor: pointer;
+  box-shadow: 0 0 12px var(--slider-glow), inset 0 0 4px rgba(0,0,0,0.4);
+  transition: box-shadow var(--slider-duration) ease;
+}
+.ease-neon-slider input[type="range"]:hover {
+  box-shadow: 0 0 20px var(--slider-glow), inset 0 0 4px rgba(0,0,0,0.4);
+}
+.ease-neon-slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background: var(--slider-thumb-color);
+  border: 2px solid var(--slider-fill-color);
+  box-shadow: 0 0 10px var(--slider-glow), 0 0 20px var(--slider-glow);
+  cursor: pointer;
+  transition: transform var(--slider-duration) ease, box-shadow var(--slider-duration) ease;
+}
+.ease-neon-slider input[type="range"]:active::-webkit-slider-thumb {
+  transform: scale(1.25);
+  box-shadow: 0 0 16px var(--slider-glow), 0 0 32px var(--slider-glow);
+}
+.ease-neon-slider input[type="range"]::-moz-range-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border: 2px solid var(--slider-fill-color);
+  border-radius: 50%;
+  background: var(--slider-thumb-color);
+  box-shadow: 0 0 10px var(--slider-glow), 0 0 20px var(--slider-glow);
+  cursor: pointer;
+}
+.ease-neon-slider input[type="range"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(0,240,255,0.3), 0 0 20px var(--slider-glow);
+}
+.ease-neon-slider.tint-pink {
+  --slider-fill-color: #ff00c8;
+  --slider-glow: rgba(255, 0, 200, 0.6);
+}
+.ease-neon-slider.tint-lime {
+  --slider-fill-color: #a3ff00;
+  --slider-glow: rgba(163, 255, 0, 0.6);
+}
+@media (prefers-reduced-motion: reduce) {
+  .ease-neon-slider input[type="range"],
+  .ease-neon-slider input[type="range"]::-webkit-slider-thumb {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #78728

## Pull Request Description
Adds a range slider styled with a glowing neon aesthetic — animated fill track that visually tracks the thumb position, a glowing thumb with hover/active glow intensification, and pink/lime tinted color variants alongside the default cyan.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-neon-interactive-slider/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Fully responsive
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A neon-styled range slider (`ease-neon-slider`) with a glowing gradient fill track, a glowing thumb that intensifies on hover/active, and tint variants (`tint-pink`, `tint-lime`) for alternate color schemes.

**How does a developer use it?**
```html
<div class="ease-neon-slider">
  <div class="slider-label-row">
    <span class="slider-name">Brightness</span>
    <span class="slider-value" data-value>50%</span>
  </div>
  <input type="range" min="0" max="100" value="50" style="--slider-percent: 50%;" />
</div>
<script>
  // updates --slider-percent and the label text on input — see demo.html
</script>
```

**Why does it fit EaseMotion CSS?**
Built on a native `<input type="range">` for full keyboard accessibility out of the box, with all glow/fill/hover styling handled in CSS via custom properties (`--slider-fill-color`, `--slider-glow`, `--slider-thumb-size`, `--slider-duration`) — no core rule changes needed. JavaScript is limited to syncing the fill position and label text on input; no visual logic lives in JS. Respects `prefers-reduced-motion` by disabling transitions.

---

## Demo
- [x] Demo added (`demo.html` — three sliders: default cyan, pink tint, lime tint)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Requirements only specified "fully responsive" and "HTML/CSS or React/SCSS" with no further detail, so I implemented a standard neon-glow range slider with color variants as a sensible interpretation. Happy to adjust if a more specific spec was intended.