### PR TITLE
feat: Add Checkmark Draw animation

### DIFF
--- a/submissions/examples/81776-checkmark-draw-ionfwsrijan/README.md
+++ b/submissions/examples/81776-checkmark-draw-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Checkmark Draw
+
+A checkbox whose checkmark draws itself with a stroke animation.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #81776

--- a/submissions/examples/81776-checkmark-draw-ionfwsrijan/demo.html
+++ b/submissions/examples/81776-checkmark-draw-ionfwsrijan/demo.html
@@ -1,0 +1,21 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkmark Draw</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <label class="check">
+        <input type="checkbox" checked />
+        <span class="box">
+          <svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg>
+        </span>
+        <span class="text">Accept terms</span>
+      </label>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/81776-checkmark-draw-ionfwsrijan/style.css
+++ b/submissions/examples/81776-checkmark-draw-ionfwsrijan/style.css
@@ -1,0 +1,27 @@
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f1f5f9;
+  font-family: system-ui, sans-serif;
+}
+.check { display: inline-flex; align-items: center; gap: 12px; cursor: pointer; }
+.check input { position: absolute; opacity: 0; }
+.box {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 2px solid #94a3b8;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  transition: border-color 200ms ease, background 200ms ease;
+}
+.box svg { width: 22px; height: 22px; fill: none; stroke: #22c55e; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: 30; stroke-dashoffset: 30; }
+.check input:checked + .box { border-color: #22c55e; background: #ecfdf5; }
+.check input:checked + .box svg { animation: draw 500ms ease forwards; }
+@keyframes draw { to { stroke-dashoffset: 0; } }
+.text { font-weight: 600; color: #334155; }


### PR DESCRIPTION
## Checkmark Draw

A checkbox whose checkmark draws itself with a stroke animation.

Adds a self-contained, working CSS animation demo under `submissions/examples/81776-checkmark-draw-ionfwsrijan`.

Closes #81776