### PR TITLE
feat: add Stacked Nested Modals example (modal-stacked-nested-qz9k)

### DIFF
--- a/submissions/examples/modal-stacked-nested-qz9k/README.md
+++ b/submissions/examples/modal-stacked-nested-qz9k/README.md
@@ -1,0 +1,44 @@
+# Stacked Nested Modals
+
+## What does this do?
+
+Two nested confirmation dialogs (settings → delete-account confirmation)
+where Escape closes only the topmost open modal, and focus returns to
+whatever specifically opened it — not to a fixed "return to page" target.
+
+## How is it used?
+
+```html
+<button onclick="msnOpen('msn-dialog-1')">Open settings</button>
+<div class="msn-dialog" id="msn-dialog-1" role="dialog" aria-modal="true" hidden>
+  <button onclick="msnOpen('msn-dialog-2')">Delete account</button>
+  <button class="msn-close" onclick="msnClose()">Close</button>
+</div>
+<div class="msn-dialog" id="msn-dialog-2" role="dialog" aria-modal="true" hidden>...</div>
+```
+
+`msnStack` is a real array of `{ dialog, lastFocused }` pairs; `msnOpen`
+pushes onto it, `msnClose` pops the top entry and restores focus to that
+specific entry's `lastFocused` — not a single shared variable, which
+would only be able to remember one previous focus target regardless of
+stack depth.
+
+## Why is it useful?
+
+A single modal's focus trap only needs to remember one thing: what was
+focused before it opened. Nested modals need a genuine stack, because each
+layer's "what to restore focus to" is different, and depends on how deep
+in the nesting that specific layer sits — closing the delete-confirmation
+dialog should return focus to the "Delete account" button inside the
+settings dialog (not to whatever was focused on the page before settings
+ever opened), and only closing settings itself should return focus that
+far back. A single `lastFocused` variable, overwritten each time a new
+modal opens, can only ever restore to the *most recently* opened modal's
+prior focus — it has no way to represent "restore to modal 1's prior focus"
+once modal 2 has also opened and overwritten that variable.
+
+Escape closing only the topmost modal (via `msnStack.pop()`, not clearing
+the whole stack) matters for the same layered reason: a user who opened
+settings then a delete confirmation, and presses Escape once, expects to
+back out one level — remaining on the settings dialog — not to be dropped
+straight back to the page with both dialogs closed at once.

--- a/submissions/examples/modal-stacked-nested-qz9k/demo.html
+++ b/submissions/examples/modal-stacked-nested-qz9k/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Stacked Nested Modals</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var msnStack = [];
+
+  function msnOpen(id) {
+    var dialog = document.getElementById(id);
+    var lastFocused = document.activeElement;
+    msnStack.push({ dialog: dialog, lastFocused: lastFocused });
+
+    dialog.hidden = false;
+    dialog.style.zIndex = 20 + msnStack.length * 2;
+    dialog.previousElementSibling.hidden = false;
+    dialog.previousElementSibling.style.zIndex = 19 + msnStack.length * 2;
+    dialog.querySelector('.msn-close, button').focus();
+
+    if (msnStack.length === 1) document.addEventListener('keydown', msnKeydown);
+  }
+
+  function msnClose() {
+    var top = msnStack.pop();
+    if (!top) return;
+    top.dialog.hidden = true;
+    top.dialog.previousElementSibling.hidden = true;
+    top.lastFocused.focus();
+
+    if (msnStack.length === 0) document.removeEventListener('keydown', msnKeydown);
+  }
+
+  function msnKeydown(event) {
+    if (event.key === 'Escape') msnClose();
+  }
+</script>
+</head>
+<body>
+<main class="msn-wrap">
+  <h1 class="msn-h1">Stacked Modals</h1>
+  <p class="msn-lede">Escape closes only the topmost modal, and focus returns to whatever specifically opened it -- a shared stack (not a single "modal open" boolean) is what lets each layer close independently in the right order.</p>
+
+  <button type="button" class="msn-btn" onclick="msnOpen('msn-dialog-1')">Open settings</button>
+
+  <div class="msn-overlay" hidden></div>
+  <div class="msn-dialog" id="msn-dialog-1" role="dialog" aria-modal="true" aria-labelledby="msn-title-1" hidden>
+    <h2 id="msn-title-1">Settings</h2>
+    <p>Change your account preferences below.</p>
+    <button type="button" onclick="msnOpen('msn-dialog-2')">Delete account</button>
+    <button type="button" class="msn-close" onclick="msnClose()">Close</button>
+  </div>
+
+  <div class="msn-overlay" hidden></div>
+  <div class="msn-dialog msn-dialog--confirm" id="msn-dialog-2" role="dialog" aria-modal="true" aria-labelledby="msn-title-2" hidden>
+    <h2 id="msn-title-2">Are you sure?</h2>
+    <p>This will permanently delete your account.</p>
+    <button type="button" onclick="msnClose()">Cancel</button>
+    <button type="button" class="msn-close msn-close--danger" onclick="msnClose()">Delete</button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/modal-stacked-nested-qz9k/style.css
+++ b/submissions/examples/modal-stacked-nested-qz9k/style.css
@@ -1,0 +1,80 @@
+/* Stacked Nested Modals
+   z-index is set inline per dialog/overlay pair from the stack's current
+   depth, not fixed in CSS -- a fixed z-index per dialog would break the
+   moment a THIRD modal opened on top of the second, since there'd be no
+   depth-aware value to place it correctly above both. */
+
+.msn-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.msn-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.msn-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.msn-btn {
+  padding: 0.6em 1.2em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #f1f4fa;
+  font: inherit;
+  cursor: pointer;
+}
+
+.msn-btn:hover { background: #e4e9f4; }
+.msn-btn:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.msn-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 18, 24, 0.4);
+}
+
+.msn-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(20rem, calc(100vw - 2rem));
+  padding: 1.5rem;
+  border-radius: 0.8rem;
+  background: #fff;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+}
+
+.msn-dialog h2 { margin: 0 0 0.5rem; font-size: 1.1rem; }
+.msn-dialog p { margin: 0 0 1.2rem; color: #576073; font-size: 0.92rem; }
+
+.msn-dialog button {
+  padding: 0.55em 1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  margin-right: 0.5rem;
+}
+
+.msn-close--danger {
+  background: #e0483f;
+  border-color: #e0483f;
+  color: #fff;
+}
+
+.msn-dialog button:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .msn-wrap { color: #e6e9f2; }
+  .msn-lede { color: #99a1b4; }
+  .msn-btn { background: #1e2430; border-color: #2a303c; color: #e6e9f2; }
+  .msn-dialog { background: #171b23; }
+  .msn-dialog p { color: #99a1b4; }
+  .msn-dialog button { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #80998

Two nested confirmation dialogs (settings → delete-account) backed by a real array stack of {dialog, lastFocused} pairs rather than one shared 'last focused' variable, which could only ever remember the most recently opened modal's prior focus. msnOpen pushes onto the stack; msnClose pops the top entry and restores focus to that specific entry's target, so closing an inner modal returns focus to the button that opened it (inside the outer modal), not to wherever focus was before the outer modal ever opened. Escape closes only the topmost modal via stack.pop().