### PR TITLE
feat: add basic file attachment row demo

### DIFF
--- a/submissions/examples/basic-file-attachment-row-kk/README.md
+++ b/submissions/examples/basic-file-attachment-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic File Attachment Row
+
+## What it does
+
+This submission adds a simple CSS-only attachment row for upload cards,
+document panels, chat attachments, project files, and form review screens.
+
+It presents a file type badge, filename, helper copy, size metadata, and upload
+state in a compact reusable row.
+
+## How to use it
+
+Add the base row class with a file badge, copy area, size label, and status
+pill:
+
+```html
+<article class="basic-file-attachment-row">
+  <span class="file-icon file-pdf" aria-hidden="true">PDF</span>
+  <div class="file-copy">
+    <strong>proposal-summary.pdf</strong>
+    <p>Project brief and review notes</p>
+  </div>
+  <span class="file-size">2.4 MB</span>
+  <span class="file-status is-ready">Uploaded</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful in
+many product interfaces. Developers can drop the row into upload panels,
+settings pages, project dashboards, or document lists without JavaScript or
+external dependencies.
+
+## Included features
+
+- PDF, image, and document file badge variants
+- Uploaded, syncing, and review status states
+- Filename and helper text truncation
+- Compact file size metadata
+- Subtle hover slide and side accent
+- Responsive wrapping for smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the attachment row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-file-attachment-row-kk/demo.html
+++ b/submissions/examples/basic-file-attachment-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic File Attachment Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic File Attachment Row</p>
+          <h1>Readable attachment rows for upload and document panels.</h1>
+          <p class="intro">
+            A CSS-only row pattern for showing attached files, file type,
+            size, upload state, and a lightweight action in one compact layout.
+          </p>
+        </header>
+
+        <section class="attachment-panel" aria-label="File attachment row examples">
+          <article class="basic-file-attachment-row">
+            <span class="file-icon file-pdf" aria-hidden="true">PDF</span>
+            <div class="file-copy">
+              <strong>proposal-summary.pdf</strong>
+              <p>Project brief and review notes</p>
+            </div>
+            <span class="file-size">2.4 MB</span>
+            <span class="file-status is-ready">Uploaded</span>
+          </article>
+
+          <article class="basic-file-attachment-row">
+            <span class="file-icon file-img" aria-hidden="true">IMG</span>
+            <div class="file-copy">
+              <strong>dashboard-preview.png</strong>
+              <p>Visual reference for the interface</p>
+            </div>
+            <span class="file-size">860 KB</span>
+            <span class="file-status is-syncing">Syncing</span>
+          </article>
+
+          <article class="basic-file-attachment-row">
+            <span class="file-icon file-doc" aria-hidden="true">DOC</span>
+            <div class="file-copy">
+              <strong>meeting-notes.docx</strong>
+              <p>Needs a newer version before sharing</p>
+            </div>
+            <span class="file-size">318 KB</span>
+            <span class="file-status is-warning">Review</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-file-attachment-row"&gt;
+  &lt;span class="file-icon file-pdf" aria-hidden="true"&gt;PDF&lt;/span&gt;
+  &lt;div class="file-copy"&gt;
+    &lt;strong&gt;proposal-summary.pdf&lt;/strong&gt;
+    &lt;p&gt;Project brief and review notes&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="file-size"&gt;2.4 MB&lt;/span&gt;
+  &lt;span class="file-status is-ready"&gt;Uploaded&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-file-attachment-row-kk/style.css
+++ b/submissions/examples/basic-file-attachment-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0a0f1c;
+  --card: rgba(16, 24, 40, 0.94);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f7fbff;
+  --muted: #9da8bb;
+  --ready: #7dd3fc;
+  --syncing: #c4b5fd;
+  --warning: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 12%, rgba(125, 211, 252, 0.16), transparent 28%),
+    radial-gradient(circle at 88% 86%, rgba(251, 191, 36, 0.12), transparent 30%),
+    linear-gradient(135deg, #070b14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--ready);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.04;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.attachment-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-file-attachment-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-file-attachment-row + .basic-file-attachment-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-file-attachment-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(125, 211, 252, 0.7);
+  transform: translateX(4px);
+}
+
+.file-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 14px;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: #07111f;
+}
+
+.file-pdf {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.file-img {
+  background: linear-gradient(135deg, #7dd3fc, #bae6fd);
+}
+
+.file-doc {
+  background: linear-gradient(135deg, #c4b5fd, #ddd6fe);
+}
+
+.file-copy {
+  min-width: 0;
+}
+
+.file-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-size,
+.file-status {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.file-size {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.file-status {
+  min-width: 5.8rem;
+  color: var(--ready);
+  background: rgba(125, 211, 252, 0.13);
+}
+
+.file-status.is-syncing {
+  color: var(--syncing);
+  background: rgba(196, 181, 253, 0.13);
+}
+
+.file-status.is-warning {
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.14);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-file-attachment-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .file-size,
+  .file-status {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic File Attachment Row demo inside `submissions/examples/basic-file-attachment-row-kk/`. This submission introduces a compact CSS-only row for upload panels, document lists, chat attachments, form reviews, and project file sections.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only file attachment row that displays a file type badge, filename, helper copy, file size, and uploaded/syncing/review status in one compact layout.

**How does a developer use it?**

```html
<article class="basic-file-attachment-row">
  <span class="file-icon file-pdf" aria-hidden="true">PDF</span>
  <div class="file-copy">
    <strong>proposal-summary.pdf</strong>
    <p>Project brief and review notes</p>
  </div>
  <span class="file-size">2.4 MB</span>
  <span class="file-status is-ready">Uploaded</span>
</article>