### PR TITLE
feat: add basic sla window row demo

### DIFF
--- a/submissions/examples/basic-sla-window-row-kk/README.md
+++ b/submissions/examples/basic-sla-window-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic SLA Window Row
+
+## What it does
+
+This submission adds a simple CSS-only SLA window row for support cards, service dashboards, response-time summaries, operations panels, and ticket queues.
+
+It aligns a response window, service title, helper copy, and small status label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a response window, copy, and status:
+
+```html
+<div class="basic-sla-window-row">
+  <span class="sla-window">15m</span>
+  <div class="sla-copy">
+    <strong>Priority support</strong>
+    <p>First response target for urgent tickets.</p>
+  </div>
+  <span class="sla-state is-fast">On track</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across support dashboards, operations cards, ticket queues, and service panels. It keeps response targets easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Response window, title, helper copy, and status layout
+- On track, normal, and queued examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the SLA window row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-sla-window-row-kk/demo.html
+++ b/submissions/examples/basic-sla-window-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic SLA Window Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic SLA Window Row</p>
+          <h1>Compact SLA rows for support, service, and response panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a response window, service title,
+            helper copy, and small status label for support and operations cards.
+          </p>
+        </header>
+
+        <section class="sla-panel" aria-label="SLA window row examples">
+          <div class="basic-sla-window-row">
+            <span class="sla-window">15m</span>
+            <div class="sla-copy">
+              <strong>Priority support</strong>
+              <p>First response target for urgent tickets.</p>
+            </div>
+            <span class="sla-state is-fast">On track</span>
+          </div>
+
+          <div class="basic-sla-window-row">
+            <span class="sla-window">4h</span>
+            <div class="sla-copy">
+              <strong>Standard review</strong>
+              <p>Expected review window for regular requests.</p>
+            </div>
+            <span class="sla-state">Normal</span>
+          </div>
+
+          <div class="basic-sla-window-row">
+            <span class="sla-window">24h</span>
+            <div class="sla-copy">
+              <strong>General queue</strong>
+              <p>Response target for low-priority updates.</p>
+            </div>
+            <span class="sla-state is-slow">Queued</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-sla-window-row"&gt;
+  &lt;span class="sla-window"&gt;15m&lt;/span&gt;
+  &lt;div class="sla-copy"&gt;
+    &lt;strong&gt;Priority support&lt;/strong&gt;
+    &lt;p&gt;First response target for urgent tickets.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="sla-state is-fast"&gt;On track&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-sla-window-row-kk/style.css
+++ b/submissions/examples/basic-sla-window-row-kk/style.css
@@ -1,0 +1,163 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #93c5fd;
+  --accent-soft: rgba(147, 197, 253, 0.14);
+  --fast: #86efac;
+  --slow: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(147, 197, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.sla-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-sla-window-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 0;
+}
+
+.basic-sla-window-row + .basic-sla-window-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sla-window {
+  width: 3.4rem;
+  flex: 0 0 3.4rem;
+  border-radius: 0.85rem;
+  padding: 0.55rem 0.35rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 900;
+  text-align: center;
+}
+
+.sla-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.sla-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.sla-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sla-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.sla-state.is-fast {
+  color: var(--fast);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.sla-state.is-slow {
+  color: var(--slow);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-sla-window-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .sla-state {
+    margin-left: 4.3rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic SLA Window Row demo inside `submissions/examples/basic-sla-window-row-kk/`. This submission introduces a compact CSS-only row pattern for support cards, service dashboards, response-time summaries, operations panels, and ticket queues.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only SLA window row for showing a response window, service title, helper copy, and small status label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-sla-window-row">
  <span class="sla-window">15m</span>
  <div class="sla-copy">
    <strong>Priority support</strong>
    <p>First response target for urgent tickets.</p>
  </div>
  <span class="sla-state is-fast">On track</span>
</div>