### PR TITLE
feat: Add Skeleton Screen animation

### DIFF
--- a/submissions/examples/82491-skeleton-screen-ionfwsrijan/README.md
+++ b/submissions/examples/82491-skeleton-screen-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Skeleton Screen
+
+Shimmering placeholder blocks that mimic content loading.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82491

--- a/submissions/examples/82491-skeleton-screen-ionfwsrijan/demo.html
+++ b/submissions/examples/82491-skeleton-screen-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skeleton Screen</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<div class="sk"><div class="ln w60"></div><div class="ln w90"></div><div class="ln w40"></div><div class="box"></div></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/82491-skeleton-screen-ionfwsrijan/style.css
+++ b/submissions/examples/82491-skeleton-screen-ionfwsrijan/style.css
@@ -1,0 +1,9 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.sk{width:260px;display:flex;flex-direction:column;gap:12px}
+.sk .ln,.sk .box{background:#1f2440;border-radius:8px;position:relative;overflow:hidden}
+.sk .ln{height:14px}.sk .w60{width:60%}.sk .w90{width:90%}.sk .w40{width:40%}
+.sk .box{height:90px}
+.sk .ln::after,.sk .box::after{content:"";position:absolute;inset:0;background:linear-gradient(90deg,transparent,#3b4170,transparent);animation:sk 1.3s infinite}
+@keyframes sk{to{transform:translateX(100%)}}


### PR DESCRIPTION
## Skeleton Screen

Shimmering placeholder blocks that mimic content loading.

Adds a self-contained, working CSS animation demo under `submissions/examples/82491-skeleton-screen-ionfwsrijan`.

Closes #82491