### PR TITLE
feat: Add Slide-in Toast animation

### DIFF
--- a/submissions/examples/81748-toast-slide-ionfwsrijan/README.md
+++ b/submissions/examples/81748-toast-slide-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Slide-in Toast
+
+A toast notification that slides in from the edge and fades out.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #81748

--- a/submissions/examples/81748-toast-slide-ionfwsrijan/demo.html
+++ b/submissions/examples/81748-toast-slide-ionfwsrijan/demo.html
@@ -1,0 +1,18 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slide-in Toast</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <div class="toast" role="alert">
+        <span class="dot"></span>
+        <span>Message saved successfully</span>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/81748-toast-slide-ionfwsrijan/style.css
+++ b/submissions/examples/81748-toast-slide-ionfwsrijan/style.css
@@ -1,0 +1,41 @@
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  font-family: system-ui, sans-serif;
+}
+.toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: #1e293b;
+  color: #e2e8f0;
+  font-weight: 600;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  animation: slide-in 500ms ease, fade-out 500ms ease 3200ms forwards;
+}
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.6);
+  animation: pulse 1500ms ease infinite;
+}
+@keyframes slide-in {
+  from { transform: translateX(120%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+@keyframes fade-out {
+  to { transform: translateX(120%); opacity: 0; }
+}
+@keyframes pulse {
+  70% { box-shadow: 0 0 0 12px rgba(34, 197, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}


### PR DESCRIPTION
## Slide-in Toast

A toast notification that slides in from the edge and fades out.

Adds a self-contained, working CSS animation demo under `submissions/examples/81748-toast-slide-ionfwsrijan`.

Closes #81748