### PR TITLE
feat: add Segmented Progress Bar example (segmented-progress-bar-qz9k)

### DIFF
--- a/submissions/examples/segmented-progress-bar-qz9k/README.md
+++ b/submissions/examples/segmented-progress-bar-qz9k/README.md
@@ -1,0 +1,46 @@
+# Segmented Progress Bar
+
+## What does this do?
+
+A step-based progress bar (onboarding flow, multi-part form) made of
+discrete segments — one per step — rather than one continuous bar filled
+to a percentage, so progress reads as a step count rather than an ambiguous
+fraction.
+
+## How is it used?
+
+```html
+<div class="spb-bar" role="progressbar" aria-valuemin="0" aria-valuemax="5" aria-valuenow="2">
+  <span class="spb-seg spb-seg--done"></span>
+  <span class="spb-seg spb-seg--done"></span>
+  <span class="spb-seg spb-seg--current"></span>
+  <span class="spb-seg"></span>
+  <span class="spb-seg"></span>
+</div>
+```
+
+Each `<span>` is `flex: 1`, so the bar always divides evenly across
+however many segments are present — a 3-step flow and an 8-step flow both
+render correctly from the same CSS, with the step count coming from how
+many `.spb-seg` elements exist in markup.
+
+## Why is it useful?
+
+A single continuous bar filled to a percentage (`width: 40%`) communicates
+*how much* progress has been made but not *how many discrete steps*
+remain — 40% could mean "2 of 5 steps" or "4 of 10 steps," and users
+scanning a progress bar for "how much further do I have to go" often care
+about the step count specifically, not the fraction. Rendering one segment
+per actual step makes the step count itself the visual information: a
+5-segment bar with 2 filled unambiguously reads as "2 done, 3 to go,"
+which a percentage-filled bar can't convey without an accompanying text
+label doing the real communication anyway.
+
+The current step gets its own partial-fill treatment
+(`.spb-seg--current::before` at a fixed 55% width) distinct from both
+"done" (fully filled) and "not yet reached" (empty), giving a three-state
+visual — complete, in-progress, upcoming — that a binary filled/unfilled
+segment can't represent on its own. `role="progressbar"` with
+`aria-valuemax` set to the actual step count (not 100) keeps the
+accessible value semantically aligned with what's visually shown: "2 of 5,"
+not "40 of 100."

--- a/submissions/examples/segmented-progress-bar-qz9k/demo.html
+++ b/submissions/examples/segmented-progress-bar-qz9k/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Segmented Progress Bar</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="spb-wrap">
+  <h1 class="spb-h1">Onboarding</h1>
+  <p class="spb-lede">Each step is its own segment with a hairline gap between them, rather than one continuous bar -- so partial progress reads as "2 of 5 steps done," not an ambiguous percentage that could represent many different underlying step counts.</p>
+
+  <div class="spb-bar" role="progressbar" aria-valuemin="0" aria-valuemax="5" aria-valuenow="2" aria-label="Onboarding progress">
+    <span class="spb-seg spb-seg--done"></span>
+    <span class="spb-seg spb-seg--done"></span>
+    <span class="spb-seg spb-seg--current"></span>
+    <span class="spb-seg"></span>
+    <span class="spb-seg"></span>
+  </div>
+  <p class="spb-status">Step 3 of 5: Connect your calendar</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/segmented-progress-bar-qz9k/style.css
+++ b/submissions/examples/segmented-progress-bar-qz9k/style.css
@@ -1,0 +1,66 @@
+/* Segmented Progress Bar
+   Segments are flex:1 so the bar always divides evenly across however many
+   step elements are present in markup -- the segment count is read from
+   the DOM, not from a hard-coded CSS rule that would need updating if the
+   onboarding flow's step count changes. */
+
+.spb-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.spb-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.spb-lede { margin: 0 0 1.75rem; color: #576073; }
+
+.spb-bar {
+  display: flex;
+  gap: 0.3rem;
+  height: 0.4rem;
+}
+
+.spb-seg {
+  flex: 1;
+  border-radius: 999px;
+  background: #e4e7ef;
+  overflow: hidden;
+  position: relative;
+}
+
+.spb-seg--done {
+  background: #34a853;
+}
+
+.spb-seg--current {
+  background: #e4e7ef;
+}
+
+.spb-seg--current::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 55%;
+  background: #4c6ef5;
+  border-radius: inherit;
+}
+
+.spb-status {
+  margin: 0.6rem 0 0;
+  font-size: 0.88rem;
+  color: #576073;
+}
+
+@media (forced-colors: active) {
+  .spb-seg { forced-color-adjust: none; background: Canvas; border: 1px solid CanvasText; }
+  .spb-seg--done { background: Highlight; }
+  .spb-seg--current::before { background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .spb-wrap { color: #e6e9f2; }
+  .spb-lede { color: #99a1b4; }
+  .spb-seg { background: #2a303c; }
+  .spb-status { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80852

Step-based progress bar with one flex:1 segment per step (segment count comes from however many elements are in markup) instead of one continuous bar filled to a percentage — a percentage alone can't distinguish '2 of 5' from '4 of 10,' which matters to users scanning for how many discrete steps remain. Current step gets a distinct partial-fill treatment separate from done/upcoming, and aria-valuemax is set to the real step count rather than 100 so the accessible value matches what's visually shown.