### PR TITLE
feat: add Currency Input example (input-currency-format-qz9k)

### DIFF
--- a/submissions/examples/input-currency-format-qz9k/README.md
+++ b/submissions/examples/input-currency-format-qz9k/README.md
@@ -1,0 +1,42 @@
+# Currency Input
+
+## What does this do?
+
+A currency field that formats live as the user types, treating input like
+a calculator display — digits fill in from the right, with the value always
+interpreted as cents and re-rendered as a formatted dollar amount
+(`$1,234.56`) on every keystroke.
+
+## How is it used?
+
+```html
+<input id="cif-input" type="text" inputmode="numeric" value="$0.00" oninput="cifFormat(this)" />
+<input type="hidden" id="cif-hidden" name="amount" value="0.00" />
+```
+
+`cifFormat` strips all non-digit characters from the current value,
+treats the remaining digit string as cents, and formats it via
+`toLocaleString('en-US', { style: 'currency', currency: 'USD' })`. A
+parallel hidden input holds the raw decimal value (`"12.34"`, not the
+formatted display string) for actual form submission.
+
+## Why is it useful?
+
+Formatting a currency input live (adding commas, a currency symbol, and a
+fixed two-decimal display) means the string's length and character
+positions change on every keystroke — a comma appearing or disappearing as
+the number crosses a thousands boundary shifts every character after it.
+Naively leaving the caret wherever `setSelectionRange` last put it (or not
+managing it at all) means the caret visibly jumps to the wrong position
+after each reformat, making it hard to keep typing fluidly. Tracking the
+caret's distance from the *end* of the string (rather than from the start)
+and restoring that same distance after reformatting works reliably because
+new digits are always typed at the rightmost position — the "distance from
+end" stays meaningful across a reformat in a way that "distance from
+start" doesn't, since characters can be inserted anywhere before the caret.
+
+The hidden input holding a clean decimal value (`"12.34"`) exists
+because the visible field's formatted text (`"$1,234.56"`) is meant for
+display, not for parsing by a form handler — submitting the raw decimal
+value directly avoids every consumer of the form needing to strip currency
+formatting characters back out themselves.

--- a/submissions/examples/input-currency-format-qz9k/demo.html
+++ b/submissions/examples/input-currency-format-qz9k/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Currency Input</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function cifFormat(input) {
+    var caretFromEnd = input.value.length - input.selectionStart;
+    var digits = input.value.replace(/\D/g, '');
+    var cents = digits ? parseInt(digits, 10) : 0;
+    var formatted = (cents / 100).toLocaleString('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    });
+
+    input.value = formatted;
+
+    // Restore caret position relative to the END of the string, since
+    // formatting can insert/remove characters (commas, decimal point)
+    // anywhere before the cursor -- anchoring from the end is stable
+    // because new digits are always typed at the rightmost position.
+    var newPos = Math.max(0, input.value.length - caretFromEnd);
+    input.setSelectionRange(newPos, newPos);
+
+    document.getElementById('cif-hidden').value = (cents / 100).toFixed(2);
+  }
+</script>
+</head>
+<body>
+<main class="cif-wrap">
+  <h1 class="cif-h1">Currency Input</h1>
+  <p class="cif-lede">Typing digits fills in from the right, like a physical calculator display, formatting live as USD -- the caret position is tracked relative to the end of the string so it stays anchored correctly through reformatting.</p>
+
+  <label class="cif-field-label" for="cif-input">Amount</label>
+  <input
+    id="cif-input"
+    class="cif-input"
+    type="text"
+    inputmode="numeric"
+    value="$0.00"
+    oninput="cifFormat(this)"
+  />
+  <input type="hidden" id="cif-hidden" name="amount" value="0.00" />
+</main>
+</body>
+</html>

--- a/submissions/examples/input-currency-format-qz9k/style.css
+++ b/submissions/examples/input-currency-format-qz9k/style.css
@@ -1,0 +1,53 @@
+/* Currency Input
+   font-variant-numeric:tabular-nums again matters here for a different
+   reason than a counter: without it, the caret's visual x-position and its
+   logical character-index position (used by setSelectionRange) can drift
+   apart slightly as digit widths vary, which is avoidable simply by
+   keeping every digit the same width. */
+
+.cif-wrap {
+  max-width: 20rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.cif-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.cif-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.cif-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.cif-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-size: 1.3rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  transition: border-color 160ms ease;
+}
+
+.cif-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cif-input { transition: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .cif-wrap { color: #e6e9f2; }
+  .cif-lede { color: #99a1b4; }
+  .cif-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80962

Currency field treated like a calculator display — digits fill from the right, formatted live as USD on every keystroke. Caret position is tracked as distance from the end of the string (not the start), since new digits are always typed rightmost and that distance stays stable through reformatting even as commas and the decimal point shift position. A parallel hidden input holds the raw decimal value for form submission, separate from the display-formatted text.