### PR TITLE
feat: add basic status legend row demo

### DIFF
--- a/submissions/examples/basic-status-legend-row-kk/README.md
+++ b/submissions/examples/basic-status-legend-row-kk/README.md
@@ -1,0 +1,47 @@
+# Basic Status Legend Row
+
+## What it does
+
+This submission adds a simple CSS-only status legend row for dashboards, chart
+legends, map panels, system health pages, and analytics interfaces.
+
+It presents a colored legend marker, status name, helper description, item
+count, and state label in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a marker, copy area, count label, and state pill:
+
+```html
+<article class="basic-status-legend-row">
+  <span class="legend-dot is-healthy" aria-hidden="true"></span>
+  <div class="legend-copy">
+    <strong>Healthy</strong>
+    <p>All monitored services are responding normally.</p>
+  </div>
+  <span class="legend-count">24 items</span>
+  <span class="legend-state is-healthy">Stable</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+dashboard interfaces. The row can be reused in map legends, analytics cards,
+monitoring panels, and status dashboards while staying lightweight and CSS-only.
+
+## Included features
+
+- Healthy, warning, and critical legend states
+- Glowing status marker with soft halo
+- Count metadata and state pill
+- Long text truncation for descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the status legend row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-status-legend-row-kk/demo.html
+++ b/submissions/examples/basic-status-legend-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Status Legend Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Status Legend Row</p>
+          <h1>Compact legend rows for dashboards and status panels.</h1>
+          <p class="intro">
+            A CSS-only row component for explaining chart colors, map states,
+            system health indicators, and dashboard severity levels.
+          </p>
+        </header>
+
+        <section class="legend-panel" aria-label="Status legend row examples">
+          <article class="basic-status-legend-row">
+            <span class="legend-dot is-healthy" aria-hidden="true"></span>
+            <div class="legend-copy">
+              <strong>Healthy</strong>
+              <p>All monitored services are responding normally.</p>
+            </div>
+            <span class="legend-count">24 items</span>
+            <span class="legend-state is-healthy">Stable</span>
+          </article>
+
+          <article class="basic-status-legend-row">
+            <span class="legend-dot is-warning" aria-hidden="true"></span>
+            <div class="legend-copy">
+              <strong>Warning</strong>
+              <p>Some metrics need review before they become incidents.</p>
+            </div>
+            <span class="legend-count">6 items</span>
+            <span class="legend-state is-warning">Watch</span>
+          </article>
+
+          <article class="basic-status-legend-row">
+            <span class="legend-dot is-critical" aria-hidden="true"></span>
+            <div class="legend-copy">
+              <strong>Critical</strong>
+              <p>Immediate action is required for affected areas.</p>
+            </div>
+            <span class="legend-count">2 items</span>
+            <span class="legend-state is-critical">Action</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-status-legend-row"&gt;
+  &lt;span class="legend-dot is-healthy" aria-hidden="true"&gt;&lt;/span&gt;
+  &lt;div class="legend-copy"&gt;
+    &lt;strong&gt;Healthy&lt;/strong&gt;
+    &lt;p&gt;All monitored services are responding normally.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="legend-count"&gt;24 items&lt;/span&gt;
+  &lt;span class="legend-state is-healthy"&gt;Stable&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-status-legend-row-kk/style.css
+++ b/submissions/examples/basic-status-legend-row-kk/style.css
@@ -1,0 +1,202 @@
+:root {
+  color-scheme: dark;
+  --page: #0a0f1c;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --healthy: #86efac;
+  --warning: #fcd34d;
+  --critical: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Optima", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(252, 165, 165, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--healthy);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.legend-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-status-legend-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-status-legend-row + .basic-status-legend-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-status-legend-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.7);
+  transform: translateX(4px);
+}
+
+.legend-dot {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  color: var(--healthy);
+  background: currentColor;
+  box-shadow:
+    0 0 0 0.38rem rgba(134, 239, 172, 0.12),
+    0 0 1rem currentColor;
+}
+
+.legend-dot.is-warning {
+  color: var(--warning);
+  box-shadow:
+    0 0 0 0.38rem rgba(252, 211, 77, 0.12),
+    0 0 1rem currentColor;
+}
+
+.legend-dot.is-critical {
+  color: var(--critical);
+  box-shadow:
+    0 0 0 0.38rem rgba(252, 165, 165, 0.12),
+    0 0 1rem currentColor;
+}
+
+.legend-copy {
+  min-width: 0;
+}
+
+.legend-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legend-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.legend-count,
+.legend-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.legend-count {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.legend-state {
+  min-width: 5.6rem;
+  color: var(--healthy);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.legend-state.is-warning {
+  color: var(--warning);
+  background: rgba(252, 211, 77, 0.13);
+}
+
+.legend-state.is-critical {
+  color: var(--critical);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-status-legend-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .legend-count,
+  .legend-state {
+    margin-left: 1.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Status Legend Row demo inside `submissions/examples/basic-status-legend-row-kk/`. This submission introduces a compact CSS-only row for dashboards, chart legends, map panels, system health pages, and analytics interfaces.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only status legend row that displays a colored marker, status name, helper description, item count, and healthy/warning/critical state label in one compact layout.

**How does a developer use it?**

```html
<article class="basic-status-legend-row">
  <span class="legend-dot is-healthy" aria-hidden="true"></span>
  <div class="legend-copy">
    <strong>Healthy</strong>
    <p>All monitored services are responding normally.</p>
  </div>
  <span class="legend-count">24 items</span>
  <span class="legend-state is-healthy">Stable</span>
</article>