### PR TITLE
feat: add Interactive Neon Dropdown (Variant B) #80045

### DIFF
--- a/submissions/examples/css-dropdown-neon-b-pure/README.md
+++ b/submissions/examples/css-dropdown-neon-b-pure/README.md
@@ -1,0 +1,14 @@
+# Interactive Neon Dropdown (Variant B)
+
+A cyber-aesthetic dropdown menu featuring glowing neon hover states, staggered reveal animations, and a sleek dark mode grid.
+
+## Features
+- **Neon Glitch Aesthetics**: Uses heavily layered `box-shadow` and `text-shadow` combinations to create authentic, glowing neon effects that transition smoothly on hover.
+- **Color Shifting**: The trigger button dynamically shifts its glow color from Cyan to Magenta when the dropdown is activated.
+- **Staggered Entry Animation**: The dropdown items slide in sequentially (staggered) utilizing CSS inline variables (`--i: 1`) combined with the `calc()` function in the `transition-delay` property.
+- **Scanline Hover Effect**: Hovering over individual menu items triggers a glossy, animated scanline effect sweeping across the item using the `::before` pseudo-element.
+- **Alert Variations**: Includes a specific style class (`.alert-link`) for destructive actions, featuring a harsh red neon glow.
+- **Responsive**: Adapts to full width on mobile viewports for easier tap targets.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Orbitron` font is loaded in your `<head>` to maintain the cyberpunk aesthetic.

--- a/submissions/examples/css-dropdown-neon-b-pure/demo.html
+++ b/submissions/examples/css-dropdown-neon-b-pure/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Neon Dropdown (Variant B)</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <!-- Interactive Neon Dropdown -->
+        <div class="neon-dropdown-wrapper">
+            
+            <button class="neon-trigger">
+                SYSTEM MENU
+                <span class="neon-arrow"></span>
+            </button>
+            
+            <div class="neon-dropdown-menu">
+                <ul class="neon-list">
+                    <li class="neon-item" style="--i: 1;">
+                        <a href="#" class="neon-link">
+                            <span class="link-icon">⚡</span>
+                            Core Modules
+                        </a>
+                    </li>
+                    <li class="neon-item" style="--i: 2;">
+                        <a href="#" class="neon-link">
+                            <span class="link-icon">🧬</span>
+                            Genetic Data
+                        </a>
+                    </li>
+                    <li class="neon-item" style="--i: 3;">
+                        <a href="#" class="neon-link">
+                            <span class="link-icon">🛡️</span>
+                            Firewall Config
+                        </a>
+                    </li>
+                    <li class="neon-item" style="--i: 4;">
+                        <a href="#" class="neon-link alert-link">
+                            <span class="link-icon">⚠️</span>
+                            Purge Memory
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-dropdown-neon-b-pure/style.css
+++ b/submissions/examples/css-dropdown-neon-b-pure/style.css
@@ -1,0 +1,199 @@
+:root {
+    --bg-color: #050505;
+    --neon-cyan: #0ff;
+    --neon-magenta: #f0f;
+    --neon-red: #ff003c;
+    --text-primary: #fff;
+    --grid-color: rgba(0, 255, 255, 0.1);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Orbitron', sans-serif;
+}
+
+body {
+    background-color: var(--bg-color);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    /* Subdued Cyberpunk Grid Background */
+    background-image: 
+        linear-gradient(var(--grid-color) 1px, transparent 1px),
+        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 30px 30px;
+    background-position: center center;
+}
+
+.container {
+    padding: 40px;
+}
+
+.neon-dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+/* Trigger Button */
+.neon-trigger {
+    background: transparent;
+    color: var(--neon-cyan);
+    border: 1px solid var(--neon-cyan);
+    padding: 15px 30px;
+    font-size: 1.1rem;
+    letter-spacing: 2px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    text-transform: uppercase;
+    box-shadow: 
+        0 0 10px rgba(0, 255, 255, 0.2),
+        inset 0 0 10px rgba(0, 255, 255, 0.2);
+}
+
+/* Neon flicker effect on hover */
+.neon-trigger:hover {
+    background: rgba(0, 255, 255, 0.1);
+    box-shadow: 
+        0 0 20px rgba(0, 255, 255, 0.5),
+        inset 0 0 20px rgba(0, 255, 255, 0.5);
+    text-shadow: 0 0 5px var(--neon-cyan);
+}
+
+/* Animated Arrow */
+.neon-arrow {
+    width: 10px;
+    height: 10px;
+    border-right: 2px solid var(--neon-cyan);
+    border-bottom: 2px solid var(--neon-cyan);
+    transform: translateY(-2px) rotate(45deg);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.neon-dropdown-wrapper:hover .neon-arrow {
+    transform: translateY(2px) rotate(225deg);
+    border-color: var(--neon-magenta);
+}
+
+.neon-dropdown-wrapper:hover .neon-trigger {
+    color: var(--text-primary);
+    border-color: var(--neon-magenta);
+    box-shadow: 
+        0 0 20px rgba(255, 0, 255, 0.5),
+        inset 0 0 20px rgba(255, 0, 255, 0.5);
+    text-shadow: 0 0 5px var(--neon-magenta);
+}
+
+/* Dropdown Menu */
+.neon-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 15px);
+    left: 0;
+    width: 250px;
+    background: rgba(5, 5, 5, 0.95);
+    border: 1px solid var(--neon-magenta);
+    backdrop-filter: blur(5px);
+    box-shadow: 0 10px 30px rgba(255, 0, 255, 0.2);
+    
+    /* Reveal Animation setup */
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-15px);
+    transition: all 0.3s ease;
+    z-index: 100;
+}
+
+/* Reveal Menu on Hover */
+.neon-dropdown-wrapper:hover .neon-dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+/* Menu List */
+.neon-list {
+    list-style: none;
+    padding: 10px 0;
+}
+
+.neon-item {
+    /* Staggered animation setup based on inline --i variable */
+    opacity: 0;
+    transform: translateX(-15px);
+    transition: all 0.3s ease calc(var(--i) * 0.05s);
+}
+
+.neon-dropdown-wrapper:hover .neon-item {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+/* Menu Links */
+.neon-link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 20px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.95rem;
+    letter-spacing: 1px;
+    position: relative;
+    overflow: hidden;
+    transition: color 0.3s ease, background 0.3s ease;
+}
+
+.link-icon {
+    font-size: 1.2rem;
+    filter: drop-shadow(0 0 2px rgba(255,255,255,0.5));
+}
+
+/* Hover Glitch/Scanline effect */
+.neon-link::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(0, 255, 255, 0.2), transparent);
+    transition: left 0.4s ease;
+}
+
+.neon-link:hover {
+    color: var(--neon-cyan);
+    background: rgba(0, 255, 255, 0.05);
+    text-shadow: 0 0 8px rgba(0, 255, 255, 0.8);
+}
+
+.neon-link:hover::before {
+    left: 100%;
+}
+
+/* Alert/Danger Link Specifics */
+.alert-link:hover {
+    color: var(--neon-red);
+    background: rgba(255, 0, 60, 0.05);
+    text-shadow: 0 0 8px rgba(255, 0, 60, 0.8);
+}
+.alert-link:hover::before {
+    background: linear-gradient(90deg, transparent, rgba(255, 0, 60, 0.2), transparent);
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+    .neon-trigger {
+        width: 100%;
+        justify-content: space-between;
+    }
+    .neon-dropdown-menu {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
**Title:** feat: add Interactive Neon Dropdown (Variant B) #80045

**Description:**
This PR introduces a highly interactive Cyberpunk-aesthetic Dropdown menu featuring pure CSS glowing neon effects and staggered reveal animations.

Fixes #80045

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-dropdown-neon-b-pure/`
- Implemented authentic, glowing neon aesthetics utilizing deeply layered `box-shadow` (both inner and outer) and `text-shadow` combinations
- Engineered a staggered list-item reveal animation by mapping an inline CSS variable (`--i`) to the `transition-delay` property via `calc()`
- Designed a dynamic trigger button that shifts glow color from Cyan to Magenta when the dropdown is activated
- Created a glossy, animated "scanline" effect that sweeps across menu items on hover using the `::before` pseudo-element
- Included specific styling for destructive/alert links (e.g., a harsh red neon glow)
- Set up a subtle, dark-mode CSS perspective grid background for the demo
