### PR TITLE
feat(scss): add reusable animation mixins for bounce, pulse, shake, spin, wobble, flip

### DIFF
--- a/submissions/scss/extended-scss-mixins-ik/README.md
+++ b/submissions/scss/extended-scss-mixins-ik/README.md
@@ -1,0 +1,38 @@
+# Extended SCSS Animation Mixins
+
+## 1. What does this SCSS package do?
+
+Provides SCSS mixin helpers for EaseMotion keyframe animations including `@include ease-bounce()`, `@include ease-pulse()`, `@include ease-shake()`, `@include ease-ping()`, `@include ease-spin()`, `@include ease-wobble()`, `@include ease-rubber-band()`, `@include ease-flip-x()`, and `@include ease-flip-y()`.
+
+## 2. Parameters Reference
+
+| Mixin | Parameters | Default Values |
+|---|---|---|
+| `@mixin ease-bounce` | `$duration, $easing, $delay, $iteration` | `600ms, cubic-bezier(0.4, 0, 0.2, 1), 0s, infinite` |
+| `@mixin ease-pulse` | `$duration, $easing, $delay, $iteration` | `1.5s, cubic-bezier(0.4, 0, 0.2, 1), 0s, infinite` |
+| `@mixin ease-shake` | `$duration, $easing, $delay, $iteration` | `500ms, cubic-bezier(0.4, 0, 0.2, 1), 0s, 1` |
+| `@mixin ease-spin` | `$duration, $easing, $delay, $iteration` | `1s, linear, 0s, infinite` |
+| `@mixin ease-wobble` | `$duration, $easing, $delay, $iteration` | `1s, cubic-bezier(0.4, 0, 0.2, 1), 0s, 1` |
+| `@mixin ease-flip-x` | `$duration, $easing, $delay, $fill` | `800ms, cubic-bezier(0.4, 0, 0.2, 1), 0s, both` |
+
+## 3. Usage Example
+
+```scss
+@use 'extended-scss-mixins-ik' as *;
+
+.badge-notification {
+  @include ease-pulse(2s);
+}
+
+.loading-spinner {
+  @include ease-spin(0.8s);
+}
+
+.alert-box {
+  @include ease-shake(400ms);
+}
+```
+
+## 4. Why does it fit EaseMotion CSS?
+
+Expands EaseMotion's SCSS integration track by offering modular mixins for keyframe animations, enabling clean SCSS `@include` syntax in custom design systems.

--- a/submissions/scss/extended-scss-mixins-ik/_extended-scss-mixins-ik.scss
+++ b/submissions/scss/extended-scss-mixins-ik/_extended-scss-mixins-ik.scss
@@ -1,0 +1,63 @@
+// ============================================================
+// EaseMotion CSS — Extended Animation SCSS Mixins (-ik)
+// Reusable SCSS mixins for shake, bounce, pulse, ping, wobble,
+// rubber-band, spin, flip-x, and flip-y keyframe animations.
+// ============================================================
+
+$duration-default: 300ms !default;
+$easing-default: cubic-bezier(0.4, 0, 0.2, 1) !default;
+
+// --- Helper Base Animation Mixin ---
+@mixin ease-animate(
+  $name,
+  $duration: $duration-default,
+  $easing: $easing-default,
+  $delay: 0s,
+  $iteration: 1,
+  $fill: both
+) {
+  animation-name:            $name;
+  animation-duration:        $duration;
+  animation-timing-function: $easing;
+  animation-delay:           $delay;
+  animation-iteration-count: $iteration;
+  animation-fill-mode:       $fill;
+}
+
+// --- Extended Named Mixins ---
+
+@mixin ease-bounce($duration: 600ms, $easing: $easing-default, $delay: 0s, $iteration: infinite) {
+  @include ease-animate(ease-kf-bounce, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-pulse($duration: 1.5s, $easing: $easing-default, $delay: 0s, $iteration: infinite) {
+  @include ease-animate(ease-kf-pulse, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-shake($duration: 500ms, $easing: $easing-default, $delay: 0s, $iteration: 1) {
+  @include ease-animate(ease-kf-shake, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-ping($duration: 1s, $easing: $easing-default, $delay: 0s, $iteration: infinite) {
+  @include ease-animate(ease-kf-ping, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-spin($duration: 1s, $easing: linear, $delay: 0s, $iteration: infinite) {
+  @include ease-animate(ease-kf-spin, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-wobble($duration: 1s, $easing: $easing-default, $delay: 0s, $iteration: 1) {
+  @include ease-animate(ease-kf-wobble, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-rubber-band($duration: 1s, $easing: $easing-default, $delay: 0s, $iteration: 1) {
+  @include ease-animate(ease-kf-rubber-band, $duration, $easing, $delay, $iteration);
+}
+
+@mixin ease-flip-x($duration: 800ms, $easing: $easing-default, $delay: 0s, $fill: both) {
+  @include ease-animate(ease-kf-flip-x, $duration, $easing, $delay, 1, $fill);
+}
+
+@mixin ease-flip-y($duration: 800ms, $easing: $easing-default, $delay: 0s, $fill: both) {
+  @include ease-animate(ease-kf-flip-y, $duration, $easing, $delay, 1, $fill);
+}


### PR DESCRIPTION

## Pull Request Description

Submits reusable SCSS animation mixins in `submissions/scss/extended-scss-mixins-ik/`.

Includes SCSS mixins for:
- `@mixin ease-bounce`
- `@mixin ease-pulse`
- `@mixin ease-shake`
- `@mixin ease-ping`
- `@mixin ease-spin`
- `@mixin ease-wobble`
- `@mixin ease-rubber-band`
- `@mixin ease-flip-x`
- `@mixin ease-flip-y`

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/scss/extended-scss-mixins-ik/`)
- [x] Includes `_extended-scss-mixins-ik.scss` — SCSS partial file
- [x] Includes `README.md` — what it does, parameters table, usage examples with `@include`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Reusable SCSS mixins for EaseMotion keyframe animations.

**How does a developer use it?**

```scss
@use 'extended-scss-mixins-ik' as *;

.badge { @include ease-pulse(2s); }
.spinner { @include ease-spin(0.8s); }
