### PR TITLE
feat: add css-only input field with neumorphism styling

### DIFF
--- a/submissions/examples/css-only-input-field-neumorphism-79851/README.md
+++ b/submissions/examples/css-only-input-field-neumorphism-79851/README.md
@@ -1,0 +1,46 @@
+# CSS-only Input Field with Neumorphism Styling
+
+A responsive input field component featuring a soft neumorphic design created entirely with HTML and CSS.
+
+## Features
+
+- Neumorphic UI design
+- CSS-only implementation
+- Responsive layout
+- Soft inset shadows
+- Clean and modern appearance
+- Lightweight and reusable
+
+## Files
+
+- demo.html
+- style.css
+
+## Usage
+
+Open `demo.html` in any modern browser.
+
+## Customization
+
+Modify:
+
+- Background colors
+- Shadow intensity
+- Border radius
+- Font size
+- Focus glow effect
+
+Example:
+
+```css
+body{
+  background:#dfe4ea;
+}
+```
+
+## Browser Support
+
+- Chrome
+- Firefox
+- Edge
+- Safari

--- a/submissions/examples/css-only-input-field-neumorphism-79851/demo.html
+++ b/submissions/examples/css-only-input-field-neumorphism-79851/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neumorphic Input Field</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+  <div class="input-wrapper">
+    <input type="text" placeholder="Enter your name">
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/css-only-input-field-neumorphism-79851/style.css
+++ b/submissions/examples/css-only-input-field-neumorphism-79851/style.css
@@ -1,0 +1,69 @@
+*{
+  margin:0;
+  padding:0;
+  box-sizing:border-box;
+}
+
+body{
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  background:#e5e7eb;
+  font-family:Arial,sans-serif;
+  padding:2rem;
+}
+
+.container{
+  width:100%;
+  max-width:450px;
+}
+
+.input-wrapper{
+  padding:1rem;
+  border-radius:24px;
+  background:#e5e7eb;
+
+  box-shadow:
+    12px 12px 24px #c5c7cb,
+    -12px -12px 24px #ffffff;
+}
+
+input{
+  width:100%;
+  border:none;
+  outline:none;
+
+  padding:1rem 1.25rem;
+  font-size:1rem;
+
+  border-radius:16px;
+  background:#e5e7eb;
+  color:#374151;
+
+  box-shadow:
+    inset 6px 6px 12px #c5c7cb,
+    inset -6px -6px 12px #ffffff;
+}
+
+input::placeholder{
+  color:#9ca3af;
+}
+
+input:focus{
+  box-shadow:
+    inset 4px 4px 10px #c5c7cb,
+    inset -4px -4px 10px #ffffff,
+    0 0 10px rgba(99,102,241,.15);
+}
+
+@media(max-width:600px){
+
+  .container{
+    max-width:100%;
+  }
+
+  input{
+    font-size:.95rem;
+  }
+}


### PR DESCRIPTION
## Description

Added a responsive CSS-only Input Field component with Neumorphism styling using pure HTML and CSS.

### Features

- Soft neumorphic design
- CSS-only implementation
- Responsive layout
- Inset shadow effects
- Modern UI appearance
- Lightweight and customizable

### Files Added

submissions/examples/css-only-input-field-neumorphism-79851/

- demo.html
- style.css
- README.md

Closes #79851