### PR TITLE
feat: add ease-animated-input-otp-cursor-sap

### DIFF
--- a/submissions/examples/ease-animated-input-otp-cursor-sap/README.md
+++ b/submissions/examples/ease-animated-input-otp-cursor-sap/README.md
@@ -1,0 +1,13 @@
+# ease-animated-input-otp-cursor-sap
+
+An OTP box group with a blinking text-cursor indicator showing exactly which box will receive the next digit, backed by a single hidden real input for correct keyboard/mobile behavior.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: visual `.otp-box` cells + one visually hidden real `<input>` that actually captures typing.
+3. Attach the render logic from `demo.html`, which mirrors the hidden input's value into the boxes and positions the blinking cursor.
+
+## Notes
+- Using one real (visually hidden) input rather than multiple visible inputs avoids the complexity of managing focus/backspace/paste across separate fields — a technique that sidesteps a lot of the auto-advance logic other OTP components need.
+- The blinking cursor element is only rendered inside the box matching the current input length, so it always marks the next entry position.
+- Respects `prefers-reduced-motion`: the blink animation is disabled, cursor remains solidly visible instead of flashing.

--- a/submissions/examples/ease-animated-input-otp-cursor-sap/demo.html
+++ b/submissions/examples/ease-animated-input-otp-cursor-sap/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-animated-input-otp-cursor-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="otp-cursor-sap" id="otpGroup">
+    <div class="otp-box current" data-i="0"><span class="otp-cursor-blink"></span></div>
+    <div class="otp-box" data-i="1"></div>
+    <div class="otp-box" data-i="2"></div>
+    <div class="otp-box" data-i="3"></div>
+  </div>
+  <input type="text" inputmode="numeric" maxlength="4" id="hiddenInput" style="position:absolute;opacity:0;pointer-events:none;">
+  <script>
+    const boxes = [...document.querySelectorAll('.otp-box')];
+    const hidden = document.getElementById('hiddenInput');
+    document.getElementById('otpGroup').addEventListener('click', () => hidden.focus());
+    hidden.focus();
+
+    function render() {
+      const val = hidden.value;
+      boxes.forEach((box, i) => {
+        box.textContent = val[i] || '';
+        box.classList.toggle('current', i === val.length);
+        if (i === val.length) {
+          const cursor = document.createElement('span');
+          cursor.className = 'otp-cursor-blink';
+          box.appendChild(cursor);
+        }
+      });
+    }
+
+    hidden.addEventListener('input', () => {
+      hidden.value = hidden.value.replace(/[^0-9]/g, '').slice(0, 4);
+      render();
+    });
+
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-input-otp-cursor-sap/style.css
+++ b/submissions/examples/ease-animated-input-otp-cursor-sap/style.css
@@ -1,0 +1,43 @@
+.otp-cursor-sap {
+  display: flex;
+  gap: 10px;
+  font-family: system-ui, sans-serif;
+}
+
+.otp-cursor-sap .otp-box {
+  position: relative;
+  width: 42px;
+  height: 50px;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: #111;
+}
+
+.otp-cursor-sap .otp-box.current {
+  border-color: #2563eb;
+}
+
+.otp-cursor-sap .otp-cursor-blink {
+  position: absolute;
+  width: 2px;
+  height: 22px;
+  background: #2563eb;
+  animation: otp-blink-sap 1s step-end infinite;
+}
+
+@keyframes otp-blink-sap {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .otp-cursor-sap .otp-cursor-blink {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-input-otp-cursor-sap`, an OTP input with a blinking next-position cursor, backed by a single hidden input.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-animated-input-otp-cursor-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- A single visually-hidden real input backs all visual boxes, sidestepping the focus/backspace/paste coordination that multi-input OTP designs need.
- The blinking cursor renders only in the box matching current input length, always marking the next entry slot.
- `prefers-reduced-motion` disables the blink, leaving a solid static cursor.

## Feature Description

Adds a reusable OTP input with animated cursor indicator component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.