### PR TITLE
feat: add basic reading time pill demo

### DIFF
--- a/submissions/examples/basic-reading-time-pill-kk/README.md
+++ b/submissions/examples/basic-reading-time-pill-kk/README.md
@@ -1,0 +1,44 @@
+# Basic Reading Time Pill
+
+## What it does
+
+This submission adds a simple CSS-only reading time pill for blogs,
+documentation cards, tutorials, changelogs, newsletters, and article previews.
+
+It helps users quickly understand the estimated reading effort before opening
+long-form content.
+
+## How to use it
+
+Add the base pill class with optional state modifiers:
+
+```html
+<span class="basic-reading-time-pill">
+  <span class="pill-icon" aria-hidden="true">3</span>
+  <span class="pill-copy">Quick read</span>
+  <strong>3 min</strong>
+</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+documentation, product blogs, tutorial cards, and knowledge-base layouts. The
+hover motion on preview cards keeps the pattern animation-friendly while the
+pill itself remains lightweight and easy to reuse.
+
+## Included features
+
+- Compact reading time pill layout
+- Quick read, deep dive, and guide variants
+- Circular time marker
+- Article preview examples
+- Subtle hover lift on cards
+- Responsive single-column layout on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the reading time pill
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-reading-time-pill-kk/demo.html
+++ b/submissions/examples/basic-reading-time-pill-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Reading Time Pill</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Reading Time Pill</p>
+          <h1>Compact reading time labels for articles and documentation.</h1>
+          <p class="intro">
+            A CSS-only pill component that helps users quickly understand the
+            estimated effort before opening a guide, blog post, or tutorial.
+          </p>
+        </header>
+
+        <section class="article-preview" aria-label="Reading time pill examples">
+          <article class="preview-card">
+            <span class="basic-reading-time-pill">
+              <span class="pill-icon" aria-hidden="true">3</span>
+              <span class="pill-copy">Quick read</span>
+              <strong>3 min</strong>
+            </span>
+            <h2>Designing Better Empty States</h2>
+            <p>Small interface details that make product pages feel helpful.</p>
+          </article>
+
+          <article class="preview-card">
+            <span class="basic-reading-time-pill is-long">
+              <span class="pill-icon" aria-hidden="true">12</span>
+              <span class="pill-copy">Deep dive</span>
+              <strong>12 min</strong>
+            </span>
+            <h2>Building Accessible Dashboard Patterns</h2>
+            <p>Layout, hierarchy, and motion rules for readable data screens.</p>
+          </article>
+
+          <article class="preview-card">
+            <span class="basic-reading-time-pill is-guide">
+              <span class="pill-icon" aria-hidden="true">7</span>
+              <span class="pill-copy">Guide</span>
+              <strong>7 min</strong>
+            </span>
+            <h2>CSS Utility Naming Basics</h2>
+            <p>How to name small utilities so developers can scan them faster.</p>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="basic-reading-time-pill"&gt;
+  &lt;span class="pill-icon" aria-hidden="true"&gt;3&lt;/span&gt;
+  &lt;span class="pill-copy"&gt;Quick read&lt;/span&gt;
+  &lt;strong&gt;3 min&lt;/strong&gt;
+&lt;/span&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-reading-time-pill-kk/style.css
+++ b/submissions/examples/basic-reading-time-pill-kk/style.css
@@ -1,0 +1,186 @@
+:root {
+  color-scheme: dark;
+  --page: #090d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.11);
+  --text: #f8fbff;
+  --muted: #9da8bb;
+  --quick: #7dd3fc;
+  --long: #fda4af;
+  --guide: #c4b5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(125, 211, 252, 0.14), transparent 30%),
+    radial-gradient(circle at 85% 78%, rgba(196, 181, 253, 0.13), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 900px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--quick);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.article-preview {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 1.3rem;
+}
+
+.preview-card {
+  min-height: 13rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    background 180ms ease;
+}
+
+.preview-card:hover {
+  border-color: rgba(125, 211, 252, 0.55);
+  background: rgba(255, 255, 255, 0.07);
+  transform: translateY(-3px);
+}
+
+.preview-card h2 {
+  margin: auto 0 0;
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
+.preview-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.basic-reading-time-pill {
+  --pill-tone: var(--quick);
+
+  width: max-content;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.36rem 0.55rem 0.36rem 0.38rem;
+  border: 1px solid rgba(125, 211, 252, 0.34);
+  border-radius: 999px;
+  color: var(--pill-tone);
+  background: rgba(125, 211, 252, 0.11);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.basic-reading-time-pill.is-long {
+  --pill-tone: var(--long);
+
+  border-color: rgba(253, 164, 175, 0.36);
+  background: rgba(253, 164, 175, 0.11);
+}
+
+.basic-reading-time-pill.is-guide {
+  --pill-tone: var(--guide);
+
+  border-color: rgba(196, 181, 253, 0.36);
+  background: rgba(196, 181, 253, 0.12);
+}
+
+.pill-icon {
+  width: 1.55rem;
+  height: 1.55rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #07111f;
+  background: var(--pill-tone);
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.pill-copy {
+  color: var(--text);
+}
+
+.basic-reading-time-pill strong {
+  font-size: 0.78rem;
+}
+
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .article-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-card {
+    padding: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Reading Time Pill demo inside `submissions/examples/basic-reading-time-pill-kk/`. This submission introduces a compact CSS-only pill for blogs, documentation cards, tutorials, changelogs, newsletters, and article previews.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only reading time pill that shows estimated reading effort with a compact label, circular time marker, and reusable style variants.

**How does a developer use it?**

```html
<span class="basic-reading-time-pill">
  <span class="pill-icon" aria-hidden="true">3</span>
  <span class="pill-copy">Quick read</span>
  <strong>3 min</strong>
</span>