### PR TITLE
feat: add Color Swatch Picker example (color-swatch-grid-qz9k)

### DIFF
--- a/submissions/examples/color-swatch-grid-qz9k/README.md
+++ b/submissions/examples/color-swatch-grid-qz9k/README.md
@@ -1,0 +1,40 @@
+# Color Swatch Picker
+
+## What does this do?
+
+A colour picker made of real radio-input swatches; the selected swatch
+shows a checkmark whose colour (white or dark) is set per-swatch via an
+inline custom property, so it stays legible against both very light and
+very dark swatch colours.
+
+## How is it used?
+
+```html
+<label class="csg-swatch" style="background: #f5a623; --csg-check: #1c2028">
+  <input type="radio" name="csg-color" value="orange" />
+  <span class="csg-sr">Orange</span>
+</label>
+```
+
+`.csg-swatch::after` draws a checkmark using `var(--csg-check, #fff)` as
+its border colour; `:has(input:checked)` scales it into view.
+
+## Why is it useful?
+
+A single hard-coded checkmark colour (white, in most examples) reads fine
+on dark or saturated swatches but disappears against light ones — a pale
+yellow swatch with a white checkmark is nearly invisible. Computing
+"should this checkmark be light or dark" from the background colour
+itself isn't something CSS can do generically (there's no built-in
+function converting an arbitrary background colour to a suitable
+foreground colour), so this decision has to be made once, by whoever
+defines the palette, and passed down per-swatch via `--csg-check` — a
+small amount of explicit authoring effort in exchange for a checkmark
+that's always legible against its own swatch.
+
+Each swatch is a real radio input with a visually-hidden but present
+`<span>` label naming the colour ("Red", "Orange", ...), so a screen reader
+announces which colour each swatch represents rather than just "radio
+button" with no indication of what selecting it does — colour alone
+conveys nothing to someone who can't perceive it, which is exactly the
+gap the hidden text label closes.

--- a/submissions/examples/color-swatch-grid-qz9k/demo.html
+++ b/submissions/examples/color-swatch-grid-qz9k/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Color Swatch Picker</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="csg-wrap">
+  <h1 class="csg-h1">Choose a Color</h1>
+  <p class="csg-lede">Each swatch is a real radio input; the checkmark on the selected swatch is generated content whose colour flips between dark and light per swatch via an inline custom property, so it stays legible against both very light and very dark swatch colours.</p>
+
+  <fieldset class="csg-field">
+    <legend class="csg-legend">Label color</legend>
+    <div class="csg-grid">
+      <label class="csg-swatch" style="background: #e0483f; --csg-check: #fff">
+        <input type="radio" name="csg-color" value="red" />
+        <span class="csg-sr">Red</span>
+      </label>
+      <label class="csg-swatch" style="background: #f5a623; --csg-check: #1c2028">
+        <input type="radio" name="csg-color" value="orange" checked />
+        <span class="csg-sr">Orange</span>
+      </label>
+      <label class="csg-swatch" style="background: #f7e35f; --csg-check: #1c2028">
+        <input type="radio" name="csg-color" value="yellow" />
+        <span class="csg-sr">Yellow</span>
+      </label>
+      <label class="csg-swatch" style="background: #34a853; --csg-check: #fff">
+        <input type="radio" name="csg-color" value="green" />
+        <span class="csg-sr">Green</span>
+      </label>
+      <label class="csg-swatch" style="background: #4c6ef5; --csg-check: #fff">
+        <input type="radio" name="csg-color" value="blue" />
+        <span class="csg-sr">Blue</span>
+      </label>
+      <label class="csg-swatch" style="background: #1c2028; --csg-check: #fff">
+        <input type="radio" name="csg-color" value="black" />
+        <span class="csg-sr">Black</span>
+      </label>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/color-swatch-grid-qz9k/style.css
+++ b/submissions/examples/color-swatch-grid-qz9k/style.css
@@ -1,0 +1,93 @@
+/* Color Swatch Picker
+   Each swatch's --csg-check custom property is set inline per-swatch
+   (not computed in CSS), since deriving "is this background light or
+   dark" from the background colour itself isn't something CSS alone can
+   compute -- that decision has to be made once, by whoever picks the
+   palette, and passed in. */
+
+.csg-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.csg-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.csg-lede { margin: 0 0 1.75rem; color: #576073; }
+
+.csg-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.csg-legend {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.csg-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.5rem;
+}
+
+.csg-swatch {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.csg-swatch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.csg-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.csg-swatch::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 0.5rem;
+  height: 0.9rem;
+  border-right: 2px solid var(--csg-check, #fff);
+  border-bottom: 2px solid var(--csg-check, #fff);
+  transform: translateY(-10%) rotate(45deg) scale(0);
+  transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.csg-swatch:has(input:checked)::after {
+  transform: translateY(-10%) rotate(45deg) scale(1);
+}
+
+.csg-swatch:has(input:checked) {
+  box-shadow: inset 0 0 0 2px #fff, 0 0 0 2px #4c6ef5;
+}
+
+.csg-swatch:has(input:focus-visible) {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .csg-swatch::after { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .csg-swatch { forced-color-adjust: none; box-shadow: inset 0 0 0 1px CanvasText; }
+  .csg-swatch:has(input:checked) { box-shadow: inset 0 0 0 2px Canvas, 0 0 0 2px Highlight; }
+}


### PR DESCRIPTION
Closes #80915

Colour swatch radio picker. Each swatch sets its own --csg-check custom property inline (light or dark), since deriving 'is this background light or dark' from the colour value isn't something CSS can compute generically — that decision is made once by whoever defines the palette and passed down per-swatch, so the checkmark stays legible against both very light and very dark swatches. Each swatch also carries a visually-hidden text label naming its colour, since colour alone conveys nothing to a screen reader user.