### PR TITLE
feat: add pure CSS Glassmorphism Tab Bar with Material Design styling(#78765)

### DIFF
--- a/submissions/examples/css-tabbar-glassmorphism-material-pure/README.md
+++ b/submissions/examples/css-tabbar-glassmorphism-material-pure/README.md
@@ -1,0 +1,20 @@
+# Glassmorphism Tab Bar: Material Design
+
+A pure CSS tab bar that merges the frosted-glass aesthetic of Glassmorphism with the interactive animations and easing curves of Material Design.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Glassmorphism Aesthetics**: Built using `backdrop-filter: blur(16px)` over a semi-transparent `rgba(255, 255, 255, 0.05)` background to create a frosted glass surface. Animated floating blobs in the background are used to demonstrate the refraction effect.
+  - **Pure CSS State Management**: Uses the "Radio Hack" to maintain state. Hidden `<input type="radio">` buttons track which tab is active, while the visible `<label>` elements serve as the interactive touch targets.
+  - **Material Sliding Indicator**: Uses the General Sibling Combinator (`~`) to animate a shared `.tab-indicator` element. Depending on which radio button is checked, the indicator slides to the corresponding index via `transform: translateX(100%)`, etc.
+  - **Material Morphing Labels**: The active tab dynamically reveals its text label (`max-height` and `opacity` transition) while shifting its icon upwards, a pattern common in Material Design bottom navigation bars.
+  - **Material Easing**: Utilizes the standard Material Design transition curve (`cubic-bezier(0.4, 0.0, 0.2, 1)`) for all sliding and morphing animations to ensure authentic motion.
+- Accessible semantic structure. Uses appropriate ARIA roles (`role="tablist"`, `role="tab"`) and honors the `prefers-reduced-motion` standard.
+
+## Usage
+Open `demo.html` in your browser. Click through the tabs to observe the active indicator slide into place and the tab labels smoothly morph open.
+
+## Files
+- `demo.html`: The HTML structure defining the radio hack, the labels, and the shared indicator.
+- `style.css`: The styling, Glassmorphism backdrop-filters, and the `~` combinator state logic.

--- a/submissions/examples/css-tabbar-glassmorphism-material-pure/demo.html
+++ b/submissions/examples/css-tabbar-glassmorphism-material-pure/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Tab Bar: Material Design</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Background decoration for glassmorphism refraction -->
+    <div class="background-decor">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
+
+    <div class="container">
+        <header class="header">
+            <h1 class="title">Glass Material Tabs</h1>
+            <p>Glassmorphism aesthetics meets Material Design interaction.</p>
+        </header>
+
+        <main class="content-area">
+            
+            <!-- Tab Bar Component -->
+            <div class="glass-tab-bar" role="tablist">
+                
+                <!-- Radio buttons for state management -->
+                <input type="radio" name="tabs" id="tab-1" class="tab-radio" checked aria-hidden="true">
+                <input type="radio" name="tabs" id="tab-2" class="tab-radio" aria-hidden="true">
+                <input type="radio" name="tabs" id="tab-3" class="tab-radio" aria-hidden="true">
+                <input type="radio" name="tabs" id="tab-4" class="tab-radio" aria-hidden="true">
+
+                <!-- Tab Labels (The clickable areas) -->
+                <label for="tab-1" class="tab-label" role="tab" aria-selected="true" tabindex="0">
+                    <span class="material-icons tab-icon">home</span>
+                    <span class="tab-text">Home</span>
+                </label>
+                
+                <label for="tab-2" class="tab-label" role="tab" aria-selected="false" tabindex="0">
+                    <span class="material-icons tab-icon">search</span>
+                    <span class="tab-text">Search</span>
+                </label>
+                
+                <label for="tab-3" class="tab-label" role="tab" aria-selected="false" tabindex="0">
+                    <span class="material-icons tab-icon">notifications</span>
+                    <span class="tab-text">Alerts</span>
+                </label>
+                
+                <label for="tab-4" class="tab-label" role="tab" aria-selected="false" tabindex="0">
+                    <span class="material-icons tab-icon">person</span>
+                    <span class="tab-text">Profile</span>
+                </label>
+
+                <!-- The Material Design Active Indicator -->
+                <div class="tab-indicator"></div>
+                
+            </div>
+            
+        </main>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-tabbar-glassmorphism-material-pure/style.css
+++ b/submissions/examples/css-tabbar-glassmorphism-material-pure/style.css
@@ -1,0 +1,224 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap');
+
+/* =========================================
+   Theming (Glassmorphism + Material)
+   ========================================= */
+:root {
+    --bg-color: #0f172a;
+    --primary-color: #00e5ff;
+    
+    --glass-bg: rgba(255, 255, 255, 0.05);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --glass-blur: blur(16px);
+    
+    --text-high: rgba(255, 255, 255, 0.87);
+    --text-medium: rgba(255, 255, 255, 0.60);
+    
+    --hover-overlay: rgba(255, 255, 255, 0.08);
+    
+    /* Material standard easing for indicator */
+    --md-ease: cubic-bezier(0.4, 0.0, 0.2, 1);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-high);
+    font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+
+
+/* =========================================
+   Background Decors for Refraction
+   ========================================= */
+.background-decor {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: -1;
+    overflow: hidden;
+}
+
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.6;
+}
+
+.blob-1 {
+    width: 300px; height: 300px;
+    background-color: #00e5ff;
+    top: 20%; left: 30%;
+    animation: float 12s ease-in-out infinite alternate;
+}
+
+.blob-2 {
+    width: 250px; height: 250px;
+    background-color: #6200ee;
+    bottom: 20%; right: 30%;
+    animation: float 15s ease-in-out infinite alternate-reverse;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(50px, -50px) scale(1.1); }
+}
+
+
+/* =========================================
+   Layout
+   ========================================= */
+.container {
+    text-align: center;
+    width: 100%;
+    padding: 20px;
+    z-index: 1;
+}
+
+.header { margin-bottom: 60px; }
+.title { font-size: 2.125rem; font-weight: 400; margin-bottom: 8px; letter-spacing: 0.25px; }
+.header p { color: var(--text-medium); font-size: 1rem; letter-spacing: 0.15px; }
+
+
+/* =========================================
+   [TECHNIQUE] Glass Material Tab Bar
+   ========================================= */
+.glass-tab-bar {
+    position: relative;
+    width: 400px;
+    max-width: 100%;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    
+    /* Glassmorphism Surface */
+    background: var(--glass-bg);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    padding: 8px 16px;
+    
+    /* Subtle Shadow */
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+}
+
+/* Hide Radio Buttons */
+.tab-radio {
+    display: none;
+}
+
+/* 
+   Tab Labels
+*/
+.tab-label {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 0;
+    cursor: pointer;
+    color: var(--text-medium);
+    border-radius: 12px;
+    transition: color 0.3s var(--md-ease), background-color 0.2s linear;
+    z-index: 2; /* Sit above the indicator */
+}
+
+.tab-label:hover {
+    background-color: var(--hover-overlay);
+}
+
+.tab-icon {
+    font-size: 24px;
+    margin-bottom: 4px;
+    transition: transform 0.3s var(--md-ease);
+}
+
+.tab-text {
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    /* Hide text initially for material morph effect */
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: max-height 0.3s var(--md-ease), opacity 0.3s var(--md-ease);
+}
+
+
+/* 
+   The Material Sliding Indicator
+*/
+.tab-indicator {
+    position: absolute;
+    top: 8px;
+    bottom: 8px;
+    left: 16px; /* Match padding */
+    width: calc((100% - 32px) / 4); /* 4 tabs, minus padding */
+    
+    /* Glassmorphism highlight */
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+    
+    /* The sliding transition */
+    transition: transform 0.4s var(--md-ease);
+    z-index: 1;
+}
+
+/* 
+   State Management (Radio Hack)
+*/
+
+/* 1. Animate the indicator position based on which radio is checked */
+#tab-1:checked ~ .tab-indicator { transform: translateX(0); }
+#tab-2:checked ~ .tab-indicator { transform: translateX(100%); }
+#tab-3:checked ~ .tab-indicator { transform: translateX(200%); }
+#tab-4:checked ~ .tab-indicator { transform: translateX(300%); }
+
+
+/* 2. Style the active tab label */
+#tab-1:checked ~ label[for="tab-1"],
+#tab-2:checked ~ label[for="tab-2"],
+#tab-3:checked ~ label[for="tab-3"],
+#tab-4:checked ~ label[for="tab-4"] {
+    color: var(--primary-color);
+}
+
+/* 3. Reveal the text for the active tab (Material morph effect) */
+#tab-1:checked ~ label[for="tab-1"] .tab-text,
+#tab-2:checked ~ label[for="tab-2"] .tab-text,
+#tab-3:checked ~ label[for="tab-3"] .tab-text,
+#tab-4:checked ~ label[for="tab-4"] .tab-text {
+    max-height: 20px;
+    opacity: 1;
+}
+
+/* 4. Shift icon up slightly when active */
+#tab-1:checked ~ label[for="tab-1"] .tab-icon,
+#tab-2:checked ~ label[for="tab-2"] .tab-icon,
+#tab-3:checked ~ label[for="tab-3"] .tab-icon,
+#tab-4:checked ~ label[for="tab-4"] .tab-icon {
+    transform: translateY(-2px);
+}
+
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .blob,
+    .tab-indicator,
+    .tab-label,
+    .tab-icon,
+    .tab-text {
+        animation: none !important;
+        transition: none !important;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a pure CSS tab bar that merges the frosted-glass aesthetic of Glassmorphism with the interactive animations and easing curves of Material Design. Resolves issue #78765.

### Changes Made:
- Added `submissions/examples/css-tabbar-glassmorphism-material-pure/` directory.
- Created `demo.html` showcasing the HTML structure defining the radio hack, the labels, and the shared indicator.
- Created `style.css` featuring the UI mechanics:
  - **Glassmorphism Aesthetics**: Built using `backdrop-filter: blur(16px)` over a semi-transparent `rgba(255, 255, 255, 0.05)` background to create a frosted glass surface. Animated floating blobs in the background are used to demonstrate the refraction effect.
  - **Pure CSS State Management**: Uses the "Radio Hack" to maintain state. Hidden `<input type="radio">` buttons track which tab is active, while the visible `<label>` elements serve as the interactive touch targets.
  - **Material Sliding Indicator**: Uses the General Sibling Combinator (`~`) to animate a shared `.tab-indicator` element. Depending on which radio button is checked, the indicator slides to the corresponding index via `transform: translateX(100%)`, etc.
  - **Material Morphing Labels**: The active tab dynamically reveals its text label (`max-height` and `opacity` transition) while shifting its icon upwards, a pattern common in Material Design bottom navigation bars.
  - **Material Easing**: Utilizes the standard Material Design transition curve (`cubic-bezier(0.4, 0.0, 0.2, 1)`) for all sliding and morphing animations to ensure authentic motion.
- Added `README.md` documenting usage and the technical mechanics of the sliding indicator logic.
- Accessible semantic structure. Uses appropriate ARIA roles (`role="tablist"`, `role="tab"`) and honors the `prefers-reduced-motion` standard.

Closes #78765
