### PR TITLE
feat: add ease-tooltip-rich-preview-sap

### DIFF
--- a/submissions/examples/ease-tooltip-rich-preview-sap/README.md
+++ b/submissions/examples/ease-tooltip-rich-preview-sap/README.md
@@ -1,0 +1,18 @@
+# ease-tooltip-rich-preview-sap
+
+A rich hover tooltip showing an image + text preview card above a link, rather than plain single-line tooltip text. Pure CSS, opacity/transform-based reveal.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Wrap link text with `.tooltip-preview-sap__card` containing your image/text, matching `demo.html`.
+
+## Customization
+- Change `width: 240px` on the card to resize the preview.
+- Adjust the `bottom: calc(100% + 12px)` offset to change gap above the trigger.
+- Swap `.tooltip-preview-sap__img` for any preview content.
+
+## Accessibility
+Reveals on `:focus-visible` as well as `:hover` for keyboard users. Respects `prefers-reduced-motion`.
+
+## Browser support
+All modern browsers.

--- a/submissions/examples/ease-tooltip-rich-preview-sap/demo.html
+++ b/submissions/examples/ease-tooltip-rich-preview-sap/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-tooltip-rich-preview-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <a href="#" class="tooltip-preview-sap">
+      Hover this link
+      <span class="tooltip-preview-sap__card">
+        <img src="https://picsum.photos/seed/sap/80/80" alt="" class="tooltip-preview-sap__img">
+        <span class="tooltip-preview-sap__text">
+          <strong>Rich Preview</strong>
+          <span>A short description shown on hover.</span>
+        </span>
+      </span>
+    </a>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-rich-preview-sap/style.css
+++ b/submissions/examples/ease-tooltip-rich-preview-sap/style.css
@@ -1,0 +1,59 @@
+.tooltip-preview-sap {
+  position: relative;
+  display: inline-block;
+  color: #43e0d8;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.tooltip-preview-sap__card {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 6px);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  width: 240px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #16161c;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.4);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.tooltip-preview-sap:hover .tooltip-preview-sap__card,
+.tooltip-preview-sap:focus-visible .tooltip-preview-sap__card {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.tooltip-preview-sap__img {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.tooltip-preview-sap__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 13px;
+  color: #d0d0d8;
+}
+
+.tooltip-preview-sap__text strong {
+  color: #fff;
+  font-size: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-preview-sap__card { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-tooltip-rich-preview-sap`, a rich image+text hover preview tooltip.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` boilerplate, self-contained.
- Reveal driven by `opacity`/`visibility`/`transform`, keeping the card out of the accessibility tree and unclickable when hidden (`pointer-events: none`).
- `:focus-visible` included alongside `:hover` so keyboard users can trigger the preview.

## Feature Description
Adds a reusable rich preview tooltip for links/cards needing more context than plain text.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.