### PR TITLE
feat: add Horizontal Scroll Timeline example (timeline-horizontal-scroll-qz9k)

### DIFF
--- a/submissions/examples/timeline-horizontal-scroll-qz9k/README.md
+++ b/submissions/examples/timeline-horizontal-scroll-qz9k/README.md
@@ -1,0 +1,46 @@
+# Horizontal Scroll Timeline
+
+## What does this do?
+
+A company-history timeline that scrolls horizontally with CSS scroll-snap,
+centering each event as the user scrolls — with no JavaScript tracking
+"which event is current," since the browser's own scroll position is the
+entire state.
+
+## How is it used?
+
+```html
+<div class="hst-track" tabindex="0" role="region" aria-label="Company history timeline, scroll horizontally">
+  <div class="hst-line" aria-hidden="true"></div>
+  <div class="hst-event">
+    <span class="hst-year">2019</span>
+    <p class="hst-text">Founded in a shared workspace with three people.</p>
+  </div>
+  <!-- ... -->
+</div>
+```
+
+`scroll-snap-type: x mandatory` on the track plus `scroll-snap-align:
+center` on each event is the entire mechanism — no JS scroll listener
+computing which event is "active" or driving the snap behavior manually.
+
+## Why is it useful?
+
+A carousel or horizontal timeline is often built with a JS-tracked
+"current index" that the scroll position is synced to (or that drives the
+scroll position programmatically), which introduces two sources of truth
+that can drift out of sync — a fast swipe gesture the JS index tracker
+doesn't catch cleanly, for instance. Relying entirely on native CSS
+scroll-snap means there's only one state: wherever the track has actually
+scrolled to. That state is inherently correct by construction, works with
+trackpad scroll, touch swipe, and keyboard scrolling (via the focusable
+`tabindex="0"` track) identically, and needs no JS to keep in sync with
+anything.
+
+Because each event snaps to *center* rather than the more common
+*start*, the track needs asymmetric padding — `padding-inline:
+calc(50% - 7rem)`, where `7rem` is half an event's width — so the first
+and last events can actually reach the centered position rather than
+stopping short against the track's edge, unable to scroll any further to
+center themselves. This padding requirement is specific to center-snap and
+wouldn't be needed for the more common start-aligned snap layout.

--- a/submissions/examples/timeline-horizontal-scroll-qz9k/demo.html
+++ b/submissions/examples/timeline-horizontal-scroll-qz9k/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Horizontal Scroll Timeline</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="hst-wrap">
+  <h1 class="hst-h1">Company History</h1>
+  <p class="hst-lede">Scroll-snap keeps each event centered as you scroll horizontally, and the track's own scroll position is the entire state -- there is no JS tracking "current index" separately from where the browser has actually scrolled.</p>
+
+  <div class="hst-track" tabindex="0" role="region" aria-label="Company history timeline, scroll horizontally">
+    <div class="hst-line" aria-hidden="true"></div>
+    <div class="hst-event">
+      <span class="hst-year">2019</span>
+      <p class="hst-text">Founded in a shared workspace with three people.</p>
+    </div>
+    <div class="hst-event">
+      <span class="hst-year">2021</span>
+      <p class="hst-text">Shipped the first public beta after 18 months of building.</p>
+    </div>
+    <div class="hst-event">
+      <span class="hst-year">2023</span>
+      <p class="hst-text">Crossed 100,000 registered users.</p>
+    </div>
+    <div class="hst-event">
+      <span class="hst-year">2025</span>
+      <p class="hst-text">Opened a second office and grew the team to 40.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/timeline-horizontal-scroll-qz9k/style.css
+++ b/submissions/examples/timeline-horizontal-scroll-qz9k/style.css
@@ -1,0 +1,89 @@
+/* Horizontal Scroll Timeline
+   scroll-snap-align:center on each event (not start) means the FIRST and
+   LAST events need extra inline padding on the track equal to roughly half
+   the viewport, or they can never actually reach the centered snap
+   position -- without it they'd stop short, flush against the track edge. */
+
+.hst-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 0;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.hst-h1 { margin: 0 1.25rem 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.hst-lede { margin: 0 1.25rem 2rem; color: #576073; }
+
+.hst-track {
+  display: flex;
+  gap: 2.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding: 1.5rem calc(50% - 7rem) 1.5rem;
+  position: relative;
+}
+
+.hst-track:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: -2px;
+}
+
+.hst-line {
+  position: absolute;
+  top: 2.7rem;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #dfe3ec;
+}
+
+.hst-event {
+  flex: none;
+  width: 14rem;
+  scroll-snap-align: center;
+  position: relative;
+  padding-top: 1.6rem;
+}
+
+.hst-event::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: #4c6ef5;
+  border: 2px solid #fff;
+}
+
+.hst-year {
+  display: block;
+  font-weight: 800;
+  color: #4c6ef5;
+  margin-bottom: 0.3rem;
+}
+
+.hst-text {
+  margin: 0;
+  color: #576073;
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hst-track { scroll-behavior: auto; }
+}
+
+@media (forced-colors: active) {
+  .hst-line { background: CanvasText; }
+  .hst-event::before { forced-color-adjust: none; background: Highlight; border-color: Canvas; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .hst-wrap { color: #e6e9f2; }
+  .hst-lede { color: #99a1b4; }
+  .hst-line { background: #2a303c; }
+  .hst-event::before { border-color: #0f1218; }
+  .hst-text { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #80963

Company-history timeline scrolling horizontally via CSS scroll-snap-type/scroll-snap-align alone — no JS tracking a 'current index' synced to scroll position, which would introduce a second source of truth that can drift from the actual scroll state during a fast swipe. Works identically across trackpad, touch, and keyboard scrolling via the focusable track. Center-snapped events need asymmetric track padding (calc(50% - half-event-width)) so the first/last events can actually reach centered position instead of stopping short at the track edge.