### PR TITLE
feat: add ease-hover-card-border-trace-sap

### DIFF
--- a/submissions/examples/ease-hover-card-border-trace-sap/README.md
+++ b/submissions/examples/ease-hover-card-border-trace-sap/README.md
@@ -1,0 +1,18 @@
+# ease-hover-card-border-trace-sap
+
+On hover, a bright segment appears to "trace" around the card's border continuously, using a masked rotating `conic-gradient` on a `::before` layer — no SVG stroke animation needed.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Wrap your card content in `.border-trace-sap`, matching `demo.html`.
+
+## Customization
+- Adjust the `conic-gradient` stops (`15%`/`30%`) to change trace segment length.
+- Change the `2.5s linear` duration for trace speed.
+- Match `padding: 2px` on `::before` to your desired border thickness.
+
+## Accessibility
+Purely decorative hover effect; respects `prefers-reduced-motion` by showing a static full-opacity trace instead of animating.
+
+## Browser support
+Requires `mask-composite`/`-webkit-mask-composite` support (all modern evergreen browsers).

--- a/submissions/examples/ease-hover-card-border-trace-sap/demo.html
+++ b/submissions/examples/ease-hover-card-border-trace-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-hover-card-border-trace-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <div class="border-trace-sap">
+      <h3>Trace Card</h3>
+      <p>Hover to trace the border</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-card-border-trace-sap/style.css
+++ b/submissions/examples/ease-hover-card-border-trace-sap/style.css
@@ -1,0 +1,39 @@
+.border-trace-sap {
+  position: relative;
+  width: 260px;
+  padding: 24px;
+  border-radius: 14px;
+  background: #16161c;
+  color: #fff;
+  overflow: hidden;
+}
+
+.border-trace-sap::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  padding: 2px;
+  background: conic-gradient(from 0deg, transparent 0%, #43e0d8 15%, transparent 30%);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  animation: border-trace-spin-sap 2.5s linear infinite paused;
+}
+
+.border-trace-sap:hover::before {
+  opacity: 1;
+  animation-play-state: running;
+}
+
+.border-trace-sap h3 { margin: 0 0 6px; }
+.border-trace-sap p { margin: 0; color: #a0a0ad; font-size: 14px; }
+
+@keyframes border-trace-spin-sap {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .border-trace-sap::before { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-hover-card-border-trace-sap`, a hover-triggered animated border trace effect for cards.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Border trace built from a `conic-gradient` masked to only the border ring (`mask-composite: exclude`), rotated via CSS animation — avoids needing an SVG `stroke-dashoffset` approach.
- Animation is paused by default and only runs on `:hover` (`animation-play-state`), so it costs nothing at rest.
- No JS, no extra DOM elements beyond the existing `::before`.

## Feature Description
Adds a reusable hover-activated animated border trace effect for cards/panels.

Level: Intermediate

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.