### PR TITLE
feat: add Reorderable List (Buttons) example (list-reorder-buttons-qz9k)

### DIFF
--- a/submissions/examples/list-reorder-buttons-qz9k/README.md
+++ b/submissions/examples/list-reorder-buttons-qz9k/README.md
@@ -1,0 +1,44 @@
+# Reorderable List (Buttons)
+
+## What does this do?
+
+A reorderable playlist using Up/Down buttons on each item instead of a
+drag gesture — every move is announced through a live region, and each
+button disables itself when the item is already first or last.
+
+## How is it used?
+
+```html
+<li class="lrb-item">
+  <span class="lrb-text">Morning Run Mix</span>
+  <button class="lrb-up" onclick="lrbMove(this, -1)" aria-label="Move up">↑</button>
+  <button class="lrb-down" onclick="lrbMove(this, 1)" aria-label="Move down">↓</button>
+</li>
+```
+
+`lrbMove` swaps the item with its adjacent sibling via `insertBefore`,
+`lrbUpdateButtons` re-evaluates every item's up/down `disabled` state after
+each move, and `lrbAnnounce` writes the item's new position into a
+`role="status"` live region.
+
+## Why is it useful?
+
+Drag-and-drop reordering (implemented elsewhere in this repo via the
+Drag and Drop API) is intuitive for mouse and touch users but structurally
+excludes keyboard-only and many screen-reader users — there's no
+equivalent "drag" gesture available to them, and drag operations are
+rarely announced meaningfully to assistive technology even when a
+keyboard fallback exists. Up/Down buttons are the accessible-by-default
+alternative: every action is a real button, individually focusable,
+individually labeled, and triggerable with Enter/Space exactly like any
+other button — no special gesture support needed for full functionality.
+
+Disabling (rather than hiding) the up button on the first item and the
+down button on the last keeps every item's action set visually and
+structurally consistent — a hidden button would mean Tab skips over it
+entirely for edge items but not others, which is a more confusing
+inconsistency than a button that's present but inert. `lrbAnnounce`
+speaking the item's name and new position ("Morning Run Mix moved to
+position 1 of 3") rather than just "moved" gives a screen reader user
+enough information to confirm the reorder did what they intended, without
+needing to re-read the entire list to check.

--- a/submissions/examples/list-reorder-buttons-qz9k/demo.html
+++ b/submissions/examples/list-reorder-buttons-qz9k/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Reorderable List (Buttons)</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function lrbMove(button, delta) {
+    var item = button.closest('.lrb-item');
+    var list = item.parentElement;
+    var sibling = delta < 0 ? item.previousElementSibling : item.nextElementSibling;
+    if (!sibling) return;
+
+    if (delta < 0) list.insertBefore(item, sibling);
+    else list.insertBefore(sibling, item);
+
+    lrbUpdateButtons(list);
+    button.focus();
+    lrbAnnounce(item);
+  }
+
+  function lrbUpdateButtons(list) {
+    var items = list.querySelectorAll('.lrb-item');
+    items.forEach(function (item, i) {
+      item.querySelector('.lrb-up').disabled = i === 0;
+      item.querySelector('.lrb-down').disabled = i === items.length - 1;
+    });
+  }
+
+  function lrbAnnounce(item) {
+    var list = item.parentElement;
+    var items = Array.from(list.querySelectorAll('.lrb-item'));
+    var position = items.indexOf(item) + 1;
+    document.getElementById('lrb-status').textContent =
+      item.querySelector('.lrb-text').textContent + ' moved to position ' + position + ' of ' + items.length;
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    lrbUpdateButtons(document.getElementById('lrb-list'));
+  });
+</script>
+</head>
+<body>
+<main class="lrb-wrap">
+  <h1 class="lrb-h1">Playlist Order</h1>
+  <p class="lrb-lede">Up/Down buttons reorder the list without any drag gesture -- a fully keyboard- and screen-reader-operable alternative to drag-and-drop reordering, with each move announced via a live region.</p>
+
+  <ul class="lrb-list" id="lrb-list">
+    <li class="lrb-item">
+      <span class="lrb-text">Morning Run Mix</span>
+      <span class="lrb-btns">
+        <button type="button" class="lrb-up" onclick="lrbMove(this, -1)" aria-label="Move up">&uarr;</button>
+        <button type="button" class="lrb-down" onclick="lrbMove(this, 1)" aria-label="Move down">&darr;</button>
+      </span>
+    </li>
+    <li class="lrb-item">
+      <span class="lrb-text">Focus Instrumentals</span>
+      <span class="lrb-btns">
+        <button type="button" class="lrb-up" onclick="lrbMove(this, -1)" aria-label="Move up">&uarr;</button>
+        <button type="button" class="lrb-down" onclick="lrbMove(this, 1)" aria-label="Move down">&darr;</button>
+      </span>
+    </li>
+    <li class="lrb-item">
+      <span class="lrb-text">Weekend Chill</span>
+      <span class="lrb-btns">
+        <button type="button" class="lrb-up" onclick="lrbMove(this, -1)" aria-label="Move up">&uarr;</button>
+        <button type="button" class="lrb-down" onclick="lrbMove(this, 1)" aria-label="Move down">&darr;</button>
+      </span>
+    </li>
+  </ul>
+  <p class="lrb-status" id="lrb-status" role="status" aria-live="polite"></p>
+</main>
+</body>
+</html>

--- a/submissions/examples/list-reorder-buttons-qz9k/style.css
+++ b/submissions/examples/list-reorder-buttons-qz9k/style.css
@@ -1,0 +1,86 @@
+/* Reorderable List (Buttons)
+   :disabled styling on the up/down buttons is the ONLY visual signal that
+   an item is first/last in the list -- deliberately not hiding the button
+   entirely, since a hidden button at the list edges would make the
+   available action set inconsistent between items, which is more
+   confusing than a visibly disabled one. */
+
+.lrb-wrap {
+  max-width: 26rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.lrb-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.lrb-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.lrb-list {
+  list-style: none;
+  margin: 0 0 0.6rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.lrb-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7em 0.9em;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.5rem;
+  background: #fbfcfe;
+}
+
+.lrb-text {
+  font-size: 0.92rem;
+}
+
+.lrb-btns {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.lrb-up,
+.lrb-down {
+  width: 1.9rem;
+  height: 1.9rem;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.35rem;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.lrb-up:hover:not(:disabled),
+.lrb-down:hover:not(:disabled) {
+  background: #f1f4fa;
+}
+
+.lrb-up:disabled,
+.lrb-down:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.lrb-up:focus-visible,
+.lrb-down:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 2px;
+}
+
+.lrb-status {
+  font-size: 0.82rem;
+  color: #576073;
+}
+
+@media (prefers-color-scheme: dark) {
+  .lrb-wrap { color: #e6e9f2; }
+  .lrb-lede, .lrb-status { color: #99a1b4; }
+  .lrb-item { background: #171b23; border-color: #2a303c; }
+  .lrb-up, .lrb-down { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .lrb-up:hover:not(:disabled), .lrb-down:hover:not(:disabled) { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #81003

Playlist reordering via Up/Down buttons rather than drag-and-drop, which structurally excludes keyboard-only and many screen-reader users since there's no equivalent drag gesture available to them. Each button is a real, individually labeled, Enter/Space-activatable control; disabling (not hiding) the up button on the first item and down on the last keeps every item's action set structurally consistent. Each move announces the item's name and new position through a live region, giving enough information to confirm the reorder without re-reading the whole list.