### PR TITLE
feat: implement Parallax Progress Bar with Neon styling #79866

### DIFF
--- a/submissions/examples/css-neon-parallax-progress-bar/README.md
+++ b/submissions/examples/css-neon-parallax-progress-bar/README.md
@@ -1,0 +1,13 @@
+# Parallax Progress Bar with Neon Styling (#79866)
+
+A vibrant neon-styled progress bar component featuring deep dark glassmorphic card framing, continuous parallax stripe animations, and radiant cyan-pink gradient glows.
+
+## Features
+- **Parallax Motion Effect:** Infinite moving striped texture overlay creating multi-layered speed perception.
+- **Neon Glow Aesthetics:** Dual-tone gradient fill (cyan to pink) amplified with multi-layered CSS box-shadow glow.
+- **Fully Responsive:** Fluid glassmorphic card container scaling cleanly across desktop and mobile viewports.
+
+## File Hierarchy
+- `style.css` - Custom properties, neon glow shadows, parallax keyframes, and media queries.
+- `demo.html` - Semantic markup demonstrating progress bar integration with ARIA accessibility standards.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-neon-parallax-progress-bar/demo.html
+++ b/submissions/examples/css-neon-parallax-progress-bar/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parallax Progress Bar with Neon Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="progress-card" role="region" aria-label="Progress status container">
+        <div class="progress-header">
+            <h2 class="progress-title">System Sync</h2>
+            <span class="progress-value">78%</span>
+        </div>
+
+        <div class="progress-track-wrapper">
+            <div class="progress-track" role="progressbar" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100">
+                <div class="progress-fill"></div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-neon-parallax-progress-bar/style.css
+++ b/submissions/examples/css-neon-parallax-progress-bar/style.css
@@ -1,0 +1,133 @@
+/* CSS Parallax Progress Bar with Neon Styling #79866 */
+
+:root {
+    --bg-dark: #0a0a12;
+    --card-bg: rgba(18, 18, 30, 0.85);
+    --border-color: rgba(255, 255, 255, 0.1);
+    --neon-cyan: #00f0ff;
+    --neon-pink: #ff007f;
+    --neon-cyan-glow: rgba(0, 240, 255, 0.4);
+    --neon-pink-glow: rgba(255, 0, 127, 0.4);
+    --track-bg: #111122;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-dark);
+    background-image: 
+        radial-gradient(circle at 20% 20%, rgba(0, 240, 255, 0.08) 0%, transparent 45%),
+        radial-gradient(circle at 80% 80%, rgba(255, 0, 127, 0.08) 0%, transparent 45%);
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+}
+
+.progress-card {
+    background: var(--card-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--border-color);
+    border-radius: 28px;
+    padding: 3rem;
+    box-shadow: 0 0 35px rgba(0, 240, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 480px;
+    width: 100%;
+}
+
+.progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.progress-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-main);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    text-shadow: 0 0 8px var(--neon-cyan-glow);
+}
+
+.progress-value {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--neon-cyan);
+    text-shadow: 0 0 8px var(--neon-cyan-glow);
+}
+
+.progress-track-wrapper {
+    position: relative;
+    perspective: 500px;
+}
+
+.progress-track {
+    width: 100%;
+    height: 24px;
+    background: var(--track-bg);
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.8);
+    overflow: hidden;
+    position: relative;
+}
+
+.progress-fill {
+    height: 100%;
+    width: 78%;
+    border-radius: 10px;
+    background: linear-gradient(90deg, var(--neon-pink), var(--neon-cyan));
+    box-shadow: 0 0 15px var(--neon-cyan-glow), 0 0 30px var(--neon-pink-glow);
+    position: relative;
+    overflow: hidden;
+    transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Parallax Depth Overlay Stripes */
+.progress-fill::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-image: linear-gradient(
+        -45deg, 
+        rgba(255, 255, 255, 0.25) 25%, 
+        transparent 25%, 
+        transparent 50%, 
+        rgba(255, 255, 255, 0.25) 50%, 
+        rgba(255, 255, 255, 0.25) 75%, 
+        transparent 75%, 
+        transparent
+    );
+    background-size: 30px 30px;
+    animation: parallaxMove 2s linear infinite;
+}
+
+@keyframes parallaxMove {
+    0% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: 30px 0;
+    }
+}
+
+@media (max-width: 480px) {
+    .progress-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Parallax Progress Bar with Neon styling** component (#79866).
gssoc 26

Closes #79866

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-neon-parallax-progress-bar/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A neon-styled progress bar component featuring animated parallax stripe overlays, cyan/pink gradient fill, and dark glassmorphic card framing.

**How does it work?**
Constructed using CSS Flexbox layout, multi-layered gradient fills with animated pseudo-element stripes (`::after`), and radiant neon box-shadow glows.