### PR TITLE
test: add password strength edge case test demo

### DIFF
--- a/submissions/examples/password-strength-regex-score-calculator-test/README.md
+++ b/submissions/examples/password-strength-regex-score-calculator-test/README.md
@@ -1,0 +1,24 @@
+# Password Strength Regex Score Calculator - Edge Case Tests
+
+## Overview
+
+This submission demonstrates edge-case testing scenarios for a password strength calculator.
+
+## Covered Cases
+
+- Empty input
+- Whitespace
+- Short passwords
+- Long passwords
+- Lowercase only
+- Uppercase + lowercase
+- Numeric
+- Special characters
+- Unicode characters
+
+## Files
+
+- demo.html
+- style.css
+
+Open demo.html in a browser to view the simulated test report.

--- a/submissions/examples/password-strength-regex-score-calculator-test/demo.html
+++ b/submissions/examples/password-strength-regex-score-calculator-test/demo.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Password Strength Regex Score Calculator - Edge Case Tests</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="container">
+    <h1>Password Strength Edge Case Tests</h1>
+    <p class="subtitle">
+        Simulated automated edge-case coverage for a Password Strength Regex Score Calculator.
+    </p>
+
+    <div class="summary">
+        <div class="card">
+            <h2>9</h2>
+            <span>Total Tests</span>
+        </div>
+
+        <div class="card pass">
+            <h2>9</h2>
+            <span>Passed</span>
+        </div>
+
+        <div class="card">
+            <h2>100%</h2>
+            <span>Coverage</span>
+        </div>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Test Case</th>
+                <th>Input</th>
+                <th>Expected</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+
+        <tbody>
+
+            <tr>
+                <td>Empty Password</td>
+                <td>""</td>
+                <td>Invalid</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Whitespace</td>
+                <td>" "</td>
+                <td>Invalid</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Lowercase Only</td>
+                <td>password</td>
+                <td>Weak</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Letters + Numbers</td>
+                <td>pass1234</td>
+                <td>Medium</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Mixed Case</td>
+                <td>Pass1234</td>
+                <td>Strong</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Special Characters</td>
+                <td>Pass@123!</td>
+                <td>Very Strong</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Long Password</td>
+                <td>64 Characters</td>
+                <td>Very Strong</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Unicode Password</td>
+                <td>密码@123</td>
+                <td>Strong</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+            <tr>
+                <td>Emoji Password</td>
+                <td>🔒Pass123!</td>
+                <td>Strong</td>
+                <td><span class="badge pass">PASS</span></td>
+            </tr>
+
+        </tbody>
+    </table>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/password-strength-regex-score-calculator-test/style.css
+++ b/submissions/examples/password-strength-regex-score-calculator-test/style.css
@@ -1,0 +1,121 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    font-family:Arial,sans-serif;
+    background:#0f172a;
+    color:#fff;
+    display:flex;
+    justify-content:center;
+    padding:40px 20px;
+}
+
+.container{
+    width:min(1100px,100%);
+}
+
+h1{
+    text-align:center;
+    margin-bottom:10px;
+}
+
+.subtitle{
+    text-align:center;
+    color:#cbd5e1;
+    margin-bottom:35px;
+}
+
+.summary{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+    gap:20px;
+    margin-bottom:35px;
+}
+
+.card{
+    background:#1e293b;
+    padding:25px;
+    border-radius:14px;
+    text-align:center;
+    border:1px solid #334155;
+    transition:.3s;
+}
+
+.card:hover{
+    transform:translateY(-6px);
+}
+
+.card h2{
+    font-size:2rem;
+    margin-bottom:8px;
+}
+
+.pass{
+    border-color:#22c55e;
+}
+
+table{
+    width:100%;
+    border-collapse:collapse;
+    overflow:hidden;
+    border-radius:14px;
+    background:#1e293b;
+}
+
+thead{
+    background:#334155;
+}
+
+th,td{
+    padding:16px;
+    text-align:left;
+    border-bottom:1px solid #475569;
+}
+
+tr:hover{
+    background:#273449;
+}
+
+.badge{
+    padding:6px 14px;
+    border-radius:30px;
+    font-weight:bold;
+    display:inline-block;
+}
+
+.badge.pass{
+    background:#22c55e;
+    color:#fff;
+}
+
+@media(max-width:700px){
+
+table,
+thead,
+tbody,
+th,
+td,
+tr{
+display:block;
+}
+
+thead{
+display:none;
+}
+
+tr{
+margin-bottom:18px;
+border-radius:12px;
+background:#1e293b;
+padding:10px;
+}
+
+td{
+border:none;
+padding:10px;
+}
+
+}


### PR DESCRIPTION
## Pull Request Description

Adds a browser-based demonstration of edge-case testing scenarios for a Password Strength Regex Score Calculator.

Closes #82036

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] Other (Testing demonstration)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Feature Description

This submission demonstrates edge-case testing scenarios for a Password Strength Regex Score Calculator using a responsive HTML/CSS dashboard. It showcases common password inputs, expected strength classifications, and simulated PASS results to visualize automated test coverage.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer

This contribution is contained entirely within the `submissions/examples/` directory to comply with repository contribution guidelines while providing a visual demonstration of password strength edge-case testing.

Closes #82036