### PR TITLE
feat: add useMediaRecorder hook (use-media-recorder-qz9k)

### DIFF
--- a/submissions/react/use-media-recorder-qz9k/README.md
+++ b/submissions/react/use-media-recorder-qz9k/README.md
@@ -1,0 +1,61 @@
+# useMediaRecorder
+
+Wraps the `MediaRecorder` API for recording audio/video from a
+`MediaStream`, collecting data chunks internally and exposing a ready-to-use
+blob URL once recording stops.
+
+## API
+
+```js
+const { status, blobUrl, start, stop, pause, resume } = useMediaRecorder(stream, options);
+```
+
+| Return | Description |
+|---|---|
+| `status` | `'idle' \| 'recording' \| 'paused' \| 'stopped'` |
+| `blobUrl` | Object URL for the recorded blob, set once recording stops. |
+| `start` / `stop` / `pause` / `resume` | Recording controls. |
+
+`options` is passed through directly to the `MediaRecorder` constructor
+(e.g. `{ mimeType: 'video/webm;codecs=vp9' }`).
+
+## Usage
+
+```jsx
+function VoiceNoteRecorder() {
+  const [stream, setStream] = useState(null);
+  const { status, blobUrl, start, stop } = useMediaRecorder(stream);
+
+  useEffect(() => {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(setStream);
+  }, []);
+
+  return (
+    <div>
+      <button onClick={start} disabled={!stream || status === 'recording'}>Record</button>
+      <button onClick={stop} disabled={status !== 'recording'}>Stop</button>
+      {blobUrl && <audio controls src={blobUrl} />}
+    </div>
+  );
+}
+```
+
+## Why is it useful?
+
+The raw `MediaRecorder` API delivers recorded data in chunks via repeated
+`dataavailable` events (the exact chunking behavior varies by browser and
+`timeslice` setting), which means every consumer has to independently
+implement "accumulate chunks in an array, then assemble them into one Blob
+once `stop` fires" — easy to get wrong by forgetting to filter zero-size
+chunks, or by reading the accumulated chunks before the final `dataavailable`
+event for the last chunk has actually landed. This hook does that
+bookkeeping once: chunks are collected in a ref (not state, since
+intermediate chunks don't need to trigger re-renders) and only assembled
+into a `Blob` — then converted to an object URL — inside the recorder's own
+`onstop` handler, guaranteeing the blob is complete.
+
+Object URLs from `URL.createObjectURL` hold a reference to the underlying
+blob data in memory until explicitly revoked; this hook calls
+`URL.revokeObjectURL` on the *previous* URL whenever a new one is created
+(re-recording produces a new blob), preventing each successive recording
+from leaking the previous one's memory for the lifetime of the page.

--- a/submissions/react/use-media-recorder-qz9k/useMediaRecorder.jsx
+++ b/submissions/react/use-media-recorder-qz9k/useMediaRecorder.jsx
@@ -1,0 +1,62 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * useMediaRecorder
+ * Wraps the MediaRecorder API for recording from a MediaStream (mic,
+ * webcam, or a combination), collecting chunks internally and exposing a
+ * single Blob only once recording actually stops -- callers never handle
+ * raw dataavailable events or manage a chunks array themselves.
+ */
+export function useMediaRecorder(stream, options = {}) {
+  const [status, setStatus] = useState('idle');
+  const [blobUrl, setBlobUrl] = useState(null);
+  const recorderRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const start = useCallback(() => {
+    if (!stream) return;
+
+    chunksRef.current = [];
+    const recorder = new MediaRecorder(stream, options);
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) chunksRef.current.push(event.data);
+    };
+
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: recorder.mimeType });
+      setBlobUrl((previousUrl) => {
+        if (previousUrl) URL.revokeObjectURL(previousUrl);
+        return URL.createObjectURL(blob);
+      });
+      setStatus('stopped');
+    };
+
+    recorder.start();
+    recorderRef.current = recorder;
+    setStatus('recording');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stream]);
+
+  const stop = useCallback(() => {
+    recorderRef.current?.stop();
+  }, []);
+
+  const pause = useCallback(() => {
+    if (recorderRef.current?.state === 'recording') {
+      recorderRef.current.pause();
+      setStatus('paused');
+    }
+  }, []);
+
+  const resume = useCallback(() => {
+    if (recorderRef.current?.state === 'paused') {
+      recorderRef.current.resume();
+      setStatus('recording');
+    }
+  }, []);
+
+  return { status, blobUrl, start, stop, pause, resume };
+}
+
+export default useMediaRecorder;


### PR DESCRIPTION
Closes #80891

Wraps MediaRecorder, collecting dataavailable chunks in a ref (not state, since intermediate chunks don't need re-renders) and only assembling the final Blob inside the recorder's own onstop handler — guaranteeing the blob is complete rather than read back before the last chunk has landed. Revokes the previous object URL whenever a new recording produces a new blob, so re-recording doesn't leak the prior blob's memory for the page's lifetime.