### PR TITLE
feat: Add Tooltip Bubble animation

### DIFF
--- a/submissions/examples/82863-tooltip-bubble-ionfwsrijan/README.md
+++ b/submissions/examples/82863-tooltip-bubble-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Tooltip Bubble
+
+A label that pops above an element on hover.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82863

--- a/submissions/examples/82863-tooltip-bubble-ionfwsrijan/demo.html
+++ b/submissions/examples/82863-tooltip-bubble-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tooltip Bubble</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<div class="tt">Hover<span class="tip">Tooltip!</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/82863-tooltip-bubble-ionfwsrijan/style.css
+++ b/submissions/examples/82863-tooltip-bubble-ionfwsrijan/style.css
@@ -1,0 +1,6 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.tt{position:relative;display:inline-block;padding:10px 16px;background:#3b82f6;color:#fff;border-radius:8px;cursor:pointer}
+.tt .tip{position:absolute;bottom:120%;left:50%;transform:translateX(-50%) scale(0);background:#0f172a;color:#fff;padding:6px 10px;border-radius:6px;white-space:nowrap;transition:.25s;transform-origin:bottom}
+.tt:hover .tip{transform:translateX(-50%) scale(1)}


### PR DESCRIPTION
## Tooltip Bubble

A label that pops above an element on hover.

Adds a self-contained, working CSS animation demo under `submissions/examples/82863-tooltip-bubble-ionfwsrijan`.

Closes #82863