### PR TITLE
feat: create Glassmorphism Breadcrumb with Retro styling (#57192) #79968

### DIFF
--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/README.md
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/README.md
@@ -1,0 +1,13 @@
+# Vaporwave Glassmorphism Breadcrumb
+
+A unique take on the "Retro Glassmorphism Breadcrumb", focusing on DOS-style paths (`C:\`) and 90s Vaporwave aesthetics rather than 8-bit arcade styles.
+
+## Features
+- Authentic frosted glass container utilizing `backdrop-filter: blur`
+- Animated Vaporwave perspective grid background (`transform: perspective`)
+- Utilizes the `VT323` terminal font from Google Fonts for a DOS aesthetic
+- Uses backslashes (`\`) as separators to match the Windows/DOS path theme
+- Pure CSS glowing text effects and pulsing animations
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `VT323` font is loaded in your `<head>`.

--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/demo.html
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Vaporwave Glass Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Retro pixel font -->
+    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Retro Vaporwave background -->
+    <div class="vaporwave-bg">
+        <div class="grid-perspective"></div>
+        <div class="glow-orb"></div>
+    </div>
+
+    <div class="container">
+        <nav class="vapor-glass-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">C:\</a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">SYSTEM32</a>
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">DRIVERS</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-current">AUDIO.SYS</span>
+                </li>
+            </ol>
+        </nav>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/style.css
+++ b/submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/style.css
@@ -1,0 +1,151 @@
+:root {
+    --vapor-cyan: #0ff;
+    --vapor-pink: #f0f;
+    --bg-dark: #00001a;
+    --glass-bg: rgba(0, 0, 26, 0.4);
+    --glass-border: rgba(0, 255, 255, 0.3);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'VT323', monospace;
+}
+
+body {
+    background-color: var(--bg-dark);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+}
+
+/* Vaporwave Background */
+.vaporwave-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 0;
+}
+
+.grid-perspective {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 50%;
+    background-image: 
+        linear-gradient(transparent 95%, var(--vapor-pink) 100%),
+        linear-gradient(90deg, transparent 95%, var(--vapor-pink) 100%);
+    background-size: 50px 50px;
+    transform: perspective(600px) rotateX(70deg);
+    transform-origin: top center;
+    animation: grid-scroll 3s linear infinite;
+}
+
+@keyframes grid-scroll {
+    0% { background-position: 0 0; }
+    100% { background-position: 0 50px; }
+}
+
+.glow-orb {
+    position: absolute;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 250px;
+    height: 250px;
+    background: radial-gradient(circle, var(--vapor-cyan) 0%, transparent 70%);
+    filter: blur(20px);
+}
+
+.container {
+    position: relative;
+    z-index: 10;
+    padding: 20px;
+    width: 90%;
+    max-width: 800px;
+}
+
+/* Breadcrumb Container */
+.vapor-glass-breadcrumb {
+    display: inline-block;
+    background: var(--glass-bg);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 2px solid var(--vapor-cyan);
+    padding: 12px 24px;
+    box-shadow: 
+        0 0 15px rgba(0, 255, 255, 0.4),
+        inset 0 0 15px rgba(255, 0, 255, 0.2);
+    border-radius: 4px;
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* Separators */
+.breadcrumb-item:not(:last-child)::after {
+    content: '\\';
+    color: var(--vapor-pink);
+    margin-left: 8px;
+    font-size: 1.5rem;
+    text-shadow: 0 0 5px var(--vapor-pink);
+}
+
+/* Links */
+.breadcrumb-link {
+    color: #fff;
+    text-decoration: none;
+    font-size: 1.5rem;
+    letter-spacing: 2px;
+    text-shadow: 2px 2px 0px rgba(0,0,0,0.8);
+    position: relative;
+    transition: all 0.3s ease;
+}
+
+.breadcrumb-link:hover {
+    color: var(--vapor-cyan);
+    text-shadow: 
+        0 0 5px var(--vapor-cyan),
+        2px 2px 0px rgba(0,0,0,0.8);
+}
+
+/* Active State */
+.breadcrumb-current {
+    color: var(--vapor-pink);
+    font-size: 1.5rem;
+    letter-spacing: 2px;
+    text-shadow: 
+        0 0 8px var(--vapor-pink),
+        2px 2px 0px rgba(0,0,0,0.8);
+    animation: pulse 2s infinite alternate;
+}
+
+@keyframes pulse {
+    0% { opacity: 0.8; }
+    100% { opacity: 1; text-shadow: 0 0 15px var(--vapor-pink); }
+}
+
+@media (max-width: 600px) {
+    .breadcrumb-link, .breadcrumb-current, .breadcrumb-item:not(:last-child)::after {
+        font-size: 1.1rem;
+    }
+    .vapor-glass-breadcrumb {
+        padding: 10px 15px;
+    }
+}


### PR DESCRIPTION
**Title:** feat: create Glassmorphism Breadcrumb with Retro styling (#57192) #79968

**Description:**
This PR introduces a unique Glassmorphism Breadcrumb component blending frosted glass effects with a nostalgic 90s Vaporwave and DOS terminal aesthetic. Built purely in HTML and CSS.

Fixes #79968

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-glassmorphism-breadcrumb-retro-pure-2/`
- Implemented an authentic frosted glass background using `backdrop-filter: blur`, highlighted by neon cyan and pink borders
- Utilized the `VT323` terminal font from Google Fonts for a retro DOS aesthetic
- Styled the breadcrumb paths to mimic Windows/DOS directory structures (e.g. `C:\SYSTEM32`), using CSS pseudo-elements to insert backslash separators
- Created an animated Vaporwave 3D perspective grid background to showcase the glassmorphism refraction
- Built CSS-only glowing text effects and pulsing animations for the active path state
