### PR TITLE
feat: add Avatar Group Stack example (avatar-group-stack-qz9k)

### DIFF
--- a/submissions/examples/avatar-group-stack-qz9k/README.md
+++ b/submissions/examples/avatar-group-stack-qz9k/README.md
@@ -1,0 +1,45 @@
+# Avatar Group Stack
+
+## What does this do?
+
+A stack of overlapping avatars (assignee list, participant group) where
+each avatar's resting stacking order is set via `:nth-last-child` rather
+than a hard-coded `z-index` per item, and hovering any avatar brings it
+fully to the front.
+
+## How is it used?
+
+```html
+<ul class="ags-group">
+  <li class="ags-avatar" style="background: #4c6ef5">RK</li>
+  <li class="ags-avatar" style="background: #34a853">CJ</li>
+  <li class="ags-avatar ags-avatar--overflow">+5</li>
+</ul>
+```
+
+Each avatar overlaps the previous one via negative `margin-left`;
+`:nth-last-child(N)` assigns `z-index: N` counting from the *end* of the
+list, so the first avatar in source order (last in the `nth-last-child`
+count) sits on top at rest — the conventional "leftmost avatar is
+frontmost" stacking order.
+
+## Why is it useful?
+
+A hard-coded `z-index` per avatar (`.avatar:nth-child(1) { z-index: 5; }`,
+`.avatar:nth-child(2) { z-index: 4; }`, ...) works but has to be
+re-derived by hand every time an avatar is added, removed, or the group's
+maximum size changes — the numbers only stay correct as long as someone
+remembers to update them in lockstep with the list. `:nth-last-child`
+counts automatically from whichever end of the list is currently present,
+so the same five fixed CSS rules correctly stack any list with up to five
+items without ever needing new numbers written for a different count (a
+group of three avatars still gets correctly-ordered `z-index` from the
+matching `nth-last-child(1)` through `(3)` rules, with the unused
+`(4)`/`(5)` rules simply not matching anything).
+
+`transition: transform 160ms ease, z-index 0s` deliberately gives
+`z-index` a zero-duration transition — `z-index` isn't a value that can be
+meaningfully interpolated over time, so if left un-transitioned it would
+otherwise inherit whatever duration the shorthand `transition: all`
+elsewhere might imply, which can produce a brief, visually confusing
+stacking-order flicker mid-hover in some engines.

--- a/submissions/examples/avatar-group-stack-qz9k/demo.html
+++ b/submissions/examples/avatar-group-stack-qz9k/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Avatar Group Stack</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ags-wrap">
+  <h1 class="ags-h1">Assigned to</h1>
+  <p class="ags-lede">Overlapping avatars stack in reverse source order using z-index derived from a CSS counter, so hovering any avatar brings it and its ring fully in front of its neighbours without a single hard-coded z-index per item.</p>
+
+  <ul class="ags-group">
+    <li class="ags-avatar" style="background: #4c6ef5">RK</li>
+    <li class="ags-avatar" style="background: #34a853">CJ</li>
+    <li class="ags-avatar" style="background: #e0483f">JM</li>
+    <li class="ags-avatar" style="background: #a855f7">AV</li>
+    <li class="ags-avatar ags-avatar--overflow">+5</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/avatar-group-stack-qz9k/style.css
+++ b/submissions/examples/avatar-group-stack-qz9k/style.css
@@ -1,0 +1,76 @@
+/* Avatar Group Stack
+   Each avatar's resting z-index counts DOWN from the total item count using
+   nth-last-child, so the first avatar in source order sits visually on top
+   at rest (a common stacking convention) without a single z-index number
+   hard-coded per avatar -- adding or removing avatars never requires
+   renumbering anything. */
+
+.ags-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ags-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ags-lede { margin: 0 0 1.75rem; color: #576073; }
+
+.ags-group {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ags-avatar {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  margin-left: -0.7rem;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  transition: transform 160ms ease, z-index 0s;
+  cursor: default;
+}
+
+.ags-avatar:first-child {
+  margin-left: 0;
+}
+
+.ags-avatar:nth-last-child(1) { z-index: 1; }
+.ags-avatar:nth-last-child(2) { z-index: 2; }
+.ags-avatar:nth-last-child(3) { z-index: 3; }
+.ags-avatar:nth-last-child(4) { z-index: 4; }
+.ags-avatar:nth-last-child(5) { z-index: 5; }
+
+.ags-avatar:hover {
+  transform: translateY(-0.3rem);
+  z-index: 10;
+}
+
+.ags-avatar--overflow {
+  background: #eceff4;
+  color: #576073;
+  font-size: 0.72rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ags-avatar { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ags-avatar { forced-color-adjust: none; border-color: Canvas; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ags-wrap { color: #e6e9f2; }
+  .ags-lede { color: #99a1b4; }
+  .ags-avatar { border-color: #0f1218; }
+  .ags-avatar--overflow { background: #2a303c; color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80851

Overlapping avatar stack whose resting z-index comes from :nth-last-child(N) rather than a hard-coded z-index per avatar — the count is derived automatically from however many avatars are actually in the list, so adding/removing one never requires renumbering the rest. z-index gets an explicit 0s transition duration since it isn't a value that can be meaningfully interpolated, avoiding a stacking-order flicker mid-hover some engines produce if it inherits a longer duration from a shorthand transition.