### PR TITLE
feat: add basic seat usage row demo

### DIFF
--- a/submissions/examples/basic-seat-usage-row-kk/README.md
+++ b/submissions/examples/basic-seat-usage-row-kk/README.md
@@ -1,0 +1,50 @@
+# Basic Seat Usage Row
+
+## What it does
+
+This submission adds a simple CSS-only seat usage row for team billing pages,
+workspace settings, admin dashboards, invite flows, and subscription panels.
+
+It displays assigned seat count, workspace label, helper copy, usage progress,
+and availability state in one compact row.
+
+## How to use it
+
+Add the base row class with a seat marker, copy, progress track, and state:
+
+```html
+<article class="basic-seat-usage-row">
+  <span class="seat-mark" aria-hidden="true">12</span>
+  <div class="seat-copy">
+    <strong>Starter workspace</strong>
+    <p>12 of 25 seats are currently assigned.</p>
+    <span class="seat-track" aria-hidden="true">
+      <span class="seat-fill" style="--value: 48%"></span>
+    </span>
+  </div>
+  <span class="seat-state is-available">Available</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common team-management and billing interfaces. The row can be reused inside
+workspace settings, subscription cards, invite panels, and admin dashboards
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Available, warning, and full seat usage states
+- Assigned seat marker, helper copy, progress track, and state pill layout
+- CSS variable-powered usage progress width
+- Text truncation for long usage descriptions
+- Subtle hover lift interaction
+- Responsive wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the seat usage row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-seat-usage-row-kk/demo.html
+++ b/submissions/examples/basic-seat-usage-row-kk/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Seat Usage Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Seat Usage Row</p>
+          <h1>Seat usage rows for team billing and workspace settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing member seat usage, plan limits,
+            helper copy, and compact availability states.
+          </p>
+        </header>
+
+        <section class="seat-panel" aria-label="Seat usage row examples">
+          <article class="basic-seat-usage-row">
+            <span class="seat-mark" aria-hidden="true">12</span>
+            <div class="seat-copy">
+              <strong>Starter workspace</strong>
+              <p>12 of 25 seats are currently assigned.</p>
+              <span class="seat-track" aria-hidden="true">
+                <span class="seat-fill" style="--value: 48%"></span>
+              </span>
+            </div>
+            <span class="seat-state is-available">Available</span>
+          </article>
+
+          <article class="basic-seat-usage-row">
+            <span class="seat-mark" aria-hidden="true">21</span>
+            <div class="seat-copy">
+              <strong>Growth workspace</strong>
+              <p>21 of 25 seats are assigned across project teams.</p>
+              <span class="seat-track" aria-hidden="true">
+                <span class="seat-fill is-warning" style="--value: 84%"></span>
+              </span>
+            </div>
+            <span class="seat-state is-warning">Warning</span>
+          </article>
+
+          <article class="basic-seat-usage-row">
+            <span class="seat-mark" aria-hidden="true">25</span>
+            <div class="seat-copy">
+              <strong>Enterprise sandbox</strong>
+              <p>All 25 seats are assigned. Add seats before inviting more users.</p>
+              <span class="seat-track" aria-hidden="true">
+                <span class="seat-fill is-full" style="--value: 100%"></span>
+              </span>
+            </div>
+            <span class="seat-state is-full">Full</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-seat-usage-row"&gt;
+  &lt;span class="seat-mark" aria-hidden="true"&gt;12&lt;/span&gt;
+  &lt;div class="seat-copy"&gt;
+    &lt;strong&gt;Starter workspace&lt;/strong&gt;
+    &lt;p&gt;12 of 25 seats are currently assigned.&lt;/p&gt;
+    &lt;span class="seat-track" aria-hidden="true"&gt;
+      &lt;span class="seat-fill" style="--value: 48%"&gt;&lt;/span&gt;
+    &lt;/span&gt;
+  &lt;/div&gt;
+  &lt;span class="seat-state is-available"&gt;Available&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-seat-usage-row-kk/style.css
+++ b/submissions/examples/basic-seat-usage-row-kk/style.css
@@ -1,0 +1,201 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --available: #86efac;
+  --warning: #fcd34d;
+  --full: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 920px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--available);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 15ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.seat-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-seat-usage-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-seat-usage-row + .basic-seat-usage-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-seat-usage-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.seat-mark {
+  width: 2.9rem;
+  height: 2.9rem;
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.9rem;
+  border: 1px solid rgba(134, 239, 172, 0.32);
+  border-radius: 0.95rem;
+  color: var(--available);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.9rem;
+  font-weight: 900;
+}
+
+.seat-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.seat-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.seat-copy p {
+  margin: 0.28rem 0 0.55rem;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seat-track {
+  height: 0.42rem;
+  overflow: hidden;
+  display: block;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.seat-fill {
+  width: var(--value);
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+  background: var(--available);
+}
+
+.seat-fill.is-warning {
+  background: var(--warning);
+}
+
+.seat-fill.is-full {
+  background: var(--full);
+}
+
+.seat-state {
+  flex: 0 0 auto;
+  min-width: 6rem;
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--available);
+  background: rgba(134, 239, 172, 0.12);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.seat-state.is-warning {
+  color: var(--warning);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.seat-state.is-full {
+  color: var(--full);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 620px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-seat-usage-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .seat-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Seat Usage Row demo inside `submissions/examples/basic-seat-usage-row-kk/`. This submission introduces a compact CSS-only row for team billing pages, workspace settings, admin dashboards, invite flows, and subscription panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only seat usage row that displays assigned seat count, workspace label, helper copy, usage progress, and available/warning/full state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-seat-usage-row">
  <span class="seat-mark" aria-hidden="true">12</span>
  <div class="seat-copy">
    <strong>Starter workspace</strong>
    <p>12 of 25 seats are currently assigned.</p>
    <span class="seat-track" aria-hidden="true">
      <span class="seat-fill" style="--value: 48%"></span>
    </span>
  </div>
  <span class="seat-state is-available">Available</span>
</article>