### PR TITLE
feat: add basic release version row demo

### DIFF
--- a/submissions/examples/basic-release-version-row-kk/README.md
+++ b/submissions/examples/basic-release-version-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Release Version Row
+
+## What it does
+
+This submission adds a simple CSS-only release version row for changelog pages,
+deployment panels, product dashboards, and release history screens.
+
+It presents a release icon, version name, helper text, release timing, and
+release state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a release icon, copy area, time label, and state
+pill:
+
+```html
+<article class="basic-release-version-row">
+  <span class="release-icon is-stable" aria-hidden="true">V1</span>
+  <div class="release-copy">
+    <strong>Version 1.8.0</strong>
+    <p>Stable release with dashboard layout improvements.</p>
+  </div>
+  <span class="release-time">Today</span>
+  <span class="release-state is-stable">Stable</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+product and deployment interfaces. The row can be reused inside changelogs,
+release history cards, deploy panels, and product dashboards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Stable, beta, and rollback release examples
+- Release timing metadata
+- Release state pills
+- Long text truncation for release notes
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the release version row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-release-version-row-kk/demo.html
+++ b/submissions/examples/basic-release-version-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Release Version Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Release Version Row</p>
+          <h1>Release rows for changelog and deployment panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing version labels, release notes,
+            deploy timing, and release state in product dashboards.
+          </p>
+        </header>
+
+        <section class="release-panel" aria-label="Release version row examples">
+          <article class="basic-release-version-row">
+            <span class="release-icon is-stable" aria-hidden="true">V1</span>
+            <div class="release-copy">
+              <strong>Version 1.8.0</strong>
+              <p>Stable release with dashboard layout improvements.</p>
+            </div>
+            <span class="release-time">Today</span>
+            <span class="release-state is-stable">Stable</span>
+          </article>
+
+          <article class="basic-release-version-row">
+            <span class="release-icon is-beta" aria-hidden="true">B2</span>
+            <div class="release-copy">
+              <strong>Version 1.9.0 beta</strong>
+              <p>Preview build for testing upcoming workflow tools.</p>
+            </div>
+            <span class="release-time">2d ago</span>
+            <span class="release-state is-beta">Beta</span>
+          </article>
+
+          <article class="basic-release-version-row">
+            <span class="release-icon is-rollback" aria-hidden="true">RB</span>
+            <div class="release-copy">
+              <strong>Version 1.7.4</strong>
+              <p>Rollback point kept available for emergency restores.</p>
+            </div>
+            <span class="release-time">Last week</span>
+            <span class="release-state is-rollback">Rollback</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-release-version-row"&gt;
+  &lt;span class="release-icon is-stable" aria-hidden="true"&gt;V1&lt;/span&gt;
+  &lt;div class="release-copy"&gt;
+    &lt;strong&gt;Version 1.8.0&lt;/strong&gt;
+    &lt;p&gt;Stable release with dashboard layout improvements.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="release-time"&gt;Today&lt;/span&gt;
+  &lt;span class="release-state is-stable"&gt;Stable&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-release-version-row-kk/style.css
+++ b/submissions/examples/basic-release-version-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --stable: #86efac;
+  --beta: #93c5fd;
+  --rollback: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--stable);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.release-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-release-version-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-release-version-row + .basic-release-version-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-release-version-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.release-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.release-icon.is-beta {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.release-icon.is-rollback {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.release-copy {
+  min-width: 0;
+}
+
+.release-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.release-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.release-time,
+.release-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.release-time {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.release-state {
+  min-width: 6rem;
+  color: var(--stable);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.release-state.is-beta {
+  color: var(--beta);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.release-state.is-rollback {
+  color: var(--rollback);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-release-version-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .release-time,
+  .release-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Release Version Row demo inside `submissions/examples/basic-release-version-row-kk/`. This submission introduces a compact CSS-only row for changelog pages, deployment panels, product dashboards, and release history screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only release version row that displays a release icon, version name, helper text, release timing, and stable/beta/rollback state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-release-version-row">
  <span class="release-icon is-stable" aria-hidden="true">V1</span>
  <div class="release-copy">
    <strong>Version 1.8.0</strong>
    <p>Stable release with dashboard layout improvements.</p>
  </div>
  <span class="release-time">Today</span>
  <span class="release-state is-stable">Stable</span>
</article>