### PR TITLE
feat: implement Parallax Toggle with Dark Mode styling #79869

### DIFF
--- a/submissions/examples/css-dark-mode-parallax-toggle/README.md
+++ b/submissions/examples/css-dark-mode-parallax-toggle/README.md
@@ -1,0 +1,13 @@
+# Parallax Toggle with Dark Mode Styling (#79869)
+
+A dark-mode parallax toggle component featuring 3D perspective translations, glassmorphic frosted card framing, and vibrant purple glow active states.
+
+## Features
+- **3D Parallax Motion:** Thumb translation along the X and Z axes (`translateZ`) in perspective space during state transitions.
+- **Dark Glassmorphism:** Deep translucent slate background filled with CSS `backdrop-filter: blur(20px)` blurring.
+- **Zero JavaScript:** Pure CSS state handling powered by hidden checkbox inputs and adjacent sibling selectors (`+`).
+
+## File Hierarchy
+- `style.css` - Custom properties, 3D perspective rules, glassmorphism metrics, and media queries.
+- `demo.html` - Semantic markup demonstrating toggle integration with ARIA accessibility roles.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-dark-mode-parallax-toggle/demo.html
+++ b/submissions/examples/css-dark-mode-parallax-toggle/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parallax Toggle with Dark Mode Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="toggle-card" role="region" aria-label="Toggle component container">
+        <div class="toggle-wrapper">
+            <input type="checkbox" id="parallaxToggle" class="toggle-checkbox">
+            <label for="parallaxToggle" class="toggle-track" aria-label="Toggle activation state">
+                <span class="toggle-thumb" aria-hidden="true">
+                    <span class="toggle-thumb-inner"></span>
+                </span>
+            </label>
+        </div>
+        <span class="toggle-label">Parallax Depth Mode</span>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dark-mode-parallax-toggle/style.css
+++ b/submissions/examples/css-dark-mode-parallax-toggle/style.css
@@ -1,0 +1,116 @@
+/* CSS Parallax Toggle with Dark Mode Styling #79869 */
+
+:root {
+    --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+    --card-bg: rgba(30, 41, 59, 0.7);
+    --card-border: rgba(255, 255, 255, 0.1);
+    --track-off: rgba(15, 23, 42, 0.8);
+    --track-on: linear-gradient(135deg, #4f46e5, #9333ea);
+    --thumb-bg: #ffffff;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+    --accent-glow: rgba(147, 51, 234, 0.4);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: var(--bg-gradient);
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+.toggle-card {
+    background: var(--card-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--card-border);
+    border-radius: 28px;
+    padding: 3rem 3.5rem;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.75rem;
+    max-width: 420px;
+    width: 100%;
+}
+
+.toggle-wrapper {
+    position: relative;
+    perspective: 600px;
+}
+
+.toggle-checkbox {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.toggle-track {
+    display: block;
+    width: 100px;
+    height: 52px;
+    background: var(--track-off);
+    border: 1px solid var(--card-border);
+    border-radius: 50px;
+    cursor: pointer;
+    position: relative;
+    box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.6);
+    transition: background 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+    transform-style: preserve-3d;
+}
+
+.toggle-thumb {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 40px;
+    height: 40px;
+    background: var(--thumb-bg);
+    border-radius: 50%;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4), 
+                0 0 0 1px rgba(255, 255, 255, 0.2);
+    transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), background-color 0.4s ease, box-shadow 0.4s ease;
+    transform: translateZ(10px);
+}
+
+.toggle-thumb-inner {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    transition: transform 0.4s ease, opacity 0.3s ease;
+}
+
+/* On / Checked State Parallax Transitions */
+.toggle-checkbox:checked + .toggle-track {
+    background: var(--track-on);
+    border-color: rgba(168, 85, 247, 0.4);
+    box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3), 0 0 25px var(--accent-glow);
+}
+
+.toggle-checkbox:checked + .toggle-track .toggle-thumb {
+    transform: translateX(48px) translateZ(20px) rotateY(180deg);
+}
+
+.toggle-label {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-main);
+    letter-spacing: -0.01em;
+}
+
+@media (max-width: 480px) {
+    .toggle-card {
+        padding: 2.5rem 2rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Parallax Toggle with Dark Mode styling** component (#79869).
gssoc 26

Closes #79869

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-dark-mode-parallax-toggle/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A dark mode parallax toggle switch component featuring 3D Z-axis perspective shifts, frosted glass background card framing, and purple glow active states.

**How does it work?**
Constructed using hidden checkbox input elements combined with CSS adjacent sibling selectors (`+`), perspective projection, and 3D transform transitions on active state change.