### PR TITLE
feat: add ease-scroll-reveal-underline-heading-sap

### DIFF
--- a/submissions/examples/ease-scroll-reveal-underline-heading-sap/README.md
+++ b/submissions/examples/ease-scroll-reveal-underline-heading-sap/README.md
@@ -1,0 +1,33 @@
+# Scroll Reveal Underline Heading
+
+Section headings that get an accent underline drawing in from the left as
+each heading scrolls into view, drawing attention to section starts
+without moving the text itself.
+
+**Level:** Beginner
+
+## Usage
+
+Apply `.underline-heading` to any heading. An `IntersectionObserver` adds
+`.is-revealed` once a heading crosses 60% visibility, triggering the
+`::after` underline's `scaleX(0)` → `scaleX(1)` transition.
+
+## Accessibility
+
+- The heading text itself is fully present and readable in the DOM from
+  page load — only the decorative underline's draw-in is deferred, never
+  the text content.
+- Each heading's reveal triggers once (`unobserve` after triggering), so
+  scrolling back up and down doesn't repeatedly re-animate it.
+- `prefers-reduced-motion` sets the underline to its fully-drawn
+  `scaleX(1)` state immediately with no transition, so it's never left
+  looking cut off or incomplete for motion-reduced users.
+
+## Notes
+
+- Underline uses `transform: scaleX()` from `transform-origin: left`
+  (not `width`), keeping the animation on the compositor thread and off the
+  layout/reflow path.
+- This is a lightweight complement to `ease-scroll-reveal-mask-text-sap`
+  (which reveals the text itself) — this component instead keeps text fully
+  visible from the start and only animates a decorative accent underneath it.

--- a/submissions/examples/ease-scroll-reveal-underline-heading-sap/demo.html
+++ b/submissions/examples/ease-scroll-reveal-underline-heading-sap/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Scroll Reveal Underline Heading</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="content">
+    <section class="spacer"><h1>Scroll Reveal Underline Heading</h1><p>Scroll down — each heading gets an underline that draws itself in as it enters view.</p></section>
+
+    <section class="block">
+      <h2 class="underline-heading">Our Mission</h2>
+      <p>We build tools that help teams move faster without breaking things.</p>
+    </section>
+
+    <section class="block">
+      <h2 class="underline-heading">Our Values</h2>
+      <p>Craft, honesty, and a bias toward shipping.</p>
+    </section>
+
+    <section class="spacer"><p>More content below.</p></section>
+  </main>
+
+  <script>
+    const headings = document.querySelectorAll('.underline-heading');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-revealed');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.6 });
+    headings.forEach(h => observer.observe(h));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-underline-heading-sap/style.css
+++ b/submissions/examples/ease-scroll-reveal-underline-heading-sap/style.css
@@ -1,0 +1,64 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: #fafaf9;
+  color: #1c1917;
+  margin: 0;
+}
+
+.content { max-width: 640px; margin: 0 auto; padding: 2rem; }
+
+.spacer {
+  min-height: 55vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+.spacer h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+.spacer p { color: #78716c; }
+
+.block {
+  min-height: 55vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-bottom: 1px solid #e7e5e4;
+}
+
+.block p { color: #57534e; max-width: 45ch; }
+
+.underline-heading {
+  position: relative;
+  display: inline-block;
+  font-size: 1.6rem;
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.5rem;
+}
+
+.underline-heading::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 3px;
+  width: 100%;
+  background: #6366f1;
+  border-radius: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.6s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.underline-heading.is-revealed::after {
+  transform: scaleX(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .underline-heading::after {
+    transition: none;
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-reveal-underline-heading-sap`, headings with a scroll-triggered draw-in underline.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/examples/ease-scroll-reveal-underline-heading-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Heading text is always fully present and readable; only the decorative
  underline draw-in is scroll-deferred, never the text itself.
- Reduced motion sets the underline to its fully-drawn state immediately,
  avoiding a cut-off appearance for motion-reduced users.

## Feature Description

Adds a reusable scroll-triggered draw-in underline heading component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.