### PR TITLE
feat: add CSS-only Progress Bar with Retro styling

### DIFF
--- a/submissions/examples/css-only-progress-bar-retro/README.md
+++ b/submissions/examples/css-only-progress-bar-retro/README.md
@@ -1,0 +1,37 @@
+# CSS-only Progress Bar (Retro)
+
+A responsive retro-inspired progress bar built using only HTML and CSS.
+
+## Features
+
+- Pure HTML & CSS
+- Retro arcade styling
+- Animated loading effect
+- Responsive layout
+- Accessible progress bar using ARIA attributes
+
+## Files
+
+```
+css-only-progress-bar-retro/
+├── demo.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+## Customization
+
+- Change animation speed in `@keyframes`.
+- Modify progress width.
+- Replace retro colors with your own palette.
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari

--- a/submissions/examples/css-only-progress-bar-retro/demo.html
+++ b/submissions/examples/css-only-progress-bar-retro/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro CSS Progress Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="wrapper">
+
+  <h1>Loading...</h1>
+
+  <div
+    class="progress"
+    role="progressbar"
+    aria-label="Loading Progress"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-valuenow="75">
+
+    <div class="fill"></div>
+
+  </div>
+
+  <span>75%</span>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-only-progress-bar-retro/style.css
+++ b/submissions/examples/css-only-progress-bar-retro/style.css
@@ -1,0 +1,75 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+    font-family:"Courier New",monospace;
+}
+
+body{
+    background:#1a1a1a;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    min-height:100vh;
+    color:#fff8dc;
+}
+
+.wrapper{
+    width:min(420px,90%);
+    text-align:center;
+}
+
+h1{
+    margin-bottom:25px;
+    color:#ffde59;
+    text-shadow:2px 2px #ff4d4d;
+}
+
+.progress{
+    width:100%;
+    height:36px;
+    background:#2e2e2e;
+    border:4px solid #ffde59;
+    overflow:hidden;
+    border-radius:8px;
+    box-shadow:0 0 0 4px #444;
+}
+
+.fill{
+    height:100%;
+    width:75%;
+    background:repeating-linear-gradient(
+        45deg,
+        #ff595e 0 15px,
+        #ffca3a 15px 30px
+    );
+    animation:load 2.5s ease-in-out infinite alternate;
+}
+
+span{
+    display:block;
+    margin-top:16px;
+    font-size:1.2rem;
+    color:#7dff72;
+}
+
+@keyframes load{
+    from{
+        width:20%;
+    }
+    to{
+        width:75%;
+    }
+}
+
+@media(max-width:600px){
+
+.progress{
+height:28px;
+}
+
+h1{
+font-size:1.6rem;
+}
+
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a **CSS-only Progress Bar with Retro styling** under `submissions/examples/css-only-progress-bar-retro/`.

**Closes #78280**

### Type of Change

- [x] 🧩 New component

### Features

- Pure HTML & CSS
- Retro arcade-inspired design
- Animated loading effect
- Responsive layout
- Accessible ARIA progress bar
- Self-contained demo

### Files Added

- `demo.html`
- `style.css`
- `README.md`

The component follows the EaseMotion CSS contribution guidelines and does not modify any existing project files.