### PR TITLE
docs(components): add comprehensive usage guide and demo for neumorphic slider #80021

### DIFF
--- a/submissions/docs/ease-neumorphic-slider/README.md
+++ b/submissions/docs/ease-neumorphic-slider/README.md
@@ -1,0 +1,80 @@
+# EaseMotion Neumorphic Slider
+
+A lightweight, pure CSS Neumorphic (soft UI) range input slider component designed for modern, tactile user interfaces.
+
+## Overview
+
+The EaseMotion Neumorphic Slider brings extruded tactile aesthetics to native range inputs without reliance on JavaScript libraries or complex DOM structures. Neumorphism relies on subtle contrast, soft dual-directional lighting, and identical background color pairing between elements and their container.
+
+### Core Neumorphic Principle
+The primary design principle behind Neumorphism is **color continuity combined with dual light sources**:
+- **Background Matching**: The element (track/thumb) and its parent container share the exact same background color (`#e0e5ec`).
+- **Paired Shadows**: Depth is generated entirely using light and dark box-shadow pairs placed diagonally opposite to each other:
+  - **Light Highlight**: Positioned top-left (e.g., `-4px -4px 8px rgba(255, 255, 255, 0.8)` or inset equivalent).
+  - **Dark Shadow**: Positioned bottom-right (e.g., `4px 4px 8px rgba(163, 177, 198, 0.7)` or inset equivalent).
+
+This dual shadow illusion creates an appearance of soft physical extrusions (for the thumb handle) or carved recessions (for the slider track) emerging directly from the surface background.
+
+---
+
+## Base Usage
+
+Integrate the Neumorphic Slider by linking `style.css` and adding a standard HTML `<input type="range">` element styled with the `.ease-neu-slider` class.
+
+### HTML Structure
+
+```html
+<div class="ease-docs-grid">
+  <div style="width: 100%; text-align: left;">
+    <label for="neu-volume" style="display: block; font-weight: 600; margin-bottom: 1rem; color: #6b7280; text-transform: uppercase; letter-spacing: 1px; font-size: 0.875rem;">
+      Master Volume
+    </label>
+    <input 
+      type="range" 
+      id="neu-volume" 
+      class="ease-neu-slider" 
+      min="0" 
+      max="100" 
+      value="50" 
+      aria-label="Master Volume"
+    >
+  </div>
+</div>
+```
+
+---
+
+## Shadow Mathematics
+
+Neumorphism shifts perceived surface height by manipulating box-shadow offsets, blur radii, and opacity values across different light angles:
+
+### Extruded Elevation (Thumb)
+- **Exterior Highlight**: `-4px -4px 8px rgba(255, 255, 255, 0.8)` simulates ambient white light striking the top-left shoulder of the thumb control.
+- **Exterior Shadow**: `4px 4px 8px rgba(163, 177, 198, 0.7)` casts a subtle shadow on the bottom-right floor.
+- **Result**: The thumb appears raised above the parent card surface.
+
+### Inset Depth (Track)
+- **Inset Shadow**: `inset 4px 4px 8px rgba(163, 177, 198, 0.7)` casts shadow inside the top-left edge of the track channel.
+- **Inset Highlight**: `inset -4px -4px 8px rgba(255, 255, 255, 0.7)` illuminates the inner bottom-right rim.
+- **Result**: The track appears recessed into the parent card.
+
+### Active Compressed State
+When pressed (`:active`), shadow distances decrease (from `4px` to `2px`) and the thumb scales down to `scale(0.9)` with cursor set to `grabbing`, visually communicating physical compression into the track.
+
+---
+
+## Accessibility (a11y)
+
+Standard Neumorphic designs often suffer from low contrast ratios because elements blend seamlessly into their background color. The EaseMotion Neumorphic Slider addresses these accessibility concerns through several focused strategies:
+
+1. **High-Contrast Focus Indicator (`:focus-visible`)**:
+   - When navigated via keyboard (Tab key), the slider thumb transitions its border color from matching `#e0e5ec` to `#3b82f6` (a prominent, WCAG-compliant blue hue).
+   - This provides clear visual focus indication without interrupting the overall aesthetic during mouse clicks.
+
+2. **Tactile Interaction Feedback**:
+   - Smooth `cubic-bezier(0.34, 1.56, 0.64, 1)` scale transitions on action provide high visual affordance.
+   - Dynamic `cursor: grab` and `cursor: grabbing` styling indicates interactive capability clearly.
+
+3. **Semantic HTML & ARIA Attributes**:
+   - Built on native `<input type="range">`, preserving default keyboard controls (Arrow keys, Page Up/Down, Home, End).
+   - Explicit `<label>` binding via `for`/`id` matching alongside `aria-label` ensures full screen reader support.

--- a/submissions/docs/ease-neumorphic-slider/demo.html
+++ b/submissions/docs/ease-neumorphic-slider/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion Neumorphic Slider Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-docs-grid">
+    <div style="width: 100%; text-align: left;">
+      <label for="neu-volume" style="display: block; font-weight: 600; margin-bottom: 1rem; color: #6b7280; text-transform: uppercase; letter-spacing: 1px; font-size: 0.875rem;">Master Volume</label>
+      <input type="range" id="neu-volume" class="ease-neu-slider" min="0" max="100" value="50" aria-label="Master Volume">
+    </div>
+    <p style="text-align: center; color: #9ca3af; font-size: 0.75rem; margin-top: 2rem;">Accessible Neumorphism • Pure CSS</p>
+  </div>
+</body>
+</html>

--- a/submissions/docs/ease-neumorphic-slider/style.css
+++ b/submissions/docs/ease-neumorphic-slider/style.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #e0e5ec;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #4b5563;
+}
+
+.ease-docs-grid {
+  display: flex;
+  gap: 4rem;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  width: 100%;
+  max-width: 600px;
+  padding: 3rem;
+  background: #e0e5ec;
+  border-radius: 24px;
+  box-shadow: 9px 9px 16px rgb(163, 177, 198, 0.6), -9px -9px 16px rgba(255, 255, 255, 0.5);
+}
+
+.ease-neu-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  outline: none;
+  margin: 1rem 0;
+}
+
+.ease-neu-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 12px;
+  background: #e0e5ec;
+  border-radius: 9999px;
+  box-shadow: inset 4px 4px 8px rgba(163, 177, 198, 0.7), inset -4px -4px 8px rgba(255, 255, 255, 0.7);
+  border: none;
+  cursor: pointer;
+}
+
+.ease-neu-slider::-moz-range-track {
+  width: 100%;
+  height: 12px;
+  background: #e0e5ec;
+  border-radius: 9999px;
+  box-shadow: inset 4px 4px 8px rgba(163, 177, 198, 0.7), inset -4px -4px 8px rgba(255, 255, 255, 0.7);
+  border: none;
+  cursor: pointer;
+}
+
+.ease-neu-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  background: #e0e5ec;
+  border-radius: 50%;
+  box-shadow: 4px 4px 8px rgba(163, 177, 198, 0.7), -4px -4px 8px rgba(255, 255, 255, 0.8);
+  cursor: grab;
+  margin-top: -8px;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+  border: 2px solid #e0e5ec;
+}
+
+.ease-neu-slider::-moz-range-thumb {
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  background: #e0e5ec;
+  border-radius: 50%;
+  box-shadow: 4px 4px 8px rgba(163, 177, 198, 0.7), -4px -4px 8px rgba(255, 255, 255, 0.8);
+  cursor: grab;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+  border: 2px solid #e0e5ec;
+}
+
+.ease-neu-slider:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  transform: scale(0.9);
+  box-shadow: 2px 2px 4px rgba(163, 177, 198, 0.7), -2px -2px 4px rgba(255, 255, 255, 0.8);
+}
+
+.ease-neu-slider:active::-moz-range-thumb {
+  cursor: grabbing;
+  transform: scale(0.9);
+  box-shadow: 2px 2px 4px rgba(163, 177, 198, 0.7), -2px -2px 4px rgba(255, 255, 255, 0.8);
+}
+
+.ease-neu-slider:focus-visible::-webkit-slider-thumb {
+  border-color: #3b82f6;
+}
+
+.ease-neu-slider:focus-visible::-moz-range-thumb {
+  border-color: #3b82f6;
+}


### PR DESCRIPTION
## Pull Request Description

This pull request introduces a comprehensive documentation guide, standalone pure CSS implementation, and interactive demo for the **EaseMotion Neumorphic Slider** under `submissions/docs/ease-neumorphic-slider/`, resolving Issue #80021.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a complete usage guide, pure CSS styling, and an interactive demo for an accessible Neumorphic (soft UI) range input slider.

**How does a developer use it?**

```html
<label for="neu-volume">Master Volume</label>
<input type="range" id="neu-volume" class="ease-neu-slider" min="0" max="100" value="50" aria-label="Master Volume">

```

**Why does it fit EaseMotion CSS?**

It provides a lightweight, pure CSS tactile component with smooth cubic-bezier spring interaction transforms and combats standard Neumorphic low-contrast accessibility flaws through a sharp :focus-visible ring.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Fixes #80021 
Placed entirely inside submissions/docs/ease-neumorphic-slider/.
Uses identical container and control background colors (#e0e5ec) with opposing light/dark box shadows to produce dual-directional elevation.
:focus-visible transitions the thumb border to #3b82f6 for WCAG-compliant keyboard accessibility.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
