### PR TITLE
feat: add basic delivery option row demo

### DIFF
--- a/submissions/examples/basic-delivery-option-row-kk/README.md
+++ b/submissions/examples/basic-delivery-option-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Delivery Option Row
+
+## What it does
+
+This submission adds a simple CSS-only delivery option row for checkout pages,
+shipping selectors, pickup flows, and ecommerce order forms.
+
+It presents a delivery method icon, method name, arrival estimate, price, and
+availability state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an icon, copy area, price label, and state pill:
+
+```html
+<article class="basic-delivery-option-row is-selected">
+  <span class="delivery-icon" aria-hidden="true">ST</span>
+  <div class="delivery-copy">
+    <strong>Standard delivery</strong>
+    <p>Arrives in 3-5 business days</p>
+  </div>
+  <span class="delivery-price">Free</span>
+  <span class="delivery-state is-selected">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+checkout interfaces. The row can be reused in shipping selectors, order forms,
+cart pages, and pickup panels while staying lightweight and CSS-only.
+
+## Included features
+
+- Standard, express, and pickup delivery examples
+- Selected, available, and pickup state pills
+- Delivery price metadata
+- Long text truncation for delivery details
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the delivery option row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-delivery-option-row-kk/demo.html
+++ b/submissions/examples/basic-delivery-option-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Delivery Option Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Delivery Option Row</p>
+          <h1>Checkout rows for shipping and pickup choices.</h1>
+          <p class="intro">
+            A CSS-only row component for showing delivery method, arrival
+            estimate, helper copy, price, and selected state.
+          </p>
+        </header>
+
+        <section class="delivery-panel" aria-label="Delivery option row examples">
+          <article class="basic-delivery-option-row is-selected">
+            <span class="delivery-icon" aria-hidden="true">ST</span>
+            <div class="delivery-copy">
+              <strong>Standard delivery</strong>
+              <p>Arrives in 3-5 business days</p>
+            </div>
+            <span class="delivery-price">Free</span>
+            <span class="delivery-state is-selected">Selected</span>
+          </article>
+
+          <article class="basic-delivery-option-row">
+            <span class="delivery-icon is-express" aria-hidden="true">EX</span>
+            <div class="delivery-copy">
+              <strong>Express delivery</strong>
+              <p>Arrives tomorrow before 8 PM</p>
+            </div>
+            <span class="delivery-price">$8.99</span>
+            <span class="delivery-state">Available</span>
+          </article>
+
+          <article class="basic-delivery-option-row">
+            <span class="delivery-icon is-pickup" aria-hidden="true">PU</span>
+            <div class="delivery-copy">
+              <strong>Store pickup</strong>
+              <p>Ready today from the nearest location</p>
+            </div>
+            <span class="delivery-price">Free</span>
+            <span class="delivery-state is-pickup">Pickup</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-delivery-option-row is-selected"&gt;
+  &lt;span class="delivery-icon" aria-hidden="true"&gt;ST&lt;/span&gt;
+  &lt;div class="delivery-copy"&gt;
+    &lt;strong&gt;Standard delivery&lt;/strong&gt;
+    &lt;p&gt;Arrives in 3-5 business days&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="delivery-price"&gt;Free&lt;/span&gt;
+  &lt;span class="delivery-state is-selected"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-delivery-option-row-kk/style.css
+++ b/submissions/examples/basic-delivery-option-row-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(16, 24, 40, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --standard: #93c5fd;
+  --express: #fbbf24;
+  --pickup: #86efac;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Verdana", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 14%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--standard);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.delivery-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-delivery-option-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-delivery-option-row + .basic-delivery-option-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-delivery-option-row:hover,
+.basic-delivery-option-row.is-selected {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(147, 197, 253, 0.72);
+  transform: translateX(4px);
+}
+
+.delivery-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.delivery-icon.is-express {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.delivery-icon.is-pickup {
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.delivery-copy {
+  min-width: 0;
+}
+
+.delivery-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delivery-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delivery-price,
+.delivery-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.delivery-price {
+  min-width: 4.5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.delivery-state {
+  min-width: 5.8rem;
+  color: var(--standard);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.delivery-state.is-selected {
+  color: var(--standard);
+  background: rgba(147, 197, 253, 0.18);
+}
+
+.delivery-state.is-pickup {
+  color: var(--pickup);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-delivery-option-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .delivery-price,
+  .delivery-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Delivery Option Row demo inside `submissions/examples/basic-delivery-option-row-kk/`. This submission introduces a compact CSS-only row for checkout pages, shipping selectors, pickup flows, and ecommerce order forms.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only delivery option row that displays a delivery method icon, method name, arrival estimate, price, and selected/available/pickup state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-delivery-option-row is-selected">
  <span class="delivery-icon" aria-hidden="true">ST</span>
  <div class="delivery-copy">
    <strong>Standard delivery</strong>
    <p>Arrives in 3-5 business days</p>
  </div>
  <span class="delivery-price">Free</span>
  <span class="delivery-state is-selected">Selected</span>
</article>