### PR TITLE
feat: add basic sort control row demo

### DIFF
--- a/submissions/examples/basic-sort-control-row-kk/README.md
+++ b/submissions/examples/basic-sort-control-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Sort Control Row
+
+## What it does
+
+This submission adds a simple CSS-only sort control row for table toolbars,
+filter panels, dashboard lists, and admin interfaces.
+
+It presents a sort option icon, label, helper text, direction label, and active
+state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an icon, copy area, sort direction, and state pill:
+
+```html
+<article class="basic-sort-control-row is-active">
+  <span class="sort-icon is-date" aria-hidden="true">DT</span>
+  <div class="sort-copy">
+    <strong>Date created</strong>
+    <p>Show newest records first</p>
+  </div>
+  <span class="sort-direction">Desc</span>
+  <span class="sort-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+table and dashboard interfaces. The row can be reused inside filter cards,
+settings panels, admin tables, and list controls while staying lightweight and
+CSS-only.
+
+## Included features
+
+- Date, name, and priority sort examples
+- Active, available, and priority state pills
+- Ascending and descending direction metadata
+- Long text truncation for sort descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the sort control row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-sort-control-row-kk/demo.html
+++ b/submissions/examples/basic-sort-control-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Sort Control Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Sort Control Row</p>
+          <h1>Compact sort rows for table and filter panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing sort options, active state,
+            direction, and helper text inside lists, tables, and dashboards.
+          </p>
+        </header>
+
+        <section class="sort-panel" aria-label="Sort control row examples">
+          <article class="basic-sort-control-row is-active">
+            <span class="sort-icon is-date" aria-hidden="true">DT</span>
+            <div class="sort-copy">
+              <strong>Date created</strong>
+              <p>Show newest records first</p>
+            </div>
+            <span class="sort-direction">Desc</span>
+            <span class="sort-state is-active">Active</span>
+          </article>
+
+          <article class="basic-sort-control-row">
+            <span class="sort-icon is-name" aria-hidden="true">AZ</span>
+            <div class="sort-copy">
+              <strong>Name</strong>
+              <p>Sort items alphabetically</p>
+            </div>
+            <span class="sort-direction">Asc</span>
+            <span class="sort-state">Available</span>
+          </article>
+
+          <article class="basic-sort-control-row">
+            <span class="sort-icon is-priority" aria-hidden="true">HI</span>
+            <div class="sort-copy">
+              <strong>Priority</strong>
+              <p>Bring urgent items to the top</p>
+            </div>
+            <span class="sort-direction">Desc</span>
+            <span class="sort-state is-priority">Priority</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-sort-control-row is-active"&gt;
+  &lt;span class="sort-icon is-date" aria-hidden="true"&gt;DT&lt;/span&gt;
+  &lt;div class="sort-copy"&gt;
+    &lt;strong&gt;Date created&lt;/strong&gt;
+    &lt;p&gt;Show newest records first&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="sort-direction"&gt;Desc&lt;/span&gt;
+  &lt;span class="sort-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-sort-control-row-kk/style.css
+++ b/submissions/examples/basic-sort-control-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --active: #93c5fd;
+  --name: #c4b5fd;
+  --priority: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Century Gothic", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(251, 191, 36, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.sort-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-sort-control-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-sort-control-row + .basic-sort-control-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-sort-control-row:hover,
+.basic-sort-control-row.is-active {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(147, 197, 253, 0.72);
+  transform: translateX(4px);
+}
+
+.sort-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.sort-icon.is-name {
+  background: linear-gradient(135deg, #c4b5fd, #ddd6fe);
+}
+
+.sort-icon.is-priority {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.sort-copy {
+  min-width: 0;
+}
+
+.sort-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sort-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sort-direction,
+.sort-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.sort-direction {
+  min-width: 4.5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sort-state {
+  min-width: 5.8rem;
+  color: var(--active);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.sort-state.is-active {
+  background: rgba(147, 197, 253, 0.18);
+}
+
+.sort-state.is-priority {
+  color: var(--priority);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-sort-control-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .sort-direction,
+  .sort-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Sort Control Row demo inside `submissions/examples/basic-sort-control-row-kk/`. This submission introduces a compact CSS-only row for table toolbars, filter panels, dashboard lists, and admin interfaces.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only sort control row that displays a sort option icon, label, helper text, direction label, and active/available/priority state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-sort-control-row is-active">
  <span class="sort-icon is-date" aria-hidden="true">DT</span>
  <div class="sort-copy">
    <strong>Date created</strong>
    <p>Show newest records first</p>
  </div>
  <span class="sort-direction">Desc</span>
  <span class="sort-state is-active">Active</span>
</article>