### PR TITLE
feat: Add Fade Tooltip animation

### DIFF
--- a/submissions/examples/81775-tooltip-ionfwsrijan/README.md
+++ b/submissions/examples/81775-tooltip-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Fade Tooltip
+
+A tooltip that fades and rises into view on hover.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #81775

--- a/submissions/examples/81775-tooltip-ionfwsrijan/demo.html
+++ b/submissions/examples/81775-tooltip-ionfwsrijan/demo.html
@@ -1,0 +1,18 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fade Tooltip</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <span class="tip-wrap">
+        Hover me
+        <span class="tip">Helpful hint!</span>
+      </span>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/81775-tooltip-ionfwsrijan/style.css
+++ b/submissions/examples/81775-tooltip-ionfwsrijan/style.css
@@ -1,0 +1,37 @@
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f8fafc;
+  font-family: system-ui, sans-serif;
+}
+.tip-wrap {
+  position: relative;
+  padding: 12px 22px;
+  background: #1e293b;
+  color: #fff;
+  border-radius: 10px;
+  cursor: help;
+  font-weight: 600;
+}
+.tip {
+  position: absolute;
+  bottom: 130%;
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  background: #0ea5e9;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+.tip-wrap:hover .tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}


### PR DESCRIPTION
## Fade Tooltip

A tooltip that fades and rises into view on hover.

Adds a self-contained, working CSS animation demo under `submissions/examples/81775-tooltip-ionfwsrijan`.

Closes #81775