### PR TITLE
feat: add ease-hover-social-icon-bounce-sap

### DIFF
--- a/submissions/examples/ease-hover-social-icon-bounce-sap/README.md
+++ b/submissions/examples/ease-hover-social-icon-bounce-sap/README.md
@@ -1,0 +1,12 @@
+# ease-hover-social-icon-bounce-sap
+
+Social icon buttons that play a springy, decaying bounce (like a dropped ball settling) each time they're hovered.
+
+## Usage
+1. Include `style.css`.
+2. Add markup: `.bounce-icon` buttons with inline SVGs.
+
+## Notes
+- The keyframe uses progressively smaller peaks (14px → 6px → 2px) to mimic a decaying physical bounce rather than a single uniform up-down motion.
+- Animation replays fully on every fresh hover since it's not `infinite` and CSS naturally restarts `:hover`-triggered animations on re-entry.
+- Respects `prefers-reduced-motion`: the bounce animation is disabled entirely on hover.

--- a/submissions/examples/ease-hover-social-icon-bounce-sap/demo.html
+++ b/submissions/examples/ease-hover-social-icon-bounce-sap/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-social-icon-bounce-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="social-bounce-sap">
+    <div class="bounce-icon" aria-label="Twitter"><svg viewBox="0 0 24 24"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53A4.48 4.48 0 0 0 22.4.36a9 9 0 0 1-2.83 1.08A4.52 4.52 0 0 0 11.5 5.5"/></svg></div>
+    <div class="bounce-icon" aria-label="GitHub"><svg viewBox="0 0 24 24"><path d="M12 2C6.5 2 2 6.5 2 12a10 10 0 0 0 6.8 9.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.1-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.5 2.3 1.1 2.9.8.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7 1 .7 2v3c0 .3.2.6.7.5A10 10 0 0 0 22 12c0-5.5-4.5-10-10-10z"/></svg></div>
+    <div class="bounce-icon" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg></div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-social-icon-bounce-sap/style.css
+++ b/submissions/examples/ease-hover-social-icon-bounce-sap/style.css
@@ -1,0 +1,41 @@
+.social-bounce-sap {
+  display: flex;
+  gap: 14px;
+}
+
+.social-bounce-sap .bounce-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #111;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.social-bounce-sap .bounce-icon svg {
+  width: 18px;
+  height: 18px;
+  fill: #fff;
+}
+
+.social-bounce-sap .bounce-icon:hover {
+  animation: icon-bounce-sap 0.6s cubic-bezier(0.28, 0.84, 0.42, 1);
+}
+
+@keyframes icon-bounce-sap {
+  0% { transform: translateY(0); }
+  30% { transform: translateY(-14px); }
+  50% { transform: translateY(0); }
+  65% { transform: translateY(-6px); }
+  80% { transform: translateY(0); }
+  90% { transform: translateY(-2px); }
+  100% { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .social-bounce-sap .bounce-icon:hover {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-social-icon-bounce-sap`, a decaying-bounce hover effect for social icon buttons.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-hover-social-icon-bounce-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Keyframe peaks decrease progressively (14px → 6px → 2px) to mimic a physically decaying bounce rather than uniform up-down motion.
- `prefers-reduced-motion` disables the bounce animation entirely.

## Feature Description

Adds a reusable decaying-bounce social icon hover effect component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.