### PR TITLE
feat: add Notification Badge Count example (notification-badge-count-qz9k)

### DIFF
--- a/submissions/examples/notification-badge-count-qz9k/README.md
+++ b/submissions/examples/notification-badge-count-qz9k/README.md
@@ -1,0 +1,46 @@
+# Notification Badge Count
+
+## What does this do?
+
+An unread-count badge on a notification bell that truncates its *display*
+to "99+" above 99, while keeping the exact underlying number in a
+`data-count` attribute for any logic that needs the real value rather than
+the display string.
+
+## How is it used?
+
+```html
+<button class="nbc-bell" id="nbc-bell" aria-label="Notifications">
+  <span class="nbc-badge" id="nbc-badge" data-count="3">3</span>
+</button>
+```
+
+```js
+nbcSet(count); // updates both the truncated display text and data-count
+```
+
+`nbcSet` writes `count > 99 ? '99+' : count` as the badge's visible text,
+but always stores the real number in `data-count` — `nbcBump` reads that
+attribute back (not the possibly-truncated `textContent`) to compute the
+next increment correctly even once the display has already switched to
+"99+".
+
+## Why is it useful?
+
+Once a badge starts displaying a capped "99+" label, any code that later
+needs the actual count — deciding whether polling should continue, sending
+an analytics event with the real unread total, incrementing on a new
+notification — breaks if it reads that value back from the badge's own
+`textContent`, since `parseInt('99+')` either produces `99` (wrong, if the
+real count is higher) or `NaN` depending on how it's parsed. Keeping the
+true integer in a separate `data-count` attribute, untouched by the display
+truncation, means the visual "99+" cap never leaks into logic that needs
+the exact number.
+
+The badge's `aria-label` on the parent button is also recomputed on every
+count change ("3 unread notifications", "1 unread notification", or plain
+"Notifications" at zero) rather than left static — a screen reader user
+landing on the bell hears the actual current count, not a generic
+"Notifications, badge 3" announcement that depends on the badge's visual
+text being read out correctly (badges are frequently `aria-hidden` or
+otherwise skipped, which this label doesn't depend on).

--- a/submissions/examples/notification-badge-count-qz9k/demo.html
+++ b/submissions/examples/notification-badge-count-qz9k/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Notification Badge Count</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function nbcSet(count) {
+    var badge = document.getElementById('nbc-badge');
+    var display = count > 99 ? '99+' : String(count);
+    badge.textContent = display;
+    badge.dataset.count = String(count);
+    badge.hidden = count === 0;
+    document.getElementById('nbc-bell').setAttribute(
+      'aria-label',
+      count === 0 ? 'Notifications' : count + ' unread notification' + (count === 1 ? '' : 's')
+    );
+  }
+
+  function nbcBump() {
+    var badge = document.getElementById('nbc-badge');
+    var current = Number(badge.dataset.count || 0);
+    nbcSet(current + 1);
+  }
+
+  function nbcClear() {
+    nbcSet(0);
+  }
+</script>
+</head>
+<body>
+<main class="nbc-wrap">
+  <h1 class="nbc-h1">Notification Badge</h1>
+  <p class="nbc-lede">Counts above 99 display as "99+" but the underlying number stays exact in a data attribute, so logic reading the real count (deciding whether to keep polling, for instance) never has to parse a display string that was already truncated for space.</p>
+
+  <button type="button" class="nbc-bell" id="nbc-bell" onclick="nbcClear()" aria-label="Notifications">
+    <svg class="nbc-icon" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M6 8a6 6 0 0 1 12 0c0 4 1.5 6 2 7H4c0.5-1 2-3 2-7Z" />
+      <path d="M10 19a2 2 0 0 0 4 0" />
+    </svg>
+    <span class="nbc-badge" id="nbc-badge" data-count="3">3</span>
+  </button>
+
+  <button type="button" class="nbc-add-btn" onclick="nbcBump()">Simulate new notification</button>
+  <script>nbcSet(3);</script>
+</main>
+</body>
+</html>

--- a/submissions/examples/notification-badge-count-qz9k/style.css
+++ b/submissions/examples/notification-badge-count-qz9k/style.css
@@ -1,0 +1,87 @@
+/* Notification Badge Count
+   min-width plus a horizontal padding (rather than a fixed width) lets the
+   badge grow from a single-digit circle to a wider pill for "99+" without
+   the text ever overflowing its own background -- the shape adapts to
+   content instead of content being clipped to a fixed shape. */
+
+.nbc-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.nbc-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.nbc-lede { margin: 0 0 2rem; color: #576073; }
+
+.nbc-bell {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.6rem;
+  background: #fff;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.nbc-bell:hover { background: #f1f4fa; }
+.nbc-bell:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.nbc-icon {
+  width: 1.3rem;
+  height: 1.3rem;
+  fill: none;
+  stroke: #576073;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.nbc-badge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: #e0483f;
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 0 2px #fff;
+}
+
+.nbc-add-btn {
+  display: block;
+  padding: 0.55em 1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+}
+
+.nbc-add-btn:hover { background: #e4e9f4; }
+.nbc-add-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+@media (forced-colors: active) {
+  .nbc-bell { border-color: CanvasText; }
+  .nbc-badge { forced-color-adjust: none; background: Highlight; box-shadow: 0 0 0 2px Canvas; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .nbc-wrap { color: #e6e9f2; }
+  .nbc-lede { color: #99a1b4; }
+  .nbc-bell { background: #171b23; border-color: #2a303c; }
+  .nbc-bell:hover { background: #1e2430; }
+  .nbc-icon { stroke: #99a1b4; }
+  .nbc-badge { box-shadow: 0 0 0 2px #0f1218; }
+  .nbc-add-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80887

Unread-count badge that displays '99+' above 99 but keeps the real integer in data-count, untouched by display truncation — code that later needs the actual count (deciding whether to keep polling, an analytics event) reads the attribute rather than parsing a possibly-truncated textContent string. The bell's aria-label recomputes on every count change to state the actual number, rather than depending on the badge's own visual text being announced (badges are frequently aria-hidden).