### PR TITLE
feat: Add Jelly Button animation

### DIFF
--- a/submissions/examples/82877-jelly-button-ionfwsrijan/README.md
+++ b/submissions/examples/82877-jelly-button-ionfwsrijan/README.md
@@ -1,0 +1,12 @@
+# Jelly Button
+
+A button with a springy jelly press.
+
+## Files
+- `demo.html` - interactive demo with the animation
+- `style.css` - original animation styles
+
+## Usage
+Open `demo.html` in any browser to view the working animation.
+
+Closes #82877

--- a/submissions/examples/82877-jelly-button-ionfwsrijan/demo.html
+++ b/submissions/examples/82877-jelly-button-ionfwsrijan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Jelly Button</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="stage">
+<button class="jb">Press</button>
+</div>
+</body>
+</html>

--- a/submissions/examples/82877-jelly-button-ionfwsrijan/style.css
+++ b/submissions/examples/82877-jelly-button-ionfwsrijan/style.css
@@ -1,0 +1,6 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,Segoe UI,sans-serif;background:#0f1226;color:#e6e8f0}
+.stage{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:28px;flex-wrap:wrap;padding:28px}
+.jb{border:0;padding:16px 38px;font-size:18px;border-radius:12px;background:#34d399;color:#04293a;cursor:pointer;transition:transform .15s}
+.jb:active{transform:scale(.9);animation:jelly .5s}
+@keyframes jelly{0%,100%{transform:scale(1)}30%{transform:scale(1.2,.8)}60%{transform:scale(.9,1.1)}}


### PR DESCRIPTION
## Jelly Button

A button with a springy jelly press.

Adds a self-contained, working CSS animation demo under `submissions/examples/82877-jelly-button-ionfwsrijan`.

Closes #82877