### PR TITLE
feat: add basic digest frequency row demo

### DIFF
--- a/submissions/examples/basic-digest-frequency-row-kk/README.md
+++ b/submissions/examples/basic-digest-frequency-row-kk/README.md
@@ -1,0 +1,46 @@
+# Basic Digest Frequency Row
+
+## What it does
+
+This submission adds a simple CSS-only digest frequency row for email
+preferences, notification settings, account panels, onboarding screens, and
+workspace settings pages.
+
+It displays a digest icon, title, helper copy, and frequency pill in one compact
+row.
+
+## How to use it
+
+Add the base row class with an icon, copy, and frequency pill:
+
+```html
+<article class="basic-digest-frequency-row">
+  <span class="digest-icon" aria-hidden="true">D</span>
+  <div class="digest-copy">
+    <strong>Daily product digest</strong>
+    <p>Receive important updates once every morning.</p>
+  </div>
+  <span class="frequency-pill is-daily">Daily</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common settings interfaces. The component keeps notification preferences easy
+to scan while using subtle CSS-only hover motion and lightweight markup.
+
+## Included features
+
+- Daily, weekly, and paused frequency states
+- Digest icon, helper copy, and frequency pill layout
+- Text truncation for long helper copy
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the digest frequency row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-digest-frequency-row-kk/demo.html
+++ b/submissions/examples/basic-digest-frequency-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Digest Frequency Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Digest Frequency Row</p>
+          <h1>Readable digest rows for email and notification settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing digest preferences, frequency
+            labels, and short helper text inside account settings.
+          </p>
+        </header>
+
+        <section class="digest-panel" aria-label="Digest frequency row examples">
+          <article class="basic-digest-frequency-row">
+            <span class="digest-icon" aria-hidden="true">D</span>
+            <div class="digest-copy">
+              <strong>Daily product digest</strong>
+              <p>Receive important updates once every morning.</p>
+            </div>
+            <span class="frequency-pill is-daily">Daily</span>
+          </article>
+
+          <article class="basic-digest-frequency-row">
+            <span class="digest-icon" aria-hidden="true">W</span>
+            <div class="digest-copy">
+              <strong>Weekly workspace summary</strong>
+              <p>Get a compact summary every Monday.</p>
+            </div>
+            <span class="frequency-pill is-weekly">Weekly</span>
+          </article>
+
+          <article class="basic-digest-frequency-row">
+            <span class="digest-icon" aria-hidden="true">P</span>
+            <div class="digest-copy">
+              <strong>Marketing digest</strong>
+              <p>Optional tips and announcements are currently paused.</p>
+            </div>
+            <span class="frequency-pill is-paused">Paused</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-digest-frequency-row"&gt;
+  &lt;span class="digest-icon" aria-hidden="true"&gt;D&lt;/span&gt;
+  &lt;div class="digest-copy"&gt;
+    &lt;strong&gt;Daily product digest&lt;/strong&gt;
+    &lt;p&gt;Receive important updates once every morning.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="frequency-pill is-daily"&gt;Daily&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-digest-frequency-row-kk/style.css
+++ b/submissions/examples/basic-digest-frequency-row-kk/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --daily: #67e8f9;
+  --weekly: #a7f3d0;
+  --paused: #fda4af;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(103, 232, 249, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(167, 243, 208, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 860px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--daily);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.digest-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-digest-frequency-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-digest-frequency-row + .basic-digest-frequency-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-digest-frequency-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.digest-icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.75rem;
+  border: 1px solid rgba(103, 232, 249, 0.32);
+  border-radius: 0.95rem;
+  color: var(--daily);
+  background: rgba(103, 232, 249, 0.12);
+  font-weight: 900;
+}
+
+.digest-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.digest-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.digest-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.frequency-pill {
+  flex: 0 0 auto;
+  min-width: 5.1rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--daily);
+  background: rgba(103, 232, 249, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.frequency-pill.is-weekly {
+  color: var(--weekly);
+  background: rgba(167, 243, 208, 0.12);
+}
+
+.frequency-pill.is-paused {
+  color: var(--paused);
+  background: rgba(253, 164, 175, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-digest-frequency-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .frequency-pill {
+    margin-left: 3.6rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Digest Frequency Row demo inside `submissions/examples/basic-digest-frequency-row-kk/`. This submission introduces a compact CSS-only row for email preferences, notification settings, account panels, onboarding screens, and workspace settings pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only digest frequency row that displays a digest icon, title, helper copy, and daily/weekly/paused frequency pill in one compact layout.

**How does a developer use it?**

```html
<article class="basic-digest-frequency-row">
  <span class="digest-icon" aria-hidden="true">D</span>
  <div class="digest-copy">
    <strong>Daily product digest</strong>
    <p>Receive important updates once every morning.</p>
  </div>
  <span class="frequency-pill is-daily">Daily</span>
</article>