### PR TITLE
feat: add ease-drag-note-sticky-move-sap

### DIFF
--- a/submissions/examples/ease-drag-note-sticky-move-sap/README.md
+++ b/submissions/examples/ease-drag-note-sticky-move-sap/README.md
@@ -1,0 +1,35 @@
+# Drag Note Sticky Move
+
+Freely draggable sticky notes on a corkboard-style canvas, lifting with a
+shadow and straightening out of their default tilt while being moved, with
+full keyboard repositioning.
+
+**Level:** Advanced
+
+## Usage
+
+Each `.sticky-note` is absolutely positioned within `.board`. Dragging
+(Pointer Events, clamped to stay within the board bounds) or Arrow keys
+(12px steps, same clamping) reposition each note independently.
+
+## Accessibility
+
+- Each note is `role="group"` with a full `aria-label` describing its
+  content and that it's draggable/keyboard-movable.
+- Fully keyboard-operable via Arrow keys per note, entirely independent of
+  pointer dragging.
+- `:focus-visible` outline shown, distinct from the drag-lift shadow/scale feedback.
+- `prefers-reduced-motion` removes the lift shadow/scale/rotate transition
+  during drag; notes still move correctly, just without the eased lift effect.
+
+## Notes
+
+- Both drag and keyboard movement are clamped against the board's own
+  bounds (accounting for each note's width/height), so notes can never be
+  dragged or keyed outside the visible corkboard area.
+- The slight default rotation (alternating ±2deg per note) straightens to
+  0deg while actively dragging, giving a "picked up and being placed
+  straight" feel, then returns to its tilt once released (via CSS, not JS,
+  since the tilt is a static per-note style rather than drag-driven state).
+- This demo doesn't persist note positions between page loads; wire up
+  storage (e.g. `localStorage` or a backend) in real usage.

--- a/submissions/examples/ease-drag-note-sticky-move-sap/demo.html
+++ b/submissions/examples/ease-drag-note-sticky-move-sap/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Drag Note Sticky Move</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Drag Note Sticky Move</h1>
+
+    <div class="board" id="board">
+      <div class="sticky-note" id="note1" style="left: 20px; top: 20px; background:#fef08a;" tabindex="0" role="group" aria-label="Sticky note: Follow up with design team. Draggable, use arrow keys to move.">
+        Follow up with design team
+      </div>
+      <div class="sticky-note" id="note2" style="left: 200px; top: 90px; background:#bbf7d0;" tabindex="0" role="group" aria-label="Sticky note: Ship v2.1. Draggable, use arrow keys to move.">
+        Ship v2.1
+      </div>
+    </div>
+
+    <p class="hint">Drag notes anywhere, or focus one and use arrow keys.</p>
+  </main>
+
+  <script>
+    const board = document.getElementById('board');
+    let dragging = null;
+    let offsetX = 0, offsetY = 0;
+
+    document.querySelectorAll('.sticky-note').forEach(note => {
+      note.addEventListener('pointerdown', (e) => {
+        dragging = note;
+        const rect = note.getBoundingClientRect();
+        offsetX = e.clientX - rect.left;
+        offsetY = e.clientY - rect.top;
+        note.setPointerCapture(e.pointerId);
+        note.classList.add('is-dragging');
+      });
+
+      note.addEventListener('pointermove', (e) => {
+        if (dragging !== note) return;
+        const boardRect = board.getBoundingClientRect();
+        let x = e.clientX - boardRect.left - offsetX;
+        let y = e.clientY - boardRect.top - offsetY;
+        x = Math.min(Math.max(x, 0), boardRect.width - note.offsetWidth);
+        y = Math.min(Math.max(y, 0), boardRect.height - note.offsetHeight);
+        note.style.left = x + 'px';
+        note.style.top = y + 'px';
+      });
+
+      note.addEventListener('pointerup', () => {
+        note.classList.remove('is-dragging');
+        dragging = null;
+      });
+
+      const STEP = 12;
+      note.addEventListener('keydown', (e) => {
+        const moves = { ArrowLeft: [-STEP, 0], ArrowRight: [STEP, 0], ArrowUp: [0, -STEP], ArrowDown: [0, STEP] };
+        if (!moves[e.key]) return;
+        e.preventDefault();
+        const boardRect = board.getBoundingClientRect();
+        const [dx, dy] = moves[e.key];
+        let x = Math.min(Math.max(parseFloat(note.style.left) + dx, 0), boardRect.width - note.offsetWidth);
+        let y = Math.min(Math.max(parseFloat(note.style.top) + dy, 0), boardRect.height - note.offsetHeight);
+        note.style.left = x + 'px';
+        note.style.top = y + 'px';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-note-sticky-move-sap/style.css
+++ b/submissions/examples/ease-drag-note-sticky-move-sap/style.css
@@ -1,0 +1,70 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.board {
+  position: relative;
+  width: 340px;
+  height: 220px;
+  background: #eef2f7;
+  border-radius: 14px;
+  border: 1px dashed #cbd5e1;
+  overflow: hidden;
+}
+
+.sticky-note {
+  position: absolute;
+  width: 130px;
+  padding: 0.75rem;
+  border-radius: 4px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #422006;
+  cursor: grab;
+  touch-action: none;
+  transform: rotate(-2deg);
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.sticky-note:nth-child(2) { transform: rotate(2deg); }
+
+.sticky-note:active,
+.sticky-note.is-dragging {
+  cursor: grabbing;
+  box-shadow: 0 12px 24px rgba(0,0,0,0.25);
+  transform: rotate(0deg) scale(1.04);
+  z-index: 5;
+}
+
+.sticky-note:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.hint {
+  margin-top: 1.25rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticky-note { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-note-sticky-move-sap`, freely draggable sticky notes on a corkboard canvas.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-drag-note-sticky-move-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Each note is independently keyboard-movable via Arrow keys with the same
  boundary clamping as pointer dragging, and carries a full descriptive
  `aria-label`.
- README notes position persistence (e.g. `localStorage`) is intentionally
  out of scope for this focused drag-interaction submission.

## Feature Description

Adds a reusable freely-draggable sticky-note board component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.