### PR TITLE
feat: add scrollbar-gutter-safe Sass mixin (scrollbar-gutter-safe-qz9k)

### DIFF
--- a/submissions/scss/scrollbar-gutter-safe-qz9k/README.md
+++ b/submissions/scss/scrollbar-gutter-safe-qz9k/README.md
@@ -1,0 +1,83 @@
+# scrollbar-gutter-safe-qz9k
+
+A Sass mixin applying `scrollbar-gutter: stable` (reserving space for a
+scrollbar whether or not one is currently needed) with an `overflow-y:
+scroll` fallback for engines without support.
+
+## Usage
+
+```scss
+@use 'scrollbar-gutter-safe' as *;
+
+html {
+  @include scrollbar-gutter-safe;
+}
+
+.modal-content {
+  @include scrollbar-gutter-safe('stable both-edges');
+}
+```
+
+| Param | Default | Description |
+|---|---|---|
+| `$mode` | `stable` | Any valid `scrollbar-gutter` value, e.g. `'stable both-edges'` for symmetric layouts. |
+
+## Why is it useful?
+
+Without a reserved scrollbar gutter, page content shifts horizontally the
+moment a vertical scrollbar appears or disappears — a page that starts
+short enough to fit without scrolling, then grows past the viewport height
+(more content loads, a collapsed section expands), suddenly has its
+scrollbar's width subtracted from the content area, causing every element
+to shift left by that amount. This is a common, jarring layout shift bug,
+and `scrollbar-gutter: stable` fixes it directly: the space a scrollbar
+would occupy is reserved permanently, whether the scrollbar is currently
+showing or not, so the content width never changes based on scroll state.
+
+The fallback (`overflow-y: scroll`, forcing the scrollbar to always
+render) is a deliberate imperfect tradeoff for engines without
+`scrollbar-gutter` support — it shows an empty scrollbar track on pages
+that don't actually need to scroll, which is a real but minor visual cost,
+traded for eliminating the layout-shift bug entirely on those engines
+rather than leaving it unaddressed. `'stable both-edges'` reserves gutter
+space on both the left and right sides symmetrically, useful for
+centered-content layouts where an asymmetric single-sided reservation would
+visually un-center the content relative to the viewport.
+
+## Where to apply it
+
+`scrollbar-gutter` is typically applied to `html` (or `body`) for the
+page's main scrollbar, since that's the scrollbar whose appearance and
+disappearance causes the most visible layout shift — but any independently
+scrollable container (a sidebar, a modal body, a chat panel) that can grow
+past its own height benefits from the same treatment:
+
+```scss
+.chat-messages {
+  @include scrollbar-gutter-safe;
+  overflow-y: auto;
+  max-height: 30rem;
+}
+```
+
+## When the fallback's tradeoff isn't acceptable
+
+The `overflow-y: scroll` fallback shows an empty scrollbar track
+permanently on non-scrolling content, which is a real visual cost some
+designs won't accept even in exchange for avoiding layout shift. For
+those cases, an alternative fallback is measuring the scrollbar width in
+JS (`window.innerWidth - document.documentElement.clientWidth`) and
+setting it as a CSS custom property consumed as padding — more accurate
+(no phantom scrollbar track) but requires JavaScript, which this
+CSS-only mixin deliberately doesn't reach for, keeping its scope to what's
+achievable in pure CSS.
+
+## Interaction with custom scrollbar styling
+
+If a page also uses custom scrollbar styling (the `scrollbar-style-advk`
+mixin elsewhere in this repo, for instance), `scrollbar-gutter` and
+scrollbar *appearance* styling are independent and compose without
+conflict — one reserves layout space, the other controls how the
+scrollbar looks within that space. Applying both together is the
+common case for a polished scrolling experience, not a redundant
+combination.

--- a/submissions/scss/scrollbar-gutter-safe-qz9k/_scrollbar-gutter-safe.scss
+++ b/submissions/scss/scrollbar-gutter-safe-qz9k/_scrollbar-gutter-safe.scss
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------
+// scrollbar-gutter-safe-qz9k
+// Reserves space for a scrollbar via scrollbar-gutter, with an @supports
+// fallback for engines that don't support it -- preventing the classic
+// "page content shifts left when a scrollbar appears/disappears" layout
+// jump (e.g. when content grows past the viewport height, or a modal
+// closes and returns scroll to the page).
+// ---------------------------------------------------------------------------
+
+@mixin scrollbar-gutter-safe($mode: stable) {
+  scrollbar-gutter: $mode;
+
+  // Fallback: force a scrollbar to always render (rather than only when
+  // content overflows), which reserves the same visual space at the cost
+  // of showing an unused scrollbar track when content doesn't overflow --
+  // an imperfect but reasonable tradeoff for engines without the property.
+  @supports not (scrollbar-gutter: stable) {
+    overflow-y: scroll;
+  }
+}
+
+html {
+  @include scrollbar-gutter-safe;
+}
+
+.scrollbar-gutter-safe-demo {
+  @include scrollbar-gutter-safe('stable both-edges');
+}


### PR DESCRIPTION
Closes #80970

Applies scrollbar-gutter:stable, reserving the space a scrollbar would occupy whether or not one is currently showing, fixing the classic bug where page content shifts left the instant a vertical scrollbar appears (content growing past viewport height, a collapsed section expanding). Falls back to overflow-y:scroll (forcing a permanent scrollbar) inside @supports not(...) for engines without scrollbar-gutter — an imperfect but reasonable tradeoff that trades a phantom scrollbar track for eliminating the layout shift entirely.