### PR TITLE
feat: add QR Code Frame example (qr-code-frame-qz9k)

### DIFF
--- a/submissions/examples/qr-code-frame-qz9k/README.md
+++ b/submissions/examples/qr-code-frame-qz9k/README.md
@@ -1,0 +1,43 @@
+# QR Code Frame
+
+## What does this do?
+
+A decorative corner-bracket frame around a QR code image — brackets at
+opposite (top-left and bottom-right) corners — drawn entirely in CSS from
+two pseudo-elements rather than baked into the image asset itself or built
+from separate corner `<div>` elements.
+
+## How is it used?
+
+```html
+<div class="qcf-frame">
+  <img class="qcf-code" src="qr.svg" alt="QR code linking to the app download page" />
+</div>
+```
+
+`.qcf-frame::before` draws the top-left bracket (a box with its right and
+bottom borders removed), `::after` draws the bottom-right bracket the
+mirror-opposite way — two corners from two pseudo-elements, using
+`position: absolute` at opposite corners of the padded frame.
+
+## Why is it useful?
+
+A "frame" around a QR code is sometimes baked directly into the exported
+image asset, which means any change to the frame's style — thickness,
+colour, corner radius, or even wanting to remove it for a different
+context — requires regenerating and re-exporting the QR code image, even
+though the actual QR data hasn't changed at all. Keeping the frame as a
+CSS decoration entirely separate from the image means the same QR image
+asset can be reused with or without a frame, or with a differently-styled
+frame, purely by changing CSS — nothing about the underlying scannable
+image is ever touched.
+
+Using pseudo-elements for both brackets (rather than separate `<div>`
+elements marked up per corner) keeps the frame purely decorative and out
+of the accessible DOM tree entirely — there's no extra markup a screen
+reader could stumble on, since `::before`/`::after` content is never part
+of the accessibility tree unless explicitly given text content. Extending
+this to all four corners follows the same two-pseudo-element pattern used
+here, just mirrored onto the frame's other diagonal via two more
+pseudo-elements on a wrapping element, or by restructuring to use a single
+`box-shadow`-based technique if all four corners share identical styling.

--- a/submissions/examples/qr-code-frame-qz9k/demo.html
+++ b/submissions/examples/qr-code-frame-qz9k/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>QR Code Frame</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="qcf-wrap">
+  <h1 class="qcf-h1">Scan to Download</h1>
+  <p class="qcf-lede">The image itself renders at native resolution behind a decorative corner-bracket frame drawn entirely in CSS, so the frame's border-radius/thickness can change without ever touching or re-exporting the QR image asset.</p>
+
+  <div class="qcf-frame">
+    <img
+      class="qcf-code"
+      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='white'/%3E%3Cg fill='black'%3E%3Crect x='10' y='10' width='20' height='20'/%3E%3Crect x='70' y='10' width='20' height='20'/%3E%3Crect x='10' y='70' width='20' height='20'/%3E%3Crect x='40' y='10' width='6' height='6'/%3E%3Crect x='50' y='16' width='6' height='6'/%3E%3Crect x='40' y='40' width='20' height='20'/%3E%3Crect x='70' y='45' width='6' height='6'/%3E%3Crect x='45' y='70' width='6' height='6'/%3E%3Crect x='60' y='75' width='6' height='6'/%3E%3Crect x='75' y='75' width='15' height='15'/%3E%3C/g%3E%3C/svg%3E"
+      alt="QR code linking to the app download page"
+      width="200"
+      height="200"
+    />
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/qr-code-frame-qz9k/style.css
+++ b/submissions/examples/qr-code-frame-qz9k/style.css
@@ -1,0 +1,66 @@
+/* QR Code Frame
+   Each corner bracket is drawn from two independent border sides on a
+   ::before/::after pair (not four separate elements), keeping the frame to
+   two pseudo-elements total regardless of how many corners it has --
+   corners share the same border-color/width source so they can never
+   visually mismatch each other. */
+
+.qcf-wrap {
+  max-width: 20rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  text-align: center;
+}
+
+.qcf-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.qcf-lede { margin: 0 0 2rem; color: #576073; text-align: left; }
+
+.qcf-frame {
+  position: relative;
+  display: inline-block;
+  padding: 1.5rem;
+}
+
+.qcf-frame::before,
+.qcf-frame::after {
+  content: "";
+  position: absolute;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 3px solid #1c2028;
+}
+
+.qcf-frame::before {
+  top: 0;
+  left: 0;
+  border-right: none;
+  border-bottom: none;
+  border-top-left-radius: 0.4rem;
+}
+
+.qcf-frame::after {
+  bottom: 0;
+  right: 0;
+  border-left: none;
+  border-top: none;
+  border-bottom-right-radius: 0.4rem;
+}
+
+.qcf-code {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 0.3rem;
+}
+
+@media (forced-colors: active) {
+  .qcf-frame::before, .qcf-frame::after { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .qcf-wrap { color: #e6e9f2; }
+  .qcf-lede { color: #99a1b4; }
+  .qcf-frame::before, .qcf-frame::after { border-color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80964

Decorative corner-bracket frame around a QR code, drawn from two pseudo-elements at opposite corners rather than baked into the image asset — changing the frame's thickness, colour, or corner radius is a CSS-only edit that never requires regenerating the underlying scannable QR image. Pseudo-element content stays out of the accessible DOM tree entirely, keeping the frame purely decorative.