### PR TITLE
feat: add line-height-crop Sass mixin (line-height-crop-qz9k)

### DIFF
--- a/submissions/scss/line-height-crop-qz9k/README.md
+++ b/submissions/scss/line-height-crop-qz9k/README.md
@@ -1,0 +1,85 @@
+# line-height-crop-qz9k
+
+A Sass mixin that removes the extra vertical space `line-height` adds
+above and below text, so a heading's box matches its actual glyph bounds
+rather than including built-in "leading" inherited from print typesetting.
+
+## Usage
+
+```scss
+@use 'line-height-crop' as *;
+
+.hero-title {
+  @include line-height-crop($line-height: 1.2, $font-size: 3rem);
+  font-size: 3rem;
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$line-height` | `1.4` | The element's own line-height. |
+| `$font-size` | `1rem` | The element's font-size (informational; sizing is expressed in `em` relative to it). |
+| `$cap-height` | `0.73` | Fraction of font-size from baseline to cap height, typeface-specific. |
+| `$ascender` | `0.9` | Fraction of font-size from baseline to the tallest ascender, typeface-specific. |
+
+## Why is it useful?
+
+`line-height` reserves space above and below the actual glyph shapes —
+useful for body text, where that breathing room improves readability
+across multiple lines, but often unwanted for large display headings where
+designers expect the text box to hug the visible letterforms tightly (to
+align precisely with an adjacent icon, or to control margin spacing
+exactly). The mismatch between a heading's `line-height`-inflated box and
+its visual glyph bounds is a common source of "why is there invisible
+space above my heading that I can't get rid of with margin alone" bugs.
+
+The crop amount depends on the specific typeface's metrics (cap height and
+ascender height as fractions of font-size), which differ between fonts —
+the defaults here approximate a typical system-ui/Inter-style sans-serif,
+but a pixel-accurate crop for a different typeface needs its own measured
+values, obtainable from the font's own metadata (many type foundries
+publish these) or by rendering sample text and measuring the visual gap
+directly in a browser dev tools inspector. This is why the mixin exposes
+`$cap-height`/`$ascender` as parameters rather than hard-coding them — the
+correct numbers are typeface-specific, not universal.
+
+## Measuring metrics for a specific typeface
+
+A practical way to derive `$cap-height`/`$ascender` for a typeface not
+already covered by the defaults:
+
+1. Render a sample string in the target typeface at a known `font-size`
+   (e.g. `100px`, so measured pixel values convert to fractions directly).
+2. Using browser dev tools, measure the pixel distance from the text
+   baseline up to the top of a capital letter (cap height) and separately
+   to the top of a tall lowercase letter like `h` or `l` (ascender height).
+3. Divide each measurement by the `font-size` used to get the fraction —
+   a cap height of 68px at 100px font-size is `$cap-height: 0.68`.
+
+Font foundries and some web font services also publish these metrics
+directly in font metadata (`OS/2` table `sCapHeight`/`sTypoAscender`
+values), which is more precise than visual measurement if that data is
+available for the specific font in use.
+
+## Why this only crops single-line text well
+
+The technique crops space above the first line and below the last line of
+a text block, using the font's own ascender/cap-height relationship — it
+doesn't compensate for the *inter-line* spacing multi-line text still
+needs between wrapped lines, which is exactly what `line-height` is
+supposed to provide there. Applying this crop to genuinely multi-line body
+text removes the extra space at the very top and bottom of the whole block
+while leaving line-to-line spacing untouched, which is the intended
+behavior for a heading that happens to wrap, but worth confirming matches
+intent before applying broadly to paragraph-level text.
+
+## Browser rendering variance
+
+Because the technique relies on approximated typeface metrics rather than
+metrics read live from the actual rendered font, the crop can be
+imprecise by a pixel or two across different browsers/OS font-rendering
+engines, particularly for system font stacks where the exact rendered
+typeface varies by platform. For a design system that needs pixel-perfect
+consistency across every browser, treat this as a close approximation
+rather than an exact guarantee, and verify visually on each target
+platform.

--- a/submissions/scss/line-height-crop-qz9k/_line-height-crop.scss
+++ b/submissions/scss/line-height-crop-qz9k/_line-height-crop.scss
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// line-height-crop-qz9k
+// Removes the extra space line-height adds above/below text (the "leading"
+// inherited from typesetting) via negative margins derived from the font's
+// own metrics, so a heading's visual box matches its glyph bounds instead
+// of including invisible padding that throws off tight vertical spacing.
+// ---------------------------------------------------------------------------
+
+@use 'sass:math';
+
+// $cap-height and $ascender are fractions of font-size specific to the
+// typeface in use -- these defaults approximate a typical system-ui/Inter-
+// style sans-serif; a different typeface needs its own measured values for
+// a pixel-accurate crop (see the README for how to measure them).
+@mixin line-height-crop(
+  $line-height: 1.4,
+  $font-size: 1rem,
+  $cap-height: 0.73,
+  $ascender: 0.9
+) {
+  line-height: $line-height;
+
+  &::before {
+    content: "";
+    display: block;
+    height: 0;
+    width: 0;
+    margin-top: calc(#{math.div($ascender - $cap-height, 2)} * -1em);
+  }
+
+  &::after {
+    content: "";
+    display: block;
+    height: 0;
+    width: 0;
+    margin-bottom: calc(#{math.div($line-height - $ascender, 2)} * -1em);
+  }
+}
+
+.line-height-crop-demo {
+  @include line-height-crop($line-height: 1.3, $font-size: 2rem);
+  font-size: 2rem;
+}


### PR DESCRIPTION
Closes #80921

Removes the extra vertical leading line-height reserves above/below text via negative margins derived from a typeface's cap-height/ascender metrics (exposed as parameters, since the correct values are typeface-specific, not universal) — solves the common 'why is there invisible space above my heading I can't remove with margin' problem for display headings where the box is expected to hug the visible glyphs tightly. README covers how to measure the metrics for a specific typeface and notes the crop only compensates for space at the very top/bottom of a text block, not inter-line spacing.