### PR TITLE
feat: add scroll-progress CSS scroll-driven bar

### DIFF
--- a/submissions/examples/scroll-progress/README.md
+++ b/submissions/examples/scroll-progress/README.md
@@ -1,0 +1,41 @@
+# Sticky Scroll-Progress Bar
+
+A slim gradient bar fixed to the top of the viewport that fills as the user scrolls down the page — built with the modern CSS scroll-driven animations spec (`animation-timeline: scroll()`), no JavaScript required.
+
+## Features
+
+- 📏 Bar fill is tied directly to scroll position via `animation-timeline: scroll(root)`
+- 🌈 Gradient fill (purple → teal)
+- 🧊 Fixed to the top of the viewport at all times
+- ♿ Respects `prefers-reduced-motion` (shows a static dimmed bar instead)
+- 🧩 Pure HTML + CSS — no JavaScript, no scroll event listeners
+
+## Usage
+
+```html
+<div class="scroll-progress"></div>
+
+<main class="page">
+  <!-- your long page content -->
+</main>
+```
+
+Place `.scroll-progress` as a direct child near the top of `<body>` — it's `position: fixed`, so its DOM position doesn't affect layout.
+
+## Browser support note
+
+This component uses `animation-timeline: scroll()`, part of the CSS Scroll-Driven Animations spec. It's supported in **Chrome/Edge 115+** and shipping in other browsers. In browsers without support, the bar simply stays at 0% width (no error, just no progress fill) — a graceful, non-breaking fallback. For guaranteed cross-browser support today, a small JS scroll listener updating a `--progress` custom property is the common polyfill approach, but this submission focuses on the pure-CSS technique as the primary implementation per the issue's "CSS keyframes only" style of request.
+
+## Why it fits EaseMotion CSS
+
+This showcases a cutting-edge pure-CSS animation technique — scroll-linked motion with zero JavaScript and zero scroll listeners, which is exactly the kind of modern, framework-free capability the project highlights.
+
+## Files
+
+- `demo.html` — a long scrollable demo page with the progress bar
+- `style.css` — the scroll-driven animation
+- `README.md` — this file
+
+## Notes
+
+`animation-timeline: scroll(root)` ties progress to the whole document's scroll range by default; use `scroll(nearest)` instead if you want the bar to track a specific scrollable container rather than the whole page.

--- a/submissions/examples/scroll-progress/demo.html
+++ b/submissions/examples/scroll-progress/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sticky Scroll-Progress Bar — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!--
+    Pure CSS scroll progress using animation-timeline: scroll(),
+    supported in modern Chrome/Edge. Falls back to a static bar
+    in browsers without support (see README for the fallback note).
+  -->
+  <div class="scroll-progress"></div>
+
+  <main class="page">
+    <h1>Scroll down to see the progress bar fill</h1>
+    <p>Section 1 — this bar at the top of the page fills based on how far you've scrolled, using pure CSS scroll-driven animations.</p>
+    <p>Section 2 — keep scrolling...</p>
+    <p>Section 3 — almost there...</p>
+    <p>Section 4 — more content to scroll through...</p>
+    <p>Section 5 — nearly at the bottom...</p>
+    <p>Section 6 — you made it! The bar above should now be full.</p>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/scroll-progress/style.css
+++ b/submissions/examples/scroll-progress/style.css
@@ -1,0 +1,77 @@
+/* ============================================
+   Sticky Scroll-Progress Bar
+   Pure CSS — no JavaScript required
+   (uses CSS scroll-driven animations)
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: #0f1115;
+  color: #a7abb3;
+}
+
+.page {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 80px 20px 400px;
+}
+
+.page h1 {
+  color: #e6e8eb;
+  font-size: 1.4rem;
+}
+
+.page p {
+  line-height: 1.7;
+  margin-bottom: 200px;
+  font-size: 0.95rem;
+}
+
+/* ---------- Progress bar ---------- */
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: transparent;
+  z-index: 999;
+}
+
+.scroll-progress::before {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform-origin: left;
+  transform: scaleX(0);
+  background: linear-gradient(90deg, #6c5ce7, #a29bfe, #00cec9);
+
+  /* Scroll-driven animation: ties transform directly to page scroll
+     progress instead of time. Supported in Chrome/Edge 115+. */
+  animation: progress-fill linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes progress-fill {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-progress::before {
+    animation: none;
+    transform: scaleX(1);
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a sticky scroll-progress bar using CSS scroll-driven animations (`animation-timeline: scroll()`), requiring zero JavaScript or scroll listeners.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- Uses `animation-timeline: scroll(root)` — Chrome/Edge 115+, degrades gracefully (0% bar, no error) elsewhere
- `prefers-reduced-motion` shows a static dimmed bar instead of the scroll-linked fill

## Feature Description

Adds a scroll-linked progress bar demonstrating the modern CSS scroll-driven animations spec.

Level: Beginner

Flagging the browser support caveat clearly in the README since this is a newer CSS feature — happy to add a JS polyfill fallback if broader compatibility is a priority for the project.

@SAPTARSHI-coder Please review the submission whenever you get a chance.

@github-actions Please validate the submission.