### PR TITLE
feat: add password-strength animated meter component

### DIFF
--- a/submissions/examples/password-strength/README.md
+++ b/submissions/examples/password-strength/README.md
@@ -1,0 +1,39 @@
+# Password Strength Meter with Animated Bars
+
+A four-segment password strength meter where filled bars animate in with a staggered fill, colored by strength level. Pure HTML and CSS — no JavaScript required for the visuals.
+
+## Features
+
+- 📊 Four-bar segmented meter with staggered fill-in animation
+- 🎨 Color-coded by strength: red (weak), orange (medium), green (strong)
+- 📱 Responsive — bars scale with container width
+- ♿ Respects `prefers-reduced-motion` (bars fill instantly)
+- 🧩 Pure HTML + CSS — no JavaScript dependencies
+
+## Usage
+
+```html
+<div class="strength-meter strength-meter--medium">
+  <span class="strength-bar"></span>
+  <span class="strength-bar"></span>
+  <span class="strength-bar"></span>
+  <span class="strength-bar"></span>
+</div>
+<p class="strength-text strength-text--medium">Medium</p>
+```
+
+Change the modifier (`strength-meter--weak`, `--medium`, `--strong`) to control how many bars fill and their color.
+
+## Why it fits EaseMotion CSS
+
+The bar fill is a single `@keyframes width` animation applied via `::after` pseudo-elements with staggered `animation-delay`, no JavaScript required to render or animate. Class names are simple and readable.
+
+## Files
+
+- `demo.html` — three example strength states (weak, medium, strong)
+- `style.css` — all styles and animations
+- `README.md` — this file
+
+## Notes
+
+Actually calculating password strength from user input requires JavaScript — this component provides the animated visual meter; your app's JS would swap the `strength-meter--*` modifier class as the user types.

--- a/submissions/examples/password-strength/demo.html
+++ b/submissions/examples/password-strength/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Password Strength Meter — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="strength-wrapper">
+    <p class="demo-title">Example strength states (pure CSS)</p>
+
+    <div class="strength-field">
+      <label class="strength-label" for="pw-weak">Weak password</label>
+      <input class="strength-input" id="pw-weak" type="password" value="1234" readonly />
+      <div class="strength-meter strength-meter--weak">
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+      </div>
+      <p class="strength-text strength-text--weak">Weak</p>
+    </div>
+
+    <div class="strength-field">
+      <label class="strength-label" for="pw-medium">Medium password</label>
+      <input class="strength-input" id="pw-medium" type="password" value="Passw0rd" readonly />
+      <div class="strength-meter strength-meter--medium">
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+      </div>
+      <p class="strength-text strength-text--medium">Medium</p>
+    </div>
+
+    <div class="strength-field">
+      <label class="strength-label" for="pw-strong">Strong password</label>
+      <input class="strength-input" id="pw-strong" type="password" value="P@ssw0rd!2026" readonly />
+      <div class="strength-meter strength-meter--strong">
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+        <span class="strength-bar"></span>
+      </div>
+      <p class="strength-text strength-text--strong">Strong</p>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/password-strength/style.css
+++ b/submissions/examples/password-strength/style.css
@@ -1,0 +1,139 @@
+/* ============================================
+   Password Strength Meter with Animated Bars
+   Pure CSS — no JavaScript required
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: #0f1115;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.strength-wrapper {
+  width: 100%;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.demo-title {
+  color: #8a8f98;
+  font-size: 0.85rem;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+/* ---------- Field ---------- */
+.strength-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.strength-label {
+  font-size: 0.78rem;
+  color: #8a8f98;
+}
+
+.strength-input {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #262a33;
+  background: #171a21;
+  color: #e6e8eb;
+  font-size: 0.85rem;
+  outline: none;
+}
+
+/* ---------- Bar meter ---------- */
+.strength-meter {
+  display: flex;
+  gap: 5px;
+}
+
+.strength-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 4px;
+  background: #262a33;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Each bar fills in via a pseudo-element that animates its width;
+   the number of filled bars is controlled by nth-child rules
+   scoped to the meter's strength modifier. */
+.strength-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: 4px;
+  animation: bar-fill 0.5s ease forwards;
+}
+
+/* Weak: 1 of 4 bars filled, red */
+.strength-meter--weak .strength-bar:nth-child(1)::after {
+  width: 100%;
+  background: #e74c3c;
+  animation-delay: 0.05s;
+}
+
+/* Medium: 2 of 4 bars filled, orange */
+.strength-meter--medium .strength-bar:nth-child(1)::after,
+.strength-meter--medium .strength-bar:nth-child(2)::after {
+  width: 100%;
+  background: #f5a623;
+}
+.strength-meter--medium .strength-bar:nth-child(1)::after { animation-delay: 0.05s; }
+.strength-meter--medium .strength-bar:nth-child(2)::after { animation-delay: 0.15s; }
+
+/* Strong: all 4 bars filled, green */
+.strength-meter--strong .strength-bar:nth-child(1)::after,
+.strength-meter--strong .strength-bar:nth-child(2)::after,
+.strength-meter--strong .strength-bar:nth-child(3)::after,
+.strength-meter--strong .strength-bar:nth-child(4)::after {
+  width: 100%;
+  background: #4ade80;
+}
+.strength-meter--strong .strength-bar:nth-child(1)::after { animation-delay: 0.05s; }
+.strength-meter--strong .strength-bar:nth-child(2)::after { animation-delay: 0.15s; }
+.strength-meter--strong .strength-bar:nth-child(3)::after { animation-delay: 0.25s; }
+.strength-meter--strong .strength-bar:nth-child(4)::after { animation-delay: 0.35s; }
+
+@keyframes bar-fill {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+/* ---------- Strength label text ---------- */
+.strength-text {
+  font-size: 0.78rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.strength-text--weak { color: #e74c3c; }
+.strength-text--medium { color: #f5a623; }
+.strength-text--strong { color: #4ade80; }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .strength-bar::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds an animated four-segment password strength meter with staggered bar fill-in and strength-based coloring, built with pure HTML and CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` structure and links `style.css`
- Bar fill uses `::after` pseudo-elements animating `width`, staggered via `animation-delay`
- `prefers-reduced-motion` disables the animation so bars appear instantly filled

## Feature Description

Adds a reusable animated password strength meter with three strength presets.

Level: Beginner

@SAPTARSHI-coder Please review the submission whenever you get a chance.

@github-actions Please validate the submission.