### PR TITLE
feat: add ease-drag-annotation-pin-sap

### DIFF
--- a/submissions/examples/ease-drag-annotation-pin-sap/README.md
+++ b/submissions/examples/ease-drag-annotation-pin-sap/README.md
@@ -1,0 +1,35 @@
+# Drag Annotation Pin
+
+A numbered annotation pin draggable across an image (like a design-review
+or feedback tool), with hover/press scale feedback and full keyboard
+repositioning.
+
+**Level:** Advanced
+
+## Usage
+
+`.pin` is positioned by percentage over `.canvas`. Dragging (Pointer
+Events, clamped 0–100%) or Arrow keys (2% steps, same clamping) reposition
+it relative to the image.
+
+## Accessibility
+
+- The pin is a real `<button>` with a full descriptive `aria-label`
+  summarizing both its annotation content and that it's draggable/keyboard-movable.
+- Fully keyboard-operable via Arrow keys, entirely independent of pointer dragging.
+- `:focus-visible` outline shown distinctly from the hover/active scale feedback.
+- `prefers-reduced-motion` removes the hover/press scale transition; the
+  pin still visibly responds to interaction state, just without eased scaling.
+
+## Notes
+
+- Uses Pointer Events with `setPointerCapture`, consistent with other
+  drag components in this set.
+- This demo covers repositioning a single existing pin; a full annotation
+  tool would also need creation (click-to-place a new pin) and a way to
+  view/edit each pin's associated comment text — both left out here to keep
+  the submission focused on the drag-to-reposition interaction itself.
+- `aria-label` is static in this demo; a production version should update
+  it if the pin's position changes in a way that affects its meaning (e.g.
+  "top-left corner" vs "center"), similar to the crop-frame component's
+  `aria-valuetext` note.

--- a/submissions/examples/ease-drag-annotation-pin-sap/demo.html
+++ b/submissions/examples/ease-drag-annotation-pin-sap/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Annotation Pin</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Annotation Pin</h1>
+
+    <div class="canvas" id="canvas">
+      <img src="https://picsum.photos/seed/annotate/500/340" alt="Product photo mockup for annotation" class="canvas-img">
+      <button
+        class="pin"
+        id="pin1"
+        style="left: 30%; top: 40%;"
+        aria-label="Annotation 1: Adjust padding here. Draggable, use arrow keys to move."
+      >1</button>
+    </div>
+
+    <p class="hint">Drag the pin, or focus it and use arrow keys.</p>
+  </main>
+
+  <script>
+    const canvas = document.getElementById('canvas');
+    const pin = document.getElementById('pin1');
+    let dragging = false;
+
+    function clamp(val, min, max) { return Math.min(Math.max(val, min), max); }
+
+    pin.addEventListener('pointerdown', (e) => {
+      dragging = true;
+      pin.setPointerCapture(e.pointerId);
+    });
+
+    pin.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      const rect = canvas.getBoundingClientRect();
+      const xPct = clamp(((e.clientX - rect.left) / rect.width) * 100, 0, 100);
+      const yPct = clamp(((e.clientY - rect.top) / rect.height) * 100, 0, 100);
+      pin.style.left = xPct + '%';
+      pin.style.top = yPct + '%';
+    });
+
+    pin.addEventListener('pointerup', () => { dragging = false; });
+
+    const STEP = 2;
+    pin.addEventListener('keydown', (e) => {
+      const moves = { ArrowLeft: [-STEP, 0], ArrowRight: [STEP, 0], ArrowUp: [0, -STEP], ArrowDown: [0, STEP] };
+      if (!moves[e.key]) return;
+      e.preventDefault();
+      const [dx, dy] = moves[e.key];
+      const leftPct = clamp(parseFloat(pin.style.left) + dx, 0, 100);
+      const topPct = clamp(parseFloat(pin.style.top) + dy, 0, 100);
+      pin.style.left = leftPct + '%';
+      pin.style.top = topPct + '%';
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-annotation-pin-sap/style.css
+++ b/submissions/examples/ease-drag-annotation-pin-sap/style.css
@@ -1,0 +1,72 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.canvas {
+  position: relative;
+  width: 500px;
+  max-width: 90vw;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.canvas-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.pin {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #ef4444;
+  color: white;
+  border: 2px solid white;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: grab;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 3px 8px rgba(0,0,0,0.35);
+  touch-action: none;
+  transition: transform 0.15s ease;
+}
+
+.pin:active { cursor: grabbing; transform: translate(-50%, -50%) scale(1.15); }
+
+.pin:hover { transform: translate(-50%, -50%) scale(1.1); }
+
+.pin:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+.hint {
+  margin-top: 1.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pin { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-annotation-pin-sap`, a draggable numbered annotation pin over an image.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-annotation-pin-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Pin is a real `<button>` with full Arrow-key repositioning independent of
  pointer dragging, and a descriptive `aria-label`.
- README scopes this submission to repositioning an existing pin only,
  explicitly flagging pin-creation and comment-editing as out-of-scope
  follow-ups for a full annotation tool.

## Feature Description

Adds a reusable draggable annotation-pin component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.