### PR TITLE
feat(docs): add tab navigation showcase and documentation

### DIFF
--- a/submissions/docs/ease-tabs-naresh/README.md
+++ b/submissions/docs/ease-tabs-naresh/README.md
@@ -1,0 +1,44 @@
+# Sliding Navigation Tabs Component
+
+## 1. What does this do?
+This component introduces lightweight, pure CSS sliding navigation tabs featuring active indicators (underline or pill capsule) that slide between selected elements via `transform: translateX` and trigger fade-in animations on tab content panels.
+
+## 2. How is it used?
+Structure the tabs navigation and panel containers using hidden radio inputs and sibling label elements:
+
+```html
+<div class="ease-tabs ease-tabs--3">
+  <!-- Hidden Radios -->
+  <input type="radio" id="tab-3-1" name="tab-group-3" checked>
+  <input type="radio" id="tab-3-2" name="tab-group-3">
+  <input type="radio" id="tab-3-3" name="tab-group-3">
+
+  <!-- Navigation Row -->
+  <div class="ease-tabs__nav" role="tablist">
+    <label for="tab-3-1" class="ease-tab" role="tab">Account</label>
+    <label for="tab-3-2" class="ease-tab" role="tab">Preferences</label>
+    <label for="tab-3-3" class="ease-tab" role="tab">Security</label>
+    <div class="ease-tabs__underline" aria-hidden="true"></div>
+  </div>
+
+  <!-- Content Panels -->
+  <div class="ease-tabs__content">
+    <div id="panel-3-1" class="ease-tab-panel" role="tabpanel">Account Content</div>
+    <div id="panel-3-2" class="ease-tab-panel" role="tabpanel">Preferences Content</div>
+    <div id="panel-3-3" class="ease-tab-panel" role="tabpanel">Security Content</div>
+  </div>
+</div>
+```
+
+### Layout Modifiers
+- `.ease-tabs--2`: Configures equal widths for 2 tabs (50% each).
+- `.ease-tabs--3`: Configures equal widths for 3 tabs (33.333% each).
+- `.ease-tabs--4`: Configures equal widths for 4 tabs (25% each).
+
+### Indicator Style Modifiers
+- `.ease-tabs--pill`: Alters the indicator style from a bottom underline to a sliding background capsule behind the active tab text.
+
+---
+
+## 3. Why is it useful?
+Tabs are essential for clean, compact page structures, helping users toggle between contexts without page reloads. Using radio inputs and sibling selectors eliminates the need for JavaScript wrappers, keeping the page layout light, SEO-friendly, and responsive.

--- a/submissions/docs/ease-tabs-naresh/demo.html
+++ b/submissions/docs/ease-tabs-naresh/demo.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion CSS - Sliding Underline Tabs Showcase</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="container">
+    <header>
+      <h1>Sliding Navigation Tabs</h1>
+      <p class="subtitle">Responsive tab bars featuring smoothly sliding active indicators and content fade-ins, built entirely with pure CSS.</p>
+    </header>
+
+    <!-- 1. Classic Sliding Underline (3 Tabs) -->
+    <section class="showcase-section">
+      <h3 class="section-title"><span>📂</span> Classic Sliding Underline (3 Tabs)</h3>
+      
+      <div class="ease-tabs ease-tabs--3">
+        <!-- Hidden Radios -->
+        <input type="radio" id="tab-3-1" name="tab-group-3" checked>
+        <input type="radio" id="tab-3-2" name="tab-group-3">
+        <input type="radio" id="tab-3-3" name="tab-group-3">
+
+        <!-- Navigation Row -->
+        <div class="ease-tabs__nav" role="tablist">
+          <label for="tab-3-1" class="ease-tab" role="tab">👤 Account</label>
+          <label for="tab-3-2" class="ease-tab" role="tab">⚙️ Preferences</label>
+          <label for="tab-3-3" class="ease-tab" role="tab">🔒 Security</label>
+          <div class="ease-tabs__underline" aria-hidden="true"></div>
+        </div>
+
+        <!-- Content Panels -->
+        <div class="ease-tabs__content">
+          <div id="panel-3-1" class="ease-tab-panel" role="tabpanel">
+            <h4 style="margin-top: 0; color: #fff;">Account Settings</h4>
+            <p>Modify your profile photo, username, email details, and associated account configuration. Keep your information updated to receive important system notifications.</p>
+          </div>
+          <div id="panel-3-2" class="ease-tab-panel" role="tabpanel">
+            <h4 style="margin-top: 0; color: #fff;">System Preferences</h4>
+            <p>Customize your user experience. Enable automatic night modes, toggle grid systems, toggle custom fonts, and adjust layouts to fit your workspace structure.</p>
+          </div>
+          <div id="panel-3-3" class="ease-tab-panel" role="tabpanel">
+            <h4 style="margin-top: 0; color: #fff;">Security & Key Management</h4>
+            <p>Manage your passwords, register multi-factor security devices (MFA), audit login sessions, and generate access tokens for API usage.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 2. Pill Capsule Background Slider (3 Tabs) -->
+    <section class="showcase-section">
+      <h3 class="section-title"><span>💊</span> Pill Capsule Background Slider</h3>
+      
+      <div class="ease-tabs ease-tabs--pill">
+        <!-- Hidden Radios (Reusing tab-group keys but under class ease-tabs--pill) -->
+        <input type="radio" id="tab-3-1-p" name="tab-group-3-p" checked>
+        <input type="radio" id="tab-3-2-p" name="tab-group-3-p">
+        <input type="radio" id="tab-3-3-p" name="tab-group-3-p">
+
+        <!-- Navigation Row -->
+        <!-- Custom CSS handles selectors specifically using inline modifiers -->
+        <div class="ease-tabs__nav" style="
+          --tab-checked-1: #tab-3-1-p:checked;
+          --tab-checked-2: #tab-3-2-p:checked;
+          --tab-checked-3: #tab-3-3-p:checked;
+        ">
+          <!-- We map the selectors manually using class targets or CSS helper variables -->
+          <style>
+            #tab-3-1-p:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(0); }
+            #tab-3-2-p:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(calc(100% + 0.35rem)); }
+            #tab-3-3-p:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(calc(200% + 0.7rem)); }
+            #tab-3-1-p:checked ~ .ease-tabs__nav label[for="tab-3-1-p"],
+            #tab-3-2-p:checked ~ .ease-tabs__nav label[for="tab-3-2-p"],
+            #tab-3-3-p:checked ~ .ease-tabs__nav label[for="tab-3-3-p"] {
+              color: var(--ease-text-main);
+              font-weight: 600;
+            }
+            #tab-3-1-p:checked ~ .ease-tabs__content #panel-3-1-p,
+            #tab-3-2-p:checked ~ .ease-tabs__content #panel-3-2-p,
+            #tab-3-3-p:checked ~ .ease-tabs__content #panel-3-3-p {
+              display: block;
+            }
+          </style>
+          
+          <label for="tab-3-1-p" class="ease-tab" role="tab">Overview</label>
+          <label for="tab-3-2-p" class="ease-tab" role="tab">Projects</label>
+          <label for="tab-3-3-p" class="ease-tab" role="tab">Integrations</label>
+          <div class="ease-tabs__underline" aria-hidden="true"></div>
+        </div>
+
+        <!-- Content Panels -->
+        <div class="ease-tabs__content">
+          <div id="panel-3-1-p" class="ease-tab-panel" role="tabpanel">
+            <p>Welcome to the project center dashboard. The active indicator slides behind the labels as a subtle background capsule, keeping focus on the selected link.</p>
+          </div>
+          <div id="panel-3-2-p" class="ease-tab-panel" role="tabpanel">
+            <p>Browse through your repository folders, commits history, active pull requests, and pending reviews. Staggered releases are shown on release panels.</p>
+          </div>
+          <div id="panel-3-3-p" class="ease-tab-panel" role="tabpanel">
+            <p>Connect your repositories to Slack, Discord, Microsoft Teams, Vercel, Netlify, or custom API endpoints using incoming webhook connectors.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 3. Sliding Underline (4 Tabs) -->
+    <section class="showcase-section">
+      <h3 class="section-title"><span>⚡</span> Equal Widths (4 Tabs)</h3>
+      
+      <div class="ease-tabs ease-tabs--4">
+        <!-- Hidden Radios -->
+        <input type="radio" id="tab-4-1" name="tab-group-4" checked>
+        <input type="radio" id="tab-4-2" name="tab-group-4">
+        <input type="radio" id="tab-4-3" name="tab-group-4">
+        <input type="radio" id="tab-4-4" name="tab-group-4">
+
+        <!-- Navigation Row -->
+        <div class="ease-tabs__nav" role="tablist">
+          <label for="tab-4-1" class="ease-tab" role="tab">Home</label>
+          <label for="tab-4-2" class="ease-tab" role="tab">Statistics</label>
+          <label for="tab-4-3" class="ease-tab" role="tab">Billing</label>
+          <label for="tab-4-4" class="ease-tab" role="tab">Developer</label>
+          <div class="ease-tabs__underline" aria-hidden="true"></div>
+        </div>
+
+        <!-- Content Panels -->
+        <div class="ease-tabs__content">
+          <div id="panel-4-1" class="ease-tab-panel" role="tabpanel">
+            <p>Main administrative homepage dashboard showing status indicators and connection states.</p>
+          </div>
+          <div id="panel-4-2" class="ease-tab-panel" role="tabpanel">
+            <p>Analytical graphs, memory charts, performance scoring, and database transactions stats.</p>
+          </div>
+          <div id="panel-4-3" class="ease-tab-panel" role="tabpanel">
+            <p>Invoices, subscription management details, payment settings, and card upgrades.</p>
+          </div>
+          <div id="panel-4-4" class="ease-tab-panel" role="tabpanel">
+            <p>API keys credentials, documentation guides, webhook payloads, and testing Sandboxes.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+</body>
+</html>

--- a/submissions/docs/ease-tabs-naresh/style.css
+++ b/submissions/docs/ease-tabs-naresh/style.css
@@ -1,0 +1,300 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:root {
+  --ease-font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
+  --ease-font-mono: 'JetBrains Mono', monospace;
+
+  /* HSL Colors */
+  --ease-primary: 250, 100%, 69%;
+  --ease-secondary: 260, 95%, 66%;
+  --ease-accent: 190, 90%, 50%;
+  
+  --ease-bg: #0b1121;
+  --ease-surface: #141e33;
+  --ease-text-main: #f8fafc;
+  --ease-text-muted: #94a3b8;
+  --ease-border: rgba(255, 255, 255, 0.08);
+  
+  --ease-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+body {
+  font-family: var(--ease-font-sans);
+  background-color: var(--ease-bg);
+  background-image: radial-gradient(circle at top left, #0e122b, #05060f);
+  color: var(--ease-text-main);
+  margin: 0;
+  padding: 4rem 1.5rem;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 4rem;
+  animation: easeTabsFadeInDown 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  background: linear-gradient(135deg, #fff 40%, hsl(var(--ease-primary)) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--ease-text-muted);
+  font-size: 1.125rem;
+}
+
+/* Sections */
+.showcase-section {
+  background: rgba(20, 30, 51, 0.4);
+  border: 1px solid var(--ease-border);
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  padding: 2.5rem;
+  margin-bottom: 2.5rem;
+  box-shadow: var(--ease-shadow);
+  animation: easeTabsFadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: hsl(var(--ease-primary));
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* ────────────────────────────────────────────────────────────
+   TABS COMPONENT
+   ──────────────────────────────────────────────────────────── */
+
+.ease-tabs {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Hidden inputs for CSS Tab Logic */
+.ease-tabs input[type="radio"] {
+  display: none;
+}
+
+/* Tab Navigation Wrapper */
+.ease-tabs__nav {
+  position: relative;
+  display: flex;
+  border-bottom: 1px solid var(--ease-border);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none; /* Hide scrollbars for Firefox */
+  -ms-overflow-style: none; /* Hide scrollbars for IE/Edge */
+}
+
+.ease-tabs__nav::-webkit-scrollbar {
+  display: none; /* Hide scrollbars for Chrome/Safari */
+}
+
+/* Single Tab Label */
+.ease-tab {
+  flex: 1;
+  text-align: center;
+  padding: 1rem 0.5rem;
+  color: var(--ease-text-muted);
+  font-weight: 500;
+  font-size: 0.95rem;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.25s ease;
+  white-space: nowrap;
+}
+
+.ease-tab:hover {
+  color: var(--ease-text-main);
+}
+
+/* Active Class Fallback (for static or JS implementations) */
+.ease-tab--active {
+  color: var(--ease-text-main) !important;
+  font-weight: 600;
+}
+
+/* Underline Indicator */
+.ease-tabs__underline {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: hsl(var(--ease-primary));
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 0 8px rgba(108, 99, 255, 0.5);
+}
+
+/* ── 3-Tab Underline Logic ── */
+.ease-tabs--3 .ease-tabs__underline {
+  width: 33.333%;
+}
+.ease-tabs--3 #tab-3-1:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(0); }
+.ease-tabs--3 #tab-3-2:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(100%); }
+.ease-tabs--3 #tab-3-3:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(200%); }
+
+/* Checked Active Styling for Tabs */
+.ease-tabs--3 #tab-3-1:checked ~ .ease-tabs__nav label[for="tab-3-1"],
+.ease-tabs--3 #tab-3-2:checked ~ .ease-tabs__nav label[for="tab-3-2"],
+.ease-tabs--3 #tab-3-3:checked ~ .ease-tabs__nav label[for="tab-3-3"] {
+  color: var(--ease-text-main);
+  font-weight: 600;
+}
+
+/* ── 4-Tab Underline Logic ── */
+.ease-tabs--4 .ease-tabs__underline {
+  width: 25%;
+}
+.ease-tabs--4 #tab-4-1:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(0); }
+.ease-tabs--4 #tab-4-2:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(100%); }
+.ease-tabs--4 #tab-4-3:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(200%); }
+.ease-tabs--4 #tab-4-4:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(300%); }
+
+.ease-tabs--4 #tab-4-1:checked ~ .ease-tabs__nav label[for="tab-4-1"],
+.ease-tabs--4 #tab-4-2:checked ~ .ease-tabs__nav label[for="tab-4-2"],
+.ease-tabs--4 #tab-4-3:checked ~ .ease-tabs__nav label[for="tab-4-3"],
+.ease-tabs--4 #tab-4-4:checked ~ .ease-tabs__nav label[for="tab-4-4"] {
+  color: var(--ease-text-main);
+  font-weight: 600;
+}
+
+
+/* ────────────────────────────────────────────────────────────
+   PILL VARIANT (Background Capsule Slider)
+   ──────────────────────────────────────────────────────────── */
+
+.ease-tabs--pill .ease-tabs__nav {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--ease-border);
+  padding: 0.35rem;
+  border-radius: 9999px;
+  gap: 0.25rem;
+}
+
+.ease-tabs--pill .ease-tab {
+  padding: 0.65rem 0.5rem;
+  border-radius: 9999px;
+  z-index: 1;
+}
+
+.ease-tabs--pill .ease-tabs__underline {
+  bottom: 0.35rem;
+  top: 0.35rem;
+  height: auto;
+  border-radius: 9999px;
+  background: rgba(108, 99, 255, 0.15);
+  border: 1px solid rgba(108, 99, 255, 0.3);
+  box-shadow: 0 0 10px rgba(108, 99, 255, 0.1);
+  width: calc(33.333% - 0.45rem);
+}
+
+/* Offset positioning with padding */
+.ease-tabs--pill #tab-3-1:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(0); }
+.ease-tabs--pill #tab-3-2:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(calc(100% + 0.35rem)); }
+.ease-tabs--pill #tab-3-3:checked ~ .ease-tabs__nav .ease-tabs__underline { transform: translateX(calc(200% + 0.7rem)); }
+
+
+/* ────────────────────────────────────────────────────────────
+   TAB CONTENT & ANIMATED PANELS
+   ──────────────────────────────────────────────────────────── */
+
+.ease-tabs__content {
+  position: relative;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+/* Tab Panel Styles */
+.ease-tab-panel {
+  display: none;
+  animation: easeTabsPanelFadeIn 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* 3-Panel Show Logic */
+#tab-3-1:checked ~ .ease-tabs__content #panel-3-1,
+#tab-3-2:checked ~ .ease-tabs__content #panel-3-2,
+#tab-3-3:checked ~ .ease-tabs__content #panel-3-3 {
+  display: block;
+}
+
+/* 4-Panel Show Logic */
+#tab-4-1:checked ~ .ease-tabs__content #panel-4-1,
+#tab-4-2:checked ~ .ease-tabs__content #panel-4-2,
+#tab-4-3:checked ~ .ease-tabs__content #panel-4-3,
+#tab-4-4:checked ~ .ease-tabs__content #panel-4-4 {
+  display: block;
+}
+
+/* Mobile responsive scrollable headers */
+@media (max-width: 640px) {
+  .ease-tab {
+    flex: none;
+    padding: 0.85rem 1.25rem;
+  }
+  
+  .ease-tabs__underline {
+    display: none; /* Hide sliding line on mobile wrapper if it scrolls */
+  }
+  
+  /* Show border below checked items instead as fallback for layout */
+  .ease-tabs #tab-3-1:checked ~ .ease-tabs__nav label[for="tab-3-1"],
+  .ease-tabs #tab-3-2:checked ~ .ease-tabs__nav label[for="tab-3-2"],
+  .ease-tabs #tab-3-3:checked ~ .ease-tabs__nav label[for="tab-3-3"],
+  .ease-tabs #tab-4-1:checked ~ .ease-tabs__nav label[for="tab-4-1"],
+  .ease-tabs #tab-4-2:checked ~ .ease-tabs__nav label[for="tab-4-2"],
+  .ease-tabs #tab-4-3:checked ~ .ease-tabs__nav label[for="tab-4-3"],
+  .ease-tabs #tab-4-4:checked ~ .ease-tabs__nav label[for="tab-4-4"] {
+    border-bottom: 2px solid hsl(var(--ease-primary));
+  }
+}
+
+/* Keyframes */
+@keyframes easeTabsPanelFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes easeTabsFadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes easeTabsFadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces a Core Component Showcase for a **Tab Navigation interface** (`.ease-tabs`) under the official GSSoC documentation track. It implements a pure-CSS tab switcher with radio buttons, dynamic underline transitions, content panel fade-ins, and standard mobile scroll responsiveness.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement / Core showcase
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (under `submissions/docs/ease-tabs-naresh/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A standalone CSS-only tabbed layout system:
- `.ease-tabs` (tab container wrapper)
- `.ease-tab` (individual tab labels)
- `.ease-tab-panel` (tab content viewport cards)

**How does a developer use it?**

```html
<div class="ease-tabs">
  <!-- CSS tabs structure with radio inputs -->
</div>
