### PR TITLE
feat: add basic locale option row demo

### DIFF
--- a/submissions/examples/basic-locale-option-row-kk/README.md
+++ b/submissions/examples/basic-locale-option-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Locale Option Row
+
+## What it does
+
+This submission adds a simple CSS-only locale option row for language settings, region pickers, account preferences, onboarding screens, and profile setup panels.
+
+It aligns a locale marker, language name, region/helper copy, and selected state in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a locale marker, copy, and state:
+
+```html
+<div class="basic-locale-option-row">
+  <span class="locale-marker" aria-hidden="true">EN</span>
+  <div class="locale-copy">
+    <strong>English</strong>
+    <p>United States - default workspace language.</p>
+  </div>
+  <span class="locale-state is-selected">Selected</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across settings screens, onboarding cards, region selectors, and profile preference panels. It keeps locale choices easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Locale marker, language title, helper copy, and state layout
+- Selected, available, and review examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the locale option row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-locale-option-row-kk/demo.html
+++ b/submissions/examples/basic-locale-option-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Locale Option Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Locale Option Row</p>
+          <h1>Compact locale rows for language, region, and account settings.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a locale marker, language details,
+            region hint, and selected state for preference and onboarding screens.
+          </p>
+        </header>
+
+        <section class="locale-panel" aria-label="Locale option row examples">
+          <div class="basic-locale-option-row">
+            <span class="locale-marker" aria-hidden="true">EN</span>
+            <div class="locale-copy">
+              <strong>English</strong>
+              <p>United States - default workspace language.</p>
+            </div>
+            <span class="locale-state is-selected">Selected</span>
+          </div>
+
+          <div class="basic-locale-option-row">
+            <span class="locale-marker" aria-hidden="true">HI</span>
+            <div class="locale-copy">
+              <strong>Hindi</strong>
+              <p>India - available for profile and help content.</p>
+            </div>
+            <span class="locale-state">Available</span>
+          </div>
+
+          <div class="basic-locale-option-row">
+            <span class="locale-marker" aria-hidden="true">ES</span>
+            <div class="locale-copy">
+              <strong>Spanish</strong>
+              <p>Spain - translation review in progress.</p>
+            </div>
+            <span class="locale-state is-review">Review</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-locale-option-row"&gt;
+  &lt;span class="locale-marker" aria-hidden="true"&gt;EN&lt;/span&gt;
+  &lt;div class="locale-copy"&gt;
+    &lt;strong&gt;English&lt;/strong&gt;
+    &lt;p&gt;United States - default workspace language.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="locale-state is-selected"&gt;Selected&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-locale-option-row-kk/style.css
+++ b/submissions/examples/basic-locale-option-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #93c5fd;
+  --accent-soft: rgba(147, 197, 253, 0.14);
+  --selected: #86efac;
+  --review: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(147, 197, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.locale-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-locale-option-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-locale-option-row + .basic-locale-option-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.locale-marker {
+  width: 2.55rem;
+  height: 2.55rem;
+  flex: 0 0 2.55rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(147, 197, 253, 0.32);
+  border-radius: 50%;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.locale-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.locale-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.locale-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.locale-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.locale-state.is-selected {
+  color: var(--selected);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.locale-state.is-review {
+  color: var(--review);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-locale-option-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .locale-state {
+    margin-left: 3.4rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Locale Option Row demo inside `submissions/examples/basic-locale-option-row-kk/`. This submission introduces a compact CSS-only row pattern for language settings, region pickers, account preferences, onboarding screens, and profile setup panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only locale option row for showing a locale marker, language name, region/helper copy, and selected state in one compact layout.

**How does a developer use it?**

```html
<div class="basic-locale-option-row">
  <span class="locale-marker" aria-hidden="true">EN</span>
  <div class="locale-copy">
    <strong>English</strong>
    <p>United States - default workspace language.</p>
  </div>
  <span class="locale-state is-selected">Selected</span>
</div>