### PR TITLE
feat: add basic workspace role row demo

### DIFF
--- a/submissions/examples/basic-workspace-role-row-kk/README.md
+++ b/submissions/examples/basic-workspace-role-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Workspace Role Row
+
+## What it does
+
+This submission adds a simple CSS-only workspace role row for team settings,
+access-control panels, admin dashboards, project member lists, and organization
+settings screens.
+
+It displays avatar initials, member details, and a role label in one compact
+row.
+
+## How to use it
+
+Add the base row class with avatar, member copy, and role pill:
+
+```html
+<article class="basic-workspace-role-row">
+  <span class="member-avatar" aria-hidden="true">KR</span>
+  <div class="member-copy">
+    <strong>Kriti Rao</strong>
+    <p>kriti@example.com</p>
+  </div>
+  <span class="role-pill role-owner">Owner</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+team-management interfaces. The row is easy to combine with settings cards,
+admin tables, and profile panels while using subtle CSS-only hover motion.
+
+## Included features
+
+- Owner, editor, and viewer role variants
+- Avatar initials and member copy layout
+- Text truncation for long email addresses
+- Compact role pill styling
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the workspace role row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-workspace-role-row-kk/demo.html
+++ b/submissions/examples/basic-workspace-role-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Workspace Role Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Workspace Role Row</p>
+          <h1>Team role rows for workspace and admin settings.</h1>
+          <p class="intro">
+            A CSS-only row component for displaying team members, email details,
+            and role labels inside project settings or access-control panels.
+          </p>
+        </header>
+
+        <section class="role-panel" aria-label="Workspace role row examples">
+          <article class="basic-workspace-role-row">
+            <span class="member-avatar" aria-hidden="true">KR</span>
+            <div class="member-copy">
+              <strong>Kriti Rao</strong>
+              <p>kriti@example.com</p>
+            </div>
+            <span class="role-pill role-owner">Owner</span>
+          </article>
+
+          <article class="basic-workspace-role-row">
+            <span class="member-avatar" aria-hidden="true">AM</span>
+            <div class="member-copy">
+              <strong>Aman Mehta</strong>
+              <p>aman@example.com</p>
+            </div>
+            <span class="role-pill role-editor">Editor</span>
+          </article>
+
+          <article class="basic-workspace-role-row">
+            <span class="member-avatar" aria-hidden="true">SN</span>
+            <div class="member-copy">
+              <strong>Sneha Nair</strong>
+              <p>sneha@example.com</p>
+            </div>
+            <span class="role-pill role-viewer">Viewer</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-workspace-role-row"&gt;
+  &lt;span class="member-avatar" aria-hidden="true"&gt;KR&lt;/span&gt;
+  &lt;div class="member-copy"&gt;
+    &lt;strong&gt;Kriti Rao&lt;/strong&gt;
+    &lt;p&gt;kriti@example.com&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="role-pill role-owner"&gt;Owner&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-workspace-role-row-kk/style.css
+++ b/submissions/examples/basic-workspace-role-row-kk/style.css
@@ -1,0 +1,182 @@
+:root {
+  color-scheme: dark;
+  --page: #080d17;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --owner: #fcd34d;
+  --editor: #93c5fd;
+  --viewer: #c4b5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(252, 211, 77, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(147, 197, 253, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 840px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--owner);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 14ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.role-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-workspace-role-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-workspace-role-row + .basic-workspace-role-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-workspace-role-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.member-avatar {
+  width: 2.8rem;
+  height: 2.8rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.8rem;
+  border: 1px solid rgba(252, 211, 77, 0.28);
+  border-radius: 50%;
+  color: var(--owner);
+  background: rgba(252, 211, 77, 0.11);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.member-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.member-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.member-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.role-pill {
+  flex: 0 0 auto;
+  min-width: 5rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--viewer);
+  background: rgba(196, 181, 253, 0.12);
+  font-size: 0.8rem;
+  font-weight: 850;
+}
+
+.role-pill.role-owner {
+  color: var(--owner);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.role-pill.role-editor {
+  color: var(--editor);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.role-pill.role-viewer {
+  color: var(--viewer);
+  background: rgba(196, 181, 253, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-workspace-role-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .role-pill {
+    margin-left: 3.65rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Workspace Role Row demo inside `submissions/examples/basic-workspace-role-row-kk/`. This submission introduces a compact CSS-only row for team settings, access-control panels, admin dashboards, project member lists, and organization settings screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only workspace role row that displays avatar initials, member details, and owner/editor/viewer role labels in one compact layout.

**How does a developer use it?**

```html
<article class="basic-workspace-role-row">
  <span class="member-avatar" aria-hidden="true">KR</span>
  <div class="member-copy">
    <strong>Kriti Rao</strong>
    <p>kriti@example.com</p>
  </div>
  <span class="role-pill role-owner">Owner</span>
</article>