### PR TITLE
feat: add basic tax id status row demo

### DIFF
--- a/submissions/examples/basic-tax-id-status-row-kk/README.md
+++ b/submissions/examples/basic-tax-id-status-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Tax ID Status Row
+
+## What it does
+
+This submission adds a simple CSS-only tax ID status row for billing settings,
+invoice panels, business profile pages, checkout flows, and admin customer
+records.
+
+It displays a region marker, tax label, helper copy, and verification status in
+one compact row.
+
+## How to use it
+
+Add the base row class with a region marker, tax copy, and status pill:
+
+```html
+<article class="basic-tax-id-status-row">
+  <span class="tax-region" aria-hidden="true">GST</span>
+  <div class="tax-copy">
+    <strong>India GSTIN</strong>
+    <p>GSTIN ending in 7K2Z is verified for monthly invoices.</p>
+  </div>
+  <span class="tax-state is-verified">Verified</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common billing and business settings interfaces. The row can be reused in
+invoice pages, checkout cards, account settings, and admin dashboards while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Verified, review, and missing tax ID states
+- GST, VAT, and TIN region examples
+- Tax label, helper copy, and status pill layout
+- Text truncation for long tax helper copy
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the tax ID status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-tax-id-status-row-kk/demo.html
+++ b/submissions/examples/basic-tax-id-status-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Tax ID Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Tax ID Status Row</p>
+          <h1>Tax ID rows for billing, invoice, and business profile settings.</h1>
+          <p class="intro">
+            A CSS-only row component for displaying tax identifiers, region
+            labels, helper copy, and verification states in account billing UI.
+          </p>
+        </header>
+
+        <section class="tax-panel" aria-label="Tax ID status row examples">
+          <article class="basic-tax-id-status-row">
+            <span class="tax-region" aria-hidden="true">GST</span>
+            <div class="tax-copy">
+              <strong>India GSTIN</strong>
+              <p>GSTIN ending in 7K2Z is verified for monthly invoices.</p>
+            </div>
+            <span class="tax-state is-verified">Verified</span>
+          </article>
+
+          <article class="basic-tax-id-status-row">
+            <span class="tax-region" aria-hidden="true">VAT</span>
+            <div class="tax-copy">
+              <strong>EU VAT number</strong>
+              <p>VAT details are waiting for billing team review.</p>
+            </div>
+            <span class="tax-state is-review">Review</span>
+          </article>
+
+          <article class="basic-tax-id-status-row">
+            <span class="tax-region" aria-hidden="true">TIN</span>
+            <div class="tax-copy">
+              <strong>Business tax ID</strong>
+              <p>Add a tax ID to keep invoices compliant for this workspace.</p>
+            </div>
+            <span class="tax-state is-missing">Missing</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-tax-id-status-row"&gt;
+  &lt;span class="tax-region" aria-hidden="true"&gt;GST&lt;/span&gt;
+  &lt;div class="tax-copy"&gt;
+    &lt;strong&gt;India GSTIN&lt;/strong&gt;
+    &lt;p&gt;GSTIN ending in 7K2Z is verified for monthly invoices.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="tax-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-tax-id-status-row-kk/style.css
+++ b/submissions/examples/basic-tax-id-status-row-kk/style.css
@@ -1,0 +1,178 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --verified: #86efac;
+  --review: #fcd34d;
+  --missing: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--verified);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 16ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tax-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-tax-id-status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-tax-id-status-row + .basic-tax-id-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-tax-id-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.tax-region {
+  width: 3.1rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 3.1rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.tax-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.tax-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.tax-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tax-state {
+  flex: 0 0 auto;
+  min-width: 5.6rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.tax-state.is-review {
+  color: var(--review);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.tax-state.is-missing {
+  color: var(--missing);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-tax-id-status-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .tax-state {
+    margin-left: 3.95rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Tax ID Status Row demo inside `submissions/examples/basic-tax-id-status-row-kk/`. This submission introduces a compact CSS-only row for billing settings, invoice panels, business profile pages, checkout flows, and admin customer records.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only tax ID status row that displays a region marker, tax label, helper copy, and verified/review/missing status in one compact layout.

**How does a developer use it?**

```html
<article class="basic-tax-id-status-row">
  <span class="tax-region" aria-hidden="true">GST</span>
  <div class="tax-copy">
    <strong>India GSTIN</strong>
    <p>GSTIN ending in 7K2Z is verified for monthly invoices.</p>
  </div>
  <span class="tax-state is-verified">Verified</span>
</article>