### PR TITLE
feat: create Neumorphic Breadcrumb with Neon styling (#32144)

### DIFF
--- a/submissions/examples/neumorphic-neon-breadcrumb/README.md
+++ b/submissions/examples/neumorphic-neon-breadcrumb/README.md
@@ -1,0 +1,15 @@
+# CSS Neumorphic Breadcrumb with Neon Styling
+
+A highly stylized, pure CSS breadcrumb navigation component. It combines the physical, extruded aesthetics of dark-mode Neumorphism with vibrant, glowing Neon hover effects.
+
+## 🎯 Features
+- **Pure CSS/HTML:** Zero JavaScript dependencies.
+- **Hybrid Styling:** Combines `box-shadow` inset/outset layering for the Neumorphic "pressed" effect with intense `text-shadow` layering for the Neon glow.
+- **Semantic & Accessible:** Utilizes native `<nav>` and `<ol>` elements, respects `aria-current="page"` for the active state, and includes `:focus-visible` outlines.
+- **Responsive:** Automatically wraps breadcrumb items securely using Flexbox on smaller viewports.
+
+## 📁 Files Included
+```text
+demo.html
+style.css
+README.md

--- a/submissions/examples/neumorphic-neon-breadcrumb/demo.html
+++ b/submissions/examples/neumorphic-neon-breadcrumb/demo.html
@@ -1,0 +1,38 @@
+<!-- submissions/examples/neumorphic-neon-breadcrumb/demo.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Neon Breadcrumb | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo-container">
+    
+    <!-- Semantic Breadcrumb Navigation -->
+    <nav class="ease-nn-breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li class="ease-nn-item">
+          <a href="#" class="ease-nn-link">Home</a>
+        </li>
+        <li class="ease-nn-item">
+          <a href="#" class="ease-nn-link">Components</a>
+        </li>
+        <li class="ease-nn-item">
+          <a href="#" class="ease-nn-link">Navigation</a>
+        </li>
+        <li class="ease-nn-item">
+          <!-- aria-current="page" denotes the active item -->
+          <a href="#" class="ease-nn-link" aria-current="page">Breadcrumbs</a>
+        </li>
+      </ol>
+    </nav>
+
+    <p class="demo-hint">Hover or focus the links to see the Neumorphic press effect with Neon glow.</p>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-neon-breadcrumb/style.css
+++ b/submissions/examples/neumorphic-neon-breadcrumb/style.css
@@ -1,0 +1,116 @@
+/* submissions/examples/neumorphic-neon-breadcrumb/style.css */
+
+/* ==========================================================================
+   1. DEMO PRESENTATION STYLES
+   ========================================================================== */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #212529; /* Dark mid-tone for Neumorphism */
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #adb5bd;
+}
+
+.demo-container {
+  padding: 3rem;
+  text-align: center;
+}
+
+.demo-hint {
+  margin-top: 3rem;
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+/* ==========================================================================
+   2. NEUMORPHIC NEON BREADCRUMB COMPONENT
+   ========================================================================== */
+.ease-nn-breadcrumb {
+  display: inline-flex;
+  padding: 1rem 2rem;
+  border-radius: 50px;
+  background: #212529;
+  /* Neumorphic Outset Shadow for the container */
+  box-shadow: 8px 8px 16px #16191c, 
+             -8px -8px 16px #2c3136;
+}
+
+.ease-nn-breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.5rem;
+}
+
+.ease-nn-item {
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+}
+
+/* Breadcrumb Separator */
+.ease-nn-item:not(:last-child)::after {
+  content: '/';
+  margin-left: 0.5rem;
+  color: #495057;
+  text-shadow: 1px 1px 1px #16191c, -1px -1px 1px #2c3136;
+}
+
+/* ── Breadcrumb Links ── */
+.ease-nn-link {
+  text-decoration: none;
+  color: #adb5bd;
+  padding: 0.5rem 1rem;
+  border-radius: 30px;
+  background: #212529;
+  /* Flat Neumorphic base for links */
+  box-shadow: 4px 4px 8px #16191c, 
+             -4px -4px 8px #2c3136;
+  transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+  outline: none;
+}
+
+/* Hover & Focus: Neon Glow + Neumorphic Inset */
+.ease-nn-link:hover,
+.ease-nn-link:focus-visible {
+  color: #0ff; /* Neon Cyan */
+  text-shadow: 0 0 5px #0ff, 0 0 10px #0ff, 0 0 20px #0ff;
+  
+  /* Switches to an inset shadow to look pressed down, combined with a neon underglow */
+  box-shadow: inset 4px 4px 8px #16191c, 
+              inset -4px -4px 8px #2c3136,
+              0 0 15px rgba(0, 255, 255, 0.3);
+}
+
+/* Active/Current Page State */
+.ease-nn-link[aria-current="page"] {
+  color: #f0f; /* Neon Magenta for the current page */
+  text-shadow: 0 0 5px #f0f, 0 0 10px #f0f;
+  box-shadow: inset 4px 4px 8px #16191c, 
+              inset -4px -4px 8px #2c3136,
+              0 0 15px rgba(255, 0, 255, 0.2);
+  cursor: default;
+  pointer-events: none; /* Prevents hovering the current page */
+}
+
+/* Accessible focus ring */
+.ease-nn-link:focus-visible {
+  border: 1px solid #0ff;
+}
+
+/* ==========================================================================
+   3. ACCESSIBILITY (PREFERS-REDUCED-MOTION)
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .ease-nn-link {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #79980 (Features #32144). This PR introduces the **Neumorphic Breadcrumb with Neon styling** component. It blends the soft extruded shadows of dark-mode Neumorphism with vivid, glowing neon text/box shadows that activate when links are hovered or focused.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/neumorphic-neon-breadcrumb/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — documentation and usage
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A stylized navigation breadcrumb that utilizes dark Neumorphic inset/outset shadows combined with intense cyan and magenta neon glowing effects for hover, focus, and active states.

**How does a developer use it?**

```html
<nav class="ease-nn-breadcrumb" aria-label="Breadcrumb">
  <ol>
    <li class="ease-nn-item"><a href="#" class="ease-nn-link">Home</a></li>
    <li class="ease-nn-item"><a href="#" class="ease-nn-link" aria-current="page">Active</a></li>
  </ol>
</nav>