### PR TITLE
feat: add basic access role row demo

### DIFF
--- a/submissions/examples/basic-access-role-row-kk/README.md
+++ b/submissions/examples/basic-access-role-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Access Role Row
+
+## What it does
+
+This submission adds a simple CSS-only access role row for team settings,
+permission panels, workspace member screens, and collaboration dashboards.
+
+It presents a role icon, role name, helper text, permission scope, and role
+state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a role icon, copy area, scope label, and role pill:
+
+```html
+<article class="basic-access-role-row">
+  <span class="role-icon is-owner" aria-hidden="true">OW</span>
+  <div class="role-copy">
+    <strong>Owner access</strong>
+    <p>Can manage billing, team members, and workspace settings.</p>
+  </div>
+  <span class="role-scope">Full</span>
+  <span class="role-state is-owner">Owner</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+team administration interfaces. The row can be reused inside settings cards,
+member lists, permission panels, and workspace dashboards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Owner, admin, and viewer role examples
+- Permission scope metadata
+- Role state pills
+- Long text truncation for permission descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the access role row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-access-role-row-kk/demo.html
+++ b/submissions/examples/basic-access-role-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Access Role Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Access Role Row</p>
+          <h1>Permission rows for team and workspace settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing access roles, permission scope,
+            helper text, and role state in admin or collaboration panels.
+          </p>
+        </header>
+
+        <section class="role-panel" aria-label="Access role row examples">
+          <article class="basic-access-role-row">
+            <span class="role-icon is-owner" aria-hidden="true">OW</span>
+            <div class="role-copy">
+              <strong>Owner access</strong>
+              <p>Can manage billing, team members, and workspace settings.</p>
+            </div>
+            <span class="role-scope">Full</span>
+            <span class="role-state is-owner">Owner</span>
+          </article>
+
+          <article class="basic-access-role-row">
+            <span class="role-icon is-admin" aria-hidden="true">AD</span>
+            <div class="role-copy">
+              <strong>Admin access</strong>
+              <p>Can manage projects, reports, and operational settings.</p>
+            </div>
+            <span class="role-scope">Manage</span>
+            <span class="role-state is-admin">Admin</span>
+          </article>
+
+          <article class="basic-access-role-row">
+            <span class="role-icon is-viewer" aria-hidden="true">VI</span>
+            <div class="role-copy">
+              <strong>Viewer access</strong>
+              <p>Can view dashboards and shared reports only.</p>
+            </div>
+            <span class="role-scope">Read</span>
+            <span class="role-state is-viewer">Viewer</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-access-role-row"&gt;
+  &lt;span class="role-icon is-owner" aria-hidden="true"&gt;OW&lt;/span&gt;
+  &lt;div class="role-copy"&gt;
+    &lt;strong&gt;Owner access&lt;/strong&gt;
+    &lt;p&gt;Can manage billing, team members, and workspace settings.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="role-scope"&gt;Full&lt;/span&gt;
+  &lt;span class="role-state is-owner"&gt;Owner&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-access-role-row-kk/style.css
+++ b/submissions/examples/basic-access-role-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --owner: #fbbf24;
+  --admin: #93c5fd;
+  --viewer: #86efac;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Verdana", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(251, 191, 36, 0.14), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--owner);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.role-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-access-role-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-access-role-row + .basic-access-role-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-access-role-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(251, 191, 36, 0.72);
+  transform: translateX(4px);
+}
+
+.role-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.role-icon.is-admin {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.role-icon.is-viewer {
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.role-copy {
+  min-width: 0;
+}
+
+.role-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.role-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.role-scope,
+.role-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.role-scope {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.role-state {
+  min-width: 5.8rem;
+  color: var(--owner);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+.role-state.is-admin {
+  color: var(--admin);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.role-state.is-viewer {
+  color: var(--viewer);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-access-role-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .role-scope,
+  .role-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Access Role Row demo inside `submissions/examples/basic-access-role-row-kk/`. This submission introduces a compact CSS-only row for team settings, permission panels, workspace member screens, and collaboration dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only access role row that displays a role icon, role name, helper text, permission scope, and owner/admin/viewer state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-access-role-row">
  <span class="role-icon is-owner" aria-hidden="true">OW</span>
  <div class="role-copy">
    <strong>Owner access</strong>
    <p>Can manage billing, team members, and workspace settings.</p>
  </div>
  <span class="role-scope">Full</span>
  <span class="role-state is-owner">Owner</span>
</article>