### PR TITLE
docs: document usage for CSS-only Tab Bar (#58801)

### DIFF
--- a/submissions/docs/58801-tab-bar-usage-ak/README.md
+++ b/submissions/docs/58801-tab-bar-usage-ak/README.md
@@ -1,0 +1,67 @@
+# Tab Bar — Usage Guide
+
+Documentation for the CSS-only Tab Bar component (`submissions/examples/tab-bar`).
+
+## What it is
+
+A lightweight, zero-dependency tab bar built with plain CSS. No JavaScript is required for the visual states — only the `active` class controls which tab is highlighted.
+
+## Markup
+
+```html
+<div class="tabs">
+  <span class="tab active">Tab 1</span>
+  <span class="tab">Tab 2</span>
+</div>
+```
+
+- `.tabs` — the container; lays out tabs in a row with a rounded, dark background.
+- `.tab` — an individual tab item.
+- `.tab.active` — marks the currently selected tab (orange background, dark text).
+
+You can add as many `.tab` elements inside `.tabs` as you need.
+
+## Styling
+
+Include the stylesheet:
+
+```html
+<link rel="stylesheet" href="style.css">
+```
+
+Key CSS classes:
+
+| Class | Purpose |
+|---|---|
+| `.tabs` | Flex container, dark rounded background |
+| `.tab` | Base tab styling, transparent background, muted text |
+| `.tab.active` | Highlighted state, orange background |
+| `.tab:hover` | Lightens text color on hover (non-active tabs) |
+
+## Making tabs interactive
+
+The component ships CSS-only, so switching the active tab requires a small script to toggle the `active` class:
+
+```html
+<script>
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelector('.tab.active')?.classList.remove('active');
+      tab.classList.add('active');
+    });
+  });
+</script>
+```
+
+## Customization
+
+Override these CSS custom properties or edit `style.css` directly to theme the tab bar:
+
+- Background color: `.tabs { background: ... }`
+- Active tab color: `.tab.active { background: ...; color: ...; }`
+- Padding/spacing: `.tab { padding: ...; }`
+
+## Notes
+
+- Works in any modern browser, no dependencies.
+- Accessibility: for production use, consider adding `role="tablist"`, `role="tab"`, and `aria-selected` attributes, since the base component only provides visual styling.

--- a/submissions/docs/58801-tab-bar-usage-ak/demo.html
+++ b/submissions/docs/58801-tab-bar-usage-ak/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Bar — Usage Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="tabs">
+    <span class="tab active">Tab 1</span>
+    <span class="tab">Tab 2</span>
+    <span class="tab">Tab 3</span>
+  </div>
+
+  <script>
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelector('.tab.active')?.classList.remove('active');
+        tab.classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/58801-tab-bar-usage-ak/style.css
+++ b/submissions/docs/58801-tab-bar-usage-ak/style.css
@@ -1,0 +1,29 @@
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  background: #0f0e17;
+  font-family: system-ui, sans-serif;
+}
+.tabs {
+  display: flex;
+  background: #1a1a2e;
+  border-radius: 0.5rem;
+}
+.tab {
+  padding: 0.5rem 1.5rem;
+  color: #72757e;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  background: transparent;
+}
+.tab.active {
+  background: #ff8906;
+  color: #0f0e17;
+}
+.tab:hover {
+  color: #fffffe;
+}


### PR DESCRIPTION
Closes #79915

## Pull Request Description
Adds usage documentation for the existing CSS-only Tab Bar component (`submissions/examples/tab-bar`), as requested in issue #79915 (referencing #58801). Docs live in `submissions/docs/58801-tab-bar-usage-ak/` and include the markup structure, class reference table, and an interactive demo showing how to toggle the active tab with a small script.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/58801-tab-bar-usage-ak/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — copied from the existing tab-bar component
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
Usage documentation for the CSS-only Tab Bar component.

**How does a developer use it?**
```html
<div class="tabs">
  <span class="tab active">Tab 1</span>
  <span class="tab">Tab 2</span>
</div>
```

**Why does it fit EaseMotion CSS?**
Documents an existing zero-dependency, human-readable component so contributors can adopt it correctly without reverse-engineering the markup from source.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Docs-only PR — no changes to the underlying component itself.