### PR TITLE
feat: add basic integration health row demo

### DIFF
--- a/submissions/examples/basic-integration-health-row-kk/README.md
+++ b/submissions/examples/basic-integration-health-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Integration Health Row
+
+## What it does
+
+This submission adds a simple CSS-only integration health row for connected app
+settings, workspace dashboards, admin panels, sync status pages, and developer
+tools.
+
+It displays a health marker, integration name, helper copy, last sync time, and
+connection state in one compact row.
+
+## How to use it
+
+Add the base row class with marker, copy, meta time, and state pill:
+
+```html
+<article class="basic-integration-health-row">
+  <span class="health-dot is-connected" aria-hidden="true"></span>
+  <div class="integration-copy">
+    <strong>GitHub integration</strong>
+    <p>Repository events are syncing normally.</p>
+  </div>
+  <span class="integration-meta">2m ago</span>
+  <span class="integration-state is-connected">Connected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful across
+common integration and workspace health interfaces. The row can be used inside
+settings cards, connected app panels, developer tools, and admin dashboards
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Connected, degraded, and disconnected integration states
+- Glowing health marker
+- Integration copy, last sync time, and state pill layout
+- Text truncation for long helper copy
+- Subtle hover lift interaction
+- Responsive two-column wrapping on small screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the integration health row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-integration-health-row-kk/demo.html
+++ b/submissions/examples/basic-integration-health-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Integration Health Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Integration Health Row</p>
+          <h1>Connection rows for integrations and workspace health panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing connected apps, sync health,
+            helper copy, and compact connection states.
+          </p>
+        </header>
+
+        <section class="integration-panel" aria-label="Integration health row examples">
+          <article class="basic-integration-health-row">
+            <span class="health-dot is-connected" aria-hidden="true"></span>
+            <div class="integration-copy">
+              <strong>GitHub integration</strong>
+              <p>Repository events are syncing normally.</p>
+            </div>
+            <span class="integration-meta">2m ago</span>
+            <span class="integration-state is-connected">Connected</span>
+          </article>
+
+          <article class="basic-integration-health-row">
+            <span class="health-dot is-degraded" aria-hidden="true"></span>
+            <div class="integration-copy">
+              <strong>Slack alerts</strong>
+              <p>Messages are delayed while retries are in progress.</p>
+            </div>
+            <span class="integration-meta">18m ago</span>
+            <span class="integration-state is-degraded">Degraded</span>
+          </article>
+
+          <article class="basic-integration-health-row">
+            <span class="health-dot is-disconnected" aria-hidden="true"></span>
+            <div class="integration-copy">
+              <strong>Calendar sync</strong>
+              <p>Reconnect the account to resume schedule updates.</p>
+            </div>
+            <span class="integration-meta">1h ago</span>
+            <span class="integration-state is-disconnected">Offline</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-integration-health-row"&gt;
+  &lt;span class="health-dot is-connected" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;div class="integration-copy"&gt;
+    &lt;strong&gt;GitHub integration&lt;/strong&gt;
+    &lt;p&gt;Repository events are syncing normally.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="integration-meta"&gt;2m ago&lt;/span&gt;
+  &lt;span class="integration-state is-connected"&gt;Connected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-integration-health-row-kk/style.css
+++ b/submissions/examples/basic-integration-health-row-kk/style.css
@@ -1,0 +1,188 @@
+:root {
+  color-scheme: dark;
+  --page: #080d18;
+  --card: rgba(15, 23, 42, 0.95);
+  --panel: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #9ca8ba;
+  --connected: #86efac;
+  --degraded: #fcd34d;
+  --disconnected: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.14), transparent 30%),
+    radial-gradient(circle at 86% 80%, rgba(252, 211, 77, 0.12), transparent 28%),
+    var(--page);
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--card);
+  box-shadow: 0 28px 78px rgba(0, 0, 0, 0.38);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--connected);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 16ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.integration-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-integration-health-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 16px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.basic-integration-health-row + .basic-integration-health-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-integration-health-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateY(-2px);
+}
+
+.health-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  color: var(--connected);
+  background: currentColor;
+  box-shadow: 0 0 0.9rem currentColor;
+}
+
+.health-dot.is-degraded {
+  color: var(--degraded);
+}
+
+.health-dot.is-disconnected {
+  color: var(--disconnected);
+}
+
+.integration-copy {
+  min-width: 0;
+}
+
+.integration-copy strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.integration-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.integration-meta,
+.integration-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.integration-meta {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.integration-state {
+  min-width: 6rem;
+  border: 1px solid currentColor;
+  color: var(--connected);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.integration-state.is-degraded {
+  color: var(--degraded);
+  background: rgba(252, 211, 77, 0.12);
+}
+
+.integration-state.is-disconnected {
+  color: var(--disconnected);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dce8ff;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-integration-health-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .integration-meta {
+    margin-left: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Integration Health Row demo inside `submissions/examples/basic-integration-health-row-kk/`. This submission introduces a compact CSS-only row for connected app settings, workspace dashboards, admin panels, sync status pages, and developer tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only integration health row that displays a health marker, integration name, helper copy, last sync time, and connected/degraded/disconnected state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-integration-health-row">
  <span class="health-dot is-connected" aria-hidden="true"></span>
  <div class="integration-copy">
    <strong>GitHub integration</strong>
    <p>Repository events are syncing normally.</p>
  </div>
  <span class="integration-meta">2m ago</span>
  <span class="integration-state is-connected">Connected</span>
</article>