### PR TITLE
docs: add engine ease-in-out easing fix showcase

### DIFF
--- a/submissions/docs/engine-easing-fix-ik/README.md
+++ b/submissions/docs/engine-easing-fix-ik/README.md
@@ -1,0 +1,25 @@
+# Engine Bug Fix: `ease-in-out` Easing Alias Correction
+
+## 1. What does this showcase do?
+
+This documentation showcase documents and demonstrates a bug fix for the EaseMotion Motion Engine parser (`easemotion/engine/parser.js`).
+
+In the parser's `EASING_MAP`, the token `'ease-in-out'` was incorrectly assigned `cubic-bezier(0.4, 0, 0.2, 1)`, which is identical to the default `'ease'` curve. As a result, writing `em="fade-in ease-in-out"` produced the exact same acceleration profile as `em="fade-in ease"`.
+
+This fix updates `'ease-in-out'` to use the standard W3C symmetric curve `cubic-bezier(0.42, 0, 0.58, 1)`.
+
+## 2. How is it used?
+
+```html
+<!-- em="" attribute — ease-in-out now uses a distinct symmetric acceleration/deceleration curve -->
+<div em="slide-up 600ms ease-in-out">Symmetric entrance</div>
+<div em="fade-in 400ms ease">Default ease curve</div>
+```
+
+## 3. Why does it fit EaseMotion CSS?
+
+EaseMotion's core philosophy is human-readable, predictable animation tokens. When developers specify `ease-in-out`, they expect a symmetric curve rather than a duplicate of `ease`. Correcting this mapping ensures that motion engine tokens accurately match their CSS spec definitions.
+
+## 4. Demo Instructions
+
+Open `demo.html` directly in any web browser and click **▶ Play Motion** to view the comparison between the original duplicate curve and the corrected symmetric `ease-in-out` curve.

--- a/submissions/docs/engine-easing-fix-ik/demo.html
+++ b/submissions/docs/engine-easing-fix-ik/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Engine Fix: ease-in-out Easing Alias Correction</title>
+    <meta name="description" content="Demonstrates the fix for ease-in-out easing curve mapping in EaseMotion CSS motion engine." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+
+    <h1>Engine Bug Fix: <code>ease-in-out</code> Easing Curve</h1>
+
+    <p class="subtitle">
+      In <code>easemotion/engine/parser.js</code>, the <code>ease-in-out</code> key was
+      mistakenly assigned <code>cubic-bezier(0.4, 0, 0.2, 1)</code> — identical to default <code>ease</code>.
+      This fix maps <code>ease-in-out</code> to standard W3C <code>cubic-bezier(0.42, 0, 0.58, 1)</code>.
+    </p>
+
+    <div class="panel-row">
+
+      <div class="panel buggy" id="panel-buggy">
+        <h2>❌ Buggy (Duplicate cubic-bezier)</h2>
+        <p class="label">cubic-bezier(0.4, 0, 0.2, 1) &nbsp; [Identical to ease]</p>
+        <div class="track" id="track-buggy">
+          <div class="box box-buggy" title="Incorrect mapping identical to ease">EASE</div>
+        </div>
+        <div class="code-block"><span class="ctx">const EASING_MAP = {</span>
+  <span class="ctx">'ease':        'cubic-bezier(0.4, 0, 0.2, 1)',</span>
+  <span class="del">'ease-in-out': 'cubic-bezier(0.4, 0, 0.2, 1)',  // BUG</span>
+<span class="ctx">};</span></div>
+      </div>
+
+      <div class="panel correct" id="panel-correct">
+        <h2>✅ Fixed (Standard Symmetric Curve)</h2>
+        <p class="label">cubic-bezier(0.42, 0, 0.58, 1) &nbsp; [Symmetric ease-in-out]</p>
+        <div class="track" id="track-correct">
+          <div class="box box-correct" title="Correct W3C ease-in-out curve">EIO</div>
+        </div>
+        <div class="code-block"><span class="ctx">const EASING_MAP = {</span>
+  <span class="ctx">'ease':        'cubic-bezier(0.4, 0, 0.2, 1)',</span>
+  <span class="add">'ease-in-out': 'cubic-bezier(0.42, 0, 0.58, 1)', // FIX</span>
+<span class="ctx">};</span></div>
+      </div>
+
+    </div>
+
+    <div class="btn-group">
+      <button class="btn" id="btn-play" onclick="runDemo()">▶ Play Motion</button>
+      <button class="btn" style="background: linear-gradient(135deg, #475569, #334155);" onclick="resetDemo()">↺ Reset</button>
+    </div>
+
+    <div class="diff-card">
+      <h2>📋 Code Change Details — <code>easemotion/engine/parser.js</code></h2>
+      <div class="code-block">
+<span class="ctx">const EASING_MAP = {</span>
+<span class="ctx">  'ease':        'cubic-bezier(0.4, 0, 0.2, 1)',</span>
+<span class="ctx">  'ease-in':     'cubic-bezier(0.4, 0, 1, 1)',</span>
+<span class="ctx">  'ease-out':    'cubic-bezier(0, 0, 0.2, 1)',</span>
+<span class="del">  'ease-in-out': 'cubic-bezier(0.4, 0, 0.2, 1)',   // BUG: duplicate of ease</span>
+<span class="add">  'ease-in-out': 'cubic-bezier(0.42, 0, 0.58, 1)', // FIX: symmetric ease-in-out</span>
+<span class="ctx">  'linear':      'linear',</span>
+<span class="ctx">  'spring':      'cubic-bezier(0.34, 1.56, 0.64, 1)',</span>
+<span class="ctx">};</span>
+      </div>
+    </div>
+
+    <footer>
+      EaseMotion CSS Submission Showcase &bull; <code>submissions/docs/engine-easing-fix-ik/</code>
+    </footer>
+
+    <script>
+      function runDemo() {
+        document.getElementById('track-buggy').classList.add('playing');
+        document.getElementById('track-correct').classList.add('playing');
+      }
+
+      function resetDemo() {
+        const buggy = document.getElementById('track-buggy');
+        const correct = document.getElementById('track-correct');
+        buggy.classList.remove('playing');
+        correct.classList.remove('playing');
+        void buggy.offsetWidth;
+        void correct.offsetWidth;
+      }
+    </script>
+
+  </body>
+</html>

--- a/submissions/docs/engine-easing-fix-ik/style.css
+++ b/submissions/docs/engine-easing-fix-ik/style.css
@@ -1,0 +1,179 @@
+/*
+ * EaseMotion CSS — Motion Engine Easing Fix Demo (Unique Suffix: -ik)
+ * ====================================================================
+ * Demonstrates the visual difference between the incorrect duplicate
+ * easing mapping and the corrected W3C symmetric ease-in-out curve.
+ * ====================================================================
+ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #0b1121;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  gap: 2rem;
+}
+
+h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  text-align: center;
+  background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+p.subtitle {
+  color: #94a3b8;
+  text-align: center;
+  max-width: 600px;
+  line-height: 1.6;
+}
+
+.panel-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+  max-width: 860px;
+}
+
+.panel {
+  flex: 1;
+  min-width: 320px;
+  background: #141e33;
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.panel h2 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel.buggy h2   { color: #f87171; }
+.panel.correct h2 { color: #4ade80; }
+
+.label {
+  font-size: 0.75rem;
+  color: #64748b;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.track {
+  height: 56px;
+  background: #0f172a;
+  border-radius: 0.5rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.box {
+  width: 52px;
+  height: 52px;
+  border-radius: 0.5rem;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.box-buggy {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #ffffff;
+  transition: transform 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.box-correct {
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  color: #ffffff;
+  transition: transform 1.2s cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.track.playing .box {
+  transform: translateX(267px);
+}
+
+.code-block {
+  background: #0f172a;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.75rem;
+  line-height: 1.7;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.del { color: #f87171; text-decoration: line-through; }
+.add { color: #4ade80; }
+.ctx { color: #64748b; }
+
+.btn-group {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.btn {
+  padding: 0.6rem 1.5rem;
+  border-radius: 9999px;
+  border: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #6c63ff, #8b5cf6);
+  color: #ffffff;
+  transition: opacity 0.2s, transform 0.15s;
+}
+
+.btn:hover  { opacity: 0.85; transform: translateY(-1px); }
+.btn:active { transform: scale(0.97); }
+
+.diff-card {
+  width: 100%;
+  max-width: 860px;
+  background: #141e33;
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.diff-card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #a78bfa;
+}
+
+footer {
+  color: #475569;
+  font-size: 0.75rem;
+  text-align: center;
+}


### PR DESCRIPTION
**Description:**

```markdown
## Pull Request Description

Submits a documentation showcase for the `ease-in-out` easing token correction in `submissions/docs/engine-easing-fix-ik/`.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/docs/engine-easing-fix-ik/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A documentation showcase illustrating the difference between default `ease` vs symmetric `ease-in-out` cubic-bezier curves for the motion engine parser.

**How does a developer use it?**

```html
<div em="slide-up 600ms ease-in-out">Symmetric entrance</div>
<div em="fade-in 400ms ease">Default ease curve</div>
```

**Why does it fit EaseMotion CSS?**

Demonstrates human-readable motion token behaviors clearly in an interactive showcase demo.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge