### PR TITLE
added glowing-material-toggle

### DIFF
--- a/submissions/examples/glowing-material-toggle/README.md
+++ b/submissions/examples/glowing-material-toggle/README.md
@@ -1,0 +1,144 @@
+# Glowing Material Toggle
+
+A Material Design 3–styled switch: an outlined track with a small thumb
+when off, a filled track with a larger elevated thumb when on, motion
+timed with MD3's own easing curve, and a soft glow halo around the thumb
+while on — plus a one-shot pulse ring that fires exactly once on every
+state change, not a continuous animation. Pure CSS, driven by the
+checkbox hack.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | A settings panel + a size/accent variant grid |
+| `style.css` | Every mechanic below, plus all styling |
+| `README.md` | This file |
+
+## Markup
+
+```html
+<label class="md-toggle">
+  <input type="checkbox" class="md-toggle__input">
+  <span class="md-toggle__track">
+    <span class="md-toggle__thumb"></span>
+  </span>
+</label>
+```
+
+## MD3 shape language: off vs on aren't just a color swap
+
+Material Design 3 switches change *shape*, not just color, between
+states — the thumb genuinely grows, and the track goes from outlined to
+filled:
+
+```css
+.md-toggle__track {
+  background: transparent;
+  border: 2px solid var(--md-text-faint);
+}
+
+.md-toggle__thumb {
+  width: var(--md-thumb-off);  /* 16px */
+  height: var(--md-thumb-off);
+}
+
+.md-toggle__input:checked ~ .md-toggle__track {
+  background: var(--md-primary);
+  border-color: var(--md-primary);
+}
+
+.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb {
+  width: var(--md-thumb-on);   /* 24px */
+  height: var(--md-thumb-on);
+}
+```
+
+Both the size change and the position change (`transform: translateX()`)
+run on the same `--md-motion-duration` / `--md-motion-ease` — MD3's
+standard "emphasized" curve, `cubic-bezier(0.2, 0, 0, 1)` — so the thumb
+grows and slides in one coherent motion rather than two competing ones.
+
+## The glow — ambient plus a one-shot pulse
+
+Two separate things are happening, and they're easy to conflate:
+
+1. **Ambient glow** — while checked, the thumb carries a permanent soft
+   `box-shadow` ring (`0 0 0 6px rgba(124, 158, 255, 0.22)`). This stays
+   as long as the toggle is on; it's not an animation.
+2. **The pulse** — a `::after` ring that animates from a small, bright
+   circle to a larger, fully-transparent one, **once**, the instant the
+   checkbox's `:checked` (or `:not(:checked)`) selector starts matching:
+
+```css
+.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb::after {
+  animation: md-pulse-on 480ms var(--md-motion-ease);
+}
+
+@keyframes md-pulse-on {
+  0%   { opacity: 0.9; transform: scale(0.6); }
+  100% { opacity: 0;   transform: scale(1.7); }
+}
+```
+
+Because a plain (non-`infinite`) CSS animation runs exactly once when the
+rule that triggers it starts applying, toggling the checkbox re-triggers
+this every single time — there's no JavaScript timer resetting anything.
+A second, dimmer `md-pulse-off` keyframe covers the reverse direction.
+
+**One honest caveat:** CSS can't distinguish "this is the default state on
+page load" from "the user just switched to this state" — both look
+identical to a selector. So the pulse for whichever state a toggle starts
+in *will* also play once on page load. In practice this reads as a nice
+little "ready" flourish rather than a bug, but it's worth knowing if a
+project wants to suppress it specifically on load (that would need a
+small script adding a "loaded" class after first paint).
+
+## CSS custom properties
+
+| Property | Default | Controls |
+|---|---|---|
+| `--md-track-w` / `--md-track-h` | `52px` / `32px` | Track dimensions |
+| `--md-thumb-off` / `--md-thumb-on` | `16px` / `24px` | Thumb size, off and on |
+| `--md-motion-duration` | `220ms` | Shared duration for size, position, and color transitions |
+| `--md-motion-ease` | `cubic-bezier(0.2, 0, 0, 1)` | MD3's standard easing curve |
+| `--md-primary` | `#7c9eff` | On-state track/glow color |
+
+## Variants
+
+- `.md-toggle-sm` — smaller MD3-proportioned geometry (all four size
+  tokens scaled down together).
+- `.md-toggle-accent` — swaps the on-state track, glow, and pulse ring to
+  a warm accent color instead of the default primary.
+- `disabled` — add the attribute to the `<input>`; the track dims to 45%
+  opacity and the cursor switches to `not-allowed` on both the track and
+  (via `:has()`, purely cosmetic if unsupported) the label itself.
+
+## Accessibility
+
+- The checkbox is real and stays in the tab order (hidden with a
+  clip-based technique, not `display: none`) — reachable with
+  <kbd>Tab</kbd>, toggled with <kbd>Space</kbd>.
+- `:focus-visible` draws a clear outline on the track when the hidden
+  input has keyboard focus.
+- The on/off state is signaled by position, track fill, thumb size, *and*
+  glow together — never color alone — so it still reads for
+  color-vision-deficient users.
+- Every toggle in the settings panel is paired with a real `<label
+  for="...">` carrying its name and a `<p>` description.
+- Respects `prefers-reduced-motion: reduce`: all transitions collapse to
+  `1ms` and the pulse ring animation is removed entirely (it's a flourish,
+  not a state indicator — the ambient glow and thumb position alone
+  already communicate on/off).
+
+## Responsive behavior
+
+The variant grid drops from four columns to two at `480px`; the settings
+panel's padding tightens slightly so labels don't crowd the toggle.
+
+## Browser support
+
+Uses CSS custom properties, `box-shadow`, and standard
+transitions/animations — supported everywhere current. The one
+modern-only touch is `:has()` on the disabled-cursor rule for the label,
+which is purely cosmetic and has no effect on function if unsupported.

--- a/submissions/examples/glowing-material-toggle/demo.html
+++ b/submissions/examples/glowing-material-toggle/demo.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Glowing Material Toggle — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="noise" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Glowing Material toggle</h1>
+    <p class="hero-sub">A Material Design&ndash;styled toggle: elevated thumb, MD3 motion curves, and a soft glow pulse that fires once on every state change. Pure CSS, driven by the checkbox hack.</p>
+  </header>
+
+  <main class="showcase">
+
+    <section class="settings-card" aria-labelledby="settings-title">
+      <h2 id="settings-title" class="settings-title">Notification settings</h2>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="tg-push" class="setting-label">Push notifications</label>
+          <p class="setting-desc">Get notified the moment something needs your attention.</p>
+        </div>
+        <label class="md-toggle">
+          <input type="checkbox" id="tg-push" class="md-toggle__input" checked>
+          <span class="md-toggle__track">
+            <span class="md-toggle__thumb"></span>
+          </span>
+        </label>
+      </div>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="tg-email" class="setting-label">Weekly email digest</label>
+          <p class="setting-desc">A summary of activity, sent every Monday morning.</p>
+        </div>
+        <label class="md-toggle">
+          <input type="checkbox" id="tg-email" class="md-toggle__input">
+          <span class="md-toggle__track">
+            <span class="md-toggle__thumb"></span>
+          </span>
+        </label>
+      </div>
+
+      <div class="setting-row">
+        <div class="setting-copy">
+          <label for="tg-auto" class="setting-label setting-label-disabled">Auto-renew billing</label>
+          <p class="setting-desc">Managed by your workspace admin.</p>
+        </div>
+        <label class="md-toggle">
+          <input type="checkbox" id="tg-auto" class="md-toggle__input" checked disabled>
+          <span class="md-toggle__track">
+            <span class="md-toggle__thumb"></span>
+          </span>
+        </label>
+      </div>
+    </section>
+
+    <section class="variants" aria-label="Size and accent variants">
+      <h2 class="variants-title">Sizes &amp; accents</h2>
+      <div class="variant-row">
+
+        <div class="variant-card">
+          <span class="variant-label">Small</span>
+          <label class="md-toggle md-toggle-sm">
+            <input type="checkbox" class="md-toggle__input" checked>
+            <span class="md-toggle__track">
+              <span class="md-toggle__thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Default</span>
+          <label class="md-toggle">
+            <input type="checkbox" class="md-toggle__input" checked>
+            <span class="md-toggle__track">
+              <span class="md-toggle__thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Accent</span>
+          <label class="md-toggle md-toggle-accent">
+            <input type="checkbox" class="md-toggle__input" checked>
+            <span class="md-toggle__track">
+              <span class="md-toggle__thumb"></span>
+            </span>
+          </label>
+        </div>
+
+        <div class="variant-card">
+          <span class="variant-label">Disabled</span>
+          <label class="md-toggle">
+            <input type="checkbox" class="md-toggle__input" disabled>
+            <span class="md-toggle__track">
+              <span class="md-toggle__thumb"></span>
+            </span>
+          </label>
+        </div>
+
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/glowing-material-toggle</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/glowing-material-toggle/style,css
+++ b/submissions/examples/glowing-material-toggle/style,css
@@ -1,0 +1,402 @@
+/* =========================================================================
+   Glowing Material Toggle — EaseMotion CSS
+   A Material Design 3–styled switch: outlined track + small thumb when
+   off, filled track + larger elevated thumb when on, motion timed with
+   MD3's standard easing curve, and a soft glow halo around the thumb
+   while on — plus a one-shot pulse ring that fires exactly once on every
+   state change (not a continuous animation). Driven by the checkbox
+   hack. Pure CSS.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --md-bg: #0e1116;
+  --md-surface: #151a21;
+  --md-surface-2: #1c222b;
+  --md-border: #262e39;
+  --md-text: #edeff2;
+  --md-text-muted: #98a2b3;
+  --md-text-faint: #6b7280;
+
+  --md-primary: #7c9eff;
+  --md-primary-strong: #9ab3ff;
+  --md-accent: #ff8a65;
+
+  --md-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --md-font-body: "Inter", "Segoe UI", sans-serif;
+  --md-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  /* MD3's standard "emphasized" easing curve, used for the thumb's
+     position and size change alike. */
+  --md-motion-duration: 220ms;
+  --md-motion-ease: cubic-bezier(0.2, 0, 0, 1);
+
+  /* Toggle geometry — MD3 switch proportions, override per-instance */
+  --md-track-w: 52px;
+  --md-track-h: 32px;
+  --md-thumb-off: 16px;
+  --md-thumb-on: 24px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--md-bg);
+  color: var(--md-text);
+  font-family: var(--md-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.035;
+  z-index: 0;
+  background-image: radial-gradient(circle at 1px 1px, #ffffff 1px, transparent 0);
+  background-size: 3px 3px;
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 92px 24px 48px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--md-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--md-primary);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--md-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--md-text-muted);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0 24px 90px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+
+/* -------------------------------------------------------------------------
+   4. Settings card
+   ------------------------------------------------------------------------- */
+
+.settings-card {
+  background: var(--md-surface);
+  border: 1px solid var(--md-border);
+  border-radius: 16px;
+  padding: 6px 24px;
+}
+
+.settings-title {
+  font-family: var(--md-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 22px 0 4px;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--md-border);
+}
+
+.setting-row:last-child {
+  border-bottom: none;
+}
+
+.setting-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--md-text);
+  cursor: pointer;
+}
+
+.setting-label-disabled {
+  color: var(--md-text-faint);
+  cursor: not-allowed;
+}
+
+.setting-desc {
+  font-size: 12.5px;
+  color: var(--md-text-muted);
+  margin: 3px 0 0;
+}
+
+
+/* -------------------------------------------------------------------------
+   5. The toggle
+   ------------------------------------------------------------------------- */
+
+.md-toggle {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+
+.md-toggle__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.md-toggle__track {
+  display: flex;
+  align-items: center;
+  width: var(--md-track-w);
+  height: var(--md-track-h);
+  padding: 0 4px;
+  border-radius: 999px;
+  background: transparent;
+  border: 2px solid var(--md-text-faint);
+  transition: background var(--md-motion-duration) var(--md-motion-ease),
+    border-color var(--md-motion-duration) var(--md-motion-ease);
+}
+
+.md-toggle__thumb {
+  position: relative;
+  width: var(--md-thumb-off);
+  height: var(--md-thumb-off);
+  border-radius: 50%;
+  background: var(--md-text-faint);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  transform: translateX(0);
+  transition: width var(--md-motion-duration) var(--md-motion-ease),
+    height var(--md-motion-duration) var(--md-motion-ease),
+    background var(--md-motion-duration) var(--md-motion-ease),
+    box-shadow var(--md-motion-duration) var(--md-motion-ease),
+    transform var(--md-motion-duration) var(--md-motion-ease);
+}
+
+/* --- Checked (on) state: filled track, larger elevated thumb --- */
+
+.md-toggle__input:checked ~ .md-toggle__track {
+  background: var(--md-primary);
+  border-color: var(--md-primary);
+}
+
+.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb {
+  width: var(--md-thumb-on);
+  height: var(--md-thumb-on);
+  background: var(--md-bg);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5), 0 0 0 6px rgba(124, 158, 255, 0.22);
+  transform: translateX(calc(var(--md-track-w) - var(--md-thumb-on) - 8px));
+}
+
+/* --- One-shot glow pulse: fires exactly once, the moment the selector
+   starts matching — not a looping animation. Two separate rules cover
+   both directions (on-pulse in primary, off-pulse in neutral), each
+   keyed to a fresh selector match. --- */
+
+.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 2px solid var(--md-primary);
+  opacity: 0;
+  animation: md-pulse-on 480ms var(--md-motion-ease);
+}
+
+.md-toggle__input:not(:checked) ~ .md-toggle__track .md-toggle__thumb::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
+  border-radius: 50%;
+  border: 2px solid var(--md-text-faint);
+  opacity: 0;
+  animation: md-pulse-off 380ms var(--md-motion-ease);
+}
+
+@keyframes md-pulse-on {
+  0% { opacity: 0.9; transform: scale(0.6); }
+  100% { opacity: 0; transform: scale(1.7); }
+}
+
+@keyframes md-pulse-off {
+  0% { opacity: 0.7; transform: scale(0.7); }
+  100% { opacity: 0; transform: scale(1.4); }
+}
+
+/* --- Focus + disabled --- */
+
+.md-toggle__input:focus-visible ~ .md-toggle__track {
+  outline: 2px solid var(--md-primary);
+  outline-offset: 3px;
+}
+
+.md-toggle__input:disabled ~ .md-toggle__track {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.md-toggle:has(.md-toggle__input:disabled) {
+  cursor: not-allowed;
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Size + accent variants
+   ------------------------------------------------------------------------- */
+
+.md-toggle-sm {
+  --md-track-w: 40px;
+  --md-track-h: 24px;
+  --md-thumb-off: 12px;
+  --md-thumb-on: 18px;
+}
+
+.md-toggle-accent .md-toggle__input:checked ~ .md-toggle__track {
+  background: var(--md-accent);
+  border-color: var(--md-accent);
+}
+
+.md-toggle-accent .md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5), 0 0 0 6px rgba(255, 138, 101, 0.22);
+}
+
+.md-toggle-accent .md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb::after {
+  border-color: var(--md-accent);
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Variant grid
+   ------------------------------------------------------------------------- */
+
+.variants-title {
+  font-family: var(--md-font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 18px;
+  text-align: center;
+}
+
+.variant-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.variant-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 22px 12px;
+  background: var(--md-surface);
+  border: 1px solid var(--md-border);
+  border-radius: 14px;
+}
+
+.variant-label {
+  font-family: var(--md-font-mono);
+  font-size: 11px;
+  color: var(--md-text-muted);
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--md-text-muted);
+  font-family: var(--md-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 68px 20px 40px;
+  }
+
+  .settings-card {
+    padding: 4px 18px;
+  }
+
+  .variant-row {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   10. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .md-toggle__track,
+  .md-toggle__thumb {
+    transition-duration: 1ms;
+  }
+
+  .md-toggle__thumb::after {
+    animation: none !important;
+    display: none;
+  }
+}


### PR DESCRIPTION
# Glowing Material Toggle

A Material Design 3–styled switch: an outlined track with a small thumb
when off, a filled track with a larger elevated thumb when on, motion
timed with MD3's own easing curve, and a soft glow halo around the thumb
while on — plus a one-shot pulse ring that fires exactly once on every
state change, not a continuous animation. Pure CSS, driven by the
checkbox hack.

## Files

| File | Purpose |
|---|---|
| `demo.html` | A settings panel + a size/accent variant grid |
| `style.css` | Every mechanic below, plus all styling |
| `README.md` | This file |

## Markup

```html
<label class="md-toggle">
  <input type="checkbox" class="md-toggle__input">
  <span class="md-toggle__track">
    <span class="md-toggle__thumb"></span>
  </span>
</label>
```

## MD3 shape language: off vs on aren't just a color swap

Material Design 3 switches change *shape*, not just color, between
states — the thumb genuinely grows, and the track goes from outlined to
filled:

```css
.md-toggle__track {
  background: transparent;
  border: 2px solid var(--md-text-faint);
}

.md-toggle__thumb {
  width: var(--md-thumb-off);  /* 16px */
  height: var(--md-thumb-off);
}

.md-toggle__input:checked ~ .md-toggle__track {
  background: var(--md-primary);
  border-color: var(--md-primary);
}

.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb {
  width: var(--md-thumb-on);   /* 24px */
  height: var(--md-thumb-on);
}
```

Both the size change and the position change (`transform: translateX()`)
run on the same `--md-motion-duration` / `--md-motion-ease` — MD3's
standard "emphasized" curve, `cubic-bezier(0.2, 0, 0, 1)` — so the thumb
grows and slides in one coherent motion rather than two competing ones.

## The glow — ambient plus a one-shot pulse

Two separate things are happening, and they're easy to conflate:

1. **Ambient glow** — while checked, the thumb carries a permanent soft
   `box-shadow` ring (`0 0 0 6px rgba(124, 158, 255, 0.22)`). This stays
   as long as the toggle is on; it's not an animation.
2. **The pulse** — a `::after` ring that animates from a small, bright
   circle to a larger, fully-transparent one, **once**, the instant the
   checkbox's `:checked` (or `:not(:checked)`) selector starts matching:

```css
.md-toggle__input:checked ~ .md-toggle__track .md-toggle__thumb::after {
  animation: md-pulse-on 480ms var(--md-motion-ease);
}

@keyframes md-pulse-on {
  0%   { opacity: 0.9; transform: scale(0.6); }
  100% { opacity: 0;   transform: scale(1.7); }
}
```

Because a plain (non-`infinite`) CSS animation runs exactly once when the
rule that triggers it starts applying, toggling the checkbox re-triggers
this every single time — there's no JavaScript timer resetting anything.
A second, dimmer `md-pulse-off` keyframe covers the reverse direction.

**One honest caveat:** CSS can't distinguish "this is the default state on
page load" from "the user just switched to this state" — both look
identical to a selector. So the pulse for whichever state a toggle starts
in *will* also play once on page load. In practice this reads as a nice
little "ready" flourish rather than a bug, but it's worth knowing if a
project wants to suppress it specifically on load (that would need a
small script adding a "loaded" class after first paint).

## CSS custom properties

| Property | Default | Controls |
|---|---|---|
| `--md-track-w` / `--md-track-h` | `52px` / `32px` | Track dimensions |
| `--md-thumb-off` / `--md-thumb-on` | `16px` / `24px` | Thumb size, off and on |
| `--md-motion-duration` | `220ms` | Shared duration for size, position, and color transitions |
| `--md-motion-ease` | `cubic-bezier(0.2, 0, 0, 1)` | MD3's standard easing curve |
| `--md-primary` | `#7c9eff` | On-state track/glow color |

## Variants

- `.md-toggle-sm` — smaller MD3-proportioned geometry (all four size
  tokens scaled down together).
- `.md-toggle-accent` — swaps the on-state track, glow, and pulse ring to
  a warm accent color instead of the default primary.
- `disabled` — add the attribute to the `<input>`; the track dims to 45%
  opacity and the cursor switches to `not-allowed` on both the track and
  (via `:has()`, purely cosmetic if unsupported) the label itself.

## Accessibility

- The checkbox is real and stays in the tab order (hidden with a
  clip-based technique, not `display: none`) — reachable with
  <kbd>Tab</kbd>, toggled with <kbd>Space</kbd>.
- `:focus-visible` draws a clear outline on the track when the hidden
  input has keyboard focus.
- The on/off state is signaled by position, track fill, thumb size, *and*
  glow together — never color alone — so it still reads for
  color-vision-deficient users.
- Every toggle in the settings panel is paired with a real `<label
  for="...">` carrying its name and a `<p>` description.
- Respects `prefers-reduced-motion: reduce`: all transitions collapse to
  `1ms` and the pulse ring animation is removed entirely (it's a flourish,
  not a state indicator — the ambient glow and thumb position alone
  already communicate on/off).

## Responsive behavior

The variant grid drops from four columns to two at `480px`; the settings
panel's padding tightens slightly so labels don't crowd the toggle.

## Browser support

Uses CSS custom properties, `box-shadow`, and standard
transitions/animations — supported everywhere current. The one
modern-only touch is `:has()` on the disabled-cursor rule for the label,
which is purely cosmetic and has no effect on function if unsupported.