### PR TITLE
feat: add basic language preference row demo

### DIFF
--- a/submissions/examples/basic-language-preference-row-v2-kk/README.md
+++ b/submissions/examples/basic-language-preference-row-v2-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Language Preference Row
+
+## What it does
+
+This submission adds a simple CSS-only language preference row for profile
+pages, account settings, onboarding screens, and localization panels.
+
+It presents a language code, language name, helper text, region label, and
+availability state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a language code, copy area, region label, and state
+pill:
+
+```html
+<article class="basic-language-preference-row is-selected">
+  <span class="language-code" aria-hidden="true">EN</span>
+  <div class="language-copy">
+    <strong>English</strong>
+    <p>Primary interface language for this workspace.</p>
+  </div>
+  <span class="language-region">US</span>
+  <span class="language-state is-selected">Default</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+profile and settings interfaces. The row can be reused inside account panels,
+localization settings, onboarding preferences, and workspace configuration pages
+while staying lightweight and CSS-only.
+
+## Included features
+
+- English, Hindi, and French language examples
+- Default, suggested, and locked state pills
+- Region metadata label
+- Long text truncation for helper descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the language preference row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-language-preference-row-v2-kk/demo.html
+++ b/submissions/examples/basic-language-preference-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Language Preference Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Language Preference Row</p>
+          <h1>Readable language rows for account preference panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing language choices, locale
+            labels, helper text, and availability state in settings screens.
+          </p>
+        </header>
+
+        <section class="language-panel" aria-label="Language preference row examples">
+          <article class="basic-language-preference-row is-selected">
+            <span class="language-code" aria-hidden="true">EN</span>
+            <div class="language-copy">
+              <strong>English</strong>
+              <p>Primary interface language for this workspace.</p>
+            </div>
+            <span class="language-region">US</span>
+            <span class="language-state is-selected">Default</span>
+          </article>
+
+          <article class="basic-language-preference-row">
+            <span class="language-code is-suggested" aria-hidden="true">HI</span>
+            <div class="language-copy">
+              <strong>Hindi</strong>
+              <p>Suggested based on your location and profile settings.</p>
+            </div>
+            <span class="language-region">IN</span>
+            <span class="language-state is-suggested">Suggested</span>
+          </article>
+
+          <article class="basic-language-preference-row">
+            <span class="language-code is-muted" aria-hidden="true">FR</span>
+            <div class="language-copy">
+              <strong>French</strong>
+              <p>Translation pack is not enabled for this account.</p>
+            </div>
+            <span class="language-region">FR</span>
+            <span class="language-state is-muted">Locked</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-language-preference-row is-selected"&gt;
+  &lt;span class="language-code" aria-hidden="true"&gt;EN&lt;/span&gt;
+  &lt;div class="language-copy"&gt;
+    &lt;strong&gt;English&lt;/strong&gt;
+    &lt;p&gt;Primary interface language for this workspace.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="language-region"&gt;US&lt;/span&gt;
+  &lt;span class="language-state is-selected"&gt;Default&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-language-preference-row-v2-kk/style.css
+++ b/submissions/examples/basic-language-preference-row-v2-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --default: #93c5fd;
+  --suggested: #86efac;
+  --locked: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Palatino", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--default);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.language-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-language-preference-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-language-preference-row + .basic-language-preference-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-language-preference-row:hover,
+.basic-language-preference-row.is-selected {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(147, 197, 253, 0.72);
+  transform: translateX(4px);
+}
+
+.language-code {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.language-code.is-suggested {
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.language-code.is-muted {
+  background: linear-gradient(135deg, #cbd5e1, #f8fafc);
+}
+
+.language-copy {
+  min-width: 0;
+}
+
+.language-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-region,
+.language-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.language-region {
+  min-width: 4.2rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.language-state {
+  min-width: 5.8rem;
+  color: var(--default);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.language-state.is-suggested {
+  color: var(--suggested);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.language-state.is-muted {
+  color: var(--locked);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-language-preference-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .language-region,
+  .language-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Language Preference Row demo inside `submissions/examples/basic-language-preference-row-v2-kk/`. This submission introduces a compact CSS-only row for profile pages, account settings, onboarding screens, and localization panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only language preference row that displays a language code, language name, helper text, region label, and default/suggested/locked state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-language-preference-row is-selected">
  <span class="language-code" aria-hidden="true">EN</span>
  <div class="language-copy">
    <strong>English</strong>
    <p>Primary interface language for this workspace.</p>
  </div>
  <span class="language-region">US</span>
  <span class="language-state is-selected">Default</span>
</article>