### PR TITLE
feat: add basic data residency row demo

### DIFF
--- a/submissions/examples/basic-data-residency-row-kk/README.md
+++ b/submissions/examples/basic-data-residency-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Data Residency Row
+
+## What it does
+
+This submission adds a simple CSS-only data residency row for privacy settings,
+SaaS admin panels, compliance dashboards, workspace settings, and account
+configuration screens.
+
+It displays a region marker, region name, helper copy, and residency status in
+one compact row.
+
+## How to use it
+
+Add the base row class with a region marker, copy, and state pill:
+
+```html
+<article class="basic-data-residency-row">
+  <span class="region-mark" aria-hidden="true">EU</span>
+  <div class="region-copy">
+    <strong>European Union</strong>
+    <p>Primary workspace data is stored in EU-based infrastructure.</p>
+  </div>
+  <span class="residency-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+privacy, compliance, and admin interfaces. The row can be dropped into settings
+cards or dashboards while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Active, available, and legacy residency states
+- Region initials marker
+- Helper copy and status pill layout
+- Text truncation for long compliance copy
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the data residency row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-data-residency-row-kk/demo.html
+++ b/submissions/examples/basic-data-residency-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Data Residency Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Data Residency Row</p>
+          <h1>Region rows for privacy and workspace compliance settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing workspace data regions,
+            residency status, and short compliance helper text.
+          </p>
+        </header>
+
+        <section class="residency-panel" aria-label="Data residency row examples">
+          <article class="basic-data-residency-row">
+            <span class="region-mark" aria-hidden="true">EU</span>
+            <div class="region-copy">
+              <strong>European Union</strong>
+              <p>Primary workspace data is stored in EU-based infrastructure.</p>
+            </div>
+            <span class="residency-state is-active">Active</span>
+          </article>
+
+          <article class="basic-data-residency-row">
+            <span class="region-mark" aria-hidden="true">IN</span>
+            <div class="region-copy">
+              <strong>India</strong>
+              <p>Regional storage is available for upcoming workspace moves.</p>
+            </div>
+            <span class="residency-state is-available">Available</span>
+          </article>
+
+          <article class="basic-data-residency-row">
+            <span class="region-mark" aria-hidden="true">US</span>
+            <div class="region-copy">
+              <strong>United States</strong>
+              <p>Legacy region kept for older account exports and audits.</p>
+            </div>
+            <span class="residency-state is-legacy">Legacy</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-data-residency-row"&gt;
+  &lt;span class="region-mark" aria-hidden="true"&gt;EU&lt;/span&gt;
+  &lt;div class="region-copy"&gt;
+    &lt;strong&gt;European Union&lt;/strong&gt;
+    &lt;p&gt;Primary workspace data is stored in EU-based infrastructure.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="residency-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-data-residency-row-kk/style.css
+++ b/submissions/examples/basic-data-residency-row-kk/style.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --active: #86efac;
+  --available: #93c5fd;
+  --legacy: #fcd34d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(147, 197, 253, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.residency-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-data-residency-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-data-residency-row + .basic-data-residency-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-data-residency-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.region-mark {
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.85rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.region-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.region-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.region-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.residency-state {
+  flex: 0 0 auto;
+  min-width: 5.7rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.residency-state.is-available {
+  color: var(--available);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.residency-state.is-legacy {
+  color: var(--legacy);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-data-residency-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .residency-state {
+    margin-left: 3.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Data Residency Row demo inside `submissions/examples/basic-data-residency-row-kk/`. This submission introduces a compact CSS-only row for privacy settings, SaaS admin panels, compliance dashboards, workspace settings, and account configuration screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only data residency row that displays a region marker, region name, helper copy, and active/available/legacy residency status in one compact layout.

**How does a developer use it?**

```html
<article class="basic-data-residency-row">
  <span class="region-mark" aria-hidden="true">EU</span>
  <div class="region-copy">
    <strong>European Union</strong>
    <p>Primary workspace data is stored in EU-based infrastructure.</p>
  </div>
  <span class="residency-state is-active">Active</span>
</article>