### PR TITLE
test: add CSS specificity safety check example

### DIFF
--- a/submissions/examples/css-specificity-safety-82022/README.md
+++ b/submissions/examples/css-specificity-safety-82022/README.md
@@ -1,0 +1,29 @@
+# CSS Specificity Calculation Safety Check
+
+A responsive CSS specificity testing example created for issue #82022.
+
+## Overview
+
+This example demonstrates CSS specificity calculation for common
+selectors, edge cases, and invalid input.
+
+The demo covers:
+
+- Element selectors
+- Class selectors
+- ID selectors
+- Attribute selectors
+- Pseudo-classes
+- Pseudo-elements
+- Combined selectors
+- Universal selectors
+- Empty input
+- Whitespace-only input
+
+## Specificity Format
+
+The result is displayed using the standard four-part specificity
+notation:
+
+```text
+A, B, C, D

--- a/submissions/examples/css-specificity-safety-82022/demo.html
+++ b/submissions/examples/css-specificity-safety-82022/demo.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Specificity Safety Check</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <header class="hero">
+      <span class="eyebrow">CSS SAFETY CHECK</span>
+      <h1>Specificity Calculator</h1>
+      <p>
+        Test CSS selector specificity against common, edge-case, and
+        invalid inputs.
+      </p>
+    </header>
+
+    <section class="calculator">
+      <div class="input-area">
+        <label for="selector">CSS Selector</label>
+
+        <div class="input-row">
+          <input
+            id="selector"
+            type="text"
+            value=".card #title:hover"
+            placeholder="Enter a CSS selector"
+            autocomplete="off"
+          >
+
+          <button id="calculate">Calculate</button>
+        </div>
+
+        <div class="examples">
+          <button data-selector="p">p</button>
+          <button data-selector=".card">.card</button>
+          <button data-selector="#hero">#hero</button>
+          <button data-selector=".card #title:hover">
+            .card #title:hover
+          </button>
+          <button data-selector="article.card[data-active]">
+            article.card[data-active]
+          </button>
+        </div>
+      </div>
+
+      <div class="result" id="result">
+        <span>Specificity</span>
+        <strong id="specificity">0, 0, 0, 0</strong>
+        <small id="message">Enter a selector to begin.</small>
+      </div>
+    </section>
+
+    <section class="tests">
+      <div class="section-heading">
+        <span>EDGE CASES</span>
+        <h2>Safety Test Matrix</h2>
+      </div>
+
+      <div class="test-grid" id="testGrid"></div>
+    </section>
+
+    <section class="info">
+      <article>
+        <span>01</span>
+        <h2>Happy Path</h2>
+        <p>
+          Valid element, class, ID, attribute, and pseudo-class
+          selectors are evaluated.
+        </p>
+      </article>
+
+      <article>
+        <span>02</span>
+        <h2>Edge Cases</h2>
+        <p>
+          Empty selectors, whitespace, universal selectors, and complex
+          selector combinations are checked.
+        </p>
+      </article>
+
+      <article>
+        <span>03</span>
+        <h2>Invalid Input</h2>
+        <p>
+          Invalid or unsupported selector input is handled without
+          crashing the interface.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    const selectorInput =
+      document.getElementById("selector");
+
+    const calculateButton =
+      document.getElementById("calculate");
+
+    const specificityOutput =
+      document.getElementById("specificity");
+
+    const messageOutput =
+      document.getElementById("message");
+
+    const testGrid =
+      document.getElementById("testGrid");
+
+    /*
+     * Specificity format:
+     * A = inline styles
+     * B = IDs
+     * C = classes, attributes, pseudo-classes
+     * D = elements and pseudo-elements
+     */
+    function calculateSpecificity(selector) {
+      if (
+        typeof selector !== "string" ||
+        selector.trim() === ""
+      ) {
+        return null;
+      }
+
+      const cleaned =
+        selector
+          .replace(/\/\*[\s\S]*?\*\//g, "")
+          .trim();
+
+      if (!cleaned) {
+        return null;
+      }
+
+      let ids = 0;
+      let classes = 0;
+      let elements = 0;
+
+      const idMatches =
+        cleaned.match(/#[a-zA-Z0-9_-]+/g);
+
+      const classMatches =
+        cleaned.match(/\.[a-zA-Z0-9_-]+/g);
+
+      const attributeMatches =
+        cleaned.match(/\[[^\]]+\]/g);
+
+      const pseudoClassMatches =
+        cleaned.match(/:(?!:)[a-zA-Z-]+(?:\([^)]*\))?/g);
+
+      ids =
+        idMatches ? idMatches.length : 0;
+
+      classes =
+        (classMatches ? classMatches.length : 0) +
+        (attributeMatches ? attributeMatches.length : 0) +
+        (pseudoClassMatches ? pseudoClassMatches.length : 0);
+
+      const withoutSpecialSelectors =
+        cleaned
+          .replace(/#[a-zA-Z0-9_-]+/g, "")
+          .replace(/\.[a-zA-Z0-9_-]+/g, "")
+          .replace(/\[[^\]]+\]/g, "")
+          .replace(/::?[a-zA-Z-]+(?:\([^)]*\))?/g, "")
+          .replace(/[*\s>+~(),]/g, " ");
+
+      const elementMatches =
+        withoutSpecialSelectors
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean);
+
+      elements = elementMatches.length;
+
+      return [0, ids, classes, elements];
+    }
+
+    function formatSpecificity(value) {
+      return value
+        ? value.join(", ")
+        : "Invalid";
+    }
+
+    function calculate() {
+      const selector =
+        selectorInput.value;
+
+      const result =
+        calculateSpecificity(selector);
+
+      if (!result) {
+        specificityOutput.textContent =
+          "Invalid";
+
+        messageOutput.textContent =
+          "Empty or invalid selector input.";
+
+        return;
+      }
+
+      specificityOutput.textContent =
+        formatSpecificity(result);
+
+      messageOutput.textContent =
+        "Specificity calculated successfully.";
+    }
+
+    calculateButton.addEventListener(
+      "click",
+      calculate
+    );
+
+    selectorInput.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key === "Enter") {
+          calculate();
+        }
+      }
+    );
+
+    document
+      .querySelectorAll("[data-selector]")
+      .forEach((button) => {
+        button.addEventListener(
+          "click",
+          () => {
+            selectorInput.value =
+              button.dataset.selector;
+
+            calculate();
+          }
+        );
+      });
+
+    const testCases = [
+      {
+        selector: "p",
+        expected: "0, 0, 0, 1"
+      },
+      {
+        selector: ".card",
+        expected: "0, 0, 1, 0"
+      },
+      {
+        selector: "#header",
+        expected: "0, 1, 0, 0"
+      },
+      {
+        selector: "div.card",
+        expected: "0, 0, 1, 1"
+      },
+      {
+        selector: "#app .card",
+        expected: "0, 1, 1, 0"
+      },
+      {
+        selector: "input[type='text']",
+        expected: "0, 0, 1, 1"
+      },
+      {
+        selector: "button:hover",
+        expected: "0, 0, 1, 1"
+      },
+      {
+        selector: "::before",
+        expected: "0, 0, 0, 1"
+      },
+      {
+        selector: "*",
+        expected: "0, 0, 0, 0"
+      },
+      {
+        selector: "",
+        expected: "Invalid"
+      },
+      {
+        selector: "   ",
+        expected: "Invalid"
+      }
+    ];
+
+    testCases.forEach((test) => {
+      const result =
+        calculateSpecificity(test.selector);
+
+      const actual =
+        result
+          ? formatSpecificity(result)
+          : "Invalid";
+
+      const passed =
+        actual === test.expected;
+
+      const card =
+        document.createElement("article");
+
+      card.className =
+        `test-card ${passed ? "passed" : "failed"}`;
+
+      card.innerHTML = `
+        <div class="test-top">
+          <code>${test.selector || "(empty)"}</code>
+          <span>${passed ? "PASS" : "FAIL"}</span>
+        </div>
+
+        <div class="test-values">
+          <div>
+            <small>Expected</small>
+            <strong>${test.expected}</strong>
+          </div>
+
+          <div>
+            <small>Actual</small>
+            <strong>${actual}</strong>
+          </div>
+        </div>
+      `;
+
+      testGrid.appendChild(card);
+    });
+
+    calculate();
+  </script>
+</body>
+</html>

--- a/submissions/examples/css-specificity-safety-82022/style.css
+++ b/submissions/examples/css-specificity-safety-82022/style.css
@@ -1,0 +1,349 @@
+:root {
+  --background: #080c13;
+  --surface: #121925;
+  --surface-alt: #182131;
+  --border: #2b3749;
+  --text: #f4f7fb;
+  --muted: #95a2b5;
+  --accent: #8fb9ff;
+  --success: #83d9a4;
+  --danger: #e58b8b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background:
+    radial-gradient(
+      circle at 15% 10%,
+      #213d61 0,
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 85% 80%,
+      #342a59 0,
+      transparent 32%
+    ),
+    var(--background);
+}
+
+.page {
+  width: min(1100px, calc(100% - 32px));
+  margin: auto;
+  padding: 60px 0;
+}
+
+.hero {
+  max-width: 760px;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+h1 {
+  margin: 12px 0;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+}
+
+.hero p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.calculator {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+}
+
+.input-area label {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.input-row {
+  display: flex;
+  gap: 10px;
+}
+
+input {
+  width: 100%;
+  min-width: 0;
+  height: 48px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  outline: none;
+  background: #0b1018;
+  color: var(--text);
+  font: inherit;
+}
+
+input:focus {
+  border-color: var(--accent);
+}
+
+button {
+  padding: 11px 18px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+.input-row button {
+  flex-shrink: 0;
+  background: #203452;
+}
+
+.examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.examples button {
+  padding: 7px 10px;
+  color: var(--muted);
+  font-family:
+    "Cascadia Code",
+    Consolas,
+    monospace;
+  font-size: 0.72rem;
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-alt);
+}
+
+.result > span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.result strong {
+  margin: 12px 0 7px;
+  color: var(--accent);
+  font-family:
+    "Cascadia Code",
+    Consolas,
+    monospace;
+  font-size: 1.8rem;
+}
+
+.result small {
+  color: var(--muted);
+}
+
+.tests {
+  margin-top: 24px;
+}
+
+.section-heading {
+  margin-bottom: 14px;
+}
+
+.section-heading > span {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.section-heading h2 {
+  margin: 8px 0 0;
+  font-size: 1.5rem;
+}
+
+.test-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.test-card {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.test-card.passed {
+  border-color: #385a4a;
+}
+
+.test-card.failed {
+  border-color: #633b3b;
+}
+
+.test-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.test-top code {
+  overflow: hidden;
+  color: var(--text);
+  font-family:
+    "Cascadia Code",
+    Consolas,
+    monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.test-top span {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  font-weight: 900;
+}
+
+.passed .test-top span {
+  color: var(--success);
+}
+
+.failed .test-top span {
+  color: var(--danger);
+}
+
+.test-values {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.test-values div {
+  padding: 10px;
+  border-radius: 9px;
+  background: var(--surface-alt);
+}
+
+.test-values small,
+.test-values strong {
+  display: block;
+}
+
+.test-values small {
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.test-values strong {
+  font-family:
+    "Cascadia Code",
+    Consolas,
+    monospace;
+  font-size: 0.8rem;
+}
+
+.info {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.info article {
+  min-height: 165px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-alt);
+}
+
+.info article > span {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.info h2 {
+  margin: 20px 0 10px;
+  font-size: 1.15rem;
+}
+
+.info p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 850px) {
+  .calculator {
+    grid-template-columns: 1fr;
+  }
+
+  .test-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .info {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    width: min(100% - 20px, 1100px);
+    padding: 40px 0;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .input-row button {
+    width: 100%;
+  }
+
+  .test-values {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Description

Added a responsive CSS Specificity Calculation Safety Check example
for issue #82022.

### Included

- CSS specificity calculator
- Happy-path selector tests
- Edge-case selector tests
- Empty and whitespace input handling
- Invalid input handling
- Interactive test result matrix
- Responsive layout
- Accessibility considerations

### Test Coverage

- Element selectors
- Class selectors
- ID selectors
- Attribute selectors
- Pseudo-classes
- Pseudo-elements
- Combined selectors
- Universal selectors
- Empty input
- Whitespace-only input

### Files

- `demo.html` — Interactive specificity calculator and test matrix
- `style.css` — Responsive styling
- `README.md` — Usage and test documentation

### Issue

Closes #82022