### PR TITLE
feat: add ease-drag-signature-strength-sap

### DIFF
--- a/submissions/examples/ease-drag-signature-strength-sap/README.md
+++ b/submissions/examples/ease-drag-signature-strength-sap/README.md
@@ -1,0 +1,18 @@
+# ease-drag-signature-strength-sap
+
+A signature pad paired with a "strength" meter that fills based on how much the user has drawn — a playful gamified take on the standard signature pad.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: canvas wrap + strength meter (track/fill/label).
+3. Attach the drawing + point-counting logic from `demo.html`.
+
+## Customization
+- `pointCount / 2` divisor: how quickly the meter fills relative to drawing complexity — tune to taste.
+- Strength label thresholds/text.
+- Canvas/meter colors.
+
+## Notes
+- "Strength" here is a simple proxy: number of drawn points accumulated during mousemove/touchmove — more strokes/complexity fills the meter faster. This is a playful visual metaphor, not a real security/uniqueness measure of the signature.
+- Same canvas drawing technique as the standalone signature pad component, extended with a live progress readout.
+- Respects `prefers-reduced-motion`: meter fill-width transition is disabled; canvas drawing itself is unaffected as direct input.

--- a/submissions/examples/ease-drag-signature-strength-sap/demo.html
+++ b/submissions/examples/ease-drag-signature-strength-sap/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-signature-strength-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="sig-strength-sap">
+    <div class="sig-canvas-wrap">
+      <canvas id="canvas"></canvas>
+    </div>
+    <div class="strength-meter">
+      <div class="strength-track"><div class="strength-fill" id="fill"></div></div>
+      <div class="strength-label" id="label">Draw your signature</div>
+    </div>
+  </div>
+  <script>
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    const fill = document.getElementById('fill');
+    const label = document.getElementById('label');
+    let drawing = false;
+    let pointCount = 0;
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width;
+      canvas.height = rect.height;
+      ctx.strokeStyle = '#111';
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+    }
+    resize();
+
+    function getPos(e) {
+      const rect = canvas.getBoundingClientRect();
+      const p = e.touches ? e.touches[0] : e;
+      return { x: p.clientX - rect.left, y: p.clientY - rect.top };
+    }
+
+    function updateStrength() {
+      const pct = Math.min(100, pointCount / 2);
+      fill.style.width = pct + '%';
+      label.textContent = pct < 30 ? 'Too simple' : pct < 70 ? 'Getting there' : 'Strong signature';
+    }
+
+    function start(e) {
+      drawing = true;
+      const p = getPos(e);
+      ctx.beginPath();
+      ctx.moveTo(p.x, p.y);
+    }
+    function move(e) {
+      if (!drawing) return;
+      e.preventDefault();
+      const p = getPos(e);
+      ctx.lineTo(p.x, p.y);
+      ctx.stroke();
+      pointCount++;
+      updateStrength();
+    }
+    function end() { drawing = false; }
+
+    canvas.addEventListener('mousedown', start);
+    canvas.addEventListener('mousemove', move);
+    canvas.addEventListener('mouseup', end);
+    canvas.addEventListener('mouseleave', end);
+    canvas.addEventListener('touchstart', start, { passive: true });
+    canvas.addEventListener('touchmove', move, { passive: false });
+    canvas.addEventListener('touchend', end);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-signature-strength-sap/style.css
+++ b/submissions/examples/ease-drag-signature-strength-sap/style.css
@@ -1,0 +1,49 @@
+.sig-strength-sap {
+  width: 280px;
+  font-family: system-ui, sans-serif;
+}
+
+.sig-strength-sap .sig-canvas-wrap {
+  position: relative;
+  height: 140px;
+  border: 2px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.sig-strength-sap canvas {
+  width: 100%;
+  height: 100%;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.sig-strength-sap .strength-meter {
+  margin-top: 12px;
+}
+
+.sig-strength-sap .strength-track {
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.sig-strength-sap .strength-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #ef4444, #f59e0b, #22c55e);
+  transition: width 0.3s ease;
+}
+
+.sig-strength-sap .strength-label {
+  font-size: 12px;
+  color: #64748b;
+  margin-top: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sig-strength-sap .strength-fill {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-signature-strength-sap`, a signature pad with a gamified drawing-strength meter.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-signature-strength-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- README explicitly clarifies "strength" is a playful drawn-point-count proxy, not a real signature security metric.
- Extends the standard canvas signature pad pattern with a live meter readout.
- `prefers-reduced-motion` disables the meter fill transition; canvas drawing remains unaffected as direct input.

## Feature Description

Adds a reusable signature pad with drawing-strength meter component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.