### PR TITLE
feat: add SVG Progress Ring example (progress-ring-svg-qz9k)

### DIFF
--- a/submissions/examples/progress-ring-svg-qz9k/README.md
+++ b/submissions/examples/progress-ring-svg-qz9k/README.md
@@ -1,0 +1,48 @@
+# SVG Progress Ring
+
+## What does this do?
+
+A circular progress indicator built from an SVG `<circle>` whose visible
+arc length is controlled by `stroke-dasharray`/`stroke-dashoffset`, with
+the full circumference computed from the circle's own radius rather than
+measured and hard-coded.
+
+## How is it used?
+
+```js
+var PRS_RADIUS = 42;
+var PRS_CIRCUMFERENCE = 2 * Math.PI * PRS_RADIUS;
+
+function prsSet(percent) {
+  var offset = PRS_CIRCUMFERENCE - (percent / 100) * PRS_CIRCUMFERENCE;
+  circle.style.strokeDashoffset = offset;
+}
+```
+
+```html
+<circle id="prs-circle" class="prs-fill" cx="50" cy="50" r="42" />
+```
+
+`stroke-dasharray` is set to the full circumference (making the dash
+pattern one long dash equal to the whole circle), and `stroke-dashoffset`
+shifts how much of that dash is hidden — offsetting by the full
+circumference hides the entire stroke; offsetting by 0 shows all of it.
+
+## Why is it useful?
+
+The circumference of a `stroke-dasharray`-based progress ring is often
+hard-coded as a measured or guessed pixel value (`stroke-dasharray:
+264`), which works for exactly one radius — resizing the ring, or reusing
+the same technique at a different radius elsewhere on the page, silently
+breaks unless someone re-measures and updates that number by hand.
+Deriving it as `2 * Math.PI * radius` from the circle's actual `r`
+attribute means the fill math is always correct for whatever radius the
+circle happens to have, with the relationship between size and
+circumference expressed as real geometry rather than a value that has to
+be kept in sync by memory.
+
+Using `role="progressbar"` with `aria-valuenow` on the `<svg>` itself
+(updated on every `prsSet` call) exposes the current percentage to
+assistive technology independent of the visual ring — a screen reader
+announces the actual numeric value rather than needing to interpret an arc
+length, which conveys nothing meaningful non-visually on its own.

--- a/submissions/examples/progress-ring-svg-qz9k/demo.html
+++ b/submissions/examples/progress-ring-svg-qz9k/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SVG Progress Ring</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var PRS_RADIUS = 42;
+  var PRS_CIRCUMFERENCE = 2 * Math.PI * PRS_RADIUS;
+
+  function prsSet(percent) {
+    var circle = document.getElementById('prs-circle');
+    var offset = PRS_CIRCUMFERENCE - (percent / 100) * PRS_CIRCUMFERENCE;
+    circle.style.strokeDashoffset = offset;
+    document.getElementById('prs-label').textContent = Math.round(percent) + '%';
+    document.getElementById('prs-svg').setAttribute('aria-valuenow', Math.round(percent));
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.getElementById('prs-circle').style.strokeDasharray = PRS_CIRCUMFERENCE;
+    prsSet(68);
+  });
+</script>
+</head>
+<body>
+<main class="prs-wrap">
+  <h1 class="prs-h1">Storage Used</h1>
+  <p class="prs-lede">The ring's fill is a stroke-dashoffset on a circle whose full circumference is computed once from its radius (2*pi*r) -- so the fill percentage is derived math, not a hand-measured magic number that would need re-deriving if the ring's size changed.</p>
+
+  <svg
+    id="prs-svg"
+    class="prs-svg"
+    viewBox="0 0 100 100"
+    role="progressbar"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-valuenow="68"
+    aria-label="Storage used"
+  >
+    <circle class="prs-track" cx="50" cy="50" r="42" />
+    <circle id="prs-circle" class="prs-fill" cx="50" cy="50" r="42" />
+    <text id="prs-label" class="prs-text" x="50" y="55" text-anchor="middle">68%</text>
+  </svg>
+</main>
+</body>
+</html>

--- a/submissions/examples/progress-ring-svg-qz9k/style.css
+++ b/submissions/examples/progress-ring-svg-qz9k/style.css
@@ -1,0 +1,62 @@
+/* SVG Progress Ring
+   The circle is rotated -90deg around its own center so its stroke starts
+   at the 12 o'clock position rather than SVG's default 3 o'clock -- a
+   purely cosmetic choice, but one that has to happen in CSS/attribute
+   space since stroke-dashoffset itself has no notion of a starting angle. */
+
+.prs-wrap {
+  max-width: 18rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+  text-align: center;
+}
+
+.prs-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.prs-lede { margin: 0 0 2rem; color: #576073; text-align: left; }
+
+.prs-svg {
+  width: 10rem;
+  height: 10rem;
+  transform: rotate(-90deg);
+}
+
+.prs-track {
+  fill: none;
+  stroke: #e4e7ef;
+  stroke-width: 8;
+}
+
+.prs-fill {
+  fill: none;
+  stroke: #4c6ef5;
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.prs-text {
+  transform: rotate(90deg);
+  transform-origin: 50px 50px;
+  font-size: 1.1rem;
+  font-weight: 800;
+  fill: #1c2028;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prs-fill { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .prs-track { stroke: CanvasText; }
+  .prs-fill { forced-color-adjust: none; stroke: Highlight; }
+  .prs-text { fill: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .prs-wrap { color: #e6e9f2; }
+  .prs-lede { color: #99a1b4; }
+  .prs-track { stroke: #2a303c; }
+  .prs-text { fill: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #81000

Circular progress ring using stroke-dasharray/stroke-dashoffset on an SVG circle, with the circumference computed as 2*Math.PI*radius from the circle's actual r attribute instead of a hard-coded pixel value that only works for one specific radius. role=progressbar with aria-valuenow updated on every change exposes the numeric percentage to assistive tech independent of the visual arc, which conveys nothing meaningful non-visually on its own.