### PR TITLE
feat: add Flip Info Card example (card-flip-info-qz9k)

### DIFF
--- a/submissions/examples/card-flip-info-qz9k/README.md
+++ b/submissions/examples/card-flip-info-qz9k/README.md
@@ -1,0 +1,43 @@
+# Flip Info Card
+
+## What does this do?
+
+A team-member card that flips to reveal a bio on the back, driven by a
+checkbox's `:checked` state — no JavaScript, and both faces are real,
+always-present markup rather than content swapped in on flip.
+
+## How is it used?
+
+```html
+<label class="cfi-card">
+  <input type="checkbox" class="cfi-toggle" aria-label="Flip card to see bio" />
+  <div class="cfi-inner">
+    <div class="cfi-face cfi-face--front">...</div>
+    <div class="cfi-face cfi-face--back">...</div>
+  </div>
+</label>
+```
+
+The checkbox lives inside the same `<label>` as the card, so clicking
+anywhere on the card toggles it; `.cfi-inner` rotates 180° on `:checked`,
+and `.cfi-face--back` is pre-rotated 180° at rest so it lands right-side-up
+once the shared rotation completes.
+
+## Why is it useful?
+
+A flip card whose back content is only inserted into the DOM (or made
+visible) after a click means that content is invisible to a screen reader
+that hasn't triggered the flip, and invisible to the browser's native
+find-in-page search regardless of interaction — both real accessibility
+and discoverability gaps compared to content that's simply present but
+visually rotated away. Because both faces here are real, always-rendered
+elements (just facing away via `backface-visibility: hidden` before the
+flip), the back text exists in the DOM from page load, reachable by
+find-in-page and by a screen reader's virtual cursor navigating the page
+linearly, independent of the visual flip state.
+
+Using a checkbox (rather than a `button` with a JS-toggled class) means
+the flip state is real form state — reachable via Tab, toggleable with
+Space, and stateful in a way that persists correctly if the card is part of
+a form that gets serialized, none of which a purely visual class-based
+toggle provides without extra work.

--- a/submissions/examples/card-flip-info-qz9k/demo.html
+++ b/submissions/examples/card-flip-info-qz9k/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Flip Info Card</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="cfi-wrap">
+  <h1 class="cfi-h1">Team Member</h1>
+  <p class="cfi-lede">A checkbox drives the flip via :checked, and both card faces are real, always-present content -- so the back face's text is reachable by a screen reader and by find-in-page even before the card is flipped, unlike content injected only on flip.</p>
+
+  <label class="cfi-card">
+    <input type="checkbox" class="cfi-toggle" aria-label="Flip card to see bio" />
+    <div class="cfi-inner">
+      <div class="cfi-face cfi-face--front">
+        <div class="cfi-avatar" aria-hidden="true">RM</div>
+        <p class="cfi-name">Riley Moreno</p>
+        <p class="cfi-role">Product Designer</p>
+        <p class="cfi-hint">Click to flip</p>
+      </div>
+      <div class="cfi-face cfi-face--back">
+        <p class="cfi-bio">Riley has spent the last six years designing developer tools, with a focus on making complex configuration screens feel approachable.</p>
+        <p class="cfi-hint">Click to flip back</p>
+      </div>
+    </div>
+  </label>
+</main>
+</body>
+</html>

--- a/submissions/examples/card-flip-info-qz9k/style.css
+++ b/submissions/examples/card-flip-info-qz9k/style.css
@@ -1,0 +1,105 @@
+/* Flip Info Card
+   .cfi-face--back is rotateY(180deg) at rest, so once the shared .cfi-inner
+   rotates 180deg on :checked, the back face lands right-side-up while the
+   front face (rotated along with its parent) ends up backface-hidden --
+   two faces, one shared rotation, no JS swapping which content renders. */
+
+.cfi-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.cfi-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.cfi-lede { margin: 0 0 2rem; color: #576073; }
+
+.cfi-card {
+  display: block;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.cfi-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.cfi-inner {
+  position: relative;
+  height: 14rem;
+  transform-style: preserve-3d;
+  transition: transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.cfi-toggle:checked ~ .cfi-inner {
+  transform: rotateY(180deg);
+}
+
+.cfi-toggle:focus-visible ~ .cfi-inner {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 4px;
+}
+
+.cfi-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.8rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  background: #fbfcfe;
+}
+
+.cfi-face--back {
+  transform: rotateY(180deg);
+  justify-content: center;
+}
+
+.cfi-avatar {
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 50%;
+  background: #4c6ef5;
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  margin-bottom: 0.8rem;
+}
+
+.cfi-name { margin: 0; font-weight: 700; }
+.cfi-role { margin: 0.2rem 0 0; color: #576073; font-size: 0.88rem; }
+.cfi-bio { margin: 0; font-size: 0.9rem; color: #576073; }
+
+.cfi-hint {
+  margin: auto 0 0;
+  padding-top: 0.8rem;
+  font-size: 0.75rem;
+  color: #a8adba;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cfi-inner { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .cfi-face { border-color: CanvasText; }
+  .cfi-avatar { forced-color-adjust: none; background: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cfi-wrap { color: #e6e9f2; }
+  .cfi-lede { color: #99a1b4; }
+  .cfi-face { background: #171b23; border-color: #2a303c; }
+  .cfi-role, .cfi-bio { color: #99a1b4; }
+  .cfi-hint { color: #4a5266; }
+}


### PR DESCRIPTION
Closes #80886

Checkbox-driven 3D flip card. Both faces are real, always-rendered elements (backface-visibility:hidden until rotated into view), not content swapped in on flip — so the back face's bio text exists in the DOM from page load, reachable by find-in-page and a screen reader's linear reading order regardless of the current flip state. Using a checkbox rather than a button+JS class also gives the flip state real, Tab-reachable, Space-toggleable form semantics.