### PR TITLE
feat: Add Underline Grow animation

### DIFF
--- a/submissions/examples/82495-underline-grow-ionfwsrijan/README.md
+++ b/submissions/examples/82495-underline-grow-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Underline Grow
+
+A link underline that grows from the left on hover.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82495

--- a/submissions/examples/82495-underline-grow-ionfwsrijan/demo.html
+++ b/submissions/examples/82495-underline-grow-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Underline Grow</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<a class="ug" href="#">Hover me</a>
+</div>
+</body>
+</html>

--- a/submissions/examples/82495-underline-grow-ionfwsrijan/style.css
+++ b/submissions/examples/82495-underline-grow-ionfwsrijan/style.css
@@ -1,0 +1,6 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.ug{font-size:30px;color:#fbbf24;text-decoration:none;position:relative}
+.ug::after{content:"";position:absolute;left:0;bottom:-6px;height:4px;width:0;background:#fbbf24;transition:width .35s ease}
+.ug:hover::after{width:100%}


### PR DESCRIPTION
## Underline Grow

A link underline that grows from the left on hover.

Adds a self-contained, working CSS animation demo under `submissions/examples/82495-underline-grow-ionfwsrijan`.

Closes #82495