### PR TITLE
feat: create Glassmorphism Breadcrumb with Retro styling (#88487) #79981

### DIFF
--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/README.md
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/README.md
@@ -1,0 +1,14 @@
+# Glassmorphism Breadcrumb with Retro Styling
+
+A nostalgic, 8-bit Synthwave-inspired breadcrumb navigation that uniquely combines modern frosted glassmorphism with retro hard-shadow aesthetics.
+
+## Features
+- Authentic frosted glass container (`backdrop-filter`) framed by hard, pixelated borders and offset drop-shadows
+- Integration of the 8-bit Google Font `Press Start 2P`
+- Animated, blinking retro cursors (`>`) used as breadcrumb separators
+- CSS pseudo-element brackets (`[ ]`) that appear dynamically on link hover
+- Interactive hover effects using step-based transitions (`steps(4)`) for a stuttering, retro frame-rate feel
+- Fully responsive setup to handle the rigid nature of pixel fonts on mobile devices
+
+## Usage
+Include `demo.html` and `style.css` in your project. The component looks best when placed over a highly saturated, visually dense background (like the included synthwave sunset) to maximize the contrast of the glassmorphism blur and hard shadows. Ensure the `Press Start 2P` font is loaded in your `<head>`.

--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/demo.html
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Glass Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Retro pixel font -->
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Retro sunset background to show off the glassmorphism -->
+    <div class="retro-bg">
+        <div class="sun"></div>
+        <div class="grid-floor"></div>
+    </div>
+
+    <div class="container">
+        <!-- Glassmorphism Breadcrumb with Retro styling -->
+        <nav class="retro-glass-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">HOME</a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">ARCADE</a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">GAMES</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-current">PAC-MAN</span>
+                </li>
+            </ol>
+        </nav>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/style.css
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure/style.css
@@ -1,0 +1,188 @@
+:root {
+    --retro-pink: #ff00ff;
+    --retro-cyan: #00ffff;
+    --retro-yellow: #ffff00;
+    --retro-bg: #1a0b2e;
+    
+    --glass-bg: rgba(26, 11, 46, 0.4);
+    --glass-border: rgba(255, 0, 255, 0.5);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Press Start 2P', monospace; /* 8-bit font */
+}
+
+body {
+    background-color: var(--retro-bg);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Retro Synthwave Background for context */
+.retro-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.sun {
+    position: absolute;
+    bottom: 50%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 300px;
+    height: 300px;
+    background: linear-gradient(to bottom, var(--retro-yellow), var(--retro-pink));
+    border-radius: 50%;
+    box-shadow: 0 0 50px var(--retro-pink);
+}
+
+.grid-floor {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 50%;
+    background-color: #000;
+    background-image: 
+        linear-gradient(transparent 95%, var(--retro-cyan) 100%),
+        linear-gradient(90deg, transparent 95%, var(--retro-cyan) 100%);
+    background-size: 40px 40px;
+    transform: perspective(500px) rotateX(60deg);
+    transform-origin: top center;
+    box-shadow: 0 -2px 10px var(--retro-cyan);
+}
+
+.container {
+    position: relative;
+    z-index: 10;
+    width: 90%;
+    max-width: 800px;
+    padding: 20px;
+    text-align: center;
+}
+
+/* Retro Glassmorphism Breadcrumb */
+.retro-glass-breadcrumb {
+    display: inline-block;
+    background: var(--glass-bg);
+    backdrop-filter: blur(8px); /* slightly pixelated look */
+    -webkit-backdrop-filter: blur(8px);
+    
+    /* Hard pixelated borders for retro feel */
+    border: 4px solid var(--retro-pink);
+    box-shadow: 
+        8px 8px 0px rgba(0, 255, 255, 0.4), /* Hard offset cyan shadow */
+        inset 0 0 15px rgba(255, 0, 255, 0.2);
+    
+    padding: 15px 25px;
+    transition: all 0.2s steps(4); /* Step transition for retro vibe */
+}
+
+.retro-glass-breadcrumb:hover {
+    transform: translate(-4px, -4px);
+    box-shadow: 
+        12px 12px 0px rgba(0, 255, 255, 0.6),
+        inset 0 0 20px rgba(255, 0, 255, 0.4);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* 8-bit Separators */
+.breadcrumb-item:not(:last-child)::after {
+    content: '>';
+    color: var(--retro-cyan);
+    margin-left: 15px;
+    font-size: 10px;
+    animation: blink 1s infinite;
+}
+
+@keyframes blink {
+    0%, 49% { opacity: 1; }
+    50%, 100% { opacity: 0; }
+}
+
+.breadcrumb-link {
+    color: #fff;
+    text-decoration: none;
+    font-size: 10px;
+    letter-spacing: 1px;
+    position: relative;
+    text-shadow: 2px 2px 0px var(--retro-pink);
+    transition: all 0.1s;
+}
+
+.breadcrumb-link:hover {
+    color: var(--retro-yellow);
+    text-shadow: 2px 2px 0px var(--retro-cyan);
+}
+
+.breadcrumb-link::before {
+    content: '[';
+    position: absolute;
+    left: -12px;
+    color: var(--retro-yellow);
+    opacity: 0;
+}
+.breadcrumb-link::after {
+    content: ']';
+    position: absolute;
+    right: -12px;
+    color: var(--retro-yellow);
+    opacity: 0;
+}
+
+.breadcrumb-link:hover::before,
+.breadcrumb-link:hover::after {
+    opacity: 1;
+}
+
+/* Active/Current Page Item */
+.breadcrumb-current {
+    color: var(--retro-cyan);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-shadow: 2px 2px 0px var(--retro-pink);
+}
+
+/* Responsive constraints for large pixel font */
+@media (max-width: 768px) {
+    .retro-glass-breadcrumb {
+        padding: 10px 15px;
+    }
+    
+    .breadcrumb-link, .breadcrumb-current {
+        font-size: 8px;
+    }
+    
+    .breadcrumb-item:not(:last-child)::after {
+        font-size: 8px;
+        margin-left: 10px;
+    }
+    
+    .breadcrumb-list {
+        gap: 10px;
+    }
+}


### PR DESCRIPTION
**Title:** feat: create Glassmorphism Breadcrumb with Retro styling (#88487) #79981

**Description:**
This PR introduces a highly stylized Breadcrumb component that uniquely blends modern frosted Glassmorphism with classic 8-bit Retro synthwave aesthetics. Built entirely with HTML and CSS.

Fixes #79981

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-glassmorphism-breadcrumb-retro-pure/`
- Applied an authentic frosted glass background using `backdrop-filter: blur`, framed by retro hard-offset borders and drop-shadows
- Integrated the classic 8-bit pixel font `Press Start 2P`
- Replaced standard separators with CSS-animated blinking cursors (`>`) for a terminal feel
- Added interactive hover states that reveal CSS pseudo-element brackets (`[ ]`) around links
- Utilized CSS `steps()` timing functions on hover states to simulate a low-framerate retro stutter effect
