### PR TITLE
feat: add basic export format row demo

### DIFF
--- a/submissions/examples/basic-export-format-row-kk/README.md
+++ b/submissions/examples/basic-export-format-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Export Format Row
+
+## What it does
+
+This submission adds a simple CSS-only export format row for report downloads,
+dashboard exports, account data pages, file sharing panels, and admin tools.
+
+It displays a format marker, export label, helper copy, and availability state
+in one compact row.
+
+## How to use it
+
+Add the base row class with a format marker, copy, and state pill:
+
+```html
+<article class="basic-export-format-row">
+  <span class="format-mark is-csv" aria-hidden="true">CSV</span>
+  <div class="format-copy">
+    <strong>Spreadsheet export</strong>
+    <p>Best for analytics, tables, and lightweight report sharing.</p>
+  </div>
+  <span class="format-state is-ready">Ready</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common dashboard and data-export interfaces. The row can be used inside report
+cards, admin tools, account data pages, and download panels while staying
+lightweight and CSS-only.
+
+## Included features
+
+- CSV, PDF, and JSON export format examples
+- Ready, popular, and advanced format states
+- Format marker, helper copy, and state pill layout
+- Text truncation for long export descriptions
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the export format row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-export-format-row-kk/demo.html
+++ b/submissions/examples/basic-export-format-row-kk/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Export Format Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Export Format Row</p>
+          <h1>Format rows for report exports and download settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing export formats, use cases,
+            helper copy, and compact availability states.
+          </p>
+        </header>
+
+        <section class="export-panel" aria-label="Export format row examples">
+          <article class="basic-export-format-row">
+            <span class="format-mark is-csv" aria-hidden="true">CSV</span>
+            <div class="format-copy">
+              <strong>Spreadsheet export</strong>
+              <p>Best for analytics, tables, and lightweight report sharing.</p>
+            </div>
+            <span class="format-state is-ready">Ready</span>
+          </article>
+
+          <article class="basic-export-format-row">
+            <span class="format-mark is-pdf" aria-hidden="true">PDF</span>
+            <div class="format-copy">
+              <strong>Printable report</strong>
+              <p>Use for invoices, summaries, and stakeholder-ready views.</p>
+            </div>
+            <span class="format-state is-popular">Popular</span>
+          </article>
+
+          <article class="basic-export-format-row">
+            <span class="format-mark is-json" aria-hidden="true">JSON</span>
+            <div class="format-copy">
+              <strong>Developer payload</strong>
+              <p>Structured export for integrations and backup workflows.</p>
+            </div>
+            <span class="format-state is-advanced">Advanced</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-export-format-row"&gt;
+  &lt;span class="format-mark is-csv" aria-hidden="true"&gt;CSV&lt;/span&gt;
+  &lt;div class="format-copy"&gt;
+    &lt;strong&gt;Spreadsheet export&lt;/strong&gt;
+    &lt;p&gt;Best for analytics, tables, and lightweight report sharing.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="format-state is-ready"&gt;Ready&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-export-format-row-kk/style.css
+++ b/submissions/examples/basic-export-format-row-kk/style.css
@@ -1,0 +1,188 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --csv: #86efac;
+  --pdf: #fca5a5;
+  --json: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(147, 197, 253, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 880px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--csv);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.export-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-export-format-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-export-format-row + .basic-export-format-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-export-format-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.format-mark {
+  width: 3.35rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 3.35rem;
+  border: 1px solid currentColor;
+  border-radius: 0.95rem;
+  color: var(--csv);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.format-mark.is-pdf {
+  color: var(--pdf);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+.format-mark.is-json {
+  color: var(--json);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.format-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.format-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.format-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.format-state {
+  flex: 0 0 auto;
+  min-width: 5.8rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--csv);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.format-state.is-popular {
+  color: var(--pdf);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+.format-state.is-advanced {
+  color: var(--json);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 560px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-export-format-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .format-state {
+    margin-left: 4.2rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Export Format Row demo inside `submissions/examples/basic-export-format-row-kk/`. This submission introduces a compact CSS-only row for report downloads, dashboard exports, account data pages, file sharing panels, and admin tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only export format row that displays a format marker, export label, helper copy, and ready/popular/advanced availability state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-export-format-row">
  <span class="format-mark is-csv" aria-hidden="true">CSV</span>
  <div class="format-copy">
    <strong>Spreadsheet export</strong>
    <p>Best for analytics, tables, and lightweight report sharing.</p>
  </div>
  <span class="format-state is-ready">Ready</span>
</article>