### PR TITLE
docs: document usage for CSS-only Navbar (#58250)

### DIFF
--- a/submissions/docs/css-only-navbar.md
+++ b/submissions/docs/css-only-navbar.md
@@ -1,0 +1,37 @@
+# CSS-Only Navbar
+
+A fully responsive, JavaScript-free navigation bar component for EaseMotion CSS. It leverages the CSS checkbox hack for mobile menu toggling and CSS flexbox for clean, responsive alignment.
+
+## 🎯 Features
+- **Pure HTML & CSS:** Zero JavaScript required for the mobile hamburger menu toggle.
+- **Responsive Design:** Automatically collapses into a mobile-friendly dropdown menu on smaller viewports.
+- **Accessible:** Uses semantic HTML (`<nav>`, `<ul>`, `<li>`) and relies on native HTML form elements for state management.
+- **Lightweight:** Minimal CSS footprint focusing on layout and transitions.
+
+## 🛠️ Usage Guide
+
+To use the CSS-only navbar, your HTML must follow a specific structure. The hidden `<input type="checkbox">` must sit at the same level as (or before) the `.ease-nav-menu` so the CSS sibling selector (`~` or `+`) can trigger the menu visibility.
+
+### Standard HTML Structure
+
+```html
+<nav class="ease-navbar">
+  <!-- Brand / Logo -->
+  <div class="ease-nav-brand">
+    <a href="#">EaseMotion</a>
+  </div>
+
+  <!-- Mobile Toggle (Hidden Checkbox + Label) -->
+  <input type="checkbox" id="ease-nav-toggle" class="ease-nav-checkbox" aria-hidden="true">
+  <label for="ease-nav-toggle" class="ease-nav-toggle-btn" aria-label="Toggle navigation">
+    <span class="ease-nav-icon"></span>
+  </label>
+
+  <!-- Navigation Links -->
+  <ul class="ease-nav-menu">
+    <li><a href="#" class="ease-nav-link active">Home</a></li>
+    <li><a href="#" class="ease-nav-link">Features</a></li>
+    <li><a href="#" class="ease-nav-link">Pricing</a></li>
+    <li><a href="#" class="ease-nav-link">Contact</a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Pull Request Description

Resolves #78787 (Documents #58250). This PR adds the required documentation for the CSS-only Navbar component. It explains the HTML structure, the underlying CSS checkbox hack mechanics, and provides a clear usage example for developers to implement the navbar without JavaScript.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (specifically `submissions/docs/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server (N/A - Documentation only)
- [ ] Includes `style.css` — raw CSS for the proposed feature (N/A - Documentation only)
- [x] Includes `README.md` or equivalent markdown documentation
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Clear, structural documentation (`css-only-navbar.md`) detailing how to implement the EaseMotion CSS-only navbar, including the exact HTML markup required to make the mobile toggle work.

**How does a developer use it?**

They can reference `submissions/docs/css-only-navbar.md` to copy the boilerplate HTML structure and understand how the hidden checkbox state manages the mobile menu.

---

## Notes for Maintainer

This PR only adds documentation inside the `submissions/docs/` folder as requested in the issue tracker.