### PR TITLE
feat: add Mobile-Truncated Breadcrumb example (breadcrumb-truncate-mobile-qz9k)

### DIFF
--- a/submissions/examples/breadcrumb-truncate-mobile-qz9k/README.md
+++ b/submissions/examples/breadcrumb-truncate-mobile-qz9k/README.md
@@ -1,0 +1,47 @@
+# Mobile-Truncated Breadcrumb
+
+## What does this do?
+
+A breadcrumb trail that shows every crumb on wide viewports, but collapses
+to just Home, an ellipsis, and the current page on narrow ones — entirely
+via a CSS media query, with no JavaScript measuring available width or
+deciding which crumbs fit.
+
+## How is it used?
+
+```html
+<ol class="btm-list">
+  <li class="btm-item btm-item--home"><a href="#">Home</a></li>
+  <li class="btm-item btm-item--mid"><a href="#">Electronics</a></li>
+  <li class="btm-item btm-item--mid"><a href="#">Computers</a></li>
+  <li class="btm-item btm-item--mid"><a href="#">Laptops</a></li>
+  <li class="btm-item btm-item--ellipsis" aria-hidden="true">&hellip;</li>
+  <li class="btm-item"><span class="btm-current" aria-current="page">14-inch Ultrabook Pro</span></li>
+</ol>
+```
+
+`.btm-item--ellipsis` is always present in markup but `display: none` by
+default; a `max-width` media query simultaneously hides every
+`.btm-item--mid` crumb and reveals the ellipsis.
+
+## Why is it useful?
+
+A long breadcrumb trail on a narrow mobile viewport either wraps onto
+multiple lines (eating vertical space and looking cluttered) or overflows
+horizontally, neither of which is desirable for what's meant to be a
+compact navigational aid. A JS-based truncation approach that measures
+each crumb's rendered width and decides how many fit is more flexible in
+principle, but adds real complexity — it has to re-run on resize, handle
+font-loading shifts that change measured widths after the fact, and
+generally introduces a layout-measurement dependency for what a media
+query can express as a static rule. Marking the middle crumbs with a
+single shared class and hiding that class below a breakpoint keeps the
+truncation behavior declarative and resize-safe for free, since CSS media
+queries already re-evaluate automatically on viewport change with no JS
+listener needed.
+
+The ellipsis is `aria-hidden="true"` since it's a purely visual truncation
+indicator carrying no navigable content of its own — a screen reader user
+on a narrow viewport still reaches Home and the current page in the
+breadcrumb, just without the (also skipped, via the same media query) mid
+crumbs' links.

--- a/submissions/examples/breadcrumb-truncate-mobile-qz9k/demo.html
+++ b/submissions/examples/breadcrumb-truncate-mobile-qz9k/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mobile-Truncated Breadcrumb</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="btm-wrap">
+  <h1 class="btm-h1">Mobile-Truncated Breadcrumb</h1>
+  <p class="btm-lede">On narrow viewports, only Home, an ellipsis, and the current page show -- the middle crumbs are hidden with the CSS media query alone, so there's no JS recalculating which crumbs fit as the viewport resizes.</p>
+
+  <nav class="btm-nav" aria-label="Breadcrumb">
+    <ol class="btm-list">
+      <li class="btm-item btm-item--home"><a class="btm-link" href="#">Home</a></li>
+      <li class="btm-item btm-item--mid"><a class="btm-link" href="#">Electronics</a></li>
+      <li class="btm-item btm-item--mid"><a class="btm-link" href="#">Computers</a></li>
+      <li class="btm-item btm-item--mid"><a class="btm-link" href="#">Laptops</a></li>
+      <li class="btm-item btm-item--ellipsis" aria-hidden="true">&hellip;</li>
+      <li class="btm-item"><span class="btm-current" aria-current="page">14-inch Ultrabook Pro</span></li>
+    </ol>
+  </nav>
+</main>
+</body>
+</html>

--- a/submissions/examples/breadcrumb-truncate-mobile-qz9k/style.css
+++ b/submissions/examples/breadcrumb-truncate-mobile-qz9k/style.css
@@ -1,0 +1,73 @@
+/* Mobile-Truncated Breadcrumb
+   .btm-item--ellipsis is ALWAYS in the DOM but display:none by default --
+   only the narrow-viewport media query reveals it, alongside hiding the
+   middle crumbs. This keeps the truncated state a pure display toggle with
+   no JS deciding which crumbs to hide based on measured widths. */
+
+.btm-wrap {
+  max-width: 30rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.btm-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.btm-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.btm-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.9rem;
+}
+
+.btm-item {
+  display: flex;
+  align-items: center;
+}
+
+.btm-item:not(:last-child)::after {
+  content: "/";
+  margin: 0 0.5rem;
+  color: #a8adba;
+}
+
+.btm-item--ellipsis {
+  display: none;
+}
+
+.btm-link {
+  color: #576073;
+  text-decoration: none;
+}
+
+.btm-link:hover { color: #4c6ef5; }
+.btm-link:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 1px; border-radius: 0.2rem; }
+
+.btm-current {
+  color: #1c2028;
+  font-weight: 600;
+}
+
+@media (max-width: 30rem) {
+  .btm-item--mid {
+    display: none;
+  }
+
+  .btm-item--ellipsis {
+    display: flex;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .btm-wrap { color: #e6e9f2; }
+  .btm-lede { color: #99a1b4; }
+  .btm-item:not(:last-child)::after { color: #4a5266; }
+  .btm-link { color: #99a1b4; }
+  .btm-link:hover { color: #e6e9f2; }
+  .btm-current { color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #81002

Breadcrumb trail collapsing to Home/ellipsis/current-page below a max-width breakpoint via a pure CSS media query. The ellipsis crumb is always present in markup but display:none by default, revealed by the same media query that hides the middle crumbs — keeping truncation a static, resize-safe declarative rule rather than a JS width-measurement approach that would need to re-run on resize and handle font-loading shifts.