### PR TITLE
feat: add basic file type badge demo

### DIFF
--- a/submissions/examples/basic-file-type-badge-kk/README.md
+++ b/submissions/examples/basic-file-type-badge-kk/README.md
@@ -1,0 +1,38 @@
+# Basic File Type Badge
+
+## What it does
+
+This submission adds a simple CSS-only file type badge for upload previews,
+attachment rows, resource cards, document lists, and admin file-review panels.
+
+It helps users quickly identify file formats like PDF, DOC, IMG, and CSS in a
+compact visual style.
+
+## How to use it
+
+Add the base badge class with a file-type modifier:
+
+```html
+<span class="basic-file-type-badge is-pdf">PDF</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful
+across common frontend interfaces. The badge can be dropped into cards, lists,
+upload rows, and attachment panels while staying lightweight and CSS-only.
+
+## Included features
+
+- PDF, DOC, IMG, and CSS badge variants
+- Compact rounded file label
+- Attachment row examples
+- Subtle hover lift on rows
+- Responsive-friendly layout
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the file type badge
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-file-type-badge-kk/demo.html
+++ b/submissions/examples/basic-file-type-badge-kk/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic File Type Badge</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic File Type Badge</p>
+          <h1>Readable file badges for upload and attachment interfaces.</h1>
+          <p class="intro">
+            A CSS-only badge pattern for showing file formats in document lists,
+            upload previews, resource cards, and attachment rows.
+          </p>
+        </header>
+
+        <section class="file-list" aria-label="File type badge examples">
+          <article class="file-row">
+            <span class="basic-file-type-badge is-pdf">PDF</span>
+            <div>
+              <strong>Project proposal</strong>
+              <p>Final document ready for review.</p>
+            </div>
+          </article>
+
+          <article class="file-row">
+            <span class="basic-file-type-badge is-doc">DOC</span>
+            <div>
+              <strong>Contribution notes</strong>
+              <p>Editable notes for the next implementation step.</p>
+            </div>
+          </article>
+
+          <article class="file-row">
+            <span class="basic-file-type-badge is-img">IMG</span>
+            <div>
+              <strong>Interface screenshot</strong>
+              <p>Visual reference for the component layout.</p>
+            </div>
+          </article>
+
+          <article class="file-row">
+            <span class="basic-file-type-badge is-css">CSS</span>
+            <div>
+              <strong>Style utility</strong>
+              <p>Raw CSS for the proposed EaseMotion pattern.</p>
+            </div>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="basic-file-type-badge is-pdf"&gt;PDF&lt;/span&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-file-type-badge-kk/style.css
+++ b/submissions/examples/basic-file-type-badge-kk/style.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ba7ba;
+  --pdf: #fb7185;
+  --doc: #60a5fa;
+  --img: #a78bfa;
+  --css: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(96, 165, 250, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(52, 211, 153, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 820px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--doc);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.file-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.file-row + .file-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.file-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.file-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.file-row p {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.basic-file-type-badge {
+  min-width: 3.6rem;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid currentColor;
+  border-radius: 0.85rem;
+  color: var(--doc);
+  background: rgba(96, 165, 250, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: inset 0 -10px 16px rgba(255, 255, 255, 0.04);
+}
+
+.basic-file-type-badge.is-pdf {
+  color: var(--pdf);
+  background: rgba(251, 113, 133, 0.12);
+}
+
+.basic-file-type-badge.is-doc {
+  color: var(--doc);
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.basic-file-type-badge.is-img {
+  color: var(--img);
+  background: rgba(167, 139, 250, 0.12);
+}
+
+.basic-file-type-badge.is-css {
+  color: var(--css);
+  background: rgba(52, 211, 153, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 540px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .file-row {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic File Type Badge demo inside `submissions/examples/basic-file-type-badge-kk/`. This submission introduces compact CSS-only file badges for upload previews, attachment rows, resource cards, document lists, and admin file-review panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only file type badge that helps users quickly identify file formats like PDF, DOC, IMG, and CSS in document lists and attachment interfaces.

**How does a developer use it?**

```html
<span class="basic-file-type-badge is-pdf">PDF</span>