### PR TITLE
feat: add Emoji Picker Grid example (emoji-picker-grid-qz9k)

### DIFF
--- a/submissions/examples/emoji-picker-grid-qz9k/README.md
+++ b/submissions/examples/emoji-picker-grid-qz9k/README.md
@@ -1,0 +1,41 @@
+# Emoji Picker Grid
+
+## What does this do?
+
+A grid of emoji reaction buttons navigable with all four arrow keys —
+`ArrowLeft`/`ArrowRight` move by one button, `ArrowUp`/`ArrowDown` jump by a
+full row — matching how a 2D grid is expected to behave with a keyboard,
+rather than only supporting linear Tab-order navigation.
+
+## How is it used?
+
+```html
+<div class="epg-grid" role="group" aria-label="Emoji reactions" onkeydown="epgKeydown(event)">
+  <button type="button" class="epg-emoji" onclick="epgSelect(this)">😀</button>
+  <!-- ...16 buttons total, 8 per row -->
+</div>
+```
+
+`epgKeydown` computes the target index for `ArrowUp`/`ArrowDown` as
+`index ± columns`, where `columns` is a JS constant matching the grid's
+CSS `grid-template-columns: repeat(8, 1fr)`.
+
+## Why is it useful?
+
+A grid of many small buttons (emoji, colour swatches, icon choices) is
+tedious to navigate with only Tab — moving from the top-left button to the
+one directly below it takes as many Tab presses as there are columns,
+rather than a single natural "down" keypress. Implementing all four arrow
+directions, with vertical movement computed from the actual column count,
+matches the interaction model users expect from a genuinely 2D control
+(similar to spreadsheet cell navigation) instead of forcing 2D content
+through a 1D navigation model.
+
+The column count (`8`) has to be kept in sync between the CSS
+`grid-template-columns` declaration and the JS `columns` variable used for
+`ArrowUp`/`ArrowDown` math — there's no way for the script to read the
+actual rendered column count generically for a fixed `repeat(8, 1fr)`
+grid, so this is one of the few places in the codebase where a single
+number is duplicated across CSS and JS by necessity, called out explicitly
+in the CSS comment so a future change to the column count doesn't silently
+break vertical keyboard navigation.

--- a/submissions/examples/emoji-picker-grid-qz9k/demo.html
+++ b/submissions/examples/emoji-picker-grid-qz9k/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Emoji Picker Grid</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function epgSelect(button) {
+    document.getElementById('epg-output').textContent = button.textContent.trim();
+  }
+
+  function epgKeydown(event) {
+    var grid = event.currentTarget;
+    var buttons = Array.from(grid.querySelectorAll('.epg-emoji'));
+    var index = buttons.indexOf(document.activeElement);
+    if (index === -1) return;
+
+    var columns = 8;
+    var next = null;
+
+    if (event.key === 'ArrowRight') next = buttons[index + 1];
+    if (event.key === 'ArrowLeft') next = buttons[index - 1];
+    if (event.key === 'ArrowDown') next = buttons[index + columns];
+    if (event.key === 'ArrowUp') next = buttons[index - columns];
+
+    if (next) {
+      event.preventDefault();
+      next.focus();
+    }
+  }
+</script>
+</head>
+<body>
+<main class="epg-wrap">
+  <h1 class="epg-h1">Pick a Reaction</h1>
+  <p class="epg-lede">A 2D grid of buttons navigable with all four arrow keys, moving by a fixed column count rather than only Tab-order left/right -- matching how a visual grid is actually expected to behave with a keyboard.</p>
+
+  <p class="epg-output" id="epg-output" aria-live="polite">😀</p>
+
+  <div class="epg-grid" role="group" aria-label="Emoji reactions" onkeydown="epgKeydown(event)">
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">😀</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">😂</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">😍</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">🤔</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">😢</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">😡</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">👍</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">🎉</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">🔥</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">💯</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">🙌</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">👀</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">🚀</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">✨</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">💡</button>
+    <button type="button" class="epg-emoji" onclick="epgSelect(this)">❤️</button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/emoji-picker-grid-qz9k/style.css
+++ b/submissions/examples/emoji-picker-grid-qz9k/style.css
@@ -1,0 +1,61 @@
+/* Emoji Picker Grid
+   The grid's column count (8) is defined once in CSS via grid-template-
+   columns AND separately relied on in JS keyboard math -- a mismatch
+   between the two would break ArrowUp/ArrowDown navigation, so both are
+   noted here as the single number that must stay in sync between files. */
+
+.epg-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.epg-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.epg-lede { margin: 0 0 1.25rem; color: #576073; }
+
+.epg-output {
+  font-size: 2.2rem;
+  text-align: center;
+  margin: 0 0 1rem;
+  height: 2.6rem;
+}
+
+.epg-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.15rem;
+}
+
+.epg-emoji {
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 0.4rem;
+  background: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.epg-emoji:hover {
+  background: #f1f4fa;
+  transform: scale(1.15);
+}
+
+.epg-emoji:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: -2px;
+  background: #eef2fd;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .epg-emoji { transition: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .epg-wrap { color: #e6e9f2; }
+  .epg-lede { color: #99a1b4; }
+  .epg-emoji:hover { background: #1e2430; }
+  .epg-emoji:focus-visible { background: #262e4a; }
+}


### PR DESCRIPTION
Closes #80914

16-emoji picker grid supporting all four arrow keys — ArrowLeft/Right move one cell, ArrowUp/Down jump by the actual column count — matching how a genuinely 2D control is expected to behave with a keyboard rather than forcing it through 1D Tab-order navigation. The column count is a single number kept in sync between the CSS grid-template-columns and the JS keyboard math, called out explicitly in a comment since it can't be read generically from the rendered grid for a fixed-column layout.