### PR TITLE
feat: create Hover Button with Material Design styling (#50547) #80011

### DIFF
--- a/submissions/examples/css-button-hover-material-pure/README.md
+++ b/submissions/examples/css-button-hover-material-pure/README.md
@@ -1,0 +1,13 @@
+# Material Design Hover Button
+
+A precise, pure CSS implementation of Google's Material Design button specifications, featuring accurate elevation shadows, typography, and a CSS-only pseudo-ripple interaction effect.
+
+## Features
+- **Three Material Variants**: Includes code for Contained (high emphasis), Outlined (medium emphasis), and Text (low emphasis) button styles as defined in the Material Design system.
+- **Accurate Elevation Physics**: Uses highly specific multi-layered `box-shadow` values matching Material Design's dp elevation scale (Elevation 2 for rest, 4 for hover, 8 for active press).
+- **CSS-Only Ripple Engine**: Simulates the iconic JavaScript-based Material ripple using only CSS. It achieves this by instantly scaling a `.md-ripple` span to 100% on `:active`, and using a slow `transition` to fade and expand it further when `:not(:active)` (the release state).
+- **Interactive State Overlays**: Uses the `::before` pseudo-element linked to `currentColor` to dynamically create the correct 8% opacity hover state overlay, ensuring the hover color mathematically matches the text color for outlined and text variants.
+- **Typography Standards**: Conforms strictly to Material guidelines for buttons: uppercase text, `0.875rem` font size, `500` font weight, and `0.0892em` letter spacing using the `Roboto` font.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Roboto` font is loaded in your `<head>` for accurate rendering.

--- a/submissions/examples/css-button-hover-material-pure/demo.html
+++ b/submissions/examples/css-button-hover-material-pure/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Hover Button</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <!-- Contained Material Button -->
+        <button class="md-btn btn-contained">
+            <span class="btn-content">
+                <svg viewBox="0 0 24 24" class="btn-icon"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
+                Create New
+            </span>
+            <span class="md-ripple"></span>
+        </button>
+
+        <!-- Outlined Material Button -->
+        <button class="md-btn btn-outlined">
+            <span class="btn-content">
+                <svg viewBox="0 0 24 24" class="btn-icon"><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>
+                Share Link
+            </span>
+            <span class="md-ripple"></span>
+        </button>
+
+        <!-- Text Material Button -->
+        <button class="md-btn btn-text">
+            <span class="btn-content">
+                Learn More
+            </span>
+            <span class="md-ripple"></span>
+        </button>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-button-hover-material-pure/style.css
+++ b/submissions/examples/css-button-hover-material-pure/style.css
@@ -1,0 +1,161 @@
+:root {
+    --md-primary: #6200ee;
+    --md-primary-hover: #7c4dff;
+    --md-on-primary: #ffffff;
+    
+    --md-surface: #ffffff;
+    --md-on-surface: #000000;
+    
+    --md-elevation-2: 0 3px 1px -2px rgba(0,0,0,0.2), 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12);
+    --md-elevation-4: 0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12);
+    --md-elevation-8: 0 5px 5px -3px rgba(0,0,0,0.2), 0 8px 10px 1px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Roboto', sans-serif;
+}
+
+body {
+    background-color: #f5f5f5;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 40px;
+}
+
+/* 
+   Base Material Button 
+*/
+.md-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    padding: 0 16px;
+    min-width: 64px;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.0892857143em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    overflow: hidden;
+    /* Smooth transitions for states */
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, 
+                box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, 
+                border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, 
+                color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.btn-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    pointer-events: none;
+}
+
+.btn-icon {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+    margin-left: -4px;
+}
+
+/* 
+   Pure CSS Ripple Effect (Hover/Active based)
+*/
+.md-ripple {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 150%;
+    aspect-ratio: 1/1;
+    background-color: currentColor;
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 0;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover State - Background Overlay */
+.md-btn:hover::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: currentColor;
+    opacity: 0.08;
+    z-index: 0;
+    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Active State - Expand Ripple */
+.md-btn:active .md-ripple {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.2;
+    transition: transform 0s, opacity 0s; /* Instant scale on press */
+}
+
+/* Release State - Fade Out Ripple */
+.md-btn:not(:active) .md-ripple {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+    transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* 
+   Contained Variant 
+*/
+.btn-contained {
+    background-color: var(--md-primary);
+    color: var(--md-on-primary);
+    box-shadow: var(--md-elevation-2);
+}
+
+.btn-contained:hover {
+    box-shadow: var(--md-elevation-4);
+}
+
+.btn-contained:active {
+    box-shadow: var(--md-elevation-8);
+}
+
+/* 
+   Outlined Variant 
+*/
+.btn-outlined {
+    background-color: transparent;
+    color: var(--md-primary);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.btn-outlined:hover {
+    border-color: var(--md-primary);
+}
+
+/* 
+   Text Variant 
+*/
+.btn-text {
+    background-color: transparent;
+    color: var(--md-primary);
+    padding: 0 8px;
+}


### PR DESCRIPTION
**Title:** feat: create Hover Button with Material Design styling (#50547) #80011

**Description:**
This PR introduces a highly accurate, pure CSS implementation of Google's Material Design button specifications, featuring correct elevation shadows and a CSS-only pseudo-ripple effect.

Fixes #80011

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-button-hover-material-pure/`
- Implemented three distinct Material button variants: Contained (High emphasis), Outlined (Medium emphasis), and Text (Low emphasis)
- Engineered a CSS-only "Ripple" interaction engine by instantly scaling a `.md-ripple` span to 100% on `:active`, and utilizing slow transition delays on `:not(:active)` to create the fade-out release effect
- Configured mathematically accurate elevation physics using layered `box-shadow` values matching standard Material Design dp scales (Elevation 2 for rest, 4 for hover, 8 for pressed states)
- Built an automatic interactive state overlay using the `::before` pseudo-element and `currentColor` to dynamically create the correct 8% opacity hover background for all variants
- Matched exact Material typography specifications: uppercase formatting, `0.875rem` font size, `500` weight, and `0.0892em` letter spacing using the `Roboto` font
