### PR TITLE
feat: create Floating Breadcrumb with Neumorphism styling (#36423) #79939

### DIFF
--- a/submissions/examples/css-breadcrumb-floating-neumorphism-pure/README.md
+++ b/submissions/examples/css-breadcrumb-floating-neumorphism-pure/README.md
@@ -1,0 +1,13 @@
+# Floating Neumorphism Breadcrumb
+
+A soft, tactile CSS breadcrumb navigation component utilizing Neumorphic (soft UI) design principles to create a floating, pill-shaped aesthetic.
+
+## Features
+- **Neumorphic Physics**: Utilizes deeply tuned `box-shadow` combinations (mixing a dark shadow with a white highlight) to make the breadcrumb container appear as if it is extruded from the background.
+- **Interactive Pressed States**: When hovering over a breadcrumb link, an `inset` box-shadow is applied, simulating the physical pressing of a soft button into the surface.
+- **Elevated Active State**: The current/active page item is styled with an extruded outer box-shadow, distinguishing it from the rest of the navigational links.
+- **Floating Layout**: Designed as an isolated, floating pill (`border-radius: 50px`) rather than a full-width block, giving it a modern app-like appearance.
+- **Responsive Wraparound**: On smaller screens, the container intelligently shifts its `border-radius` to accommodate flex-wrapping links without breaking the visual aesthetic.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Nunito` font is loaded in your `<head>`. This component requires the background color of the parent container to perfectly match the `--neu-bg` CSS variable (`#e0e5ec`) for the Neumorphic optical illusion to work correctly.

--- a/submissions/examples/css-breadcrumb-floating-neumorphism-pure/demo.html
+++ b/submissions/examples/css-breadcrumb-floating-neumorphism-pure/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Neumorphism Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <!-- Floating Neumorphism Breadcrumb -->
+        <nav class="neumorphic-breadcrumb" aria-label="Breadcrumb">
+            <ol class="breadcrumb-list">
+                
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">
+                        <svg class="home-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>
+                    </a>
+                    <span class="separator">
+                        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg>
+                    </span>
+                </li>
+
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">Settings</a>
+                    <span class="separator">
+                        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg>
+                    </span>
+                </li>
+
+                <li class="breadcrumb-item">
+                    <a href="#" class="breadcrumb-link">Account</a>
+                    <span class="separator">
+                        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg>
+                    </span>
+                </li>
+
+                <li class="breadcrumb-item active" aria-current="page">
+                    <span class="breadcrumb-link">Security</span>
+                </li>
+
+            </ol>
+        </nav>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-floating-neumorphism-pure/style.css
+++ b/submissions/examples/css-breadcrumb-floating-neumorphism-pure/style.css
@@ -1,0 +1,129 @@
+:root {
+    --neu-bg: #e0e5ec;
+    --neu-light: #ffffff;
+    --neu-shadow: #a3b1c6;
+    
+    --text-primary: #4a5568;
+    --text-active: #3182ce;
+    
+    --accent: #3182ce;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Nunito', sans-serif;
+}
+
+body {
+    background-color: var(--neu-bg);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    padding: 20px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+/* 
+   Floating Neumorphism Container
+*/
+.neumorphic-breadcrumb {
+    background-color: var(--neu-bg);
+    padding: 16px 24px;
+    border-radius: 50px; /* Pill shape */
+    
+    /* Soft Neumorphic floating shadow */
+    box-shadow: 
+        9px 9px 16px var(--neu-shadow), 
+        -9px -9px 16px var(--neu-light);
+        
+    /* Subtle border for definition */
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.breadcrumb-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    flex-wrap: wrap; /* Allows wrapping on very small screens */
+    gap: 8px;
+}
+
+.breadcrumb-item {
+    display: flex;
+    align-items: center;
+}
+
+/* 
+   Links & Interactivity 
+*/
+.breadcrumb-link {
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 700;
+    padding: 8px 16px;
+    border-radius: 30px;
+    display: flex;
+    align-items: center;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.home-icon {
+    width: 20px;
+    height: 20px;
+}
+
+/* Hover Effect: Pressed Neumorphic State */
+li:not(.active) .breadcrumb-link:hover {
+    color: var(--accent);
+    /* Inset shadow simulates the button being pressed into the surface */
+    box-shadow: 
+        inset 4px 4px 8px var(--neu-shadow), 
+        inset -4px -4px 8px var(--neu-light);
+}
+
+/* Active/Current Item */
+.breadcrumb-item.active .breadcrumb-link {
+    color: var(--text-active);
+    cursor: default;
+    /* Elevated/Popped state for the active item */
+    background-color: var(--neu-bg);
+    box-shadow: 
+        4px 4px 8px var(--neu-shadow), 
+        -4px -4px 8px var(--neu-light);
+}
+
+/* Separators */
+.separator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--neu-shadow);
+    margin: 0 4px;
+}
+
+.separator svg {
+    width: 18px;
+    height: 18px;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+    .neumorphic-breadcrumb {
+        padding: 12px 16px;
+        border-radius: 20px; /* Switch from pill to rounded box on wrap */
+    }
+    
+    .breadcrumb-link {
+        padding: 6px 12px;
+        font-size: 0.85rem;
+    }
+}


### PR DESCRIPTION

**Title:** feat: create Floating Breadcrumb with Neumorphism styling (#36423) #79939

**Description:**
This PR introduces a soft, tactile pure CSS breadcrumb navigation component utilizing Neumorphic (soft UI) design principles to create a modern floating aesthetic.

Fixes #79939

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-breadcrumb-floating-neumorphism-pure/`
- Engineered precise Neumorphic optical illusions utilizing layered `box-shadow` configurations (mixing a dark shadow with a bright highlight)
- Implemented an isolated, floating "pill" container layout (`border-radius: 50px`) rather than a traditional full-width block
- Designed interactive pressed states for links using an `inset` box-shadow to simulate a physical button being pressed into the surface on `:hover`
- Created a distinct, extruded active state for the current page item
- Ensured responsiveness; the container gracefully shifts its border-radius to accommodate flex-wrapping links on very small mobile viewports
- Applied clean `Nunito` typography for a friendly, soft visual tone that matches the CSS style
