### PR TITLE
feat: add basic credential status row demo

### DIFF
--- a/submissions/examples/basic-credential-status-row-kk/README.md
+++ b/submissions/examples/basic-credential-status-row-kk/README.md
@@ -1,0 +1,41 @@
+# Basic Credential Status Row
+
+## What it does
+
+This submission adds a simple CSS-only credential status row for profile verification, account settings, onboarding screens, admin review panels, and identity summaries.
+
+It aligns a credential marker, verification title, helper copy, and small state label in one compact layout.
+
+## How to use it
+
+Add the utility class to a row containing a credential marker, copy, and state:
+
+```html
+<div class="basic-credential-status-row">
+  <span class="credential-marker" aria-hidden="true">ID</span>
+  <div class="credential-copy">
+    <strong>Identity verification</strong>
+    <p>Government ID has been reviewed and approved.</p>
+  </div>
+  <span class="credential-state is-verified">Verified</span>
+</div>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful across profile pages, account settings, onboarding cards, verification panels, and admin review workflows. It keeps credential state information easy to scan with pure HTML and CSS.
+
+## Included features
+
+- Credential marker, title, helper copy, and state layout
+- Verified, review, and pending examples
+- Divider support between rows
+- Text truncation for long helper copy
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the credential status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-credential-status-row-kk/demo.html
+++ b/submissions/examples/basic-credential-status-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Credential Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Credential Status Row</p>
+          <h1>Compact credential rows for verification and account panels.</h1>
+          <p class="intro">
+            This CSS-only utility aligns a credential marker, verification copy,
+            helper text, and state label for profile and admin review sections.
+          </p>
+        </header>
+
+        <section class="credential-panel" aria-label="Credential status row examples">
+          <div class="basic-credential-status-row">
+            <span class="credential-marker" aria-hidden="true">ID</span>
+            <div class="credential-copy">
+              <strong>Identity verification</strong>
+              <p>Government ID has been reviewed and approved.</p>
+            </div>
+            <span class="credential-state is-verified">Verified</span>
+          </div>
+
+          <div class="basic-credential-status-row">
+            <span class="credential-marker" aria-hidden="true">EDU</span>
+            <div class="credential-copy">
+              <strong>Education proof</strong>
+              <p>Student credential is waiting for manual review.</p>
+            </div>
+            <span class="credential-state is-review">Review</span>
+          </div>
+
+          <div class="basic-credential-status-row">
+            <span class="credential-marker" aria-hidden="true">ORG</span>
+            <div class="credential-copy">
+              <strong>Organization email</strong>
+              <p>Workspace domain confirmation has not been completed.</p>
+            </div>
+            <span class="credential-state">Pending</span>
+          </div>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;div class="basic-credential-status-row"&gt;
+  &lt;span class="credential-marker" aria-hidden="true"&gt;ID&lt;/span&gt;
+  &lt;div class="credential-copy"&gt;
+    &lt;strong&gt;Identity verification&lt;/strong&gt;
+    &lt;p&gt;Government ID has been reviewed and approved.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="credential-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/div&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-credential-status-row-kk/style.css
+++ b/submissions/examples/basic-credential-status-row-kk/style.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.94);
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f7f9ff;
+  --muted: #9da9bd;
+  --accent: #c4b5fd;
+  --accent-soft: rgba(196, 181, 253, 0.14);
+  --verified: #86efac;
+  --review: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(196, 181, 253, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.1), transparent 26%),
+    var(--page);
+  color: var(--text);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 76px rgba(0, 0, 0, 0.36);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.9rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.06;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.credential-panel,
+.usage-card {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--panel);
+}
+
+.basic-credential-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 0;
+}
+
+.basic-credential-status-row + .basic-credential-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.credential-marker {
+  width: 3rem;
+  height: 2.4rem;
+  flex: 0 0 3rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(196, 181, 253, 0.32);
+  border-radius: 0.8rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.credential-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.credential-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.credential-copy p {
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.credential-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.42rem 0.72rem;
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.credential-state.is-verified {
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.13);
+}
+
+.credential-state.is-review {
+  color: var(--review);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-credential-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .credential-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Credential Status Row demo inside `submissions/examples/basic-credential-status-row-kk/`. This submission introduces a compact CSS-only row pattern for profile verification, account settings, onboarding screens, admin review panels, and identity summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only credential status row for showing a credential marker, verification title, helper copy, and small state label in one compact layout.

**How does a developer use it?**

```html
<div class="basic-credential-status-row">
  <span class="credential-marker" aria-hidden="true">ID</span>
  <div class="credential-copy">
    <strong>Identity verification</strong>
    <p>Government ID has been reviewed and approved.</p>
  </div>
  <span class="credential-state is-verified">Verified</span>
</div>