### PR TITLE
feat: create Glowing Toggle with Material Design styling (#22808) #80002

### DIFF
--- a/submissions/examples/css-toggle-glowing-material-pure/README.md
+++ b/submissions/examples/css-toggle-glowing-material-pure/README.md
@@ -1,0 +1,13 @@
+# Glowing Material Design Toggle
+
+A highly polished, pure CSS toggle switch (checkbox) built on Material Design principles, enhanced with dynamic neon glow effects.
+
+## Features
+- **Material Easing**: Utilizes the standard Material Design curve `cubic-bezier(0.4, 0, 0.2, 1)` for all slider animations, providing a snappy, tactile feel.
+- **Glowing Active State**: When toggled on, the track emits a colored drop-shadow (glow) utilizing CSS `box-shadow`.
+- **Multiple Color Themes**: Includes pre-built classes (`glow-blue`, `glow-red`, `glow-green`) that instantly apply different active colors and corresponding glow effects.
+- **Ripple Effect Interaction**: Features a CSS-only material ripple effect when the toggle is clicked (using the `:active` pseudo-class and a scaling `::after` element).
+- **Accessibility**: Built on top of a native `<input type="checkbox">` ensuring it remains semantic, focusable (`:focus-visible`), and compatible with screen readers.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Roboto` font is loaded in your `<head>`. Apply the desired color class (e.g. `glow-blue`) to the `.toggle-track` span.

--- a/submissions/examples/css-toggle-glowing-material-pure/demo.html
+++ b/submissions/examples/css-toggle-glowing-material-pure/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Material Toggle</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <div class="toggle-card">
+            <h2 class="card-title">Settings</h2>
+            
+            <div class="setting-row">
+                <div class="setting-info">
+                    <span class="setting-name">Enable Hyperdrive</span>
+                    <span class="setting-desc">Initiate FTL background process</span>
+                </div>
+                
+                <!-- Glowing Material Toggle 1 -->
+                <label class="material-toggle">
+                    <input type="checkbox" class="toggle-input" checked>
+                    <span class="toggle-track glow-blue"></span>
+                </label>
+            </div>
+            
+            <div class="setting-row">
+                <div class="setting-info">
+                    <span class="setting-name">Overclock Core</span>
+                    <span class="setting-desc">Warning: May cause instability</span>
+                </div>
+                
+                <!-- Glowing Material Toggle 2 -->
+                <label class="material-toggle">
+                    <input type="checkbox" class="toggle-input">
+                    <span class="toggle-track glow-red"></span>
+                </label>
+            </div>
+            
+            <div class="setting-row">
+                <div class="setting-info">
+                    <span class="setting-name">Shield Generators</span>
+                    <span class="setting-desc">Maintain optimal defense matrix</span>
+                </div>
+                
+                <!-- Glowing Material Toggle 3 -->
+                <label class="material-toggle">
+                    <input type="checkbox" class="toggle-input" checked>
+                    <span class="toggle-track glow-green"></span>
+                </label>
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-toggle-glowing-material-pure/style.css
+++ b/submissions/examples/css-toggle-glowing-material-pure/style.css
@@ -1,0 +1,188 @@
+:root {
+    --bg-dark: #121212;
+    --surface-dark: #1e1e1e;
+    --text-primary: #ffffff;
+    --text-secondary: #aaaaaa;
+    
+    /* Toggle Colors */
+    --track-off: #424242;
+    --thumb-off: #bdbdbd;
+    
+    --glow-blue: #2196f3;
+    --glow-red: #f44336;
+    --glow-green: #4caf50;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Roboto', sans-serif;
+}
+
+body {
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    width: 100%;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+}
+
+/* Settings Card */
+.toggle-card {
+    background-color: var(--surface-dark);
+    width: 100%;
+    max-width: 450px;
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.card-title {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-bottom: 25px;
+    letter-spacing: 0.5px;
+}
+
+.setting-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.setting-row:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.setting-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.setting-name {
+    font-size: 1.05rem;
+    font-weight: 500;
+}
+
+.setting-desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+/* 
+   Glowing Material Toggle 
+*/
+.material-toggle {
+    position: relative;
+    display: inline-block;
+    width: 52px;
+    height: 32px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* Hide the actual checkbox */
+.toggle-input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+/* The Track */
+.toggle-track {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--track-off);
+    border-radius: 34px;
+    transition: background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* The Thumb (Circle) */
+.toggle-track::before {
+    position: absolute;
+    content: "";
+    height: 24px;
+    width: 24px;
+    left: 4px;
+    bottom: 4px;
+    background-color: var(--thumb-off);
+    border-radius: 50%;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
+}
+
+/* Ripple effect on click */
+.toggle-track::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 16px; /* Center over the thumb's initial position */
+    width: 40px;
+    height: 40px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.toggle-input:active + .toggle-track::after {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+}
+
+.toggle-input:checked:active + .toggle-track::after {
+    left: calc(100% - 16px); /* Move ripple center to checked position */
+}
+
+/* 
+   Checked States & Glow Logic
+*/
+.toggle-input:checked + .toggle-track::before {
+    transform: translateX(20px);
+    background-color: #ffffff;
+}
+
+/* Blue Glow */
+.toggle-input:checked + .glow-blue {
+    background-color: var(--glow-blue);
+    box-shadow: 0 0 15px rgba(33, 150, 243, 0.5), inset 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Red Glow */
+.toggle-input:checked + .glow-red {
+    background-color: var(--glow-red);
+    box-shadow: 0 0 15px rgba(244, 67, 54, 0.5), inset 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Green Glow */
+.toggle-input:checked + .glow-green {
+    background-color: var(--glow-green);
+    box-shadow: 0 0 15px rgba(76, 175, 80, 0.5), inset 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Accessibility */
+.toggle-input:focus-visible + .toggle-track {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+}


### PR DESCRIPTION
**Title:** feat: create Glowing Toggle with Material Design styling (#22808) #80002

**Description:**
This PR introduces a pure CSS toggle switch built on Material Design principles, enhanced with dynamic neon glow effects for active states.

Fixes #80002

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-toggle-glowing-material-pure/`
- Implemented standard Material Design easing curves (`cubic-bezier(0.4, 0, 0.2, 1)`) for all slider animations to ensure a snappy, tactile feel
- Built CSS-only glow physics utilizing layered `box-shadow` properties that activate when the checkbox is `:checked`
- Included three color-theme variants (Blue, Red, Green) managed via simple CSS utility classes (`glow-blue`, `glow-red`, `glow-green`)
- Engineered a pure CSS ripple effect upon user interaction using the `:active` pseudo-class and a scaling `::after` element
- Ensured semantic accessibility by building directly on top of a native `<input type="checkbox">` structure, preserving `:focus-visible` behaviors
