### PR TITLE
feat: add basic confidence score row demo

### DIFF
--- a/submissions/examples/basic-confidence-score-row-kk/README.md
+++ b/submissions/examples/basic-confidence-score-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Confidence Score Row
+
+## What it does
+
+This submission adds a simple CSS-only confidence score row for review panels, report cards, search results, quality checks, and analysis summaries.
+
+It aligns a score, result title, helper copy, and confidence label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a score, copy, and confidence label:
+
+```html
+<div class="basic-confidence-score-row">
+  <strong class="confidence-score">96%</strong>
+  <div class="confidence-copy">
+    <span>High match</span>
+    <p>The submitted pattern closely matches the expected layout.</p>
+  </div>
+  <span class="confidence-label is-high">High</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across reports, review panels, result cards, quality checks, and dashboard summaries. It keeps confidence information easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Score, title, helper copy, and confidence label layout
+- High, medium, and low confidence examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the confidence score row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-confidence-score-row-kk/demo.html
+++ b/submissions/examples/basic-confidence-score-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Confidence Score Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Confidence Score Row</p>
+          <h1>Compact confidence rows for reviews, reports, and result cards.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a score, result title, helper copy,
+            and confidence label for scannable analysis and review interfaces.
+          </p>
+        </header>
+
+        <section class="confidence-panel" aria-label="Confidence score row examples">
+          <div class="basic-confidence-score-row">
+            <strong class="confidence-score">96%</strong>
+            <div class="confidence-copy">
+              <span>High match</span>
+              <p>The submitted pattern closely matches the expected layout.</p>
+            </div>
+            <span class="confidence-label is-high">High</span>
+          </div>
+
+          <div class="basic-confidence-score-row">
+            <strong class="confidence-score">74%</strong>
+            <div class="confidence-copy">
+              <span>Needs review</span>
+              <p>Some spacing and wording may need a second pass.</p>
+            </div>
+            <span class="confidence-label is-medium">Medium</span>
+          </div>
+
+          <div class="basic-confidence-score-row">
+            <strong class="confidence-score">42%</strong>
+            <div class="confidence-copy">
+              <span>Low signal</span>
+              <p>The result needs clearer evidence before approval.</p>
+            </div>
+            <span class="confidence-label">Low</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-confidence-score-row"&gt;
+  &lt;strong class="confidence-score"&gt;96%&lt;/strong&gt;
+  &lt;div class="confidence-copy"&gt;
+    &lt;span&gt;High match&lt;/span&gt;
+    &lt;p&gt;The submitted pattern closely matches the expected layout.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="confidence-label is-high"&gt;High&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-confidence-score-row-kk/style.css
+++ b/submissions/examples/basic-confidence-score-row-kk/style.css
@@ -1,0 +1,160 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --high: #86efac;
+  --medium: #fcd34d;
+  --low: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(252, 165, 165, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--high);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.confidence-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-confidence-score-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-confidence-score-row + .basic-confidence-score-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.confidence-score {
+  width: 3.8rem;
+  flex: 0 0 3.8rem;
+  color: var(--text);
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.confidence-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.confidence-copy span {
+  display: block;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.confidence-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.confidence-label {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--low);
+  background: rgba(252, 165, 165, 0.13);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.confidence-label.is-high {
+  color: var(--high);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.confidence-label.is-medium {
+  color: var(--medium);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-confidence-score-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .confidence-label {
+    margin-left: 4.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Confidence Score Row demo inside `submissions/examples/basic-confidence-score-row-kk/`. This submission introduces a compact CSS-only row pattern for review panels, report cards, search results, quality checks, and analysis summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only confidence score row for showing a score, result title, helper copy, and confidence label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-confidence-score-row">
  <strong class="confidence-score">96%</strong>
  <div class="confidence-copy">
    <span>High match</span>
    <p>The submitted pattern closely matches the expected layout.</p>
  </div>
  <span class="confidence-label is-high">High</span>
</div>