### PR TITLE
feat: add Expandable Card List example (expandable-card-list-qz9k)

### DIFF
--- a/submissions/examples/expandable-card-list-qz9k/README.md
+++ b/submissions/examples/expandable-card-list-qz9k/README.md
@@ -1,0 +1,45 @@
+# Expandable Card List
+
+## What does this do?
+
+An order-history list where each card expands to reveal details, using a
+`grid-template-rows: 0fr` to `1fr` transition so the detail panel animates
+to its real content height with no JavaScript measuring `scrollHeight`.
+
+## How is it used?
+
+```html
+<li class="ecd-card">
+  <button class="ecd-summary" onclick="ecdToggle(this)" aria-expanded="false" aria-controls="ecd-detail-1">
+    <span>Order #4471</span>
+    <span class="ecd-chevron" aria-hidden="true"></span>
+  </button>
+  <div class="ecd-detail" id="ecd-detail-1">
+    <div class="ecd-detail-inner"><p>...</p></div>
+  </div>
+</li>
+```
+
+`ecdToggle` only flips `aria-expanded` and a `.ecd-card--open` class — the
+actual height animation is entirely CSS-driven from that one class.
+
+## Why is it useful?
+
+Animating an expand/collapse panel to its natural content height with
+`max-height` requires either a hard-coded ceiling (which clips long content
+or wastes most of the transition on empty space for short content) or a JS
+measurement of `scrollHeight` at the moment of toggling — and that
+measurement goes stale the instant the detail content's own height changes
+later without a re-toggle, e.g. if a subsequent order gets an extra line
+item added to its detail view. `grid-template-rows: 0fr → 1fr` sidesteps
+both problems: `1fr` always resolves to the content's actual current
+height at animation time, computed fresh by the browser's own layout
+engine, so it's correct regardless of when or how the content's height
+last changed.
+
+`.ecd-detail-inner` needs `overflow: hidden` specifically because a `0fr`
+grid track still allows its content to overflow visually without that —
+the grid track shrinking to zero height doesn't clip content on its own,
+only combined with `overflow: hidden` on the child does the collapsed
+state actually hide the detail text rather than leaving it visibly poking
+out above the collapsed card.

--- a/submissions/examples/expandable-card-list-qz9k/demo.html
+++ b/submissions/examples/expandable-card-list-qz9k/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Expandable Card List</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function ecdToggle(button) {
+    var card = button.closest('.ecd-card');
+    var expanded = button.getAttribute('aria-expanded') === 'true';
+    button.setAttribute('aria-expanded', String(!expanded));
+    card.classList.toggle('ecd-card--open', !expanded);
+  }
+</script>
+</head>
+<body>
+<main class="ecd-wrap">
+  <h1 class="ecd-h1">Order History</h1>
+  <p class="ecd-lede">Each card's detail panel measures its own natural height via grid-template-rows animating 0fr to 1fr, so no JS ever measures scrollHeight -- the same technique works correctly even if the detail content's height changes later (e.g. an item added to an order).</p>
+
+  <ul class="ecd-list">
+    <li class="ecd-card">
+      <button type="button" class="ecd-summary" onclick="ecdToggle(this)" aria-expanded="false" aria-controls="ecd-detail-1">
+        <span>Order #4471</span>
+        <span class="ecd-chevron" aria-hidden="true"></span>
+      </button>
+      <div class="ecd-detail" id="ecd-detail-1">
+        <div class="ecd-detail-inner">
+          <p>Placed March 3 &middot; $84.20 &middot; 3 items</p>
+          <p>Shipped to 221 Maple Street, delivered March 6.</p>
+        </div>
+      </div>
+    </li>
+    <li class="ecd-card">
+      <button type="button" class="ecd-summary" onclick="ecdToggle(this)" aria-expanded="false" aria-controls="ecd-detail-2">
+        <span>Order #4502</span>
+        <span class="ecd-chevron" aria-hidden="true"></span>
+      </button>
+      <div class="ecd-detail" id="ecd-detail-2">
+        <div class="ecd-detail-inner">
+          <p>Placed March 9 &middot; $19.99 &middot; 1 item</p>
+          <p>Shipped to 221 Maple Street, delivered March 11.</p>
+        </div>
+      </div>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/submissions/examples/expandable-card-list-qz9k/style.css
+++ b/submissions/examples/expandable-card-list-qz9k/style.css
@@ -1,0 +1,99 @@
+/* Expandable Card List
+   .ecd-detail is a 1-row grid animating grid-template-rows 0fr -> 1fr, the
+   same measured-height-free technique as the accordion example elsewhere
+   in this repo -- .ecd-detail-inner needs overflow:hidden since a 0fr
+   track still lets its content overflow without it. */
+
+.ecd-wrap {
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ecd-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ecd-lede { margin: 0 0 1.75rem; color: #576073; }
+
+.ecd-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ecd-card {
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+  background: #fbfcfe;
+}
+
+.ecd-summary {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9em 1.1em;
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ecd-summary:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: -2px;
+}
+
+.ecd-chevron {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 2px solid #8b93a3;
+  border-bottom: 2px solid #8b93a3;
+  transform: rotate(45deg);
+  transition: transform 200ms ease;
+}
+
+.ecd-card--open .ecd-chevron {
+  transform: rotate(-135deg);
+}
+
+.ecd-detail {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ecd-card--open .ecd-detail {
+  grid-template-rows: 1fr;
+}
+
+.ecd-detail-inner {
+  overflow: hidden;
+}
+
+.ecd-detail-inner p {
+  margin: 0;
+  padding: 0 1.1em 0.9em;
+  color: #576073;
+  font-size: 0.88rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ecd-chevron, .ecd-detail { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ecd-card { border-color: CanvasText; }
+  .ecd-chevron { border-color: CanvasText; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ecd-wrap { color: #e6e9f2; }
+  .ecd-lede { color: #99a1b4; }
+  .ecd-card { background: #171b23; border-color: #2a303c; }
+  .ecd-detail-inner p { color: #99a1b4; }
+}


### PR DESCRIPTION
Closes #81044

Order-history card list expanding via grid-template-rows 0fr -> 1fr, the same measured-height-free technique used for the accordion elsewhere in this repo. 1fr always resolves to the content's real current height at animation time, so it stays correct even if the detail content's own height changes later without a re-toggle. .ecd-detail-inner needs overflow:hidden since a 0fr grid track alone doesn't clip its content.