### PR TITLE
feat: add basic license info row demo

### DIFF
--- a/submissions/examples/basic-license-info-row-kk/README.md
+++ b/submissions/examples/basic-license-info-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic License Info Row
+
+## What it does
+
+This submission adds a simple CSS-only license info row for billing pages, account settings, SaaS dashboards, admin panels, and subscription summaries.
+
+It aligns a license marker, plan title, renewal/helper copy, and small state label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a marker, license copy, and state:
+
+```html
+<div class="basic-license-info-row">
+  <span class="license-marker" aria-hidden="true">PRO</span>
+  <div class="license-copy">
+    <strong>Professional plan</strong>
+    <p>Renews on Sep 12 with 12 active seats.</p>
+  </div>
+  <span class="license-state is-active">Active</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across account settings, billing cards, admin dashboards, and subscription panels. It keeps license and plan details easy to scan with pure HTML and CSS.
+
+## Included features
+
+- License marker, plan title, helper copy, and state layout
+- Active, review, and included examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the license info row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-license-info-row-kk/demo.html
+++ b/submissions/examples/basic-license-info-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic License Info Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic License Info Row</p>
+          <h1>Compact license rows for billing, settings, and admin panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a license marker, plan details,
+            renewal note, and small state label for account summary sections.
+          </p>
+        </header>
+
+        <section class="license-panel" aria-label="License info row examples">
+          <div class="basic-license-info-row">
+            <span class="license-marker" aria-hidden="true">PRO</span>
+            <div class="license-copy">
+              <strong>Professional plan</strong>
+              <p>Renews on Sep 12 with 12 active seats.</p>
+            </div>
+            <span class="license-state is-active">Active</span>
+          </div>
+
+          <div class="basic-license-info-row">
+            <span class="license-marker" aria-hidden="true">EDU</span>
+            <div class="license-copy">
+              <strong>Education license</strong>
+              <p>Verification pending for the next billing cycle.</p>
+            </div>
+            <span class="license-state is-review">Review</span>
+          </div>
+
+          <div class="basic-license-info-row">
+            <span class="license-marker" aria-hidden="true">API</span>
+            <div class="license-copy">
+              <strong>API access add-on</strong>
+              <p>Usage limit available through the current workspace.</p>
+            </div>
+            <span class="license-state">Included</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-license-info-row"&gt;
+  &lt;span class="license-marker" aria-hidden="true"&gt;PRO&lt;/span&gt;
+  &lt;div class="license-copy"&gt;
+    &lt;strong&gt;Professional plan&lt;/strong&gt;
+    &lt;p&gt;Renews on Sep 12 with 12 active seats.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="license-state is-active"&gt;Active&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-license-info-row-kk/style.css
+++ b/submissions/examples/basic-license-info-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #fbbf24;
+  --accent-soft: rgba(251, 191, 36, 0.14);
+  --active: #86efac;
+  --review: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(251, 191, 36, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.license-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-license-info-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-license-info-row + .basic-license-info-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.license-marker {
+  width: 3.1rem;
+  height: 2.35rem;
+  flex: 0 0 3.1rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(251, 191, 36, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.license-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.license-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.license-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.license-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.license-state.is-active {
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.license-state.is-review {
+  color: var(--review);
+  background: rgba(147, 197, 253, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-license-info-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .license-state {
+    margin-left: 3.95rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic License Info Row demo inside `submissions/examples/basic-license-info-row-kk/`. This submission introduces a compact CSS-only row pattern for billing pages, account settings, SaaS dashboards, admin panels, and subscription summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only license info row for showing a license marker, plan title, renewal/helper copy, and small state label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-license-info-row">
  <span class="license-marker" aria-hidden="true">PRO</span>
  <div class="license-copy">
    <strong>Professional plan</strong>
    <p>Renews on Sep 12 with 12 active seats.</p>
  </div>
  <span class="license-state is-active">Active</span>
</div>