### PR TITLE
feat: add ease-hover-nav-underline-follow-sap

### DIFF
--- a/submissions/examples/ease-hover-nav-underline-follow-sap/README.md
+++ b/submissions/examples/ease-hover-nav-underline-follow-sap/README.md
@@ -1,0 +1,19 @@
+# ease-hover-nav-underline-follow-sap
+
+A nav bar underline that follows whichever link is currently hovered (not just the active one), sliding smoothly between links and fading out when the cursor leaves the nav entirely.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.nav-underline-follow-sap` markup from `demo.html` — any number of `.nav-underline-follow-sap__link` items plus one `.nav-underline-follow-sap__indicator` span.
+3. Include the `mouseenter`/`mouseleave` script from `demo.html` — measuring link position/width requires JS; CSS handles the slide/fade transition.
+
+## Customization
+- Adjust `gap` between links for spacing.
+- Change the `0.3s cubic-bezier(...)` transition for slide feel.
+- Swap the gradient on the indicator to restyle.
+
+## Accessibility
+This is a purely visual hover enhancement; ensure your active-page link is still indicated separately (e.g. `aria-current="page"` + a persistent style) since this indicator only tracks hover, not selection.
+
+## Browser support
+All modern browsers.

--- a/submissions/examples/ease-hover-nav-underline-follow-sap/demo.html
+++ b/submissions/examples/ease-hover-nav-underline-follow-sap/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-hover-nav-underline-follow-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <nav class="nav-underline-follow-sap">
+      <a href="#" class="nav-underline-follow-sap__link">Home</a>
+      <a href="#" class="nav-underline-follow-sap__link">Docs</a>
+      <a href="#" class="nav-underline-follow-sap__link">Pricing</a>
+      <a href="#" class="nav-underline-follow-sap__link">Contact</a>
+      <span class="nav-underline-follow-sap__indicator"></span>
+    </nav>
+  </div>
+
+  <script>
+    const nav = document.querySelector('.nav-underline-follow-sap');
+    const links = nav.querySelectorAll('.nav-underline-follow-sap__link');
+    const indicator = nav.querySelector('.nav-underline-follow-sap__indicator');
+
+    function move(el) {
+      indicator.style.width = `${el.offsetWidth}px`;
+      indicator.style.left = `${el.offsetLeft}px`;
+      indicator.style.opacity = '1';
+    }
+
+    links.forEach(link => link.addEventListener('mouseenter', () => move(link)));
+    nav.addEventListener('mouseleave', () => { indicator.style.opacity = '0'; });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-hover-nav-underline-follow-sap/style.css
+++ b/submissions/examples/ease-hover-nav-underline-follow-sap/style.css
@@ -1,0 +1,34 @@
+.nav-underline-follow-sap {
+  position: relative;
+  display: inline-flex;
+  gap: 28px;
+  padding-bottom: 4px;
+}
+
+.nav-underline-follow-sap__link {
+  color: #a0a0ad;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 6px 0;
+  transition: color 0.2s ease;
+}
+
+.nav-underline-follow-sap__link:hover {
+  color: #fff;
+}
+
+.nav-underline-follow-sap__indicator {
+  position: absolute;
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #6d5efc, #43e0d8);
+  opacity: 0;
+  transition: left 0.3s cubic-bezier(0.4, 0.2, 0.2, 1),
+              width 0.3s cubic-bezier(0.4, 0.2, 0.2, 1),
+              opacity 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-underline-follow-sap__indicator { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-hover-nav-underline-follow-sap`, a nav underline that follows the hovered link.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Indicator position/width computed from `offsetLeft`/`offsetWidth` of the hovered link on `mouseenter`; actual motion is a pure CSS `transition` on `left`/`width`/`opacity`.
- Indicator fades out (not just stays put) on `mouseleave` from the whole nav, avoiding a "stuck" underline after the cursor leaves.
- README explicitly notes this tracks hover only, not page-active state — flagged so it isn't mistaken for a selection indicator.

## Feature Description
Adds a reusable nav bar hover-following underline indicator.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.