### PR TITLE
feat: add CSS-only Glassmorphism Badge (Minimal) #80037

### DIFF
--- a/submissions/examples/css-badge-glassmorphism-minimal-pure/README.md
+++ b/submissions/examples/css-badge-glassmorphism-minimal-pure/README.md
@@ -1,0 +1,13 @@
+# Minimalist Glassmorphism Badge
+
+A clean, modern CSS badge component utilizing a bright, minimalist glassmorphism aesthetic suitable for light-mode SaaS dashboards and web applications.
+
+## Features
+- **Light Glassmorphism Engine**: Uses a highly translucent white background (`rgba(255, 255, 255, 0.4)`) combined with `backdrop-filter: blur(12px)` to create a frosted, milky-glass effect.
+- **Pill Architecture**: Designed with fully rounded corners (`border-radius: 100px`) and tight padding for a compact, UI-friendly footprint.
+- **Status Indicators**: Includes integrated support for colored status dots (Blue/In Progress, Green/Completed, Red/Failed) with subtle, matching drop-shadows to provide context.
+- **Micro-interactions**: Features a gentle `:hover` state that increases opacity, elevates the badge (`translateY(-2px)`), and deepens the drop-shadow for a tactile feel.
+- **Icon Support**: Easily integrates SVG icons directly inline with the text (demonstrated in the Premium Member variant).
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Inter` font family is loaded via your `<head>`. Note: For the glassmorphism effect to be visible, the badge must be placed over a colored or textured background.

--- a/submissions/examples/css-badge-glassmorphism-minimal-pure/demo.html
+++ b/submissions/examples/css-badge-glassmorphism-minimal-pure/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimal Glassmorphism Badge</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <!-- Colorful background to demonstrate glass blur -->
+    <div class="bg-mesh"></div>
+
+    <div class="container">
+        
+        <div class="badge-row">
+            <!-- Glassmorphism Badge 1 -->
+            <span class="glass-badge">
+                <span class="dot dot-blue"></span>
+                In Progress
+            </span>
+
+            <!-- Glassmorphism Badge 2 -->
+            <span class="glass-badge">
+                <span class="dot dot-green"></span>
+                Completed
+            </span>
+
+            <!-- Glassmorphism Badge 3 -->
+            <span class="glass-badge">
+                <span class="dot dot-red"></span>
+                Failed
+            </span>
+        </div>
+
+        <div class="badge-row mt-4">
+            <!-- Glassmorphism Badge with Icon -->
+            <span class="glass-badge badge-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+                Premium Member
+            </span>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-badge-glassmorphism-minimal-pure/style.css
+++ b/submissions/examples/css-badge-glassmorphism-minimal-pure/style.css
@@ -1,0 +1,113 @@
+:root {
+    --text-primary: #111827;
+    --text-muted: #4b5563;
+    
+    --glass-bg: rgba(255, 255, 255, 0.4);
+    --glass-border: rgba(255, 255, 255, 0.6);
+    --glass-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+    
+    --dot-blue: #3b82f6;
+    --dot-green: #10b981;
+    --dot-red: #ef4444;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Inter', sans-serif;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    background-color: #f3f4f6;
+}
+
+/* 
+   Abstract Mesh Background to show off glass effect 
+*/
+.bg-mesh {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background-image: 
+        radial-gradient(at 0% 0%, hsla(253,16%,7%,1) 0, transparent 50%), 
+        radial-gradient(at 50% 0%, hsla(225,39%,30%,1) 0, transparent 50%), 
+        radial-gradient(at 100% 0%, hsla(339,49%,30%,1) 0, transparent 50%);
+    opacity: 0.15;
+    filter: blur(40px);
+}
+
+.container {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+}
+
+.badge-row {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.mt-4 {
+    margin-top: 1rem;
+}
+
+/* 
+   Minimal Glassmorphism Badge 
+*/
+.glass-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 100px; /* Pill shape */
+    
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    
+    /* The Glass Effect */
+    background: var(--glass-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    
+    transition: all 0.2s ease;
+    cursor: default;
+}
+
+.glass-badge:hover {
+    background: rgba(255, 255, 255, 0.6);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+/* Status Dots */
+.dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.dot-blue { background-color: var(--dot-blue); box-shadow: 0 0 8px rgba(59, 130, 246, 0.4); }
+.dot-green { background-color: var(--dot-green); box-shadow: 0 0 8px rgba(16, 185, 129, 0.4); }
+.dot-red { background-color: var(--dot-red); box-shadow: 0 0 8px rgba(239, 68, 68, 0.4); }
+
+/* SVG Icons inside badges */
+.badge-icon svg {
+    width: 14px;
+    height: 14px;
+    color: var(--dot-blue);
+    fill: rgba(59, 130, 246, 0.2);
+}


### PR DESCRIPTION
**Title:** feat: add CSS-only Glassmorphism Badge (Minimal) #80037

**Description:**
This PR introduces a clean, minimalist pure CSS badge component utilizing a bright light-mode glassmorphism aesthetic.

Fixes #80037

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-badge-glassmorphism-minimal-pure/`
- Engineered a "milky-glass" rendering engine utilizing a highly translucent white background (`rgba(255, 255, 255, 0.4)`) combined with `backdrop-filter: blur(12px)`
- Designed a UI-friendly pill architecture (`border-radius: 100px`) tailored for compact dashboard elements
- Implemented built-in colored status dots (Blue, Green, Red) enhanced with matching drop-shadows to provide immediate visual context
- Added a gentle `:hover` micro-interaction that increases the badge's opacity, slightly elevates it on the Y-axis, and deepens the shadow for a tactile feel
- Set up a custom abstract CSS mesh background on the demo file to effectively showcase the glass blur refraction properties
