### PR TITLE
feat: add basic domain verification row demo

### DIFF
--- a/submissions/examples/basic-domain-verification-row-kk/README.md
+++ b/submissions/examples/basic-domain-verification-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Domain Verification Row
+
+## What it does
+
+This submission adds a simple CSS-only domain verification row for workspace
+setup pages, DNS verification screens, admin settings, custom domain panels,
+and onboarding flows.
+
+It displays a domain marker, domain name, DNS helper copy, record type, and
+verification state in one compact row.
+
+## How to use it
+
+Add the base row class with a domain marker, copy, record type, and state:
+
+```html
+<article class="basic-domain-verification-row">
+  <span class="domain-mark" aria-hidden="true">.com</span>
+  <div class="domain-copy">
+    <strong>app.example.com</strong>
+    <p>TXT record matched and workspace routing is active.</p>
+  </div>
+  <span class="domain-record">TXT</span>
+  <span class="domain-state is-verified">Verified</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+workspace setup and admin interfaces. The row can be reused in DNS panels,
+custom domain cards, onboarding screens, and settings pages while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Verified, pending, and failed domain states
+- Domain suffix marker
+- DNS helper copy, record type pill, and state pill layout
+- Text truncation for long DNS helper copy
+- Subtle hover lift interaction
+- Responsive two-column wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the domain verification row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-domain-verification-row-kk/demo.html
+++ b/submissions/examples/basic-domain-verification-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Domain Verification Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Domain Verification Row</p>
+          <h1>Domain rows for workspace setup and DNS verification.</h1>
+          <p class="intro">
+            A CSS-only row component for showing workspace domains, DNS helper
+            text, and verification states inside admin setup screens.
+          </p>
+        </header>
+
+        <section class="domain-panel" aria-label="Domain verification row examples">
+          <article class="basic-domain-verification-row">
+            <span class="domain-mark" aria-hidden="true">.com</span>
+            <div class="domain-copy">
+              <strong>app.example.com</strong>
+              <p>TXT record matched and workspace routing is active.</p>
+            </div>
+            <span class="domain-record">TXT</span>
+            <span class="domain-state is-verified">Verified</span>
+          </article>
+
+          <article class="basic-domain-verification-row">
+            <span class="domain-mark" aria-hidden="true">.dev</span>
+            <div class="domain-copy">
+              <strong>docs.example.dev</strong>
+              <p>Waiting for DNS propagation before the domain can be used.</p>
+            </div>
+            <span class="domain-record">CNAME</span>
+            <span class="domain-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-domain-verification-row">
+            <span class="domain-mark" aria-hidden="true">.io</span>
+            <div class="domain-copy">
+              <strong>portal.example.io</strong>
+              <p>DNS value does not match the expected verification record.</p>
+            </div>
+            <span class="domain-record">TXT</span>
+            <span class="domain-state is-failed">Failed</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-domain-verification-row"&gt;
+  &lt;span class="domain-mark" aria-hidden="true"&gt;.com&lt;/span&gt;
+  &lt;div class="domain-copy"&gt;
+    &lt;strong&gt;app.example.com&lt;/strong&gt;
+    &lt;p&gt;TXT record matched and workspace routing is active.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="domain-record"&gt;TXT&lt;/span&gt;
+  &lt;span class="domain-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-domain-verification-row-kk/style.css
+++ b/submissions/examples/basic-domain-verification-row-kk/style.css
@@ -1,0 +1,185 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --verified: #86efac;
+  --pending: #fcd34d;
+  --failed: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--verified);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.domain-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-domain-verification-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-domain-verification-row + .basic-domain-verification-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-domain-verification-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.domain-mark {
+  width: 3.35rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.domain-copy {
+  min-width: 0;
+}
+
+.domain-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.domain-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.domain-record,
+.domain-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.domain-record {
+  min-width: 4.6rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.domain-state {
+  min-width: 5.8rem;
+  border: 1px solid currentColor;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.domain-state.is-pending {
+  color: var(--pending);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.domain-state.is-failed {
+  color: var(--failed);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-domain-verification-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .domain-record {
+    margin-left: 4.2rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Domain Verification Row demo inside `submissions/examples/basic-domain-verification-row-kk/`. This submission introduces a compact CSS-only row for workspace setup pages, DNS verification screens, admin settings, custom domain panels, and onboarding flows.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only domain verification row that displays a domain marker, domain name, DNS helper copy, record type, and verified/pending/failed state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-domain-verification-row">
  <span class="domain-mark" aria-hidden="true">.com</span>
  <div class="domain-copy">
    <strong>app.example.com</strong>
    <p>TXT record matched and workspace routing is active.</p>
  </div>
  <span class="domain-record">TXT</span>
  <span class="domain-state is-verified">Verified</span>
</article>