### PR TITLE
docs: add Hover Toggle documentation

### DIFF
--- a/submissions/docs/hover-toggle/README.md
+++ b/submissions/docs/hover-toggle/README.md
@@ -1,0 +1,111 @@
+# Hover Toggle
+
+A simple, responsive CSS-only toggle interaction that changes its state visually when the user hovers over the toggle.
+
+## Features
+
+* Pure HTML and CSS
+* No JavaScript required
+* Smooth hover animation
+* Responsive design
+* Easy to customize
+* Lightweight implementation
+
+## Folder Structure
+
+```text
+hover-toggle/
+├── index.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+Include the stylesheet in your HTML file:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Then add the toggle markup:
+
+```html
+<div class="toggle-wrapper">
+  <span class="label">Hover me</span>
+
+  <div class="toggle">
+    <div class="toggle-knob"></div>
+  </div>
+</div>
+```
+
+## How It Works
+
+The component uses the CSS `:hover` pseudo-class to create the interaction.
+
+When the user hovers over the toggle:
+
+* The toggle background changes.
+* The knob smoothly moves to the opposite side.
+* The transition creates a smooth visual effect.
+
+The main interaction is implemented using:
+
+```css
+.toggle:hover {
+  background: #6366f1;
+}
+
+.toggle:hover .toggle-knob {
+  transform: translateX(34px);
+}
+```
+
+## Customization
+
+You can customize the component by changing:
+
+* Toggle width and height
+* Knob size
+* Background colors
+* Animation duration
+* Border radius
+* Hover movement distance
+
+For example:
+
+```css
+.toggle:hover {
+  background: #6366f1;
+}
+
+.toggle:hover .toggle-knob {
+  transform: translateX(34px);
+}
+```
+
+## Responsive Design
+
+The component adapts to smaller screens using a CSS media query:
+
+```css
+@media (max-width: 480px) {
+  .container {
+    padding: 30px 20px;
+  }
+}
+```
+
+## Browser Support
+
+The component uses standard HTML and CSS features and works in modern browsers including:
+
+* Chrome
+* Firefox
+* Edge
+* Safari
+
+## License
+
+This contribution is made as part of the EaseMotion-css open-source project.

--- a/submissions/docs/hover-toggle/demo.html
+++ b/submissions/docs/hover-toggle/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hover Toggle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+    <h1>Hover Toggle</h1>
+    <p class="description">
+      A simple CSS-only toggle interaction that changes its appearance
+      when the user hovers over it.
+    </p>
+
+    <div class="toggle-wrapper">
+      <span class="label">Hover me</span>
+
+      <div class="toggle">
+        <div class="toggle-knob"></div>
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/hover-toggle/style.css
+++ b/submissions/docs/hover-toggle/style.css
@@ -1,0 +1,92 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  
+  body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    font-family: Arial, sans-serif;
+    background: #f4f6f8;
+  }
+  
+  .container {
+    width: min(100%, 500px);
+    padding: 40px 30px;
+    text-align: center;
+    background: #ffffff;
+    border-radius: 20px;
+    box-shadow: 0 12px 35px rgba(0, 0, 0, 0.1);
+  }
+  
+  h1 {
+    margin-bottom: 12px;
+    font-size: 2rem;
+  }
+  
+  .description {
+    margin-bottom: 35px;
+    line-height: 1.6;
+    color: #666;
+  }
+  
+  .toggle-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 18px;
+  }
+  
+  .label {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+  
+  .toggle {
+    width: 70px;
+    height: 36px;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    border-radius: 50px;
+    background: #cbd5e1;
+    cursor: pointer;
+    transition: background 0.3s ease;
+  }
+  
+  .toggle-knob {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #ffffff;
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+    transition: transform 0.35s ease;
+  }
+  
+  /* Hover interaction */
+  .toggle:hover {
+    background: #6366f1;
+  }
+  
+  .toggle:hover .toggle-knob {
+    transform: translateX(34px);
+  }
+  
+  /* Responsive */
+  @media (max-width: 480px) {
+    .container {
+      padding: 30px 20px;
+    }
+  
+    h1 {
+      font-size: 1.6rem;
+    }
+  
+    .toggle-wrapper {
+      gap: 12px;
+    }
+  }


### PR DESCRIPTION
# PR Title

`docs: add Hover Toggle documentation`

## Description

This PR adds documentation for the **Hover Toggle** component as requested in issue #78401.

### Changes Made

* Added `index.html` with a responsive Hover Toggle example.
* Added `style.css` with hover animation and responsive styling.
* Added `README.md` explaining:

  * Component usage
  * HTML structure
  * CSS behavior
  * Customization options
  * Responsive design
  * Browser support

### Issue

Closes #78401

### Checklist

* [x] Added documentation under `submissions/docs/`
* [x] Added HTML example
* [x] Added CSS styling
* [x] Added README documentation
* [x] Made the example responsive
* [x] No JavaScript required
