### PR TITLE
feat: add cyberpunk dynamic button component

### DIFF
--- a/submissions/examples/ease-cyberpunk-dynamic-button/README.md
+++ b/submissions/examples/ease-cyberpunk-dynamic-button/README.md
@@ -1,0 +1,42 @@
+# Ease Cyberpunk Dynamic Button
+
+## Description
+A button styled for cyberpunk interfaces — neon glow border, an animated scan-line sweep on hover, a text glitch-flicker effect on hover, and a rotating conic-gradient neon border chase. Pure CSS, zero JavaScript.
+
+## Features
+- Glowing neon border and text shadow at rest
+- Scan-line light sweep across the button on hover
+- Text glitch-flicker animation (RGB-split style) on hover
+- Rotating neon border chase revealed on hover
+- Pink/cyan `variant-pink` color scheme available
+- Fully responsive (inline-block, scales with content)
+- Respects `prefers-reduced-motion`
+
+## Usage
+```html
+<button type="button" class="ease-cyber-btn">
+  <span class="btn-text">Initialize</span>
+</button>
+
+<button type="button" class="ease-cyber-btn variant-pink">
+  <span class="btn-text">Access Denied</span>
+</button>
+```
+The `<span class="btn-text">` wrapper is required — it's the element the glitch-flicker animation targets.
+
+## Customization (CSS custom properties)
+| Property | Default | Description |
+|---|---|---|
+| `--btn-fg` | `#00f0ff` | Primary neon color (border, text, glow) |
+| `--btn-accent-2` | `#ff00c8` | Secondary color (glitch flicker, border chase, focus outline) |
+| `--btn-glow` | `rgba(0, 240, 255, 0.6)` | Glow shadow color |
+| `--btn-duration` | `0.3s` | Hover transition speed |
+| `--btn-radius` | `6px` | Corner rounding |
+
+## Accessibility
+Standard `<button>` element with visible `:focus-visible` outline. Respects `prefers-reduced-motion` by disabling the scan-line sweep, border chase, and glitch flicker animations entirely.
+
+## Files
+- `demo.html` — live example with default and pink variants
+- `style.css` — component styles and all animations
+- `README.md` — this file

--- a/submissions/examples/ease-cyberpunk-dynamic-button/demo.html
+++ b/submissions/examples/ease-cyberpunk-dynamic-button/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ease Cyberpunk Dynamic Button — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 24px;
+      align-items: center;
+      justify-content: center;
+      background: #05050a;
+      padding: 40px;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+
+  <button type="button" class="ease-cyber-btn">
+    <span class="btn-text">Initialize</span>
+  </button>
+
+  <button type="button" class="ease-cyber-btn variant-pink">
+    <span class="btn-text">Access Denied</span>
+  </button>
+
+</body>
+</html>

--- a/submissions/examples/ease-cyberpunk-dynamic-button/style.css
+++ b/submissions/examples/ease-cyberpunk-dynamic-button/style.css
@@ -1,0 +1,112 @@
+.ease-cyber-btn {
+  --btn-bg: #0a0a12;
+  --btn-fg: #00f0ff;
+  --btn-accent-2: #ff00c8;
+  --btn-glow: rgba(0, 240, 255, 0.6);
+  --btn-duration: 0.3s;
+  --btn-radius: 6px;
+
+  position: relative;
+  display: inline-block;
+  padding: 14px 32px;
+  background: var(--btn-bg);
+  border: 1.5px solid var(--btn-fg);
+  border-radius: var(--btn-radius);
+  color: var(--btn-fg);
+  font-family: 'Courier New', monospace;
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 0 8px var(--btn-glow);
+  cursor: pointer;
+  overflow: hidden;
+  box-shadow: 0 0 14px var(--btn-glow), inset 0 0 14px rgba(0, 240, 255, 0.08);
+  transition: box-shadow var(--btn-duration) ease, transform 0.15s ease;
+}
+
+.ease-cyber-btn:hover {
+  box-shadow: 0 0 28px var(--btn-glow), inset 0 0 20px rgba(0, 240, 255, 0.2);
+}
+
+.ease-cyber-btn:active {
+  transform: scale(0.96);
+}
+
+.ease-cyber-btn:focus-visible {
+  outline: 2px solid var(--btn-accent-2);
+  outline-offset: 3px;
+}
+
+/* animated scan-line sweep on hover */
+.ease-cyber-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 30%, rgba(0, 240, 255, 0.4) 50%, transparent 70%);
+  transform: translateX(-120%);
+  transition: transform 0.6s ease;
+}
+
+.ease-cyber-btn:hover::before {
+  transform: translateX(120%);
+}
+
+/* glitch flicker on hover */
+.ease-cyber-btn:hover .btn-text {
+  animation: glitch-flicker 0.4s steps(2) 1;
+}
+
+@keyframes glitch-flicker {
+  0%   { transform: translate(0); text-shadow: 0 0 8px var(--btn-glow); }
+  20%  { transform: translate(-2px, 1px); text-shadow: 2px 0 var(--btn-accent-2), -2px 0 var(--btn-fg); }
+  40%  { transform: translate(2px, -1px); text-shadow: -2px 0 var(--btn-accent-2), 2px 0 var(--btn-fg); }
+  60%  { transform: translate(-1px, 0); text-shadow: 1px 0 var(--btn-accent-2); }
+  100% { transform: translate(0); text-shadow: 0 0 8px var(--btn-glow); }
+}
+
+.ease-cyber-btn .btn-text {
+  position: relative;
+  z-index: 1;
+}
+
+/* rotating neon border chase */
+.ease-cyber-btn::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  padding: 2px;
+  background: conic-gradient(from 0deg, var(--btn-fg), var(--btn-accent-2), var(--btn-fg));
+  opacity: 0;
+  animation: border-spin 3s linear infinite;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  transition: opacity var(--btn-duration) ease;
+  pointer-events: none;
+}
+
+.ease-cyber-btn:hover::after {
+  opacity: 1;
+}
+
+@keyframes border-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ease-cyber-btn.variant-pink {
+  --btn-fg: #ff00c8;
+  --btn-accent-2: #00f0ff;
+  --btn-glow: rgba(255, 0, 200, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-cyber-btn::before,
+  .ease-cyber-btn::after,
+  .ease-cyber-btn .btn-text {
+    animation: none !important;
+    transition: opacity 0.2s ease !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Closes #78644

## Pull Request Description
Adds a cyberpunk-styled button with a glowing neon border, an animated scan-line sweep on hover, a text glitch-flicker effect (RGB-split style), and a rotating conic-gradient neon border chase. Pure CSS, zero JavaScript.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/examples/ease-cyberpunk-dynamic-button/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] Fully responsive
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A cyberpunk-styled button (`ease-cyber-btn`) with a neon glow border, hover scan-line sweep, text glitch-flicker on hover, and a rotating conic-gradient border chase, plus a pink/cyan `variant-pink` color scheme.

**How does a developer use it?**
```html
<button type="button" class="ease-cyber-btn">
  <span class="btn-text">Initialize</span>
</button>
```

**Why does it fit EaseMotion CSS?**
All effects — scan-line sweep (`::before` gradient sliding), text glitch (`@keyframes` on `transform`/`text-shadow`), and rotating border (masked `conic-gradient`) — are pure CSS with zero JavaScript, fully controllable via CSS custom properties (`--btn-fg`, `--btn-accent-2`, `--btn-glow`, `--btn-duration`) without touching core rules, consistent with the framework's animation-first, zero-dependency philosophy. Built on a native `<button>` with a visible `:focus-visible` outline, and every animation is disabled under `prefers-reduced-motion`.

---

## Demo
- [x] Demo added (`demo.html` — default cyan and pink variant buttons)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Requirements only specified "fully responsive" and "HTML/CSS or React/SCSS" with no further detail, so I implemented a standard cyberpunk-glow button with hover glitch/scan-line/border-chase effects as a sensible interpretation. Happy to adjust if a more specific spec was intended.