### PR TITLE
feat: add CSS-only Glassmorphism Carousel (V2) #80044

### DIFF
--- a/submissions/examples/css-carousel-glassmorphism-v2-pure/README.md
+++ b/submissions/examples/css-carousel-glassmorphism-v2-pure/README.md
@@ -1,0 +1,13 @@
+# Glassmorphism Carousel V2
+
+A visually stunning, pure CSS interactive carousel featuring deep glassmorphism rendering, staggered entrance animations, and an ambient background layout.
+
+## Features
+- **Double Glassmorphism Architecture**: Utilizes a frosted glass outer container (`backdrop-filter: blur(10px)`) housing deeply frosted inner content cards (`backdrop-filter: blur(20px)`), creating a rich, multi-layered optical depth effect.
+- **Pure CSS State Management**: Entirely functional without Javascript. Utilizes hidden `<input type="radio">` tags and the `~` general sibling combinator to control slide translation (`transform: translateX()`).
+- **Staggered Content Animations**: When a slide becomes active, its inner text elements (badge, title, description, button) fade and slide up sequentially, controlled by CSS `transition-delay` logic linked directly to the radio button states.
+- **Responsive Controls**: Fully functional previous/next arrows and pagination dots mapped to the `for` attribute of `<label>` tags to trigger the hidden radio inputs.
+- **Ambient Blob Background**: Includes CSS-animated, heavily blurred color orbs in the background specifically designed to highlight the glass refraction and blur properties of the carousel.
+
+## Usage
+Include `demo.html` and `style.css` in your project. The `Outfit` font is utilized for a clean, modern geometric aesthetic. The carousel relies on fixed percentages (`33.3333%`) based on the total number of slides (3). If you add more slides, adjust the `.slides-wrapper` width (e.g., `400%` for 4) and `.slide` width (`25%`) accordingly.

--- a/submissions/examples/css-carousel-glassmorphism-v2-pure/demo.html
+++ b/submissions/examples/css-carousel-glassmorphism-v2-pure/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Carousel V2</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Ambient background to showcase glass blur -->
+    <div class="ambient-bg">
+        <div class="blob blob-1"></div>
+        <div class="blob blob-2"></div>
+        <div class="blob blob-3"></div>
+    </div>
+
+    <div class="container">
+        
+        <!-- CSS-only Glassmorphism Carousel -->
+        <div class="glass-carousel">
+            
+            <!-- Hidden Radio Inputs for State Management -->
+            <input type="radio" name="slider" id="slide-1" class="carousel-input" checked>
+            <input type="radio" name="slider" id="slide-2" class="carousel-input">
+            <input type="radio" name="slider" id="slide-3" class="carousel-input">
+
+            <!-- Slides Container -->
+            <div class="slides-wrapper">
+                
+                <div class="slide slide-1">
+                    <div class="glass-card">
+                        <span class="slide-badge">New Arrival</span>
+                        <h2 class="slide-title">Nebula Series</h2>
+                        <p class="slide-desc">Explore the depths of interstellar design with our latest ambient glass interfaces.</p>
+                        <a href="#" class="glass-btn">Explore Now</a>
+                    </div>
+                </div>
+
+                <div class="slide slide-2">
+                    <div class="glass-card">
+                        <span class="slide-badge">Pro Edition</span>
+                        <h2 class="slide-title">Aurora Borealis</h2>
+                        <p class="slide-desc">Harness the power of natural light phenomena to create stunning web experiences.</p>
+                        <a href="#" class="glass-btn">Upgrade</a>
+                    </div>
+                </div>
+
+                <div class="slide slide-3">
+                    <div class="glass-card">
+                        <span class="slide-badge">Limited</span>
+                        <h2 class="slide-title">Deep Ocean</h2>
+                        <p class="slide-desc">Dive into fluid animations and deep, responsive blur effects that captivate users.</p>
+                        <a href="#" class="glass-btn">Learn More</a>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- Navigation Arrows -->
+            <div class="nav-arrows">
+                <!-- Slide 1 Arrows -->
+                <label for="slide-3" class="arrow arrow-prev nav-1"><svg viewBox="0 0 24 24"><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/></svg></label>
+                <label for="slide-2" class="arrow arrow-next nav-1"><svg viewBox="0 0 24 24"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg></label>
+                
+                <!-- Slide 2 Arrows -->
+                <label for="slide-1" class="arrow arrow-prev nav-2"><svg viewBox="0 0 24 24"><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/></svg></label>
+                <label for="slide-3" class="arrow arrow-next nav-2"><svg viewBox="0 0 24 24"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg></label>
+                
+                <!-- Slide 3 Arrows -->
+                <label for="slide-2" class="arrow arrow-prev nav-3"><svg viewBox="0 0 24 24"><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/></svg></label>
+                <label for="slide-1" class="arrow arrow-next nav-3"><svg viewBox="0 0 24 24"><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/></svg></label>
+            </div>
+
+            <!-- Pagination Dots -->
+            <div class="pagination">
+                <label for="slide-1" class="dot"></label>
+                <label for="slide-2" class="dot"></label>
+                <label for="slide-3" class="dot"></label>
+            </div>
+
+        </div>
+        
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-carousel-glassmorphism-v2-pure/style.css
+++ b/submissions/examples/css-carousel-glassmorphism-v2-pure/style.css
@@ -1,0 +1,315 @@
+:root {
+    --glass-bg: rgba(255, 255, 255, 0.1);
+    --glass-border: rgba(255, 255, 255, 0.2);
+    --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.2);
+    
+    --text-primary: #ffffff;
+    --text-secondary: rgba(255, 255, 255, 0.8);
+    
+    --accent: #ff007f;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Outfit', sans-serif;
+}
+
+body {
+    background-color: #0f172a;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+
+/* 
+   Ambient Background 
+*/
+.ambient-bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.6;
+}
+
+.blob-1 {
+    width: 400px;
+    height: 400px;
+    background: #ff007f;
+    top: -100px;
+    left: -100px;
+    animation: move 15s infinite alternate ease-in-out;
+}
+
+.blob-2 {
+    width: 300px;
+    height: 300px;
+    background: #00f2fe;
+    bottom: -50px;
+    right: 10%;
+    animation: move 18s infinite alternate-reverse ease-in-out;
+}
+
+.blob-3 {
+    width: 250px;
+    height: 250px;
+    background: #7928ca;
+    top: 40%;
+    left: 40%;
+    animation: move 20s infinite alternate ease-in-out;
+}
+
+@keyframes move {
+    0% { transform: translate(0, 0) scale(1); }
+    100% { transform: translate(100px, 50px) scale(1.2); }
+}
+
+.container {
+    width: 100%;
+    max-width: 800px;
+    padding: 20px;
+    position: relative;
+    z-index: 10;
+}
+
+/* 
+   Glassmorphism Carousel V2
+*/
+.glass-carousel {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16/9;
+    border-radius: 24px;
+    overflow: hidden;
+    /* Outer Glass Container */
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: var(--glass-shadow);
+}
+
+.carousel-input {
+    display: none;
+}
+
+.slides-wrapper {
+    width: 300%; /* 3 slides = 300% */
+    height: 100%;
+    display: flex;
+    transition: transform 0.8s cubic-bezier(0.77, 0, 0.175, 1);
+}
+
+.slide {
+    width: 33.3333%; /* 100% / 3 */
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px;
+}
+
+/* Inner Glass Card Content */
+.glass-card {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    padding: 40px;
+    border-radius: 20px;
+    max-width: 500px;
+    text-align: center;
+    color: var(--text-primary);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.2);
+    
+    /* Animation initial state for inner content */
+    opacity: 0;
+    transform: translateY(30px) scale(0.95);
+    transition: all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Staggered text animations inside active slide */
+.slide-badge, .slide-title, .slide-desc, .glass-btn {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.slide-badge { transition-delay: 0.1s; }
+.slide-title { transition-delay: 0.2s; }
+.slide-desc { transition-delay: 0.3s; }
+.glass-btn { transition-delay: 0.4s; }
+
+.slide-badge {
+    display: inline-block;
+    padding: 6px 12px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 15px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.slide-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 15px;
+    line-height: 1.2;
+}
+
+.slide-desc {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin-bottom: 25px;
+    line-height: 1.6;
+}
+
+.glass-btn {
+    display: inline-block;
+    padding: 12px 30px;
+    background: var(--text-primary);
+    color: #0f172a;
+    text-decoration: none;
+    border-radius: 30px;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.glass-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px rgba(255,255,255,0.2);
+}
+
+/* 
+   State Logic via Radio Buttons 
+*/
+
+/* Move the wrapper */
+#slide-1:checked ~ .slides-wrapper { transform: translateX(0%); }
+#slide-2:checked ~ .slides-wrapper { transform: translateX(-33.3333%); }
+#slide-3:checked ~ .slides-wrapper { transform: translateX(-66.6666%); }
+
+/* Trigger active card animations */
+#slide-1:checked ~ .slides-wrapper .slide-1 .glass-card,
+#slide-2:checked ~ .slides-wrapper .slide-2 .glass-card,
+#slide-3:checked ~ .slides-wrapper .slide-3 .glass-card {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+/* Trigger inner text animations with delay */
+#slide-1:checked ~ .slides-wrapper .slide-1 .slide-badge,
+#slide-2:checked ~ .slides-wrapper .slide-2 .slide-badge,
+#slide-3:checked ~ .slides-wrapper .slide-3 .slide-badge,
+
+#slide-1:checked ~ .slides-wrapper .slide-1 .slide-title,
+#slide-2:checked ~ .slides-wrapper .slide-2 .slide-title,
+#slide-3:checked ~ .slides-wrapper .slide-3 .slide-title,
+
+#slide-1:checked ~ .slides-wrapper .slide-1 .slide-desc,
+#slide-2:checked ~ .slides-wrapper .slide-2 .slide-desc,
+#slide-3:checked ~ .slides-wrapper .slide-3 .slide-desc,
+
+#slide-1:checked ~ .slides-wrapper .slide-1 .glass-btn,
+#slide-2:checked ~ .slides-wrapper .slide-2 .glass-btn,
+#slide-3:checked ~ .slides-wrapper .slide-3 .glass-btn {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Navigation Arrows */
+.nav-arrows {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    transform: translateY(-50%);
+    display: flex;
+    justify-content: space-between;
+    padding: 0 20px;
+    pointer-events: none; /* Let clicks pass through empty space */
+}
+
+.arrow {
+    width: 44px;
+    height: 44px;
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    color: white;
+    pointer-events: auto;
+    transition: all 0.3s ease;
+    display: none; /* Hidden by default */
+}
+
+.arrow svg {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+}
+
+.arrow:hover {
+    background: rgba(255, 255, 255, 0.4);
+    transform: scale(1.1);
+}
+
+/* Show correct arrows based on active slide */
+#slide-1:checked ~ .nav-arrows .nav-1 { display: flex; }
+#slide-2:checked ~ .nav-arrows .nav-2 { display: flex; }
+#slide-3:checked ~ .nav-arrows .nav-3 { display: flex; }
+
+/* Pagination Dots */
+.pagination {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 10px;
+}
+
+.dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+/* Active Dot Logic */
+#slide-1:checked ~ .pagination .dot:nth-child(1),
+#slide-2:checked ~ .pagination .dot:nth-child(2),
+#slide-3:checked ~ .pagination .dot:nth-child(3) {
+    background: #ffffff;
+    transform: scale(1.3);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .glass-carousel {
+        aspect-ratio: auto;
+        height: 500px;
+    }
+    .slide-title {
+        font-size: 2rem;
+    }
+}


### PR DESCRIPTION
**Title:** feat: add CSS-only Glassmorphism Carousel (V2) #80044

**Description:**
This PR introduces a highly interactive, pure CSS Carousel utilizing advanced double-layered glassmorphism rendering and staggered entrance animations.

Fixes #80044

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-glassmorphism-v2-pure/`
- Implemented a pure CSS state management engine utilizing hidden `<input type="radio">` tags and sibling combinators (`~`), requiring zero Javascript
- Engineered a "Double Glassmorphism" layout: a frosted outer container (`backdrop-filter: blur(10px)`) housing deeply frosted inner content cards (`blur(20px)`), producing rich optical depth
- Built staggered content entrance animations: when a slide activates, its internal text elements (badge, title, description, button) fade and slide into place sequentially via cascading CSS `transition-delay` logic
- Added fully functional next/prev navigation arrows and pagination dots mapped dynamically via `<label for="...">`
- Created a background layer featuring CSS-animated, blurred color orbs designed specifically to showcase the refraction properties of the glass components
