### PR TITLE
feat: add ease-tooltip-rating-preview-sap

### DIFF
--- a/submissions/examples/ease-tooltip-rating-preview-sap/README.md
+++ b/submissions/examples/ease-tooltip-rating-preview-sap/README.md
@@ -1,0 +1,18 @@
+# ease-tooltip-rating-preview-sap
+
+A hover tooltip on a star rating that reveals the full 5-to-1-star distribution as mini bars, rather than just a plain numeric tooltip.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.rating-preview-sap` markup from `demo.html`, setting each `.rating-preview-sap__bar span` inline `width` to your actual percentage breakdown per star level.
+
+## Customization
+- Adjust `width: 180px` on the card to resize.
+- Change bar `background` colors to restyle.
+- Reposition via `top`/`left` on `.rating-preview-sap__card` for above/below/side placement.
+
+## Accessibility
+`tabindex="0"` on the trigger plus `:focus-visible` reveal makes this keyboard-accessible; add `aria-label` summarizing the distribution for screen readers.
+
+## Browser support
+All modern browsers.

--- a/submissions/examples/ease-tooltip-rating-preview-sap/demo.html
+++ b/submissions/examples/ease-tooltip-rating-preview-sap/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-tooltip-rating-preview-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <span class="rating-preview-sap" tabindex="0">
+      &#9733;&#9733;&#9733;&#9733;&#9734; 4.2
+      <span class="rating-preview-sap__card">
+        <span class="rating-preview-sap__row"><span>5</span><span class="rating-preview-sap__bar"><span style="width:70%"></span></span></span>
+        <span class="rating-preview-sap__row"><span>4</span><span class="rating-preview-sap__bar"><span style="width:18%"></span></span></span>
+        <span class="rating-preview-sap__row"><span>3</span><span class="rating-preview-sap__bar"><span style="width:8%"></span></span></span>
+        <span class="rating-preview-sap__row"><span>2</span><span class="rating-preview-sap__bar"><span style="width:3%"></span></span></span>
+        <span class="rating-preview-sap__row"><span>1</span><span class="rating-preview-sap__bar"><span style="width:1%"></span></span></span>
+      </span>
+    </span>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-tooltip-rating-preview-sap/style.css
+++ b/submissions/examples/ease-tooltip-rating-preview-sap/style.css
@@ -1,0 +1,60 @@
+.rating-preview-sap {
+  position: relative;
+  display: inline-block;
+  color: #ffb84d;
+  font-size: 15px;
+  cursor: default;
+}
+
+.rating-preview-sap__card {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translate(-50%, 6px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 180px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #16161c;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.4);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.rating-preview-sap:hover .rating-preview-sap__card,
+.rating-preview-sap:focus-visible .rating-preview-sap__card {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.rating-preview-sap__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: #a0a0ad;
+}
+
+.rating-preview-sap__bar {
+  flex: 1;
+  height: 5px;
+  border-radius: 3px;
+  background: #2a2a32;
+  overflow: hidden;
+}
+
+.rating-preview-sap__bar span {
+  display: block;
+  height: 100%;
+  background: #ffb84d;
+  border-radius: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rating-preview-sap__card { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-tooltip-rating-preview-sap`, a hover tooltip showing a full star-rating distribution breakdown.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Distribution bars are plain `div`/`span` width-based bars (percentages set inline per instance), not a canvas/SVG chart — keeps the component dependency-free and easy to theme.
- Reveal via `opacity`/`visibility`/`transform`, gated on both `:hover` and `:focus-visible` for keyboard accessibility.
- `tabindex="0"` added to the trigger span since it isn't a naturally focusable element.

## Feature Description
Adds a reusable rich rating-distribution hover preview.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.