### PR TITLE
feat: add ease-drag-multi-thumb-range-sap

### DIFF
--- a/submissions/examples/ease-drag-multi-thumb-range-sap/README.md
+++ b/submissions/examples/ease-drag-multi-thumb-range-sap/README.md
@@ -1,0 +1,35 @@
+# Drag Multi Thumb Range
+
+A three-segment range with two draggable boundary thumbs, splitting a track
+into three colored proportional sections (e.g. shift scheduling), each
+thumb independently draggable and keyboard-adjustable.
+
+**Level:** Advanced
+
+## Usage
+
+Each thumb is `role="slider"` and clamped against the other thumb (with a
+minimum gap) so boundaries can't cross or collapse a segment to zero width.
+Segment widths/positions are recalculated from both thumb values on every change.
+
+## Accessibility
+
+- Each thumb has its own `role="slider"` with a descriptive `aria-label`
+  identifying which boundary it represents ("Boundary between shift 1 and
+  2"), and `aria-valuemin`/`aria-valuemax`/`aria-valuenow` kept in sync.
+- Both thumbs are independently focusable and fully operable via
+  ArrowLeft/ArrowRight, with the same clamping logic as pointer dragging.
+- `:focus-visible` outline shown on whichever thumb has keyboard focus.
+- `prefers-reduced-motion` has no continuous animation to disable (segment/
+  thumb positions update directly); included for consistency with the rest
+  of the set.
+
+## Notes
+
+- Each thumb's clamp uses a small minimum gap (3%) against the other
+  thumb's current value, preventing a segment from ever fully collapsing to
+  zero width, which would make it visually disappear and harder to
+  re-select via dragging.
+- This generalizes the two-thumb `ease-drag-range-dual-thumb-sap` pattern
+  to three segments; the same approach extends to N segments/thumbs by
+  clamping each thumb against its immediate neighbors only.

--- a/submissions/examples/ease-drag-multi-thumb-range-sap/demo.html
+++ b/submissions/examples/ease-drag-multi-thumb-range-sap/demo.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Multi Thumb Range</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Multi Thumb Range</h1>
+
+    <div class="multi-range">
+      <p class="range-legend">Working hours split across 3 shifts</p>
+      <div class="range-track" id="rangeTrack">
+        <div class="seg seg-1" id="seg1"></div>
+        <div class="seg seg-2" id="seg2"></div>
+        <div class="seg seg-3" id="seg3"></div>
+        <button class="thumb" id="thumbA" role="slider" aria-label="Boundary between shift 1 and 2" aria-valuemin="0" aria-valuemax="100" aria-valuenow="33" tabindex="0"></button>
+        <button class="thumb" id="thumbB" role="slider" aria-label="Boundary between shift 2 and 3" aria-valuemin="0" aria-valuemax="100" aria-valuenow="66" tabindex="0"></button>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const track = document.getElementById('rangeTrack');
+    const thumbA = document.getElementById('thumbA');
+    const thumbB = document.getElementById('thumbB');
+    const seg1 = document.getElementById('seg1');
+    const seg2 = document.getElementById('seg2');
+    const seg3 = document.getElementById('seg3');
+
+    let values = { a: 33, b: 66 };
+
+    function render() {
+      thumbA.style.left = values.a + '%';
+      thumbB.style.left = values.b + '%';
+      seg1.style.width = values.a + '%';
+      seg2.style.left = values.a + '%';
+      seg2.style.width = (values.b - values.a) + '%';
+      seg3.style.left = values.b + '%';
+      seg3.style.width = (100 - values.b) + '%';
+      thumbA.setAttribute('aria-valuenow', Math.round(values.a));
+      thumbB.setAttribute('aria-valuenow', Math.round(values.b));
+    }
+
+    function pctFromEvent(e) {
+      const rect = track.getBoundingClientRect();
+      return Math.min(Math.max(((e.clientX - rect.left) / rect.width) * 100, 0), 100);
+    }
+
+    function bind(thumb, key, other, isBefore) {
+      let dragging = false;
+      thumb.addEventListener('pointerdown', (e) => {
+        dragging = true;
+        thumb.setPointerCapture(e.pointerId);
+      });
+      thumb.addEventListener('pointermove', (e) => {
+        if (!dragging) return;
+        let pct = pctFromEvent(e);
+        pct = isBefore ? Math.min(pct, values[other] - 3) : Math.max(pct, values[other] + 3);
+        values[key] = Math.min(Math.max(pct, 0), 100);
+        render();
+      });
+      thumb.addEventListener('pointerup', () => { dragging = false; });
+
+      thumb.addEventListener('keydown', (e) => {
+        const step = 2;
+        let delta = 0;
+        if (e.key === 'ArrowRight') delta = step;
+        if (e.key === 'ArrowLeft') delta = -step;
+        if (!delta) return;
+        e.preventDefault();
+        let next = values[key] + delta;
+        next = isBefore ? Math.min(next, values[other] - 3) : Math.max(next, values[other] + 3);
+        values[key] = Math.min(Math.max(next, 0), 100);
+        render();
+      });
+    }
+
+    bind(thumbA, 'a', 'b', true);
+    bind(thumbB, 'b', 'a', false);
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-multi-thumb-range-sap/style.css
+++ b/submissions/examples/ease-drag-multi-thumb-range-sap/style.css
@@ -1,0 +1,68 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.wrap { width: min(360px, 90vw); text-align: center; }
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.75rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.range-legend { font-size: 0.8rem; color: #64748b; margin: 0 0 1.5rem; }
+
+.range-track {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  margin: 0 10px;
+  overflow: visible;
+}
+
+.seg {
+  position: absolute;
+  height: 100%;
+  top: 0;
+}
+
+.seg-1 { left: 0; background: #6366f1; border-radius: 999px 0 0 999px; }
+.seg-2 { background: #a855f7; }
+.seg-3 { background: #ec4899; border-radius: 0 999px 999px 0; }
+
+.thumb {
+  position: absolute;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  border: 3px solid #1e293b;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  transform: translate(-50%, -50%);
+  cursor: grab;
+  padding: 0;
+  touch-action: none;
+}
+
+.thumb:active { cursor: grabbing; }
+
+.thumb:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thumb, .seg { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-multi-thumb-range-sap`, a three-segment draggable multi-thumb range component.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-multi-thumb-range-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Each thumb is an independent `role="slider"` with its own descriptive
  `aria-label` and full keyboard support, clamped against its neighbor with
  a minimum gap to prevent segment collapse.
- README notes this generalizes the dual-thumb range pattern to N segments
  by clamping each thumb only against its immediate neighbors.

## Feature Description

Adds a reusable three-segment multi-thumb draggable range component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.