### PR TITLE
feat: add basic security level badge demo

### DIFF
--- a/submissions/examples/basic-security-level-badge-kk/README.md
+++ b/submissions/examples/basic-security-level-badge-kk/README.md
@@ -1,0 +1,40 @@
+# Basic Security Level Badge
+
+## What it does
+
+This submission adds a simple CSS-only security level badge for account panels,
+admin tools, risk summaries, verification screens, and profile settings.
+
+It helps users quickly identify low, medium, and high security states in a
+compact and readable format.
+
+## How to use it
+
+Add the base badge class with a level modifier:
+
+```html
+<span class="basic-security-level-badge level-high">High</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful
+across common account and admin interfaces. The badge adds a small animated
+visual signal through glow styling and row hover motion while staying fully
+CSS-only.
+
+## Included features
+
+- Low, medium, and high security level variants
+- Compact pill badge layout
+- Built-in glowing status dot
+- Account/security row examples
+- Subtle hover lift on rows
+- Responsive stacking on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the security level badge
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-security-level-badge-kk/demo.html
+++ b/submissions/examples/basic-security-level-badge-kk/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Security Level Badge</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Security Level Badge</p>
+          <h1>Readable security badges for account and admin settings.</h1>
+          <p class="intro">
+            A CSS-only badge component for showing low, medium, and high
+            security levels in account panels, risk summaries, and admin tools.
+          </p>
+        </header>
+
+        <section class="security-panel" aria-label="Security level badge examples">
+          <article class="security-row">
+            <div>
+              <strong>Two-factor authentication</strong>
+              <p>Extra login protection is enabled for this account.</p>
+            </div>
+            <span class="basic-security-level-badge level-high">High</span>
+          </article>
+
+          <article class="security-row">
+            <div>
+              <strong>Password strength</strong>
+              <p>Password is usable but should be refreshed soon.</p>
+            </div>
+            <span class="basic-security-level-badge level-medium">Medium</span>
+          </article>
+
+          <article class="security-row">
+            <div>
+              <strong>Recovery method</strong>
+              <p>No backup contact method has been confirmed yet.</p>
+            </div>
+            <span class="basic-security-level-badge level-low">Low</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="basic-security-level-badge level-high"&gt;High&lt;/span&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-security-level-badge-kk/style.css
+++ b/submissions/examples/basic-security-level-badge-kk/style.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --high: #86efac;
+  --medium: #fcd34d;
+  --low: #fb7185;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.13), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(251, 113, 133, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--high);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 14ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.security-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.security-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.security-row + .security-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.security-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.security-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.security-row p {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.basic-security-level-badge {
+  flex: 0 0 auto;
+  min-width: 5.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.72rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--medium);
+  background: rgba(252, 211, 77, 0.12);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.basic-security-level-badge::before {
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0.85rem currentColor;
+  content: "";
+}
+
+.basic-security-level-badge.level-high {
+  color: var(--high);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.basic-security-level-badge.level-medium {
+  color: var(--medium);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.basic-security-level-badge.level-low {
+  color: var(--low);
+  background: rgba(251, 113, 133, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .security-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Security Level Badge demo inside `submissions/examples/basic-security-level-badge-kk/`. This submission introduces compact CSS-only security badges for account panels, admin tools, risk summaries, verification screens, and profile settings.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only security level badge that helps users quickly identify low, medium, and high security states in account and admin interfaces.

**How does a developer use it?**

```html
<span class="basic-security-level-badge level-high">High</span>