### PR TITLE
feat: add basic app version badge demo

### DIFF
--- a/submissions/examples/basic-app-version-badge-kk/README.md
+++ b/submissions/examples/basic-app-version-badge-kk/README.md
@@ -1,0 +1,39 @@
+# Basic App Version Badge
+
+## What it does
+
+This submission adds a simple CSS-only app version badge for settings pages,
+release notes, documentation cards, admin dashboards, and changelog summaries.
+
+It helps users quickly identify stable, beta, and deprecated release states in
+a compact visual format.
+
+## How to use it
+
+Add the base badge class with a release-state modifier:
+
+```html
+<span class="basic-app-version-badge is-stable">v2.4.1</span>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common product interfaces. The badge can be placed inside cards, release rows,
+settings panels, and changelog sections while staying lightweight and CSS-only.
+
+## Included features
+
+- Stable, beta, and deprecated release variants
+- Compact pill badge layout
+- Built-in status dot
+- Release row examples
+- Subtle hover lift on rows
+- Responsive stacking on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the app version badge
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-app-version-badge-kk/demo.html
+++ b/submissions/examples/basic-app-version-badge-kk/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic App Version Badge</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic App Version Badge</p>
+          <h1>Compact version badges for settings and release notes.</h1>
+          <p class="intro">
+            A CSS-only badge pattern for showing app versions, release channels,
+            and lifecycle states in documentation, dashboards, and settings UI.
+          </p>
+        </header>
+
+        <section class="release-panel" aria-label="App version badge examples">
+          <article class="release-row">
+            <div>
+              <strong>Current production build</strong>
+              <p>Recommended stable version for all users.</p>
+            </div>
+            <span class="basic-app-version-badge is-stable">v2.4.1</span>
+          </article>
+
+          <article class="release-row">
+            <div>
+              <strong>Preview channel</strong>
+              <p>Early feature build available for testing.</p>
+            </div>
+            <span class="basic-app-version-badge is-beta">Beta</span>
+          </article>
+
+          <article class="release-row">
+            <div>
+              <strong>Legacy package</strong>
+              <p>Older version kept for migration reference.</p>
+            </div>
+            <span class="basic-app-version-badge is-deprecated">Legacy</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;span class="basic-app-version-badge is-stable"&gt;v2.4.1&lt;/span&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-app-version-badge-kk/style.css
+++ b/submissions/examples/basic-app-version-badge-kk/style.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: dark;
+  --page: #080e19;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --stable: #6ee7b7;
+  --beta: #93c5fd;
+  --deprecated: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(110, 231, 183, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(147, 197, 253, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--stable);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.release-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.release-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.release-row + .release-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.release-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.release-row strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.release-row p {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.basic-app-version-badge {
+  flex: 0 0 auto;
+  min-width: 5.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.72rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--stable);
+  background: rgba(110, 231, 183, 0.12);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.basic-app-version-badge::before {
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-right: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.basic-app-version-badge.is-beta {
+  color: var(--beta);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.basic-app-version-badge.is-deprecated {
+  color: var(--deprecated);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .release-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic App Version Badge demo inside `submissions/examples/basic-app-version-badge-kk/`. This submission introduces compact CSS-only version badges for settings pages, release notes, documentation cards, admin dashboards, and changelog summaries.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only app version badge that helps users quickly identify stable, beta, and deprecated release states in product interfaces.

**How does a developer use it?**

```html
<span class="basic-app-version-badge is-stable">v2.4.1</span>