### PR TITLE
feat: implement Animated Tooltip with Dark Mode styling #79865

### DIFF
--- a/submissions/examples/css-dark-mode-animated-tooltip/README.md
+++ b/submissions/examples/css-dark-mode-animated-tooltip/README.md
@@ -1,0 +1,13 @@
+# Animated Tooltip with Dark Mode Styling (#79865)
+
+A dark-mode animated tooltip component featuring cubic-bezier scale/translation spring reveals, dark glassmorphic card framing, caret indicators, and accessible keyboard focus states.
+
+## Features
+- **Spring Reveal Animation:** Tooltip emerges using cubic-bezier scale up and negative vertical translation (`translateY`).
+- **Dark Glassmorphism:** Deep slate container framing enhanced with CSS `backdrop-filter: blur(20px)` and indigo glow highlights.
+- **Accessible Interactions:** Triggered via standard hover states as well as keyboard focus accessibility triggers.
+
+## File Hierarchy
+- `style.css` - Custom properties, spring curve animation metrics, caret border tricks, and media queries.
+- `demo.html` - Semantic markup demonstrating tooltip integration with ARIA accessibility references.
+- `README.md` - Technical specification and architecture overview.

--- a/submissions/examples/css-dark-mode-animated-tooltip/demo.html
+++ b/submissions/examples/css-dark-mode-animated-tooltip/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Tooltip with Dark Mode Styling | EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tooltip-card" role="region" aria-label="Tooltip showcase container">
+        <div class="tooltip-header">
+            <h2 class="tooltip-title">Dark Mode Tooltip</h2>
+            <p class="tooltip-subtitle">Hover or focus trigger button to reveal tooltip</p>
+        </div>
+
+        <div class="tooltip-wrapper">
+            <button class="tooltip-trigger" aria-describedby="tooltip-info">Hover Me</button>
+            <div id="tooltip-info" class="tooltip-content" role="tooltip">
+                <span>⚡ Secure Node Connection</span>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dark-mode-animated-tooltip/style.css
+++ b/submissions/examples/css-dark-mode-animated-tooltip/style.css
@@ -1,0 +1,136 @@
+/* CSS Animated Tooltip with Dark Mode Styling #79865 */
+
+:root {
+    --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+    --card-bg: rgba(30, 41, 59, 0.7);
+    --card-border: rgba(255, 255, 255, 0.1);
+    --tooltip-bg: #020617;
+    --tooltip-border: rgba(255, 255, 255, 0.15);
+    --accent-indigo: #6366f1;
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+    --shadow-glow: rgba(99, 102, 241, 0.25);
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: var(--bg-gradient);
+    font-family: system-ui, -apple-system, sans-serif;
+    padding: 2rem;
+}
+
+.tooltip-card {
+    background: var(--card-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--card-border);
+    border-radius: 28px;
+    padding: 3.5rem;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+    max-width: 440px;
+    width: 100%;
+}
+
+.tooltip-header {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.tooltip-title {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.tooltip-subtitle {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--text-sub);
+}
+
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltip-trigger {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--card-border);
+    color: var(--text-main);
+    padding: 0.85rem 1.5rem;
+    border-radius: 14px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.tooltip-trigger:hover, .tooltip-trigger:focus {
+    background: rgba(99, 102, 241, 0.15);
+    border-color: var(--accent-indigo);
+    color: #ffffff;
+    box-shadow: 0 0 20px var(--shadow-glow);
+}
+
+.tooltip-content {
+    position: absolute;
+    bottom: calc(100% + 12px);
+    left: 50%;
+    transform: translateX(-50%) translateY(8px) scale(0.95);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    background: var(--tooltip-bg);
+    border: 1px solid var(--tooltip-border);
+    color: var(--text-main);
+    padding: 0.75rem 1.15rem;
+    border-radius: 12px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.6), 0 0 15px var(--shadow-glow);
+    transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), 
+                opacity 0.2s ease, 
+                visibility 0.2s ease;
+    z-index: 10;
+}
+
+/* Tooltip Caret / Arrow */
+.tooltip-content::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: var(--tooltip-bg) transparent transparent transparent;
+}
+
+/* Hover & Focus State Triggers */
+.tooltip-wrapper:hover .tooltip-content,
+.tooltip-trigger:focus + .tooltip-content {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0) scale(1);
+}
+
+@media (max-width: 480px) {
+    .tooltip-card {
+        padding: 2.5rem 1.5rem;
+        margin: 1rem;
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This PR implements the **Animated Tooltip with Dark Mode styling** component (#79865).
gssoc 26

Closes #79865

---

## Type of Change
- [ ] 🛠️ DevOps / Tooling
- [x] 🧩 New component / motion pattern
- [ ] 📝 Documentation improvement

---

## Submission Checklist
- [x] Files created under `submissions/examples/css-dark-mode-animated-tooltip/`
- [x] Includes `demo.html`, `style.css`, and `README.md`
- [x] Pure CSS implementation with zero JavaScript
- [x] Fully responsive layout with accessibility attributes

---

## Feature Description
**What does this add?**
An animated dark-mode tooltip component featuring spring-like cubic-bezier entrance motion, dark glassmorphic card framing, directional caret indicators, and indigo focus glows.

**How does it work?**
Constructed using CSS absolute positioning relative to a wrapper container, pseudo-element CSS triangle arrows (`::after`), and transition effects on `:hover` and `:focus` states.