### PR TITLE
test: add edge case coverage for File Dropzone drop validation

### DIFF
--- a/submissions/examples/file-dropzone-drop-validation-edgecases/README.md
+++ b/submissions/examples/file-dropzone-drop-validation-edgecases/README.md
@@ -1,0 +1,32 @@
+# File Dropzone Drop File Validation Edge Tests
+
+## Overview
+
+Vitest edge-case tests for validating dropped files.
+
+### Covers
+
+- Valid uploads
+- Maximum file count
+- Too many files
+- Invalid MIME type
+- Oversized files
+- Negative size
+- Missing properties
+- Empty array
+- Null input
+- Undefined input
+- Malformed objects
+- Custom validation configuration
+
+## Files
+
+- demo.html
+- style.css
+- file-dropzone-edge.test.js
+
+Run:
+
+```bash
+vitest
+```

--- a/submissions/examples/file-dropzone-drop-validation-edgecases/demo.html
+++ b/submissions/examples/file-dropzone-drop-validation-edgecases/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>File Dropzone Validation Demo</title>
+<link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+<div class="dropzone">
+    Drop files here
+</div>
+
+</body>
+</html>

--- a/submissions/examples/file-dropzone-drop-validation-edgecases/file-dropzone-edge.test.js
+++ b/submissions/examples/file-dropzone-drop-validation-edgecases/file-dropzone-edge.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+
+function validateDroppedFiles(files, options = {}) {
+  const {
+    maxSize = 1024 * 1024,
+    allowedTypes = ["image/png", "image/jpeg"],
+    maxFiles = 5,
+  } = options;
+
+  if (!Array.isArray(files)) return false;
+  if (files.length === 0) return false;
+  if (files.length > maxFiles) return false;
+
+  return files.every((file) => {
+    if (!file) return false;
+    if (typeof file.name !== "string") return false;
+    if (typeof file.size !== "number") return false;
+    if (typeof file.type !== "string") return false;
+
+    return (
+      file.size >= 0 &&
+      file.size <= maxSize &&
+      allowedTypes.includes(file.type)
+    );
+  });
+}
+
+describe("File Dropzone Drop File Validation - Edge Cases", () => {
+  it("accepts a valid PNG", () => {
+    expect(
+      validateDroppedFiles([
+        { name: "a.png", size: 500, type: "image/png" },
+      ])
+    ).toBe(true);
+  });
+
+  it("accepts maximum allowed files", () => {
+    const files = Array.from({ length: 5 }, (_, i) => ({
+      name: `${i}.png`,
+      size: 100,
+      type: "image/png",
+    }));
+
+    expect(validateDroppedFiles(files)).toBe(true);
+  });
+
+  it("rejects more than maximum files", () => {
+    const files = Array.from({ length: 6 }, (_, i) => ({
+      name: `${i}.png`,
+      size: 100,
+      type: "image/png",
+    }));
+
+    expect(validateDroppedFiles(files)).toBe(false);
+  });
+
+  it("rejects unsupported MIME type", () => {
+    expect(
+      validateDroppedFiles([
+        { name: "doc.pdf", size: 200, type: "application/pdf" },
+      ])
+    ).toBe(false);
+  });
+
+  it("rejects oversized file", () => {
+    expect(
+      validateDroppedFiles([
+        { name: "large.png", size: 3000000, type: "image/png" },
+      ])
+    ).toBe(false);
+  });
+
+  it("rejects negative file size", () => {
+    expect(
+      validateDroppedFiles([
+        { name: "bad.png", size: -1, type: "image/png" },
+      ])
+    ).toBe(false);
+  });
+
+  it("rejects missing type", () => {
+    expect(
+      validateDroppedFiles([
+        { name: "a.png", size: 100 },
+      ])
+    ).toBe(false);
+  });
+
+  it("rejects null input", () => {
+    expect(validateDroppedFiles(null)).toBe(false);
+  });
+
+  it("rejects undefined input", () => {
+    expect(validateDroppedFiles(undefined)).toBe(false);
+  });
+
+  it("rejects empty array", () => {
+    expect(validateDroppedFiles([])).toBe(false);
+  });
+
+  it("rejects malformed object", () => {
+    expect(validateDroppedFiles([{}])).toBe(false);
+  });
+
+  it("supports custom configuration", () => {
+    expect(
+      validateDroppedFiles(
+        [
+          {
+            name: "notes.txt",
+            size: 300,
+            type: "text/plain",
+          },
+        ],
+        {
+          maxSize: 500,
+          allowedTypes: ["text/plain"],
+          maxFiles: 2,
+        }
+      )
+    ).toBe(true);
+  });
+});

--- a/submissions/examples/file-dropzone-drop-validation-edgecases/style.css
+++ b/submissions/examples/file-dropzone-drop-validation-edgecases/style.css
@@ -1,0 +1,32 @@
+*{
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
+}
+
+body{
+    height:100vh;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    background:#0f172a;
+    font-family:Arial,sans-serif;
+}
+
+.dropzone{
+    width:340px;
+    height:180px;
+    border:3px dashed #38bdf8;
+    border-radius:14px;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    background:#1e293b;
+    color:white;
+    transition:.3s ease;
+}
+
+.dropzone:hover{
+    border-color:#22d3ee;
+    transform:scale(1.03);
+}


### PR DESCRIPTION
## Pull Request Description

Adds comprehensive Vitest edge-case coverage for **File Dropzone Drop File Validation**.

---

## Type of Change

- [x] Documentation improvement

---

## Submission Checklist

- [x] All files are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes Vitest test file
- [x] One feature per PR

---

## Test Coverage

- Happy path
- Maximum file count
- Invalid MIME types
- Oversized files
- Negative file size
- Missing properties
- Null/undefined input
- Empty array
- Malformed objects
- Custom validation options

---

Closes #82004
```