### PR TITLE
feat: add File Upload Drop Zone example (file-upload-drop-zone-qz9k)

### DIFF
--- a/submissions/examples/file-upload-drop-zone-qz9k/README.md
+++ b/submissions/examples/file-upload-drop-zone-qz9k/README.md
@@ -1,0 +1,45 @@
+# File Upload Drop Zone
+
+## What does this do?
+
+A drag-and-drop file upload zone that also works as an ordinary
+click-to-browse file input, using a drag-enter counter (not a boolean) to
+correctly track when the pointer has actually left the zone versus merely
+crossed into a child element inside it.
+
+## How is it used?
+
+```html
+<div class="fdz-zone" ondragenter="fdzDragEnter(event)" ondragover="fdzDragOver(event)"
+     ondragleave="fdzDragLeave(event)" ondrop="fdzDrop(event)">
+  <input type="file" id="fdz-input" class="fdz-input" multiple onchange="fdzHandleFiles(this.files)" />
+  <label for="fdz-input" class="fdz-label">Drag files here or <span class="fdz-browse">browse</span></label>
+</div>
+```
+
+`fdzDepth` increments on every `dragenter` and decrements on every
+`dragleave`; the zone's active styling is only removed once `fdzDepth`
+returns to `0`, and `fdzDrop` resets it unconditionally.
+
+## Why is it useful?
+
+A drop zone with any visual children (the icon, the text, the hint) fires
+its own `dragenter`/`dragleave` pair on *each* child element as the pointer
+moves across them during a drag, because those events bubble and target
+whatever element the pointer is currently over — not just the outer zone.
+A naive implementation using a boolean "is dragging over" flag toggles that
+flag off the instant the pointer crosses from the zone itself onto a child
+element (a `dragleave` on the zone, immediately followed by a `dragenter`
+on the child), which visibly flickers the active-state styling on and off
+as the user drags across the zone's own content. Counting enter/leave pairs
+instead only clears the active state once the *net* count returns to zero
+— i.e., the pointer has genuinely left the zone's entire bounding area, not
+just crossed an internal element boundary.
+
+Keeping the real `<input type="file">` visible-but-transparent
+(`opacity: 0`, stretched to fill the zone) rather than hidden with
+`display: none` and proxied through a JS click on a hidden input means the
+native `<label for>` association and default click-to-browse behavior work
+unmodified — no `.click()` call needed to open the file picker, and no risk
+of that proxy click being blocked by browser popup/file-picker security
+heuristics that sometimes apply to synthetic clicks.

--- a/submissions/examples/file-upload-drop-zone-qz9k/demo.html
+++ b/submissions/examples/file-upload-drop-zone-qz9k/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>File Upload Drop Zone</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var fdzDepth = 0;
+
+  function fdzDragEnter(event) {
+    event.preventDefault();
+    fdzDepth++;
+    document.getElementById('fdz-zone').classList.add('fdz-zone--active');
+  }
+
+  function fdzDragOver(event) {
+    event.preventDefault();
+  }
+
+  function fdzDragLeave(event) {
+    event.preventDefault();
+    fdzDepth = Math.max(0, fdzDepth - 1);
+    if (fdzDepth === 0) {
+      document.getElementById('fdz-zone').classList.remove('fdz-zone--active');
+    }
+  }
+
+  function fdzDrop(event) {
+    event.preventDefault();
+    fdzDepth = 0;
+    document.getElementById('fdz-zone').classList.remove('fdz-zone--active');
+    fdzHandleFiles(event.dataTransfer.files);
+  }
+
+  function fdzHandleFiles(fileList) {
+    var list = document.getElementById('fdz-list');
+    list.innerHTML = '';
+    Array.from(fileList).forEach(function (file) {
+      var li = document.createElement('li');
+      li.className = 'fdz-file';
+      li.textContent = file.name + ' (' + Math.round(file.size / 1024) + ' KB)';
+      list.appendChild(li);
+    });
+  }
+</script>
+</head>
+<body>
+<main class="fdz-wrap">
+  <h1 class="fdz-h1">Upload Files</h1>
+  <p class="fdz-lede">A drag counter (not a boolean flag) tracks nested dragenter/dragleave pairs, since a child element inside the drop zone fires its own leave event when the pointer crosses into it -- a boolean would flip the zone's active state off prematurely.</p>
+
+  <div
+    class="fdz-zone"
+    id="fdz-zone"
+    ondragenter="fdzDragEnter(event)"
+    ondragover="fdzDragOver(event)"
+    ondragleave="fdzDragLeave(event)"
+    ondrop="fdzDrop(event)"
+  >
+    <input type="file" id="fdz-input" class="fdz-input" multiple onchange="fdzHandleFiles(this.files)" aria-describedby="fdz-hint" />
+    <label for="fdz-input" class="fdz-label">
+      <span class="fdz-icon" aria-hidden="true"></span>
+      <span class="fdz-text">Drag files here or <span class="fdz-browse">browse</span></span>
+      <span class="fdz-hint" id="fdz-hint">Up to 10 files, 5MB each</span>
+    </label>
+  </div>
+
+  <ul class="fdz-list" id="fdz-list"></ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/file-upload-drop-zone-qz9k/style.css
+++ b/submissions/examples/file-upload-drop-zone-qz9k/style.css
@@ -1,0 +1,123 @@
+/* File Upload Drop Zone
+   The <input type=file> stays visible-but-transparent and stretched over
+   the whole zone (not display:none) so the label's for/id association and
+   native click-to-browse behavior keep working without any JS click
+   proxying to a hidden input. */
+
+.fdz-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.fdz-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.fdz-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.fdz-zone {
+  position: relative;
+  border: 2px dashed #d3d8e2;
+  border-radius: 0.8rem;
+  padding: 2rem 1.25rem;
+  text-align: center;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.fdz-zone--active {
+  border-color: #4c6ef5;
+  background: #eef2fd;
+}
+
+.fdz-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.fdz-label {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  pointer-events: none;
+}
+
+.fdz-icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 2px solid #a8adba;
+  border-radius: 0.4rem;
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  position: relative;
+}
+
+.fdz-icon::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: -2px;
+  right: -2px;
+  height: 2px;
+  background: #a8adba;
+}
+
+.fdz-text {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.fdz-browse {
+  color: #4c6ef5;
+  text-decoration: underline;
+}
+
+.fdz-hint {
+  font-size: 0.82rem;
+  color: #8b93a3;
+}
+
+.fdz-input:focus-visible ~ .fdz-label {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 4px;
+}
+
+.fdz-list {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.fdz-file {
+  padding: 0.5em 0.75em;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fdz-zone { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .fdz-zone { border-color: CanvasText; }
+  .fdz-zone--active { forced-color-adjust: none; border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fdz-wrap { color: #e6e9f2; }
+  .fdz-lede { color: #99a1b4; }
+  .fdz-zone { border-color: #2a303c; }
+  .fdz-zone--active { background: #1b2138; }
+  .fdz-file { border-color: #2a303c; }
+  .fdz-hint { color: #6b7386; }
+}


### PR DESCRIPTION
Closes #80850

Drag-and-drop file upload zone. A drag-enter counter (incremented on dragenter, decremented on dragleave) tracks nested enter/leave pairs correctly — a boolean flag flickers the active-state styling on and off every time the pointer crosses an internal child element (the icon, the text), since those fire their own bubbling dragenter/dragleave events. The real file input stays visible-but-transparent, not display:none, so native label-for click-to-browse behavior works unmodified with no proxy click needed.