### PR TITLE
feat: add Neumorphic Neon Breadcrumb (Express) #80057

### DIFF
--- a/submissions/examples/css-breadcrumb-neumorphic-neon-pure/README.md
+++ b/submissions/examples/css-breadcrumb-neumorphic-neon-pure/README.md
@@ -1,0 +1,14 @@
+# Neumorphic Neon Breadcrumb
+
+A dark-mode Neumorphic breadcrumb navigation infused with glowing neon cyber-aesthetics.
+
+## Features
+- Deep, dark Neumorphic physical styling crafted utilizing precise light/dark `box-shadow` values on a `#12141c` base
+- Navigational links are styled as extruded physical buttons that invert to an inset state (`:active`)
+- Glowing Neon hover states utilizing `text-shadow`
+- An animated pulsing neon underline effect on the active/current page indicator
+- Custom CSS-drawn inset separators to match the physical styling
+- Fully responsive layout
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the background color of your parent container perfectly matches the `--bg-dark` variable (`#12141c`) to maintain the physical depth illusion required by Neumorphism.

--- a/submissions/examples/css-breadcrumb-neumorphic-neon-pure/demo.html
+++ b/submissions/examples/css-breadcrumb-neumorphic-neon-pure/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Neon Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <!-- Dark Neumorphic Base with Neon Accents -->
+        <nav class="neu-neon-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neu-btn">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                            <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                        </svg>
+                    </a>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neu-btn">Cyber</a>
+                </li>
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link neu-btn">Systems</a>
+                </li>
+                
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-current neu-inset neon-glow">Core</span>
+                </li>
+
+            </ol>
+        </nav>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-neumorphic-neon-pure/style.css
+++ b/submissions/examples/css-breadcrumb-neumorphic-neon-pure/style.css
@@ -1,0 +1,162 @@
+:root {
+    --bg-dark: #12141c;
+    --neu-shadow-dark: #0a0b10;
+    --neu-shadow-light: #1a1d28;
+    --neon-accent: #00ffcc;
+    --text-muted: #6b7280;
+    --text-active: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Montserrat', sans-serif;
+}
+
+body {
+    background-color: var(--bg-dark);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 90%;
+    max-width: 800px;
+    padding: 20px;
+}
+
+/* Dark Neumorphic Base */
+.neu-neon-breadcrumb {
+    background-color: var(--bg-dark);
+    padding: 20px 30px;
+    border-radius: 20px;
+    box-shadow: 
+        10px 10px 20px var(--neu-shadow-dark),
+        -10px -10px 20px var(--neu-shadow-light);
+    border: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* Custom Separator line */
+.breadcrumb-item:not(:last-child)::after {
+    content: '';
+    display: inline-block;
+    width: 20px;
+    height: 2px;
+    background-color: var(--bg-dark);
+    box-shadow: 
+        inset 1px 1px 2px var(--neu-shadow-dark),
+        inset -1px -1px 2px var(--neu-shadow-light);
+    margin-left: 15px;
+    border-radius: 2px;
+}
+
+/* Extruded Buttons */
+.neu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-dark);
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 700;
+    padding: 10px 20px;
+    border-radius: 12px;
+    box-shadow: 
+        5px 5px 10px var(--neu-shadow-dark),
+        -5px -5px 10px var(--neu-shadow-light);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.01);
+}
+
+/* Neon Hover State */
+.neu-btn:hover {
+    color: var(--neon-accent);
+    text-shadow: 0 0 8px rgba(0, 255, 204, 0.6);
+}
+
+/* Pressed State */
+.neu-btn:active {
+    box-shadow: 
+        inset 4px 4px 8px var(--neu-shadow-dark),
+        inset -4px -4px 8px var(--neu-shadow-light);
+    color: var(--neon-accent);
+}
+
+/* Inset Active Page */
+.neu-inset {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-dark);
+    color: var(--text-active);
+    font-size: 0.95rem;
+    font-weight: 700;
+    padding: 10px 20px;
+    border-radius: 12px;
+    box-shadow: 
+        inset 4px 4px 8px var(--neu-shadow-dark),
+        inset -4px -4px 8px var(--neu-shadow-light);
+    border: 1px solid rgba(0, 255, 204, 0.1);
+}
+
+/* Neon Glow Effect for the current page */
+.neon-glow {
+    color: var(--neon-accent);
+    text-shadow: 0 0 10px rgba(0, 255, 204, 0.8);
+    position: relative;
+    overflow: hidden;
+}
+
+/* Pulsing neon underline */
+.neon-glow::after {
+    content: '';
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 20px;
+    height: 2px;
+    background: var(--neon-accent);
+    box-shadow: 0 0 8px var(--neon-accent);
+    border-radius: 2px;
+    animation: pulseWidth 2s infinite alternate;
+}
+
+@keyframes pulseWidth {
+    0% { width: 10px; opacity: 0.5; }
+    100% { width: 30px; opacity: 1; }
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .neu-neon-breadcrumb {
+        padding: 15px;
+    }
+    
+    .neu-btn, .neu-inset {
+        padding: 8px 14px;
+        font-size: 0.85rem;
+    }
+    
+    .breadcrumb-item:not(:last-child)::after {
+        width: 10px;
+        margin-left: 10px;
+    }
+}


### PR DESCRIPTION
**Title:** feat: add Neumorphic Neon Breadcrumb (Express) #80057

**Description:**
This PR introduces a striking Neumorphic Breadcrumb component infused with glowing Neon Cyber-aesthetics. Built entirely with HTML and CSS.

Fixes #80057

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-breadcrumb-neumorphic-neon-pure/`
- Implemented deep dark-mode Neumorphic physical styling using precise light/dark `box-shadow` pairing on a `#12141c` base
- Styled links as extruded physical buttons that invert to an inset shadow state (`:active`) when pressed
- Integrated pure CSS glowing neon hover effects using `text-shadow`
- Added an animated, pulsing neon underline to the active/current page indicator using `@keyframes`
- Designed custom CSS-drawn inset separators to seamlessly match the physical aesthetic
