### PR TITLE
perf: add will-change GPU memory benchmark

### DIFF
--- a/submissions/examples/will-change-gpu-memory-82097/README.md
+++ b/submissions/examples/will-change-gpu-memory-82097/README.md
@@ -1,0 +1,86 @@
+# CSS Will-Change GPU Memory Overhead Benchmark
+
+A responsive performance benchmark created for issue #82097.
+
+## Overview
+
+This example provides a controlled rendering workload for evaluating
+the performance impact of CSS `will-change` during animated transforms.
+
+The demo compares:
+
+- Normal transform rendering
+- Rendering with `will-change: transform`
+
+The benchmark reports:
+
+- FPS
+- CSS bundle size in bytes
+- Execution time in milliseconds
+- Performance budget status
+
+## Performance Budget
+
+| Metric | Threshold |
+| --- | ---: |
+| Minimum FPS | 50 FPS |
+| Maximum CSS bundle size | 50 KB |
+| Maximum execution time | 2000 ms |
+
+The benchmark passes only when all configured thresholds are satisfied.
+
+## Files
+
+- `demo.html` — Interactive rendering benchmark.
+- `style.css` — Original responsive benchmark styling.
+- `README.md` — Benchmark documentation.
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+The page contains two rendering workloads:
+
+1. Normal rendering without explicit `will-change`.
+2. Rendering using `will-change: transform`.
+
+Click **Run GPU Benchmark** to execute the animation workload.
+
+The benchmark displays:
+
+- Measured FPS
+- CSS bundle size
+- Execution time
+- PASS or FAIL status
+
+A detailed metrics table is also written to the browser console.
+
+## Will-Change Consideration
+
+`will-change` can allow the browser to prepare an element for changes,
+but excessive use may result in unnecessary layer promotion and increased
+resource usage.
+
+For this reason, `will-change` should be applied selectively to elements
+that are expected to change.
+
+## Headless Chrome / Puppeteer
+
+The page can be loaded by a Headless Chrome Puppeteer runner:
+
+```js
+const browser = await puppeteer.launch({
+  headless: true
+});
+
+const page = await browser.newPage();
+
+await page.setViewport({
+  width: 1280,
+  height: 900,
+  deviceScaleFactor: 1
+});
+
+await page.goto("file:///path/to/demo.html", {
+  waitUntil: "load"
+});

--- a/submissions/examples/will-change-gpu-memory-82097/demo.html
+++ b/submissions/examples/will-change-gpu-memory-82097/demo.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Will-Change GPU Memory Benchmark</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <header class="hero">
+      <span class="eyebrow">CI PERFORMANCE BENCHMARK</span>
+      <h1>Will-Change GPU Memory</h1>
+      <p>
+        A controlled workload for comparing rendering performance and
+        memory overhead caused by CSS will-change promotion.
+      </p>
+    </header>
+
+    <section class="metrics" aria-label="Benchmark metrics">
+      <article class="metric">
+        <span>FPS</span>
+        <strong id="fps">--</strong>
+        <small>Minimum: 50 FPS</small>
+      </article>
+
+      <article class="metric">
+        <span>Bundle</span>
+        <strong id="bundle">--</strong>
+        <small>Maximum: 50 KB</small>
+      </article>
+
+      <article class="metric">
+        <span>Execution</span>
+        <strong id="execution">--</strong>
+        <small>Maximum: 2000 ms</small>
+      </article>
+
+      <article class="metric">
+        <span>Status</span>
+        <strong id="status">READY</strong>
+        <small id="statusText">Awaiting benchmark</small>
+      </article>
+    </section>
+
+    <section class="controls">
+      <button id="runBenchmark">Run GPU Benchmark</button>
+      <span id="message">Ready to measure the workload.</span>
+    </section>
+
+    <section class="comparison">
+      <article class="panel without-hint">
+        <div class="panel-heading">
+          <span>01</span>
+          <h2>Normal Rendering</h2>
+        </div>
+
+        <div class="stage" id="normalStage">
+          <div class="orb"></div>
+          <div class="orb"></div>
+          <div class="orb"></div>
+          <div class="orb"></div>
+        </div>
+
+        <p>
+          Elements are animated without explicit will-change promotion.
+        </p>
+      </article>
+
+      <article class="panel with-hint">
+        <div class="panel-heading">
+          <span>02</span>
+          <h2>Will-Change Rendering</h2>
+        </div>
+
+        <div class="stage" id="willChangeStage">
+          <div class="orb promoted"></div>
+          <div class="orb promoted"></div>
+          <div class="orb promoted"></div>
+          <div class="orb promoted"></div>
+        </div>
+
+        <p>
+          Elements use <code>will-change: transform</code> to request
+          compositor promotion.
+        </p>
+      </article>
+    </section>
+
+    <section class="memory-info">
+      <h2>GPU Memory Consideration</h2>
+      <p>
+        The <code>will-change</code> property can improve animation
+        smoothness but excessive layer promotion may increase GPU memory
+        consumption. This example provides a controlled workload for
+        performance testing.
+      </p>
+    </section>
+  </main>
+
+  <script>
+    const button = document.getElementById("runBenchmark");
+    const normalStage = document.getElementById("normalStage");
+    const willChangeStage = document.getElementById("willChangeStage");
+
+    const fpsOutput = document.getElementById("fps");
+    const bundleOutput = document.getElementById("bundle");
+    const executionOutput = document.getElementById("execution");
+    const statusOutput = document.getElementById("status");
+    const statusText = document.getElementById("statusText");
+    const message = document.getElementById("message");
+
+    const BUDGET = {
+      minimumFps: 50,
+      maximumBundleBytes: 50 * 1024,
+      maximumExecutionMs: 2000
+    };
+
+    button.addEventListener("click", async () => {
+      button.disabled = true;
+      statusOutput.textContent = "RUNNING";
+      statusText.textContent = "Animating compositor workload";
+      message.textContent = "Collecting frame metrics...";
+
+      const start = performance.now();
+      const duration = 1000;
+      let frames = 0;
+
+      await new Promise((resolve) => {
+        const animationStart = performance.now();
+
+        function render(time) {
+          frames++;
+
+          const elapsed = time - animationStart;
+          const angle = elapsed / 140;
+
+          const normalX = Math.sin(angle) * 80;
+          const normalY = Math.cos(angle) * 25;
+
+          const promotedX = Math.cos(angle) * 80;
+          const promotedY = Math.sin(angle) * 25;
+
+          normalStage.style.setProperty(
+            "--motion-x",
+            `${normalX}px`
+          );
+
+          normalStage.style.setProperty(
+            "--motion-y",
+            `${normalY}px`
+          );
+
+          willChangeStage.style.setProperty(
+            "--motion-x",
+            `${promotedX}px`
+          );
+
+          willChangeStage.style.setProperty(
+            "--motion-y",
+            `${promotedY}px`
+          );
+
+          if (elapsed < duration) {
+            requestAnimationFrame(render);
+          } else {
+            resolve();
+          }
+        }
+
+        requestAnimationFrame(render);
+      });
+
+      const executionMs = performance.now() - start;
+      const fps = Math.round(frames);
+
+      let bundleBytes = 0;
+
+      try {
+        const response = await fetch("style.css", {
+          cache: "no-store"
+        });
+
+        const css = await response.text();
+        bundleBytes = new Blob([css]).size;
+      } catch (error) {
+        console.warn("Unable to measure stylesheet:", error);
+      }
+
+      const passed =
+        fps >= BUDGET.minimumFps &&
+        bundleBytes <= BUDGET.maximumBundleBytes &&
+        executionMs <= BUDGET.maximumExecutionMs;
+
+      fpsOutput.textContent = fps;
+      bundleOutput.textContent =
+        `${(bundleBytes / 1024).toFixed(2)} KB`;
+      executionOutput.textContent =
+        `${Math.round(executionMs)} ms`;
+
+      statusOutput.textContent =
+        passed ? "PASS" : "FAIL";
+
+      statusText.textContent = passed
+        ? "Performance budget passed"
+        : "Performance budget failed";
+
+      message.textContent = passed
+        ? "Benchmark completed successfully."
+        : "One or more thresholds were exceeded.";
+
+      console.table({
+        fps,
+        bundleSizeBytes: bundleBytes,
+        executionMs: Number(executionMs.toFixed(2)),
+        minimumFps: BUDGET.minimumFps,
+        maximumBundleBytes: BUDGET.maximumBundleBytes,
+        maximumExecutionMs: BUDGET.maximumExecutionMs,
+        passed
+      });
+
+      button.disabled = false;
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/will-change-gpu-memory-82097/style.css
+++ b/submissions/examples/will-change-gpu-memory-82097/style.css
@@ -1,0 +1,299 @@
+:root {
+  --background: #080c14;
+  --surface: #121925;
+  --surface-alt: #182131;
+  --border: #2a374a;
+  --text: #f5f8ff;
+  --muted: #94a1b4;
+  --accent: #7ab0ff;
+  --motion-x: 0px;
+  --motion-y: 0px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 10%,
+      #203b60 0,
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      #342b58 0,
+      transparent 32%
+    ),
+    var(--background);
+}
+
+.page {
+  width: min(1180px, calc(100% - 32px));
+  margin: auto;
+  padding: 64px 0;
+}
+
+.hero {
+  max-width: 760px;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+h1 {
+  margin: 12px 0;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+}
+
+.hero p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.metric {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+}
+
+.metric span,
+.metric small {
+  display: block;
+  color: var(--muted);
+}
+
+.metric span {
+  margin-bottom: 8px;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  display: block;
+  margin-bottom: 7px;
+  font-size: 1.6rem;
+}
+
+.metric small {
+  font-size: 0.75rem;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+button {
+  padding: 12px 20px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+#message {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+
+.panel {
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel-heading span {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.stage {
+  position: relative;
+  height: 240px;
+  margin: 22px 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background:
+    linear-gradient(
+      145deg,
+      #192233,
+      #0d121b
+    );
+}
+
+.orb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle at 30% 25%,
+      #d5e8ff,
+      #6b9cff 35%,
+      #334d86 75%
+    );
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.3);
+  transform:
+    translate(
+      calc(-50% + var(--motion-x)),
+      calc(-50% + var(--motion-y))
+    );
+}
+
+.orb:nth-child(2) {
+  width: 46px;
+  height: 46px;
+  opacity: 0.8;
+  transform:
+    translate(
+      calc(-50% + var(--motion-y)),
+      calc(-50% - var(--motion-x))
+    );
+}
+
+.orb:nth-child(3) {
+  width: 38px;
+  height: 38px;
+  opacity: 0.65;
+  transform:
+    translate(
+      calc(-50% - var(--motion-x)),
+      calc(-50% + var(--motion-y))
+    );
+}
+
+.orb:nth-child(4) {
+  width: 30px;
+  height: 30px;
+  opacity: 0.5;
+}
+
+.promoted {
+  will-change: transform;
+}
+
+.panel p,
+.memory-info p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+code {
+  padding: 2px 5px;
+  border-radius: 5px;
+  background: #202b3c;
+  color: var(--accent);
+}
+
+.memory-info {
+  margin-top: 18px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+}
+
+.memory-info h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+@media (max-width: 850px) {
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .comparison {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    width: min(100% - 20px, 1180px);
+    padding: 40px 0;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Description

Added a responsive CSS `will-change` GPU memory/performance benchmark
for issue #82097.

### Included

- Normal versus `will-change: transform` rendering workloads
- FPS measurement
- CSS bundle-size measurement
- Execution-time measurement
- Performance budget validation
- Headless Chrome/Puppeteer integration guidance
- Responsive benchmark demo
- Reproducible benchmark configuration

### Performance Budgets

- Minimum FPS: 50
- Maximum CSS bundle size: 50 KB
- Maximum execution time: 2000 ms

### Files

- `demo.html` — Interactive GPU rendering benchmark
- `style.css` — Responsive `will-change` benchmark styling
- `README.md` — Benchmark and CI documentation

### Issue

Closes #82097