### PR TITLE
feat: add ease-hover-button-ripple-click-sap

### DIFF
--- a/submissions/examples/ease-hover-button-ripple-click-sap/README.md
+++ b/submissions/examples/ease-hover-button-ripple-click-sap/README.md
@@ -1,0 +1,35 @@
+# Hover Button Ripple Click
+
+Buttons combining a hover lift with a click-triggered ripple that expands
+from the exact click point, layered together for a two-stage tactile feel.
+
+**Level:** Intermediate
+
+## Usage
+
+Apply `.dual-btn` (plus optional `.dual-btn-danger` variant) to any button.
+Hover applies a small lift via `transform`; clicking spawns a ripple `span`
+at the pointer position, same technique as `ease-hover-button-ripple-sap`.
+
+## Accessibility
+
+- Ripple is layered behind the button's text (`z-index: -1` +
+  `isolation: isolate`), never obscuring the label, and `pointer-events:
+  none` keeps it from intercepting clicks.
+- Bound to the `click` event, so it also fires for keyboard-activated
+  (Enter/Space) button presses, giving keyboard users the same feedback as
+  mouse users.
+- Each ripple self-removes on `animationend`, avoiding buildup from rapid
+  repeated clicks.
+- `prefers-reduced-motion` disables both the hover lift `transform` and the
+  ripple animation (hiding the ripple layer entirely), leaving only the
+  background color change as interactive feedback.
+
+## Notes
+
+- This is a close variant of `ease-hover-button-ripple-sap`, adding a
+  persistent hover-lift `transform` on top of the click ripple — the two
+  effects layer without conflicting since the lift is a continuous
+  hover-state transform and the ripple is a one-shot spawned element.
+- Includes a `.dual-btn-danger` color variant to demonstrate the effect
+  isn't tied to one specific button color.

--- a/submissions/examples/ease-hover-button-ripple-click-sap/demo.html
+++ b/submissions/examples/ease-hover-button-ripple-click-sap/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Button Ripple Click</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Button Ripple Click</h1>
+
+    <button class="dual-btn">Add to cart</button>
+    <button class="dual-btn dual-btn-danger">Delete item</button>
+  </main>
+
+  <script>
+    document.querySelectorAll('.dual-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        const rect = btn.getBoundingClientRect();
+        const ripple = document.createElement('span');
+        const size = Math.max(rect.width, rect.height) * 2.2;
+        const x = e.clientX ? e.clientX - rect.left : rect.width / 2;
+        const y = e.clientY ? e.clientY - rect.top : rect.height / 2;
+        ripple.className = 'click-ripple';
+        ripple.style.width = ripple.style.height = size + 'px';
+        ripple.style.left = (x - size / 2) + 'px';
+        ripple.style.top = (y - size / 2) + 'px';
+        btn.appendChild(ripple);
+        ripple.addEventListener('animationend', () => ripple.remove());
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-button-ripple-click-sap/style.css
+++ b/submissions/examples/ease-hover-button-ripple-click-sap/style.css
@@ -1,0 +1,67 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.dual-btn {
+  position: relative;
+  overflow: hidden;
+  padding: 0.85rem 2.2rem;
+  border-radius: 10px;
+  border: none;
+  background: #6366f1;
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  isolation: isolate;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.dual-btn:hover { background: #4f46e5; transform: translateY(-2px); }
+.dual-btn:active { transform: translateY(0); }
+
+.dual-btn-danger { background: #ef4444; }
+.dual-btn-danger:hover { background: #dc2626; }
+
+.dual-btn:focus-visible {
+  outline: 2px solid #1e293b;
+  outline-offset: 3px;
+}
+
+.click-ripple {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.5);
+  transform: scale(0);
+  animation: ripple-grow 0.55s ease-out;
+  pointer-events: none;
+  z-index: -1;
+}
+
+@keyframes ripple-grow {
+  to { transform: scale(1); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dual-btn { transition: background 0.2s ease; }
+  .dual-btn:hover { transform: none; }
+  .click-ripple { animation: none; display: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-button-ripple-click-sap`, buttons combining a hover lift with a click-point ripple.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-button-ripple-click-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Ripple bound to `click` (fires for keyboard activation too), layered
  behind text with `pointer-events: none`, and self-removes on `animationend`.
- Reduced motion disables both the hover-lift transform and the ripple
  animation, leaving only a background color change.

## Feature Description

Adds a reusable hover-lift + click-ripple button component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.