### PR TITLE
feat: add Table with Sticky First Column example (table-sticky-column-qz9k)

### DIFF
--- a/submissions/examples/table-sticky-column-qz9k/README.md
+++ b/submissions/examples/table-sticky-column-qz9k/README.md
@@ -1,0 +1,44 @@
+# Table with Sticky First Column
+
+## What does this do?
+
+A wide data table where the first column (row labels) stays pinned in
+place while the rest of the columns scroll horizontally, using
+`position: sticky` rather than a JS-synchronized frozen-column
+implementation.
+
+## How is it used?
+
+```html
+<div class="tsc-scroll">
+  <table class="tsc-table">
+    <thead><tr><th class="tsc-sticky">Region</th><th>Q1</th>...</tr></thead>
+    <tbody><tr><td class="tsc-sticky">North America</td><td>$482K</td>...</tr></tbody>
+  </table>
+</div>
+```
+
+`.tsc-sticky` on both header and body cells of the first column sets
+`position: sticky; left: 0`; the header's sticky cell additionally needs a
+higher `z-index` than the body's, since the header row itself also needs
+to stay above scrolled-under body content.
+
+## Why is it useful?
+
+`position: sticky` handles the geometry of "stay pinned during horizontal
+scroll" natively, without a JS scroll listener syncing a duplicated frozen
+column's position to the real table's scroll offset — a common alternative
+implementation that requires the frozen column to be an entirely separate
+table (or absolutely-positioned overlay) kept in visual sync via
+`scrollLeft` events, which is more code and a source of subtle
+misalignment if the two tables' row heights ever drift apart (differing
+font rendering, dynamic content, etc.).
+
+The explicit `background` on `.tsc-sticky` is the detail that's easy to
+miss: `position: sticky` doesn't paint over or clip content that scrolls
+underneath the stuck element by default, so a sticky cell with no
+background (or a transparent one) would show the scrolling columns'
+content bleeding through it as the table scrolls — the sticky column needs
+its own opaque background matching its row's colour specifically to
+visually block what's scrolling beneath it, which is what makes it read
+as a "frozen" column rather than a floating transparent overlay.

--- a/submissions/examples/table-sticky-column-qz9k/demo.html
+++ b/submissions/examples/table-sticky-column-qz9k/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Table with Sticky First Column</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="tsc-wrap">
+  <h1 class="tsc-h1">Quarterly Revenue</h1>
+  <p class="tsc-lede">The first column stays pinned while the rest of the table scrolls horizontally -- position:sticky with left:0 on both header and body cells of that one column, needing an explicit background since sticky cells otherwise show the table's transparent gaps as content scrolls beneath them.</p>
+
+  <div class="tsc-scroll">
+    <table class="tsc-table">
+      <thead>
+        <tr>
+          <th class="tsc-sticky">Region</th>
+          <th>Q1</th><th>Q2</th><th>Q3</th><th>Q4</th><th>Q1 (prior)</th><th>Q2 (prior)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="tsc-sticky">North America</td>
+          <td>$482K</td><td>$510K</td><td>$495K</td><td>$530K</td><td>$440K</td><td>$460K</td>
+        </tr>
+        <tr>
+          <td class="tsc-sticky">Europe</td>
+          <td>$310K</td><td>$322K</td><td>$298K</td><td>$340K</td><td>$280K</td><td>$295K</td>
+        </tr>
+        <tr>
+          <td class="tsc-sticky">Asia Pacific</td>
+          <td>$275K</td><td>$290K</td><td>$305K</td><td>$318K</td><td>$250K</td><td>$260K</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/table-sticky-column-qz9k/style.css
+++ b/submissions/examples/table-sticky-column-qz9k/style.css
@@ -1,0 +1,70 @@
+/* Table with Sticky First Column
+   .tsc-sticky needs a solid background matching the row's own background
+   (white for body cells) precisely because position:sticky doesn't clip
+   or paint over content that scrolls beneath it by default -- without an
+   opaque background, scrolled-under cell content would show through the
+   "stuck" column instead of being hidden by it. */
+
+.tsc-wrap {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.tsc-h1 { margin: 0 0 0.4em; font-size: clamp(1.4rem, 4vw, 1.9rem); }
+.tsc-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.tsc-scroll {
+  overflow-x: auto;
+  border: 1px solid #dfe3ec;
+  border-radius: 0.6rem;
+}
+
+.tsc-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.88rem;
+  white-space: nowrap;
+}
+
+.tsc-table th,
+.tsc-table td {
+  padding: 0.65em 1em;
+  text-align: right;
+  border-bottom: 1px solid #eceff4;
+}
+
+.tsc-table th:first-child,
+.tsc-table td:first-child {
+  text-align: left;
+}
+
+.tsc-table thead th {
+  font-weight: 700;
+  border-bottom: 2px solid #d3d8e2;
+}
+
+.tsc-sticky {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: #fff;
+  box-shadow: 1px 0 0 #dfe3ec;
+}
+
+thead .tsc-sticky {
+  z-index: 2;
+  background: #fafbfd;
+}
+
+@media (prefers-color-scheme: dark) {
+  .tsc-wrap { color: #e6e9f2; }
+  .tsc-lede { color: #99a1b4; }
+  .tsc-scroll { border-color: #2a303c; }
+  .tsc-table th, .tsc-table td { border-color: #1e2430; }
+  .tsc-table thead th { border-color: #2a303c; }
+  .tsc-sticky { background: #171b23; box-shadow: 1px 0 0 #2a303c; }
+  thead .tsc-sticky { background: #1b212b; }
+}


### PR DESCRIPTION
Closes #81048

Wide table with position:sticky; left:0 on the first column's cells, avoiding a JS-synced frozen-column implementation that needs a separate duplicated table kept in visual alignment via scrollLeft events. The sticky cells carry an explicit opaque background matching their row colour specifically because position:sticky doesn't paint over content scrolling beneath it by default — without that background, scrolled columns would visibly bleed through the 'frozen' column.