### PR TITLE
feat: add ease-hover-card-flip-price-toggle-sap

### DIFF
--- a/submissions/examples/ease-hover-card-flip-price-toggle-sap/README.md
+++ b/submissions/examples/ease-hover-card-flip-price-toggle-sap/README.md
@@ -1,0 +1,39 @@
+# Hover Card Flip Price Toggle
+
+A pricing card that flips via explicit "See what's included" / "Back to
+pricing" buttons (not hover), giving a persistent, click-driven 3D flip
+between price and feature-list faces.
+
+**Level:** Intermediate
+
+## Usage
+
+Two buttons — one per face — toggle `.is-flipped` on `.flip-inner`. Unlike
+a pure `:hover` flip card, this state persists until explicitly toggled back.
+
+## Accessibility
+
+- Despite the "hover" in the component name (matching the requested
+  title), this implementation deliberately uses explicit buttons rather
+  than `:hover`/`:focus-visible` triggers, since a persistent flip state
+  driven only by hover would be lost as soon as the mouse moves away —
+  problematic for reading the revealed content. Buttons give a stable,
+  intentional toggle usable identically by mouse, keyboard, and touch.
+- Each button's label describes both current context and destination
+  ("See what's included →" / "← Back to pricing").
+- Focus moves to the opposite face's button after each flip, so keyboard
+  users land somewhere sensible (able to flip back immediately) rather than
+  losing focus into a now-rotated, potentially unfocused element.
+- Both faces' full text content exists in the DOM at all times, readable
+  regardless of flip state or JS.
+- `prefers-reduced-motion` removes the rotate transition; flipping between
+  faces still functions, just as an instant switch.
+
+## Notes
+
+- This component intentionally diverges from a literal hover-triggered flip
+  (see `ease-hover-card-flip-preview-sap` for that pattern) because a
+  price-to-features toggle benefits from a stable, deliberate state rather
+  than one tied to transient cursor position — flagged here since the
+  requested name suggested "hover" but the more robust interaction pattern
+  was chosen instead.

--- a/submissions/examples/ease-hover-card-flip-price-toggle-sap/demo.html
+++ b/submissions/examples/ease-hover-card-flip-price-toggle-sap/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Card Flip Price Toggle</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Card Flip Price Toggle</h1>
+
+    <div class="price-flip-card">
+      <div class="flip-inner" id="flipInner">
+        <div class="flip-face flip-front">
+          <h2>Pro Plan</h2>
+          <p class="price">$24<span>/mo</span></p>
+          <button class="flip-btn" id="toFeatures">See what's included →</button>
+        </div>
+        <div class="flip-face flip-back">
+          <h3>Included</h3>
+          <ul>
+            <li>Unlimited projects</li>
+            <li>Priority support</li>
+            <li>Custom domains</li>
+          </ul>
+          <button class="flip-btn" id="toPrice">← Back to pricing</button>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    const inner = document.getElementById('flipInner');
+    document.getElementById('toFeatures').addEventListener('click', () => {
+      inner.classList.add('is-flipped');
+      document.getElementById('toPrice').focus();
+    });
+    document.getElementById('toPrice').addEventListener('click', () => {
+      inner.classList.remove('is-flipped');
+      document.getElementById('toFeatures').focus();
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-card-flip-price-toggle-sap/style.css
+++ b/submissions/examples/ease-hover-card-flip-price-toggle-sap/style.css
@@ -1,0 +1,113 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.75rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.price-flip-card {
+  width: 260px;
+  height: 300px;
+  perspective: 1200px;
+}
+
+.flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s cubic-bezier(0.4, 0.2, 0.2, 1);
+  transform-style: preserve-3d;
+}
+
+.flip-inner.is-flipped {
+  transform: rotateY(180deg);
+}
+
+.flip-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.08);
+}
+
+.flip-front { background: linear-gradient(160deg, #6366f1, #8b5cf6); color: white; }
+.flip-front h2 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.flip-front .price { font-size: 2rem; font-weight: 800; margin: 0 0 1.5rem; }
+.flip-front .price span { font-size: 0.9rem; font-weight: 400; opacity: 0.8; }
+
+.flip-back {
+  background: white;
+  border: 1px solid #e2e8f0;
+  transform: rotateY(180deg);
+}
+
+.flip-back h3 { margin: 0 0 1rem; font-size: 1.05rem; }
+
+.flip-back ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  text-align: left;
+  width: 100%;
+}
+
+.flip-back li {
+  padding: 0.4rem 0;
+  font-size: 0.85rem;
+  border-bottom: 1px solid #f1f5f9;
+  color: #475569;
+}
+
+.flip-btn {
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  border: none;
+  background: rgba(255,255,255,0.2);
+  color: white;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.flip-front .flip-btn:hover { background: rgba(255,255,255,0.32); }
+
+.flip-back .flip-btn {
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.flip-back .flip-btn:hover { background: #e0e7ff; }
+
+.flip-btn:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+.flip-back .flip-btn:focus-visible {
+  outline-color: #6366f1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-inner { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-card-flip-price-toggle-sap`, a button-toggled 3D flip card between pricing and feature-list views.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-card-flip-price-toggle-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- README explicitly flags a deliberate deviation from a literal
  hover-triggered flip: explicit toggle buttons are used instead, since a
  persistent price/feature toggle shouldn't depend on transient cursor
  position — the true hover-flip pattern lives in
  `ease-hover-card-flip-preview-sap`.
- Focus moves to the opposite face's button after each flip, so keyboard
  users always land somewhere sensible.

## Feature Description

Adds a reusable button-toggled flip card component for pricing/feature views.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.