### PR TITLE
feat: add ease-animated-toggle-day-night-sap

### DIFF
--- a/submissions/examples/ease-animated-toggle-day-night-sap/README.md
+++ b/submissions/examples/ease-animated-toggle-day-night-sap/README.md
@@ -1,0 +1,39 @@
+# Animated Toggle Day Night
+
+A toggle switch styled as a sun/moon sliding across a sky, morphing color
+and craters/glow, while the whole page background crossfades between a day
+and night gradient.
+
+**Level:** Advanced
+
+## Usage
+
+The switch is `role="switch" aria-checked`. Clicking toggles state, flips
+`is-night` on the page wrapper (driving the background/text color
+crossfade), and slides/morphs the sun-to-moon `.celestial` element plus
+fading in star dots.
+
+## Accessibility
+
+- Implemented as `role="switch"` with `aria-checked` kept in sync and
+  `aria-label` describing the next action ("Switch to night mode"/"Switch
+  to day mode").
+- Fully keyboard-operable as a real `<button>`, with `:focus-visible` outline shown.
+- Text color also crossfades between light/dark variants alongside the
+  background, so contrast is maintained in both day and night states rather
+  than only styling the toggle itself.
+- `prefers-reduced-motion` removes all transitions (background, text color,
+  celestial slide/morph, star fade); the correct end state for
+  day/night still applies immediately based on toggle state.
+
+## Notes
+
+- The sun-to-moon morph uses `box-shadow: inset` to fake craters on the
+  "moon" state rather than swapping to a different image/icon, keeping it a
+  single continuously-animating element.
+- Star opacity transitions have a slight delay (`0.2s`) relative to the
+  background so they fade in just as the sky has visually darkened enough
+  to read against, rather than appearing prematurely against a still-light background.
+- This toggle also demonstrates page-wide theme switching triggered from a
+  single control, similar in spirit to `ease-toggle-theme-switch-sap` but
+  with a much more elaborate, illustrated toggle control itself.

--- a/submissions/examples/ease-animated-toggle-day-night-sap/demo.html
+++ b/submissions/examples/ease-animated-toggle-day-night-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Animated Toggle Day Night</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="wrap" id="sceneWrap">
+    <button
+      class="day-night-toggle"
+      id="dnToggle"
+      role="switch"
+      aria-checked="false"
+      aria-label="Switch to night mode"
+    >
+      <span class="sky">
+        <span class="star s1"></span>
+        <span class="star s2"></span>
+        <span class="star s3"></span>
+        <span class="celestial"></span>
+      </span>
+    </button>
+
+    <h1>Animated Toggle Day Night</h1>
+  </main>
+
+  <script>
+    const btn = document.getElementById('dnToggle');
+    const scene = document.getElementById('sceneWrap');
+    btn.addEventListener('click', () => {
+      const isNight = btn.getAttribute('aria-checked') === 'true';
+      btn.setAttribute('aria-checked', String(!isNight));
+      btn.setAttribute('aria-label', isNight ? 'Switch to night mode' : 'Switch to day mode');
+      scene.classList.toggle('is-night', !isNight);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-toggle-day-night-sap/style.css
+++ b/submissions/examples/ease-animated-toggle-day-night-sap/style.css
@@ -1,0 +1,95 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  margin: 0;
+}
+
+.wrap {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  background: linear-gradient(180deg, #7dd3fc, #fef3c7);
+  transition: background 0.6s ease;
+}
+
+.wrap.is-night {
+  background: linear-gradient(180deg, #0f172a, #1e293b);
+}
+
+h1 {
+  font-size: 1.25rem;
+  color: #1e293b;
+  font-weight: 600;
+  margin: 0;
+  transition: color 0.6s ease;
+}
+
+.wrap.is-night h1 { color: #e2e8f0; }
+
+.day-night-toggle {
+  width: 100px;
+  height: 52px;
+  border-radius: 999px;
+  border: none;
+  background: #38bdf8;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.5s ease;
+  padding: 0;
+  overflow: hidden;
+}
+
+.wrap.is-night .day-night-toggle {
+  background: #1e293b;
+}
+
+.day-night-toggle:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 3px;
+}
+
+.sky { position: absolute; inset: 0; }
+
+.celestial {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #fef08a;
+  box-shadow: 0 0 16px 4px rgba(254, 240, 138, 0.7);
+  transition: transform 0.5s cubic-bezier(0.34, 1.2, 0.64, 1), background 0.5s ease, box-shadow 0.5s ease;
+}
+
+.is-night .celestial {
+  transform: translateX(48px);
+  background: #e2e8f0;
+  box-shadow: inset -8px -2px 0 0 #94a3b8, 0 0 10px 2px rgba(226, 232, 240, 0.4);
+}
+
+.star {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: white;
+  opacity: 0;
+  transition: opacity 0.4s ease 0.2s;
+}
+
+.is-night .star { opacity: 1; }
+
+.s1 { top: 10px; left: 55px; }
+.s2 { top: 30px; left: 70px; }
+.s3 { top: 14px; left: 80px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .wrap, h1, .day-night-toggle, .celestial, .star {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-toggle-day-night-sap`, a sun/moon toggle switch that crossfades the whole page theme.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-animated-toggle-day-night-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Toggle is `role="switch"` with `aria-checked`/`aria-label` kept in sync;
  text color crossfades alongside the background so contrast holds in both
  day and night states, not just the toggle control itself.
- Star fade-in is intentionally delayed slightly relative to the background
  darkening, so stars don't appear prematurely against a still-light sky.

## Feature Description

Adds a reusable animated sun/moon day-night theme toggle component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.