### PR TITLE
feat: add ease-card-team-hover-reveal-sap - layered team card hover r…

### DIFF
--- a/submissions/examples/ease-card-team-hover-reveal-sap/README.md
+++ b/submissions/examples/ease-card-team-hover-reveal-sap/README.md
@@ -1,0 +1,27 @@
+# ease-card-team-hover-reveal-sap
+
+**Level: Intermediate**
+
+A team-member card where name/title are always partially visible, and social links reveal further on hover.
+
+## Usage
+
+```html
+<div class="team-card-sap">
+  <img src="member.jpg" alt="...">
+  <div class="team-info-sap">
+    <h4>Name</h4>
+    <p>Role</p>
+    <div class="team-social-sap">Social links</div>
+  </div>
+</div>
+```
+
+## Notes
+
+- Info panel starts partially visible (`translateY(60%)`) so name/title show by default — only the social row is fully hidden until hover.
+- Social row fades in with a slight delay (`0.1s`) after the panel slides up, for a layered reveal feel.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/ease-card-team-hover-reveal-sap/demo.html
+++ b/submissions/examples/ease-card-team-hover-reveal-sap/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-card-team-hover-reveal-sap demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="team-card-sap">
+    <img src="https://i.pravatar.cc/220?img=12" alt="Team member">
+    <div class="team-info-sap">
+      <h4>Alex Rivera</h4>
+      <p>Product Designer</p>
+      <div class="team-social-sap">Twitter · LinkedIn</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-card-team-hover-reveal-sap/style.css
+++ b/submissions/examples/ease-card-team-hover-reveal-sap/style.css
@@ -1,0 +1,38 @@
+.team-card-sap {
+  position: relative;
+  width: 220px;
+  overflow: hidden;
+  border-radius: 12px;
+}
+
+.team-card-sap img {
+  display: block;
+  width: 100%;
+}
+
+.team-info-sap {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 16px;
+  background: linear-gradient(to top, rgba(0,0,0,0.85), transparent);
+  color: #fff;
+  transform: translateY(60%);
+  transition: transform 0.4s ease;
+}
+
+.team-card-sap:hover .team-info-sap {
+  transform: translateY(0);
+}
+
+.team-social-sap {
+  font-size: 12px;
+  opacity: 0;
+  margin-top: 6px;
+  transition: opacity 0.3s ease 0.1s;
+}
+
+.team-card-sap:hover .team-social-sap {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
Adds `ease-card-team-hover-reveal-sap`, a layered hover-reveal team member card.

## Changes
- New `.team-card-sap` / `.team-info-sap` / `.team-social-sap` classes
- Demo with a sample team member card
- README explaining the layered reveal timing

## Why
"About us" / team pages commonly need this pattern — always-visible name with progressive disclosure of extra info on hover.

## Testing
Verified partial-visible default state and full reveal + delayed social fade-in on hover.

## Level
Intermediate — layered transform + delayed opacity transitions.

## Checklist
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

@SAPTARSHI-coder Please review the submission
@github-actions Please validate the submission