### PR TITLE
feat: add Icon Button with Tooltip example (icon-button-tooltip-qz9k)

### DIFF
--- a/submissions/examples/icon-button-tooltip-qz9k/README.md
+++ b/submissions/examples/icon-button-tooltip-qz9k/README.md
@@ -1,0 +1,45 @@
+# Icon Button with Tooltip
+
+## What does this do?
+
+A toolbar of icon-only buttons where each button's hover/focus tooltip is
+generated CSS content reading directly from `data-tooltip` via `attr()` —
+the same string that also names the button for assistive technology
+through `aria-label`, so there's exactly one authored string per button,
+not two that could drift apart.
+
+## How is it used?
+
+```html
+<button class="ibt-btn" aria-label="Bold" data-tooltip="Bold">
+  <svg aria-hidden="true">...</svg>
+</button>
+```
+
+```css
+.ibt-btn::after {
+  content: attr(data-tooltip);
+  /* positioning + hover/focus visibility */
+}
+```
+
+## Why is it useful?
+
+Icon-only buttons need an accessible name (via `aria-label`, since there's
+no visible text for a screen reader to read) and, separately, sighted
+users benefit from a tooltip confirming what the icon means before they
+click. Authoring these as two independent strings — `aria-label="Bold"`
+and a separately-typed tooltip element containing "Bold" elsewhere — means
+a future edit to one (renaming the label to be more specific, say) can
+silently miss updating the other, leaving the visible tooltip and the
+screen-reader-announced name saying different things for the same button.
+Deriving the tooltip's CSS content from `attr(data-tooltip)` reads it
+straight from markup, and using the same value for both `aria-label` and
+`data-tooltip` means editing a button's label always keeps both in sync,
+since there's structurally only one place that value lives.
+
+The tooltip appears identically on `:hover` and `:focus-visible`, so
+keyboard users tabbing through the toolbar get the same confirmation
+sighted mouse users do — a tooltip that only responds to `:hover` would
+leave keyboard-only users with icon-only buttons and no visible
+confirmation of what each one does before activating it.

--- a/submissions/examples/icon-button-tooltip-qz9k/demo.html
+++ b/submissions/examples/icon-button-tooltip-qz9k/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Icon Button with Tooltip</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="ibt-wrap">
+  <h1 class="ibt-h1">Toolbar</h1>
+  <p class="ibt-lede">The tooltip is generated content driven by the button's own aria-label, read via attr() -- so the visible tooltip text and the accessible name can never drift apart into two different strings, since there's only one string to begin with.</p>
+
+  <div class="ibt-toolbar" role="toolbar" aria-label="Formatting">
+    <button type="button" class="ibt-btn" aria-label="Bold" data-tooltip="Bold">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 4h6a4 4 0 0 1 0 8H7z" /><path d="M7 12h7a4 4 0 0 1 0 8H7z" /></svg>
+    </button>
+    <button type="button" class="ibt-btn" aria-label="Italic" data-tooltip="Italic">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><line x1="14" y1="4" x2="10" y2="20" /><line x1="6" y1="20" x2="14" y2="20" /><line x1="10" y1="4" x2="18" y2="4" /></svg>
+    </button>
+    <button type="button" class="ibt-btn" aria-label="Underline" data-tooltip="Underline">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4v7a6 6 0 0 0 12 0V4" /><line x1="4" y1="20" x2="20" y2="20" /></svg>
+    </button>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/icon-button-tooltip-qz9k/style.css
+++ b/submissions/examples/icon-button-tooltip-qz9k/style.css
@@ -1,0 +1,96 @@
+/* Icon Button with Tooltip
+   content:attr(data-tooltip) reads the tooltip text directly from the
+   button's own markup rather than being duplicated as separate tooltip
+   markup elsewhere in the DOM -- one attribute is both the button's
+   accessible name source and the visible tooltip's text source. */
+
+.ibt-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.ibt-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.ibt-lede { margin: 0 0 2rem; color: #576073; }
+
+.ibt-toolbar {
+  display: inline-flex;
+  gap: 0.3rem;
+  padding: 0.4rem;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+}
+
+.ibt-btn {
+  position: relative;
+  width: 2.4rem;
+  height: 2.4rem;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 0.4rem;
+  background: none;
+  color: #576073;
+  cursor: pointer;
+}
+
+.ibt-btn svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.ibt-btn:hover,
+.ibt-btn:focus-visible {
+  background: #f1f4fa;
+  color: #1c2028;
+}
+
+.ibt-btn:focus-visible {
+  outline: 2px solid #4c6ef5;
+  outline-offset: 1px;
+}
+
+.ibt-btn::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 0.4rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  padding: 0.3em 0.6em;
+  border-radius: 0.35rem;
+  background: #1c2028;
+  color: #fff;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.ibt-btn:hover::after,
+.ibt-btn:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ibt-btn::after { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .ibt-btn::after { forced-color-adjust: none; background: ButtonText; color: ButtonFace; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ibt-wrap { color: #e6e9f2; }
+  .ibt-lede { color: #99a1b4; }
+  .ibt-toolbar { border-color: #2a303c; }
+  .ibt-btn { color: #99a1b4; }
+  .ibt-btn:hover, .ibt-btn:focus-visible { background: #1e2430; color: #e6e9f2; }
+}


### PR DESCRIPTION
Closes #81045

Icon-only toolbar buttons whose tooltip is generated CSS content reading content: attr(data-tooltip) — the same string also set as aria-label, so there's exactly one authored string per button rather than two that could silently drift apart after an edit to one but not the other. Tooltip shows identically on :hover and :focus-visible, so keyboard users get the same confirmation sighted mouse users do before activating an icon-only button.