### PR TITLE
feat: Add Dual Ring Loader animation

### DIFF
--- a/submissions/examples/82486-dual-ring-loader-ionfwsrijan/README.md
+++ b/submissions/examples/82486-dual-ring-loader-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Dual Ring Loader
+
+Two interlocking rings spinning in opposite directions to signal loading.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82486

--- a/submissions/examples/82486-dual-ring-loader-ionfwsrijan/demo.html
+++ b/submissions/examples/82486-dual-ring-loader-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dual Ring Loader</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<div class="dr"><span></span><span></span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/82486-dual-ring-loader-ionfwsrijan/style.css
+++ b/submissions/examples/82486-dual-ring-loader-ionfwsrijan/style.css
@@ -1,0 +1,9 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.dr{position:relative;width:90px;height:90px}
+.dr span{position:absolute;inset:0;border-radius:50%;border:7px solid transparent}
+.dr span:nth-child(1){border-top-color:#5eead4;border-bottom-color:#5eead4;animation:spinA 1.1s linear infinite}
+.dr span:nth-child(2){border-left-color:#a78bfa;border-right-color:#a78bfa;animation:spinB 1.6s linear infinite}
+@keyframes spinA{to{transform:rotate(360deg)}}
+@keyframes spinB{to{transform:rotate(-360deg)}}


### PR DESCRIPTION
## Dual Ring Loader

Two interlocking rings spinning in opposite directions to signal loading.

Adds a self-contained, working CSS animation demo under `submissions/examples/82486-dual-ring-loader-ionfwsrijan`.

Closes #82486