### PR TITLE
feat: add ease-drag-image-comparison-handle-sap

### DIFF
--- a/submissions/examples/ease-drag-image-comparison-handle-sap/README.md
+++ b/submissions/examples/ease-drag-image-comparison-handle-sap/README.md
@@ -1,0 +1,12 @@
+# ease-drag-image-comparison-handle-sap
+
+A minimal draggable comparison handle splitting two content layers (e.g., before/after treatments), simpler variant of the full image before/after slider.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.cmp-before` (base layer) + `.cmp-after` (clipped overlay, with inner content set to full container width) + `.cmp-handle`.
+
+## Notes
+- The "after" content span is fixed to the full container's width (not the clipped wrapper's), preventing distortion as the wrapper narrows during drag — same technique as the full before/after image slider.
+- This variant focuses purely on the drag handle mechanic without image assets, useful as a lightweight base for any two-state comparison UI.
+- Respects `prefers-reduced-motion`: no persistent transition exists to gate since dragging is 1:1 direct input; a defensive rule is included for future additions.

--- a/submissions/examples/ease-drag-image-comparison-handle-sap/demo.html
+++ b/submissions/examples/ease-drag-image-comparison-handle-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-image-comparison-handle-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="compare-handle-sap" id="compare">
+    <div class="cmp-layer cmp-before">Original</div>
+    <div class="cmp-layer cmp-after" id="afterLayer"><span>Enhanced</span></div>
+    <div class="cmp-handle" id="handle"></div>
+  </div>
+  <script>
+    const container = document.getElementById('compare');
+    const after = document.getElementById('afterLayer');
+    const handle = document.getElementById('handle');
+    let dragging = false;
+
+    function setPct(x) {
+      const rect = container.getBoundingClientRect();
+      let pct = ((x - rect.left) / rect.width) * 100;
+      pct = Math.max(0, Math.min(100, pct));
+      after.style.width = pct + '%';
+      handle.style.left = pct + '%';
+    }
+
+    handle.addEventListener('mousedown', () => dragging = true);
+    window.addEventListener('mousemove', (e) => { if (dragging) setPct(e.clientX); });
+    window.addEventListener('mouseup', () => dragging = false);
+    handle.addEventListener('touchstart', () => dragging = true, { passive: true });
+    window.addEventListener('touchmove', (e) => { if (dragging) setPct(e.touches[0].clientX); }, { passive: true });
+    window.addEventListener('touchend', () => dragging = false);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-image-comparison-handle-sap/style.css
+++ b/submissions/examples/ease-drag-image-comparison-handle-sap/style.css
@@ -1,0 +1,63 @@
+.compare-handle-sap {
+  position: relative;
+  width: 340px;
+  height: 220px;
+  border-radius: 14px;
+  overflow: hidden;
+  user-select: none;
+}
+
+.compare-handle-sap .cmp-layer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.compare-handle-sap .cmp-before { background: linear-gradient(135deg, #64748b, #334155); }
+.compare-handle-sap .cmp-after {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  width: 50%;
+  overflow: hidden;
+}
+.compare-handle-sap .cmp-after span { width: 340px; display: flex; align-items: center; justify-content: center; height: 220px; }
+
+.compare-handle-sap .cmp-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  background: #fff;
+  cursor: ew-resize;
+  transform: translateX(-50%);
+}
+
+.compare-handle-sap .cmp-handle::after {
+  content: "⇔";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  color: #111;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compare-handle-sap .cmp-after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-image-comparison-handle-sap`, a minimal draggable comparison split handle.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-image-comparison-handle-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Overlay content is sized to the container's full width (not its clipped wrapper), preventing distortion during drag — consistent with the full before/after slider component.
- Provides a lighter-weight base for two-state comparison UIs without requiring image assets.
- `prefers-reduced-motion`: drag is direct 1:1 input with no persistent transition; a defensive rule is included.

## Feature Description

Adds a reusable minimal draggable comparison handle component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.