### PR TITLE
feat: add ease-animated-tab-underline-slide-sap

### DIFF
--- a/submissions/examples/ease-animated-tab-underline-slide-sap/README.md
+++ b/submissions/examples/ease-animated-tab-underline-slide-sap/README.md
@@ -1,0 +1,19 @@
+# ease-animated-tab-underline-slide-sap
+
+A tab navigation bar where the active-state underline slides smoothly between tabs, rather than snapping. Underline position/width is computed from `offsetLeft`/`offsetWidth` on click and applied via CSS transition.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.tab-underline-sap` markup from `demo.html` (any number of `.tab-underline-sap__tab` buttons + one `.tab-underline-sap__indicator` span).
+3. Include the click handler script from `demo.html` — measuring tab position/width requires JS; CSS handles the slide transition.
+
+## Customization
+- Change the `gap` between tabs to adjust spacing.
+- Edit the `0.3s cubic-bezier(...)` transition for a snappier/softer slide.
+- Swap the `linear-gradient` on the indicator to restyle.
+
+## Accessibility
+Includes `role="tablist"`/`role="tab"`; add `aria-selected` toggling alongside `.is-active` for full ARIA tab pattern compliance.
+
+## Browser support
+All modern browsers.

--- a/submissions/examples/ease-animated-tab-underline-slide-sap/demo.html
+++ b/submissions/examples/ease-animated-tab-underline-slide-sap/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-animated-tab-underline-slide-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <div class="tab-underline-sap" role="tablist">
+      <button class="tab-underline-sap__tab is-active" role="tab">Overview</button>
+      <button class="tab-underline-sap__tab" role="tab">Features</button>
+      <button class="tab-underline-sap__tab" role="tab">Pricing</button>
+      <span class="tab-underline-sap__indicator"></span>
+    </div>
+  </div>
+
+  <script>
+    const nav = document.querySelector('.tab-underline-sap');
+    const tabs = nav.querySelectorAll('.tab-underline-sap__tab');
+    const indicator = nav.querySelector('.tab-underline-sap__indicator');
+
+    function moveIndicator(tab) {
+      indicator.style.width = `${tab.offsetWidth}px`;
+      indicator.style.left = `${tab.offsetLeft}px`;
+    }
+
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('is-active'));
+        tab.classList.add('is-active');
+        moveIndicator(tab);
+      });
+    });
+
+    window.addEventListener('load', () => moveIndicator(nav.querySelector('.is-active')));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-tab-underline-slide-sap/style.css
+++ b/submissions/examples/ease-animated-tab-underline-slide-sap/style.css
@@ -1,0 +1,35 @@
+.tab-underline-sap {
+  position: relative;
+  display: inline-flex;
+  gap: 24px;
+  border-bottom: 2px solid #22222a;
+  padding-bottom: 0;
+}
+
+.tab-underline-sap__tab {
+  padding: 12px 4px;
+  border: none;
+  background: none;
+  color: #8a8a96;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.tab-underline-sap__tab.is-active {
+  color: #fff;
+}
+
+.tab-underline-sap__indicator {
+  position: absolute;
+  bottom: -2px;
+  height: 2px;
+  background: linear-gradient(90deg, #6d5efc, #43e0d8);
+  transition: left 0.3s cubic-bezier(0.4, 0.2, 0.2, 1),
+              width 0.3s cubic-bezier(0.4, 0.2, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-underline-sap__indicator { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-animated-tab-underline-slide-sap`, a tab bar with a sliding active-state underline.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` boilerplate, self-contained.
- Indicator position/width computed via `offsetLeft`/`offsetWidth` on tab click (unavoidable in JS since it depends on rendered tab dimensions); the actual slide motion is a pure CSS `transition` on `left`/`width`.
- Recalculates indicator position on `load` so it matches the initial active tab without a flash.

## Feature Description
Adds a reusable animated tab underline indicator for tab navigation components.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.