### PR TITLE
feat: add basic notification permission row demo

### DIFF
--- a/submissions/examples/basic-notification-permission-row-kk/README.md
+++ b/submissions/examples/basic-notification-permission-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Notification Permission Row
+
+## What it does
+
+This submission adds a simple CSS-only notification permission row for settings
+pages, onboarding flows, privacy panels, account preferences, and admin tools.
+
+It displays a permission icon, label, helper copy, state pill, and toggle-style
+visual in one compact row.
+
+## How to use it
+
+Add the base row class with state and toggle elements:
+
+```html
+<article class="basic-notification-permission-row">
+  <span class="permission-icon" aria-hidden="true">N</span>
+  <div class="permission-copy">
+    <strong>Product updates</strong>
+    <p>Receive release notes and important announcements.</p>
+  </div>
+  <span class="permission-state is-granted">Allowed</span>
+  <span class="permission-toggle is-on" aria-hidden="true"></span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common account and settings interfaces. The row uses subtle hover motion and a
+CSS-only toggle visual while keeping the markup lightweight.
+
+## Included features
+
+- Granted, prompt, and blocked permission states
+- Permission icon, copy, state, and toggle-style layout
+- CSS-only toggle visual
+- Text truncation for long helper copy
+- Subtle hover lift interaction
+- Responsive two-column wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the notification permission row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-notification-permission-row-kk/demo.html
+++ b/submissions/examples/basic-notification-permission-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Notification Permission Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Notification Permission Row</p>
+          <h1>Permission rows for notification and privacy settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing permission copy, current state,
+            and a simple toggle-style control in settings or onboarding screens.
+          </p>
+        </header>
+
+        <section class="permission-panel" aria-label="Notification permission row examples">
+          <article class="basic-notification-permission-row">
+            <span class="permission-icon" aria-hidden="true">N</span>
+            <div class="permission-copy">
+              <strong>Product updates</strong>
+              <p>Receive release notes and important feature announcements.</p>
+            </div>
+            <span class="permission-state is-granted">Allowed</span>
+            <span class="permission-toggle is-on" aria-hidden="true"></span>
+          </article>
+
+          <article class="basic-notification-permission-row">
+            <span class="permission-icon" aria-hidden="true">R</span>
+            <div class="permission-copy">
+              <strong>Review reminders</strong>
+              <p>Get notified before pending reviews become inactive.</p>
+            </div>
+            <span class="permission-state is-prompt">Ask</span>
+            <span class="permission-toggle" aria-hidden="true"></span>
+          </article>
+
+          <article class="basic-notification-permission-row">
+            <span class="permission-icon" aria-hidden="true">M</span>
+            <div class="permission-copy">
+              <strong>Marketing messages</strong>
+              <p>Optional product tips and promotional updates are disabled.</p>
+            </div>
+            <span class="permission-state is-blocked">Blocked</span>
+            <span class="permission-toggle is-off" aria-hidden="true"></span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-notification-permission-row"&gt;
+  &lt;span class="permission-icon" aria-hidden="true"&gt;N&lt;/span&gt;
+  &lt;div class="permission-copy"&gt;
+    &lt;strong&gt;Product updates&lt;/strong&gt;
+    &lt;p&gt;Receive release notes and important announcements.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="permission-state is-granted"&gt;Allowed&lt;/span&gt;
+  &lt;span class="permission-toggle is-on" aria-hidden="true"&gt;&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-notification-permission-row-kk/style.css
+++ b/submissions/examples/basic-notification-permission-row-kk/style.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --accent: #93c5fd;
+  --granted: #86efac;
+  --prompt: #fcd34d;
+  --blocked: #fb7185;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(134, 239, 172, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.permission-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-notification-permission-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-notification-permission-row + .basic-notification-permission-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-notification-permission-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.permission-icon {
+  width: 2.7rem;
+  height: 2.7rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(147, 197, 253, 0.32);
+  border-radius: 0.95rem;
+  color: var(--accent);
+  background: rgba(147, 197, 253, 0.12);
+  font-weight: 900;
+}
+
+.permission-copy {
+  min-width: 0;
+}
+
+.permission-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.permission-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.permission-state {
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  color: var(--accent);
+  background: rgba(147, 197, 253, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.permission-state.is-granted {
+  color: var(--granted);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.permission-state.is-prompt {
+  color: var(--prompt);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.permission-state.is-blocked {
+  color: var(--blocked);
+  background: rgba(251, 113, 133, 0.12);
+}
+
+.permission-toggle {
+  width: 3rem;
+  height: 1.55rem;
+  position: relative;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.permission-toggle::after {
+  width: 1.15rem;
+  height: 1.15rem;
+  position: absolute;
+  top: 0.2rem;
+  left: 0.22rem;
+  border-radius: 50%;
+  background: #ffffff;
+  content: "";
+  transition: transform 180ms ease;
+}
+
+.permission-toggle.is-on {
+  background: rgba(134, 239, 172, 0.35);
+}
+
+.permission-toggle.is-on::after {
+  transform: translateX(1.35rem);
+}
+
+.permission-toggle.is-off {
+  background: rgba(251, 113, 133, 0.25);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 680px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-notification-permission-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .permission-state {
+    margin-left: 3.55rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Notification Permission Row demo inside `submissions/examples/basic-notification-permission-row-kk/`. This submission introduces a compact CSS-only row for settings pages, onboarding flows, privacy panels, account preferences, and admin tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only notification permission row that displays a permission icon, label, helper copy, state pill, and toggle-style visual in one compact layout.

**How does a developer use it?**

```html
<article class="basic-notification-permission-row">
  <span class="permission-icon" aria-hidden="true">N</span>
  <div class="permission-copy">
    <strong>Product updates</strong>
    <p>Receive release notes and important announcements.</p>
  </div>
  <span class="permission-state is-granted">Allowed</span>
  <span class="permission-toggle is-on" aria-hidden="true"></span>
</article>