### PR TITLE
feat: add Tree View with Cascading Checkboxes example (tree-view-checkbox-qz9k)

### DIFF
--- a/submissions/examples/tree-view-checkbox-qz9k/README.md
+++ b/submissions/examples/tree-view-checkbox-qz9k/README.md
@@ -1,0 +1,48 @@
+# Tree View with Cascading Checkboxes
+
+## What does this do?
+
+A file/folder tree where checking a parent checkbox cascades the check
+state down to every descendant, and checking or unchecking a leaf
+propagates back up — setting an ancestor to `indeterminate` when only some
+of its children are checked.
+
+## How is it used?
+
+```html
+<li class="tvc-node">
+  <label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcParentChange(this); tvcChildChange(this)" /> components/</label>
+  <ul class="tvc-children">
+    <li class="tvc-node"><label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcChildChange(this)" /> Button.jsx</label></li>
+  </ul>
+</li>
+```
+
+A node with children calls both `tvcParentChange` (cascade down to its own
+descendants) and `tvcChildChange` (propagate its new state up to its
+ancestors) on change; a leaf node only ever needs `tvcChildChange`, since it
+has no descendants to cascade to.
+
+## Why is it useful?
+
+Cascading tree checkboxes are a genuinely two-directional problem — a
+change anywhere in the tree can require both propagating downward
+(checking a folder checks everything inside it) and upward (checking every
+file in a folder should check the folder itself; checking only some should
+mark it indeterminate) — and it's easy to implement only one direction and
+call it done, which leaves the other direction stale (checking all files
+individually doesn't visually check their parent folder, or checking a
+folder doesn't visually check its files). Splitting the two directions into
+separate functions (`tvcParentChange` walks down, `tvcChildChange` walks
+up) keeps each one simple — a single loop over immediate children in each
+case — rather than one recursive function trying to handle both directions
+from a single change event, which tends to produce update-order bugs where
+a cascade in one direction interferes with a cascade already in progress in
+the other.
+
+`checkbox.indeterminate` is a real DOM property (not reflected as an HTML
+attribute, only settable via JS) representing the "some but not all
+children checked" state — using it here means the visual dash-in-box
+indeterminate rendering comes from the browser's own native checkbox
+styling, not a custom CSS-drawn substitute that would need to be kept in
+sync with the actual selection state by hand.

--- a/submissions/examples/tree-view-checkbox-qz9k/demo.html
+++ b/submissions/examples/tree-view-checkbox-qz9k/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Tree View with Cascading Checkboxes</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function tvcParentChange(checkbox) {
+    var group = checkbox.closest('.tvc-node').querySelector('.tvc-children');
+    if (!group) return;
+    var children = group.querySelectorAll(':scope > .tvc-node > .tvc-check');
+    children.forEach(function (child) {
+      child.checked = checkbox.checked;
+      child.indeterminate = false;
+      tvcParentChange(child);
+    });
+  }
+
+  function tvcChildChange(checkbox) {
+    var parentNode = checkbox.closest('.tvc-children')?.closest('.tvc-node');
+    if (!parentNode) return;
+    var parentCheck = parentNode.querySelector(':scope > .tvc-label > .tvc-check');
+    var siblings = checkbox.closest('.tvc-children').querySelectorAll(':scope > .tvc-node > .tvc-check');
+    var checkedCount = Array.from(siblings).filter(function (c) { return c.checked; }).length;
+
+    parentCheck.checked = checkedCount === siblings.length;
+    parentCheck.indeterminate = checkedCount > 0 && checkedCount < siblings.length;
+    tvcChildChange(parentCheck);
+  }
+</script>
+</head>
+<body>
+<main class="tvc-wrap">
+  <h1 class="tvc-h1">Select Files</h1>
+  <p class="tvc-lede">Checking a parent cascades down to every descendant; checking or unchecking a leaf propagates back up, setting the parent to indeterminate when only some children are checked -- both directions kept in sync by two small functions rather than one shared state object.</p>
+
+  <ul class="tvc-tree">
+    <li class="tvc-node">
+      <label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcParentChange(this)" /> src/</label>
+      <ul class="tvc-children">
+        <li class="tvc-node">
+          <label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcParentChange(this); tvcChildChange(this)" /> components/</label>
+          <ul class="tvc-children">
+            <li class="tvc-node"><label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcChildChange(this)" /> Button.jsx</label></li>
+            <li class="tvc-node"><label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcChildChange(this)" checked /> Modal.jsx</label></li>
+          </ul>
+        </li>
+        <li class="tvc-node"><label class="tvc-label"><input type="checkbox" class="tvc-check" onchange="tvcParentChange(this); tvcChildChange(this)" /> index.js</label></li>
+      </ul>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/tree-view-checkbox-qz9k/style.css
+++ b/submissions/examples/tree-view-checkbox-qz9k/style.css
@@ -1,0 +1,62 @@
+/* Tree View with Cascading Checkboxes
+   Indentation comes from nested <ul>/padding, not a computed --depth custom
+   property, since the tree's real DOM nesting already encodes depth --
+   duplicating that into an explicit variable per level would be state that
+   could drift from the actual markup structure. */
+
+.tvc-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.tvc-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.tvc-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.tvc-tree,
+.tvc-children {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tvc-children {
+  padding-left: 1.4rem;
+}
+
+.tvc-node {
+  margin: 0.15rem 0;
+}
+
+.tvc-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2em 0.3em;
+  border-radius: 0.35rem;
+  cursor: pointer;
+  font-size: 0.92rem;
+}
+
+.tvc-label:hover {
+  background: #f1f4fa;
+}
+
+.tvc-check {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #4c6ef5;
+}
+
+.tvc-check:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tvc-wrap { color: #e6e9f2; }
+  .tvc-lede { color: #99a1b4; }
+  .tvc-label:hover { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #80888

File-tree with cascading checkboxes, split into two small functions instead of one recursive function handling both directions: tvcParentChange walks down (checking a folder checks every descendant), tvcChildChange walks up (checking all children checks the parent; checking some sets it indeterminate). Uses the real checkbox.indeterminate DOM property for the native dash-in-box rendering rather than a custom CSS substitute that would need manual syncing to selection state.