### PR TITLE
feat: Add Shimmer Skeleton Card animation

### DIFF
--- a/submissions/examples/81745-shimmer-card-ionfwsrijan/README.md
+++ b/submissions/examples/81745-shimmer-card-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Shimmer Skeleton Card
+
+A content placeholder card that shows a sweeping shimmer while data loads.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #81745

--- a/submissions/examples/81745-shimmer-card-ionfwsrijan/demo.html
+++ b/submissions/examples/81745-shimmer-card-ionfwsrijan/demo.html
@@ -1,0 +1,20 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shimmer Skeleton Card</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <article class="skeleton">
+        <span class="sk-avatar"></span>
+        <span class="sk-line w70"></span>
+        <span class="sk-line w90"></span>
+        <span class="sk-line w50"></span>
+      </article>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/81745-shimmer-card-ionfwsrijan/style.css
+++ b/submissions/examples/81745-shimmer-card-ionfwsrijan/style.css
@@ -1,0 +1,48 @@
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  font-family: system-ui, sans-serif;
+}
+.skeleton {
+  width: 300px;
+  padding: 22px;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 14px;
+}
+.sk-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #e2e8f0;
+}
+.sk-line {
+  height: 14px;
+  border-radius: 8px;
+  background: #e2e8f0;
+}
+.w70 { width: 70%; }
+.w90 { width: 90%; }
+.w50 { width: 50%; }
+.sk-avatar, .sk-line {
+  position: relative;
+  overflow: hidden;
+}
+.sk-avatar::after, .sk-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.85), transparent);
+  animation: shimmer 1400ms infinite;
+}
+@keyframes shimmer {
+  to { transform: translateX(100%); }
+}


### PR DESCRIPTION
## Shimmer Skeleton Card

A content placeholder card that shows a sweeping shimmer while data loads.

Adds a self-contained, working CSS animation demo under `submissions/examples/81745-shimmer-card-ionfwsrijan`.

Closes #81745