### PR TITLE
feat: add ease-animated-breadcrumb-slide-sap - sequential breadcrumb …

### DIFF
--- a/submissions/examples/ease-animated-breadcrumb-slide-sap/README.md
+++ b/submissions/examples/ease-animated-breadcrumb-slide-sap/README.md
@@ -1,0 +1,26 @@
+# ease-animated-breadcrumb-slide-sap
+
+**Level: Beginner**
+
+A breadcrumb trail where each segment slides in sequentially on page load, instead of appearing all at once.
+
+## Usage
+
+```html
+<nav class="breadcrumb-slide-sap">
+  <a href="#">Home</a>
+  <span class="sep-sap">/</span>
+  <a href="#">Category</a>
+  <span class="sep-sap">/</span>
+  <span class="current-sap">Current Page</span>
+</nav>
+```
+
+## Notes
+
+- Delays are hardcoded per `nth-child` position (0s, 0.1s, 0.2s...) — for breadcrumbs with more than 5 segments, extend the `nth-child` rules or switch to a JS-assigned delay like in `ease-scroll-fade-in-stagger-list-sap`.
+- The `current-sap` span (final crumb) is styled differently to indicate the active page.
+
+## Browser support
+
+All modern browsers.

--- a/submissions/examples/ease-animated-breadcrumb-slide-sap/demo.html
+++ b/submissions/examples/ease-animated-breadcrumb-slide-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ease-animated-breadcrumb-slide-sap demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="breadcrumb-slide-sap">
+    <a href="#">Home</a>
+    <span class="sep-sap">/</span>
+    <a href="#">Products</a>
+    <span class="sep-sap">/</span>
+    <span class="current-sap">Wireless Headphones</span>
+  </nav>
+</body>
+</html>

--- a/submissions/examples/ease-animated-breadcrumb-slide-sap/style.css
+++ b/submissions/examples/ease-animated-breadcrumb-slide-sap/style.css
@@ -1,0 +1,36 @@
+.breadcrumb-slide-sap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.breadcrumb-slide-sap a,
+.breadcrumb-slide-sap span {
+  opacity: 0;
+  transform: translateX(-10px);
+  animation: breadcrumb-in-sap 0.4s ease forwards;
+}
+
+.breadcrumb-slide-sap a:nth-child(1) { animation-delay: 0s; }
+.breadcrumb-slide-sap span:nth-child(2) { animation-delay: 0.1s; }
+.breadcrumb-slide-sap a:nth-child(3) { animation-delay: 0.2s; }
+.breadcrumb-slide-sap span:nth-child(4) { animation-delay: 0.3s; }
+.breadcrumb-slide-sap span:nth-child(5) { animation-delay: 0.4s; }
+
+.breadcrumb-slide-sap a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.breadcrumb-slide-sap .current-sap {
+  color: #555;
+  font-weight: 600;
+}
+
+@keyframes breadcrumb-in-sap {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
## Summary
Adds `ease-animated-breadcrumb-slide-sap`, a sequential slide-in animation for breadcrumb trails.

## Changes
- New `.breadcrumb-slide-sap` class with per-segment animation delays
- Demo with a 3-level breadcrumb trail
- README noting the nth-child delay limitation for longer trails

## Why
Breadcrumbs are a small UI element that benefit from a subtle load-in animation, especially on content-heavy pages.

## Testing
Verified sequential timing across all breadcrumb segments and separators.

## Level
Beginner — keyframe animation with nth-child-based delay staggering.

## Checklist
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

@SAPTARSHI-coder Please review the submission
@github-actions Please validate the submission