### PR TITLE
docs: document usage for Responsive Toggle

### DIFF
--- a/submissions/docs/responsive-toggle-ak/README.md
+++ b/submissions/docs/responsive-toggle-ak/README.md
@@ -1,0 +1,79 @@
+# Responsive Toggle
+
+A responsive, accessible ON/OFF toggle switch with a retro arcade-inspired visual style, built with pure HTML and CSS.
+
+## Overview
+
+The Responsive Toggle component provides a reusable checkbox-based switch for boolean settings (e.g. dark mode, notifications, feature flags). It uses a native `<input type="checkbox">` under the hood for full keyboard and screen-reader support, with all visual states — including the sliding thumb and ON/OFF text swap — handled purely in CSS.
+
+## Usage
+
+Include the stylesheet and add the toggle markup, built on a native checkbox:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<label class="retro-toggle">
+  <input class="retro-toggle__input" type="checkbox">
+
+  <span class="retro-toggle__track">
+    <span class="retro-toggle__thumb"></span>
+    <span class="retro-toggle__text retro-toggle__text--off">OFF</span>
+    <span class="retro-toggle__text retro-toggle__text--on">ON</span>
+  </span>
+
+  <span class="retro-toggle__label">Retro Mode</span>
+</label>
+```
+
+To render the toggle already switched on, add `checked` to the `<input>`:
+
+```html
+<input class="retro-toggle__input" type="checkbox" checked>
+```
+
+## CSS Classes
+
+| Class                        | Description                                          |
+|-------------------------------|-------------------------------------------------------|
+| `.retro-toggle`               | Wrapping `<label>`; makes the whole control clickable |
+| `.retro-toggle__input`        | The native (visually hidden) checkbox that drives state |
+| `.retro-toggle__track`        | The pill-shaped track/background of the switch       |
+| `.retro-toggle__thumb`        | The sliding knob inside the track                     |
+| `.retro-toggle__text`         | Base class for the ON/OFF text labels inside the track |
+| `.retro-toggle__text--off`    | The "OFF" label, visible when unchecked                |
+| `.retro-toggle__text--on`     | The "ON" label, visible when checked                   |
+| `.retro-toggle__label`        | The visible text label next to the switch              |
+
+## States
+
+- **Unchecked (default):** thumb sits left, "OFF" text visible, "ON" text hidden.
+- **Checked:** thumb slides right, accent color applied to track/thumb, "ON" text visible, "OFF" text hidden.
+- **Hover:** thumb shadow shifts to the accent green for visual feedback.
+- **Active (pressed):** thumb shifts slightly to simulate a physical press.
+- **Focus-visible:** a dashed outline appears around the track for keyboard users.
+
+All state transitions are pure CSS (`:checked`, `:hover`, `:active`, `:focus-visible` — no JavaScript required).
+
+## Responsiveness
+
+The component adapts at two breakpoints:
+
+- **≤600px:** the label stacks below the switch instead of sitting beside it, and surrounding spacing/shadows shrink.
+- **≤420px:** the track and thumb themselves shrink further, with adjusted thumb travel distance to match.
+
+## Accessibility
+
+- Built on a real `<input type="checkbox">`, so it's operable via keyboard (`Tab` + `Space`) and announced correctly by screen readers.
+- The checkbox is visually hidden with a clip-based technique (not `display: none`), keeping it in the accessibility tree.
+- A visible `focus-visible` outline is provided for keyboard users.
+- Respects `prefers-reduced-motion`: all transitions are disabled for users who request reduced motion.
+
+## Demo
+
+See `demo.html` for a live, styled example of the toggle in both states.
+
+## Related Files
+
+- `demo.html` — standalone usage example
+- `style.css` — component styles

--- a/submissions/docs/responsive-toggle-ak/demo.html
+++ b/submissions/docs/responsive-toggle-ak/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="Responsive retro-styled CSS toggle component"
+    >
+    <title>Retro Toggle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="retro-page">
+        <section class="retro-card" aria-labelledby="retro-title">
+
+            <div class="retro-card__header">
+                <span class="retro-card__badge">CSS COMPONENT</span>
+                <h1 id="retro-title">RETRO TOGGLE</h1>
+                <p>
+                    A responsive toggle switch inspired by classic arcade
+                    interfaces and pixel-era controls.
+                </p>
+            </div>
+
+            <div class="retro-card__demo">
+
+                <label class="retro-toggle">
+                    <input
+                        class="retro-toggle__input"
+                        type="checkbox"
+                        checked
+                    >
+                    <span class="retro-toggle__track">
+                        <span class="retro-toggle__thumb"></span>
+                        <span class="retro-toggle__text retro-toggle__text--off">
+                            OFF
+                        </span>
+                        <span class="retro-toggle__text retro-toggle__text--on">
+                            ON
+                        </span>
+                    </span>
+                    <span class="retro-toggle__label">
+                        Retro Mode
+                    </span>
+                </label>
+
+            </div>
+
+            <div class="retro-card__footer">
+                <span>PURE HTML + CSS</span>
+                <span>RESPONSIVE</span>
+                <span>NO JAVASCRIPT</span>
+            </div>
+
+        </section>
+    </main>
+
+</body>
+</html>

--- a/submissions/docs/responsive-toggle-ak/style.css
+++ b/submissions/docs/responsive-toggle-ak/style.css
@@ -1,0 +1,357 @@
+/* =========================================
+   Retro Toggle
+   Part 1: Base Layout & Component Structure
+   ========================================= */
+
+:root {
+    --retro-bg: #111111;
+    --retro-surface: #1c1c1c;
+    --retro-panel: #252525;
+    --retro-border: #f4e8c1;
+    --retro-accent: #ffcc33;
+    --retro-accent-dark: #b88700;
+    --retro-text: #f4e8c1;
+    --retro-muted: #a89f83;
+    --retro-shadow: #000000;
+    --retro-green: #7ed957;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    min-height: 100%;
+}
+
+body {
+    min-height: 100vh;
+    margin: 0;
+    font-family:
+        "Courier New",
+        Courier,
+        monospace;
+    background:
+        linear-gradient(
+            135deg,
+            rgba(255, 204, 51, 0.04) 25%,
+            transparent 25%
+        ),
+        var(--retro-bg);
+    color: var(--retro-text);
+}
+
+body::before {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    content: "";
+    pointer-events: none;
+    background:
+        repeating-linear-gradient(
+            0deg,
+            transparent 0,
+            transparent 3px,
+            rgba(244, 232, 193, 0.025) 3px,
+            rgba(244, 232, 193, 0.025) 4px
+        );
+}
+
+.retro-page {
+    display: grid;
+    min-height: 100vh;
+    padding: 2rem;
+    place-items: center;
+}
+
+.retro-card {
+    width: min(100%, 680px);
+    overflow: hidden;
+    background: var(--retro-surface);
+    border: 4px solid var(--retro-border);
+    box-shadow:
+        8px 8px 0 var(--retro-shadow),
+        12px 12px 0 var(--retro-accent-dark);
+}
+
+.retro-card__header {
+    padding: 2rem;
+    border-bottom: 4px solid var(--retro-border);
+}
+
+.retro-card__badge {
+    display: inline-block;
+    margin-bottom: 1rem;
+    padding: 0.35rem 0.65rem;
+    color: var(--retro-bg);
+    background: var(--retro-accent);
+    font-size: 0.7rem;
+    font-weight: 900;
+    letter-spacing: 0.12em;
+}
+
+.retro-card__header h1 {
+    margin: 0;
+    color: var(--retro-accent);
+    font-size: clamp(2rem, 7vw, 4rem);
+    line-height: 0.95;
+    letter-spacing: 0.04em;
+    text-shadow: 4px 4px 0 var(--retro-shadow);
+}
+
+.retro-card__header p {
+    max-width: 560px;
+    margin: 1.25rem 0 0;
+    color: var(--retro-muted);
+    font-size: clamp(0.8rem, 2vw, 1rem);
+    line-height: 1.7;
+}
+
+.retro-card__demo {
+    display: grid;
+    min-height: 260px;
+    padding: 2rem;
+    background: var(--retro-panel);
+    place-items: center;
+}
+
+.retro-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 1.25rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.retro-toggle__input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    white-space: nowrap;
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+}
+
+.retro-toggle__track {
+    position: relative;
+    display: block;
+    width: 170px;
+    height: 76px;
+    overflow: hidden;
+    background: var(--retro-bg);
+    border: 4px solid var(--retro-border);
+    box-shadow:
+        5px 5px 0 var(--retro-shadow),
+        inset 0 0 0 3px #333333;
+    transition:
+        border-color 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.retro-toggle__thumb {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 3;
+    width: 52px;
+    height: 52px;
+    background: var(--retro-border);
+    border: 4px solid var(--retro-bg);
+    box-shadow: 4px 4px 0 var(--retro-accent-dark);
+    transition:
+        transform 220ms steps(4, end),
+        background-color 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.retro-toggle__text {
+    position: absolute;
+    top: 50%;
+    z-index: 2;
+    transform: translateY(-50%);
+    font-size: 0.8rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    pointer-events: none;
+    transition:
+        opacity 180ms ease,
+        transform 180ms ease;
+}
+
+.retro-toggle__text--off {
+    right: 12px;
+    color: var(--retro-muted);
+}
+
+.retro-toggle__text--on {
+    left: 12px;
+    color: var(--retro-bg);
+    opacity: 0;
+    transform: translateY(-50%) translateX(-5px);
+}
+
+.retro-toggle__label {
+    color: var(--retro-text);
+    font-size: clamp(0.9rem, 3vw, 1.1rem);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+}
+
+.retro-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+    color: var(--retro-muted);
+    border-top: 4px solid var(--retro-border);
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+/* =========================================
+   Retro Toggle
+   Part 2: States, Focus & Responsiveness
+   ========================================= */
+
+.retro-toggle__input:checked + .retro-toggle__track {
+    border-color: var(--retro-accent);
+    box-shadow:
+        5px 5px 0 var(--retro-shadow),
+        inset 0 0 0 3px var(--retro-accent-dark);
+}
+
+.retro-toggle__input:checked + .retro-toggle__track .retro-toggle__thumb {
+    background: var(--retro-accent);
+    box-shadow: 4px 4px 0 var(--retro-green);
+    transform: translateX(92px);
+}
+
+.retro-toggle__input:checked + .retro-toggle__track .retro-toggle__text--off {
+    opacity: 0;
+    transform: translateY(-50%) translateX(5px);
+}
+
+.retro-toggle__input:checked + .retro-toggle__track .retro-toggle__text--on {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+}
+
+.retro-toggle__input:focus-visible + .retro-toggle__track {
+    outline: 3px dashed var(--retro-green);
+    outline-offset: 6px;
+}
+
+.retro-toggle:hover .retro-toggle__thumb {
+    box-shadow: 4px 4px 0 var(--retro-green);
+}
+
+.retro-toggle:active .retro-toggle__thumb {
+    transform: translate(2px, 2px);
+}
+
+.retro-toggle__input:checked + .retro-toggle__track .retro-toggle__thumb:active {
+    transform: translate(94px, 2px);
+}
+
+/* Tablet */
+
+@media (max-width: 600px) {
+    .retro-page {
+        padding: 1.25rem;
+    }
+
+    .retro-card {
+        border-width: 3px;
+        box-shadow:
+            6px 6px 0 var(--retro-shadow),
+            9px 9px 0 var(--retro-accent-dark);
+    }
+
+    .retro-card__header {
+        padding: 1.5rem;
+        border-bottom-width: 3px;
+    }
+
+    .retro-card__demo {
+        min-height: 230px;
+        padding: 1.5rem;
+    }
+
+    .retro-toggle {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .retro-card__footer {
+        padding: 0.9rem 1rem;
+    }
+}
+
+/* Mobile */
+
+@media (max-width: 420px) {
+    .retro-page {
+        padding: 0.85rem;
+    }
+
+    .retro-card {
+        box-shadow:
+            4px 4px 0 var(--retro-shadow),
+            6px 6px 0 var(--retro-accent-dark);
+    }
+
+    .retro-card__header {
+        padding: 1.2rem;
+    }
+
+    .retro-card__header p {
+        line-height: 1.55;
+    }
+
+    .retro-card__demo {
+        min-height: 210px;
+        padding: 1.25rem;
+    }
+
+    .retro-toggle__track {
+        width: 150px;
+        height: 68px;
+    }
+
+    .retro-toggle__thumb {
+        top: 7px;
+        left: 7px;
+        width: 46px;
+        height: 46px;
+    }
+
+    .retro-toggle__input:checked + .retro-toggle__track .retro-toggle__thumb {
+        transform: translateX(80px);
+    }
+
+    .retro-toggle__input:checked + .retro-toggle__track .retro-toggle__thumb:active {
+        transform: translateX(82px) translateY(2px);
+    }
+
+    .retro-card__footer {
+        justify-content: center;
+        text-align: center;
+        font-size: 0.58rem;
+    }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+    .retro-toggle__track,
+    .retro-toggle__thumb,
+    .retro-toggle__text {
+        transition: none;
+    }
+}


### PR DESCRIPTION
Closes #79649

## Pull Request Description
Adds usage documentation for the Responsive Toggle component (retro-styled ON/OFF switch) under `submissions/docs/`.

## Type of Change
- [x] 📝 Documentation improvement

## Submission Checklist
- [x] All changes are inside `submissions/docs/responsive-toggle-ak/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

## Feature Description
**What does this add?**
Documentation explaining how to use the Responsive Toggle component, including markup, CSS class reference, states, responsiveness, and accessibility notes.

**How does a developer use it?**
```html
<label class="retro-toggle">
  <input class="retro-toggle__input" type="checkbox">
  <span class="retro-toggle__track">
    <span class="retro-toggle__thumb"></span>
    <span class="retro-toggle__text retro-toggle__text--off">OFF</span>
    <span class="retro-toggle__text retro-toggle__text--on">ON</span>
  </span>
  <span class="retro-toggle__label">Retro Mode</span>
</label>
```

**Why does it fit EaseMotion CSS?**
Documents an existing pure-CSS, zero-dependency component with human-readable class names, in line with the project's docs structure and animation-first philosophy.

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

## Browser Testing
- [x] Chrome

## Notes for Maintainer
Docs cover the existing `responsive-toggle-retro-v1` example — no changes made to that component's CSS or markup, only documentation added.