### PR TITLE
feat: add ease-animated-copy-clipboard-sap

### DIFF
--- a/submissions/examples/ease-animated-copy-clipboard-sap/README.md
+++ b/submissions/examples/ease-animated-copy-clipboard-sap/README.md
@@ -1,0 +1,19 @@
+# ease-animated-copy-clipboard-sap
+
+A copy-to-clipboard button where the icon morphs from a clipboard glyph to a checkmark (rotate + scale swap) on successful copy, then reverts after a short delay. Uses the Clipboard API.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.copy-clipboard-sap` markup from `demo.html`, setting `data-copy="text to copy"`.
+3. Include the click handler script — clipboard writing requires JS (`navigator.clipboard.writeText`); CSS handles the icon morph animation.
+
+## Customization
+- Change the `1800`ms `setTimeout` to adjust how long "Copied!" stays visible.
+- Swap the copy/check glyphs for SVG icons.
+- Adjust the `cubic-bezier(0.34, 1.56, 0.64, 1)` on the check icon for a bouncier/subtler pop-in.
+
+## Accessibility
+Update the button's `aria-live` region or `aria-label` alongside the label text swap so screen readers announce the copy success.
+
+## Browser support
+Clipboard API requires a secure context (HTTPS/localhost); falls back silently (no crash) if unavailable.

--- a/submissions/examples/ease-animated-copy-clipboard-sap/demo.html
+++ b/submissions/examples/ease-animated-copy-clipboard-sap/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-animated-copy-clipboard-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <button class="copy-clipboard-sap" data-copy="npm install easemotion-css">
+      <span class="copy-clipboard-sap__icon copy-clipboard-sap__icon--copy">&#128203;</span>
+      <span class="copy-clipboard-sap__icon copy-clipboard-sap__icon--check">&#10003;</span>
+      <span class="copy-clipboard-sap__label">Copy</span>
+    </button>
+  </div>
+
+  <script>
+    document.querySelectorAll('.copy-clipboard-sap').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(btn.dataset.copy);
+        } catch (e) { /* clipboard unavailable */ }
+        btn.classList.add('is-copied');
+        const label = btn.querySelector('.copy-clipboard-sap__label');
+        label.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.classList.remove('is-copied');
+          label.textContent = 'Copy';
+        }, 1800);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-animated-copy-clipboard-sap/style.css
+++ b/submissions/examples/ease-animated-copy-clipboard-sap/style.css
@@ -1,0 +1,50 @@
+.copy-clipboard-sap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 8px;
+  background: #1c1c22;
+  color: #e4e4ec;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.copy-clipboard-sap__icon {
+  position: relative;
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.copy-clipboard-sap__icon--copy {
+  transform: scale(1) rotate(0deg);
+  transition: transform 0.25s cubic-bezier(0.4, 0.2, 0.2, 1), opacity 0.2s ease;
+}
+
+.copy-clipboard-sap__icon--check {
+  position: absolute;
+  color: #43e0d8;
+  transform: scale(0) rotate(-45deg);
+  opacity: 0;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.2s ease;
+}
+
+.copy-clipboard-sap.is-copied .copy-clipboard-sap__icon--copy {
+  transform: scale(0) rotate(45deg);
+  opacity: 0;
+}
+
+.copy-clipboard-sap.is-copied .copy-clipboard-sap__icon--check {
+  transform: scale(1) rotate(0deg);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-clipboard-sap__icon--copy,
+  .copy-clipboard-sap__icon--check { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-animated-copy-clipboard-sap`, a copy button with an animated clipboard-to-checkmark icon morph.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Icon swap uses two absolutely-stacked icons cross-animating `scale`/`rotate`/`opacity`, driven by a single `.is-copied` class toggle — not a DOM icon replacement, avoiding layout jump.
- `navigator.clipboard.writeText` wrapped in try/catch since it requires a secure context and can reject.
- Auto-reverts to the default state after 1.8s via `setTimeout`.

## Feature Description
Adds a reusable animated copy-to-clipboard button with success feedback.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.