### PR TITLE
feat: add basic source attribution row demo

### DIFF
--- a/submissions/examples/basic-source-attribution-row-kk/README.md
+++ b/submissions/examples/basic-source-attribution-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Source Attribution Row
+
+## What it does
+
+This submission adds a simple CSS-only source attribution row for documentation pages, reports, article cards, research summaries, and content reference sections.
+
+It aligns a source marker, reference title, supporting detail, and source label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a source marker, copy, and label:
+
+```html
+<div class="basic-source-attribution-row">
+  <span class="source-mark" aria-hidden="true">01</span>
+  <div class="source-copy">
+    <strong>Design system notes</strong>
+    <p>Used as the reference for spacing and tone.</p>
+  </div>
+  <span class="source-label">Internal</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across docs, reports, article layouts, research cards, dashboards, and content reference panels. It keeps attribution details easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Source marker, title, helper copy, and label layout
+- Internal, report, and docs examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the source attribution row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-source-attribution-row-kk/demo.html
+++ b/submissions/examples/basic-source-attribution-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Source Attribution Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Source Attribution Row</p>
+          <h1>Compact source rows for docs, reports, and content references.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a source marker, reference title,
+            supporting detail, and source label for attribution-friendly layouts.
+          </p>
+        </header>
+
+        <section class="source-panel" aria-label="Source attribution row examples">
+          <div class="basic-source-attribution-row">
+            <span class="source-mark" aria-hidden="true">01</span>
+            <div class="source-copy">
+              <strong>Design system notes</strong>
+              <p>Used as the reference for spacing and tone.</p>
+            </div>
+            <span class="source-label">Internal</span>
+          </div>
+
+          <div class="basic-source-attribution-row">
+            <span class="source-mark" aria-hidden="true">02</span>
+            <div class="source-copy">
+              <strong>Research summary</strong>
+              <p>Supports the report recommendation section.</p>
+            </div>
+            <span class="source-label is-report">Report</span>
+          </div>
+
+          <div class="basic-source-attribution-row">
+            <span class="source-mark" aria-hidden="true">03</span>
+            <div class="source-copy">
+              <strong>Documentation page</strong>
+              <p>Referenced for implementation details.</p>
+            </div>
+            <span class="source-label is-doc">Docs</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-source-attribution-row"&gt;
+  &lt;span class="source-mark" aria-hidden="true"&gt;01&lt;/span&gt;
+  &lt;div class="source-copy"&gt;
+    &lt;strong&gt;Design system notes&lt;/strong&gt;
+    &lt;p&gt;Used as the reference for spacing and tone.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="source-label"&gt;Internal&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-source-attribution-row-kk/style.css
+++ b/submissions/examples/basic-source-attribution-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #c4b5fd;
+  --accent-soft: rgba(196, 181, 253, 0.14);
+  --report: #fcd34d;
+  --doc: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(196, 181, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.11), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.source-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-source-attribution-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-source-attribution-row + .basic-source-attribution-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.source-mark {
+  width: 2.35rem;
+  height: 2.35rem;
+  flex: 0 0 2.35rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(196, 181, 253, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.source-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.source-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.source-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-label {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.source-label.is-report {
+  color: var(--report);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+.source-label.is-doc {
+  color: var(--doc);
+  background: rgba(147, 197, 253, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-source-attribution-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .source-label {
+    margin-left: 3.2rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Source Attribution Row demo inside `submissions/examples/basic-source-attribution-row-kk/`. This submission introduces a compact CSS-only row pattern for documentation pages, reports, article cards, research summaries, and content reference sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only source attribution row for showing a source marker, reference title, supporting detail, and source label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-source-attribution-row">
  <span class="source-mark" aria-hidden="true">01</span>
  <div class="source-copy">
    <strong>Design system notes</strong>
    <p>Used as the reference for spacing and tone.</p>
  </div>
  <span class="source-label">Internal</span>
</div>