### PR TITLE
feat: add basic key fact row demo

### DIFF
--- a/submissions/examples/basic-key-fact-row-kk/README.md
+++ b/submissions/examples/basic-key-fact-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Key Fact Row
+
+## What it does
+
+This submission adds a simple CSS-only key fact row for reports, documentation pages, article summaries, dashboard cards, and review panels.
+
+It aligns a fact label, main value, helper copy, and small context tag in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a label, fact copy, and optional tag:
+
+```html
+<div class="basic-key-fact-row">
+  <span class="fact-label">Coverage</span>
+  <div class="fact-copy">
+    <strong>92%</strong>
+    <p>Most checklist items are complete and ready to review.</p>
+  </div>
+  <span class="fact-tag is-good">Strong</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across docs, reports, dashboards, article cards, and compact summaries. It keeps important facts easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Fact label, value, helper copy, and context tag layout
+- Strong, default, and muted tag examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive stacked layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the key fact row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-key-fact-row-kk/demo.html
+++ b/submissions/examples/basic-key-fact-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Key Fact Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Key Fact Row</p>
+          <h1>Compact fact rows for reports, docs, and summary panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a fact label, main value, helper copy,
+            and small context tag for scannable information summaries.
+          </p>
+        </header>
+
+        <section class="fact-panel" aria-label="Key fact row examples">
+          <div class="basic-key-fact-row">
+            <span class="fact-label">Coverage</span>
+            <div class="fact-copy">
+              <strong>92%</strong>
+              <p>Most checklist items are complete and ready to review.</p>
+            </div>
+            <span class="fact-tag is-good">Strong</span>
+          </div>
+
+          <div class="basic-key-fact-row">
+            <span class="fact-label">Response</span>
+            <div class="fact-copy">
+              <strong>18 min</strong>
+              <p>Average support response time during active hours.</p>
+            </div>
+            <span class="fact-tag">Today</span>
+          </div>
+
+          <div class="basic-key-fact-row">
+            <span class="fact-label">Risk</span>
+            <div class="fact-copy">
+              <strong>Low</strong>
+              <p>No blocking issues were found in the latest review.</p>
+            </div>
+            <span class="fact-tag is-muted">Stable</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-key-fact-row"&gt;
+  &lt;span class="fact-label"&gt;Coverage&lt;/span&gt;
+  &lt;div class="fact-copy"&gt;
+    &lt;strong&gt;92%&lt;/strong&gt;
+    &lt;p&gt;Most checklist items are complete and ready to review.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="fact-tag is-good"&gt;Strong&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-key-fact-row-kk/style.css
+++ b/submissions/examples/basic-key-fact-row-kk/style.css
@@ -1,0 +1,161 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #f0abfc;
+  --accent-soft: rgba(240, 171, 252, 0.14);
+  --good: #86efac;
+  --quiet: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(240, 171, 252, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.fact-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-key-fact-row {
+  display: grid;
+  grid-template-columns: minmax(5rem, 0.7fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-key-fact-row + .basic-key-fact-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.fact-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fact-copy {
+  min-width: 0;
+}
+
+.fact-copy strong {
+  display: block;
+  color: var(--text);
+  font-size: 1.15rem;
+}
+
+.fact-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fact-tag {
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.fact-tag.is-good {
+  color: var(--good);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.fact-tag.is-muted {
+  color: var(--quiet);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 640px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-key-fact-row {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .fact-tag {
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Key Fact Row demo inside `submissions/examples/basic-key-fact-row-kk/`. This submission introduces a compact CSS-only row pattern for reports, documentation pages, article summaries, dashboard cards, and review panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only key fact row for showing a fact label, main value, helper copy, and small context tag in one compact layout.

**How does a developer use it?**

```html
<div class="basic-key-fact-row">
  <span class="fact-label">Coverage</span>
  <div class="fact-copy">
    <strong>92%</strong>
    <p>Most checklist items are complete and ready to review.</p>
  </div>
  <span class="fact-tag is-good">Strong</span>
</div>