### PR TITLE
[BUG]: /claim command assigns closed issues instead of rejecting them

### DIFF
--- a/.github/workflows/auto_claim.yml
+++ b/.github/workflows/auto_claim.yml
@@ -1,13 +1,10 @@
 name: Issue Commands Handler
-
 on:
   issue_comment:
     types: [created]
-
 permissions:
   issues: write
   contents: read
-
 jobs:
   handle-commands:
     runs-on: ubuntu-latest
@@ -17,16 +14,30 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
       - name: Handle /claim or /assign
-        if: startsWith(github.event.comment.body, '/claim') || startsWith(github.event.comment.body, '/assign')
+        if: >-
+          (startsWith(github.event.comment.body, '/claim') || startsWith(github.event.comment.body, '/assign')) &&
+          github.event.issue.state == 'open'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { handleClaim } = require('./.github/scripts/autoClaimHandle.js');
             await handleClaim({ github, context });
-
+      - name: Reject claim on closed issue
+        if: >-
+          (startsWith(github.event.comment.body, '/claim') || startsWith(github.event.comment.body, '/assign')) &&
+          github.event.issue.state != 'open'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `@${context.payload.comment.user.login} this issue is already closed, so it can't be claimed.`
+            });
       - name: Handle /unclaim
         if: startsWith(github.event.comment.body, '/unclaim')
         uses: actions/github-script@v7


### PR DESCRIPTION
## Bug Description

The Issue Commands Handler workflow (`.github/workflows/autoclaim.yml`) assigns a user to an issue when they comment `/claim` or `/assign`, but it never checks whether the issue is open or closed. This means the command succeeds even on closed issues, silently assigning contributors to work that has already been resolved.

This can result in:
- Contributors being assigned to issues that no longer need work.
- Confusion over who is actively working on what, since closed issues can still accumulate assignees.
- Wasted contributor effort if someone starts working on a closed issue believing it's open.

---

## Steps to Reproduce

1. Open the repository's Issues tab.
2. Find or create a **closed** issue.
3. Comment `/claim` on that closed issue.
4. Observe that the bot assigns you to the issue anyway.

---

## Expected Behaviour

The bot should check the issue's state before processing `/claim` or `/assign`, and only assign the commenter if the issue is open. If the issue is closed, the bot should either post a comment explaining that closed issues can't be claimed, or simply take no action.

---

## Actual Behaviour

The workflow's `if` condition only checks:
- `!github.event.issue.pull_request`
- `github.event.comment.user.type != 'Bot'`

It does not check `github.event.issue.state`, so `/claim` and `/assign` succeed regardless of whether the issue is open or closed.

---

## Screenshots / Errors

No runtime errors observed — this is a logic gap, not a crash. The bot runs successfully and assigns the user even though it shouldn't.

---

## Environment

- Affected file: `.github/workflows/autoclaim.yml`
- Affected script: `.github/scripts/autoClaimHandle.js`
- Trigger: `issue_comment` event, `/claim` or `/assign` command

---

## Additional Context

### Impact

This is a workflow/CI automation bug, not a CSS issue — the fix belongs in the repo's GitHub Actions/DevOps layer rather than `core/` or `components/`.

### Suggested Fix

Add a state check before assignment logic runs, either in the workflow `if` condition or inside `autoClaimHandle.js`:

allow assignment only if `context.payload.issue.state === 'open'`; otherwise post a short comment telling the user the issue is already closed and exit without assigning.