### PR TITLE
feat: create CSS-only Breadcrumb with Neumorphism styling (#64420) #79977

### DIFF
--- a/submissions/examples/css-breadcrumb-neumorphism-pure/README.md
+++ b/submissions/examples/css-breadcrumb-neumorphism-pure/README.md
@@ -1,0 +1,14 @@
+# CSS-only Breadcrumb with Neumorphism Styling
+
+A soft, tactile breadcrumb navigation utilizing Neumorphism (Soft UI) design principles. Built entirely with HTML and CSS.
+
+## Features
+- Deep Neumorphic visual styling utilizing meticulously paired `box-shadow` values (light source and dark drop shadow)
+- Navigational links act as extruded, physical buttons that invert to an inset state upon being clicked (`:active`)
+- The current page indicator is styled with a permanent inset shadow to indicate its inactive/selected state
+- Custom CSS-drawn chevron separators that incorporate subtle lighting highlights to match the physical aesthetic
+- Fully accessible structured markup (`<nav aria-label="Breadcrumb">`, `<ol>`)
+- Flexbox based responsive layout
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the background color of your parent container perfectly matches the `--bg-color` variable defined in the CSS (`#e0e5ec`). Neumorphism relies heavily on the elements having the exact same base color as their background to create the physical illusion.

--- a/submissions/examples/css-breadcrumb-neumorphism-pure/demo.html
+++ b/submissions/examples/css-breadcrumb-neumorphism-pure/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        <!-- Neumorphic Breadcrumb Container -->
+        <nav class="neumorphic-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neumorphic-btn">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                            <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                        </svg>
+                    </a>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neumorphic-btn">Products</a>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neumorphic-btn">Electronics</a>
+                </li>
+                
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-current neumorphic-inset">Smartphones</span>
+                </li>
+
+            </ol>
+        </nav>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-neumorphism-pure/style.css
+++ b/submissions/examples/css-breadcrumb-neumorphism-pure/style.css
@@ -1,0 +1,127 @@
+:root {
+    --bg-color: #e0e5ec;
+    --text-primary: #4a5568;
+    --text-active: #3182ce;
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Nunito', sans-serif;
+}
+
+body {
+    background-color: var(--bg-color);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 90%;
+    max-width: 800px;
+    padding: 20px;
+}
+
+/* Base Neumorphic Container */
+.neumorphic-breadcrumb {
+    background-color: var(--bg-color);
+    padding: 20px 30px;
+    border-radius: 20px;
+    box-shadow: 
+        10px 10px 20px var(--shadow-dark),
+        -10px -10px 20px var(--shadow-light);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* Custom Separator chevron */
+.breadcrumb-item:not(:last-child)::after {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-top: 3px solid var(--shadow-dark);
+    border-right: 3px solid var(--shadow-dark);
+    transform: rotate(45deg);
+    margin-left: 20px;
+    border-radius: 1px;
+    box-shadow: 1px -1px 1px rgba(255,255,255,0.8);
+}
+
+/* Link elements styled as extruded Neumorphic buttons */
+.neumorphic-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 10px 20px;
+    border-radius: 12px;
+    box-shadow: 
+        5px 5px 10px var(--shadow-dark),
+        -5px -5px 10px var(--shadow-light);
+    transition: all 0.2s ease;
+}
+
+.neumorphic-btn:hover {
+    color: var(--text-active);
+}
+
+.neumorphic-btn:active {
+    box-shadow: 
+        inset 4px 4px 8px var(--shadow-dark),
+        inset -4px -4px 8px var(--shadow-light);
+}
+
+/* Current page element styled as inset Neumorphic */
+.neumorphic-inset {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-color);
+    color: var(--text-active);
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 10px 20px;
+    border-radius: 12px;
+    box-shadow: 
+        inset 4px 4px 8px var(--shadow-dark),
+        inset -4px -4px 8px var(--shadow-light);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .neumorphic-breadcrumb {
+        padding: 15px 20px;
+    }
+    
+    .neumorphic-btn, .neumorphic-inset {
+        padding: 8px 14px;
+        font-size: 0.9rem;
+    }
+    
+    .breadcrumb-item:not(:last-child)::after {
+        margin-left: 12px;
+        width: 6px;
+        height: 6px;
+    }
+}


### PR DESCRIPTION

**Title:** feat: create CSS-only Breadcrumb with Neumorphism styling (#64420) #79977

**Description:**
This PR introduces a tactile, highly interactive Breadcrumb navigation component utilizing Neumorphism (Soft UI) styling. Built entirely with HTML and CSS.

Fixes #79977

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-breadcrumb-neumorphism-pure/`
- Implemented deep Neumorphic physical styling using precise `box-shadow` configurations (pairing light and dark drop shadows)
- Styled breadcrumb links as extruded buttons that physically invert to an inset state upon being clicked (`:active`)
- Styled the active/current page indicator with a permanent inset shadow to indicate its selected state
- Created custom CSS-drawn chevron separators featuring subtle lighting highlights
- Ensured a fully responsive flexbox layout with semantic `<nav aria-label="Breadcrumb">` markup
