### PR TITLE
feat: add Scroll-Triggered Stat Counter example (stat-counter-scroll-qz9k)

### DIFF
--- a/submissions/examples/stat-counter-scroll-qz9k/README.md
+++ b/submissions/examples/stat-counter-scroll-qz9k/README.md
@@ -1,0 +1,37 @@
+# Scroll-Triggered Stat Counter
+
+## What does this do?
+
+Statistics that count up from 0 to their target value the moment they
+scroll into view, using `IntersectionObserver` to trigger the animation
+exactly once — scrolling back up and down again doesn't restart the count.
+
+## How is it used?
+
+```html
+<p class="scs-number" data-target="48000">0</p>
+```
+
+`scsInit` observes every `.scs-number` element; on intersection,
+`scsAnimate` reads the target from `data-target` and animates toward it via
+`requestAnimationFrame`, then the observer calls `unobserve` on that
+specific element so the same counter never re-triggers.
+
+## Why is it useful?
+
+A scroll-triggered counter that doesn't unobserve after firing re-plays
+the count-up animation every time the element scrolls back into the
+viewport — a user scrolling up to re-read a section above the stats, then
+scrolling back down past them, sees the numbers reset to 0 and count up
+again, which reads as a bug rather than an intentional entrance effect.
+Calling `observer.unobserve(entry.target)` the first time an element
+intersects makes the animation genuinely one-shot: it plays exactly once,
+on first appearance, regardless of how many more times the element
+crosses the viewport afterward.
+
+`font-variant-numeric: tabular-nums` on the counter keeps every digit the
+same fixed width throughout the animation — without it, proportional-width
+digits (a `1` narrower than an `8`, for instance) cause the number's total
+width to fluctuate slightly as it counts, which shows up as the whole stat
+and its label jittering left and right during the animation rather than
+staying visually still.

--- a/submissions/examples/stat-counter-scroll-qz9k/demo.html
+++ b/submissions/examples/stat-counter-scroll-qz9k/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Scroll-Triggered Stat Counter</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function scsAnimate(el) {
+    var target = Number(el.dataset.target);
+    var duration = 1200;
+    var start = null;
+
+    function tick(timestamp) {
+      if (start === null) start = timestamp;
+      var progress = Math.min(1, (timestamp - start) / duration);
+      var eased = 1 - Math.pow(1 - progress, 3);
+      el.textContent = Math.round(target * eased).toLocaleString();
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+
+    requestAnimationFrame(tick);
+  }
+
+  function scsInit() {
+    var counters = document.querySelectorAll('.scs-number');
+    if (!('IntersectionObserver' in window)) {
+      counters.forEach(scsAnimate);
+      return;
+    }
+
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          scsAnimate(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.6 });
+
+    counters.forEach(function (el) { observer.observe(el); });
+  }
+
+  document.addEventListener('DOMContentLoaded', scsInit);
+</script>
+</head>
+<body>
+<main class="scs-wrap">
+  <h1 class="scs-h1">Our Impact</h1>
+  <p class="scs-lede">Each counter animates from 0 only once it scrolls into view, and only once ever -- the observer unobserves itself after firing, so scrolling back up and down again doesn't restart the count.</p>
+
+  <div class="scs-grid">
+    <div class="scs-stat">
+      <p class="scs-number" data-target="48000">0</p>
+      <p class="scs-label">Active users</p>
+    </div>
+    <div class="scs-stat">
+      <p class="scs-number" data-target="120">0</p>
+      <p class="scs-label">Countries</p>
+    </div>
+    <div class="scs-stat">
+      <p class="scs-number" data-target="99">0</p>
+      <p class="scs-label">Uptime %</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/stat-counter-scroll-qz9k/style.css
+++ b/submissions/examples/stat-counter-scroll-qz9k/style.css
@@ -1,0 +1,45 @@
+/* Scroll-Triggered Stat Counter
+   font-variant-numeric:tabular-nums keeps each digit the same width as the
+   count animates, so the surrounding label doesn't visibly shift left and
+   right as the number's character count or specific digits change mid-
+   animation -- proportional digits would otherwise cause that jitter. */
+
+.scs-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.scs-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); text-align: center; }
+.scs-lede { margin: 0 0 2.5rem; color: #576073; text-align: center; }
+
+.scs-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.scs-stat {
+  text-align: center;
+}
+
+.scs-number {
+  margin: 0;
+  font-size: clamp(1.6rem, 6vw, 2.4rem);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: #4c6ef5;
+}
+
+.scs-label {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  color: #576073;
+}
+
+@media (prefers-color-scheme: dark) {
+  .scs-wrap { color: #e6e9f2; }
+  .scs-lede, .scs-label { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80961

Statistics that count up from 0 the moment they scroll into view, using IntersectionObserver to trigger exactly once — observer.unobserve() is called the first time an element intersects, so scrolling up to re-read content and back down past the stats never re-triggers the animation. font-variant-numeric:tabular-nums keeps every digit a fixed width so the label doesn't jitter left/right as the number's specific digits change mid-count.