### PR TITLE
feat: add OTP Input with SMS Autofill example (input-otp-autofill-qz9k)

### DIFF
--- a/submissions/examples/input-otp-autofill-qz9k/README.md
+++ b/submissions/examples/input-otp-autofill-qz9k/README.md
@@ -1,0 +1,50 @@
+# OTP Input with SMS Autofill
+
+## What does this do?
+
+A six-digit verification code field built from a single real
+`<input autocomplete="one-time-code">` overlaid transparently on six
+purely decorative visual boxes, rather than six separate real inputs each
+managing its own digit.
+
+## How is it used?
+
+```html
+<div class="ioa-field">
+  <div class="ioa-boxes" aria-hidden="true">
+    <span class="ioa-box ioa-box--active"></span>
+    <!-- ...6 boxes total -->
+  </div>
+  <input id="ioa-input" class="ioa-input" type="text" inputmode="numeric"
+    autocomplete="one-time-code" maxlength="6" aria-label="6-digit verification code" />
+</div>
+```
+
+The input's `input` event handler strips non-digits, updates each box's
+`textContent` and `--filled`/`--active` state to mirror the current value,
+and the boxes container forwards clicks to the (invisible) input so
+tapping anywhere in the row focuses it.
+
+## Why is it useful?
+
+The common six-separate-inputs OTP pattern (used elsewhere in this
+codebase, in `pin-code-input-qz9k`) needs real per-box focus management —
+auto-advance on type, Backspace-to-previous — and specifically handles
+multi-character paste/autofill by distributing digits across boxes. That
+works, but mobile browsers' native SMS-autofill suggestion (the QuickType
+bar above the keyboard offering to fill a detected code) anchors its
+behavior to *one specific* focused input with `autocomplete="one-time-code"`
+— autofilling into a six-input layout means the OS has to guess which of
+six inputs to target and fire a synthetic paste-like event that the
+six-input implementation then has to redistribute, which is exactly the
+kind of edge case that's fragile across OS/browser combinations. This
+single-input variant sidesteps that entirely: there's only ever one real
+input for the OS to target, so autofill lands directly in the one place
+it's designed to land, and the visual boxes are just a passive display
+mirroring whatever that one input currently contains.
+
+Positioning the real input exactly over the visual box row (not hidden
+off-screen) matters specifically for iOS, where the autofill suggestion
+bar's on-screen anchor point is tied to the focused input's actual
+position — moving the input elsewhere visually disconnects the "tap to
+autofill" prompt from the code field the user is looking at.

--- a/submissions/examples/input-otp-autofill-qz9k/demo.html
+++ b/submissions/examples/input-otp-autofill-qz9k/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OTP Input with SMS Autofill</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function ioaInit() {
+    var input = document.getElementById('ioa-input');
+    var boxes = document.querySelectorAll('.ioa-box');
+
+    input.addEventListener('input', function () {
+      var digits = input.value.replace(/\D/g, '').slice(0, 6);
+      input.value = digits;
+      boxes.forEach(function (box, i) {
+        box.textContent = digits[i] || '';
+        box.classList.toggle('ioa-box--filled', Boolean(digits[i]));
+      });
+      boxes.forEach(function (box, i) {
+        box.classList.toggle('ioa-box--active', i === digits.length && digits.length < 6);
+      });
+
+      if (digits.length === 6) {
+        document.getElementById('ioa-status').textContent = 'Code entered: ' + digits;
+      }
+    });
+
+    document.querySelector('.ioa-boxes').addEventListener('click', function () {
+      input.focus();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', ioaInit);
+</script>
+</head>
+<body>
+<main class="ioa-wrap">
+  <h1 class="ioa-h1">Enter verification code</h1>
+  <p class="ioa-lede">A single real input (type=one-time-code) drives six visual boxes that are purely decorative; mobile browsers autofill an SMS code into the ONE input they can see, and the boxes just mirror whatever it contains -- no per-box focus juggling to fight the autofill flow.</p>
+
+  <div class="ioa-field">
+    <div class="ioa-boxes" aria-hidden="true">
+      <span class="ioa-box ioa-box--active"></span>
+      <span class="ioa-box"></span>
+      <span class="ioa-box"></span>
+      <span class="ioa-box"></span>
+      <span class="ioa-box"></span>
+      <span class="ioa-box"></span>
+    </div>
+    <input
+      id="ioa-input"
+      class="ioa-input"
+      type="text"
+      inputmode="numeric"
+      autocomplete="one-time-code"
+      maxlength="6"
+      aria-label="6-digit verification code"
+    />
+  </div>
+  <p class="ioa-status" id="ioa-status" role="status" aria-live="polite"></p>
+</main>
+</body>
+</html>

--- a/submissions/examples/input-otp-autofill-qz9k/style.css
+++ b/submissions/examples/input-otp-autofill-qz9k/style.css
@@ -1,0 +1,82 @@
+/* OTP Input with SMS Autofill
+   The real <input> is positioned exactly over the box row (opacity:0, full
+   width/height) rather than hidden off-screen -- iOS's autofill suggestion
+   bar anchors to the input's actual on-screen position, so moving it away
+   from the boxes visually detaches the autofill prompt from what the user
+   is looking at. */
+
+.ioa-wrap {
+  max-width: 24rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ioa-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.ioa-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.ioa-field {
+  position: relative;
+}
+
+.ioa-boxes {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ioa-box {
+  width: 2.4rem;
+  height: 2.8rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font-size: 1.3rem;
+  font-weight: 700;
+  transition: border-color 140ms ease;
+}
+
+.ioa-box--active {
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.ioa-box--filled {
+  border-color: #34a853;
+}
+
+.ioa-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  border: none;
+  font-size: 1.3rem;
+  letter-spacing: 2.9rem;
+  padding-left: 0.7rem;
+}
+
+.ioa-status {
+  margin: 0.9rem 0 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #34a853;
+  min-height: 1.2em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ioa-box { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ioa-box { border-color: CanvasText; }
+  .ioa-box--filled { forced-color-adjust: none; border-color: Highlight; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ioa-wrap { color: #e6e9f2; }
+  .ioa-lede { color: #99a1b4; }
+  .ioa-box { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #81001

Six-digit code field built from ONE real input (autocomplete=one-time-code) overlaid transparently on six decorative visual boxes that mirror its value, rather than six separate real inputs each managing its own digit. Mobile SMS-autofill anchors to a single focused input with that autocomplete value — targeting six separate inputs means the OS has to guess which one to fill, an edge case that's fragile across OS/browser combinations. The real input is positioned exactly over the visual boxes (not hidden off-screen) since iOS's autofill suggestion bar anchors to the input's actual on-screen position.