### PR TITLE
feat: add basic reminder schedule row demo

### DIFF
--- a/submissions/examples/basic-reminder-schedule-row-kk/README.md
+++ b/submissions/examples/basic-reminder-schedule-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Reminder Schedule Row
+
+## What it does
+
+This submission adds a simple CSS-only reminder schedule row for task apps,
+calendar panels, notification settings, and productivity dashboards.
+
+It presents a reminder type icon, reminder name, schedule helper text, next run
+time, and reminder state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a reminder icon, copy area, time label, and state
+pill:
+
+```html
+<article class="basic-reminder-schedule-row">
+  <span class="reminder-icon is-daily" aria-hidden="true">DY</span>
+  <div class="reminder-copy">
+    <strong>Daily standup reminder</strong>
+    <p>Repeats every weekday at 9:30 AM.</p>
+  </div>
+  <span class="reminder-time">Today</span>
+  <span class="reminder-state is-daily">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+calendar and task interfaces. The row can be reused inside reminder settings,
+notification panels, productivity dashboards, and schedule cards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Daily, weekly, and overdue reminder examples
+- Next-run time metadata
+- Active, scheduled, and overdue state pills
+- Long text truncation for schedule descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the reminder schedule row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-reminder-schedule-row-kk/demo.html
+++ b/submissions/examples/basic-reminder-schedule-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Reminder Schedule Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Reminder Schedule Row</p>
+          <h1>Reminder rows for task and notification settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing reminder frequency, schedule
+            details, next run time, and reminder status in compact panels.
+          </p>
+        </header>
+
+        <section class="reminder-panel" aria-label="Reminder schedule row examples">
+          <article class="basic-reminder-schedule-row">
+            <span class="reminder-icon is-daily" aria-hidden="true">DY</span>
+            <div class="reminder-copy">
+              <strong>Daily standup reminder</strong>
+              <p>Repeats every weekday at 9:30 AM.</p>
+            </div>
+            <span class="reminder-time">Today</span>
+            <span class="reminder-state is-daily">Active</span>
+          </article>
+
+          <article class="basic-reminder-schedule-row">
+            <span class="reminder-icon is-weekly" aria-hidden="true">WK</span>
+            <div class="reminder-copy">
+              <strong>Weekly report reminder</strong>
+              <p>Sent every Friday before the dashboard review.</p>
+            </div>
+            <span class="reminder-time">Fri</span>
+            <span class="reminder-state is-weekly">Scheduled</span>
+          </article>
+
+          <article class="basic-reminder-schedule-row">
+            <span class="reminder-icon is-overdue" aria-hidden="true">OD</span>
+            <div class="reminder-copy">
+              <strong>Contract renewal reminder</strong>
+              <p>Needs attention because the previous reminder was missed.</p>
+            </div>
+            <span class="reminder-time">2d late</span>
+            <span class="reminder-state is-overdue">Overdue</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-reminder-schedule-row"&gt;
+  &lt;span class="reminder-icon is-daily" aria-hidden="true"&gt;DY&lt;/span&gt;
+  &lt;div class="reminder-copy"&gt;
+    &lt;strong&gt;Daily standup reminder&lt;/strong&gt;
+    &lt;p&gt;Repeats every weekday at 9:30 AM.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="reminder-time"&gt;Today&lt;/span&gt;
+  &lt;span class="reminder-state is-daily"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-reminder-schedule-row-kk/style.css
+++ b/submissions/examples/basic-reminder-schedule-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a0f1d;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --daily: #93c5fd;
+  --weekly: #86efac;
+  --overdue: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(252, 165, 165, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--daily);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.reminder-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-reminder-schedule-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-reminder-schedule-row + .basic-reminder-schedule-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-reminder-schedule-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(147, 197, 253, 0.72);
+  transform: translateX(4px);
+}
+
+.reminder-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.reminder-icon.is-weekly {
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.reminder-icon.is-overdue {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.reminder-copy {
+  min-width: 0;
+}
+
+.reminder-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reminder-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reminder-time,
+.reminder-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.reminder-time {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.reminder-state {
+  min-width: 6rem;
+  color: var(--daily);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.reminder-state.is-weekly {
+  color: var(--weekly);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.reminder-state.is-overdue {
+  color: var(--overdue);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-reminder-schedule-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .reminder-time,
+  .reminder-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Reminder Schedule Row demo inside `submissions/examples/basic-reminder-schedule-row-kk/`. This submission introduces a compact CSS-only row for task apps, calendar panels, notification settings, and productivity dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only reminder schedule row that displays a reminder type icon, reminder name, schedule helper text, next run time, and active/scheduled/overdue state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-reminder-schedule-row">
  <span class="reminder-icon is-daily" aria-hidden="true">DY</span>
  <div class="reminder-copy">
    <strong>Daily standup reminder</strong>
    <p>Repeats every weekday at 9:30 AM.</p>
  </div>
  <span class="reminder-time">Today</span>
  <span class="reminder-state is-daily">Active</span>
</article>