### PR TITLE
docs: document usage for Morphing Sidebar #78379

### DIFF
--- a/submissions/docs/morphing-sidebar-78379/README.md
+++ b/submissions/docs/morphing-sidebar-78379/README.md
@@ -1,0 +1,19 @@
+# Morphing Sidebar
+
+### What does this do?
+This is a morphing sidebar component that smoothly animates between a collapsed icon-only state and an expanded full-text state on hover.
+
+### How is it used?
+```html
+<aside class="morphing-sidebar">
+  <nav class="sidebar-nav">
+    <a href="#" class="nav-item">
+      <span class="icon">🏠</span>
+      <span class="text">Home</span>
+    </a>
+  </nav>
+</aside>
+```
+
+### Why is it useful?
+It provides a space-saving navigation pattern that elegantly reveals its contents, fitting EaseMotion's philosophy of smooth, purposeful micro-interactions and ensuring an engaging user experience without taking up too much screen space initially.

--- a/submissions/docs/morphing-sidebar-78379/demo.html
+++ b/submissions/docs/morphing-sidebar-78379/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morphing Sidebar Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="layout">
+        <aside class="morphing-sidebar">
+            <nav class="sidebar-nav">
+                <a href="#" class="nav-item">
+                    <span class="icon">🏠</span>
+                    <span class="text">Home</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="icon">📊</span>
+                    <span class="text">Dashboard</span>
+                </a>
+                <a href="#" class="nav-item">
+                    <span class="icon">⚙️</span>
+                    <span class="text">Settings</span>
+                </a>
+            </nav>
+        </aside>
+        <main class="main-content">
+            <h1>Morphing Sidebar</h1>
+            <p>Hover over the sidebar to expand it.</p>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/docs/morphing-sidebar-78379/style.css
+++ b/submissions/docs/morphing-sidebar-78379/style.css
@@ -1,0 +1,74 @@
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: #f4f4f5;
+}
+
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+.morphing-sidebar {
+    width: 64px;
+    background-color: #18181b;
+    color: white;
+    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 0;
+}
+
+.morphing-sidebar:hover {
+    width: 240px;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    color: #a1a1aa;
+    text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease;
+    white-space: nowrap;
+}
+
+.nav-item:hover {
+    color: white;
+    background-color: #27272a;
+}
+
+.nav-item .icon {
+    width: 32px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.25rem;
+    flex-shrink: 0;
+}
+
+.nav-item .text {
+    margin-left: 1rem;
+    opacity: 0;
+    transform: translateX(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition-delay: 0s;
+}
+
+.morphing-sidebar:hover .nav-item .text {
+    opacity: 1;
+    transform: translateX(0);
+    transition-delay: 0.1s;
+}
+
+.main-content {
+    flex: 1;
+    padding: 2rem;
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds documentation and a usage example for the **Morphing Sidebar** component. It smoothly animates between a collapsed icon-only state and an expanded full-text state on hover, saving screen space while remaining accessible.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A morphing sidebar component that smoothly animates between a collapsed icon-only state and an expanded full-text state on hover.

**How does a developer use it?**

```html
<aside class="morphing-sidebar">
  <nav class="sidebar-nav">
    <a href="#" class="nav-item">
      <span class="icon">🏠</span>
      <span class="text">Home</span>
    </a>
  </nav>
</aside>
