### PR TITLE
feat: add basic maintenance window row demo

### DIFF
--- a/submissions/examples/basic-maintenance-window-row-kk/README.md
+++ b/submissions/examples/basic-maintenance-window-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Maintenance Window Row
+
+## What it does
+
+This submission adds a simple CSS-only maintenance window row for status pages,
+admin dashboards, incident panels, service health cards, and operations
+settings screens.
+
+It displays a service marker, maintenance title, helper copy, time pill, and
+state label in one compact row.
+
+## How to use it
+
+Add the base row class with marker, copy, time, and state:
+
+```html
+<article class="basic-maintenance-window-row">
+  <span class="window-marker is-scheduled" aria-hidden="true"></span>
+  <div class="window-copy">
+    <strong>Database index refresh</strong>
+    <p>Scheduled maintenance for search and reporting services.</p>
+  </div>
+  <span class="window-time">10:30 PM</span>
+  <span class="window-state is-scheduled">Scheduled</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+status and admin interfaces. The row can be used in service dashboards,
+incident summaries, and operations cards while staying lightweight and CSS-only.
+
+## Included features
+
+- Scheduled, live, and completed maintenance states
+- Glowing service marker
+- Maintenance title, helper copy, time pill, and state layout
+- Text truncation for long maintenance copy
+- Subtle hover lift interaction
+- Responsive two-column wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the maintenance window row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-maintenance-window-row-kk/demo.html
+++ b/submissions/examples/basic-maintenance-window-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Maintenance Window Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Maintenance Window Row</p>
+          <h1>Maintenance rows for status pages and admin dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing planned maintenance windows,
+            service timing, and operational states in a compact layout.
+          </p>
+        </header>
+
+        <section class="maintenance-panel" aria-label="Maintenance window row examples">
+          <article class="basic-maintenance-window-row">
+            <span class="window-marker is-scheduled" aria-hidden="true"></span>
+            <div class="window-copy">
+              <strong>Database index refresh</strong>
+              <p>Scheduled maintenance for search and reporting services.</p>
+            </div>
+            <span class="window-time">10:30 PM</span>
+            <span class="window-state is-scheduled">Scheduled</span>
+          </article>
+
+          <article class="basic-maintenance-window-row">
+            <span class="window-marker is-live" aria-hidden="true"></span>
+            <div class="window-copy">
+              <strong>API gateway patch</strong>
+              <p>Traffic is being shifted during the active update window.</p>
+            </div>
+            <span class="window-time">Now</span>
+            <span class="window-state is-live">Live</span>
+          </article>
+
+          <article class="basic-maintenance-window-row">
+            <span class="window-marker is-complete" aria-hidden="true"></span>
+            <div class="window-copy">
+              <strong>Asset cache migration</strong>
+              <p>Static asset cache maintenance completed successfully.</p>
+            </div>
+            <span class="window-time">08:00 PM</span>
+            <span class="window-state is-complete">Done</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-maintenance-window-row"&gt;
+  &lt;span class="window-marker is-scheduled" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;div class="window-copy"&gt;
+    &lt;strong&gt;Database index refresh&lt;/strong&gt;
+    &lt;p&gt;Scheduled maintenance for search and reporting services.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="window-time"&gt;10:30 PM&lt;/span&gt;
+  &lt;span class="window-state is-scheduled"&gt;Scheduled&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-maintenance-window-row-kk/style.css
+++ b/submissions/examples/basic-maintenance-window-row-kk/style.css
@@ -1,0 +1,195 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --scheduled: #93c5fd;
+  --live: #fcd34d;
+  --complete: #86efac;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--scheduled);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.maintenance-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-maintenance-window-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-maintenance-window-row + .basic-maintenance-window-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-maintenance-window-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.window-marker {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  background: var(--scheduled);
+  box-shadow: 0 0 0.9rem currentColor;
+}
+
+.window-marker.is-scheduled {
+  color: var(--scheduled);
+  background: var(--scheduled);
+}
+
+.window-marker.is-live {
+  color: var(--live);
+  background: var(--live);
+}
+
+.window-marker.is-complete {
+  color: var(--complete);
+  background: var(--complete);
+}
+
+.window-copy {
+  min-width: 0;
+}
+
+.window-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.window-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.window-time,
+.window-state {
+  flex: 0 0 auto;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.window-time {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.window-state {
+  min-width: 5.8rem;
+  border: 1px solid currentColor;
+  color: var(--scheduled);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.window-state.is-live {
+  color: var(--live);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.window-state.is-complete {
+  color: var(--complete);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-maintenance-window-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .window-time {
+    margin-left: 1.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Maintenance Window Row demo inside `submissions/examples/basic-maintenance-window-row-kk/`. This submission introduces a compact CSS-only row for status pages, admin dashboards, incident panels, service health cards, and operations settings screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only maintenance window row that displays a service marker, maintenance title, helper copy, time pill, and scheduled/live/completed state label in one compact layout.

**How does a developer use it?**

```html
<article class="basic-maintenance-window-row">
  <span class="window-marker is-scheduled" aria-hidden="true"></span>
  <div class="window-copy">
    <strong>Database index refresh</strong>
    <p>Scheduled maintenance for search and reporting services.</p>
  </div>
  <span class="window-time">10:30 PM</span>
  <span class="window-state is-scheduled">Scheduled</span>
</article>