### PR TITLE
feat: add ease-animated-dropdown-chevron-sap

### DIFF
--- a/submissions/examples/ease-animated-dropdown-chevron-sap/README.md
+++ b/submissions/examples/ease-animated-dropdown-chevron-sap/README.md
@@ -1,0 +1,19 @@
+# ease-animated-dropdown-chevron-sap
+
+A dropdown built on native `<details>`/`<summary>` where the chevron icon smoothly rotates 180° on open/close via the `[open]` attribute selector — no JS for the open/close logic itself.
+
+## Usage
+1. Copy `style.css` into your project.
+2. Copy the `<details class="dropdown-chevron-sap">` markup from `demo.html`.
+3. No JS required — `<details>` handles open/close state natively.
+
+## Customization
+- Change the `0.3s cubic-bezier(...)` transition on the chevron for a different rotation feel.
+- Restyle `.dropdown-chevron-sap__panel` links for your design system.
+- Swap the `&#9662;` glyph for an SVG chevron icon if preferred.
+
+## Accessibility
+Native `<details>`/`<summary>` is keyboard-operable (Enter/Space to toggle) and exposes correct semantics to assistive tech out of the box, unlike a custom `div`+JS dropdown.
+
+## Browser support
+All modern browsers (`<details>`/`<summary>`, `[open]` attribute selector).

--- a/submissions/examples/ease-animated-dropdown-chevron-sap/demo.html
+++ b/submissions/examples/ease-animated-dropdown-chevron-sap/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ease-animated-dropdown-chevron-sap Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-wrap">
+    <details class="dropdown-chevron-sap">
+      <summary class="dropdown-chevron-sap__summary">
+        Select an option
+        <span class="dropdown-chevron-sap__chevron">&#9662;</span>
+      </summary>
+      <div class="dropdown-chevron-sap__panel">
+        <a href="#">Option One</a>
+        <a href="#">Option Two</a>
+        <a href="#">Option Three</a>
+      </div>
+    </details>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-animated-dropdown-chevron-sap/style.css
+++ b/submissions/examples/ease-animated-dropdown-chevron-sap/style.css
@@ -1,0 +1,55 @@
+.dropdown-chevron-sap {
+  width: 220px;
+  border-radius: 10px;
+  background: #16161c;
+  overflow: hidden;
+}
+
+.dropdown-chevron-sap__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.dropdown-chevron-sap__summary::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown-chevron-sap__chevron {
+  display: inline-block;
+  color: #a0a0ad;
+  transition: transform 0.3s cubic-bezier(0.4, 0.2, 0.2, 1);
+}
+
+.dropdown-chevron-sap[open] .dropdown-chevron-sap__chevron {
+  transform: rotate(180deg);
+}
+
+.dropdown-chevron-sap__panel {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 8px 10px;
+}
+
+.dropdown-chevron-sap__panel a {
+  padding: 8px 8px;
+  border-radius: 6px;
+  color: #c8c8d2;
+  font-size: 13px;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.dropdown-chevron-sap__panel a:hover {
+  background: #22222a;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-chevron-sap__chevron { transition: none; }
+}


### PR DESCRIPTION
## Summary
Adds `ease-animated-dropdown-chevron-sap`, a native `<details>`-based dropdown with an animated rotating chevron.

- [x] Includes `demo.html`, `style.css`, `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Built on native `<details>`/`<summary>` rather than a custom JS toggle — gets keyboard support, correct ARIA semantics, and open/close state for free.
- Chevron rotation driven purely by the `[open]` attribute CSS selector on the parent `<details>`, no JS listener needed.
- `::-webkit-details-marker` hidden so only the custom chevron shows, avoiding a duplicate default disclosure triangle.

## Feature Description
Adds a reusable native-details dropdown with an animated chevron indicator.

Level: Beginner

@SAPTARSHI-coder Please review the submission.
@github-actions Please validate the submission.