### PR TITLE
feat: add basic export format row demo

### DIFF
--- a/submissions/examples/basic-export-format-row-v2-kk/README.md
+++ b/submissions/examples/basic-export-format-row-v2-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Export Format Row
+
+## What it does
+
+This submission adds a simple CSS-only export format row for report builders,
+download panels, data tables, analytics pages, and admin dashboards.
+
+It presents an export format icon, format name, helper text, estimated file
+size, and availability state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a format icon, copy area, size label, and state
+pill:
+
+```html
+<article class="basic-export-format-row is-selected">
+  <span class="export-icon is-csv" aria-hidden="true">CSV</span>
+  <div class="export-copy">
+    <strong>Spreadsheet export</strong>
+    <p>Best for editing data in sheets and reporting tools.</p>
+  </div>
+  <span class="export-size">240 KB</span>
+  <span class="export-state is-ready">Ready</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+data-heavy product interfaces. The row can be reused inside report builders,
+download modals, export panels, and admin dashboards while staying lightweight
+and CSS-only.
+
+## Included features
+
+- CSV, PDF, and JSON export format examples
+- Ready, popular, and developer state pills
+- Estimated file size metadata
+- Long text truncation for export descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the export format row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-export-format-row-v2-kk/demo.html
+++ b/submissions/examples/basic-export-format-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Export Format Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Export Format Row</p>
+          <h1>Export rows for reports, tables, and download panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing export formats, helper copy,
+            estimated file size, and availability state in compact interfaces.
+          </p>
+        </header>
+
+        <section class="export-panel" aria-label="Export format row examples">
+          <article class="basic-export-format-row is-selected">
+            <span class="export-icon is-csv" aria-hidden="true">CSV</span>
+            <div class="export-copy">
+              <strong>Spreadsheet export</strong>
+              <p>Best for editing data in sheets and reporting tools.</p>
+            </div>
+            <span class="export-size">240 KB</span>
+            <span class="export-state is-ready">Ready</span>
+          </article>
+
+          <article class="basic-export-format-row">
+            <span class="export-icon is-pdf" aria-hidden="true">PDF</span>
+            <div class="export-copy">
+              <strong>Printable report</strong>
+              <p>Preserves layout for sharing and stakeholder reviews.</p>
+            </div>
+            <span class="export-size">1.8 MB</span>
+            <span class="export-state is-popular">Popular</span>
+          </article>
+
+          <article class="basic-export-format-row">
+            <span class="export-icon is-json" aria-hidden="true">JSN</span>
+            <div class="export-copy">
+              <strong>Developer payload</strong>
+              <p>Structured data for integrations and API workflows.</p>
+            </div>
+            <span class="export-size">520 KB</span>
+            <span class="export-state is-dev">Developer</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-export-format-row is-selected"&gt;
+  &lt;span class="export-icon is-csv" aria-hidden="true"&gt;CSV&lt;/span&gt;
+  &lt;div class="export-copy"&gt;
+    &lt;strong&gt;Spreadsheet export&lt;/strong&gt;
+    &lt;p&gt;Best for editing data in sheets and reporting tools.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="export-size"&gt;240 KB&lt;/span&gt;
+  &lt;span class="export-state is-ready"&gt;Ready&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-export-format-row-v2-kk/style.css
+++ b/submissions/examples/basic-export-format-row-v2-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --csv: #86efac;
+  --pdf: #fca5a5;
+  --json: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--csv);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.export-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-export-format-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-export-format-row + .basic-export-format-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-export-format-row:hover,
+.basic-export-format-row.is-selected {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.export-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.export-icon.is-pdf {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.export-icon.is-json {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.export-copy {
+  min-width: 0;
+}
+
+.export-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.export-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.export-size,
+.export-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.export-size {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.export-state {
+  min-width: 6rem;
+  color: var(--csv);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.export-state.is-popular {
+  color: var(--pdf);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+.export-state.is-dev {
+  color: var(--json);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-export-format-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .export-size,
+  .export-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Export Format Row demo inside `submissions/examples/basic-export-format-row-v2-kk/`. This submission introduces a compact CSS-only row for report builders, download panels, data tables, analytics pages, and admin dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only export format row that displays an export format icon, format name, helper text, estimated file size, and ready/popular/developer state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-export-format-row is-selected">
  <span class="export-icon is-csv" aria-hidden="true">CSV</span>
  <div class="export-copy">
    <strong>Spreadsheet export</strong>
    <p>Best for editing data in sheets and reporting tools.</p>
  </div>
  <span class="export-size">240 KB</span>
  <span class="export-state is-ready">Ready</span>
</article>