### PR TITLE
added glass-breadcrumb-saas

### DIFF
--- a/submissions/examples/glass-breadcrumb-saas/README.md
+++ b/submissions/examples/glass-breadcrumb-saas/README.md
@@ -1,0 +1,144 @@
+# Glassmorphism Breadcrumb
+
+`.ease-glass-breadcrumb` — a frosted-glass breadcrumb bar for SaaS
+dashboards. Real `backdrop-filter` blur, a hover underline that grows in
+from center, and a fade-scroll edge mask so a long trail degrades to
+horizontal scroll on narrow viewports instead of wrapping awkwardly or
+overflowing the bar. Pure CSS.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo.html` | Short trail, long trail (try narrowing the window), and a dark variant |
+| `style.css` | The component, its variant, and the demo backdrop |
+| `README.md` | This file |
+
+## Usage
+
+```html
+<nav class="ease-glass-breadcrumb" aria-label="Breadcrumb">
+  <ol class="breadcrumb-list">
+    <li class="breadcrumb-item">
+      <a href="#" class="breadcrumb-link">Home</a>
+    </li>
+    <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+    <li class="breadcrumb-item">
+      <span class="breadcrumb-link breadcrumb-current" aria-current="page">Overview</span>
+    </li>
+  </ol>
+</nav>
+```
+
+Like any glassmorphism component, this needs something visually busy
+behind it — the demo ships a colorful backdrop specifically so the blur
+is visible; over a flat background it'll just look like a translucent
+bar.
+
+## Long trails: fade-scroll instead of wrapping
+
+Rather than trying to make a breadcrumb bar reflow onto a second line (a
+common source of janky, tall headers) or collapsing middle items into a
+"…" that then needs its own interaction, this component takes the
+simplest robust approach: the list scrolls horizontally, and a CSS
+`mask-image` fades both edges so the cut-off feels intentional rather
+than abrupt:
+
+```css
+.breadcrumb-list {
+  overflow-x: auto;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 16px,
+    black calc(100% - 16px),
+    transparent 100%
+  );
+}
+```
+
+When the trail is short enough to fit without scrolling, the mask has
+nothing to fade against and is effectively invisible — this one rule
+covers both cases without a media query or a "does it overflow"
+JavaScript check.
+
+## The hover underline
+
+Rather than a static border, each link's underline is a `::after`
+element that scales in from the center on hover:
+
+```css
+.breadcrumb-link::after {
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--bc-duration) var(--bc-ease);
+}
+
+.breadcrumb-link:hover::after {
+  transform: scaleX(1);
+}
+```
+
+Scaling (rather than animating `width`) keeps the browser on the GPU
+compositor path, and animating from a `scaleX(0)` center point reads as
+more deliberate than a line that just fades or slides in from one side.
+
+## CSS custom properties
+
+| Property | Default | Controls |
+|---|---|---|
+| `--bc-glass-bg` | `rgba(255,255,255,0.12)` | The glass tint |
+| `--bc-glass-border` | `rgba(255,255,255,0.3)` | Edge highlight |
+| `--bc-glass-blur` | `16px` | Backdrop blur radius |
+| `--bc-accent` | `#7de0c0` | Underline + focus ring color |
+| `--bc-duration` / `--bc-ease` | `200ms` / custom curve | Hover transitions |
+
+## Dark surface variant
+
+`.ease-glass-breadcrumb-dark` swaps the glass tint from a light,
+white-based one to a dark, black-based one — useful over lighter
+backdrops where white-tinted glass would wash out, same reasoning as the
+frosted-glass-card submission's dark variant.
+
+## Accessibility
+
+- Uses a real `<nav aria-label="Breadcrumb">` wrapping an `<ol>` — the
+  semantically correct structure for a breadcrumb trail, not a `<div>`
+  soup.
+- The current page is a `<span aria-current="page">`, not a link — it's
+  not actionable, and screen readers announce it as the current location
+  rather than a clickable item.
+- Separators (`/`) are `aria-hidden="true"` on their `<li>`, since
+  they're purely visual — the `<ol>`'s own list semantics already convey
+  the sequence to assistive tech.
+- Every real link has a visible `:focus-visible` ring in the accent
+  color, distinct from hover styling.
+- Respects `prefers-reduced-motion: reduce`: hover transitions collapse
+  to `1ms`.
+
+## Fallback for unsupported browsers
+
+```css
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ease-glass-breadcrumb {
+    background: rgba(16, 18, 24, 0.85);
+  }
+}
+```
+
+Where `backdrop-filter` isn't supported, the bar falls back to a solid
+dark panel rather than a fully see-through one with illegible text over
+a busy backdrop.
+
+## Responsive behavior
+
+Below `520px`, link padding and font size tighten slightly; the
+fade-scroll mechanism handles overflow at any width without a dedicated
+breakpoint of its own.
+
+## Browser support
+
+`backdrop-filter` needs the `-webkit-` prefix on Safari (included above)
+and `mask-image` needs it too for the same reason — both included. Where
+`mask-image` is unsupported, the list simply clips at a hard edge instead
+of fading, with no loss of function.

--- a/submissions/examples/glass-breadcrumb-saas/demo.html
+++ b/submissions/examples/glass-breadcrumb-saas/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Glassmorphism Breadcrumb — EaseMotion CSS</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="backdrop" aria-hidden="true"></div>
+
+  <header class="hero">
+    <p class="eyebrow">EaseMotion CSS &middot; showcase</p>
+    <h1 class="hero-title">Glassmorphism breadcrumb</h1>
+    <p class="hero-sub">A frosted-glass breadcrumb bar for SaaS dashboards &mdash; real <code>backdrop-filter</code> blur, a sliding highlight under the current page, and a fade-scroll fallback for long trails on mobile. Pure CSS.</p>
+  </header>
+
+  <main class="showcase">
+
+    <!-- ================= Short trail ================= -->
+    <section class="demo-block">
+      <p class="demo-block-label">Short trail</p>
+      <nav class="ease-glass-breadcrumb" aria-label="Breadcrumb">
+        <ol class="breadcrumb-list">
+          <li class="breadcrumb-item">
+            <a href="#" class="breadcrumb-link">
+              <svg class="breadcrumb-home-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5 1.5 7v7.5h4V10h5v4.5h4V7z" fill="currentColor"/></svg>
+              Home
+            </a>
+          </li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item">
+            <a href="#" class="breadcrumb-link">Projects</a>
+          </li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item">
+            <span class="breadcrumb-link breadcrumb-current" aria-current="page">Overview</span>
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+    <!-- ================= Long trail — fade-scroll on narrow viewports ================= -->
+    <section class="demo-block">
+      <p class="demo-block-label">Long trail (narrow the window to see it scroll)</p>
+      <nav class="ease-glass-breadcrumb" aria-label="Breadcrumb">
+        <ol class="breadcrumb-list">
+          <li class="breadcrumb-item">
+            <a href="#" class="breadcrumb-link">
+              <svg class="breadcrumb-home-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5 1.5 7v7.5h4V10h5v4.5h4V7z" fill="currentColor"/></svg>
+              Home
+            </a>
+          </li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Workspace</a></li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Engineering</a></li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Sprint Board</a></li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Ticket #4821</a></li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item">
+            <span class="breadcrumb-link breadcrumb-current" aria-current="page">Activity log</span>
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+    <!-- ================= Dark surface variant ================= -->
+    <section class="demo-block demo-block-dark">
+      <p class="demo-block-label">Dark surface variant</p>
+      <nav class="ease-glass-breadcrumb ease-glass-breadcrumb-dark" aria-label="Breadcrumb">
+        <ol class="breadcrumb-list">
+          <li class="breadcrumb-item">
+            <a href="#" class="breadcrumb-link">
+              <svg class="breadcrumb-home-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5 1.5 7v7.5h4V10h5v4.5h4V7z" fill="currentColor"/></svg>
+              Home
+            </a>
+          </li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Billing</a></li>
+          <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
+          <li class="breadcrumb-item">
+            <span class="breadcrumb-link breadcrumb-current" aria-current="page">Invoices</span>
+          </li>
+        </ol>
+      </nav>
+    </section>
+
+  </main>
+
+  <footer class="footer">
+    <p>EaseMotion CSS &middot; submissions/examples/glass-breadcrumb-saas</p>
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/glass-breadcrumb-saas/style.css
+++ b/submissions/examples/glass-breadcrumb-saas/style.css
@@ -1,0 +1,323 @@
+/* =========================================================================
+   Glassmorphism Breadcrumb — EaseMotion CSS
+   .ease-glass-breadcrumb: a frosted-glass breadcrumb bar for SaaS
+   dashboards. Real backdrop-filter blur (needs something behind it —
+   the demo ships a colorful backdrop for exactly that reason), a
+   underline that grows in on link hover, and a fade-scroll edge mask so
+   a long trail degrades to horizontal scroll instead of wrapping or
+   overflowing on narrow viewports. Pure CSS.
+   ========================================================================= */
+
+
+/* -------------------------------------------------------------------------
+   1. Design tokens
+   ------------------------------------------------------------------------- */
+
+:root {
+  --bc-text: #ffffff;
+  --bc-text-muted: rgba(255, 255, 255, 0.7);
+  --bc-text-dim: rgba(255, 255, 255, 0.45);
+
+  --bc-glass-bg: rgba(255, 255, 255, 0.12);
+  --bc-glass-border: rgba(255, 255, 255, 0.3);
+  --bc-glass-blur: 16px;
+
+  --bc-accent: #7de0c0;
+
+  --bc-font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --bc-font-body: "Inter", "Segoe UI", sans-serif;
+  --bc-font-mono: "IBM Plex Mono", "Courier New", monospace;
+
+  --bc-duration: 200ms;
+  --bc-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--bc-text);
+  font-family: var(--bc-font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 20% 25%, #4d6bff 0%, transparent 45%),
+    radial-gradient(circle at 80% 20%, #7de0c0 0%, transparent 45%),
+    radial-gradient(circle at 30% 85%, #ff8a65 0%, transparent 50%),
+    radial-gradient(circle at 85% 80%, #b06aff 0%, transparent 45%),
+    #0e1116;
+}
+
+
+/* -------------------------------------------------------------------------
+   2. Hero
+   ------------------------------------------------------------------------- */
+
+.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 88px 24px 40px;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--bc-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  margin: 0 0 20px;
+}
+
+.hero-title {
+  font-family: var(--bc-font-display);
+  font-weight: 600;
+  font-size: clamp(30px, 5.5vw, 48px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 16px;
+  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
+}
+
+.hero-sub {
+  font-size: 15px;
+  color: var(--bc-text-muted);
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.hero-sub code {
+  font-family: var(--bc-font-mono);
+  font-size: 13px;
+  color: var(--bc-text);
+  background: rgba(0, 0, 0, 0.25);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+
+
+/* -------------------------------------------------------------------------
+   3. Layout
+   ------------------------------------------------------------------------- */
+
+.showcase {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 24px 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.demo-block-label {
+  font-family: var(--bc-font-mono);
+  font-size: 12px;
+  color: var(--bc-text-muted);
+  margin: 0 0 12px;
+}
+
+.demo-block-dark {
+  padding: 20px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+
+/* -------------------------------------------------------------------------
+   4. THE COMPONENT — .ease-glass-breadcrumb
+   ------------------------------------------------------------------------- */
+
+.ease-glass-breadcrumb {
+  position: relative;
+  border-radius: 14px;
+  background: var(--bc-glass-bg);
+  border: 1px solid var(--bc-glass-border);
+  backdrop-filter: blur(var(--bc-glass-blur));
+  -webkit-backdrop-filter: blur(var(--bc-glass-blur));
+  box-shadow:
+    0 12px 30px -16px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.breadcrumb-list {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 6px 10px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  /* Fade-scroll: when the trail is longer than the bar, both edges
+     soften instead of hard-clipping mid-word — and the fade collapses
+     to nothing when there's no overflow to hint at. */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 16px,
+    black calc(100% - 16px),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 16px,
+    black calc(100% - 16px),
+    transparent 100%
+  );
+}
+
+.breadcrumb-list::-webkit-scrollbar {
+  display: none;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--bc-text-muted);
+  text-decoration: none;
+  white-space: nowrap;
+  position: relative;
+  transition: color var(--bc-duration) var(--bc-ease),
+    background var(--bc-duration) var(--bc-ease);
+}
+
+.breadcrumb-link:hover {
+  color: var(--bc-text);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.breadcrumb-link:focus-visible {
+  outline: 2px solid var(--bc-accent);
+  outline-offset: 2px;
+}
+
+/* Underline that grows in from the center on hover, rather than a
+   static border — reads as more "alive" for a glass surface. */
+.breadcrumb-link::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 2px;
+  height: 1.5px;
+  background: var(--bc-accent);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--bc-duration) var(--bc-ease);
+}
+
+.breadcrumb-link:hover::after {
+  transform: scaleX(1);
+}
+
+.breadcrumb-current {
+  color: var(--bc-text);
+  font-weight: 600;
+  cursor: default;
+}
+
+.breadcrumb-current::after {
+  display: none;
+}
+
+.breadcrumb-home-icon {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+
+.breadcrumb-sep {
+  color: var(--bc-text-dim);
+  font-size: 13px;
+  margin: 0 2px;
+  user-select: none;
+}
+
+
+/* -------------------------------------------------------------------------
+   5. Dark surface variant
+   ------------------------------------------------------------------------- */
+
+.ease-glass-breadcrumb-dark {
+  --bc-glass-bg: rgba(0, 0, 0, 0.35);
+  --bc-glass-border: rgba(255, 255, 255, 0.14);
+}
+
+
+/* -------------------------------------------------------------------------
+   6. Footer
+   ------------------------------------------------------------------------- */
+
+.footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 8px 24px 48px;
+  font-size: 12.5px;
+  color: var(--bc-text-muted);
+  font-family: var(--bc-font-mono);
+}
+
+
+/* -------------------------------------------------------------------------
+   7. Responsive
+   ------------------------------------------------------------------------- */
+
+@media (max-width: 520px) {
+  .hero {
+    padding: 68px 20px 32px;
+  }
+
+  .breadcrumb-link {
+    font-size: 13px;
+    padding: 6px 8px;
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   8. Fallback for browsers without backdrop-filter support
+   ------------------------------------------------------------------------- */
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ease-glass-breadcrumb {
+    background: rgba(16, 18, 24, 0.85);
+  }
+}
+
+
+/* -------------------------------------------------------------------------
+   9. Reduced motion
+   ------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumb-link,
+  .breadcrumb-link::after {
+    transition-duration: 1ms;
+  }
+}


### PR DESCRIPTION
Closes #79916

## Pull Request Description
Adds `.ease-glass-breadcrumb` — a frosted-glass breadcrumb bar with real `backdrop-filter` blur, a center-out hover underline, and a fade-scroll mask so long trails degrade gracefully on narrow viewports. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] Fully responsive
- [x] Placed under `submissions/examples/` (`submissions/examples/glass-breadcrumb-saas/`)
- [x] Includes `demo.html`, `style.css`, `README.md`

## Feature Description

**What does this add?**
A glassmorphism breadcrumb nav with semantically correct markup (`<nav>` + `<ol>`, `aria-current="page"` on the active crumb), plus a self-adjusting fade-scroll behavior for trails too long to fit.

**How does a developer use it?**
```html
<nav class="ease-glass-breadcrumb" aria-label="Breadcrumb">
  <ol class="breadcrumb-list">
    <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Home</a></li>
    <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
    <li class="breadcrumb-item"><span class="breadcrumb-link breadcrumb-current" aria-current="page">Overview</span></li>
  </ol>
</nav>
```
Add `.ease-glass-breadcrumb-dark` for a darker glass tint over lighter backdrops.

**Why does it fit EaseMotion CSS?**
Same glassmorphism family as the earlier glass-card submission but solves a genuinely different layout problem (a long, horizontally-constrained trail) with a single `mask-image` rule rather than JS overflow detection or a collapsing "…" menu.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Both `backdrop-filter` and `mask-image` carry `-webkit-` prefixes for Safari. Included an `@supports` fallback (solid dark panel) for browsers without `backdrop-filter` support, same pattern as the earlier glass-card PR.