### PR TITLE
feat: add Expandable Search Bar example (expandable-search-bar-qz9k)

### DIFF
--- a/submissions/examples/expandable-search-bar-qz9k/README.md
+++ b/submissions/examples/expandable-search-bar-qz9k/README.md
@@ -1,0 +1,40 @@
+# Expandable Search Bar
+
+## What does this do?
+
+A search icon that expands into a text field on click, collapsing back to
+an icon on blur — but only if the field is empty. A non-empty query stays
+visually expanded even without focus, so clicking elsewhere to interact
+with search results doesn't hide the query the results are for.
+
+## How is it used?
+
+```html
+<div class="esb-bar" id="esb-bar">
+  <button class="esb-toggle" onclick="esbOpen(this)" aria-expanded="false" aria-controls="esb-input">🔍</button>
+  <input type="search" id="esb-input" class="esb-input" onblur="esbClose(this)" onkeydown="esbKeydown(event)" />
+</div>
+```
+
+`esbClose` checks `input.value.trim()` before collapsing — an empty field
+collapses on blur, a field with text stays expanded. `Escape` explicitly
+clears the field and forces a collapse, giving users a deliberate way to
+exit search regardless of whether they've typed something.
+
+## Why is it useful?
+
+A version of this pattern that collapses unconditionally on blur has an
+awkward interaction: type a query, then click a result or scroll to read
+something else on the page, and the search bar collapses back to a bare
+icon — visually discarding the query that's still active, even though
+nothing about the search itself was cancelled. Checking whether the field
+has content before collapsing keeps an active search visibly represented
+on screen for as long as it's actually in effect, and only auto-collapses
+the empty, "nothing was typed" case where hiding it back to an icon is
+genuinely just tidying up unused UI.
+
+`Escape` is handled as an explicit override regardless of content, since a
+keyboard user pressing Escape is unambiguously signaling "I want to exit
+search now" — deferring to the emptiness check there as well would trap a
+user with typed-but-abandoned text in an expanded state they have no
+single-keypress way out of.

--- a/submissions/examples/expandable-search-bar-qz9k/demo.html
+++ b/submissions/examples/expandable-search-bar-qz9k/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Expandable Search Bar</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function esbOpen(button) {
+    var bar = document.getElementById('esb-bar');
+    bar.classList.add('esb-bar--open');
+    button.setAttribute('aria-expanded', 'true');
+    document.getElementById('esb-input').focus();
+  }
+
+  function esbClose(input) {
+    if (input.value.trim()) return;
+    var bar = document.getElementById('esb-bar');
+    bar.classList.remove('esb-bar--open');
+    document.getElementById('esb-toggle').setAttribute('aria-expanded', 'false');
+  }
+
+  function esbKeydown(event) {
+    if (event.key === 'Escape') {
+      event.target.value = '';
+      esbClose(event.target);
+      document.getElementById('esb-toggle').focus();
+    }
+  }
+</script>
+</head>
+<body>
+<main class="esb-wrap">
+  <h1 class="esb-h1">Expandable Search</h1>
+  <p class="esb-lede">The search field collapses back to an icon on blur only if it's empty -- a non-empty query stays expanded even without focus, so the visible query isn't hidden the moment the user clicks elsewhere to review results.</p>
+
+  <div class="esb-bar" id="esb-bar">
+    <button type="button" class="esb-toggle" id="esb-toggle" onclick="esbOpen(this)" aria-expanded="false" aria-controls="esb-input" aria-label="Open search">
+      <svg class="esb-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.5" y2="16.5" /></svg>
+    </button>
+    <input
+      type="search"
+      id="esb-input"
+      class="esb-input"
+      placeholder="Search..."
+      onblur="esbClose(this)"
+      onkeydown="esbKeydown(event)"
+    />
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/expandable-search-bar-qz9k/style.css
+++ b/submissions/examples/expandable-search-bar-qz9k/style.css
@@ -1,0 +1,84 @@
+/* Expandable Search Bar
+   The input's width transitions between 0 and its expanded value, with
+   overflow:hidden on the bar container -- padding stays constant on the
+   input itself so text doesn't visibly reflow/jump as the box grows,
+   only the available width changes. */
+
+.esb-wrap {
+  max-width: 20rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.esb-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.esb-lede { margin: 0 0 2rem; color: #576073; }
+
+.esb-bar {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #f1f4fa;
+  overflow: hidden;
+}
+
+.esb-toggle {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border: none;
+  border-radius: 50%;
+  background: none;
+  color: #576073;
+  cursor: pointer;
+}
+
+.esb-toggle:hover { color: #1c2028; }
+.esb-toggle:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.esb-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.esb-input {
+  width: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  padding: 0;
+  transition: width 220ms ease, padding 220ms ease;
+}
+
+.esb-bar--open .esb-input {
+  width: 11rem;
+  padding: 0 1rem 0 0;
+}
+
+.esb-input::placeholder {
+  color: #8b93a3;
+}
+
+.esb-input:focus {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .esb-input { transition: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .esb-wrap { color: #e6e9f2; }
+  .esb-lede { color: #99a1b4; }
+  .esb-bar { background: #1e2430; }
+  .esb-toggle { color: #99a1b4; }
+  .esb-toggle:hover { color: #e6e9f2; }
+  .esb-input { color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80916

Search icon that expands on click, collapsing back on blur only if the field is empty (input.value.trim() check) — a version that collapses unconditionally on blur visually discards an active query the moment the user clicks a result or scrolls to read something else, even though the search itself wasn't cancelled. Escape is handled as an explicit override regardless of content, giving keyboard users a single deliberate way to exit search rather than being stuck in an expanded state with abandoned text.