### PR TITLE
feat: add Multi-Expand Accordion example (accordion-multi-expand-qz9k)

### DIFF
--- a/submissions/examples/accordion-multi-expand-qz9k/README.md
+++ b/submissions/examples/accordion-multi-expand-qz9k/README.md
@@ -1,0 +1,45 @@
+# Multi-Expand Accordion
+
+## What does this do?
+
+An FAQ-style accordion where any number of panels can be open at once,
+built from independent `<details>` elements with no JavaScript needed to
+coordinate their open/closed state.
+
+## How is it used?
+
+```html
+<div class="ame-list">
+  <details class="ame-item" open>
+    <summary class="ame-sum">Question one<span class="ame-chevron" aria-hidden="true"></span></summary>
+    <div class="ame-panel"><p>Answer one.</p></div>
+  </details>
+  <details class="ame-item">
+    <summary class="ame-sum">Question two<span class="ame-chevron" aria-hidden="true"></span></summary>
+    <div class="ame-panel"><p>Answer two.</p></div>
+  </details>
+</div>
+```
+
+Any item can carry the `open` attribute independently; there's no grouping
+mechanism linking the `<details>` elements to each other.
+
+## Why is it useful?
+
+A single-open accordion (only one panel visible at a time) is often built
+from radio inputs sharing one `name`, which structurally *enforces*
+mutual exclusivity — selecting one radio deselects all others in the group.
+That's the wrong foundation for an FAQ page, where a visitor scanning
+several relevant questions should be able to keep multiple answers open
+simultaneously for comparison, rather than having each newly-opened answer
+force-close whatever they had open before. Plain `<details>` elements have
+no such grouping by default, so multi-expand is simply what happens when
+nothing artificially links them — no JS state management, no radio-group
+workaround, and no risk of the "only one open" behavior being
+half-implemented and buggy.
+
+The chevron rotates via a CSS attribute selector (`.ame-item[open]
+.ame-chevron`) reading the same `open` attribute that already drives the
+browser's native show/hide behavior — one native, no-JS toggle produces
+both the content reveal and the icon rotation, kept in sync by
+construction rather than by a script watching for changes.

--- a/submissions/examples/accordion-multi-expand-qz9k/demo.html
+++ b/submissions/examples/accordion-multi-expand-qz9k/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Multi-Expand Accordion</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ame-wrap">
+  <h1 class="ame-h1">FAQ</h1>
+  <p class="ame-lede">Each panel is an independent &lt;details&gt; element, so any number of them can stay open simultaneously -- unlike a single-open accordion built from radio inputs, which structurally allows only one panel open at a time.</p>
+
+  <div class="ame-list">
+    <details class="ame-item" open>
+      <summary class="ame-sum">What payment methods do you accept?<span class="ame-chevron" aria-hidden="true"></span></summary>
+      <div class="ame-panel"><p>We accept all major credit cards, PayPal, and bank transfers for annual plans.</p></div>
+    </details>
+    <details class="ame-item">
+      <summary class="ame-sum">Can I change plans later?<span class="ame-chevron" aria-hidden="true"></span></summary>
+      <div class="ame-panel"><p>Yes, you can upgrade or downgrade at any time from your account settings. Changes take effect on your next billing cycle.</p></div>
+    </details>
+    <details class="ame-item">
+      <summary class="ame-sum">Is there a free trial?<span class="ame-chevron" aria-hidden="true"></span></summary>
+      <div class="ame-panel"><p>Every plan includes a 14-day free trial with full feature access, no credit card required to start.</p></div>
+    </details>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/accordion-multi-expand-qz9k/style.css
+++ b/submissions/examples/accordion-multi-expand-qz9k/style.css
@@ -1,0 +1,81 @@
+/* Multi-Expand Accordion
+   Each <details> is fully independent -- there is no shared "name" grouping
+   them the way radio inputs would need, which is precisely what allows any
+   combination of panels to be open at once with zero JS coordination. */
+
+.ame-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ame-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ame-lede { margin: 0 0 2rem; color: #576073; }
+
+.ame-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ame-item {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+  background: #fbfcfe;
+}
+
+.ame-sum {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  padding: 0.9em 1.1em;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.ame-sum::-webkit-details-marker { display: none; }
+.ame-sum:hover { background: #f1f4fa; }
+.ame-sum:focus-visible { outline: 2px solid #4c6ef5; outline-offset: -2px; }
+
+.ame-chevron {
+  flex: none;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 2px solid #8b93a3;
+  border-bottom: 2px solid #8b93a3;
+  transform: rotate(45deg);
+  transition: transform 200ms ease;
+}
+
+.ame-item[open] .ame-chevron {
+  transform: rotate(-135deg);
+}
+
+.ame-panel {
+  padding: 0 1.1em 1.1em;
+  color: #576073;
+  font-size: 0.94rem;
+}
+
+.ame-panel p { margin: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ame-chevron { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ame-item { border-color: CanvasText; }
+  .ame-chevron { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ame-wrap { color: #e6e9f2; }
+  .ame-lede { color: #99a1b4; }
+  .ame-item { background: #171b23; border-color: #2a303c; }
+  .ame-sum:hover { background: #1e2430; }
+  .ame-panel { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80847

FAQ accordion built from independent <details> elements with no radio-group-style linking, so any number of panels can stay open simultaneously — appropriate for a page where a visitor scanning several questions should be able to compare multiple open answers, unlike a single-open accordion that force-closes the previous panel. Chevron rotation is driven by the same native [open] attribute the browser toggles, kept in sync by construction rather than a script watching for changes.