### PR TITLE
feat: add basic domain verification row demo

### DIFF
--- a/submissions/examples/basic-domain-verification-row-v2-kk/README.md
+++ b/submissions/examples/basic-domain-verification-row-v2-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Domain Verification Row
+
+## What it does
+
+This submission adds a simple CSS-only domain verification row for workspace
+settings, DNS setup panels, website dashboards, and custom domain screens.
+
+It presents a domain status icon, domain name, helper text, DNS record type, and
+verification state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a status icon, copy area, DNS record label, and
+state pill:
+
+```html
+<article class="basic-domain-verification-row">
+  <span class="domain-icon is-verified" aria-hidden="true">OK</span>
+  <div class="domain-copy">
+    <strong>app.example.com</strong>
+    <p>TXT record was found and ownership is confirmed.</p>
+  </div>
+  <span class="domain-record">TXT</span>
+  <span class="domain-state is-verified">Verified</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+developer and workspace settings interfaces. The row can be reused inside DNS
+setup cards, custom domain pages, website dashboards, and verification panels
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Verified, pending DNS, and failed verification examples
+- DNS record type metadata
+- Verification state pills
+- Long text truncation for domain helper copy
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the domain verification row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-domain-verification-row-v2-kk/demo.html
+++ b/submissions/examples/basic-domain-verification-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Domain Verification Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Domain Verification Row</p>
+          <h1>Domain rows for DNS and workspace verification panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing domain name, DNS record type,
+            helper copy, and verification state in settings dashboards.
+          </p>
+        </header>
+
+        <section class="domain-panel" aria-label="Domain verification row examples">
+          <article class="basic-domain-verification-row">
+            <span class="domain-icon is-verified" aria-hidden="true">OK</span>
+            <div class="domain-copy">
+              <strong>app.example.com</strong>
+              <p>TXT record was found and ownership is confirmed.</p>
+            </div>
+            <span class="domain-record">TXT</span>
+            <span class="domain-state is-verified">Verified</span>
+          </article>
+
+          <article class="basic-domain-verification-row">
+            <span class="domain-icon is-pending" aria-hidden="true">DNS</span>
+            <div class="domain-copy">
+              <strong>docs.example.com</strong>
+              <p>Waiting for DNS propagation before the next check.</p>
+            </div>
+            <span class="domain-record">CNAME</span>
+            <span class="domain-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-domain-verification-row">
+            <span class="domain-icon is-failed" aria-hidden="true">ERR</span>
+            <div class="domain-copy">
+              <strong>shop.example.com</strong>
+              <p>Record value does not match the expected verification token.</p>
+            </div>
+            <span class="domain-record">TXT</span>
+            <span class="domain-state is-failed">Fix DNS</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-domain-verification-row"&gt;
+  &lt;span class="domain-icon is-verified" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="domain-copy"&gt;
+    &lt;strong&gt;app.example.com&lt;/strong&gt;
+    &lt;p&gt;TXT record was found and ownership is confirmed.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="domain-record"&gt;TXT&lt;/span&gt;
+  &lt;span class="domain-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-domain-verification-row-v2-kk/style.css
+++ b/submissions/examples/basic-domain-verification-row-v2-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --verified: #86efac;
+  --pending: #93c5fd;
+  --failed: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--verified);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.domain-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-domain-verification-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-domain-verification-row + .basic-domain-verification-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-domain-verification-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.domain-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.domain-icon.is-pending {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.domain-icon.is-failed {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.domain-copy {
+  min-width: 0;
+}
+
+.domain-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.domain-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.domain-record,
+.domain-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.domain-record {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.domain-state {
+  min-width: 6rem;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.domain-state.is-pending {
+  color: var(--pending);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.domain-state.is-failed {
+  color: var(--failed);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-domain-verification-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .domain-record,
+  .domain-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Domain Verification Row demo inside `submissions/examples/basic-domain-verification-row-v2-kk/`. This submission introduces a compact CSS-only row for workspace settings, DNS setup panels, website dashboards, and custom domain screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only domain verification row that displays a domain status icon, domain name, helper text, DNS record type, and verified/pending DNS/failed verification state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-domain-verification-row">
  <span class="domain-icon is-verified" aria-hidden="true">OK</span>
  <div class="domain-copy">
    <strong>app.example.com</strong>
    <p>TXT record was found and ownership is confirmed.</p>
  </div>
  <span class="domain-record">TXT</span>
  <span class="domain-state is-verified">Verified</span>
</article>