### PR TITLE
feat: add basic currency preference row demo

### DIFF
--- a/submissions/examples/basic-currency-preference-row-v2-kk/README.md
+++ b/submissions/examples/basic-currency-preference-row-v2-kk/README.md
@@ -1,0 +1,50 @@
+# Basic Currency Preference Row
+
+## What it does
+
+This submission adds a simple CSS-only currency preference row for billing
+settings, account preferences, checkout configuration, and workspace setup
+screens.
+
+It presents a currency code icon, currency name, helper text, region metadata,
+and preference state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a currency icon, copy area, region label, and state
+pill:
+
+```html
+<article class="basic-currency-preference-row is-selected">
+  <span class="currency-icon is-primary" aria-hidden="true">USD</span>
+  <div class="currency-copy">
+    <strong>US Dollar</strong>
+    <p>Primary billing currency for invoices and receipts.</p>
+  </div>
+  <span class="currency-region">United States</span>
+  <span class="currency-state is-primary">Primary</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+billing and account interfaces. The row can be reused inside checkout settings,
+workspace configuration, localization panels, and subscription dashboards while
+staying lightweight and CSS-only.
+
+## Included features
+
+- USD, INR, and EUR currency examples
+- Primary, suggested, and locked state pills
+- Region metadata label
+- Long text truncation for currency helper copy
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the currency preference row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-currency-preference-row-v2-kk/demo.html
+++ b/submissions/examples/basic-currency-preference-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Currency Preference Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Currency Preference Row</p>
+          <h1>Currency rows for billing and account preference screens.</h1>
+          <p class="intro">
+            A CSS-only row component for showing currency code, region helper
+            text, conversion note, and preference state in billing settings.
+          </p>
+        </header>
+
+        <section class="currency-panel" aria-label="Currency preference row examples">
+          <article class="basic-currency-preference-row is-selected">
+            <span class="currency-icon is-primary" aria-hidden="true">USD</span>
+            <div class="currency-copy">
+              <strong>US Dollar</strong>
+              <p>Primary billing currency for invoices and receipts.</p>
+            </div>
+            <span class="currency-region">United States</span>
+            <span class="currency-state is-primary">Primary</span>
+          </article>
+
+          <article class="basic-currency-preference-row">
+            <span class="currency-icon is-suggested" aria-hidden="true">INR</span>
+            <div class="currency-copy">
+              <strong>Indian Rupee</strong>
+              <p>Suggested based on workspace location and tax profile.</p>
+            </div>
+            <span class="currency-region">India</span>
+            <span class="currency-state is-suggested">Suggested</span>
+          </article>
+
+          <article class="basic-currency-preference-row">
+            <span class="currency-icon is-locked" aria-hidden="true">EUR</span>
+            <div class="currency-copy">
+              <strong>Euro</strong>
+              <p>Available after enabling multi-currency billing.</p>
+            </div>
+            <span class="currency-region">Europe</span>
+            <span class="currency-state is-locked">Locked</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-currency-preference-row is-selected"&gt;
+  &lt;span class="currency-icon is-primary" aria-hidden="true"&gt;USD&lt;/span&gt;
+  &lt;div class="currency-copy"&gt;
+    &lt;strong&gt;US Dollar&lt;/strong&gt;
+    &lt;p&gt;Primary billing currency for invoices and receipts.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="currency-region"&gt;United States&lt;/span&gt;
+  &lt;span class="currency-state is-primary"&gt;Primary&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-currency-preference-row-v2-kk/style.css
+++ b/submissions/examples/basic-currency-preference-row-v2-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --primary: #86efac;
+  --suggested: #93c5fd;
+  --locked: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--primary);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.currency-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-currency-preference-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-currency-preference-row + .basic-currency-preference-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-currency-preference-row:hover,
+.basic-currency-preference-row.is-selected {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.currency-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.currency-icon.is-suggested {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.currency-icon.is-locked {
+  background: linear-gradient(135deg, #cbd5e1, #f8fafc);
+}
+
+.currency-copy {
+  min-width: 0;
+}
+
+.currency-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.currency-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.currency-region,
+.currency-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.currency-region {
+  min-width: 6.5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.currency-state {
+  min-width: 6rem;
+  color: var(--primary);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.currency-state.is-suggested {
+  color: var(--suggested);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.currency-state.is-locked {
+  color: var(--locked);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-currency-preference-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .currency-region,
+  .currency-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Currency Preference Row demo inside `submissions/examples/basic-currency-preference-row-v2-kk/`. This submission introduces a compact CSS-only row for billing settings, account preferences, checkout configuration, and workspace setup screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only currency preference row that displays a currency code icon, currency name, helper text, region metadata, and primary/suggested/locked state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-currency-preference-row is-selected">
  <span class="currency-icon is-primary" aria-hidden="true">USD</span>
  <div class="currency-copy">
    <strong>US Dollar</strong>
    <p>Primary billing currency for invoices and receipts.</p>
  </div>
  <span class="currency-region">United States</span>
  <span class="currency-state is-primary">Primary</span>
</article>