### PR TITLE
feat: add Half-Star Rating example (star-rating-half-qz9k)

### DIFF
--- a/submissions/examples/star-rating-half-qz9k/README.md
+++ b/submissions/examples/star-rating-half-qz9k/README.md
@@ -1,0 +1,41 @@
+# Half-Star Rating
+
+## What does this do?
+
+A 5-star rating widget supporting half-point increments (3.5, 4.5), built
+from ten real radio inputs — two per visual star, a left half and a right
+half — rather than a slider or a JS-computed fractional fill percentage.
+
+## How is it used?
+
+```html
+<input type="radio" id="shr-3-5" name="shr-rating" value="3.5" />
+<label for="shr-3-5" class="shr-half shr-half--left"><span class="shr-sr">3.5 stars</span></label>
+<input type="radio" id="shr-4" name="shr-rating" value="4" />
+<label for="shr-4" class="shr-half shr-half--right"><span class="shr-sr">4 stars</span></label>
+```
+
+Each label is half the width of a full star glyph, clipped via
+`clip-path: inset()` to show only its own half — the left label clips away
+the right side of the `★` character, the right label clips away the left
+side, so the two halves visually reconstruct one whole star.
+
+## Why is it useful?
+
+A whole-star rating widget's sibling-combinator fill technique (checking
+one radio fills every star before it) extends naturally to half-stars only
+if there's a real radio input for every half-point value — otherwise the
+"fill up to here" logic has nothing to fill up to for a fractional value,
+and a common workaround falls back to computing a fill percentage in
+JavaScript from a slider's continuous value instead, which loses the pure-
+CSS, no-JS quality the whole-star version has. Splitting each visual star
+into two half-width, half-clipped labels sharing one glyph means every
+half-point value gets its own real radio input, and the exact same
+sibling-combinator technique from a whole-star rating applies unmodified —
+the widget stays entirely CSS-driven, just with twice as many discrete
+steps.
+
+Each half carries its own visually-hidden accessible label ("3.5 stars",
+"4 stars") rather than a bare glyph fragment, so a screen reader announces
+a specific, meaningful value for every selectable half-star rather than an
+ambiguous "half of a star" with no numeric context.

--- a/submissions/examples/star-rating-half-qz9k/demo.html
+++ b/submissions/examples/star-rating-half-qz9k/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Half-Star Rating</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="shr-wrap">
+  <h1 class="shr-h1">Rate this Recipe</h1>
+  <p class="shr-lede">Each star is split into a left half and right half radio, so the widget supports half-point increments (3.5, 4.5) using ten real inputs rather than a single slider or a JS-computed fractional fill.</p>
+
+  <fieldset class="shr-field">
+    <legend class="shr-legend">Your rating</legend>
+    <div class="shr-stars">
+      <input type="radio" id="shr-0-5" name="shr-rating" value="0.5" />
+      <label for="shr-0-5" class="shr-half shr-half--left"><span class="shr-sr">0.5 stars</span></label>
+      <input type="radio" id="shr-1" name="shr-rating" value="1" />
+      <label for="shr-1" class="shr-half shr-half--right"><span class="shr-sr">1 star</span></label>
+
+      <input type="radio" id="shr-1-5" name="shr-rating" value="1.5" />
+      <label for="shr-1-5" class="shr-half shr-half--left"><span class="shr-sr">1.5 stars</span></label>
+      <input type="radio" id="shr-2" name="shr-rating" value="2" />
+      <label for="shr-2" class="shr-half shr-half--right"><span class="shr-sr">2 stars</span></label>
+
+      <input type="radio" id="shr-2-5" name="shr-rating" value="2.5" />
+      <label for="shr-2-5" class="shr-half shr-half--left"><span class="shr-sr">2.5 stars</span></label>
+      <input type="radio" id="shr-3" name="shr-rating" value="3" checked />
+      <label for="shr-3" class="shr-half shr-half--right"><span class="shr-sr">3 stars</span></label>
+
+      <input type="radio" id="shr-3-5" name="shr-rating" value="3.5" />
+      <label for="shr-3-5" class="shr-half shr-half--left"><span class="shr-sr">3.5 stars</span></label>
+      <input type="radio" id="shr-4" name="shr-rating" value="4" />
+      <label for="shr-4" class="shr-half shr-half--right"><span class="shr-sr">4 stars</span></label>
+
+      <input type="radio" id="shr-4-5" name="shr-rating" value="4.5" />
+      <label for="shr-4-5" class="shr-half shr-half--left"><span class="shr-sr">4.5 stars</span></label>
+      <input type="radio" id="shr-5" name="shr-rating" value="5" />
+      <label for="shr-5" class="shr-half shr-half--right"><span class="shr-sr">5 stars</span></label>
+    </div>
+  </fieldset>
+</main>
+</body>
+</html>

--- a/submissions/examples/star-rating-half-qz9k/style.css
+++ b/submissions/examples/star-rating-half-qz9k/style.css
@@ -1,0 +1,102 @@
+/* Half-Star Rating
+   Each visual star is two adjacent labels (left half, right half) with no
+   gap between them and no visible border, sitting over one shared star
+   glyph background -- clicking the left label commits a .5 value, the
+   right label commits a whole value, while the star glyph beneath both
+   is what actually renders. */
+
+.shr-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.shr-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.shr-lede { margin: 0 0 2rem; color: #576073; }
+
+.shr-field {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.shr-legend {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.shr-stars {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+  width: max-content;
+}
+
+.shr-stars input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.shr-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.shr-half {
+  position: relative;
+  display: inline-block;
+  width: 1rem;
+  height: 1.9rem;
+  cursor: pointer;
+  color: #d8dce6;
+}
+
+.shr-half::before {
+  content: "★";
+  position: absolute;
+  top: 0;
+  font-size: 1.9rem;
+  line-height: 1;
+  color: inherit;
+}
+
+.shr-half--left::before { left: 0; clip-path: inset(0 50% 0 0); }
+.shr-half--right::before { left: -1rem; clip-path: inset(0 0 0 50%); }
+
+/* Fill every half up to and including the checked one, or currently
+   hovered one -- later-in-source halves (visually earlier, due to
+   row-reverse) get the sibling-combinator fill. */
+.shr-stars input:checked ~ label.shr-half,
+.shr-stars input:hover ~ label.shr-half,
+.shr-stars label.shr-half:hover ~ label.shr-half {
+  color: #f2a712;
+}
+
+.shr-stars input:focus-visible + label.shr-half {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 1px;
+}
+
+@media (forced-colors: active) {
+  .shr-half { forced-color-adjust: none; color: CanvasText; }
+
+  .shr-stars input:checked ~ label.shr-half,
+  .shr-stars input:hover ~ label.shr-half,
+  .shr-stars label.shr-half:hover ~ label.shr-half {
+    color: Highlight;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .shr-wrap { color: #e6e9f2; }
+  .shr-lede { color: #99a1b4; }
+  .shr-half { color: #3a4150; }
+}


### PR DESCRIPTION
Closes #80965

5-star rating supporting half-point increments via ten real radio inputs — each visual star split into a left-half and right-half label, clip-path-ed to show only its own half of the ★ glyph. Because every half-point value gets a real radio input, the same sibling-combinator fill technique a whole-star rating uses extends unmodified, keeping the widget entirely CSS-driven rather than falling back to a JS-computed slider fill. Each half carries its own visually-hidden accessible label naming the specific value.