### PR TITLE
added the filrs

### DIFF
--- a/submissions/examples/parallax-spinner-retro/README.md
+++ b/submissions/examples/parallax-spinner-retro/README.md
@@ -1,0 +1,14 @@
+# Parallax Spinner - Retro Styling
+
+A 3D multi-layered retro arcade spinner component built using pure CSS parallax rotations.
+
+## Design Highlights
+
+- **3D Parallax Depth**: Combines `perspective` with differential `rotateX` and `rotateY` axis tilts across concentric rings.
+- **Retro Color Palette**: Utilizes classic vintage neon hues (Cyan `#00ffff`, Gold `#ffcc00`, Magenta `#ff0055`).
+- **Zero JavaScript**: Pure HTML & CSS implementation optimized for 60fps GPU acceleration.
+
+## Usage
+
+1. Copy the structure from `demo.html`.
+2. Link `style.css` in your project to apply the retro parallax animation.

--- a/submissions/examples/parallax-spinner-retro/demo.html
+++ b/submissions/examples/parallax-spinner-retro/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Parallax Spinner - Retro Styling</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="container">
+    <h1 class="retro-title">RETRO PARALLAX SPINNER</h1>
+    <p class="subtitle">Multi-layered concentric depth spinner with vintage arcade aesthetics.</p>
+
+    <!-- Parallax Spinner Component -->
+    <div class="parallax-spinner-wrapper" aria-label="Loading...">
+      <div class="spinner-layer layer-outer"></div>
+      <div class="spinner-layer layer-mid"></div>
+      <div class="spinner-layer layer-inner"></div>
+      <div class="spinner-core"></div>
+    </div>
+
+    <p class="loading-text">LOADING SYSTEM...</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/parallax-spinner-retro/style.css
+++ b/submissions/examples/parallax-spinner-retro/style.css
@@ -1,0 +1,151 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Courier New', Courier, monospace, system-ui;
+  background-color: #1a0c27;
+  color: #ff0055;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.retro-title {
+  font-size: 1.75rem;
+  letter-spacing: 0.15em;
+  color: #ffcc00;
+  text-shadow: 3px 3px 0px #ff0055, 6px 6px 0px #00ffff;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #a080c0;
+  font-size: 0.9rem;
+  margin-bottom: 3rem;
+  font-family: system-ui, sans-serif;
+}
+
+/* Spinner Outer Container */
+.parallax-spinner-wrapper {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  perspective: 600px;
+}
+
+/* Base Rotating Layer */
+.spinner-layer {
+  position: absolute;
+  border-radius: 50%;
+  border: 4px solid transparent;
+  transform-style: preserve-3d;
+}
+
+/* Outer Layer - Neon Cyan */
+.layer-outer {
+  width: 130px;
+  height: 130px;
+  border-top-color: #00ffff;
+  border-bottom-color: #00ffff;
+  box-shadow: 0 0 15px rgba(0, 255, 255, 0.4);
+  animation: spinOuter 2s cubic-bezier(0.68, -0.55, 0.265, 1.55) infinite;
+}
+
+/* Middle Layer - Vintage Gold */
+.layer-mid {
+  width: 90px;
+  height: 90px;
+  border-left-color: #ffcc00;
+  border-right-color: #ffcc00;
+  box-shadow: 0 0 12px rgba(255, 204, 0, 0.4);
+  animation: spinMid 1.4s ease-in-out infinite reverse;
+}
+
+/* Inner Layer - Hot Magenta */
+.layer-inner {
+  width: 50px;
+  height: 50px;
+  border-top-color: #ff0055;
+  border-left-color: #ff0055;
+  box-shadow: 0 0 10px rgba(255, 0, 85, 0.5);
+  animation: spinInner 0.9s linear infinite;
+}
+
+/* Center Core Pulse */
+.spinner-core {
+  width: 14px;
+  height: 14px;
+  background-color: #ffcc00;
+  border-radius: 50%;
+  box-shadow: 0 0 12px #ffcc00, 0 0 24px #ff0055;
+  animation: corePulse 1s ease-in-out infinite alternate;
+}
+
+/* Parallax 3D & Depth Rotations */
+@keyframes spinOuter {
+  0% {
+    transform: rotateX(35deg) rotateY(-20deg) rotateZ(0deg);
+  }
+  100% {
+    transform: rotateX(35deg) rotateY(-20deg) rotateZ(360deg);
+  }
+}
+
+@keyframes spinMid {
+  0% {
+    transform: rotateX(-30deg) rotateY(35deg) rotateZ(0deg);
+  }
+  100% {
+    transform: rotateX(-30deg) rotateY(35deg) rotateZ(360deg);
+  }
+}
+
+@keyframes spinInner {
+  0% {
+    transform: rotateX(15deg) rotateY(15deg) rotateZ(0deg);
+  }
+  100% {
+    transform: rotateX(15deg) rotateY(15deg) rotateZ(360deg);
+  }
+}
+
+@keyframes corePulse {
+  from {
+    transform: scale(0.8);
+    opacity: 0.7;
+  }
+  to {
+    transform: scale(1.3);
+    opacity: 1;
+  }
+}
+
+.loading-text {
+  margin-top: 2.5rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  color: #00ffff;
+  text-shadow: 0 0 8px rgba(0, 255, 255, 0.6);
+  animation: blink 1.2s infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}


### PR DESCRIPTION
Closes #79916

## Pull Request Description
Adds `.ease-glass-breadcrumb` — a frosted-glass breadcrumb bar with real `backdrop-filter` blur, a center-out hover underline, and a fade-scroll mask so long trails degrade gracefully on narrow viewports. No JavaScript.

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component

## Submission Checklist
- [x] Fully responsive
- [x] Placed under `submissions/examples/` (`submissions/examples/glass-breadcrumb-saas/`)
- [x] Includes `demo.html`, `style.css`, `README.md`

## Feature Description

**What does this add?**
A glassmorphism breadcrumb nav with semantically correct markup (`<nav>` + `<ol>`, `aria-current="page"` on the active crumb), plus a self-adjusting fade-scroll behavior for trails too long to fit.

**How does a developer use it?**
```html
<nav class="ease-glass-breadcrumb" aria-label="Breadcrumb">
  <ol class="breadcrumb-list">
    <li class="breadcrumb-item"><a href="#" class="breadcrumb-link">Home</a></li>
    <li class="breadcrumb-item" aria-hidden="true"><span class="breadcrumb-sep">/</span></li>
    <li class="breadcrumb-item"><span class="breadcrumb-link breadcrumb-current" aria-current="page">Overview</span></li>
  </ol>
</nav>
```
Add `.ease-glass-breadcrumb-dark` for a darker glass tint over lighter backdrops.

**Why does it fit EaseMotion CSS?**
Same glassmorphism family as the earlier glass-card submission but solves a genuinely different layout problem (a long, horizontally-constrained trail) with a single `mask-image` rule rather than JS overflow detection or a collapsing "…" menu.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

## Notes for Maintainer
Both `backdrop-filter` and `mask-image` carry `-webkit-` prefixes for Safari. Included an `@supports` fallback (solid dark panel) for browsers without `backdrop-filter` support, same pattern as the earlier glass-card PR.