### PR TITLE
feat: add Numeric Rating Scale example (rating-input-numeric-qz9k)

### DIFF
--- a/submissions/examples/rating-input-numeric-qz9k/README.md
+++ b/submissions/examples/rating-input-numeric-qz9k/README.md
@@ -1,0 +1,39 @@
+# Numeric Rating Scale
+
+## What does this do?
+
+An 11-point (0–10) NPS-style rating scale where clicking a number fills its
+box solid, driven entirely by `:has(input:checked)` on the wrapping label —
+no click handler needed to apply the "selected" visual state.
+
+## How is it used?
+
+```html
+<div class="rin-scale">
+  <label class="rin-num"><input type="radio" name="rin-score" value="7" /><span>7</span></label>
+  <!-- ...0 through 10 -->
+</div>
+```
+
+Every number shares the same radio `name`, so the browser's native radio
+semantics guarantee exactly one can be selected; `.rin-num:has(input:checked)`
+styles whichever label currently wraps the checked radio.
+
+## Why is it useful?
+
+A version of this pattern without `:has()` typically needs a `click`
+listener that removes a "selected" class from every button and adds it to
+the one just clicked — essentially reimplementing radio-group exclusivity
+in JavaScript on top of elements that could have just been real radio
+inputs to begin with. Using actual `<input type="radio">` elements means
+the browser's own radio-group semantics (exactly one checked, arrow-key
+navigation between options once one has focus) apply for free, and
+`:has()` lets the *visual* styling react to that native state without a
+script mirroring it into a separate class.
+
+The visible number lives in a `<span>` alongside the visually-hidden radio
+inside the same `<label>`, rather than as a sibling — that's what makes
+`:has()` able to reach both the input (to check its state) and drive
+styling on the label itself, since `:has()` matches based on descendants,
+and the label is the common ancestor of both the checkbox and its number
+text.

--- a/submissions/examples/rating-input-numeric-qz9k/demo.html
+++ b/submissions/examples/rating-input-numeric-qz9k/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Numeric Rating Scale</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="rin-wrap">
+  <h1 class="rin-h1">How likely are you to recommend us?</h1>
+  <p class="rin-lede">A 0-10 NPS-style scale where the selected number's own background grows to fill the button, driven by :checked on its paired radio -- no JS click handler required to apply the "selected" visual state.</p>
+
+  <fieldset class="rin-field">
+    <legend class="rin-legend">Likelihood to recommend</legend>
+    <div class="rin-scale">
+      <label class="rin-num"><input type="radio" name="rin-score" value="0" /><span>0</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="1" /><span>1</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="2" /><span>2</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="3" /><span>3</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="4" /><span>4</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="5" /><span>5</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="6" /><span>6</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="7" checked /><span>7</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="8" /><span>8</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="9" /><span>9</span></label>
+      <label class="rin-num"><input type="radio" name="rin-score" value="10" /><span>10</span></label>
+    </div>
+    <div class="rin-endpoints">
+      <span>Not likely</span>
+      <span>Very likely</span>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/rating-input-numeric-qz9k/style.css
+++ b/submissions/examples/rating-input-numeric-qz9k/style.css
@@ -1,0 +1,96 @@
+/* Numeric Rating Scale
+   The visible number sits in its own <span>, layered above the radio via
+   the label's grid, so the radio's :checked state can drive the label's
+   background/color through the :has() relationship without needing the
+   number's text node to also be a sibling of the input. */
+
+.rin-wrap {
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.rin-h1 { margin: 0 0 0.4em; font-size: clamp(1.25rem, 4vw, 1.7rem); }
+.rin-lede { margin: 0 0 2rem; color: #576073; }
+
+.rin-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.rin-legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.rin-scale {
+  display: grid;
+  grid-template-columns: repeat(11, 1fr);
+  gap: 0.3rem;
+}
+
+.rin-num {
+  position: relative;
+  display: grid;
+  place-items: center;
+  aspect-ratio: 1;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, color 140ms ease;
+}
+
+.rin-num input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.rin-num:has(input:checked) {
+  background: #4c6ef5;
+  border-color: #4c6ef5;
+  color: #fff;
+}
+
+.rin-num:has(input:focus-visible) {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.rin-num:hover {
+  border-color: #4c6ef5;
+}
+
+.rin-endpoints {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: #8b93a3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rin-num { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .rin-num { border-color: CanvasText; }
+  .rin-num:has(input:checked) { forced-color-adjust: none; background: Highlight; color: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rin-wrap { color: #e6e9f2; }
+  .rin-lede { color: #99a1b4; }
+  .rin-num { border-color: #2a303c; }
+  .rin-endpoints { color: #6b7386; }
+}


### PR DESCRIPTION
Closes #80849

0-10 NPS-style scale where each number is a real radio input sharing one name, giving native radio-group exclusivity and keyboard navigation for free. :has(input:checked) on the wrapping label drives the filled selected style, so there's no click handler manually toggling a 'selected' class across every button — the visual state reacts directly to the same native checked state the browser already manages.