### PR TITLE
feat: add ease-scroll-fade-in-stagger-list-sap - staggered list scrol…

### DIFF
--- a/submissions/examples/ease-scroll-fade-in-stagger-list-sap/README.md
+++ b/submissions/examples/ease-scroll-fade-in-stagger-list-sap/README.md
@@ -1,0 +1,25 @@
+# ease-scroll-fade-in-stagger-list-sap
+
+**Level: Intermediate**
+
+A list where items fade/slide in one after another as the list scrolls into view.
+
+## Usage
+
+```html
+<ul class="stagger-list-sap">
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+```
+
+Requires the `IntersectionObserver` in `demo.html`, which assigns a staggered `transition-delay` to each item based on its index.
+
+## Notes
+
+- Delay is `index * 0.1s` — increase the multiplier for a slower cascade, decrease for a snappier one.
+- Each item is observed individually, so the effect works correctly even if only part of a long list is initially in the viewport.
+
+## Browser support
+
+All modern browsers with `IntersectionObserver` support.

--- a/submissions/examples/ease-scroll-fade-in-stagger-list-sap/demo.html
+++ b/submissions/examples/ease-scroll-fade-in-stagger-list-sap/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-scroll-fade-in-stagger-list-sap demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <ul class="stagger-list-sap">
+    <li>First item</li>
+    <li>Second item</li>
+    <li>Third item</li>
+    <li>Fourth item</li>
+  </ul>
+
+  <script>
+    const items = document.querySelectorAll('.stagger-list-sap li');
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.style.transitionDelay = (entry.target.dataset.i * 0.1) + 's';
+          entry.target.classList.add('visible');
+        }
+      });
+    }, { threshold: 0.2 });
+    items.forEach((li, i) => {
+      li.dataset.i = i;
+      observer.observe(li);
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-fade-in-stagger-list-sap/style.css
+++ b/submissions/examples/ease-scroll-fade-in-stagger-list-sap/style.css
@@ -1,0 +1,19 @@
+.stagger-list-sap {
+  list-style: none;
+  padding: 0;
+}
+
+.stagger-list-sap li {
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.stagger-list-sap li.visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
Adds `ease-scroll-fade-in-stagger-list-sap`, a scroll-triggered staggered list reveal.

## Changes
- New `.stagger-list-sap` class
- Demo with IntersectionObserver assigning per-item delays
- README with delay-tuning note

## Why
Staggered list reveals are a common and effective way to draw attention to feature lists or content sections on scroll.

## Testing
Verified staggered timing across items and correct triggering for partially-visible lists.

## Level
Intermediate — per-item IntersectionObserver with dynamically assigned transition-delay.

## Checklist
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

@SAPTARSHI-coder Please review the submission
@github-actions Please validate the submission