### PR TITLE
feat: create Glowing Breadcrumb with Glassmorphism styling (#45721) #79986

### DIFF
--- a/submissions/examples/css-glowing-breadcrumb-glass-pure/README.md
+++ b/submissions/examples/css-glowing-breadcrumb-glass-pure/README.md
@@ -1,0 +1,14 @@
+# Glowing Breadcrumb with Glassmorphism Styling
+
+A striking navigation component combining frosted glassmorphism with cyberpunk-inspired glowing neon aesthetics.
+
+## Features
+- Authentic frosted glass container utilizing `backdrop-filter: blur`
+- Cyberpunk dual-tone glowing orbs and a subtle grid background to highlight the glass effect
+- Pure CSS glowing hover states utilizing `text-shadow` and `drop-shadow` for SVGs
+- Animated inner gradient reveals on link hover (`transform: translateY`)
+- Fully accessible structured markup (`<nav aria-label="Breadcrumb">`, `<ol>`)
+- Responsive font sizing and padding for mobile devices
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the component sits atop a visually engaging, dark background (like the provided neon orbs) so the glassmorphism blur and neon text shadows have adequate contrast.

--- a/submissions/examples/css-glowing-breadcrumb-glass-pure/demo.html
+++ b/submissions/examples/css-glowing-breadcrumb-glass-pure/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Glass Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Cyberpunk abstract background -->
+    <div class="bg-orb orb-1"></div>
+    <div class="bg-orb orb-2"></div>
+    <div class="bg-grid"></div>
+
+    <div class="container">
+        <!-- Glowing Glassmorphism Breadcrumb -->
+        <nav class="glass-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                            <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                        </svg>
+                        Dashboard
+                    </a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">Projects</a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">EaseMotion</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-current">Design System</span>
+                </li>
+            </ol>
+        </nav>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glowing-breadcrumb-glass-pure/style.css
+++ b/submissions/examples/css-glowing-breadcrumb-glass-pure/style.css
@@ -1,0 +1,199 @@
+:root {
+    --bg-dark: #050510;
+    --neon-cyan: #00f3ff;
+    --neon-purple: #9d00ff;
+    --glass-bg: rgba(15, 15, 25, 0.4);
+    --glass-border: rgba(0, 243, 255, 0.2);
+    --text-muted: #8b9bb4;
+    --text-active: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Outfit', sans-serif;
+}
+
+body {
+    background-color: var(--bg-dark);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+    color: var(--text-active);
+}
+
+/* Cyberpunk Background */
+.bg-grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-size: 50px 50px;
+    background-image: 
+        linear-gradient(to right, rgba(0, 243, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(0, 243, 255, 0.03) 1px, transparent 1px);
+    z-index: 0;
+}
+
+.bg-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    z-index: 0;
+    animation: drift 10s infinite alternate ease-in-out;
+}
+
+.orb-1 {
+    width: 400px;
+    height: 400px;
+    background: rgba(0, 243, 255, 0.15);
+    top: 10%;
+    left: 10%;
+}
+
+.orb-2 {
+    width: 300px;
+    height: 300px;
+    background: rgba(157, 0, 255, 0.15);
+    bottom: 10%;
+    right: 10%;
+    animation-delay: -5s;
+}
+
+@keyframes drift {
+    0% { transform: translate(0, 0); }
+    100% { transform: translate(50px, -50px); }
+}
+
+.container {
+    position: relative;
+    z-index: 10;
+    width: 90%;
+    max-width: 800px;
+    padding: 20px;
+}
+
+/* Glassmorphism Breadcrumb Container */
+.glass-breadcrumb {
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border);
+    border-radius: 12px;
+    padding: 16px 24px;
+    box-shadow: 
+        0 8px 32px 0 rgba(0, 0, 0, 0.3),
+        inset 0 0 20px rgba(0, 243, 255, 0.05);
+    display: inline-block;
+    transition: all 0.4s ease;
+}
+
+.glass-breadcrumb:hover {
+    border-color: rgba(0, 243, 255, 0.4);
+    box-shadow: 
+        0 8px 32px 0 rgba(0, 0, 0, 0.5),
+        inset 0 0 20px rgba(0, 243, 255, 0.1),
+        0 0 20px rgba(0, 243, 255, 0.2);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* Separators */
+.breadcrumb-item:not(:last-child)::after {
+    content: '/';
+    color: rgba(0, 243, 255, 0.5);
+    margin-left: 12px;
+    margin-right: 4px;
+    font-weight: 300;
+    text-shadow: 0 0 5px rgba(0, 243, 255, 0.5);
+}
+
+.breadcrumb-link {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 500;
+    padding: 6px 10px;
+    border-radius: 6px;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+/* Link Hover Glow Effect */
+.breadcrumb-link::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to top, rgba(0, 243, 255, 0.15), transparent);
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+    z-index: -1;
+}
+
+.breadcrumb-link:hover {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 8px rgba(0, 243, 255, 0.6);
+}
+
+.breadcrumb-link:hover::before {
+    transform: translateY(0);
+}
+
+.breadcrumb-link svg {
+    transition: transform 0.3s ease;
+}
+
+.breadcrumb-link:hover svg {
+    transform: scale(1.1);
+    filter: drop-shadow(0 0 5px var(--neon-cyan));
+}
+
+/* Active/Current Page Item */
+.breadcrumb-current {
+    display: flex;
+    align-items: center;
+    color: var(--text-active);
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 6px 10px;
+    letter-spacing: 0.5px;
+    text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .glass-breadcrumb {
+        padding: 12px 16px;
+    }
+    .breadcrumb-item:not(:last-child)::after {
+        margin-left: 6px;
+        margin-right: 2px;
+    }
+    .breadcrumb-link, .breadcrumb-current {
+        font-size: 0.85rem;
+        padding: 4px 6px;
+    }
+}


### PR DESCRIPTION

**Title:** feat: create Glowing Breadcrumb with Glassmorphism styling (#45721) #79986

**Description:**
This PR introduces a visually striking Glassmorphism Breadcrumb navigation component infused with Cyberpunk-style glowing neon aesthetics. Built purely with HTML and CSS.

Fixes #79986

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-glowing-breadcrumb-glass-pure/`
- Implemented an authentic frosted glass container using `backdrop-filter: blur`
- Styled pure CSS glowing hover states using `text-shadow` for text and `drop-shadow` for SVGs
- Created an animated inner gradient reveal on link hover using `transform`
- Added an abstract background featuring blurred glowing orbs and a subtle grid to highlight the glass effect
- Ensured semantic, accessible markup utilizing `<nav aria-label="Breadcrumb">` and a structured `<ol>`
