### PR TITLE
feat: implement Responsive Slider with Neon styling #79870

### DIFF
--- a/submissions/examples/css-neon-responsive-slider/README.md
+++ b/submissions/examples/css-neon-responsive-slider/README.md
@@ -1,0 +1,13 @@
+# Responsive Slider with Neon Styling (#79870)
+
+A futuristic neon-styled responsive range slider component featuring dark glassmorphic card framing, custom cyan/pink glow thumb indicators, and responsive flexbox alignment.
+
+## Features
+- **Neon Glow Styling:** Radiant cyan and pink glowing range thumbs with multi-layered CSS box-shadow effects.
+- **Dark Glassmorphism:** Translucent slate card backdrop with CSS `backdrop-filter: blur(20px)` blurring.
+- **Cross-Browser Styling:** Tailored custom pseudo-element styles for WebKit and Mozilla browser engines.
+
+## File Hierarchy
+- `style.css` - Custom properties, neon glow shadows, range track resets, and media queries.
+- `demo.html` - Semantic markup demonstrating slider controls with accessible labels.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-neon-responsive-slider/demo.html
+++ b/submissions/examples/css-neon-responsive-slider/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Responsive Slider with Neon Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="slider-card" role="region" aria-label="Neon slider controls">
+        <div class="slider-header">
+            <h2 class="slider-title">Cyber Control</h2>
+        </div>
+
+        <div class="slider-group">
+            <div class="slider-label-row">
+                <label for="range1">Intensity</label>
+                <span>75%</span>
+            </div>
+            <input type="range" id="range1" class="neon-range" min="0" max="100" value="75">
+        </div>
+
+        <div class="slider-group">
+            <div class="slider-label-row">
+                <label for="range2">Frequency</label>
+                <span>40%</span>
+            </div>
+            <input type="range" id="range2" class="neon-range" min="0" max="100" value="40">
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-neon-responsive-slider/style.css
+++ b/submissions/examples/css-neon-responsive-slider/style.css
@@ -1,0 +1,140 @@
+/* CSS Responsive Slider with Neon Styling #79870 */
+
+:root {
+    --bg-dark: #0a0a12;
+    --card-bg: rgba(18, 18, 30, 0.85);
+    --border-color: rgba(255, 255, 255, 0.1);
+    --neon-cyan: #00f0ff;
+    --neon-pink: #ff007f;
+    --neon-cyan-glow: rgba(0, 240, 255, 0.4);
+    --neon-pink-glow: rgba(255, 0, 127, 0.4);
+    --track-bg: #1a1a2e;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-dark);
+    background-image: 
+        radial-gradient(circle at 15% 20%, rgba(0, 240, 255, 0.08) 0%, transparent 40%),
+        radial-gradient(circle at 85% 80%, rgba(255, 0, 127, 0.08) 0%, transparent 40%);
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+}
+
+.slider-card {
+    background: var(--card-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 3rem 3.5rem;
+    box-shadow: 0 0 30px rgba(0, 240, 255, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 480px;
+    width: 100%;
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.slider-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-main);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    text-shadow: 0 0 8px var(--neon-cyan-glow);
+}
+
+.slider-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.slider-label-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-sub);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.neon-range {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 10px;
+    border-radius: 5px;
+    background: var(--track-bg);
+    outline: none;
+    box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.8), 0 0 2px var(--border-color);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+/* Chrome, Safari, Edge Thumb */
+.neon-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 2px solid var(--neon-cyan);
+    box-shadow: 0 0 10px var(--neon-cyan), 0 0 20px var(--neon-cyan);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.neon-range::-webkit-slider-thumb:hover {
+    transform: scale(1.15);
+    background: var(--neon-cyan);
+    box-shadow: 0 0 15px var(--neon-cyan), 0 0 30px var(--neon-cyan);
+}
+
+.neon-range:focus::-webkit-slider-thumb {
+    border-color: var(--neon-pink);
+    box-shadow: 0 0 15px var(--neon-pink), 0 0 30px var(--neon-pink);
+}
+
+/* Firefox Thumb */
+.neon-range::-moz-range-thumb {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff;
+    border: 2px solid var(--neon-cyan);
+    box-shadow: 0 0 10px var(--neon-cyan), 0 0 20px var(--neon-cyan);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.neon-range::-moz-range-thumb:hover {
+    transform: scale(1.15);
+    background: var(--neon-cyan);
+    box-shadow: 0 0 15px var(--neon-cyan), 0 0 30px var(--neon-cyan);
+}
+
+@media (max-width: 480px) {
+    .slider-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Responsive Slider with Neon styling** component (#79870).
gssoc 26

Closes #79870

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-neon-responsive-slider/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A neon-styled responsive range slider component featuring dark glassmorphic card framing, glowing cyan/pink thumb indicators, and cross-browser slider pseudo-element overrides.

**How does it work?**
Constructed using semantic HTML range inputs, CSS backdrop blur filters, and customized `-webkit-slider-thumb` / `-moz-range-thumb` styling with glowing box shadows.