### PR TITLE
feat: add ease-scroll-count-down-banner-sap

### DIFF
--- a/submissions/examples/ease-scroll-count-down-banner-sap/README.md
+++ b/submissions/examples/ease-scroll-count-down-banner-sap/README.md
@@ -1,0 +1,38 @@
+# Scroll Countdown Banner
+
+A fixed countdown-timer banner that slides up from the bottom once the
+reader scrolls to a designated "sale" section, staying pinned while visible.
+
+**Level:** Intermediate
+
+## Usage
+
+`IntersectionObserver` toggles `.is-visible` on `.countdown-banner` based
+on whether `#promoAnchor` is intersecting the viewport at all. The
+countdown itself ticks down every second via `setInterval`.
+
+## Accessibility
+
+- The banner uses `role="status"` but with `aria-live="off"` deliberately —
+  a countdown ticking every second would otherwise cause an `aria-live`
+  region to re-announce constantly, which is disruptive noise rather than
+  useful information; `role="status"` without an active live region still
+  correctly identifies its semantic purpose for anyone who navigates to it directly.
+- The banner only becomes visible (slides in) when its anchor section is
+  actually in view, so it's not permanently obstructing content, and slides
+  away again once scrolled past.
+- `prefers-reduced-motion` removes the slide transition; the banner still
+  appears/disappears correctly, just as an instant show/hide rather than an
+  animated slide.
+
+## Notes
+
+- Deliberately using `aria-live="off"` here is a considered choice, not an
+  oversight — ticking countdowns are one of the few cases where an active
+  live region actively harms the experience; if the *banner's appearance*
+  itself needs announcing (rather than every second's tick), a separate,
+  one-time `aria-live="polite"` announcement on first appearance would be a
+  more surgical addition, left as a note rather than implemented to avoid
+  conflating the two different live-region needs.
+- This is a demo countdown; wire `remaining` to a real deadline timestamp
+  in production rather than a fixed in-memory starting value.

--- a/submissions/examples/ease-scroll-count-down-banner-sap/demo.html
+++ b/submissions/examples/ease-scroll-count-down-banner-sap/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Countdown Banner</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Countdown Banner</h1><p>Scroll down — a sticky countdown banner slides into view and stays pinned.</p></section>
+
+    <section class="promo-anchor" id="promoAnchor">
+      <p>You've reached the sale section.</p>
+    </section>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <div class="countdown-banner" id="countdownBanner" role="status" aria-live="off">
+    <span class="banner-text">Sale ends in</span>
+    <span class="banner-time" id="bannerTime">02:00:00</span>
+  </div>
+
+  <script>
+    const anchor = document.getElementById('promoAnchor');
+    const banner = document.getElementById('countdownBanner');
+    const timeEl = document.getElementById('bannerTime');
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => banner.classList.toggle('is-visible', entry.isIntersecting));
+    }, { threshold: 0 });
+    observer.observe(anchor);
+
+    let remaining = 2 * 60 * 60;
+    function fmt(sec) {
+      const h = String(Math.floor(sec / 3600)).padStart(2, '0');
+      const m = String(Math.floor((sec % 3600) / 60)).padStart(2, '0');
+      const s = String(sec % 60).padStart(2, '0');
+      return `${h}:${m}:${s}`;
+    }
+    setInterval(() => {
+      if (remaining > 0) remaining--;
+      timeEl.textContent = fmt(remaining);
+    }, 1000);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-count-down-banner-sap/style.css
+++ b/submissions/examples/ease-scroll-count-down-banner-sap/style.css
@@ -1,0 +1,65 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  margin: 0;
+}
+
+.content { max-width: 700px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 65vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #64748b; }
+
+.promo-anchor {
+  min-height: 30vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+}
+
+.countdown-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  background: #dc2626;
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 600;
+
+  transform: translateY(100%);
+  transition: transform 0.35s cubic-bezier(0.2, 0.6, 0.3, 1);
+  z-index: 50;
+}
+
+.countdown-banner.is-visible {
+  transform: translateY(0);
+}
+
+.banner-time {
+  font-variant-numeric: tabular-nums;
+  background: rgba(255,255,255,0.15);
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .countdown-banner { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-count-down-banner-sap`, a scroll-triggered sticky countdown-timer banner.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-count-down-banner-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `aria-live="off"` on the countdown is a deliberate choice, explained in
  the README, since a per-second ticking live region would be disruptive
  noise rather than useful — a separate one-time appearance announcement is
  suggested as a more surgical alternative if needed.
- Banner only appears while its anchor section is actually in view, so it
  never permanently obstructs page content.

## Feature Description

Adds a reusable scroll-triggered sticky countdown banner component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.