### PR TITLE
feat: add basic invite status row demo

### DIFF
--- a/submissions/examples/basic-invite-status-row-kk/README.md
+++ b/submissions/examples/basic-invite-status-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Invite Status Row
+
+## What it does
+
+This submission adds a simple CSS-only invite status row for team settings,
+workspace member panels, onboarding dashboards, and collaboration tools.
+
+It presents an invite state icon, recipient email, helper text, assigned role,
+and invitation state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an invite icon, copy area, role label, and state
+pill:
+
+```html
+<article class="basic-invite-status-row">
+  <span class="invite-icon is-accepted" aria-hidden="true">AC</span>
+  <div class="invite-copy">
+    <strong>maya@example.com</strong>
+    <p>Accepted the invitation and joined the workspace.</p>
+  </div>
+  <span class="invite-role">Admin</span>
+  <span class="invite-state is-accepted">Accepted</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+team management interfaces. The row can be reused inside member lists, invite
+panels, workspace settings, and onboarding dashboards while staying lightweight
+and CSS-only.
+
+## Included features
+
+- Accepted, pending, and expired invite examples
+- Assigned role metadata
+- Invitation state pills
+- Long text truncation for recipient and helper copy
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the invite status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-invite-status-row-kk/demo.html
+++ b/submissions/examples/basic-invite-status-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Invite Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Invite Status Row</p>
+          <h1>Invitation rows for team and workspace settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing invite recipient, assigned
+            role, helper copy, and invitation state in member management panels.
+          </p>
+        </header>
+
+        <section class="invite-panel" aria-label="Invite status row examples">
+          <article class="basic-invite-status-row">
+            <span class="invite-icon is-accepted" aria-hidden="true">AC</span>
+            <div class="invite-copy">
+              <strong>maya@example.com</strong>
+              <p>Accepted the invitation and joined the workspace.</p>
+            </div>
+            <span class="invite-role">Admin</span>
+            <span class="invite-state is-accepted">Accepted</span>
+          </article>
+
+          <article class="basic-invite-status-row">
+            <span class="invite-icon is-pending" aria-hidden="true">PN</span>
+            <div class="invite-copy">
+              <strong>dev@example.com</strong>
+              <p>Invitation email sent and waiting for response.</p>
+            </div>
+            <span class="invite-role">Editor</span>
+            <span class="invite-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-invite-status-row">
+            <span class="invite-icon is-expired" aria-hidden="true">EX</span>
+            <div class="invite-copy">
+              <strong>ops@example.com</strong>
+              <p>Invite link expired before the user joined.</p>
+            </div>
+            <span class="invite-role">Viewer</span>
+            <span class="invite-state is-expired">Expired</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-invite-status-row"&gt;
+  &lt;span class="invite-icon is-accepted" aria-hidden="true"&gt;AC&lt;/span&gt;
+  &lt;div class="invite-copy"&gt;
+    &lt;strong&gt;maya@example.com&lt;/strong&gt;
+    &lt;p&gt;Accepted the invitation and joined the workspace.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="invite-role"&gt;Admin&lt;/span&gt;
+  &lt;span class="invite-state is-accepted"&gt;Accepted&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-invite-status-row-kk/style.css
+++ b/submissions/examples/basic-invite-status-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --accepted: #86efac;
+  --pending: #93c5fd;
+  --expired: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accepted);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.invite-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-invite-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-invite-status-row + .basic-invite-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-invite-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.invite-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.invite-icon.is-pending {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.invite-icon.is-expired {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.invite-copy {
+  min-width: 0;
+}
+
+.invite-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invite-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invite-role,
+.invite-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.invite-role {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.invite-state {
+  min-width: 6rem;
+  color: var(--accepted);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.invite-state.is-pending {
+  color: var(--pending);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.invite-state.is-expired {
+  color: var(--expired);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-invite-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .invite-role,
+  .invite-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Invite Status Row demo inside `submissions/examples/basic-invite-status-row-kk/`. This submission introduces a compact CSS-only row for team settings, workspace member panels, onboarding dashboards, and collaboration tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only invite status row that displays an invite state icon, recipient email, helper text, assigned role, and accepted/pending/expired invitation state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-invite-status-row">
  <span class="invite-icon is-accepted" aria-hidden="true">AC</span>
  <div class="invite-copy">
    <strong>maya@example.com</strong>
    <p>Accepted the invitation and joined the workspace.</p>
  </div>
  <span class="invite-role">Admin</span>
  <span class="invite-state is-accepted">Accepted</span>
</article>