### PR TITLE
feat: add basic workspace storage row demo

### DIFF
--- a/submissions/examples/basic-workspace-storage-row-kk/README.md
+++ b/submissions/examples/basic-workspace-storage-row-kk/README.md
@@ -1,0 +1,51 @@
+# Basic Workspace Storage Row
+
+## What it does
+
+This submission adds a simple CSS-only workspace storage row for settings
+pages, admin dashboards, file managers, usage panels, and workspace billing
+screens.
+
+It displays a storage marker, storage label, helper copy, usage progress, and
+storage state in one compact row.
+
+## How to use it
+
+Add the base row class with a marker, copy, progress track, and state:
+
+```html
+<article class="basic-workspace-storage-row">
+  <span class="storage-mark" aria-hidden="true">A</span>
+  <div class="storage-copy">
+    <strong>Assets folder</strong>
+    <p>2.4 GB used from a 10 GB workspace allocation.</p>
+    <span class="storage-track" aria-hidden="true">
+      <span class="storage-fill" style="--value: 24%"></span>
+    </span>
+  </div>
+  <span class="storage-state is-safe">Safe</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+settings, billing, and file-management interfaces. The row can be reused inside
+usage panels, admin dashboards, and storage summaries while staying lightweight
+and CSS-only.
+
+## Included features
+
+- Safe, warning, and full storage states
+- Storage marker, helper copy, progress track, and state pill layout
+- CSS variable-powered usage progress width
+- Text truncation for long storage descriptions
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the workspace storage row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-workspace-storage-row-kk/demo.html
+++ b/submissions/examples/basic-workspace-storage-row-kk/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Workspace Storage Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Workspace Storage Row</p>
+          <h1>Storage rows for workspace settings and file dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing storage usage, helper copy,
+            compact usage states, and a lightweight progress track.
+          </p>
+        </header>
+
+        <section class="storage-panel" aria-label="Workspace storage row examples">
+          <article class="basic-workspace-storage-row">
+            <span class="storage-mark" aria-hidden="true">A</span>
+            <div class="storage-copy">
+              <strong>Assets folder</strong>
+              <p>2.4 GB used from a 10 GB workspace allocation.</p>
+              <span class="storage-track" aria-hidden="true">
+                <span class="storage-fill" style="--value: 24%"></span>
+              </span>
+            </div>
+            <span class="storage-state is-safe">Safe</span>
+          </article>
+
+          <article class="basic-workspace-storage-row">
+            <span class="storage-mark" aria-hidden="true">D</span>
+            <div class="storage-copy">
+              <strong>Design uploads</strong>
+              <p>7.6 GB used from a 10 GB workspace allocation.</p>
+              <span class="storage-track" aria-hidden="true">
+                <span class="storage-fill is-warning" style="--value: 76%"></span>
+              </span>
+            </div>
+            <span class="storage-state is-warning">Warning</span>
+          </article>
+
+          <article class="basic-workspace-storage-row">
+            <span class="storage-mark" aria-hidden="true">L</span>
+            <div class="storage-copy">
+              <strong>Log archive</strong>
+              <p>9.8 GB used from a 10 GB workspace allocation.</p>
+              <span class="storage-track" aria-hidden="true">
+                <span class="storage-fill is-full" style="--value: 98%"></span>
+              </span>
+            </div>
+            <span class="storage-state is-full">Full</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-workspace-storage-row"&gt;
+  &lt;span class="storage-mark" aria-hidden="true"&gt;A&lt;/span&gt;
+  &lt;div class="storage-copy"&gt;
+    &lt;strong&gt;Assets folder&lt;/strong&gt;
+    &lt;p&gt;2.4 GB used from a 10 GB workspace allocation.&lt;/p&gt;
+    &lt;span class="storage-track" aria-hidden="true"&gt;
+      &lt;span class="storage-fill" style="--value: 24%"&gt;&lt;/span&gt;
+    &lt;/span&gt;
+  &lt;/div&gt;
+  &lt;span class="storage-state is-safe"&gt;Safe&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-workspace-storage-row-kk/style.css
+++ b/submissions/examples/basic-workspace-storage-row-kk/style.css
@@ -1,0 +1,201 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --safe: #86efac;
+  --warning: #fcd34d;
+  --full: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--safe);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.storage-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-workspace-storage-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-workspace-storage-row + .basic-workspace-storage-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-workspace-storage-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.storage-mark {
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.85rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--safe);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.storage-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.storage-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.storage-copy p {
+  margin: 0.28rem 0 0.55rem;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.storage-track {
+  height: 0.42rem;
+  overflow: hidden;
+  display: block;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.storage-fill {
+  width: var(--value);
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+  background: var(--safe);
+}
+
+.storage-fill.is-warning {
+  background: var(--warning);
+}
+
+.storage-fill.is-full {
+  background: var(--full);
+}
+
+.storage-state {
+  flex: 0 0 auto;
+  min-width: 5.7rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--safe);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.storage-state.is-warning {
+  color: var(--warning);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.storage-state.is-full {
+  color: var(--full);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 620px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-workspace-storage-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .storage-state {
+    margin-left: 3.7rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Workspace Storage Row demo inside `submissions/examples/basic-workspace-storage-row-kk/`. This submission introduces a compact CSS-only row for settings pages, admin dashboards, file managers, usage panels, and workspace billing screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only workspace storage row that displays a storage marker, label, helper copy, usage progress track, and safe/warning/full state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-workspace-storage-row">
  <span class="storage-mark" aria-hidden="true">A</span>
  <div class="storage-copy">
    <strong>Assets folder</strong>
    <p>2.4 GB used from a 10 GB workspace allocation.</p>
    <span class="storage-track" aria-hidden="true">
      <span class="storage-fill" style="--value: 24%"></span>
    </span>
  </div>
  <span class="storage-state is-safe">Safe</span>
</article>