### PR TITLE
feat: add ease-modal-v9 — Pure CSS glowing pop-in modal window (glow-modal-v9-ak)

### DIFF
--- a/submissions/examples/glow-modal-v9-ak/README.md
+++ b/submissions/examples/glow-modal-v9-ak/README.md
@@ -1,0 +1,17 @@
+# glow-modal-v9-ak
+
+Pure CSS animated glowing pop-in modal window component — no JavaScript required.
+
+## How to use
+
+```html
+<input type="checkbox" id="m" class="ease-modal-checkbox-v9" />
+<label for="m" class="ease-modal-trigger-v9">Open Modal</label>
+
+<div class="ease-modal-overlay-v9">
+  <div class="ease-modal-dialog-v9">
+    <h3 class="ease-modal-title-v9">Title</h3>
+    <p class="ease-modal-desc-v9">Content</p>
+    <label for="m" class="ease-modal-close-v9">Close</label>
+  </div>
+</div>

--- a/submissions/examples/glow-modal-v9-ak/demo.html
+++ b/submissions/examples/glow-modal-v9-ak/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Glowing Modal Window — EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <p class="label">Pure CSS Animated Pop-In Modal Window</p>
+
+  <input type="checkbox" id="modal-v9-ak" class="ease-modal-checkbox-v9" />
+  <label for="modal-v9-ak" class="ease-modal-trigger-v9">Open Modal</label>
+
+  <div class="ease-modal-overlay-v9">
+    <div class="ease-modal-dialog-v9">
+      <h3 class="ease-modal-title-v9">✨ Neon Modal</h3>
+      <p class="ease-modal-desc-v9">Spring scale pop-in modal window with glassmorphism backdrop blur. Zero JS.</p>
+      <div>
+        <label for="modal-v9-ak" class="ease-modal-close-v9">Close Modal</label>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/glow-modal-v9-ak/style.css
+++ b/submissions/examples/glow-modal-v9-ak/style.css
@@ -1,0 +1,102 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+  padding: 3rem 1.5rem;
+  color: #fff;
+}
+
+.label {
+  color: rgba(255,255,255,0.3);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  margin-bottom: -1.5rem;
+}
+
+.ease-modal-trigger-v9 {
+  padding: 0.85rem 2rem;
+  background: #6c63ff;
+  border: none;
+  border-radius: 9999px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(108, 99, 255, 0.35);
+  transition: transform 0.2s ease;
+}
+
+.ease-modal-trigger-v9:hover { transform: translateY(-2px); }
+
+.ease-modal-checkbox-v9 {
+  position: fixed;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-modal-overlay-v9 {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 14, 23, 0.8);
+  backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.ease-modal-dialog-v9 {
+  width: 90%;
+  max-width: 400px;
+  padding: 2rem;
+  background: #181625;
+  border: 1.5px solid #6c63ff;
+  border-radius: 20px;
+  box-shadow: 0 0 35px rgba(108, 99, 255, 0.4);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transform: scale(0.85) translateY(20px);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-modal-title-v9 { font-size: 1.3rem; font-weight: 800; }
+.ease-modal-desc-v9 { font-size: 0.85rem; color: rgba(255, 255, 255, 0.65); line-height: 1.5; }
+
+.ease-modal-close-v9 {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 10px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.ease-modal-checkbox-v9:checked ~ .ease-modal-overlay-v9 {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ease-modal-checkbox-v9:checked ~ .ease-modal-overlay-v9 .ease-modal-dialog-v9 {
+  transform: scale(1) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal-overlay-v9, .ease-modal-dialog-v9 { transition: none; }
+}


### PR DESCRIPTION
## What
Pure CSS modal window using checkbox `:checked` state with spring scale pop-in and glassmorphism backdrop blur. Zero JS.

## How to review
Open submissions/examples/glow-modal-v9-ak/demo.html directly in browser.

## Checklist
- [x] Only files under submissions/examples/glow-modal-v9-ak/
- [x] demo.html works without a server
- [x] No CDN or external JS
- [x] Unique suffix -ak