### PR TITLE
feat: add Parallax Breadcrumb with Glassmorphism styling (#78754)

### DIFF
--- a/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/README.md
+++ b/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/README.md
@@ -1,0 +1,19 @@
+# Parallax Breadcrumb with Glassmorphism Styling
+
+A highly interactive, pure CSS breadcrumb component featuring a beautiful glassmorphism aesthetic and a 3D parallax hover effect.
+
+## Features
+- **Pure HTML/CSS**: No JavaScript required for the 3D transforms or hover states.
+- **Glassmorphism**: Uses `backdrop-filter: blur`, semi-transparent backgrounds, and subtle lighting borders to create a frosted glass effect.
+- **3D Parallax Hover**: The entire breadcrumb container uses CSS `perspective`, `transform: rotateX() rotateY() translateZ()`, and `transform-style: preserve-3d` to tilt and lift off the page when hovered.
+- **Animated Background**: Includes slow-moving, blurred, floating CSS blobs in the background to emphasize the glass effect.
+- **Smooth Interactions**: Links feature an expanding highlight effect on hover.
+- **Responsive**: Adapts to smaller screens by adjusting padding and disabling complex 3D transforms to prioritize usability on mobile devices.
+- **Accessibility**: Includes `prefers-reduced-motion` to disable animations and transforms for users who prefer it.
+
+## Usage
+Open `demo.html` in your browser. Move your mouse over the breadcrumb container to see the parallax tilt effect.
+
+## Files
+- `demo.html`: The HTML structure including the SVG icons and background blob elements.
+- `style.css`: The CSS containing the glassmorphism variables, 3D transform logic, and responsive adjustments.

--- a/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/demo.html
+++ b/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parallax Glassmorphism Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Using Google Fonts for better typography -->
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Background scene for parallax effect -->
+    <div class="background-elements">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+        <div class="blob blob-3"></div>
+    </div>
+
+    <!-- The Component -->
+    <div class="parallax-container">
+        <nav class="breadcrumb-glass" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link" aria-current="false">
+                        <svg class="breadcrumb-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
+                        <span>Home</span>
+                    </a>
+                </li>
+                
+                <li class="breadcrumb-separator" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link" aria-current="false">
+                        <span>Products</span>
+                    </a>
+                </li>
+                
+                <li class="breadcrumb-separator" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link" aria-current="false">
+                        <span>Electronics</span>
+                    </a>
+                </li>
+                
+                <li class="breadcrumb-separator" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                </li>
+                
+                <li class="breadcrumb-item breadcrumb-active">
+                    <a href="#" class="breadcrumb-link" aria-current="page">
+                        <span>Wireless Headphones</span>
+                    </a>
+                </li>
+            </ol>
+        </nav>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/style.css
+++ b/submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/style.css
@@ -1,0 +1,260 @@
+:root {
+    /* Glassmorphism Theme */
+    --glass-bg: rgba(255, 255, 255, 0.05);
+    --glass-border: rgba(255, 255, 255, 0.15);
+    --glass-highlight: rgba(255, 255, 255, 0.25);
+    --glass-shadow: rgba(0, 0, 0, 0.2);
+    
+    /* Text Colors */
+    --text-primary: rgba(255, 255, 255, 0.9);
+    --text-secondary: rgba(255, 255, 255, 0.6);
+    --text-active: #ffffff;
+    
+    /* Background Colors for blobs */
+    --blob-1: #4158D0;
+    --blob-2: #C850C0;
+    --blob-3: #FFCC70;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: #0f0f13;
+    font-family: 'Outfit', sans-serif;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+}
+
+/* =========================================
+   Background Blobs for Glass Effect
+   ========================================= */
+.background-elements {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    overflow: hidden;
+    filter: blur(80px);
+}
+
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    animation: float 20s infinite alternate cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.blob-1 {
+    width: 300px;
+    height: 300px;
+    background: var(--blob-1);
+    top: 20%;
+    left: 25%;
+    animation-delay: -5s;
+}
+
+.blob-2 {
+    width: 400px;
+    height: 400px;
+    background: var(--blob-2);
+    bottom: 10%;
+    right: 20%;
+    animation-direction: alternate-reverse;
+}
+
+.blob-3 {
+    width: 250px;
+    height: 250px;
+    background: var(--blob-3);
+    top: 40%;
+    right: 40%;
+    animation-delay: -10s;
+}
+
+@keyframes float {
+    0% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(50px, -50px) scale(1.1); }
+    100% { transform: translate(-30px, 30px) scale(0.9); }
+}
+
+/* =========================================
+   Parallax Container
+   ========================================= */
+.parallax-container {
+    perspective: 1000px; /* Perspective for 3D effect */
+    padding: 2rem;
+    width: 100%;
+    max-width: 800px;
+    display: flex;
+    justify-content: center;
+}
+
+/* =========================================
+   Breadcrumb (Glassmorphism)
+   ========================================= */
+.breadcrumb-glass {
+    background: var(--glass-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 100px;
+    padding: 0.75rem 1.5rem;
+    box-shadow: 0 8px 32px 0 var(--glass-shadow), 
+                inset 0 1px 1px var(--glass-highlight);
+    
+    /* CSS-only Parallax Effect using hover */
+    transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                box-shadow 0.4s ease, background 0.4s ease;
+    transform-style: preserve-3d;
+}
+
+/* When the container is hovered, the breadcrumb tilts slightly */
+.parallax-container:hover .breadcrumb-glass {
+    transform: rotateX(5deg) rotateY(-5deg) translateZ(20px);
+    box-shadow: 15px 20px 40px 0 var(--glass-shadow), 
+                inset 0 1px 2px var(--glass-highlight);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    /* Lift content off the glass background */
+    transform: translateZ(30px);
+    transition: transform 0.4s ease;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* Links */
+.breadcrumb-link {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 500;
+    padding: 0.4rem 0.75rem;
+    border-radius: 50px;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+/* Background hover effect */
+.breadcrumb-link::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--glass-highlight);
+    opacity: 0;
+    border-radius: 50px;
+    transform: scale(0.8);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: -1;
+}
+
+.breadcrumb-link:hover {
+    color: var(--text-primary);
+    transform: translateY(-2px);
+}
+
+.breadcrumb-link:hover::before {
+    opacity: 1;
+    transform: scale(1);
+}
+
+/* Icon */
+.breadcrumb-icon {
+    opacity: 0.8;
+    transition: transform 0.3s ease;
+}
+
+.breadcrumb-link:hover .breadcrumb-icon {
+    transform: scale(1.1);
+}
+
+/* Active State */
+.breadcrumb-active .breadcrumb-link {
+    color: var(--text-active);
+    font-weight: 600;
+    cursor: default;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--glass-border);
+}
+
+.breadcrumb-active .breadcrumb-link:hover {
+    transform: none;
+}
+
+.breadcrumb-active .breadcrumb-link::before {
+    display: none;
+}
+
+/* Separator */
+.breadcrumb-separator {
+    color: rgba(255, 255, 255, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+    .breadcrumb-glass {
+        padding: 0.5rem 1rem;
+        border-radius: 20px;
+    }
+    
+    .breadcrumb-list {
+        gap: 0.25rem;
+    }
+    
+    .breadcrumb-link {
+        font-size: 0.85rem;
+        padding: 0.3rem 0.5rem;
+    }
+    
+    /* Disable 3D transforms on small screens for better UX */
+    .parallax-container:hover .breadcrumb-glass {
+        transform: translateY(-5px);
+    }
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    .blob {
+        animation: none;
+        filter: none;
+        opacity: 0.5;
+    }
+    
+    .parallax-container:hover .breadcrumb-glass {
+        transform: none;
+    }
+    
+    .breadcrumb-link {
+        transition: none;
+    }
+    
+    .breadcrumb-link:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a pure HTML/CSS Parallax Breadcrumb component featuring Glassmorphism aesthetics. Resolves issue #78754.

### Changes Made:
- Added `submissions/examples/css-breadcrumb-parallax-glassmorphism-pure/` directory.
- Created `demo.html` featuring the semantic `<nav aria-label="Breadcrumb">` structure, SVG icons, and a container setup for 3D parallax.
- Created `style.css` featuring the UI mechanics:
  - **Glassmorphism**: Uses `backdrop-filter: blur`, semi-transparent backgrounds, and inner highlight shadows.
  - **3D Parallax Tilt**: The container utilizes `perspective` and `transform-style: preserve-3d`. On hover, the breadcrumb rotates slightly while the child elements push outward using `translateZ()`.
  - **Animated Background**: Added blurred, slow-moving CSS blobs in the background to emphasize the glass transparency.
  - **Accessibility**: Includes `prefers-reduced-motion` to disable animations and 3D transforms for users who prefer it.
- Added `README.md` documenting the features and structure.

Closes #78754
