### PR TITLE
feat: add basic invoice tax row demo

### DIFF
--- a/submissions/examples/basic-invoice-tax-row-kk/README.md
+++ b/submissions/examples/basic-invoice-tax-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Invoice Tax Row
+
+## What it does
+
+This submission adds a simple CSS-only invoice tax row for checkout summaries,
+invoice breakdowns, billing panels, and payment review screens.
+
+It presents a tax type icon, tax label, helper text, rate metadata, and amount
+in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a tax icon, copy area, rate label, and amount pill:
+
+```html
+<article class="basic-invoice-tax-row">
+  <span class="tax-icon is-gst" aria-hidden="true">GST</span>
+  <div class="tax-copy">
+    <strong>Goods and Services Tax</strong>
+    <p>Applied according to the billing address region.</p>
+  </div>
+  <span class="tax-rate">18%</span>
+  <span class="tax-amount is-gst">$24.30</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+billing interfaces. The row can be reused inside invoices, checkout summaries,
+subscription billing cards, and payment review panels while staying lightweight
+and CSS-only.
+
+## Included features
+
+- GST, VAT, and processing fee examples
+- Rate metadata and amount pill
+- Region/helper copy for tax context
+- Long text truncation for tax descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the invoice tax row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-invoice-tax-row-kk/demo.html
+++ b/submissions/examples/basic-invoice-tax-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Invoice Tax Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Invoice Tax Row</p>
+          <h1>Tax rows for checkout and invoice breakdown panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing tax type, rate, helper copy,
+            amount, and billing state in compact invoice summaries.
+          </p>
+        </header>
+
+        <section class="tax-panel" aria-label="Invoice tax row examples">
+          <article class="basic-invoice-tax-row">
+            <span class="tax-icon is-gst" aria-hidden="true">GST</span>
+            <div class="tax-copy">
+              <strong>Goods and Services Tax</strong>
+              <p>Applied according to the billing address region.</p>
+            </div>
+            <span class="tax-rate">18%</span>
+            <span class="tax-amount is-gst">$24.30</span>
+          </article>
+
+          <article class="basic-invoice-tax-row">
+            <span class="tax-icon is-vat" aria-hidden="true">VAT</span>
+            <div class="tax-copy">
+              <strong>Value Added Tax</strong>
+              <p>Calculated for international subscription billing.</p>
+            </div>
+            <span class="tax-rate">12%</span>
+            <span class="tax-amount is-vat">$16.20</span>
+          </article>
+
+          <article class="basic-invoice-tax-row">
+            <span class="tax-icon is-fee" aria-hidden="true">FEE</span>
+            <div class="tax-copy">
+              <strong>Processing fee</strong>
+              <p>Small fixed charge for payment gateway handling.</p>
+            </div>
+            <span class="tax-rate">Flat</span>
+            <span class="tax-amount is-fee">$2.50</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-invoice-tax-row"&gt;
+  &lt;span class="tax-icon is-gst" aria-hidden="true"&gt;GST&lt;/span&gt;
+  &lt;div class="tax-copy"&gt;
+    &lt;strong&gt;Goods and Services Tax&lt;/strong&gt;
+    &lt;p&gt;Applied according to the billing address region.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="tax-rate"&gt;18%&lt;/span&gt;
+  &lt;span class="tax-amount is-gst"&gt;$24.30&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-invoice-tax-row-kk/style.css
+++ b/submissions/examples/basic-invoice-tax-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --gst: #86efac;
+  --vat: #93c5fd;
+  --fee: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--gst);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.tax-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-invoice-tax-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-invoice-tax-row + .basic-invoice-tax-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-invoice-tax-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.tax-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.tax-icon.is-vat {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.tax-icon.is-fee {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.tax-copy {
+  min-width: 0;
+}
+
+.tax-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tax-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tax-rate,
+.tax-amount {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.tax-rate {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tax-amount {
+  min-width: 6rem;
+  color: var(--gst);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.tax-amount.is-vat {
+  color: var(--vat);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.tax-amount.is-fee {
+  color: var(--fee);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-invoice-tax-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .tax-rate,
+  .tax-amount {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Invoice Tax Row demo inside `submissions/examples/basic-invoice-tax-row-kk/`. This submission introduces a compact CSS-only row for checkout summaries, invoice breakdowns, billing panels, and payment review screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only invoice tax row that displays a tax type icon, tax label, helper text, rate metadata, and amount in one compact layout.

**How does a developer use it?**

```html
<article class="basic-invoice-tax-row">
  <span class="tax-icon is-gst" aria-hidden="true">GST</span>
  <div class="tax-copy">
    <strong>Goods and Services Tax</strong>
    <p>Applied according to the billing address region.</p>
  </div>
  <span class="tax-rate">18%</span>
  <span class="tax-amount is-gst">$24.30</span>
</article>