### PR TITLE
feat: add basic language preference row demo

### DIFF
--- a/submissions/examples/basic-language-preference-row-kk/README.md
+++ b/submissions/examples/basic-language-preference-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Language Preference Row
+
+## What it does
+
+This submission adds a simple CSS-only language preference row for profile
+settings, onboarding forms, account preferences, localization panels, and
+documentation settings screens.
+
+It displays a language marker, language name, helper copy, and state label in
+one compact row.
+
+## How to use it
+
+Add the base row class with a language marker, copy, and state:
+
+```html
+<article class="basic-language-preference-row is-selected">
+  <span class="language-mark" aria-hidden="true">EN</span>
+  <div class="language-copy">
+    <strong>English</strong>
+    <p>Used for product UI, email updates, and help articles.</p>
+  </div>
+  <span class="language-state">Default</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common account and localization interfaces. The row can be added to settings
+cards, profile screens, onboarding steps, and documentation tools while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Default, available, and beta language states
+- Language initials marker
+- Helper copy and state label layout
+- Selected row styling
+- Text truncation for long descriptions
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the language preference row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-language-preference-row-kk/demo.html
+++ b/submissions/examples/basic-language-preference-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Language Preference Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Language Preference Row</p>
+          <h1>Simple language rows for profile and onboarding settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing preferred languages, locale
+            hints, and selected/default states in account settings.
+          </p>
+        </header>
+
+        <section class="language-panel" aria-label="Language preference row examples">
+          <article class="basic-language-preference-row is-selected">
+            <span class="language-mark" aria-hidden="true">EN</span>
+            <div class="language-copy">
+              <strong>English</strong>
+              <p>Used for product UI, email updates, and help articles.</p>
+            </div>
+            <span class="language-state">Default</span>
+          </article>
+
+          <article class="basic-language-preference-row">
+            <span class="language-mark" aria-hidden="true">HI</span>
+            <div class="language-copy">
+              <strong>Hindi</strong>
+              <p>Available for regional content and onboarding support.</p>
+            </div>
+            <span class="language-state is-available">Available</span>
+          </article>
+
+          <article class="basic-language-preference-row">
+            <span class="language-mark" aria-hidden="true">ES</span>
+            <div class="language-copy">
+              <strong>Spanish</strong>
+              <p>Can be selected for translated guides and notifications.</p>
+            </div>
+            <span class="language-state is-beta">Beta</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-language-preference-row is-selected"&gt;
+  &lt;span class="language-mark" aria-hidden="true"&gt;EN&lt;/span&gt;
+  &lt;div class="language-copy"&gt;
+    &lt;strong&gt;English&lt;/strong&gt;
+    &lt;p&gt;Used for product UI, email updates, and help articles.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="language-state"&gt;Default&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-language-preference-row-kk/style.css
+++ b/submissions/examples/basic-language-preference-row-kk/style.css
@@ -1,0 +1,181 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --accent: #93c5fd;
+  --available: #86efac;
+  --beta: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.language-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-language-preference-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    border-color 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-language-preference-row + .basic-language-preference-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-language-preference-row:hover,
+.basic-language-preference-row.is-selected {
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.basic-language-preference-row:hover {
+  transform: translateY(-2px);
+}
+
+.language-mark {
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.85rem;
+  border: 1px solid rgba(147, 197, 253, 0.32);
+  border-radius: 0.95rem;
+  color: var(--accent);
+  background: rgba(147, 197, 253, 0.12);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.language-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.language-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.language-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-state {
+  flex: 0 0 auto;
+  min-width: 5.2rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  color: var(--accent);
+  background: rgba(147, 197, 253, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.language-state.is-available {
+  color: var(--available);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.language-state.is-beta {
+  color: var(--beta);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-language-preference-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .language-state {
+    margin-left: 3.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Language Preference Row demo inside `submissions/examples/basic-language-preference-row-kk/`. This submission introduces a compact CSS-only row for profile settings, onboarding forms, account preferences, localization panels, and documentation settings screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only language preference row that displays a language marker, language name, helper copy, and default/available/beta state label in one compact layout.

**How does a developer use it?**

```html
<article class="basic-language-preference-row is-selected">
  <span class="language-mark" aria-hidden="true">EN</span>
  <div class="language-copy">
    <strong>English</strong>
    <p>Used for product UI, email updates, and help articles.</p>
  </div>
  <span class="language-state">Default</span>
</article>