### PR TITLE
feat: add CSS-only Avatar with Dark Mode styling (#78758)

### DIFF
--- a/submissions/examples/css-avatar-darkmode-pure/README.md
+++ b/submissions/examples/css-avatar-darkmode-pure/README.md
@@ -1,0 +1,19 @@
+# Dark Mode Avatar Component
+
+A sleek, pure CSS avatar component designed for dark mode interfaces.
+
+## Features
+- Pure HTML and CSS implementation.
+- **Dark Mode Optimized**: Uses a dark color palette with subtle borders and shadows to separate elements cleanly without overpowering contrast.
+- **Status Indicators**: Bottom-right status dots indicating Online (green, glowing), Offline (gray), and Busy (red, glowing).
+- **Notification Badge**: Top-right bouncing notification badge for alerts.
+- **Image & Initials Support**: Fallback initial avatars with a dark gradient background if an image is not available.
+- **Interactivity**: Smooth hover transformations (lifting up) with a subtle brightness bump to the image, and a slight scale up of the status indicator.
+- **Accessibility**: Includes `prefers-reduced-motion` media queries to disable animations for users who prefer it.
+
+## Usage
+Open `demo.html` in your browser. Hover over the avatars to view the interactive transformations.
+
+## Files
+- `demo.html`: The HTML structure for three different avatar states (Online, Offline/Initials, Busy/Notifications).
+- `style.css`: The styling, flexbox layout, CSS variables, and hover/animation effects.

--- a/submissions/examples/css-avatar-darkmode-pure/demo.html
+++ b/submissions/examples/css-avatar-darkmode-pure/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Avatars</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        <!-- Avatar 1: Online Status with Image -->
+        <div class="avatar-wrapper">
+            <div class="avatar avatar-online">
+                <img src="https://i.pravatar.cc/150?img=11" alt="User profile" class="avatar-img">
+                <span class="status-indicator"></span>
+            </div>
+            <div class="avatar-info">
+                <h3 class="avatar-name">Sarah Jenkins</h3>
+                <p class="avatar-role">Admin</p>
+            </div>
+        </div>
+
+        <!-- Avatar 2: Offline Status with Initials -->
+        <div class="avatar-wrapper">
+            <div class="avatar avatar-offline">
+                <div class="avatar-initials">MR</div>
+                <span class="status-indicator"></span>
+            </div>
+            <div class="avatar-info">
+                <h3 class="avatar-name">Michael Ross</h3>
+                <p class="avatar-role">Developer</p>
+            </div>
+        </div>
+
+        <!-- Avatar 3: Busy Status with Image & Notification Badge -->
+        <div class="avatar-wrapper">
+            <div class="avatar avatar-busy">
+                <img src="https://i.pravatar.cc/150?img=33" alt="User profile" class="avatar-img">
+                <span class="status-indicator"></span>
+                <span class="notification-badge">3</span>
+            </div>
+            <div class="avatar-info">
+                <h3 class="avatar-name">Elena Rodriguez</h3>
+                <p class="avatar-role">Designer</p>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-avatar-darkmode-pure/style.css
+++ b/submissions/examples/css-avatar-darkmode-pure/style.css
@@ -1,0 +1,199 @@
+:root {
+    /* Dark Mode Palette */
+    --bg-dark: #121212;
+    --bg-panel: #1e1e1e;
+    --text-primary: #ffffff;
+    --text-secondary: #a0a0a0;
+    --border-color: #333333;
+    
+    /* Status Colors */
+    --status-online: #10b981; /* Emerald green */
+    --status-offline: #6b7280; /* Gray */
+    --status-busy: #ef4444; /* Red */
+    --notification: #3b82f6; /* Blue */
+    
+    /* Metrics */
+    --avatar-size: 80px;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.container {
+    display: flex;
+    gap: 3rem;
+    background-color: var(--bg-panel);
+    padding: 3rem 4rem;
+    border-radius: 16px;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+/* =========================================
+   Avatar Component
+   ========================================= */
+.avatar-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.avatar-wrapper:hover {
+    transform: translateY(-8px);
+}
+
+.avatar {
+    position: relative;
+    width: var(--avatar-size);
+    height: var(--avatar-size);
+    border-radius: 50%;
+    /* Subtle inner glow and border for dark mode */
+    box-shadow: 0 0 0 4px var(--bg-panel), 0 0 0 6px var(--border-color);
+    transition: box-shadow 0.3s ease;
+    cursor: pointer;
+}
+
+.avatar-wrapper:hover .avatar {
+    box-shadow: 0 0 0 4px var(--bg-panel), 0 0 0 6px rgba(255, 255, 255, 0.2);
+}
+
+/* The Image inside avatar */
+.avatar-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+    filter: brightness(0.9);
+    transition: filter 0.3s ease;
+}
+
+.avatar-wrapper:hover .avatar-img {
+    filter: brightness(1.1);
+}
+
+/* Fallback Initials */
+.avatar-initials {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #2c2c2c, #1a1a1a);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-transform: uppercase;
+}
+
+/* =========================================
+   Status Indicators 
+   ========================================= */
+.status-indicator {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 3px solid var(--bg-panel);
+    z-index: 2;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.avatar-wrapper:hover .status-indicator {
+    transform: scale(1.2);
+}
+
+.avatar-online .status-indicator {
+    background-color: var(--status-online);
+    box-shadow: 0 0 10px rgba(16, 185, 129, 0.4);
+}
+
+.avatar-offline .status-indicator {
+    background-color: var(--status-offline);
+}
+
+.avatar-busy .status-indicator {
+    background-color: var(--status-busy);
+    box-shadow: 0 0 10px rgba(239, 68, 68, 0.4);
+}
+
+/* =========================================
+   Notification Badge
+   ========================================= */
+.notification-badge {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    background-color: var(--notification);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 12px;
+    border: 3px solid var(--bg-panel);
+    z-index: 3;
+    animation: bounceBadge 2s infinite;
+}
+
+@keyframes bounceBadge {
+    0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+    40% { transform: translateY(-4px); }
+    60% { transform: translateY(-2px); }
+}
+
+/* =========================================
+   Info Text
+   ========================================= */
+.avatar-info {
+    text-align: center;
+}
+
+.avatar-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 0.2rem;
+    transition: color 0.3s ease;
+}
+
+.avatar-wrapper:hover .avatar-name {
+    color: var(--notification);
+}
+
+.avatar-role {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+/* Accessibility - Prefers Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .avatar-wrapper,
+    .avatar,
+    .status-indicator,
+    .avatar-name,
+    .notification-badge {
+        transition: none;
+        animation: none;
+        transform: none !important;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure CSS avatar component designed for dark mode interfaces. Resolves issue #78758.

### Changes Made:
- Added `submissions/examples/css-avatar-darkmode-pure/` directory.
- Created `demo.html` featuring three different avatar states (Online with Image, Offline with Initials fallback, and Busy with a Notification Badge).
- Created `style.css` featuring the UI mechanics:
  - **Dark Mode Optimized**: Uses a dark color palette with subtle borders and shadows.
  - **Status Indicators**: Bottom-right status dots indicating Online (green glow), Offline (gray), and Busy (red glow).
  - **Notification Badge**: Top-right bouncing notification badge for alerts.
  - **Interactivity**: Smooth hover transformations (lifting up) with a subtle brightness bump to the image, and a slight scale up of the status indicator.
  - **Accessibility**: Includes `prefers-reduced-motion` media queries to disable animations for accessibility.
- Added `README.md` documenting the features and structure.

Closes #78758
