### PR TITLE
feat: add Right-Click Context Menu example (context-menu-right-click-qz9k)

### DIFF
--- a/submissions/examples/context-menu-right-click-qz9k/README.md
+++ b/submissions/examples/context-menu-right-click-qz9k/README.md
@@ -1,0 +1,41 @@
+# Right-Click Context Menu
+
+## What does this do?
+
+A custom context menu triggered by right-click (`contextmenu` event),
+positioned at the click location and clamped so it never renders partially
+off-screen near the viewport's right or bottom edge.
+
+## How is it used?
+
+```html
+<div class="cmr-target" oncontextmenu="cmrOpen(event)">Right-click here</div>
+<ul class="cmr-menu" id="cmr-menu" role="menu" hidden>
+  <li role="none"><button role="menuitem" class="cmr-item" onclick="cmrClose()">Rename</button></li>
+</ul>
+```
+
+`cmrOpen` calls `event.preventDefault()` to suppress the browser's native
+context menu, computes a clamped `x`/`y` from `event.clientX`/`clientY`
+against `window.innerWidth`/`innerHeight`, and moves focus to the menu's
+first item.
+
+## Why is it useful?
+
+A context menu positioned directly at the raw click coordinates
+(`left: event.clientX; top: event.clientY`) looks correct for most clicks
+but breaks the moment the user right-clicks near the edge of the browser
+window — the menu renders partially or fully off-screen, with no way to
+reach the cut-off items. Clamping both coordinates against the viewport
+dimensions (minus the menu's own width/height) keeps the menu fully visible
+regardless of where in the viewport the click landed, which a
+CSS-only `position: fixed` with static coordinates can't do on its own
+since CSS has no way to read the click position or the viewport bounds at
+declaration time.
+
+The menu closes on both an outside click and `Escape`, and moves focus to
+its first `role="menuitem"` on open — closing behavior alone (without the
+focus move) leaves a keyboard user's focus stuck on whatever element they
+right-clicked, with no way to reach the newly-opened menu without first
+tabbing away and back. `role="menu"`/`role="menuitem"` mark the structure
+for assistive technology as an actual menu widget, not just a styled list.

--- a/submissions/examples/context-menu-right-click-qz9k/demo.html
+++ b/submissions/examples/context-menu-right-click-qz9k/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Right-Click Context Menu</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var cmrOpenMenu = null;
+
+  function cmrOpen(event) {
+    event.preventDefault();
+    var menu = document.getElementById('cmr-menu');
+
+    // Clamp position so the menu never renders partially off-screen when
+    // the click lands near the right or bottom edge of the viewport.
+    var menuWidth = 180;
+    var menuHeight = 148;
+    var x = Math.min(event.clientX, window.innerWidth - menuWidth - 8);
+    var y = Math.min(event.clientY, window.innerHeight - menuHeight - 8);
+
+    menu.style.left = x + 'px';
+    menu.style.top = y + 'px';
+    menu.hidden = false;
+    cmrOpenMenu = menu;
+    menu.querySelector('[role="menuitem"]').focus();
+    document.addEventListener('click', cmrCloseOnOutsideClick);
+    document.addEventListener('keydown', cmrKeydown);
+  }
+
+  function cmrClose() {
+    if (!cmrOpenMenu) return;
+    cmrOpenMenu.hidden = true;
+    cmrOpenMenu = null;
+    document.removeEventListener('click', cmrCloseOnOutsideClick);
+    document.removeEventListener('keydown', cmrKeydown);
+  }
+
+  function cmrCloseOnOutsideClick(event) {
+    if (cmrOpenMenu && !cmrOpenMenu.contains(event.target)) cmrClose();
+  }
+
+  function cmrKeydown(event) {
+    if (event.key === 'Escape') cmrClose();
+  }
+</script>
+</head>
+<body>
+<main class="cmr-wrap">
+  <h1 class="cmr-h1">Right-Click Context Menu</h1>
+  <p class="cmr-lede">Right-clicking the panel below opens a custom menu clamped to stay within the viewport; clicking outside it or pressing Escape closes it, and focus moves to the first item on open.</p>
+
+  <div class="cmr-target" oncontextmenu="cmrOpen(event)" tabindex="0">
+    Right-click anywhere in this panel
+  </div>
+
+  <ul class="cmr-menu" id="cmr-menu" role="menu" hidden>
+    <li role="none"><button type="button" role="menuitem" class="cmr-item" onclick="cmrClose()">Rename</button></li>
+    <li role="none"><button type="button" role="menuitem" class="cmr-item" onclick="cmrClose()">Duplicate</button></li>
+    <li role="none"><hr class="cmr-sep" /></li>
+    <li role="none"><button type="button" role="menuitem" class="cmr-item cmr-item--danger" onclick="cmrClose()">Delete</button></li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/context-menu-right-click-qz9k/style.css
+++ b/submissions/examples/context-menu-right-click-qz9k/style.css
@@ -1,0 +1,91 @@
+/* Right-Click Context Menu
+   The menu is position:fixed with its left/top set directly from clamped
+   pointer coordinates in JS, rather than being anchored via CSS to the
+   target element -- a context menu's position is defined by where the
+   click happened, not by the geometry of what was clicked. */
+
+.cmr-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.cmr-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.cmr-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.cmr-target {
+  padding: 3rem 1rem;
+  border: 2px dashed #d3d8e2;
+  border-radius: 0.7rem;
+  text-align: center;
+  color: #576073;
+  user-select: none;
+}
+
+.cmr-target:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.cmr-menu {
+  position: fixed;
+  z-index: 50;
+  width: 11.25rem;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.6rem;
+  box-shadow: 0 10px 24px rgba(28, 32, 40, 0.16);
+}
+
+.cmr-item {
+  display: block;
+  width: 100%;
+  padding: 0.5em 0.65em;
+  border: none;
+  border-radius: 0.35rem;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.cmr-item:hover,
+.cmr-item:focus-visible {
+  background: #f1f4fa;
+  outline: none;
+}
+
+.cmr-item--danger {
+  color: #e0483f;
+}
+
+.cmr-item--danger:hover,
+.cmr-item--danger:focus-visible {
+  background: #fdecea;
+}
+
+.cmr-sep {
+  margin: 0.3rem 0.2rem;
+  border: none;
+  border-top: 1px solid #eceff4;
+}
+
+@media (forced-colors: active) {
+  .cmr-menu { border-color: CanvasText; }
+  .cmr-item:hover, .cmr-item:focus-visible { forced-color-adjust: none; background: Highlight; color: HighlightText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cmr-wrap { color: #e6e9f2; }
+  .cmr-lede { color: #99a1b4; }
+  .cmr-target { border-color: #2a303c; color: #99a1b4; }
+  .cmr-menu { background: #171b23; border-color: #2a303c; }
+  .cmr-item { color: #e6e9f2; }
+  .cmr-item:hover, .cmr-item:focus-visible { background: #1e2430; }
+  .cmr-sep { border-color: #2a303c; }
+}


### PR DESCRIPTION
Closes #80884

Custom contextmenu handler that preventDefaults the native browser menu and positions a custom one at the click coordinates, clamped against window.innerWidth/innerHeight minus the menu's own dimensions so it never renders partially off-screen near an edge. Closes on outside click and Escape, and moves focus to the first role=menuitem on open — without that focus move, a keyboard user right-clicking has no way to reach the newly-opened menu without tabbing away first.