### PR TITLE
feat: add Multi-Select Dropdown example (dropdown-multi-select-qz9k)

### DIFF
--- a/submissions/examples/dropdown-multi-select-qz9k/README.md
+++ b/submissions/examples/dropdown-multi-select-qz9k/README.md
@@ -1,0 +1,45 @@
+# Multi-Select Dropdown
+
+## What does this do?
+
+A tag filter dropdown whose closed trigger summarizes the current
+selection — the single tag's name, or a count once more than one tag is
+checked — computed live from the checked checkboxes rather than tracked as
+separate state.
+
+## How is it used?
+
+```html
+<button class="dms-trigger" onclick="dmsToggle()" aria-expanded="false" aria-haspopup="true">
+  <span id="dms-trigger-label">Filter by tag</span>
+</button>
+<div class="dms-panel" id="dms-panel" hidden>
+  <label class="dms-option"><input type="checkbox" value="Bug" onchange="dmsUpdate()" /> Bug</label>
+  <!-- ... -->
+</div>
+```
+
+`dmsUpdate` queries `.dms-option input:checked` directly and derives the
+trigger's label from that live count — there's no separate array or object
+tracking "which tags are selected" that the checkboxes' actual state has
+to be kept in sync with.
+
+## Why is it useful?
+
+A common implementation tracks selected tags in a separate JS array,
+updated in the checkbox change handler, with the trigger label rendered
+from that array — which means the array and the checkboxes' actual
+`checked` state are two representations of the same information that have
+to be kept in sync by hand. Deriving the trigger label by querying
+`:checked` directly at the moment it's needed means there's only one
+source of truth (the checkboxes' own native state), so there's no failure
+mode where the array gets out of sync with what's actually checked (a
+missed update on one code path, a checkbox toggled through some other
+means that doesn't also update the array).
+
+The dropdown panel stays a real, always-present list of labeled
+`<input type="checkbox">` elements rather than custom-drawn toggle chips
+with a JS-managed `selected` class — native checkboxes bring keyboard
+activation (Space), correct checked/unchecked screen-reader announcement,
+and Tab-order navigation through the options for free, leaving only the
+open/close behavior and the trigger's summary label as custom logic.

--- a/submissions/examples/dropdown-multi-select-qz9k/demo.html
+++ b/submissions/examples/dropdown-multi-select-qz9k/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Multi-Select Dropdown</title>
+<link rel="stylesheet" href="style.css" />
+<script>
+  function dmsToggle() {
+    var panel = document.getElementById('dms-panel');
+    var trigger = document.getElementById('dms-trigger');
+    var open = !panel.hidden;
+    panel.hidden = open;
+    trigger.setAttribute('aria-expanded', String(!open));
+    if (!open) document.addEventListener('click', dmsOutsideClick);
+    else document.removeEventListener('click', dmsOutsideClick);
+  }
+
+  function dmsOutsideClick(event) {
+    var container = document.getElementById('dms-container');
+    if (!container.contains(event.target)) dmsToggle();
+  }
+
+  function dmsUpdate() {
+    var checked = document.querySelectorAll('.dms-option input:checked');
+    var trigger = document.getElementById('dms-trigger-label');
+    if (checked.length === 0) {
+      trigger.textContent = 'Filter by tag';
+    } else if (checked.length === 1) {
+      trigger.textContent = checked[0].value;
+    } else {
+      trigger.textContent = checked.length + ' tags selected';
+    }
+  }
+</script>
+</head>
+<body>
+<main class="dms-wrap">
+  <h1 class="dms-h1">Multi-Select Dropdown</h1>
+  <p class="dms-lede">The trigger button's own label summarizes the current selection (one tag's name, or a count once more than one is picked), computed from the checked checkboxes rather than kept as separate JS state that could fall out of sync with what's actually checked.</p>
+
+  <div class="dms-container" id="dms-container">
+    <button type="button" class="dms-trigger" id="dms-trigger" onclick="dmsToggle()" aria-expanded="false" aria-haspopup="true">
+      <span id="dms-trigger-label">Filter by tag</span>
+      <span class="dms-caret" aria-hidden="true"></span>
+    </button>
+    <div class="dms-panel" id="dms-panel" hidden>
+      <label class="dms-option"><input type="checkbox" value="Bug" onchange="dmsUpdate()" /> Bug</label>
+      <label class="dms-option"><input type="checkbox" value="Feature" onchange="dmsUpdate()" /> Feature</label>
+      <label class="dms-option"><input type="checkbox" value="Docs" onchange="dmsUpdate()" /> Docs</label>
+      <label class="dms-option"><input type="checkbox" value="Urgent" onchange="dmsUpdate()" /> Urgent</label>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/submissions/examples/dropdown-multi-select-qz9k/style.css
+++ b/submissions/examples/dropdown-multi-select-qz9k/style.css
@@ -1,0 +1,79 @@
+/* Multi-Select Dropdown
+   The checkbox panel stays a real, always-navigable list of labeled
+   checkboxes rather than custom-drawn "chip" toggles -- native checkbox
+   semantics (space to toggle, screen-reader checked/unchecked state) come
+   free, and the only custom UI is the trigger button summarizing state. */
+
+.dms-wrap {
+  max-width: 20rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  font: 400 1rem/1.6 ui-sans-serif, system-ui, sans-serif;
+  color: #1c2028;
+}
+
+.dms-h1 { margin: 0 0 0.4em; font-size: clamp(1.3rem, 4vw, 1.75rem); }
+.dms-lede { margin: 0 0 1.5rem; color: #576073; }
+
+.dms-container {
+  position: relative;
+  display: inline-block;
+}
+
+.dms-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6em 1em;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  background: #fff;
+  font: inherit;
+  cursor: pointer;
+}
+
+.dms-trigger:hover { background: #f8f9fb; }
+.dms-trigger:focus-visible { outline: 2px solid #4c6ef5; outline-offset: 2px; }
+
+.dms-caret {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid #8b93a3;
+  border-bottom: 2px solid #8b93a3;
+  transform: rotate(45deg);
+}
+
+.dms-panel {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  min-width: 100%;
+  padding: 0.4rem;
+  background: #fff;
+  border: 1px solid #d3d8e2;
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 20px rgba(28, 32, 40, 0.12);
+  z-index: 10;
+}
+
+.dms-option {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5em 0.6em;
+  border-radius: 0.35rem;
+  cursor: pointer;
+  font-size: 0.92rem;
+  white-space: nowrap;
+}
+
+.dms-option:hover { background: #f1f4fa; }
+
+@media (prefers-color-scheme: dark) {
+  .dms-wrap { color: #e6e9f2; }
+  .dms-lede { color: #99a1b4; }
+  .dms-trigger { background: #171b23; border-color: #2a303c; color: #e6e9f2; }
+  .dms-trigger:hover { background: #1e2430; }
+  .dms-panel { background: #171b23; border-color: #2a303c; }
+  .dms-option:hover { background: #1e2430; }
+}


### PR DESCRIPTION
Closes #81049

Tag filter dropdown whose trigger label (one tag's name, or a count once multiple are selected) is computed live by querying :checked checkboxes directly, rather than tracked in a separate JS array kept in sync with the checkboxes by hand — removing the class of bug where that array drifts from what's actually checked. The panel stays a real list of labeled checkboxes, giving native keyboard activation and screen-reader announcement for free.