### PR TITLE
feat: create CSS-only Avatar with Retro styling (#95837) #79967

### DIFF
--- a/submissions/examples/css-avatar-retro-pure/README.md
+++ b/submissions/examples/css-avatar-retro-pure/README.md
@@ -1,0 +1,14 @@
+# CSS-only Avatar with Retro Styling
+
+A nostalgic, 8-bit arcade-style avatar component built purely with HTML and CSS.
+
+## Features
+- Simulated 8-bit pixelated borders created entirely using layered CSS `box-shadow` properties (no images used for the frame)
+- CSS filters applied to the avatar image (`image-rendering: pixelated`, `contrast`, `sepia`) to give modern photos a retro CRT feel
+- A pure CSS pixel-grid overlay using repeating `linear-gradient` to simulate low-res screens
+- Classic arcade "Player 1 vs Player 2" color schemes
+- Offline state styling with greyscale filtering and classic blinking "INSERT COIN" animation using `steps()` timing functions
+- 8-bit rigid jump animation on hover
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Press Start 2P` font is loaded in your `<head>`. You can modify the `--pixel-size` CSS variable to easily scale the thickness of the 8-bit borders.

--- a/submissions/examples/css-avatar-retro-pure/demo.html
+++ b/submissions/examples/css-avatar-retro-pure/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Avatar</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="avatar-container">
+        
+        <!-- Player 1 Avatar -->
+        <div class="retro-avatar-wrapper">
+            <div class="retro-avatar player-1">
+                <img src="https://i.pravatar.cc/150?img=11" alt="Player 1">
+                <div class="pixel-overlay"></div>
+            </div>
+            <div class="avatar-label">
+                <span class="p-num">P1</span>
+                <span class="score">9999</span>
+            </div>
+        </div>
+
+        <!-- Player 2 Avatar (Offline state) -->
+        <div class="retro-avatar-wrapper offline">
+            <div class="retro-avatar player-2">
+                <img src="https://i.pravatar.cc/150?img=12" alt="Player 2">
+                <div class="pixel-overlay"></div>
+            </div>
+            <div class="avatar-label">
+                <span class="p-num">P2</span>
+                <span class="score">INSERT COIN</span>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-avatar-retro-pure/style.css
+++ b/submissions/examples/css-avatar-retro-pure/style.css
@@ -1,0 +1,165 @@
+:root {
+    --retro-red: #ff0000;
+    --retro-blue: #0000ff;
+    --retro-yellow: #ffff00;
+    --retro-black: #111;
+    --retro-white: #fff;
+    --pixel-size: 4px;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Press Start 2P', monospace;
+}
+
+body {
+    background-color: var(--retro-black);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.avatar-container {
+    display: flex;
+    gap: 50px;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 20px;
+}
+
+.retro-avatar-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 15px;
+    width: 150px;
+}
+
+/* 8-bit Avatar Frame */
+.retro-avatar {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    background-color: var(--retro-black);
+    
+    /* Pixelated border utilizing inset box shadows */
+    box-shadow: 
+        inset var(--pixel-size) 0 0 var(--retro-white),
+        inset calc(var(--pixel-size) * -1) 0 0 var(--retro-white),
+        inset 0 var(--pixel-size) 0 var(--retro-white),
+        inset 0 calc(var(--pixel-size) * -1) 0 var(--retro-white),
+        inset calc(var(--pixel-size) * 2) 0 0 var(--retro-black),
+        inset calc(var(--pixel-size) * -2) 0 0 var(--retro-black),
+        inset 0 calc(var(--pixel-size) * 2) 0 var(--retro-black),
+        inset 0 calc(var(--pixel-size) * -2) 0 var(--retro-black);
+        
+    padding: calc(var(--pixel-size) * 2);
+    transition: transform 0.1s steps(2);
+}
+
+.retro-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    /* Force image pixelation on scaling */
+    image-rendering: pixelated;
+    /* Reduce contrast/saturation to feel more retro */
+    filter: contrast(1.2) saturate(0.8) sepia(0.3);
+}
+
+/* Simulated CRT/Pixel grid overlay */
+.pixel-overlay {
+    position: absolute;
+    top: calc(var(--pixel-size) * 2);
+    left: calc(var(--pixel-size) * 2);
+    right: calc(var(--pixel-size) * 2);
+    bottom: calc(var(--pixel-size) * 2);
+    background-image: 
+        linear-gradient(rgba(0,0,0,0.1) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0,0,0,0.1) 1px, transparent 1px);
+    background-size: 4px 4px;
+    pointer-events: none;
+    z-index: 10;
+}
+
+/* Player 1 Specific Colors */
+.player-1 .retro-avatar {
+    box-shadow: 
+        inset var(--pixel-size) 0 0 var(--retro-red),
+        inset calc(var(--pixel-size) * -1) 0 0 var(--retro-red),
+        inset 0 var(--pixel-size) 0 var(--retro-red),
+        inset 0 calc(var(--pixel-size) * -1) 0 var(--retro-red);
+}
+
+.player-1 .p-num {
+    color: var(--retro-red);
+}
+
+/* Player 2 Specific Colors */
+.player-2 .retro-avatar {
+    box-shadow: 
+        inset var(--pixel-size) 0 0 var(--retro-blue),
+        inset calc(var(--pixel-size) * -1) 0 0 var(--retro-blue),
+        inset 0 var(--pixel-size) 0 var(--retro-blue),
+        inset 0 calc(var(--pixel-size) * -1) 0 var(--retro-blue);
+}
+
+.player-2 .p-num {
+    color: var(--retro-blue);
+}
+
+/* Offline/Insert Coin state */
+.offline .retro-avatar img {
+    filter: grayscale(1) contrast(1.5);
+    opacity: 0.5;
+}
+
+.offline .score {
+    animation: blink 1s infinite steps(2);
+    color: var(--retro-yellow);
+}
+
+/* Labels */
+.avatar-label {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.p-num {
+    font-size: 1rem;
+    text-shadow: 2px 2px 0px rgba(255,255,255,0.2);
+}
+
+.score {
+    color: var(--retro-white);
+    font-size: 0.65rem;
+    line-height: 1.4;
+}
+
+/* Hover Animation (Simulated 8-bit jump) */
+.retro-avatar-wrapper:hover .retro-avatar {
+    transform: translateY(-8px);
+}
+
+@keyframes blink {
+    0% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+@media (max-width: 500px) {
+    .retro-avatar {
+        width: 100px;
+        height: 100px;
+    }
+    .p-num {
+        font-size: 0.8rem;
+    }
+    .score {
+        font-size: 0.5rem;
+    }
+}


### PR DESCRIPTION
**Title:** feat: create CSS-only Avatar with Retro styling (#95837) #79967

**Description:**
This PR introduces a highly nostalgic, 8-bit arcade-style Avatar component built entirely in HTML and CSS without the use of image assets for the framing.

Fixes #79967

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-avatar-retro-pure/`
- Engineered a simulated 8-bit pixelated border utilizing carefully layered CSS `box-shadow` properties, making it infinitely scalable
- Implemented CSS image filters (`image-rendering: pixelated`, `sepia`, `contrast`) to give modern avatar images an authentic low-res CRT monitor feel
- Created a pure CSS pixel-grid overlay using repeating `linear-gradient` to overlay scanlines on the avatar image
- Designed an "Offline/Insert Coin" state complete with greyscale filtering and a classic CSS `steps()` blinking animation
- Integrated the `Press Start 2P` font for authentic arcade typography
