### PR TITLE
feat: add ease-drag-checklist-strike-sap

### DIFF
--- a/submissions/examples/ease-drag-checklist-strike-sap/README.md
+++ b/submissions/examples/ease-drag-checklist-strike-sap/README.md
@@ -1,0 +1,19 @@
+# ease-drag-checklist-strike-sap
+
+A reorderable checklist: drag items via the handle to reorder (HTML5 drag-and-drop), and checking an item animates a strikethrough line across the label rather than using `text-decoration: line-through` directly.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `<ul class="checklist-strike-sap">` markup from `demo.html` — each item needs `draggable="true"`, a checkbox, and a label.
+3. Include the drag-and-drop script from `demo.html` — reordering requires native HTML5 drag events; CSS handles the strike animation and drag-state styling.
+
+## Customization
+- Adjust the `::after` line `background`/`height` on the label for a different strike style.
+- Change the `0.3s` strike transition duration.
+- Restyle `.checklist-strike-sap__item` background/radius to match your design system.
+
+## Accessibility
+Uses real `<input type="checkbox">` + `<label for>` pairs, keyboard-operable. Native HTML5 drag-and-drop is mouse/touch-oriented; consider adding keyboard reorder controls (move up/down buttons) for full accessibility.
+
+## Browser support
+All modern browsers (HTML5 Drag and Drop API).

--- a/submissions/examples/ease-drag-checklist-strike-sap/demo.html
+++ b/submissions/examples/ease-drag-checklist-strike-sap/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-drag-checklist-strike-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <ul class="checklist-strike-sap">
+      <li class="checklist-strike-sap__item" draggable="true">
+        <input type="checkbox" class="checklist-strike-sap__box" id="c1">
+        <label for="c1" class="checklist-strike-sap__label">Draft proposal</label>
+        <span class="checklist-strike-sap__handle">&#8942;&#8942;</span>
+      </li>
+      <li class="checklist-strike-sap__item" draggable="true">
+        <input type="checkbox" class="checklist-strike-sap__box" id="c2">
+        <label for="c2" class="checklist-strike-sap__label">Review with team</label>
+        <span class="checklist-strike-sap__handle">&#8942;&#8942;</span>
+      </li>
+      <li class="checklist-strike-sap__item" draggable="true">
+        <input type="checkbox" class="checklist-strike-sap__box" id="c3">
+        <label for="c3" class="checklist-strike-sap__label">Ship to production</label>
+        <span class="checklist-strike-sap__handle">&#8942;&#8942;</span>
+      </li>
+    </ul>
+  </div>
+
+  <script>
+    const list = document.querySelector('.checklist-strike-sap');
+    let dragEl = null;
+
+    list.querySelectorAll('.checklist-strike-sap__item').forEach(item => {
+      item.addEventListener('dragstart', () => {
+        dragEl = item;
+        item.classList.add('is-dragging');
+      });
+      item.addEventListener('dragend', () => item.classList.remove('is-dragging'));
+      item.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        const target = e.currentTarget;
+        if (target === dragEl) return;
+        const rect = target.getBoundingClientRect();
+        const before = (e.clientY - rect.top) < rect.height / 2;
+        list.insertBefore(dragEl, before ? target : target.nextSibling);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-checklist-strike-sap/style.css
+++ b/submissions/examples/ease-drag-checklist-strike-sap/style.css
@@ -1,0 +1,68 @@
+.checklist-strike-sap {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.checklist-strike-sap__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: #16161c;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.checklist-strike-sap__item.is-dragging {
+  opacity: 0.4;
+}
+
+.checklist-strike-sap__box {
+  accent-color: #6d5efc;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.checklist-strike-sap__label {
+  position: relative;
+  color: #e4e4ec;
+  font-size: 14px;
+  flex: 1;
+}
+
+.checklist-strike-sap__label::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 1.5px;
+  width: 0;
+  background: #8a8a96;
+  transition: width 0.3s ease;
+}
+
+.checklist-strike-sap__box:checked + .checklist-strike-sap__label {
+  color: #6a6a75;
+}
+
+.checklist-strike-sap__box:checked + .checklist-strike-sap__label::after {
+  width: 100%;
+}
+
+.checklist-strike-sap__handle {
+  cursor: grab;
+  color: #55555f;
+  font-size: 12px;
+  letter-spacing: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .checklist-strike-sap__label::after,
+  .checklist-strike-sap__item { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-drag-checklist-strike-sap`, a drag-to-reorder checklist with an animated strikethrough on check.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Reordering uses native HTML5 Drag and Drop (`dragstart`/`dragover`/`dragend`), inserting the dragged node before/after the hover target based on cursor Y position relative to target midpoint.
- Strikethrough is an animated `::after` line (`width: 0 → 100%`) rather than `text-decoration`, so it visibly draws across on check instead of appearing instantly.
- Noted accessibility gap in README re: keyboard-only reordering.

## Feature Description
Adds a reusable draggable checklist component with animated check-off feedback.

Level: Intermediate

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.