### PR TITLE
docs: add documentation for morphing card component #78315

### DIFF
--- a/submissions/docs/morphing-card-doc-ss/README.md
+++ b/submissions/docs/morphing-card-doc-ss/README.md
@@ -1,0 +1,16 @@
+# Morphing Card
+
+This documentation showcases the usage of the Morphing Card component, a dynamic card that transforms its shape and reveals content on hover.
+
+## Usage
+```html
+<div class="ease-morphing-card">
+  <div class="ease-morphing-card-inner">
+    <h3>Card Title</h3>
+    <p>Hover me to see the morphing effect.</p>
+  </div>
+</div>
+```
+
+## Why is it useful?
+This component fits EaseMotion's philosophy by providing a complex, fluid animation using pure CSS and standardized utility classes without relying on JavaScript, enhancing user engagement while maintaining high performance.

--- a/submissions/docs/morphing-card-doc-ss/demo.html
+++ b/submissions/docs/morphing-card-doc-ss/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Morphing Card Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="ease-morphing-card">
+    <div class="ease-morphing-card-inner">
+      <h3>Morphing Card</h3>
+      <p>Hover me to see the morphing effect.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/docs/morphing-card-doc-ss/style.css
+++ b/submissions/docs/morphing-card-doc-ss/style.css
@@ -1,0 +1,56 @@
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #1a1a2e;
+  font-family: sans-serif;
+  color: #fff;
+}
+
+.ease-morphing-card {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background: linear-gradient(135deg, #00c6ff, #0072ff);
+  border-radius: 50%;
+  transition: all 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.ease-morphing-card:hover {
+  width: 300px;
+  height: 400px;
+  border-radius: 20px;
+}
+
+.ease-morphing-card-inner {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.4s ease-out;
+  transition-delay: 0s;
+  text-align: center;
+  padding: 20px;
+}
+
+.ease-morphing-card:hover .ease-morphing-card-inner {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0.2s;
+}
+
+.ease-morphing-card-inner h3 {
+  margin: 0 0 10px 0;
+  font-size: 1.5rem;
+}
+
+.ease-morphing-card-inner p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds documentation and a showcase for the **Morphing Card** component, resolving issue #78315. It includes a fully functional pure CSS hover transformation that expands the card and gracefully reveals inner content.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds a usage demonstration of the Morphing Card component, which transforms its shape and smoothly fades in hidden content on hover.

**How does a developer use it?**

```html
<div class="ease-morphing-card">
  <div class="ease-morphing-card-inner">
    <h3>Card Title</h3>
    <p>Hover me to see the morphing effect.</p>
  </div>
</div>
