### PR TITLE
feat: add basic billing address row demo

### DIFF
--- a/submissions/examples/basic-billing-address-row-kk/README.md
+++ b/submissions/examples/basic-billing-address-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Billing Address Row
+
+## What it does
+
+This submission adds a simple CSS-only billing address row for checkout pages,
+account billing settings, subscription panels, invoice settings, and admin
+customer profiles.
+
+It displays a region marker, address label, helper copy, and address state in
+one compact row.
+
+## How to use it
+
+Add the base row class with an address marker, copy, and state pill:
+
+```html
+<article class="basic-billing-address-row">
+  <span class="address-mark" aria-hidden="true">IN</span>
+  <div class="address-copy">
+    <strong>Primary billing address</strong>
+    <p>Bengaluru, Karnataka, India - used for monthly invoices.</p>
+  </div>
+  <span class="address-state is-default">Default</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common checkout and account settings interfaces. The row can be used inside
+cards, billing profiles, customer dashboards, and subscription panels while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Default, backup, and archived address states
+- Region initials marker
+- Address title, helper copy, and state pill layout
+- Text truncation for long address descriptions
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the billing address row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-billing-address-row-kk/demo.html
+++ b/submissions/examples/basic-billing-address-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Billing Address Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Billing Address Row</p>
+          <h1>Clean address rows for checkout and account billing settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing saved billing addresses,
+            address labels, helper copy, and account state badges.
+          </p>
+        </header>
+
+        <section class="address-panel" aria-label="Billing address row examples">
+          <article class="basic-billing-address-row">
+            <span class="address-mark" aria-hidden="true">IN</span>
+            <div class="address-copy">
+              <strong>Primary billing address</strong>
+              <p>Bengaluru, Karnataka, India - used for monthly invoices.</p>
+            </div>
+            <span class="address-state is-default">Default</span>
+          </article>
+
+          <article class="basic-billing-address-row">
+            <span class="address-mark" aria-hidden="true">US</span>
+            <div class="address-copy">
+              <strong>Backup tax address</strong>
+              <p>San Jose, California, United States - saved for exports.</p>
+            </div>
+            <span class="address-state is-backup">Backup</span>
+          </article>
+
+          <article class="basic-billing-address-row">
+            <span class="address-mark" aria-hidden="true">EU</span>
+            <div class="address-copy">
+              <strong>Old billing profile</strong>
+              <p>Berlin, Germany - no longer used for active subscriptions.</p>
+            </div>
+            <span class="address-state is-archived">Archived</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-billing-address-row"&gt;
+  &lt;span class="address-mark" aria-hidden="true"&gt;IN&lt;/span&gt;
+  &lt;div class="address-copy"&gt;
+    &lt;strong&gt;Primary billing address&lt;/strong&gt;
+    &lt;p&gt;Bengaluru, Karnataka, India - used for monthly invoices.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="address-state is-default"&gt;Default&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-billing-address-row-kk/style.css
+++ b/submissions/examples/basic-billing-address-row-kk/style.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --default: #86efac;
+  --backup: #93c5fd;
+  --archived: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(147, 197, 253, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--default);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.address-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-billing-address-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-billing-address-row + .basic-billing-address-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-billing-address-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.address-mark {
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.85rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--default);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.address-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.address-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.address-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.address-state {
+  flex: 0 0 auto;
+  min-width: 5.5rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--default);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.address-state.is-backup {
+  color: var(--backup);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.address-state.is-archived {
+  color: var(--archived);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-billing-address-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .address-state {
+    margin-left: 3.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Billing Address Row demo inside `submissions/examples/basic-billing-address-row-kk/`. This submission introduces a compact CSS-only row for checkout pages, account billing settings, subscription panels, invoice settings, and admin customer profiles.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only billing address row that displays a region marker, address label, helper copy, and default/backup/archived address state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-billing-address-row">
  <span class="address-mark" aria-hidden="true">IN</span>
  <div class="address-copy">
    <strong>Primary billing address</strong>
    <p>Bengaluru, Karnataka, India - used for monthly invoices.</p>
  </div>
  <span class="address-state is-default">Default</span>
</article>