### PR TITLE
feat: add Search with Recent Suggestions example (input-search-suggestions-qz9k)

### DIFF
--- a/submissions/examples/input-search-suggestions-qz9k/README.md
+++ b/submissions/examples/input-search-suggestions-qz9k/README.md
@@ -1,0 +1,42 @@
+# Search with Recent Suggestions
+
+## What does this do?
+
+A search field that shows recent searches immediately on focus (before
+typing anything), then narrows the list to matches as the user types —
+with a suggestion panel that survives a click on one of its own items
+without the input's blur handler hiding it first.
+
+## How is it used?
+
+```html
+<input id="iss-input" type="search" onfocus="issFocus(this)" oninput="issInput(this)" onblur="issBlur()" />
+<div class="iss-panel" id="iss-panel" hidden></div>
+```
+
+`issBlur` delays hiding the panel by 150ms via `setTimeout` rather than
+hiding it immediately on the input's `blur` event.
+
+## Why is it useful?
+
+Clicking a suggestion in the panel causes the input to lose focus (`blur`)
+*before* the click's own `click` event fires — that's the DOM's actual
+event order for a pointer interaction that moves focus away from a
+focused element. If `blur` hides the panel synchronously, the panel (and
+the button being clicked) can be removed from the DOM or hidden before the
+click event has a chance to complete, silently breaking "click a
+suggestion to select it." Delaying the hide by a short `setTimeout` gives
+the click event's own handler time to run first — a small, deliberate
+race condition resolved in favor of the click completing, rather than the
+blur hiding winning outright.
+
+Showing recent searches on focus (not waiting for the first keystroke)
+matters because a search field with prior activity has useful information
+to offer *before* the user types anything — a blank field with no
+suggestions until typing starts wastes the opportunity to remind the user
+what they've searched for before, especially useful for a returning
+search they want to repeat exactly. Each suggestion is a real `<button>`,
+not a clickable `<div>`, since only a real interactive element reliably
+fires a `click` event in every browser/input-method combination the panel
+needs to support (touch, mouse, and — for the item itself — potentially
+keyboard navigation into the panel).

--- a/submissions/examples/input-search-suggestions-qz9k/demo.html
+++ b/submissions/examples/input-search-suggestions-qz9k/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Search with Recent Suggestions</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  var issRecent = ['wireless mouse', 'usb-c hub', 'mechanical keyboard'];
+
+  function issFocus(input) {
+    if (!input.value) issRenderRecent(input);
+  }
+
+  function issInput(input) {
+    var query = input.value.trim();
+    if (!query) {
+      issRenderRecent(input);
+      return;
+    }
+    var matches = issRecent.filter(function (term) {
+      return term.toLowerCase().indexOf(query.toLowerCase()) > -1;
+    });
+    issRenderList(matches, 'Matching searches', input);
+  }
+
+  function issRenderRecent(input) {
+    issRenderList(issRecent, 'Recent searches', input);
+  }
+
+  function issRenderList(terms, heading, input) {
+    var panel = document.getElementById('iss-panel');
+    if (!terms.length) {
+      panel.hidden = true;
+      return;
+    }
+    panel.innerHTML = '';
+    var h = document.createElement('p');
+    h.className = 'iss-heading';
+    h.textContent = heading;
+    panel.appendChild(h);
+
+    terms.forEach(function (term) {
+      var item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'iss-item';
+      item.textContent = term;
+      item.onclick = function () {
+        input.value = term;
+        panel.hidden = true;
+      };
+      panel.appendChild(item);
+    });
+    panel.hidden = false;
+  }
+
+  function issBlur() {
+    setTimeout(function () {
+      document.getElementById('iss-panel').hidden = true;
+    }, 150);
+  }
+</script>
+</head>
+<body>
+<main class="iss-wrap">
+  <h1 class="iss-h1">Search Products</h1>
+  <p class="iss-lede">Focusing an empty field shows recent searches immediately; typing narrows to matches. The blur handler delays hiding the panel by 150ms specifically so a click on a suggestion registers before blur removes it from the DOM.</p>
+
+  <div class="iss-field">
+    <input
+      id="iss-input"
+      class="iss-input"
+      type="search"
+      placeholder="Search products..."
+      onfocus="issFocus(this)"
+      oninput="issInput(this)"
+      onblur="issBlur()"
+    />
+    <div class="iss-panel" id="iss-panel" hidden></div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/input-search-suggestions-qz9k/style.css
+++ b/submissions/examples/input-search-suggestions-qz9k/style.css
@@ -1,0 +1,85 @@
+/* Search with Recent Suggestions
+   .iss-item is a real <button>, not a <div onclick>, specifically so a
+   pointer click on it registers as a genuine click event BEFORE the
+   input's blur-triggered timeout fires and hides the panel -- a non-
+   focusable, non-button element would have its click handler race against
+   the blur hide in a way that isn't guaranteed to resolve correctly. */
+
+.iss-wrap {
+  max-width: 22rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.iss-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.iss-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.iss-field {
+  position: relative;
+}
+
+.iss-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65em 0.8em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  font: inherit;
+}
+
+.iss-input:focus-visible {
+  outline: none;
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+}
+
+.iss-panel {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  padding: 0.4rem;
+  background: #fff;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 20px rgba(28, 32, 40, 0.12);
+}
+
+.iss-heading {
+  margin: 0.2rem 0.4rem 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #a8adba;
+}
+
+.iss-item {
+  display: block;
+  width: 100%;
+  padding: 0.5em 0.6em;
+  border: none;
+  border-radius: 0.35rem;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.iss-item:hover,
+.iss-item:focus-visible {
+  background: #f1f4fa;
+  outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .iss-wrap { color: #e6e9f2; }
+  .iss-lede { color: #99a1b4; }
+  .iss-input { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .iss-panel { background: #171b23; border-color: #2a303c; }
+  .iss-item { color: #e6e9f2; }
+  .iss-item:hover, .iss-item:focus-visible { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #81046

Search field showing recent searches on focus (before any typing) and narrowing to matches once the user types. issBlur delays hiding the suggestion panel by 150ms via setTimeout rather than immediately on blur — clicking a suggestion causes blur to fire BEFORE the click event completes (real DOM event order), so hiding synchronously on blur would remove the clicked button before its own click handler runs. Suggestions are real <button> elements, not clickable divs, for reliable click firing across input methods.