### PR TITLE
fix(layout): resolve shape-outside 3d transform bug #80452

### DIFF
--- a/submissions/examples/ease-shape-outside-3d-fix/README.md
+++ b/submissions/examples/ease-shape-outside-3d-fix/README.md
@@ -1,0 +1,23 @@
+# Abstract
+
+This example demonstrates the architectural resolution for Issue #80452, where applying CSS 3D matrix transforms directly to floated elements with `shape-outside: polygon()` causes inline text wrapping to break. By decoupling layout properties from GPU-accelerated rendering transforms, inline content wraps along complex polygon boundaries while maintaining hardware-accelerated 3D effects.
+
+## The GPU Compositing Bug
+
+When a CSS 3D transform (such as `transform: rotateY()`) is applied directly to an element that utilizes `float` and `shape-outside`, the browser's rendering engine promotes that element to a separate compositing/GPU layer. 
+
+Because the browser's layout engine calculates float geometry and text line wrapping on the main CPU thread *before* GPU compositing transforms are calculated, hoisting the element strips the main-thread layout engine of the element's actual shape geometry. As a result, the inline text reflows into a default rectangular bounding box, completely disregarding the `shape-outside: polygon()` path.
+
+## The Decoupled Architecture
+
+To resolve this without sacrificing hardware-accelerated 3D animations, we isolate layout responsibilities using a two-tier DOM structure:
+
+1. **Static Layout Wrapper (`.ease-shape-wrapper`)**:
+   - Manages all main-thread layout responsibilities: `float: left`, `shape-outside: polygon(...)`, and `clip-path: polygon(...)`.
+   - Establishes a 3D perspective context (`perspective: 1000px`) without initiating a 3D transform on itself.
+   - Remains un-transformed, guaranteeing that the browser float engine accurately wraps surrounding inline text along the polygon boundaries.
+
+2. **Transformed Render Child (`.ease-shape-img`)**:
+   - Resides strictly within the bounds of the static wrapper.
+   - Receives all GPU-accelerated visual transformation instructions (`transform: rotateY(...)`).
+   - Rotates and scales freely in 3D space on hover without triggering main-thread layout reflows or interfering with text wrapping.

--- a/submissions/examples/ease-shape-outside-3d-fix/demo.html
+++ b/submissions/examples/ease-shape-outside-3d-fix/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Decoupling Layout from Rendering</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <article class="ease-magazine-article">
+    <h1 style="color: #f8fafc; font-size: 2.5rem; margin-bottom: 2rem;">Decoupling Layout from Rendering</h1>
+    <div class="ease-shape-wrapper">
+      <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=2400&auto=format&fit=crop" alt="Abstract 3D Art" class="ease-shape-img">
+    </div>
+    <p>When engineering modern web interfaces, developers frequently encounter friction between legacy CSS layout models and hardware-accelerated rendering contexts. The float property, designed decades ago for simple document flow, struggles to comprehend the mathematical complexities of 3D matrix transformations.</p>
+    <p>If you apply a <code>transform: rotateY()</code> directly to a floated element utilizing <code>shape-outside</code>, the browser's compositing engine hoists the element onto a separate GPU layer. This action inadvertently strips the float layout engine of its physical boundaries, causing inline text to violently reflow into a rigid, rectangular box, completely ignoring your carefully crafted polygon paths.</p>
+    <p>The solution requires strict architectural discipline. We must decouple the spatial layout logic from the visual rendering logic. By maintaining the <code>float</code>, <code>shape-outside</code>, and <code>clip-path</code> on a static, un-transformed parent wrapper, we preserve the structural integrity of the DOM. We then inject the 3D <code>transform</code> exclusively on the child element. Hover over the geometric shape to the left to observe the hardware-accelerated 3D rotation operating flawlessly without causing a single layout shift or text reflow in the surrounding paragraphs.</p>
+  </article>
+</body>
+</html>

--- a/submissions/examples/ease-shape-outside-3d-fix/style.css
+++ b/submissions/examples/ease-shape-outside-3d-fix/style.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #cbd5e1;
+  padding: 2rem;
+}
+
+.ease-magazine-article {
+  max-width: 800px;
+  line-height: 1.8;
+  font-size: 1.1rem;
+  text-align: justify;
+}
+
+.ease-magazine-article p {
+  margin-bottom: 1.5rem;
+}
+
+.ease-shape-wrapper {
+  float: left;
+  width: 300px;
+  height: 300px;
+  margin: 0 2rem 1rem 0;
+  shape-outside: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  perspective: 1000px;
+}
+
+.ease-shape-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: rotateY(15deg) scale(1.1);
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.3, 1);
+}
+
+.ease-shape-wrapper:hover .ease-shape-img {
+  transform: rotateY(-15deg) scale(1.2);
+}


### PR DESCRIPTION
## Pull Request Description

Resolves Issue #80452 where applying CSS 3D matrix transforms (`transform: rotateY()`) directly to a floated element using `shape-outside: polygon()` causes inline text wrapping to break. The solution decouples the main-thread spatial layout logic (`float`, `shape-outside`, `clip-path`) onto a static parent wrapper (`.ease-shape-wrapper`) from the hardware-accelerated visual rendering logic (`transform`) on the inner child element (`.ease-shape-img`).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/ease-shape-outside-3d-fix/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A decoupled layout pattern that prevents browser GPU layer hoisting from stripping main-thread `shape-outside` polygon text wrapping during 3D transformations.

**How does a developer use it?**

```html
<article class="ease-magazine-article">
  <div class="ease-shape-wrapper">
    <img src="image.jpg" alt="3D Art" class="ease-shape-img">
  </div>
  <p>Inline text wraps fluidly around the polygon shape while the image rotates in 3D on hover...</p>
</article>
>
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Fixes #80452 
<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
