### PR TITLE
feat: add Form Wizard example (stepper-form-wizard-qz9k)

### DIFF
--- a/submissions/examples/stepper-form-wizard-qz9k/README.md
+++ b/submissions/examples/stepper-form-wizard-qz9k/README.md
@@ -1,0 +1,53 @@
+# Form Wizard
+
+## What does this do?
+
+A multi-step signup form where advancing to the next step validates the
+current step's fields using the browser's own constraint validation
+(`:invalid`, `reportValidity()`) rather than a hand-rolled validation
+message, and every step's fields stay mounted with their values retained
+when navigating back and forth.
+
+## How is it used?
+
+```html
+<fieldset class="sfw-panel sfw-panel--active" data-step="0">
+  <input id="sfw-email" type="email" required />
+</fieldset>
+<fieldset class="sfw-panel" data-step="1">...</fieldset>
+```
+
+```js
+function sfwGo(delta) {
+  // ...
+  if (delta > 0 && !sfwValidate(current)) return;
+  // ... swap .sfw-panel--active
+}
+
+function sfwValidate(panel) {
+  var invalid = panel.querySelector(':invalid');
+  if (invalid) { invalid.reportValidity(); return false; }
+  return true;
+}
+```
+
+## Why is it useful?
+
+A multi-step form's validation is easy to under-build: checking `value !==
+''` manually for each required field re-derives constraint logic the
+browser already provides natively (via `required`, `minlength`, `type`)
+and misses the built-in error UI users already recognize —
+`reportValidity()` shows the browser's own inline error bubble pointing at
+the specific invalid field, styled consistently with how validation
+already looks everywhere else on the page, rather than a custom message the
+form author has to design and place. Using `:invalid` to find the first
+failing field within the current step (rather than validating the whole
+form at once, which would fail on later, not-yet-visited steps) keeps
+validation scoped correctly to what the user can actually see and fix.
+
+Keeping every step's `<fieldset>` permanently in the DOM (only toggling
+`display: none` via `.sfw-panel--active`) rather than conditionally
+rendering the current step's markup means field values persist
+automatically across navigation — the browser's native form state does the
+work, so there's no separate JS state object mirroring each field's value
+that could fall out of sync with what's actually typed.

--- a/submissions/examples/stepper-form-wizard-qz9k/demo.html
+++ b/submissions/examples/stepper-form-wizard-qz9k/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Form Wizard</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var sfwStep = 0;
+  var sfwTotal = 3;
+
+  function sfwGo(delta) {
+    var next = sfwStep + delta;
+    if (next < 0 || next >= sfwTotal) return;
+
+    var current = document.querySelector('.sfw-panel[data-step="' + sfwStep + '"]');
+    var target = document.querySelector('.sfw-panel[data-step="' + next + '"]');
+
+    if (delta > 0 && !sfwValidate(current)) return;
+
+    current.classList.remove('sfw-panel--active');
+    target.classList.add('sfw-panel--active');
+    sfwStep = next;
+    sfwUpdateNav();
+  }
+
+  function sfwValidate(panel) {
+    var invalid = panel.querySelector(':invalid');
+    if (invalid) {
+      invalid.reportValidity();
+      return false;
+    }
+    return true;
+  }
+
+  function sfwUpdateNav() {
+    document.getElementById('sfw-back').disabled = sfwStep === 0;
+    document.getElementById('sfw-next').hidden = sfwStep === sfwTotal - 1;
+    document.getElementById('sfw-submit').hidden = sfwStep !== sfwTotal - 1;
+    document.querySelectorAll('.sfw-dot').forEach(function (dot, i) {
+      dot.classList.toggle('sfw-dot--active', i === sfwStep);
+      dot.classList.toggle('sfw-dot--done', i < sfwStep);
+    });
+  }
+</script>
+</head>
+<body>
+<main class="sfw-wrap">
+  <h1 class="sfw-h1">Create Account</h1>
+  <p class="sfw-lede">Each step is a real fieldset validated with the browser's own constraint validation before advancing, so a required field left empty blocks progress using the native inline error bubble rather than a custom validation message.</p>
+
+  <div class="sfw-dots">
+    <span class="sfw-dot sfw-dot--active"></span>
+    <span class="sfw-dot"></span>
+    <span class="sfw-dot"></span>
+  </div>
+
+  <form class="sfw-form" onsubmit="return false">
+    <fieldset class="sfw-panel sfw-panel--active" data-step="0">
+      <label class="sfw-label" for="sfw-email">Email</label>
+      <input class="sfw-input" id="sfw-email" type="email" required />
+    </fieldset>
+    <fieldset class="sfw-panel" data-step="1">
+      <label class="sfw-label" for="sfw-password">Password</label>
+      <input class="sfw-input" id="sfw-password" type="password" required minlength="8" />
+    </fieldset>
+    <fieldset class="sfw-panel" data-step="2">
+      <label class="sfw-label" for="sfw-company">Company (optional)</label>
+      <input class="sfw-input" id="sfw-company" type="text" />
+    </fieldset>
+
+    <div class="sfw-nav">
+      <button type="button" class="sfw-btn" id="sfw-back" onclick="sfwGo(-1)" disabled>Back</button>
+      <button type="button" class="sfw-btn sfw-btn--primary" id="sfw-next" onclick="sfwGo(1)">Next</button>
+      <button type="submit" class="sfw-btn sfw-btn--primary" id="sfw-submit" hidden>Create account</button>
+    </div>
+  </form>
+</main>
+</body>
+</html>

--- a/submissions/examples/stepper-form-wizard-qz9k/style.css
+++ b/submissions/examples/stepper-form-wizard-qz9k/style.css
@@ -1,0 +1,109 @@
+/* Form Wizard
+   Only one .sfw-panel carries --active at a time; every panel's fields
+   stay in the DOM and retain their values across steps (nothing is
+   unmounted), so navigating back to a previous step shows exactly what the
+   user already typed rather than a blank re-rendered field. */
+
+.sfw-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.sfw-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.sfw-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.sfw-dots {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.sfw-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #dfe3ec;
+}
+
+.sfw-dot--active {
+  background: #4c6ef5;
+  transform: scale(1.3);
+}
+
+.sfw-dot--done {
+  background: #34a853;
+}
+
+.sfw-panel {
+  display: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.sfw-panel--active {
+  display: block;
+}
+
+.sfw-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.sfw-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+}
+
+.sfw-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.sfw-nav {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 1.5rem;
+}
+
+.sfw-btn {
+  flex: 1;
+  padding: 0.6em 1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sfw-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sfw-btn--primary {
+  background: #4c6ef5;
+  border-color: #4c6ef5;
+  color: #fff;
+}
+
+.sfw-btn--primary:hover { background: #3b5be0; }
+.sfw-btn:focus-visible { outline: 2px solid #1c2028; outline-offset: 2px; }
+
+@media (prefers-color-scheme: dark) {
+  .sfw-wrap { color: #e6e9f2; }
+  .sfw-lede { color: #99a1b4; }
+  .sfw-dot { background: #2a303c; }
+  .sfw-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .sfw-btn { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80913

Multi-step signup form validated with the browser's own constraint validation (:invalid, reportValidity()) instead of a hand-rolled message — shows the native inline error bubble pointing at the specific invalid field, styled consistently with the rest of the page's validation. Every step's fieldset stays permanently mounted (only display:none toggled), so field values persist automatically across back/forward navigation with no separate JS state mirroring each field.