### PR TITLE
feat: add tag-pill Sass mixins (tag-pill-qz9k)

### DIFF
--- a/submissions/scss/tag-pill-qz9k/README.md
+++ b/submissions/scss/tag-pill-qz9k/README.md
@@ -1,0 +1,82 @@
+# tag-pill-qz9k
+
+Sass mixins for tag/pill badges deriving both a tinted background and a
+readable text colour from a single accent colour, plus a solid-fill
+variant.
+
+## Usage
+
+```scss
+@use 'tag-pill' as *;
+
+.tag-bug { @include tag-pill(#e0483f); }
+.tag-feature { @include tag-pill(#34a853); }
+
+.status-badge--live { @include tag-pill-solid(#f5a623); }
+```
+
+| Mixin | Look |
+|---|---|
+| `tag-pill($accent)` | Light tinted background, darkened accent text. |
+| `tag-pill-solid($accent)` | Solid accent background, auto black/white text. |
+
+## Why is it useful?
+
+A tag system with many categories (bug/feature/docs labels, status
+badges) usually wants each category to have a distinct colour, which means
+picking a background/text pair *per tag* — and it's easy for one of those
+pairs to end up with poor contrast if picked independently by eye, since a
+colour that looks fine as an accent doesn't automatically produce readable
+text against a background derived from it. `tag-pill` sidesteps
+per-tag colour picking entirely: given one accent colour, `color.mix($accent,
+white, 15%)` produces a light, low-saturation tint for the background, and
+`color.adjust($accent, $lightness: -12%)` darkens the same accent for the
+text — both derived from one input, so every tag automatically gets a
+background/text pairing with a consistent, reasonable contrast
+relationship regardless of which accent colour is chosen.
+
+`tag-pill-solid` picks between black and white text automatically based on
+the accent's own lightness channel (read via `color.channel($accent,
+"lightness", $space: hsl)` — light accents like `#f5a623` get dark text;
+dark accents get white text), rather than requiring a second colour
+parameter — a caller only ever supplies the one accent colour they
+actually care about, and the mixin works out what's readable against it.
+
+## The 60% lightness threshold is a heuristic, not a guarantee
+
+Picking black-or-white text based on a single lightness threshold is a
+reasonable default that works for most saturated accent colours, but it's
+a heuristic, not a WCAG contrast guarantee — a colour near the 60%
+boundary, or a low-saturation colour whose perceived brightness doesn't
+track its HSL lightness value closely, can still land on a text/background
+pairing with borderline contrast. For a design system with strict
+accessibility requirements, verify contrast on the actual accent palette
+in use (rather than trusting the threshold blindly for arbitrary future
+accent colours), or use `tag-pill` (the tinted variant) instead, which
+always pairs a light background with darkened text of the same hue and
+tends to land in a safer contrast range across a wider variety of inputs.
+
+## Extending with a border for low-contrast environments
+
+Both mixins can be paired with a subtle border to keep the pill's edge
+distinguishable from its surroundings under `forced-colors` or a
+high-contrast OS theme, since `background`/`color` alone can be overridden
+entirely by a forced-colors palette:
+
+```scss
+.tag-status {
+  @include tag-pill-solid(#34a853);
+
+  @media (forced-colors: active) {
+    forced-color-adjust: none;
+    border: 1px solid CanvasText;
+  }
+}
+```
+
+## Usage in a filterable tag list
+
+Combined with the `useArray`/`toggle` pattern from `use-array-qz9k`, these
+mixins pair naturally with a multi-select tag filter where each tag's pill
+colour also communicates its category at a glance, independent of whether
+it's currently selected.

--- a/submissions/scss/tag-pill-qz9k/_tag-pill.scss
+++ b/submissions/scss/tag-pill-qz9k/_tag-pill.scss
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// tag-pill-qz9k
+// A tag/pill mixin whose text and background colours are both derived from
+// one accent colour via Sass colour functions, so a caller supplies one
+// value and gets an accessible-contrast pairing rather than picking two
+// colours that might fail contrast against each other.
+// ---------------------------------------------------------------------------
+
+@use 'sass:color';
+
+@mixin tag-pill($accent: #4c6ef5) {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25em 0.7em;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+
+  // A light tint of the accent as background, with the accent itself
+  // darkened for text -- keeps contrast reasonable across a wide range of
+  // input accent colours without per-tag manual tuning.
+  background: color.mix($accent, white, 15%);
+  color: color.adjust($accent, $lightness: -12%);
+}
+
+@mixin tag-pill-solid($accent: #4c6ef5) {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25em 0.7em;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+  background: $accent;
+
+  @if color.channel($accent, "lightness", $space: hsl) > 60% {
+    color: #1c2028;
+  } @else {
+    color: #fff;
+  }
+}
+
+.tag-pill-demo {
+  @include tag-pill(#4c6ef5);
+}
+
+.tag-pill-demo--solid {
+  @include tag-pill-solid(#f5a623);
+}


### PR DESCRIPTION
Closes #80857

Tag/pill mixins deriving both background and text colour from one accent colour via color.mix/color.adjust rather than requiring two independently hand-picked colours per tag, which risks poor contrast when picked by eye. The solid variant auto-selects black or white text based on the accent's own lightness channel via color.channel(). README notes the lightness threshold is a heuristic, not a WCAG guarantee, and recommends verifying contrast on the actual palette in use.