### PR TITLE
feat: add ease-scroll-parallax-text-depth-sap

### DIFF
--- a/submissions/examples/ease-scroll-parallax-text-depth-sap/README.md
+++ b/submissions/examples/ease-scroll-parallax-text-depth-sap/README.md
@@ -1,0 +1,19 @@
+# ease-scroll-parallax-text-depth-sap
+
+Stacked text layers that scroll at different speeds relative to each other (via `data-depth` multipliers), creating a sense of depth — nearer layers move less, farther layers move more.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `.parallax-depth-sap` markup from `demo.html`, stacking `.parallax-depth-sap__layer` elements each with a `data-depth` (0–1, higher = moves more).
+3. Include the scroll listener from `demo.html` — depth-based movement needs live scroll position, which pure CSS can't read without `animation-timeline: scroll()` (not yet universally supported); this uses a `passive` scroll listener for broad compatibility.
+
+## Customization
+- Adjust each layer's `data-depth` value to change its parallax speed.
+- Change the `-0.3` multiplier in JS to scale overall parallax intensity.
+- Restyle layer `color`/`opacity`/`font-size` independently per layer.
+
+## Accessibility
+Respects `prefers-reduced-motion` by disabling all transform movement, leaving layers static.
+
+## Browser support
+All modern browsers (`scroll` event with passive listener).

--- a/submissions/examples/ease-scroll-parallax-text-depth-sap/demo.html
+++ b/submissions/examples/ease-scroll-parallax-text-depth-sap/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-scroll-parallax-text-depth-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="parallax-depth-sap">
+    <h1 class="parallax-depth-sap__layer" data-depth="0.2">FRONT</h1>
+    <h1 class="parallax-depth-sap__layer" data-depth="0.5">MIDDLE</h1>
+    <h1 class="parallax-depth-sap__layer" data-depth="0.9">BACK</h1>
+  </div>
+  <div style="height:150vh;"></div>
+
+  <script>
+    const layers = document.querySelectorAll('.parallax-depth-sap__layer');
+    function onScroll() {
+      const y = window.scrollY;
+      layers.forEach(layer => {
+        const depth = parseFloat(layer.dataset.depth);
+        layer.style.transform = `translateY(${y * depth * -0.3}px)`;
+      });
+    }
+    document.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-parallax-text-depth-sap/style.css
+++ b/submissions/examples/ease-scroll-parallax-text-depth-sap/style.css
@@ -1,0 +1,26 @@
+.parallax-depth-sap {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #0a0a0d;
+}
+
+.parallax-depth-sap__layer {
+  position: absolute;
+  margin: 0;
+  font-size: clamp(40px, 10vw, 120px);
+  font-weight: 800;
+  color: #fff;
+  will-change: transform;
+}
+
+.parallax-depth-sap__layer:nth-child(1) { opacity: 1; z-index: 3; }
+.parallax-depth-sap__layer:nth-child(2) { opacity: 0.5; z-index: 2; color: #6d5efc; }
+.parallax-depth-sap__layer:nth-child(3) { opacity: 0.2; z-index: 1; color: #43e0d8; }
+
+@media (prefers-reduced-motion: reduce) {
+  .parallax-depth-sap__layer { transform: none !important; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-scroll-parallax-text-depth-sap`, multi-layer scroll-parallax text with per-layer depth.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Used a `passive: true` scroll listener updating `transform: translateY()` per layer via a `data-depth` multiplier, rather than the newer `animation-timeline: scroll()` CSS feature, for broader current browser support.
- `will-change: transform` set on layers to hint compositing and avoid scroll jank.
- `prefers-reduced-motion` fully disables transform movement rather than just slowing it, per WCAG guidance on parallax effects.

## Feature Description
Adds a reusable multi-layer scroll-parallax text depth effect.

Level: Intermediate

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.