### PR TITLE
feat: Add Button Fill Up animation

### DIFF
--- a/submissions/examples/82497-button-fill-up-ionfwsrijan/README.md
+++ b/submissions/examples/82497-button-fill-up-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Button Fill Up
+
+A button that fills with color from the bottom on hover.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82497

--- a/submissions/examples/82497-button-fill-up-ionfwsrijan/demo.html
+++ b/submissions/examples/82497-button-fill-up-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Button Fill Up</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<button class="bf">Submit</button>
+</div>
+</body>
+</html>

--- a/submissions/examples/82497-button-fill-up-ionfwsrijan/style.css
+++ b/submissions/examples/82497-button-fill-up-ionfwsrijan/style.css
@@ -1,0 +1,6 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.bf{position:relative;overflow:hidden;border:2px solid #34d399;background:transparent;color:#34d399;padding:16px 40px;font-size:18px;border-radius:10px;cursor:pointer}
+.bf::before{content:"";position:absolute;inset:0;background:#34d399;transform:translateY(100%);transition:transform .35s ease;z-index:-1}
+.bf:hover{color:#0f1226}.bf:hover::before{transform:translateY(0)}


### PR DESCRIPTION
## Button Fill Up

A button that fills with color from the bottom on hover.

Adds a self-contained, working CSS animation demo under `submissions/examples/82497-button-fill-up-ionfwsrijan`.

Closes #82497