### PR TITLE
feat: add ease-drag-splitter-panel-sap

### DIFF
--- a/submissions/examples/ease-drag-splitter-panel-sap/README.md
+++ b/submissions/examples/ease-drag-splitter-panel-sap/README.md
@@ -1,0 +1,18 @@
+# ease-drag-splitter-panel-sap
+
+A two-pane layout with a draggable vertical splitter handle to resize the panels, common in code editors and file browsers.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.split-pane.left` (fixed width) + `.split-handle` + `.split-pane.right` (`flex: 1`, fills remaining space).
+3. Attach the drag logic from `demo.html`.
+
+## Customization
+- `Math.max(15, Math.min(85, pct))` clamp range: minimum/maximum pane width percentages.
+- Handle width/hover color.
+- Right pane uses `flex: 1` so it automatically fills whatever space the left pane doesn't take — no need to manually calculate its width in JS.
+
+## Notes
+- Only the left pane's `width` is set directly from drag position; the right pane's `flex: 1` handles the remainder automatically, avoiding redundant calculation.
+- Clamping the percentage (15–85%) prevents either pane from being dragged down to zero or unusable width.
+- Respects `prefers-reduced-motion`: handle hover color transition is disabled; live drag resizing is unaffected as direct input.

--- a/submissions/examples/ease-drag-splitter-panel-sap/demo.html
+++ b/submissions/examples/ease-drag-splitter-panel-sap/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-splitter-panel-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="splitter-sap" id="splitter">
+    <div class="split-pane left" id="leftPane">Left panel content</div>
+    <div class="split-handle" id="handle"></div>
+    <div class="split-pane right">Right panel content</div>
+  </div>
+  <script>
+    const splitter = document.getElementById('splitter');
+    const leftPane = document.getElementById('leftPane');
+    const handle = document.getElementById('handle');
+    let dragging = false;
+
+    handle.addEventListener('mousedown', () => {
+      dragging = true;
+      handle.classList.add('dragging');
+    });
+
+    window.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      const rect = splitter.getBoundingClientRect();
+      let pct = ((e.clientX - rect.left) / rect.width) * 100;
+      pct = Math.max(15, Math.min(85, pct));
+      leftPane.style.width = pct + '%';
+    });
+
+    window.addEventListener('mouseup', () => {
+      dragging = false;
+      handle.classList.remove('dragging');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-splitter-panel-sap/style.css
+++ b/submissions/examples/ease-drag-splitter-panel-sap/style.css
@@ -1,0 +1,45 @@
+.splitter-sap {
+  display: flex;
+  width: 360px;
+  height: 220px;
+  border-radius: 14px;
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
+}
+
+.splitter-sap .split-pane {
+  padding: 16px;
+  color: #fff;
+  font-size: 13px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.splitter-sap .split-pane.left {
+  background: #2563eb;
+  width: 50%;
+}
+
+.splitter-sap .split-pane.right {
+  background: #7c3aed;
+  flex: 1;
+}
+
+.splitter-sap .split-handle {
+  width: 6px;
+  background: #111;
+  cursor: col-resize;
+  flex-shrink: 0;
+  transition: background 0.2s ease;
+}
+
+.splitter-sap .split-handle:hover,
+.splitter-sap .split-handle.dragging {
+  background: #f59e0b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splitter-sap .split-handle {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-splitter-panel-sap`, a draggable two-pane resizable splitter layout.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-splitter-panel-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Only the left pane's width is set directly from drag position; the right pane's `flex: 1` automatically fills the remainder, avoiding redundant width calculation.
- Drag percentage is clamped (15–85%) to prevent either pane from collapsing to unusable width.
- `prefers-reduced-motion` disables the handle's hover color transition; live drag resizing remains unaffected as direct input.

## Feature Description

Adds a reusable draggable resizable two-pane splitter component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.