### PR TITLE
feat: add basic data source row demo

### DIFF
--- a/submissions/examples/basic-data-source-row-kk/README.md
+++ b/submissions/examples/basic-data-source-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Data Source Row
+
+## What it does
+
+This submission adds a simple CSS-only data source row for sync panels, connector settings, dashboards, admin cards, and integration summaries.
+
+It aligns a source marker, source name, sync details, and a small connection status in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a source marker, copy, and status:
+
+```html
+<div class="basic-data-source-row">
+  <span class="source-marker" aria-hidden="true">DB</span>
+  <div class="source-copy">
+    <strong>Production database</strong>
+    <p>PostgreSQL - synced 4 minutes ago</p>
+  </div>
+  <span class="source-status is-online">Online</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across dashboard settings, admin panels, connector lists, and data-heavy interfaces. It keeps source status details easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Source marker, name, sync details, and status layout
+- Online, pending, and paused examples
+- Divider support between rows
+- Text truncation for long sync details
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the data source row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-data-source-row-kk/demo.html
+++ b/submissions/examples/basic-data-source-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Data Source Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Data Source Row</p>
+          <h1>Compact source rows for sync, connector, and settings panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a source marker, source name,
+            sync details, and a small connection status in one reusable row.
+          </p>
+        </header>
+
+        <section class="source-panel" aria-label="Data source row examples">
+          <div class="basic-data-source-row">
+            <span class="source-marker" aria-hidden="true">DB</span>
+            <div class="source-copy">
+              <strong>Production database</strong>
+              <p>PostgreSQL - synced 4 minutes ago</p>
+            </div>
+            <span class="source-status is-online">Online</span>
+          </div>
+
+          <div class="basic-data-source-row">
+            <span class="source-marker" aria-hidden="true">CSV</span>
+            <div class="source-copy">
+              <strong>Monthly import</strong>
+              <p>Spreadsheet upload - waiting for review</p>
+            </div>
+            <span class="source-status is-pending">Pending</span>
+          </div>
+
+          <div class="basic-data-source-row">
+            <span class="source-marker" aria-hidden="true">API</span>
+            <div class="source-copy">
+              <strong>Analytics service</strong>
+              <p>External API - sync paused</p>
+            </div>
+            <span class="source-status">Paused</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-data-source-row"&gt;
+  &lt;span class="source-marker" aria-hidden="true"&gt;DB&lt;/span&gt;
+  &lt;div class="source-copy"&gt;
+    &lt;strong&gt;Production database&lt;/strong&gt;
+    &lt;p&gt;PostgreSQL - synced 4 minutes ago&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="source-status is-online"&gt;Online&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-data-source-row-kk/style.css
+++ b/submissions/examples/basic-data-source-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #67e8f9;
+  --accent-soft: rgba(103, 232, 249, 0.14);
+  --online: #86efac;
+  --pending: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(103, 232, 249, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.source-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-data-source-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-data-source-row + .basic-data-source-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.source-marker {
+  width: 2.7rem;
+  height: 2.7rem;
+  flex: 0 0 2.7rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(103, 232, 249, 0.32);
+  border-radius: 0.85rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.source-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.source-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.source-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-status {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.source-status.is-online {
+  color: var(--online);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.source-status.is-pending {
+  color: var(--pending);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-data-source-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .source-status {
+    margin-left: 3.55rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Data Source Row demo inside `submissions/examples/basic-data-source-row-kk/`. This submission introduces a compact CSS-only row pattern for sync panels, connector settings, dashboards, admin cards, and integration summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only data source row for showing a source marker, source name, sync details, and small connection status in one compact layout.

**How does a developer use it?**

```html
<div class="basic-data-source-row">
  <span class="source-marker" aria-hidden="true">DB</span>
  <div class="source-copy">
    <strong>Production database</strong>
    <p>PostgreSQL - synced 4 minutes ago</p>
  </div>
  <span class="source-status is-online">Online</span>
</div>