### PR TITLE
feat: add pure CSS Glassmorphism Button with Neumorphism styling (#78762)

### DIFF
--- a/submissions/examples/css-button-glass-neumorphic-pure/README.md
+++ b/submissions/examples/css-button-glass-neumorphic-pure/README.md
@@ -1,0 +1,19 @@
+# Glass-Neumorphic Button
+
+A pure CSS button component that hybridizes two popular UI trends: the frosted transparency of Glassmorphism and the tactile, soft extrusion of Neumorphism.
+
+## Features
+- Pure CSS and HTML implementation. No JavaScript required.
+- **Component Architecture & Styling Mechanics**: 
+  - **Glassmorphism Base**: Uses a semi-transparent `rgba(255, 255, 255, 0.35)` background coupled with `backdrop-filter: blur(12px)` to allow the underlying background elements (like animated color blobs) to bleed through as a frosted blur.
+  - **Frosty Edges**: Achieved via an asymmetrical border. The top and left borders are highly opaque white `rgba(255, 255, 255, 0.9)` to simulate a light source reflecting off the top-left edge of the glass, while the bottom and right are less opaque.
+  - **Neumorphic Extrusion**: Adds the soft UI extrusion using `box-shadow: 8px 8px 16px rgba(163, 177, 198, 0.8), -8px -8px 16px rgba(255, 255, 255, 0.9)`. The crucial technique here is that these shadows *must* be derived from the solid `body` background color behind the button to sell the illusion that the button is pushed out of the surface itself.
+  - **Interactive Press (Inset)**: On `:active` and `:focus-visible`, the button presses inward. The `box-shadow` changes from `outset` to `inset`, and the asymmetrical border is reversed (the bottom-right becomes opaque) to simulate the light source hitting the inner cavity.
+- Accessible semantic structure using the native `<button>` element. Supports keyboard navigation (`:focus-visible` outline) and the `prefers-reduced-motion` media query (disables blob animations and button transitions).
+
+## Usage
+Open `demo.html` in your browser. Notice how the background color blobs animate behind the button, becoming blurred by the glass filter. Click the button to experience the tactile Neumorphic inset shadow.
+
+## Files
+- `demo.html`: The HTML structure containing the background blobs and the button component.
+- `style.css`: The styling, variables, hybrid glass-neu mechanics, and interaction states.

--- a/submissions/examples/css-button-glass-neumorphic-pure/demo.html
+++ b/submissions/examples/css-button-glass-neumorphic-pure/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass-Neumorphic Button</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Ionicons -->
+    <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
+</head>
+<body>
+
+    <!-- Background elements to showcase Glassmorphism blur -->
+    <div class="background-blobs">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+    </div>
+
+    <div class="container">
+        <div class="showcase">
+            <!-- The Glassmorphism + Neumorphism Button -->
+            <button class="btn-glass-neu">
+                <span class="icon-wrap"><ion-icon name="finger-print-outline"></ion-icon></span>
+                <span class="btn-text">Authenticate</span>
+            </button>
+        </div>
+        
+        <div class="info">
+            <h2>Hybrid Aesthetics</h2>
+            <p>Combining the tactile extrusion of <strong>Neumorphism</strong> with the frosted transparency of <strong>Glassmorphism</strong>.</p>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-button-glass-neumorphic-pure/style.css
+++ b/submissions/examples/css-button-glass-neumorphic-pure/style.css
@@ -1,0 +1,225 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap');
+
+/* =========================================
+   Theming (Hybrid Glass-Neu)
+   ========================================= */
+:root {
+    /* Base base background (light mode grey/blue tint) */
+    --bg-base: #e0e5ec;
+    
+    /* Text */
+    --text-main: #2d3748;
+    --text-accent: #3182ce;
+    
+    /* Neumorphic Shadow Colors */
+    --neu-dark: rgba(163, 177, 198, 0.8);
+    --neu-light: rgba(255, 255, 255, 0.9);
+    
+    /* Glassmorphic Colors */
+    --glass-bg: rgba(255, 255, 255, 0.35);
+    --glass-border: rgba(255, 255, 255, 0.6);
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-base);
+    font-family: 'Space Grotesk', sans-serif;
+    color: var(--text-main);
+    overflow: hidden; /* Hide blob overflow */
+}
+
+/* =========================================
+   Background Scenery (For Glassmorphism)
+   ========================================= */
+.background-blobs {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(40px);
+    opacity: 0.7;
+    animation: float 10s infinite ease-in-out alternate;
+}
+
+.blob-1 {
+    width: 300px;
+    height: 300px;
+    background: linear-gradient(135deg, #a1c4fd 0%, #c2e9fb 100%);
+    top: 20%;
+    left: 20%;
+}
+
+.blob-2 {
+    width: 250px;
+    height: 250px;
+    background: linear-gradient(135deg, #fbc2eb 0%, #a6c1ee 100%);
+    bottom: 20%;
+    right: 25%;
+    animation-delay: -5s;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(30px, -50px) scale(1.1); }
+}
+
+/* =========================================
+   Layout Container
+   ========================================= */
+.container {
+    text-align: center;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 50px;
+}
+
+.info h2 {
+    font-size: 2rem;
+    margin-bottom: 10px;
+    color: #1a202c;
+}
+
+.info p {
+    max-width: 400px;
+    color: #4a5568;
+    line-height: 1.5;
+}
+
+
+/* =========================================
+   [TECHNIQUE] Glass-Neu Button
+   ========================================= */
+.btn-glass-neu {
+    /* Layout */
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 32px;
+    border-radius: 50px;
+    cursor: pointer;
+    
+    /* Typography */
+    font-family: inherit;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-main);
+    
+    /* 1. Glassmorphism Base */
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    
+    /* 2. Glassmorphism Border (The Frosty Edge) */
+    border: 1px solid var(--glass-border);
+    border-top: 1px solid rgba(255, 255, 255, 0.9);
+    border-left: 1px solid rgba(255, 255, 255, 0.9);
+    
+    /* 3. Neumorphism Extrusion (The Drop Shadows) 
+       Note: The shadows must match the base background color (--bg-base) 
+       to create the illusion of extrusion.
+    */
+    box-shadow: 
+        8px 8px 16px var(--neu-dark), 
+        -8px -8px 16px var(--neu-light);
+        
+    /* Interaction transition */
+    transition: all 0.3s cubic-bezier(0.25, 1, 0.5, 1);
+    outline: none;
+}
+
+.icon-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    color: var(--text-accent);
+    transition: transform 0.3s ease;
+}
+
+/* =========================================
+   Interaction States
+   ========================================= */
+
+/* Hover: Lift slightly */
+.btn-glass-neu:hover {
+    transform: translateY(-2px);
+    box-shadow: 
+        10px 10px 20px var(--neu-dark), 
+        -10px -10px 20px var(--neu-light);
+    background: rgba(255, 255, 255, 0.45);
+}
+
+.btn-glass-neu:hover .icon-wrap {
+    transform: scale(1.1);
+}
+
+/* Active/Focus: Press Inward (Neumorphic Inset) */
+.btn-glass-neu:active,
+.btn-glass-neu:focus-visible {
+    transform: translateY(0);
+    /* Convert outsets to insets to "press" the glass into the surface */
+    box-shadow: 
+        inset 6px 6px 12px var(--neu-dark), 
+        inset -6px -6px 12px var(--neu-light);
+    
+    /* Adjust border to simulate pressed light source */
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+    border-left: 1px solid rgba(255, 255, 255, 0.2);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.8);
+    border-right: 1px solid rgba(255, 255, 255, 0.8);
+    
+    color: var(--text-accent);
+}
+
+.btn-glass-neu:active .icon-wrap,
+.btn-glass-neu:focus-visible .icon-wrap {
+    transform: scale(0.95);
+}
+
+/* Focus Accessibility */
+.btn-glass-neu:focus-visible {
+    outline: 2px dashed var(--text-accent);
+    outline-offset: 10px;
+}
+
+
+/* =========================================
+   Responsive Design
+   ========================================= */
+@media (max-width: 480px) {
+    .btn-glass-neu {
+        padding: 14px 28px;
+        font-size: 1rem;
+    }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .blob {
+        animation: none;
+        filter: blur(20px);
+    }
+    
+    .btn-glass-neu, .icon-wrap {
+        transition: none !important;
+    }
+    .btn-glass-neu:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION

### Description
This PR introduces a pure CSS button component that hybridizes two popular UI trends: the frosted transparency of Glassmorphism and the tactile, soft extrusion of Neumorphism. Resolves issue #78762.

### Changes Made:
- Added `submissions/examples/css-button-glass-neumorphic-pure/` directory.
- Created `demo.html` showcasing the HTML structure containing animated background blobs (to demonstrate the blur) and the button component.
- Created `style.css` featuring the UI mechanics:
  - **Glassmorphism Base**: Uses a semi-transparent `rgba(255, 255, 255, 0.35)` background coupled with `backdrop-filter: blur(12px)` to allow the underlying background elements to bleed through as a frosted blur.
  - **Frosty Edges**: Achieved via an asymmetrical border. The top and left borders are highly opaque white to simulate a light source reflecting off the top-left edge of the glass.
  - **Neumorphic Extrusion**: Adds the soft UI extrusion using drop shadows that are derived from the solid `body` background color behind the button to sell the illusion that the button is pushed out of the surface itself.
  - **Interactive Press (Inset)**: On `:active` and `:focus-visible`, the button presses inward. The `box-shadow` changes from `outset` to `inset`, and the asymmetrical border is reversed to simulate the light source hitting the inner cavity.
- Added `README.md` documenting usage and the technical mechanics of the hybrid styling.
- Accessible semantic structure using native `<button>`. Features keyboard navigation support and honors the `prefers-reduced-motion` standard.

Closes #78762
