### PR TITLE
feat: add ease-scroll-stat-bar-chart-sap

### DIFF
--- a/submissions/examples/ease-scroll-stat-bar-chart-sap/README.md
+++ b/submissions/examples/ease-scroll-stat-bar-chart-sap/README.md
@@ -1,0 +1,19 @@
+# ease-scroll-stat-bar-chart-sap
+
+Horizontal stat bars that grow from 0 to their target value when scrolled into view, using `IntersectionObserver` to trigger a class and a CSS custom property (`--value`) to drive the fill width.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.stat-bar-chart-sap` markup from `demo.html`, setting `style="--value: XX%;"` per bar.
+3. Include the observer script from `demo.html` — scroll-triggering needs JS; CSS handles the fill animation.
+
+## Customization
+- Change the `1.1s cubic-bezier(...)` transition for a faster/slower fill.
+- Adjust `threshold: 0.4` in the observer to trigger earlier/later.
+- Swap the `linear-gradient` fill color to restyle.
+
+## Accessibility
+Add `role="img"` with an `aria-label` describing each stat's percentage for screen readers, since the value is conveyed visually via width.
+
+## Browser support
+All modern browsers (`IntersectionObserver`, CSS custom properties).

--- a/submissions/examples/ease-scroll-stat-bar-chart-sap/demo.html
+++ b/submissions/examples/ease-scroll-stat-bar-chart-sap/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-scroll-stat-bar-chart-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <div class="stat-bar-chart-sap">
+      <div class="stat-bar-chart-sap__bar" style="--value: 80%;"><span>Design</span></div>
+      <div class="stat-bar-chart-sap__bar" style="--value: 55%;"><span>Development</span></div>
+      <div class="stat-bar-chart-sap__bar" style="--value: 92%;"><span>Testing</span></div>
+    </div>
+  </div>
+
+  <script>
+    const bars = document.querySelectorAll('.stat-bar-chart-sap__bar');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.4 });
+    bars.forEach(bar => observer.observe(bar));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-stat-bar-chart-sap/style.css
+++ b/submissions/examples/ease-scroll-stat-bar-chart-sap/style.css
@@ -1,0 +1,44 @@
+.stat-bar-chart-sap {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+}
+
+.stat-bar-chart-sap__bar {
+  position: relative;
+  height: 34px;
+  border-radius: 8px;
+  background: #1c1c22;
+  overflow: hidden;
+}
+
+.stat-bar-chart-sap__bar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #6d5efc, #43e0d8);
+  transition: width 1.1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.stat-bar-chart-sap__bar.is-visible::before {
+  width: var(--value);
+}
+
+.stat-bar-chart-sap__bar span {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 12px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-bar-chart-sap__bar::before { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-scroll-stat-bar-chart-sap`, scroll-triggered animated horizontal stat bars.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Each bar's target fill is set per-instance via inline `--value` custom property, keeping the CSS file generic/reusable across any set of stats.
- `IntersectionObserver` toggles `.is-visible` once per bar and unobserves immediately after, so the fill animation runs exactly once per page view.
- Fill uses `width` transition on a `::before` layer rather than animating the bar container itself, keeping layout stable.

## Feature Description
Adds a reusable scroll-triggered animated bar chart for displaying stats/skills.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.