### PR TITLE
feat: add ease-hover-image-grid-lightbox-sap

### DIFF
--- a/submissions/examples/ease-hover-image-grid-lightbox-sap/README.md
+++ b/submissions/examples/ease-hover-image-grid-lightbox-sap/README.md
@@ -1,0 +1,38 @@
+# Hover Image Grid Lightbox
+
+A thumbnail grid where clicking any image opens a full-size lightbox
+overlay with a fade/scale-in animation, full focus management, and
+Escape/outside-click/close-button dismissal.
+
+**Level:** Advanced
+
+## Usage
+
+Each thumbnail is a `<button>` with `data-full` pointing to the full-size
+image URL. Clicking calls `openLightbox()`, which populates and reveals the
+overlay; `closeLightbox()` reverses it.
+
+## Accessibility
+
+- Each thumbnail button has a descriptive `aria-label` ("Open image 1 of 3
+  in lightbox"), and every image (thumbnail and full-size) carries real
+  descriptive `alt` text.
+- The lightbox is `role="dialog" aria-modal="true"` with a labeled close
+  button; focus moves to the close button on open and is restored to the
+  originating thumbnail on close.
+- Escape closes the lightbox; clicking the dark backdrop (not the image
+  itself) also closes it.
+- The keydown listener is only attached while the lightbox is open and
+  removed on close.
+- `prefers-reduced-motion` removes the backdrop fade and image scale/fade
+  transitions; open/close still function, just instantly.
+
+## Notes
+
+- `lightbox.hidden` is only set back to `true` after `transitionend`, so
+  the close animation plays fully before removal from layout/accessibility tree.
+- This demo omits a focus trap within the lightbox (unlike
+  `ease-modal-fade-backdrop-sap`) since there's only one interactive element
+  (the close button) inside it — for a lightbox with next/prev navigation
+  controls, a full focus trap (as in the modal component) would become
+  necessary and should be added.

--- a/submissions/examples/ease-hover-image-grid-lightbox-sap/demo.html
+++ b/submissions/examples/ease-hover-image-grid-lightbox-sap/demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hover Image Grid Lightbox</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap">
+    <h1>Hover Image Grid Lightbox</h1>
+
+    <div class="thumb-grid">
+      <button class="thumb-btn" data-full="https://picsum.photos/seed/lightbox1/900/600" aria-label="Open image 1 of 3 in lightbox">
+        <img src="https://picsum.photos/seed/lightbox1/240/160" alt="Mountain lake at sunrise">
+      </button>
+      <button class="thumb-btn" data-full="https://picsum.photos/seed/lightbox2/900/600" aria-label="Open image 2 of 3 in lightbox">
+        <img src="https://picsum.photos/seed/lightbox2/240/160" alt="Desert dunes at dusk">
+      </button>
+      <button class="thumb-btn" data-full="https://picsum.photos/seed/lightbox3/900/600" aria-label="Open image 3 of 3 in lightbox">
+        <img src="https://picsum.photos/seed/lightbox3/240/160" alt="Forest waterfall">
+      </button>
+    </div>
+  </main>
+
+  <div class="lightbox" id="lightbox" hidden role="dialog" aria-modal="true" aria-label="Image preview">
+    <button class="lightbox-close" id="lightboxClose" aria-label="Close lightbox">✕</button>
+    <img id="lightboxImg" class="lightbox-img" src="" alt="">
+  </div>
+
+  <script>
+    const grid = document.querySelector('.thumb-grid');
+    const lightbox = document.getElementById('lightbox');
+    const lightboxImg = document.getElementById('lightboxImg');
+    const closeBtn = document.getElementById('lightboxClose');
+    let lastFocused = null;
+
+    function openLightbox(btn) {
+      lastFocused = btn;
+      lightboxImg.src = btn.dataset.full;
+      lightboxImg.alt = btn.querySelector('img').alt;
+      lightbox.hidden = false;
+      requestAnimationFrame(() => lightbox.classList.add('is-open'));
+      closeBtn.focus();
+      document.addEventListener('keydown', onKeydown);
+    }
+
+    function closeLightbox() {
+      lightbox.classList.remove('is-open');
+      document.removeEventListener('keydown', onKeydown);
+      lightbox.addEventListener('transitionend', function h() {
+        lightbox.hidden = true;
+        lightbox.removeEventListener('transitionend', h);
+        lastFocused?.focus();
+      }, { once: true });
+    }
+
+    function onKeydown(e) {
+      if (e.key === 'Escape') closeLightbox();
+    }
+
+    grid.querySelectorAll('.thumb-btn').forEach(btn => {
+      btn.addEventListener('click', () => openLightbox(btn));
+    });
+
+    closeBtn.addEventListener('click', closeLightbox);
+    lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox(); });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-image-grid-lightbox-sap/style.css
+++ b/submissions/examples/ease-hover-image-grid-lightbox-sap/style.css
@@ -1,0 +1,104 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #1e293b;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.thumb-btn {
+  padding: 0;
+  border: none;
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  line-height: 0;
+  transition: transform 0.2s ease;
+}
+
+.thumb-btn:hover, .thumb-btn:focus-visible {
+  transform: scale(1.04);
+}
+
+.thumb-btn:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 3px;
+}
+
+.thumb-btn img {
+  width: 120px;
+  height: 80px;
+  object-fit: cover;
+  display: block;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  transition: background 0.25s ease;
+}
+
+.lightbox.is-open { background: rgba(0,0,0,0.85); }
+
+.lightbox-img {
+  max-width: 90vw;
+  max-height: 85vh;
+  border-radius: 8px;
+  transform: scale(0.92);
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.lightbox.is-open .lightbox-img {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.lightbox-close:hover { background: rgba(255,255,255,0.28); }
+
+.lightbox-close:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lightbox, .lightbox-img, .thumb-btn { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-image-grid-lightbox-sap`, a thumbnail grid opening into a full-size fade/scale lightbox.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-hover-image-grid-lightbox-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Lightbox is `role="dialog" aria-modal="true"` with focus moved to the
  close button on open and restored to the origin thumbnail on close, plus
  Escape and outside-click dismissal.
- README notes a full focus trap (like the standalone modal component) is
  intentionally omitted here since there's only one interactive element,
  but flags it as necessary if next/prev controls are ever added.

## Feature Description

Adds a reusable image-grid-to-lightbox component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.