### PR TITLE
feat: add ease-drag-photo-stack-shuffle-sap - shuffling photo stack

### DIFF
--- a/submissions/examples/ease-drag-photo-stack-shuffle-sap/README.md
+++ b/submissions/examples/ease-drag-photo-stack-shuffle-sap/README.md
@@ -1,0 +1,25 @@
+## Summary
+Adds `ease-drag-photo-stack-shuffle-sap`, a photo stack that shuffles the top image to the back.
+
+## Changes
+- New `.photo-stack-sap` class driven by `--i`
+- Demo with shuffle-to-back button
+- README noting the click-vs-drag interaction choice
+
+## Why
+Physical photo-stack browsing is a charming interaction for galleries/portfolios.
+
+## Testing
+Verified shuffle animation, re-stacking order, and z-index correctness after multiple shuffles.
+
+## Level
+Intermediate — custom-property-driven stacking with reordering logic.
+
+## Checklist
+- [x] Includes `README.md`
+- [x] No changes to `core/`
+- [x] No changes to `components/`
+- [x] One feature per PR
+
+@SAPTARSHI-coder Please review the submission
+@github-actions Please validate the submission

--- a/submissions/examples/ease-drag-photo-stack-shuffle-sap/demo.html
+++ b/submissions/examples/ease-drag-photo-stack-shuffle-sap/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-drag-photo-stack-shuffle-sap demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="photo-stack-sap" id="stack">
+    <img src="https://picsum.photos/id/1015/220/150" style="--i:0;">
+    <img src="https://picsum.photos/id/1016/220/150" style="--i:1;">
+    <img src="https://picsum.photos/id/1018/220/150" style="--i:2;">
+  </div>
+  <button onclick="shuffleTop()">Shuffle to Back</button>
+
+  <script>
+    function shuffleTop() {
+      const stack = document.getElementById('stack');
+      const top = stack.querySelector('img');
+      top.classList.add('sending-back');
+      setTimeout(() => {
+        top.classList.remove('sending-back');
+        stack.appendChild(top);
+        [...stack.children].forEach((img, i) => img.style.setProperty('--i', i));
+      }, 350);
+    }
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-photo-stack-shuffle-sap/style.css
+++ b/submissions/examples/ease-drag-photo-stack-shuffle-sap/style.css
@@ -1,0 +1,24 @@
+.photo-stack-sap {
+  position: relative;
+  width: 220px;
+  height: 150px;
+}
+
+.photo-stack-sap img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.2);
+  cursor: grab;
+  transform: rotate(calc(var(--i) * 3deg)) translate(calc(var(--i) * 6px), calc(var(--i) * 6px));
+  transition: transform 0.35s ease, opacity 0.35s ease;
+  z-index: calc(10 - var(--i));
+}
+
+.photo-stack-sap img.sending-back {
+  transform: translateY(-40px) rotate(15deg);
+  opacity: 0.3;
+}


### PR DESCRIPTION
## Summary
Adds `ease-drag-photo-stack-shuffle-sap`, a photo stack that shuffles the top image to the back.

## Changes
- New `.photo-stack-sap` class driven by `--i`
- Demo with shuffle-to-back button
- README noting the click-vs-drag interaction choice

## Why
Physical photo-stack browsing is a charming interaction for galleries/portfolios.

## Testing
Verified shuffle animation, re-stacking order, and z-index correctness after multiple shuffles.

## Level
Intermediate — custom-property-driven stacking with reordering logic.

## Checklist
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

@SAPTARSHI-coder Please review the submission
@github-actions Please validate the submission