### PR TITLE
feat: create CSS-only dropdown with glassmorphism styling for #79803

### DIFF
--- a/submissions/examples/79803-css-only-dropdown-glassmorphism/README.md
+++ b/submissions/examples/79803-css-only-dropdown-glassmorphism/README.md
@@ -1,0 +1,34 @@
+# CSS-only Dropdown - Glassmorphism
+
+A responsive dropdown component using pure HTML and CSS with a soft glassmorphism visual style.
+
+## Features
+
+- CSS-only interaction
+- Glassmorphism effect
+- Frosted glass background
+- Smooth dropdown animation
+- Responsive layout
+- Keyboard focus support
+- Hover states
+- Reduced-motion support
+- No JavaScript or external dependencies
+
+## Files
+
+- `demo.html` - Demo markup
+- `style.css` - Component styling
+
+## Usage
+
+Open `demo.html` in a modern browser to preview the dropdown.
+
+The dropdown opens on hover or keyboard focus.
+
+## Responsive Design
+
+The component uses flexible sizing and responsive media queries for smaller screens.
+
+## Accessibility
+
+The trigger uses a semantic button element with visible keyboard focus styling, while dropdown links remain keyboard accessible.

--- a/submissions/examples/79803-css-only-dropdown-glassmorphism/demo.html
+++ b/submissions/examples/79803-css-only-dropdown-glassmorphism/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS-only Glassmorphism Dropdown</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="page">
+    <section class="showcase">
+      <span class="eyebrow">EaseMotion CSS</span>
+
+      <h1>Glassmorphism Dropdown</h1>
+
+      <p class="description">
+        A clean CSS-only dropdown with a frosted glass interface,
+        soft shadows, and responsive behavior.
+      </p>
+
+      <div class="dropdown">
+        <button class="dropdown-toggle" type="button">
+          <span class="toggle-content">
+            <span class="status-dot"></span>
+            Select a category
+          </span>
+          <span class="chevron" aria-hidden="true"></span>
+        </button>
+
+        <div class="dropdown-menu">
+          <a href="#" class="dropdown-item">
+            <span class="item-icon">✦</span>
+            <span>
+              <strong>Design</strong>
+              <small>UI and visual systems</small>
+            </span>
+          </a>
+
+          <a href="#" class="dropdown-item">
+            <span class="item-icon">⌘</span>
+            <span>
+              <strong>Development</strong>
+              <small>Code and engineering</small>
+            </span>
+          </a>
+
+          <a href="#" class="dropdown-item">
+            <span class="item-icon">◈</span>
+            <span>
+              <strong>Marketing</strong>
+              <small>Growth and campaigns</small>
+            </span>
+          </a>
+
+          <a href="#" class="dropdown-item">
+            <span class="item-icon">⚡</span>
+            <span>
+              <strong>Product</strong>
+              <small>Ideas and strategy</small>
+            </span>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/79803-css-only-dropdown-glassmorphism/style.css
+++ b/submissions/examples/79803-css-only-dropdown-glassmorphism/style.css
@@ -1,0 +1,247 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #eef1ff;
+  --surface: rgba(255, 255, 255, 0.48);
+  --surface-strong: rgba(255, 255, 255, 0.78);
+  --border: rgba(255, 255, 255, 0.82);
+  --text: #34364d;
+  --muted: #7c8098;
+  --accent: #8175d6;
+  --accent-soft: rgba(129, 117, 214, 0.13);
+  --shadow: rgba(83, 78, 125, 0.18);
+}
+
+body {
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 12% 18%, #ffd9e8 0, transparent 28%),
+    radial-gradient(circle at 88% 22%, #d7e9ff 0, transparent 30%),
+    radial-gradient(circle at 50% 100%, #ded8ff 0, transparent 34%),
+    var(--bg);
+}
+
+.page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.showcase {
+  position: relative;
+  width: min(100%, 640px);
+  padding: clamp(34px, 6vw, 56px);
+  text-align: center;
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  background: var(--surface);
+  box-shadow:
+    0 28px 70px var(--shadow),
+    inset 0 1px rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 14px;
+  padding: 7px 13px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.48);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 3.2rem);
+  line-height: 1.05;
+  letter-spacing: -0.05em;
+}
+
+.description {
+  max-width: 520px;
+  margin: 15px auto 36px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.dropdown {
+  position: relative;
+  width: min(100%, 380px);
+  margin: 0 auto;
+}
+
+.dropdown-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 58px;
+  padding: 0 18px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  color: var(--text);
+  background: var(--surface-strong);
+  box-shadow:
+    0 12px 28px rgba(83, 78, 125, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.9);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.toggle-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 10px rgba(129, 117, 214, 0.5);
+}
+
+.chevron {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform 200ms ease;
+}
+
+.dropdown:hover .chevron,
+.dropdown:focus-within .chevron {
+  transform: rotate(225deg) translate(-2px, -2px);
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.64);
+  box-shadow:
+    0 22px 42px rgba(83, 78, 125, 0.16),
+    inset 0 1px rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transform-origin: top center;
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease,
+    transform 180ms ease;
+}
+
+.dropdown:hover .dropdown-menu,
+.dropdown:focus-within .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  color: var(--text);
+  text-decoration: none;
+  text-align: left;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus-visible {
+  background: var(--accent-soft);
+  transform: translateX(3px);
+  outline: none;
+}
+
+.item-icon {
+  display: grid;
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 11px;
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.56);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.8);
+}
+
+.dropdown-item strong,
+.dropdown-item small {
+  display: block;
+}
+
+.dropdown-item strong {
+  font-size: 0.86rem;
+}
+
+.dropdown-item small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.dropdown-toggle:focus-visible {
+  outline: 3px solid rgba(129, 117, 214, 0.32);
+  outline-offset: 4px;
+}
+
+@media (max-width: 520px) {
+  .page {
+    padding: 14px;
+  }
+
+  .showcase {
+    padding: 34px 18px;
+    border-radius: 24px;
+  }
+
+  .dropdown-toggle {
+    min-height: 54px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron,
+  .dropdown-menu,
+  .dropdown-item {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description## Description

It is a critical issue to add a reusable CSS-only Dropdown component with a modern glassmorphism visual style.

This PR introduces a responsive dropdown built with pure HTML and CSS, featuring a frosted glass interface, smooth interactions, responsive sizing, and keyboard accessibility.

## Changes

- Added CSS-only dropdown component
- Added glassmorphism styling
- Added smooth opening animation
- Added responsive layout
- Added hover and focus states
- Added keyboard accessibility
- Added reduced-motion support
- Added component documentation

## Files Added

- `submissions/examples/79803-css-only-dropdown-glassmorphism/demo.html`
- `submissions/examples/79803-css-only-dropdown-glassmorphism/style.css`
- `submissions/examples/79803-css-only-dropdown-glassmorphism/README.md`

## Testing

- Tested dropdown hover interaction
- Tested keyboard focus behavior
- Tested responsive layout
- Verified CSS-only behavior

Closes #79803