### PR TITLE
feat: add basic plan feature row demo

### DIFF
--- a/submissions/examples/basic-plan-feature-row-kk/README.md
+++ b/submissions/examples/basic-plan-feature-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Plan Feature Row
+
+## What it does
+
+This submission adds a simple CSS-only plan feature row for pricing tables,
+feature comparison sections, subscription pages, and product upgrade screens.
+
+It presents a feature state icon, feature name, helper copy, plan name, and
+availability badge in a compact reusable row.
+
+## How to use it
+
+Add the base row class with a state marker, copy area, plan label, and feature
+badge:
+
+```html
+<article class="basic-plan-feature-row">
+  <span class="feature-state is-included" aria-hidden="true">✓</span>
+  <div class="feature-copy">
+    <strong>Unlimited projects</strong>
+    <p>Create and organize as many active projects as needed.</p>
+  </div>
+  <span class="plan-name">Pro</span>
+  <span class="feature-badge is-included">Included</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, reusable, and useful across
+common SaaS and product interfaces. The row can be combined with cards, pricing
+sections, billing dashboards, or comparison tables while staying CSS-only and
+self-contained.
+
+## Included features
+
+- Included, limited, and unavailable feature states
+- Circular status marker
+- Plan label and availability badge
+- Filename-style text truncation for long feature copy
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the plan feature row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-plan-feature-row-kk/demo.html
+++ b/submissions/examples/basic-plan-feature-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Plan Feature Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Plan Feature Row</p>
+          <h1>Readable pricing rows for plan comparison sections.</h1>
+          <p class="intro">
+            A CSS-only row component for comparing plan features with included,
+            limited, and unavailable states.
+          </p>
+        </header>
+
+        <section class="plan-panel" aria-label="Plan feature row examples">
+          <article class="basic-plan-feature-row">
+            <span class="feature-state is-included" aria-hidden="true">✓</span>
+            <div class="feature-copy">
+              <strong>Unlimited projects</strong>
+              <p>Create and organize as many active projects as needed.</p>
+            </div>
+            <span class="plan-name">Pro</span>
+            <span class="feature-badge is-included">Included</span>
+          </article>
+
+          <article class="basic-plan-feature-row">
+            <span class="feature-state is-limited" aria-hidden="true">~</span>
+            <div class="feature-copy">
+              <strong>Team audit history</strong>
+              <p>Access recent activity with limited retention.</p>
+            </div>
+            <span class="plan-name">Starter</span>
+            <span class="feature-badge is-limited">Limited</span>
+          </article>
+
+          <article class="basic-plan-feature-row">
+            <span class="feature-state is-unavailable" aria-hidden="true">×</span>
+            <div class="feature-copy">
+              <strong>Priority support</strong>
+              <p>Dedicated support is available on higher plans.</p>
+            </div>
+            <span class="plan-name">Free</span>
+            <span class="feature-badge is-unavailable">Upgrade</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-plan-feature-row"&gt;
+  &lt;span class="feature-state is-included" aria-hidden="true"&gt;✓&lt;/span&gt;
+  &lt;div class="feature-copy"&gt;
+    &lt;strong&gt;Unlimited projects&lt;/strong&gt;
+    &lt;p&gt;Create and organize as many active projects as needed.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="plan-name"&gt;Pro&lt;/span&gt;
+  &lt;span class="feature-badge is-included"&gt;Included&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-plan-feature-row-kk/style.css
+++ b/submissions/examples/basic-plan-feature-row-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0d111c;
+  --card: rgba(18, 24, 38, 0.96);
+  --panel: rgba(255, 255, 255, 0.045);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a3adbd;
+  --included: #86efac;
+  --limited: #facc15;
+  --unavailable: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 20% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 90% 72%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a12, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--included);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.plan-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-plan-feature-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-plan-feature-row + .basic-plan-feature-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-plan-feature-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.feature-state {
+  display: grid;
+  width: 2.35rem;
+  height: 2.35rem;
+  place-items: center;
+  border-radius: 50%;
+  font-size: 1rem;
+  font-weight: 950;
+  color: var(--included);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.feature-state.is-limited {
+  color: var(--limited);
+  background: rgba(250, 204, 21, 0.13);
+}
+
+.feature-state.is-unavailable {
+  color: var(--unavailable);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+.feature-copy {
+  min-width: 0;
+}
+
+.feature-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feature-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-name,
+.feature-badge {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.plan-name {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.feature-badge {
+  min-width: 5.8rem;
+  color: var(--included);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.feature-badge.is-limited {
+  color: var(--limited);
+  background: rgba(250, 204, 21, 0.13);
+}
+
+.feature-badge.is-unavailable {
+  color: var(--unavailable);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-plan-feature-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .plan-name,
+  .feature-badge {
+    margin-left: 3.2rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Plan Feature Row demo inside `submissions/examples/basic-plan-feature-row-kk/`. This submission introduces a compact CSS-only row for pricing tables, feature comparison sections, subscription pages, and product upgrade screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only plan feature row that displays a feature state icon, feature name, helper copy, plan label, and included/limited/unavailable availability badge in one compact layout.

**How does a developer use it?**

```html
<article class="basic-plan-feature-row">
  <span class="feature-state is-included" aria-hidden="true">✓</span>
  <div class="feature-copy">
    <strong>Unlimited projects</strong>
    <p>Create and organize as many active projects as needed.</p>
  </div>
  <span class="plan-name">Pro</span>
  <span class="feature-badge is-included">Included</span>
</article>