### PR TITLE
feat: add ease-hover-card-3d-shadow-lift-sap

### DIFF
--- a/submissions/examples/ease-hover-card-3d-shadow-lift-sap/README.md
+++ b/submissions/examples/ease-hover-card-3d-shadow-lift-sap/README.md
@@ -1,0 +1,15 @@
+# ease-hover-card-3d-shadow-lift-sap
+
+A card that lifts on hover with a *separate* ground shadow beneath it that spreads and darkens independently, simulating the card floating away from a surface.
+
+## Usage
+1. Include `style.css`.
+2. Add markup:
+```html
+   <div class="shadow-lift-sap"><h3>Title</h3><p>Text</p></div>
+```
+
+## Notes
+- The ground shadow is a dedicated `::after` radial-gradient blob positioned beneath the card (not the card's own `box-shadow`), so it can animate its spread/opacity independently from the card's lift — the card's own `box-shadow` also softens slightly as it "moves away" from the shadow's light source.
+- This two-part shadow system (card box-shadow + separate ground shadow) reads more like a physical object lifting off a surface than a single box-shadow blur increase.
+- Respects `prefers-reduced-motion`: the lift transform and ground shadow spread transform are removed; opacity/shadow-color transitions remain as reduced feedback.

--- a/submissions/examples/ease-hover-card-3d-shadow-lift-sap/demo.html
+++ b/submissions/examples/ease-hover-card-3d-shadow-lift-sap/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-card-3d-shadow-lift-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="shadow-lift-sap">
+    <h3>Floating Card</h3>
+    <p>Hover to lift — a separate ground shadow beneath spreads and darkens as the card rises.</p>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-card-3d-shadow-lift-sap/style.css
+++ b/submissions/examples/ease-hover-card-3d-shadow-lift-sap/style.css
@@ -1,0 +1,60 @@
+.shadow-lift-sap {
+  position: relative;
+  width: 240px;
+  padding: 24px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  transform: translateY(0);
+  transition: transform 0.3s cubic-bezier(0.2, 0.8, 0.3, 1), box-shadow 0.3s ease;
+  font-family: system-ui, sans-serif;
+}
+
+.shadow-lift-sap::after {
+  content: "";
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  bottom: -12px;
+  height: 20px;
+  background: radial-gradient(ellipse at center, rgba(0,0,0,0.2), transparent 70%);
+  opacity: 0.4;
+  transform: scaleX(0.9);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: -1;
+}
+
+.shadow-lift-sap:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 10px 20px rgba(0,0,0,0.06);
+}
+
+.shadow-lift-sap:hover::after {
+  opacity: 0.7;
+  transform: scaleX(1.05);
+}
+
+.shadow-lift-sap h3 {
+  margin: 0 0 8px;
+  color: #111;
+}
+
+.shadow-lift-sap p {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+  line-height: 1.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shadow-lift-sap,
+  .shadow-lift-sap::after {
+    transition: box-shadow 0.2s ease, opacity 0.2s ease;
+  }
+  .shadow-lift-sap:hover {
+    transform: none;
+  }
+  .shadow-lift-sap:hover::after {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-card-3d-shadow-lift-sap`, a hover-lift card with an independent ground shadow.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-hover-card-3d-shadow-lift-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Ground shadow is a dedicated `::after` blob independent of the card's own `box-shadow`, allowing separate spread/opacity animation for a more physical "lifting off a surface" read.
- `prefers-reduced-motion` removes lift and shadow-spread transforms, keeping opacity/color transitions as reduced feedback.

## Feature Description

Adds a reusable hover-lift card with ground shadow component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.