### PR TITLE
feat: add basic notification channel row demo

### DIFF
--- a/submissions/examples/basic-notification-channel-row-kk/README.md
+++ b/submissions/examples/basic-notification-channel-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Notification Channel Row
+
+## What it does
+
+This submission adds a simple CSS-only notification channel row for account
+settings, onboarding preferences, notification centers, privacy panels, and
+workspace settings screens.
+
+It displays a channel marker, channel label, helper copy, and delivery state in
+one compact row.
+
+## How to use it
+
+Add the base row class with a channel marker, copy, and state pill:
+
+```html
+<article class="basic-notification-channel-row">
+  <span class="channel-mark" aria-hidden="true">@</span>
+  <div class="channel-copy">
+    <strong>Email notifications</strong>
+    <p>Send product updates and security alerts to the primary email.</p>
+  </div>
+  <span class="channel-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common notification and account settings interfaces. The row can be used in
+settings cards, onboarding screens, privacy panels, and preference dashboards
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Active, quiet, and disabled channel states
+- Email, SMS, and in-app channel examples
+- Channel marker, helper copy, and state pill layout
+- Text truncation for long helper copy
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the notification channel row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-notification-channel-row-kk/demo.html
+++ b/submissions/examples/basic-notification-channel-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Notification Channel Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Notification Channel Row</p>
+          <h1>Channel rows for account notification preferences.</h1>
+          <p class="intro">
+            A CSS-only row component for showing notification delivery channels,
+            helper copy, and active, quiet, or disabled states.
+          </p>
+        </header>
+
+        <section class="channel-panel" aria-label="Notification channel row examples">
+          <article class="basic-notification-channel-row">
+            <span class="channel-mark" aria-hidden="true">@</span>
+            <div class="channel-copy">
+              <strong>Email notifications</strong>
+              <p>Send product updates and security alerts to the primary email.</p>
+            </div>
+            <span class="channel-state is-active">Active</span>
+          </article>
+
+          <article class="basic-notification-channel-row">
+            <span class="channel-mark" aria-hidden="true">#</span>
+            <div class="channel-copy">
+              <strong>SMS reminders</strong>
+              <p>Only urgent reminders are delivered during quiet hours.</p>
+            </div>
+            <span class="channel-state is-quiet">Quiet</span>
+          </article>
+
+          <article class="basic-notification-channel-row">
+            <span class="channel-mark" aria-hidden="true">IN</span>
+            <div class="channel-copy">
+              <strong>In-app messages</strong>
+              <p>Workspace tips and promotional messages are disabled.</p>
+            </div>
+            <span class="channel-state is-disabled">Disabled</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-notification-channel-row"&gt;
+  &lt;span class="channel-mark" aria-hidden="true"&gt;@&lt;/span&gt;
+  &lt;div class="channel-copy"&gt;
+    &lt;strong&gt;Email notifications&lt;/strong&gt;
+    &lt;p&gt;Send product updates and security alerts to the primary email.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="channel-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-notification-channel-row-kk/style.css
+++ b/submissions/examples/basic-notification-channel-row-kk/style.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --active: #86efac;
+  --quiet: #fcd34d;
+  --disabled: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 14ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.channel-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-notification-channel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-notification-channel-row + .basic-notification-channel-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-notification-channel-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.channel-mark {
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.85rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.channel-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.channel-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.channel-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.channel-state {
+  flex: 0 0 auto;
+  min-width: 5.7rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.channel-state.is-quiet {
+  color: var(--quiet);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.channel-state.is-disabled {
+  color: var(--disabled);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-notification-channel-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .channel-state {
+    margin-left: 3.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Notification Channel Row demo inside `submissions/examples/basic-notification-channel-row-kk/`. This submission introduces a compact CSS-only row for account settings, onboarding preferences, notification centers, privacy panels, and workspace settings screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only notification channel row that displays a channel marker, channel label, helper copy, and active/quiet/disabled delivery state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-notification-channel-row">
  <span class="channel-mark" aria-hidden="true">@</span>
  <div class="channel-copy">
    <strong>Email notifications</strong>
    <p>Send product updates and security alerts to the primary email.</p>
  </div>
  <span class="channel-state is-active">Active</span>
</article>