### PR TITLE
feat: add 3D cyberpunk navbar component

### DIFF
--- a/submissions/examples/cyberpunk-navbar/README.md
+++ b/submissions/examples/cyberpunk-navbar/README.md
@@ -1,0 +1,50 @@
+# Access Terminal Navbar (`ease-navbar--terminal`)
+
+A navbar designed as a corp-net access terminal panel rather than a generic neon sign — a CRT amber/cyan duotone, a clipped tech-armor silhouette, corner-bracket framing, a live link-status LED, and hex-indexed nav links revealed by a circuit-trace line. Built with **pure CSS**, no JavaScript.
+
+## Files
+
+- `demo.html` — standalone live demo
+- `style.css` — the component
+
+## Design intent
+
+Cyberpunk UI in games and film (Blade Runner terminals, Cyberpunk 2077's netrunner interfaces) leans on *diegetic* HUD details — status readouts, hex addresses, bracket framing, scanlines — rather than a rounded pill with a magenta glow. This component borrows that vocabulary instead of the generic "neon gradient" look:
+
+- **Clipped panel, not a rounded pill** — `clip-path` bevels two corners for an armor-plate silhouette.
+- **Corner brackets** — four L-shaped brackets frame the whole nav like a targeting reticle, independent of the panel itself.
+- **Hex-indexed links** — each nav item carries an address (`0x00`–`0x03`) that dims at rest and brightens on hover/focus, alongside a circuit-trace underline that grows in from the left.
+- **Status LED + blinking cursor** — the brand block reads like a real terminal ident line (`SYS // LINK STABLE`), with a two-color pulsing LED and a blinking text cursor after the brand name.
+- **Data-bus divider** — a dashed line beneath the panel with a glowing dot traveling along it, like a status pulse on a bus line.
+
+## How it works
+
+- **No JS**: the mobile menu uses the checkbox hack — `<input type="checkbox">` + `<label>` styled as `[ = ]` / `[ x ]`, toggled via the `:checked` sibling selector.
+- **Boot-in animation**: the panel scales/brightens in on load (`ease-term-boot`) — a single deliberate moment rather than scattered ambient effects.
+- **LED + cursor**: `ease-term-blink` cycles the status LED between cyan and amber; `ease-term-cursor` blinks a text cursor after the brand name, both using `step-end`/simple opacity keyframes, no JS timers.
+- **Trace-line hover**: `.ease-navbar__link::after` grows `width: 0% → 100%` on hover/focus, paired with the hex index fading to full opacity — deliberate and readable, not a screen-flicker glitch.
+- **Bus pulse**: `.ease-navbar__bus::after` is a small radial-gradient dot animated with `left` from off-screen to 100%, riding along a dashed "circuit" line.
+- **Accessibility**:
+  - Label/checkbox toggle is keyboard-focusable and works with the browser's native label-click and `Space` on the checkbox.
+  - `:focus-visible` styling matches hover state on links.
+  - `aria-label` on the burger toggle.
+  - Respects `prefers-reduced-motion`: disables the boot animation, LED blink, cursor blink, and bus pulse; hover/focus states remain instant.
+  - Color contrast: primary text (`--term-text`) and active-state colors meet WCAG AA against the dark panel background.
+- **Responsive**: full horizontal layout down to 680px, then collapses into a stacked terminal-style menu.
+
+## Customization
+
+```css
+.ease-navbar--terminal {
+  --term-amber: #ffb000;
+  --term-cyan: #55e6d5;
+  --term-bg: #05080b;
+  --ease-animation-duration: 2.4s;
+}
+```
+
+The demo loads JetBrains Mono from Google Fonts for the terminal typography; swap `--term-mono` to any monospace stack if you'd rather self-host.
+
+## Naming
+
+Uses the `ease-` prefix (`ease-navbar--terminal`, `ease-navbar__panel`, `ease-navbar__link`, `ease-navbar__bus`, `ease-term-boot` / `ease-term-blink` / `ease-term-cursor` / `ease-term-pulse-travel` keyframes) to match EaseMotion CSS conventions.

--- a/submissions/examples/cyberpunk-navbar/demo.html
+++ b/submissions/examples/cyberpunk-navbar/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Access Terminal Navbar — Demo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at 15% 0%, rgba(85, 230, 213, 0.06), transparent 45%),
+      #05080b;
+    font-family: Inter, sans-serif;
+  }
+  .page-content {
+    max-width: 900px;
+    margin: 3rem auto;
+    padding: 0 1.25rem;
+    color: #8fa89b;
+    line-height: 1.6;
+  }
+  .page-content h1 {
+    font-family: "JetBrains Mono", monospace;
+    color: #d8f5e3;
+    font-size: 1.3rem;
+    letter-spacing: 0.02em;
+  }
+  .page-content code {
+    color: #55e6d5;
+    background: rgba(85, 230, 213, 0.08);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+</style>
+</head>
+<body>
+
+<nav class="ease-navbar--terminal">
+  <div class="ease-navbar__frame">
+    <span class="ease-navbar__bracket-tl"></span>
+    <span class="ease-navbar__bracket-br"></span>
+
+    <div class="ease-navbar__panel">
+      <div class="ease-navbar__ident">
+        <span class="ease-navbar__led"></span>
+        <div class="ease-navbar__brandblock">
+          <span class="ease-navbar__eyebrow">SYS // LINK STABLE</span>
+          <span class="ease-navbar__brand">NETRUNNER</span>
+        </div>
+      </div>
+
+      <input type="checkbox" id="navToggle" class="ease-navbar__toggle" />
+      <label for="navToggle" class="ease-navbar__burger" aria-label="Toggle navigation menu"></label>
+
+      <ul class="ease-navbar__links">
+        <li><a href="#" class="ease-navbar__link is-active"><span class="ease-navbar__link-index">0x00</span>Console</a></li>
+        <li><a href="#" class="ease-navbar__link"><span class="ease-navbar__link-index">0x01</span>Archive</a></li>
+        <li><a href="#" class="ease-navbar__link"><span class="ease-navbar__link-index">0x02</span>Contracts</a></li>
+        <li><a href="#" class="ease-navbar__link"><span class="ease-navbar__link-index">0x03</span>Uplink</a></li>
+      </ul>
+    </div>
+
+    <div class="ease-navbar__bus"></div>
+  </div>
+</nav>
+
+<div class="page-content">
+  <h1>&gt; ACCESS_GRANTED</h1>
+  <p>
+    Pure CSS, no JavaScript. The panel is clipped with <code>clip-path</code>
+    for a beveled tech-armor silhouette instead of a rounded pill, framed by
+    corner brackets like a targeting reticle. Each nav link carries a hex
+    address (<code>0x00</code>–<code>0x03</code>) that brightens on hover as
+    a circuit-trace line grows underneath it. The status LED cycles cyan/amber
+    like a real link-status indicator, and a pulse travels along the data-bus
+    line beneath the panel. Resize below 680px for the terminal-style mobile
+    toggle.
+  </p>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-navbar/style.css
+++ b/submissions/examples/cyberpunk-navbar/style.css
@@ -1,0 +1,383 @@
+/* ==========================================================================
+   ease-navbar--terminal
+   "Access Terminal" navbar — a corp-net HUD panel, not a neon sign.
+   CRT amber/cyan duotone, clipped tech-armor panel, corner-bracket frame,
+   live status readout, hex-indexed nav links with a trace-line reveal.
+   Pure CSS (checkbox hack for mobile), no JS.
+   Submission for: EaseMotion CSS
+   ========================================================================== */
+
+.ease-navbar--terminal {
+  --term-bg: #05080b;
+  --term-panel: #0b120f;
+  --term-panel-alt: #0f1a15;
+  --term-amber: #ffb000;
+  --term-cyan: #55e6d5;
+  --term-text: #d8f5e3;
+  --term-muted: #5d7a6c;
+  --term-alert: #ff5c5c;
+  --term-mono: "JetBrains Mono", "Space Mono", ui-monospace, "SFMono-Regular", monospace;
+  --term-sans: Inter, -apple-system, "Segoe UI", sans-serif;
+
+  --ease-transition-speed: 200ms;
+  --ease-transition-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-animation-duration: 2.4s;
+  --ease-animation-iterations: infinite;
+
+  position: relative;
+  background: var(--term-bg);
+  padding: 1.5rem 1.25rem;
+  font-family: var(--term-sans);
+}
+
+/* ---- outer frame: corner brackets like a targeting reticle ---- */
+.ease-navbar__frame {
+  position: relative;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 6px;
+}
+
+.ease-navbar__frame::before,
+.ease-navbar__frame::after,
+.ease-navbar__frame .ease-navbar__bracket-tl,
+.ease-navbar__frame .ease-navbar__bracket-br {
+  content: "";
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--term-cyan);
+  opacity: 0.8;
+}
+.ease-navbar__frame::before {
+  top: 0;
+  left: 0;
+  border-right: none;
+  border-bottom: none;
+}
+.ease-navbar__frame::after {
+  top: 0;
+  right: 0;
+  border-left: none;
+  border-bottom: none;
+}
+.ease-navbar__frame .ease-navbar__bracket-tl {
+  bottom: 0;
+  left: 0;
+  border-right: none;
+  border-top: none;
+}
+.ease-navbar__frame .ease-navbar__bracket-br {
+  bottom: 0;
+  right: 0;
+  border-left: none;
+  border-top: none;
+}
+
+/* ---- the clipped tech-armor panel ---- */
+.ease-navbar__panel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 1.5rem;
+  background: linear-gradient(180deg, var(--term-panel-alt), var(--term-panel));
+  border: 1px solid rgba(85, 230, 213, 0.25);
+  clip-path: polygon(
+    16px 0,
+    100% 0,
+    100% calc(100% - 16px),
+    calc(100% - 16px) 100%,
+    0 100%,
+    0 16px
+  );
+  animation: ease-term-boot 700ms var(--ease-transition-ease) both;
+}
+
+/* faint scanline texture across the panel */
+.ease-navbar__panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(216, 245, 227, 0.035) 0px,
+    rgba(216, 245, 227, 0.035) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  pointer-events: none;
+}
+
+/* ---- left cluster: status + brand ---- */
+.ease-navbar__ident {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  position: relative;
+  z-index: 1;
+}
+
+.ease-navbar__led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--term-cyan);
+  box-shadow: 0 0 6px var(--term-cyan);
+  animation: ease-term-blink var(--ease-animation-duration) ease-in-out
+    var(--ease-animation-iterations);
+  flex: 0 0 auto;
+}
+
+.ease-navbar__brandblock {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+}
+
+.ease-navbar__eyebrow {
+  font-family: var(--term-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--term-muted);
+}
+
+.ease-navbar__brand {
+  font-family: var(--term-mono);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--term-text);
+}
+
+.ease-navbar__brand::after {
+  content: "_";
+  color: var(--term-amber);
+  animation: ease-term-cursor 1s step-end var(--ease-animation-iterations);
+}
+
+/* ---- nav links: hex-indexed, trace-line reveal ---- */
+.ease-navbar__links {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-navbar__link {
+  position: relative;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--term-muted);
+  text-decoration: none;
+  font-family: var(--term-sans);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding-bottom: 0.3rem;
+  transition: color var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+.ease-navbar__link-index {
+  font-family: var(--term-mono);
+  font-size: 0.68rem;
+  color: var(--term-amber);
+  opacity: 0.55;
+  transition: opacity var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+/* trace line grows under the link on hover, like a circuit trace lighting up */
+.ease-navbar__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 1px;
+  width: 0%;
+  background: var(--term-cyan);
+  box-shadow: 0 0 6px var(--term-cyan);
+  transition: width var(--ease-transition-speed) var(--ease-transition-ease);
+}
+
+.ease-navbar__link:hover,
+.ease-navbar__link:focus-visible {
+  color: var(--term-text);
+  outline: none;
+}
+.ease-navbar__link:hover::after,
+.ease-navbar__link:focus-visible::after {
+  width: 100%;
+}
+.ease-navbar__link:hover .ease-navbar__link-index,
+.ease-navbar__link:focus-visible .ease-navbar__link-index {
+  opacity: 1;
+}
+
+.ease-navbar__link.is-active {
+  color: var(--term-text);
+}
+.ease-navbar__link.is-active::after {
+  width: 100%;
+  background: var(--term-amber);
+  box-shadow: 0 0 6px var(--term-amber);
+}
+.ease-navbar__link.is-active .ease-navbar__link-index {
+  opacity: 1;
+  color: var(--term-cyan);
+}
+
+/* ---- data-bus divider beneath the panel: a traveling pulse ---- */
+.ease-navbar__bus {
+  position: relative;
+  height: 2px;
+  margin-top: 0.75rem;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(85, 230, 213, 0.25) 0px,
+    rgba(85, 230, 213, 0.25) 5px,
+    transparent 5px,
+    transparent 10px
+  );
+  overflow: hidden;
+}
+.ease-navbar__bus::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: 0;
+  width: 40px;
+  height: 6px;
+  background: radial-gradient(circle, var(--term-cyan), transparent 70%);
+  animation: ease-term-pulse-travel 3.2s linear var(--ease-animation-iterations);
+}
+
+/* ---- mobile toggle (checkbox hack, no JS) ---- */
+.ease-navbar__toggle {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-navbar__burger {
+  position: relative;
+  z-index: 2;
+  display: none;
+  align-items: center;
+  font-family: var(--term-mono);
+  font-size: 0.85rem;
+  color: var(--term-cyan);
+  cursor: pointer;
+  user-select: none;
+}
+.ease-navbar__burger::before {
+  content: "[ = ]";
+}
+.ease-navbar__toggle:checked ~ .ease-navbar__burger::before {
+  content: "[ x ]";
+  color: var(--term-alert);
+}
+
+/* --- keyframes --- */
+@keyframes ease-term-boot {
+  0% {
+    opacity: 0;
+    transform: scaleY(0.6);
+    filter: brightness(2.2);
+  }
+  60% {
+    opacity: 1;
+    filter: brightness(1.4);
+  }
+  100% {
+    opacity: 1;
+    transform: scaleY(1);
+    filter: brightness(1);
+  }
+}
+
+@keyframes ease-term-blink {
+  0%,
+  100% {
+    background: var(--term-cyan);
+    box-shadow: 0 0 6px var(--term-cyan);
+  }
+  50% {
+    background: var(--term-amber);
+    box-shadow: 0 0 6px var(--term-amber);
+  }
+}
+
+@keyframes ease-term-cursor {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes ease-term-pulse-travel {
+  0% {
+    left: -40px;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+/* --- responsive --- */
+@media (max-width: 680px) {
+  .ease-navbar__burger {
+    display: flex;
+  }
+
+  .ease-navbar__links {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 6px;
+    right: 6px;
+    z-index: 5;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    background: var(--term-panel);
+    border: 1px solid rgba(85, 230, 213, 0.25);
+    padding: 0.4rem 0;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height var(--ease-transition-speed) var(--ease-transition-ease),
+      opacity var(--ease-transition-speed) var(--ease-transition-ease);
+  }
+
+  .ease-navbar__link {
+    padding: 0.7rem 1.25rem;
+  }
+
+  .ease-navbar__toggle:checked ~ .ease-navbar__links {
+    max-height: 280px;
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-navbar__panel,
+  .ease-navbar__led,
+  .ease-navbar__brand::after,
+  .ease-navbar__bus::after {
+    animation: none;
+  }
+  .ease-navbar__link,
+  .ease-navbar__link::after,
+  .ease-navbar__link-index {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

Adds an **Access Terminal Navbar** (`ease-navbar--terminal`) — a corp-net HUD-style navigation bar rather than a generic neon navbar. Built around a CRT amber/cyan terminal aesthetic: a clipped tech-armor panel framed by corner brackets, a live status LED with blinking cursor, and hex-indexed nav links revealed by a circuit-trace underline. Fully responsive with a pure-CSS checkbox-hack mobile menu — no JavaScript.

Closes #78628

## Design intent

Rather than a rounded panel with a generic neon glow, this leans on diegetic HUD details borrowed from cyberpunk terminal UIs (status readouts, hex addresses, bracket framing, scanlines):

- **Clipped panel silhouette** via `clip-path` — beveled corners instead of a rounded pill
- **Corner-bracket frame** — four L-shaped brackets like a targeting reticle
- **Hex-indexed links** (`0x00`–`0x03`) with a circuit-trace underline that grows in on hover/focus
- **Status ident block** — two-color pulsing LED + blinking text cursor, reading like a real terminal link-status line
- **Data-bus divider** — dashed line beneath the panel with a glowing pulse traveling along it

## What's included

- Boot-in entrance animation on the panel (single deliberate moment, not scattered effects)
- Animated status LED (cyan/amber pulse) and blinking cursor
- Hex-indexed nav links with trace-line hover reveal
- Data-bus pulse animation beneath the nav
- Responsive checkbox-hack mobile menu (`[ = ]` → `[ x ]`), no JavaScript
- Respects `prefers-reduced-motion` (disables all ambient animation, keeps hover/focus instant)
- WCAG AA contrast on text/active states against the dark panel

## Changes