### PR TITLE
feat: add ease-hover-menu-underline-slide-sap

### DIFF
--- a/submissions/examples/ease-hover-menu-underline-slide-sap/README.md
+++ b/submissions/examples/ease-hover-menu-underline-slide-sap/README.md
@@ -1,0 +1,13 @@
+# ease-hover-menu-underline-slide-sap
+
+A single shared underline that slides beneath whichever nav link is currently hovered, appearing only while any link in the group is hovered.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `<a>` links + one `.slide-underline` element inside `.underline-slide-sap`.
+3. Attach the `mouseenter` position/width calculation from `demo.html`.
+
+## Notes
+- Single shared underline (vs a per-link `::after`) travels between links via `transform: translateX()` and `width`, giving a connected "sliding" feel rather than each link having its own independent underline animation.
+- Group-level `:hover` on the wrapper controls the underline's overall visibility, so it disappears entirely once the cursor leaves the whole nav.
+- Respects `prefers-reduced-motion`: position/width transition is removed, only opacity visibility remains animated.

--- a/submissions/examples/ease-hover-menu-underline-slide-sap/demo.html
+++ b/submissions/examples/ease-hover-menu-underline-slide-sap/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-menu-underline-slide-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <nav class="underline-slide-sap" id="nav">
+    <a href="#">Home</a>
+    <a href="#">Features</a>
+    <a href="#">Pricing</a>
+    <a href="#">Contact</a>
+    <div class="slide-underline" id="underline"></div>
+  </nav>
+  <script>
+    const nav = document.getElementById('nav');
+    const underline = document.getElementById('underline');
+    const links = [...nav.querySelectorAll('a')];
+
+    links.forEach(link => {
+      link.addEventListener('mouseenter', () => {
+        underline.style.width = link.offsetWidth + 'px';
+        underline.style.transform = `translateX(${link.offsetLeft}px)`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-menu-underline-slide-sap/style.css
+++ b/submissions/examples/ease-hover-menu-underline-slide-sap/style.css
@@ -1,0 +1,40 @@
+.underline-slide-sap {
+  position: relative;
+  display: flex;
+  gap: 24px;
+  font-family: system-ui, sans-serif;
+  padding-bottom: 4px;
+}
+
+.underline-slide-sap a {
+  color: #475569;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 0;
+}
+
+.underline-slide-sap a:hover {
+  color: #111;
+}
+
+.underline-slide-sap .slide-underline {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  width: 0;
+  background: #2563eb;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0;
+}
+
+.underline-slide-sap:hover .slide-underline {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .underline-slide-sap .slide-underline {
+    transition: opacity 0.2s ease;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-menu-underline-slide-sap`, a shared sliding underline nav indicator.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-hover-menu-underline-slide-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- One shared underline element travels between links via `transform`/`width`, distinct from per-link independent underlines, giving a connected sliding feel.
- Group-level hover controls overall visibility so the underline fully disappears once leaving the nav.
- `prefers-reduced-motion` removes the position/width transition, keeping only opacity visibility animated.

## Feature Description

Adds a reusable shared sliding underline nav component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.