### PR TITLE
feat: add ease-drag-splitscreen-resize-sap

### DIFF
--- a/submissions/examples/ease-drag-splitscreen-resize-sap/README.md
+++ b/submissions/examples/ease-drag-splitscreen-resize-sap/README.md
@@ -1,0 +1,30 @@
+# Drag Splitscreen Resize
+
+A before/after split-view layout with a draggable divider that resizes both
+panes, built as a proper ARIA separator with full keyboard support.
+
+**Level:** Advanced
+
+## Usage
+
+Drag `.split-handle` left/right to resize `#paneLeft` (percentage-based,
+clamped 20–80%); `#paneRight` fills the remainder via `flex: 1`. Arrow keys
+adjust by 5%, Home/End jump to the min/max bounds.
+
+## Accessibility
+
+- Handle uses `role="separator"` with `aria-orientation="vertical"` and
+  `aria-valuemin`/`aria-valuemax`/`aria-valuenow` kept in sync on every resize.
+- Fully keyboard-operable via ArrowLeft/ArrowRight/Home/End, independent of
+  pointer dragging.
+- `:focus-visible` outline shown on the handle.
+- `prefers-reduced-motion` removes the handle's hover/focus grip-indicator
+  transition; resizing itself is a direct, non-eased width change regardless.
+
+## Notes
+
+- Uses Pointer Events with `setPointerCapture`, consistent with the other
+  drag-resize components in this set, so dragging stays reliable even if
+  the pointer leaves the thin handle mid-drag.
+- Bounds are clamped to 20–80% so neither pane can be fully collapsed,
+  keeping both "before" and "after" content always at least partially visible.

--- a/submissions/examples/ease-drag-splitscreen-resize-sap/demo.html
+++ b/submissions/examples/ease-drag-splitscreen-resize-sap/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Splitscreen Resize</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Splitscreen Resize</h1>
+
+    <div class="split-container" id="splitContainer">
+      <section class="split-pane" id="paneLeft">
+        <h2>Before</h2>
+        <p>Original content goes here.</p>
+      </section>
+      <div
+        class="split-handle"
+        id="splitHandle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panels"
+        aria-valuemin="20"
+        aria-valuemax="80"
+        aria-valuenow="50"
+        tabindex="0"
+      ></div>
+      <section class="split-pane" id="paneRight">
+        <h2>After</h2>
+        <p>Updated content goes here.</p>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    const container = document.getElementById('splitContainer');
+    const left = document.getElementById('paneLeft');
+    const handle = document.getElementById('splitHandle');
+    const MIN = 20, MAX = 80;
+    let dragging = false;
+
+    function setSplit(pct) {
+      pct = Math.min(Math.max(pct, MIN), MAX);
+      left.style.width = pct + '%';
+      handle.setAttribute('aria-valuenow', Math.round(pct));
+    }
+
+    handle.addEventListener('pointerdown', (e) => {
+      dragging = true;
+      handle.setPointerCapture(e.pointerId);
+      document.body.classList.add('is-resizing');
+    });
+
+    handle.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      const rect = container.getBoundingClientRect();
+      setSplit(((e.clientX - rect.left) / rect.width) * 100);
+    });
+
+    ['pointerup', 'pointercancel'].forEach(evt =>
+      handle.addEventListener(evt, () => {
+        dragging = false;
+        document.body.classList.remove('is-resizing');
+      })
+    );
+
+    handle.addEventListener('keydown', (e) => {
+      const current = parseFloat(handle.getAttribute('aria-valuenow'));
+      if (e.key === 'ArrowLeft') { e.preventDefault(); setSplit(current - 5); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); setSplit(current + 5); }
+      if (e.key === 'Home') { e.preventDefault(); setSplit(MIN); }
+      if (e.key === 'End') { e.preventDefault(); setSplit(MAX); }
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-splitscreen-resize-sap/style.css
+++ b/submissions/examples/ease-drag-splitscreen-resize-sap/style.css
@@ -1,0 +1,90 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f1f5f9;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(700px, 92vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.split-container {
+  display: flex;
+  height: 260px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #cbd5e1;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.06);
+}
+
+.split-pane {
+  padding: 1.5rem;
+  text-align: left;
+  overflow: hidden;
+}
+
+#paneLeft {
+  width: 50%;
+  flex-shrink: 0;
+  background: #eef2ff;
+}
+
+#paneRight {
+  flex: 1;
+  background: white;
+}
+
+.split-pane h2 { margin: 0 0 0.4rem; font-size: 1rem; color: #4338ca; }
+.split-pane p { margin: 0; font-size: 0.85rem; color: #64748b; }
+
+.split-handle {
+  width: 10px;
+  flex-shrink: 0;
+  background: #e2e8f0;
+  cursor: col-resize;
+  position: relative;
+  touch-action: none;
+}
+
+.split-handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 32px;
+  background: #94a3b8;
+  border-radius: 2px;
+  transform: translate(-50%, -50%);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.split-handle:hover::after,
+.split-handle:focus-visible::after {
+  background: #6366f1;
+  transform: translate(-50%, -50%) scaleY(1.15);
+}
+
+.split-handle:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
+body.is-resizing { cursor: col-resize; user-select: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .split-handle::after { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-splitscreen-resize-sap`, a draggable before/after split-view resize component.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-splitscreen-resize-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Handle is a proper `role="separator"` with live `aria-valuenow` updates
  and full ArrowLeft/Right/Home/End keyboard support, not pointer-only.
- Resize bounds are clamped to 20–80% so neither pane can be fully collapsed.

## Feature Description

Adds a reusable draggable split-view resize component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.