### PR TITLE
a11y: Add accessibility audit and Chip Component Dismiss Button ARIA Label (enhancement) #81966

### DIFF
--- a/submissions/examples/a11y-chip-component-dismiss/README.md
+++ b/submissions/examples/a11y-chip-component-dismiss/README.md
@@ -1,0 +1,16 @@
+# Accessible Chip Component (Dismissible)
+
+A highly accessible, WCAG 2.1 AA compliant Chip (Tag) component featuring a dismiss button. Engineered with best practices for screen readers, keyboard navigation, and high-contrast environments.
+
+## Accessibility Features
+
+- **Semantic HTML & Native Controls**: Uses a native `<button>` element for the dismiss action, ensuring out-of-the-box support for `Enter` and `Space` keyboard interactions.
+- **ARIA Labels**: 
+  - `aria-label="Remove [Item] filter"` provides explicit context for screen readers when focusing the dismiss button.
+  - The SVG icon is marked with `aria-hidden="true"` to prevent redundant screen reader announcements.
+- **State Announcements (aria-live)**: Utilizes an `aria-live="polite"` region to actively announce to screen readers when a chip has been removed from the DOM.
+- **Focus Management**: Implements a high-visibility `:focus-visible` state with `outline-offset` to ensure keyboard navigators can clearly see the active element, satisfying WCAG Focus Visible guidelines.
+- **Forced Colors Support**: Includes a `@media (forced-colors: active)` query to automatically map standard background and text colors to the operating system's system colors (`Canvas`, `CanvasText`, `Highlight`) when Windows High Contrast Mode is enabled.
+
+## Usage
+Include `demo.html` and `style.css` in your project. The component relies on a tiny, essential JavaScript function to hide the chip and trigger the `aria-live` announcement.

--- a/submissions/examples/a11y-chip-component-dismiss/demo.html
+++ b/submissions/examples/a11y-chip-component-dismiss/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Chip Component</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="container">
+        <h1>Accessible Chip Components</h1>
+        <p>Use the Tab key to navigate. Press Enter or Space to dismiss a chip.</p>
+        
+        <div class="chip-group" role="group" aria-label="Selected filters">
+            
+            <div class="chip" id="chip-1">
+                <span class="chip-text">Accessibility</span>
+                <button type="button" class="chip-dismiss" aria-label="Remove Accessibility filter" aria-controls="chip-1" onclick="dismissChip('chip-1')">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                    </svg>
+                </button>
+            </div>
+            
+            <div class="chip" id="chip-2">
+                <span class="chip-text">Design Systems</span>
+                <button type="button" class="chip-dismiss" aria-label="Remove Design Systems filter" aria-controls="chip-2" onclick="dismissChip('chip-2')">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                    </svg>
+                </button>
+            </div>
+
+            <div class="chip" id="chip-3">
+                <span class="chip-text">WCAG 2.1 AA</span>
+                <button type="button" class="chip-dismiss" aria-label="Remove WCAG 2.1 AA filter" aria-controls="chip-3" onclick="dismissChip('chip-3')">
+                    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                    </svg>
+                </button>
+            </div>
+
+        </div>
+
+        <!-- Live region for screen reader announcements -->
+        <div aria-live="polite" class="sr-only" id="announcer"></div>
+
+    </main>
+
+    <script>
+        function dismissChip(chipId) {
+            const chip = document.getElementById(chipId);
+            if (chip) {
+                const text = chip.querySelector('.chip-text').innerText;
+                chip.style.display = 'none';
+                
+                // Announce removal to screen readers
+                const announcer = document.getElementById('announcer');
+                announcer.innerText = `${text} filter removed.`;
+                
+                // Keep focus in the document
+                document.body.focus();
+            }
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/a11y-chip-component-dismiss/style.css
+++ b/submissions/examples/a11y-chip-component-dismiss/style.css
@@ -1,0 +1,139 @@
+:root {
+    --chip-bg: #e2e8f0;
+    --chip-text: #0f172a;
+    --chip-hover-bg: #cbd5e1;
+    --chip-focus-ring: #2563eb;
+    --chip-icon: #334155;
+    
+    --bg-page: #f8fafc;
+    --text-main: #0f172a;
+}
+
+/* 
+   Forced Colors (High Contrast Mode) Support 
+   Ensures WCAG compliance when users enable high contrast modes in OS
+*/
+@media (forced-colors: active) {
+    :root {
+        --chip-bg: Canvas;
+        --chip-text: CanvasText;
+        --chip-hover-bg: Highlight;
+        --chip-focus-ring: CanvasText;
+        --chip-icon: CanvasText;
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-page);
+    color: var(--text-main);
+    padding: 2rem;
+    line-height: 1.5;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+/* 
+   Chip Group container
+*/
+.chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 1.5rem 0;
+}
+
+/* 
+   Individual Chip
+*/
+.chip {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--chip-bg);
+    color: var(--chip-text);
+    border-radius: 9999px; /* Pill shape */
+    padding: 0.25rem 0.25rem 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+}
+
+/* Add visible border in high contrast mode */
+@media (forced-colors: active) {
+    .chip {
+        border-color: CanvasText;
+    }
+}
+
+.chip-text {
+    margin-right: 0.375rem;
+}
+
+/* 
+   Dismiss Button
+*/
+.chip-dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: none;
+    background-color: transparent;
+    color: var(--chip-icon);
+    cursor: pointer;
+    padding: 0;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+/* Interactive Hover State */
+.chip-dismiss:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+    color: var(--chip-text);
+}
+
+@media (forced-colors: active) {
+    .chip-dismiss:hover {
+        background-color: Highlight;
+        color: HighlightText;
+    }
+}
+
+/* 
+   Keyboard Navigation Focus State 
+   Ensures WCAG 2.1 Focus Visible requirement
+*/
+.chip-dismiss:focus-visible {
+    outline: 2px solid var(--chip-focus-ring);
+    outline-offset: 2px;
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+/* 
+   Screen Reader Only utility class
+   Visually hides content while keeping it accessible to screen readers
+*/
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}


### PR DESCRIPTION

**Title:** a11y: Add accessibility audit and Chip Component Dismiss Button ARIA Label (enhancement) #81966

**Description:**
This PR introduces a highly accessible, WCAG 2.1 AA compliant Chip (Tag) component featuring a dismiss button designed with best practices for screen readers, keyboard navigation, and high-contrast environments.

Fixes #81966

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/a11y-chip-component-dismiss/`
- Implemented **Semantic HTML & Native Controls**: Uses a native `<button>` element for the dismiss action to ensure out-of-the-box support for `Enter` and `Space` keyboard interactions
- Engineered precise **ARIA Labels**: 
  - Added `aria-label="Remove [Item] filter"` providing explicit context for screen readers when focusing the dismiss button
  - Marked the SVG icon with `aria-hidden="true"` to prevent redundant screen reader announcements
- Built **State Announcements (aria-live)**: Utilizes an `aria-live="polite"` region and a small JS function to actively announce to screen readers when a chip has been removed from the DOM
- Designed **Focus Management**: Implemented a high-visibility `:focus-visible` state with `outline-offset` to ensure keyboard navigators can clearly see the active element, satisfying WCAG Focus Visible guidelines
- Added **Forced Colors Support**: Included a `@media (forced-colors: active)` query to automatically map standard background and text colors to the OS system colors (`Canvas`, `CanvasText`, `Highlight`) when Windows High Contrast Mode is enabled
