### PR TITLE
feat: implement Hover Badge with Cyberpunk styling #79882

### DIFF
--- a/submissions/examples/css-cyberpunk-hover-badge/README.md
+++ b/submissions/examples/css-cyberpunk-hover-badge/README.md
@@ -1,0 +1,13 @@
+# Hover Badge with Cyberpunk Styling (#79882)
+
+A cyberpunk-styled status badge component featuring chamfered polygon clip paths, vibrant neon accents, monospace typography, and inverted color shift hover transitions.
+
+## Features
+- **Chamfered Polygon Edges:** Distinctive cyberpunk geometric corners rendered via CSS `clip-path: polygon()`.
+- **Inverted Hover Mechanics:** Smooth color inversion transition where border and text colors shift to solid background fill with neon glow on hover.
+- **Fully Responsive:** Adaptive grid and flexbox layout scaling cleanly across all viewport dimensions.
+
+## File Hierarchy
+- `style.css` - Custom properties, clip-path geometry, neon glow transitions, and media queries.
+- `demo.html` - Semantic markup demonstrating status badges with accessible roles.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-cyberpunk-hover-badge/demo.html
+++ b/submissions/examples/css-cyberpunk-hover-badge/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Badge with Cyberpunk Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="badge-card" role="region" aria-label="Cyberpunk badges showcase">
+        <div class="badge-header">
+            <h2 class="badge-title">System Status</h2>
+            <p class="badge-subtitle">Hover badges to inspect protocol states</p>
+        </div>
+
+        <div class="badge-container">
+            <div class="cyber-badge" role="status">
+                <span class="badge-status-dot"></span>
+                <span>ONLINE v2.0</span>
+            </div>
+
+            <div class="cyber-badge cyber-badge-cyan" role="status">
+                <span class="badge-status-dot"></span>
+                <span>NEURAL SYNC</span>
+            </div>
+
+            <div class="cyber-badge cyber-badge-magenta" role="status">
+                <span class="badge-status-dot"></span>
+                <span>OVERDRIVE</span>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-cyberpunk-hover-badge/style.css
+++ b/submissions/examples/css-cyberpunk-hover-badge/style.css
@@ -1,0 +1,138 @@
+/* CSS Hover Badge with Cyberpunk Styling #79882 */
+
+:root {
+    --bg-dark: #09090d;
+    --card-bg: #12121a;
+    --border-color: #2a2a3c;
+    --cyber-yellow: #facc15;
+    --cyber-cyan: #00f0ff;
+    --cyber-magenta: #ff0055;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--bg-dark);
+    background-image: 
+        linear-gradient(rgba(0, 240, 255, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 240, 255, 0.03) 1px, transparent 1px);
+    background-size: 30px 30px;
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+}
+
+.badge-card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 3rem 3.5rem;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+    max-width: 460px;
+    width: 100%;
+}
+
+.badge-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    text-align: center;
+}
+
+.badge-title {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: var(--text-main);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.badge-subtitle {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-sub);
+}
+
+.badge-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.cyber-badge {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.65rem 1.25rem;
+    background: #181824;
+    color: var(--cyber-yellow);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border: 1px solid var(--cyber-yellow);
+    clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+    cursor: pointer;
+    user-select: none;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cyber-badge-cyan {
+    color: var(--cyber-cyan);
+    border-color: var(--cyber-cyan);
+}
+
+.cyber-badge-magenta {
+    color: var(--cyber-magenta);
+    border-color: var(--cyber-magenta);
+}
+
+.badge-status-dot {
+    width: 8px;
+    height: 8px;
+    background-color: currentColor;
+    border-radius: 50%;
+    box-shadow: 0 0 8px currentColor;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Hover Mechanics & Inversion Effects */
+.cyber-badge:hover {
+    background-color: currentColor;
+    color: #000000;
+    transform: translateY(-3px) scale(1.03);
+    box-shadow: 0 0 20px currentColor;
+}
+
+.cyber-badge:hover .badge-status-dot {
+    background-color: #000000;
+    box-shadow: none;
+}
+
+.cyber-badge::before {
+    content: '//';
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
+
+@media (max-width: 480px) {
+    .badge-card {
+        padding: 2rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Hover Badge with Cyberpunk styling** component (#79882).
gssoc 26

Closes #79882

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-cyberpunk-hover-badge/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
A cyberpunk status badge component featuring chamfered geometric clip paths, monospace typography, neon yellow/cyan/magenta theme variants, and color-inverting hover transitions.

**How does it work?**
Constructed using CSS `clip-path: polygon()`, monospace fonts, and smooth color/background-color inversion transitions coupled with neon box-shadow glows on `:hover`.