### PR TITLE
feat: create Neumorphic Tooltip with Minimalist styling (#26092) #79908

### DIFF
--- a/submissions/examples/css-tooltip-neumorphic-minimalist-pure/README.md
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist-pure/README.md
@@ -1,0 +1,14 @@
+# Neumorphic Minimalist Tooltip
+
+A soft, elegant CSS tooltip component featuring precise Neumorphic (soft UI) drop-shadows and spring-physics entrance animations.
+
+## Features
+- **Neumorphic Extrusion Physics**: Both the trigger button and the tooltip utilize carefully tuned, opposing `box-shadow` configurations (mixing a dark shadow with a bright highlight) to simulate physical objects extruded from the background material.
+- **Interactive Pressed States**: The trigger button features a tactile `:active` state that replaces the outer box-shadow with an `inset` shadow, simulating a physical button press.
+- **Advanced CSS Tooltip Pointer**: Because standard CSS border-triangles cannot accurately inherit complex drop-shadows, the tooltip pointer is engineered using a rotated `::before` pseudo-element square (`transform: rotate(45deg)`). Its box-shadow is meticulously split to match the direction of the tooltip's main shadows.
+- **Spring Reveal Animation**: When hovered, the tooltip fades in and elegantly slides into position using a `cubic-bezier` timing function, providing a high-quality, native app feel.
+- **Directional Variants**: Includes CSS configurations for both Top-aligned and Bottom-aligned tooltips.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the `Poppins` font is loaded in your `<head>`.
+- **Important**: The Neumorphic optical illusion requires that the parent container (or `body`) background color perfectly matches the `--neu-bg` CSS variable (`#e0e5ec`). If you change the background color, you must also recalculate the highlight (`--neu-shadow-light`) and shadow (`--neu-shadow-dark`) hex values.

--- a/submissions/examples/css-tooltip-neumorphic-minimalist-pure/demo.html
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist-pure/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Minimalist Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <div class="container">
+        
+        <!-- Tooltip Wrapper (Top) -->
+        <div class="tooltip-container">
+            <button class="neu-btn">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
+                Information
+            </button>
+            
+            <div class="neu-tooltip tooltip-top">
+                <span class="tooltip-title">System Status</span>
+                <span class="tooltip-text">All services are currently running optimally.</span>
+            </div>
+        </div>
+
+        <!-- Tooltip Wrapper (Bottom) -->
+        <div class="tooltip-container">
+            <button class="neu-btn">
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .43-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.49-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
+                Settings
+            </button>
+            
+            <div class="neu-tooltip tooltip-bottom">
+                <span class="tooltip-title">Configuration</span>
+                <span class="tooltip-text">Manage your personal preferences and account settings here.</span>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-tooltip-neumorphic-minimalist-pure/style.css
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist-pure/style.css
@@ -1,0 +1,180 @@
+:root {
+    --neu-bg: #e0e5ec;
+    --neu-shadow-dark: #a3b1c6;
+    --neu-shadow-light: #ffffff;
+    
+    --text-primary: #4a5568;
+    --text-secondary: #718096;
+    
+    --accent: #3182ce;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Poppins', sans-serif;
+}
+
+body {
+    background-color: var(--neu-bg);
+    color: var(--text-primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    display: flex;
+    gap: 40px;
+    padding: 40px;
+}
+
+/* 
+   Neumorphic Button (Trigger) 
+*/
+.neu-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 24px;
+    background-color: var(--neu-bg);
+    color: var(--text-primary);
+    border: none;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 
+        6px 6px 12px var(--neu-shadow-dark), 
+        -6px -6px 12px var(--neu-shadow-light);
+    transition: all 0.2s ease;
+    outline: none;
+}
+
+.neu-btn:hover {
+    color: var(--accent);
+}
+
+.neu-btn:active {
+    box-shadow: 
+        inset 4px 4px 8px var(--neu-shadow-dark), 
+        inset -4px -4px 8px var(--neu-shadow-light);
+}
+
+/* 
+   Tooltip Base Container
+*/
+.tooltip-container {
+    position: relative;
+    display: inline-block;
+}
+
+/* 
+   Neumorphic Tooltip Styling
+*/
+.neu-tooltip {
+    position: absolute;
+    width: max-content;
+    max-width: 250px;
+    background-color: var(--neu-bg);
+    padding: 16px;
+    border-radius: 12px;
+    box-shadow: 
+        8px 8px 16px var(--neu-shadow-dark), 
+        -8px -8px 16px var(--neu-shadow-light);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    
+    /* Animation Base State */
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    z-index: 100;
+}
+
+/* Tooltip Typography */
+.tooltip-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.tooltip-text {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+/* 
+   Tooltip Pointer Arrow (Neumorphic Hack)
+   Because box-shadows don't play well with CSS borders for triangles,
+   we use a rotated square with the same neumorphic shadows.
+*/
+.neu-tooltip::before {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    background-color: var(--neu-bg);
+    transform: rotate(45deg);
+    z-index: -1; /* Push behind the tooltip body */
+}
+
+/* 
+   Top Tooltip Variant 
+*/
+.tooltip-top {
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, 15px); /* Start slightly down */
+    margin-bottom: 20px;
+}
+
+.tooltip-top::before {
+    bottom: -8px;
+    left: calc(50% - 8px);
+    /* Cast shadow downwards */
+    box-shadow: 6px 6px 12px var(--neu-shadow-dark); 
+}
+
+/* Hover State - Animate Up */
+.tooltip-container:hover .tooltip-top {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
+}
+
+/* 
+   Bottom Tooltip Variant 
+*/
+.tooltip-bottom {
+    top: 100%;
+    left: 50%;
+    transform: translate(-50%, -15px); /* Start slightly up */
+    margin-top: 20px;
+}
+
+.tooltip-bottom::before {
+    top: -8px;
+    left: calc(50% - 8px);
+    /* Cast shadow upwards */
+    box-shadow: -6px -6px 12px var(--neu-shadow-light); 
+}
+
+/* Hover State - Animate Down */
+.tooltip-container:hover .tooltip-bottom {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .container {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
**Title:** feat: create Neumorphic Tooltip with Minimalist styling (#26092) #79908

**Description:**
This PR introduces a soft, elegant pure CSS tooltip component featuring precise Neumorphic (soft UI) drop-shadows and spring-physics entrance animations.

Fixes #79908

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-neumorphic-minimalist-pure/`
- Configured a Neumorphic physics engine using layered `box-shadow` combinations (mixing a dark shadow with a bright highlight) to simulate physical objects extruded from the background material (`#e0e5ec`)
- Built a tactile `:active` state for the trigger button that replaces the outer box-shadow with an `inset` shadow, simulating a physical button press
- Engineered an advanced CSS tooltip pointer using a rotated `::before` pseudo-element square (`transform: rotate(45deg)`) with its box-shadow meticulously split to inherit the correct Neumorphic depth
- Added smooth spring-reveal animations utilizing a `cubic-bezier` timing function to slide and fade the tooltip into position on hover
- Included structural configurations for both Top-aligned and Bottom-aligned tooltip variants
- Styled with clean `Poppins` typography for a minimalist, modern aesthetic
