### PR TITLE
feat: add basic availability status row demo

### DIFF
--- a/submissions/examples/basic-availability-status-row-kk/README.md
+++ b/submissions/examples/basic-availability-status-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Availability Status Row
+
+## What it does
+
+This submission adds a simple CSS-only availability status row for team directories, support hours, booking panels, profile cards, and service status sections.
+
+It aligns a status marker, person or service name, helper copy, and an availability label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a status marker, copy, and label:
+
+```html
+<div class="basic-availability-status-row">
+  <span class="availability-dot is-available" aria-hidden="true"></span>
+  <div class="availability-copy">
+    <strong>Support desk</strong>
+    <p>Replies usually arrive within 10 minutes.</p>
+  </div>
+  <span class="availability-label is-available">Available</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across team pages, booking cards, support dashboards, profile sections, and service panels. It keeps availability information easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Status marker, title, helper copy, and label layout
+- Available, busy, and offline examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the availability status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-availability-status-row-kk/demo.html
+++ b/submissions/examples/basic-availability-status-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Availability Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Availability Status Row</p>
+          <h1>Compact availability rows for teams, support, and booking panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a status marker, person or service name,
+            helper copy, and an availability label in one reusable row.
+          </p>
+        </header>
+
+        <section class="availability-panel" aria-label="Availability status row examples">
+          <div class="basic-availability-status-row">
+            <span class="availability-dot is-available" aria-hidden="true"></span>
+            <div class="availability-copy">
+              <strong>Support desk</strong>
+              <p>Replies usually arrive within 10 minutes.</p>
+            </div>
+            <span class="availability-label is-available">Available</span>
+          </div>
+
+          <div class="basic-availability-status-row">
+            <span class="availability-dot is-busy" aria-hidden="true"></span>
+            <div class="availability-copy">
+              <strong>Design review</strong>
+              <p>Next review slot opens after the current session.</p>
+            </div>
+            <span class="availability-label is-busy">Busy</span>
+          </div>
+
+          <div class="basic-availability-status-row">
+            <span class="availability-dot" aria-hidden="true"></span>
+            <div class="availability-copy">
+              <strong>Office hours</strong>
+              <p>Scheduled availability resumes tomorrow morning.</p>
+            </div>
+            <span class="availability-label">Offline</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-availability-status-row"&gt;
+  &lt;span class="availability-dot is-available" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;div class="availability-copy"&gt;
+    &lt;strong&gt;Support desk&lt;/strong&gt;
+    &lt;p&gt;Replies usually arrive within 10 minutes.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="availability-label is-available"&gt;Available&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-availability-status-row-kk/style.css
+++ b/submissions/examples/basic-availability-status-row-kk/style.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --available: #86efac;
+  --busy: #fcd34d;
+  --offline: #94a3b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(252, 211, 77, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--available);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.availability-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-availability-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-availability-status-row + .basic-availability-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.availability-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 0.9rem;
+  border-radius: 50%;
+  background: var(--offline);
+  box-shadow: 0 0 0 0.35rem rgba(148, 163, 184, 0.12);
+}
+
+.availability-dot.is-available {
+  background: var(--available);
+  box-shadow: 0 0 0 0.35rem rgba(134, 239, 172, 0.12);
+}
+
+.availability-dot.is-busy {
+  background: var(--busy);
+  box-shadow: 0 0 0 0.35rem rgba(252, 211, 77, 0.12);
+}
+
+.availability-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.availability-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.availability-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.availability-label {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--offline);
+  background: rgba(148, 163, 184, 0.13);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.availability-label.is-available {
+  color: var(--available);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.availability-label.is-busy {
+  color: var(--busy);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-availability-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .availability-label {
+    margin-left: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Availability Status Row demo inside `submissions/examples/basic-availability-status-row-kk/`. This submission introduces a compact CSS-only row pattern for team directories, support hours, booking panels, profile cards, and service status sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only availability status row for showing a status marker, person or service name, helper copy, and an availability label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-availability-status-row">
  <span class="availability-dot is-available" aria-hidden="true"></span>
  <div class="availability-copy">
    <strong>Support desk</strong>
    <p>Replies usually arrive within 10 minutes.</p>
  </div>
  <span class="availability-label is-available">Available</span>
</div>