### PR TITLE
feat: add basic backup status row demo

### DIFF
--- a/submissions/examples/basic-backup-status-row-kk/README.md
+++ b/submissions/examples/basic-backup-status-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Backup Status Row
+
+## What it does
+
+This submission adds a simple CSS-only backup status row for admin panels, storage dashboards, recovery summaries, settings screens, and restore workflows.
+
+It aligns a backup marker, snapshot title, helper copy, and small status label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a marker, backup copy, and status:
+
+```html
+<div class="basic-backup-status-row">
+  <span class="backup-marker" aria-hidden="true">01</span>
+  <div class="backup-copy">
+    <strong>Daily snapshot</strong>
+    <p>Completed at 03:30 with all workspace files included.</p>
+  </div>
+  <span class="backup-state is-complete">Complete</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across admin dashboards, backup settings, recovery panels, and storage summaries. It keeps backup state information easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Backup marker, title, helper copy, and status layout
+- Complete, pending, and ready examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the backup status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-backup-status-row-kk/demo.html
+++ b/submissions/examples/basic-backup-status-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Backup Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Backup Status Row</p>
+          <h1>Compact backup rows for admin, storage, and recovery panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a backup marker, snapshot details,
+            storage note, and status label for clean recovery summaries.
+          </p>
+        </header>
+
+        <section class="backup-panel" aria-label="Backup status row examples">
+          <div class="basic-backup-status-row">
+            <span class="backup-marker" aria-hidden="true">01</span>
+            <div class="backup-copy">
+              <strong>Daily snapshot</strong>
+              <p>Completed at 03:30 with all workspace files included.</p>
+            </div>
+            <span class="backup-state is-complete">Complete</span>
+          </div>
+
+          <div class="basic-backup-status-row">
+            <span class="backup-marker" aria-hidden="true">02</span>
+            <div class="backup-copy">
+              <strong>Media archive</strong>
+              <p>Queued for sync after current storage validation.</p>
+            </div>
+            <span class="backup-state is-pending">Pending</span>
+          </div>
+
+          <div class="basic-backup-status-row">
+            <span class="backup-marker" aria-hidden="true">03</span>
+            <div class="backup-copy">
+              <strong>Restore point</strong>
+              <p>Available for rollback from the last stable release.</p>
+            </div>
+            <span class="backup-state">Ready</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-backup-status-row"&gt;
+  &lt;span class="backup-marker" aria-hidden="true"&gt;01&lt;/span&gt;
+  &lt;div class="backup-copy"&gt;
+    &lt;strong&gt;Daily snapshot&lt;/strong&gt;
+    &lt;p&gt;Completed at 03:30 with all workspace files included.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="backup-state is-complete"&gt;Complete&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-backup-status-row-kk/style.css
+++ b/submissions/examples/basic-backup-status-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #a7f3d0;
+  --accent-soft: rgba(167, 243, 208, 0.14);
+  --complete: #86efac;
+  --pending: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(167, 243, 208, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.backup-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-backup-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-backup-status-row + .basic-backup-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.backup-marker {
+  width: 2.35rem;
+  height: 2.35rem;
+  flex: 0 0 2.35rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(167, 243, 208, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.backup-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.backup-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.backup-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backup-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.backup-state.is-complete {
+  color: var(--complete);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.backup-state.is-pending {
+  color: var(--pending);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-backup-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .backup-state {
+    margin-left: 3.2rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Backup Status Row demo inside `submissions/examples/basic-backup-status-row-kk/`. This submission introduces a compact CSS-only row pattern for admin panels, storage dashboards, recovery summaries, settings screens, and restore workflows.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only backup status row for showing a backup marker, snapshot title, helper copy, and small status label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-backup-status-row">
  <span class="backup-marker" aria-hidden="true">01</span>
  <div class="backup-copy">
    <strong>Daily snapshot</strong>
    <p>Completed at 03:30 with all workspace files included.</p>
  </div>
  <span class="backup-state is-complete">Complete</span>
</div>