### PR TITLE
feat: Add Day Night Toggle animation

### DIFF
--- a/submissions/examples/81773-day-night-ionfwsrijan/README.md
+++ b/submissions/examples/81773-day-night-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Day Night Toggle
+
+A sun and moon toggle that slides and swaps between day and night.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #81773

--- a/submissions/examples/81773-day-night-ionfwsrijan/demo.html
+++ b/submissions/examples/81773-day-night-ionfwsrijan/demo.html
@@ -1,0 +1,18 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Day Night Toggle</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <label class="switch">
+        <input type="checkbox" />
+        <span class="slot"><span class="knob"></span></span>
+      </label>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/81773-day-night-ionfwsrijan/style.css
+++ b/submissions/examples/81773-day-night-ionfwsrijan/style.css
@@ -1,0 +1,38 @@
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #fde68a;
+  font-family: system-ui, sans-serif;
+}
+.switch input { position: absolute; opacity: 0; }
+.slot {
+  display: block;
+  width: 110px;
+  height: 52px;
+  border-radius: 999px;
+  background: linear-gradient(#38bdf8, #818cf8);
+  position: relative;
+  cursor: pointer;
+  transition: background 300ms ease;
+}
+.knob {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #fef08a;
+  box-shadow: 0 0 14px rgba(254, 240, 138, 0.9);
+  transition: transform 320ms cubic-bezier(0.34, 1.56, 0.64, 1), background 300ms ease;
+}
+.switch input:checked + .slot { background: linear-gradient(#0f172a, #312e81); }
+.switch input:checked + .slot .knob {
+  transform: translateX(58px);
+  background: #e2e8f0;
+  box-shadow: inset -8px -4px 0 0 #94a3b8;
+}


### PR DESCRIPTION
## Day Night Toggle

A sun and moon toggle that slides and swaps between day and night.

Adds a self-contained, working CSS animation demo under `submissions/examples/81773-day-night-ionfwsrijan`.

Closes #81773