### PR TITLE
feat: create Interactive Tab Bar with Dark Mode styling (#39765) #79984

### DIFF
--- a/submissions/examples/css-tabbar-interactive-darkmode-pure/README.md
+++ b/submissions/examples/css-tabbar-interactive-darkmode-pure/README.md
@@ -1,0 +1,13 @@
+# Interactive Tab Bar (Dark Mode)
+
+A premium, highly interactive pure CSS mobile tab navigation bar tailored specifically for modern dark mode applications.
+
+## Features
+- **Floating Pill Architecture**: The tab bar is detached from the bottom edge of the screen with rounded corners, creating a modern, "floating" UI aesthetic.
+- **Pure CSS State Engine**: Employs the hidden `<input type="radio">` pattern alongside the `~` sibling selector to drive complex animations without relying on Javascript.
+- **Dynamic Pill Indicator**: Uses a transparent blue background pill (`rgba`) that smoothly slides behind the active tab using a custom `cubic-bezier` spring transition.
+- **Active Tab Micro-interactions**: When a tab is selected, the icon smoothly translates upwards (`translateY`) and plays a custom `@keyframes` pop animation, while the label text fades in and slides up from below.
+- **Notification Badging**: Includes a pre-styled CSS notification badge structure nested securely relative to the tab icon.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Inter` font is loaded via your `<head>`. The layout is designed to sit inside a mobile app wrapper; the active indicator pill math dynamically adjusts based on the `--tab-count` CSS variable defined in the `:root`.

--- a/submissions/examples/css-tabbar-interactive-darkmode-pure/demo.html
+++ b/submissions/examples/css-tabbar-interactive-darkmode-pure/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Dark Mode Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="mobile-frame">
+        
+        <header class="app-header">
+            <h2>Activity</h2>
+        </header>
+
+        <!-- Interactive Dark Mode Tab Bar -->
+        <nav class="dark-tab-bar">
+            
+            <input type="radio" name="tabs" id="tab-dashboard" class="tab-input" checked>
+            <label for="tab-dashboard" class="tab-item">
+                <div class="icon-container">
+                    <svg class="tab-icon" viewBox="0 0 24 24"><path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/></svg>
+                </div>
+                <span class="tab-text">Dashboard</span>
+            </label>
+
+            <input type="radio" name="tabs" id="tab-analytics" class="tab-input">
+            <label for="tab-analytics" class="tab-item">
+                <div class="icon-container">
+                    <svg class="tab-icon" viewBox="0 0 24 24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/></svg>
+                </div>
+                <span class="tab-text">Analytics</span>
+            </label>
+
+            <input type="radio" name="tabs" id="tab-messages" class="tab-input">
+            <label for="tab-messages" class="tab-item">
+                <div class="icon-container">
+                    <svg class="tab-icon" viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    <span class="notification-badge">3</span>
+                </div>
+                <span class="tab-text">Messages</span>
+            </label>
+
+            <input type="radio" name="tabs" id="tab-settings" class="tab-input">
+            <label for="tab-settings" class="tab-item">
+                <div class="icon-container">
+                    <svg class="tab-icon" viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .43-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.49-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
+                </div>
+                <span class="tab-text">Settings</span>
+            </label>
+            
+            <!-- Animated Pill Indicator -->
+            <div class="pill-indicator"></div>
+
+        </nav>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-tabbar-interactive-darkmode-pure/style.css
+++ b/submissions/examples/css-tabbar-interactive-darkmode-pure/style.css
@@ -1,0 +1,204 @@
+:root {
+    --bg-app: #0f172a; /* Slate 900 */
+    --bg-tabbar: #1e293b; /* Slate 800 */
+    
+    --text-inactive: #64748b; /* Slate 500 */
+    --text-active: #38bdf8; /* Light Blue 400 */
+    
+    --pill-bg: rgba(56, 189, 248, 0.15);
+    --badge-bg: #ef4444; /* Red 500 */
+    
+    /* Config for 4 tabs */
+    --tab-count: 4;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Inter', sans-serif;
+}
+
+body {
+    background-color: #000;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Mobile App Mockup Frame */
+.mobile-frame {
+    width: 100%;
+    max-width: 414px;
+    height: 736px;
+    background-color: var(--bg-app);
+    border-radius: 40px;
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 25px 50px -12px rgba(255, 255, 255, 0.05);
+    border: 8px solid #222;
+}
+
+.app-header {
+    padding: 60px 30px 20px;
+    color: #fff;
+}
+
+.app-header h2 {
+    font-size: 2rem;
+    font-weight: 600;
+    letter-spacing: -0.5px;
+}
+
+/* 
+   Dark Mode Tab Bar 
+*/
+.dark-tab-bar {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    right: 20px;
+    height: 70px;
+    background-color: var(--bg-tabbar);
+    border-radius: 24px;
+    display: flex;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+    padding: 0 10px;
+    align-items: center;
+}
+
+/* Hidden Inputs */
+.tab-input {
+    display: none;
+}
+
+/* Tab Items */
+.tab-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: var(--text-inactive);
+    cursor: pointer;
+    position: relative;
+    z-index: 10;
+    height: 100%;
+    transition: color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.icon-container {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.tab-icon {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+    transition: transform 0.3s ease;
+}
+
+.tab-text {
+    font-size: 0.7rem;
+    font-weight: 500;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    position: absolute;
+    bottom: 8px;
+}
+
+/* Notification Badge */
+.notification-badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+    background-color: var(--badge-bg);
+    color: #fff;
+    font-size: 0.6rem;
+    font-weight: 700;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    border: 2px solid var(--bg-tabbar);
+}
+
+/* Active State Styles */
+.tab-input:checked + .tab-item {
+    color: var(--text-active);
+}
+
+/* Move icon up and show text when active */
+.tab-input:checked + .tab-item .icon-container {
+    transform: translateY(-8px);
+}
+
+.tab-input:checked + .tab-item .tab-text {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Active Icon spring animation */
+.tab-input:checked + .tab-item .tab-icon {
+    animation: iconPop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes iconPop {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+/* 
+   Animated Pill Indicator 
+*/
+.pill-indicator {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 10px; /* Accounts for nav padding */
+    width: calc((100% - 20px) / var(--tab-count));
+    height: 50px;
+    background-color: var(--pill-bg);
+    border-radius: 16px;
+    pointer-events: none;
+    z-index: 5;
+    transition: left 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Logic to move the indicator pill */
+#tab-dashboard:checked ~ .pill-indicator {
+    left: 10px;
+}
+
+#tab-analytics:checked ~ .pill-indicator {
+    left: calc(10px + ((100% - 20px) / var(--tab-count)) * 1);
+}
+
+#tab-messages:checked ~ .pill-indicator {
+    left: calc(10px + ((100% - 20px) / var(--tab-count)) * 2);
+}
+
+#tab-settings:checked ~ .pill-indicator {
+    left: calc(10px + ((100% - 20px) / var(--tab-count)) * 3);
+}
+
+/* Responsive adjustment for wider screens */
+@media (min-width: 600px) {
+    .mobile-frame {
+        border-radius: 20px;
+        height: 600px;
+        width: 80%;
+        max-width: 800px;
+    }
+}


### PR DESCRIPTION
**Title:** feat: create Interactive Tab Bar with Dark Mode styling (#39765) #79984

**Description:**
This PR introduces a premium, pure CSS mobile Tab Navigation Bar tailored specifically for dark mode interfaces with complex active-state animations.

Fixes #79984

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tabbar-interactive-darkmode-pure/`
- Designed a modern "floating" UI layout where the tab bar is detached from the viewport edge with rounded corners (`border-radius: 24px`)
- Implemented a pure CSS state engine utilizing the hidden `<input type="radio">` trick, driving animations entirely without Javascript
- Engineered a dynamic background pill indicator (`rgba(56, 189, 248, 0.15)`) that slides seamlessly between tabs using a `cubic-bezier` spring transition
- Built complex active tab micro-interactions: icons physically translate upwards (`translateY`) and play a custom `@keyframes` pop animation, while text labels fade and slide into view from below
- Added a pre-styled CSS notification badge structure nested within the tab icon container
- Styled with modern Slate colors (`#0f172a`, `#1e293b`) and `Inter` typography for a native app feel
