### PR TITLE
feat: add ease-hover-button-icon-slide-sap

### DIFF
--- a/submissions/examples/ease-hover-button-icon-slide-sap/README.md
+++ b/submissions/examples/ease-hover-button-icon-slide-sap/README.md
@@ -1,0 +1,18 @@
+# ease-hover-button-icon-slide-sap
+
+A button whose arrow icon slides in and fades in from the left on hover, rather than being always visible — draws the eye toward the CTA direction.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.btn-icon-slide-sap` markup from `demo.html`, replacing the icon glyph as needed.
+
+## Customization
+- Swap the `&#8594;` glyph for an SVG/icon-font icon.
+- Adjust `max-width: 24px` in the hover state to fit a wider icon.
+- Change the `0.3s cubic-bezier(...)` transition for a snappier/softer slide.
+
+## Accessibility
+Icon is decorative; add `aria-hidden="true"` to the icon span if it doesn't convey unique meaning beyond the label text.
+
+## Browser support
+All modern browsers.

--- a/submissions/examples/ease-hover-button-icon-slide-sap/demo.html
+++ b/submissions/examples/ease-hover-button-icon-slide-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-hover-button-icon-slide-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <button class="btn-icon-slide-sap">
+      <span class="btn-icon-slide-sap__label">Continue</span>
+      <span class="btn-icon-slide-sap__icon">&#8594;</span>
+    </button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-button-icon-slide-sap/style.css
+++ b/submissions/examples/ease-hover-button-icon-slide-sap/style.css
@@ -1,0 +1,34 @@
+.btn-icon-slide-sap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 24px;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #6d5efc, #43e0d8);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.btn-icon-slide-sap__icon {
+  display: inline-block;
+  transform: translateX(-8px);
+  opacity: 0;
+  max-width: 0;
+  transition: transform 0.3s cubic-bezier(0.4, 0.2, 0.2, 1),
+              opacity 0.25s ease,
+              max-width 0.3s ease;
+}
+
+.btn-icon-slide-sap:hover .btn-icon-slide-sap__icon {
+  transform: translateX(0);
+  opacity: 1;
+  max-width: 24px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-icon-slide-sap__icon { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-hover-button-icon-slide-sap`, a button with a hover-triggered sliding/fading icon.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` boilerplate, self-contained.
- Icon reveal combines `transform`, `opacity`, and `max-width` so the button doesn't reflow abruptly — width animates alongside the slide instead of popping in.
- No JS — hover-only via `:hover`.

## Feature Description
Adds a reusable hover button where a directional icon slides/fades in to reinforce the CTA.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.