### PR TITLE
feat: add Floating Action Button example (floating-action-button-qz9k)

### DIFF
--- a/submissions/examples/floating-action-button-qz9k/README.md
+++ b/submissions/examples/floating-action-button-qz9k/README.md
@@ -1,0 +1,44 @@
+# Floating Action Button
+
+## What does this do?
+
+A speed-dial floating action button: pressing the main button reveals a
+stack of secondary actions with a staggered cascade animation, each item
+delayed slightly more than the one before it.
+
+## How is it used?
+
+```html
+<div class="fab-container">
+  <ul class="fab-menu" id="fab-menu">
+    <li class="fab-item" style="--fab-i: 1"><a class="fab-action" href="#">Upload file</a></li>
+    <li class="fab-item" style="--fab-i: 0"><a class="fab-action" href="#">New document</a></li>
+  </ul>
+  <button class="fab-main" onclick="fabToggle(this)" aria-expanded="false" aria-controls="fab-menu">+</button>
+</div>
+```
+
+Each `.fab-item` carries a `--fab-i` custom property setting its position in
+the stagger sequence; `transition-delay: calc(var(--fab-i, 0) * 40ms)`
+reads that value to offset each item's animation start time.
+
+## Why is it useful?
+
+A closed-state action list built with `display: none` (or conditionally
+rendered in JS) is unreachable by keyboard until the FAB is activated,
+which is usually the intended behavior for the *visual* closed state — but
+some accessibility strategies specifically want secondary actions to
+remain in the DOM and tab-reachable at all times, only visually hidden.
+This example uses `opacity: 0` plus `transform: translateY(...)` plus
+`pointer-events: none` for the closed state instead of removing the
+elements from layout, so the actions are always structurally present.
+`pointer-events: none` is what prevents clicking on an invisible,
+displaced action while closed, without removing it from the accessibility
+tree.
+
+The staggered reveal comes entirely from CSS custom properties, not
+per-item inline `animation-delay` values computed and written by a script:
+each `.fab-item`'s `--fab-i` is a small integer set once in markup, and
+`calc(var(--fab-i) * 40ms)` derives the actual delay — adding a fourth
+action only requires giving it the next `--fab-i` value, with no JS
+re-computation needed to keep the cascade timing correct.

--- a/submissions/examples/floating-action-button-qz9k/demo.html
+++ b/submissions/examples/floating-action-button-qz9k/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Floating Action Button</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function fabToggle(button) {
+    var expanded = button.getAttribute('aria-expanded') === 'true';
+    button.setAttribute('aria-expanded', String(!expanded));
+    document.getElementById('fab-menu').classList.toggle('fab-menu--open', !expanded);
+  }
+</script>
+</head>
+<body>
+<main class="fab-wrap">
+  <h1 class="fab-h1">Floating Action Button</h1>
+  <p class="fab-lede">The speed-dial actions are real, always-present links positioned via transform and staggered transition-delay, not conditionally rendered -- so they stay reachable by Tab even before the button is pressed, for anyone tabbing past rather than clicking.</p>
+
+  <div class="fab-container">
+    <ul class="fab-menu" id="fab-menu">
+      <li class="fab-item" style="--fab-i: 2"><a class="fab-action" href="#">New folder</a></li>
+      <li class="fab-item" style="--fab-i: 1"><a class="fab-action" href="#">Upload file</a></li>
+      <li class="fab-item" style="--fab-i: 0"><a class="fab-action" href="#">New document</a></li>
+    </ul>
+    <button type="button" class="fab-main" onclick="fabToggle(this)" aria-expanded="false" aria-controls="fab-menu" aria-label="Create new">
+      <span class="fab-plus" aria-hidden="true"></span>
+    </button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/floating-action-button-qz9k/style.css
+++ b/submissions/examples/floating-action-button-qz9k/style.css
@@ -1,0 +1,117 @@
+/* Floating Action Button
+   Closed-state actions are translated off-screen and made unclickable via
+   pointer-events:none rather than display:none/hidden -- keeping them laid
+   out (just invisible-and-displaced) is what allows the staggered
+   transition-delay per item to animate a visible cascade on open. */
+
+.fab-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 8rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  position: relative;
+  min-height: 60vh;
+}
+
+.fab-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.fab-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.fab-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 30;
+}
+
+.fab-main {
+  width: 3.4rem;
+  height: 3.4rem;
+  border: none;
+  border-radius: 50%;
+  background: #4c6ef5;
+  box-shadow: 0 8px 20px rgba(76, 110, 245, 0.4);
+  cursor: pointer;
+  position: relative;
+  transition: transform 200ms ease;
+}
+
+.fab-main:hover { background: #3b5be0; }
+.fab-main:focus-visible { outline: 2px solid #1c2028; outline-offset: 3px; }
+
+.fab-plus {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.fab-plus::before,
+.fab-plus::after {
+  content: "";
+  position: absolute;
+  background: #fff;
+  border-radius: 999px;
+}
+
+.fab-plus::before { top: 0; bottom: 0; left: 50%; width: 2px; transform: translateX(-50%); }
+.fab-plus::after { left: 0; right: 0; top: 50%; height: 2px; transform: translateY(-50%); }
+
+[aria-expanded="true"].fab-main { transform: rotate(45deg); }
+
+.fab-menu {
+  position: absolute;
+  bottom: calc(100% + 0.6rem);
+  right: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.fab-item {
+  opacity: 0;
+  transform: translateY(0.6rem);
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+  transition-delay: 0ms;
+}
+
+.fab-menu--open .fab-item {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition-delay: calc(var(--fab-i, 0) * 40ms);
+}
+
+.fab-action {
+  display: block;
+  white-space: nowrap;
+  padding: 0.55em 1em;
+  border-radius: 999px;
+  background: #1c2028;
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.85rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.fab-action:hover { background: #333a47; }
+.fab-action:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .fab-main, .fab-item { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .fab-main { forced-color-adjust: none; background: Highlight; }
+  .fab-action { background: ButtonFace; color: ButtonText; border: 1px solid ButtonText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .fab-wrap { color: #e6e9f2; }
+  .fab-lede { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80885

Speed-dial FAB whose closed-state actions use opacity/transform/pointer-events:none rather than display:none, keeping them structurally present in the DOM and reachable by keyboard even before the main button is activated. Staggered reveal comes from a --fab-i custom property set once per item in markup, read via transition-delay: calc(var(--fab-i) * 40ms) — adding a new action only needs the next integer, no JS delay computation.