### PR TITLE
feat: add basic review approval row demo

### DIFF
--- a/submissions/examples/basic-review-approval-row-kk/README.md
+++ b/submissions/examples/basic-review-approval-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Review Approval Row
+
+## What it does
+
+This submission adds a simple CSS-only review approval row for workflow panels,
+review dashboards, task approvals, and release checklists.
+
+It presents a review type icon, review name, helper text, review time, and
+approval state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a review icon, copy area, time label, and state
+pill:
+
+```html
+<article class="basic-review-approval-row">
+  <span class="review-icon is-approved" aria-hidden="true">AP</span>
+  <div class="review-copy">
+    <strong>Design review</strong>
+    <p>Approved by the product design reviewer.</p>
+  </div>
+  <span class="review-time">8m ago</span>
+  <span class="review-state is-approved">Approved</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+workflow and collaboration interfaces. The row can be reused inside approval
+dashboards, release checklists, review panels, and task boards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Approved, pending, and changes-requested review examples
+- Review timing metadata
+- Approval state pills
+- Long text truncation for review descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the review approval row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-review-approval-row-kk/demo.html
+++ b/submissions/examples/basic-review-approval-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Review Approval Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Review Approval Row</p>
+          <h1>Approval rows for review and workflow panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing reviewers, decision state,
+            helper copy, and review timing inside approval dashboards.
+          </p>
+        </header>
+
+        <section class="review-panel" aria-label="Review approval row examples">
+          <article class="basic-review-approval-row">
+            <span class="review-icon is-approved" aria-hidden="true">AP</span>
+            <div class="review-copy">
+              <strong>Design review</strong>
+              <p>Approved by the product design reviewer.</p>
+            </div>
+            <span class="review-time">8m ago</span>
+            <span class="review-state is-approved">Approved</span>
+          </article>
+
+          <article class="basic-review-approval-row">
+            <span class="review-icon is-pending" aria-hidden="true">PD</span>
+            <div class="review-copy">
+              <strong>Engineering review</strong>
+              <p>Waiting for implementation notes and final checks.</p>
+            </div>
+            <span class="review-time">Open</span>
+            <span class="review-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-review-approval-row">
+            <span class="review-icon is-changes" aria-hidden="true">CR</span>
+            <div class="review-copy">
+              <strong>Content review</strong>
+              <p>Small wording updates are requested before release.</p>
+            </div>
+            <span class="review-time">1h ago</span>
+            <span class="review-state is-changes">Changes</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-review-approval-row"&gt;
+  &lt;span class="review-icon is-approved" aria-hidden="true"&gt;AP&lt;/span&gt;
+  &lt;div class="review-copy"&gt;
+    &lt;strong&gt;Design review&lt;/strong&gt;
+    &lt;p&gt;Approved by the product design reviewer.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="review-time"&gt;8m ago&lt;/span&gt;
+  &lt;span class="review-state is-approved"&gt;Approved&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-review-approval-row-kk/style.css
+++ b/submissions/examples/basic-review-approval-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --approved: #86efac;
+  --pending: #93c5fd;
+  --changes: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Verdana", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(251, 191, 36, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--approved);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.review-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-review-approval-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-review-approval-row + .basic-review-approval-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-review-approval-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.review-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.review-icon.is-pending {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.review-icon.is-changes {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.review-copy {
+  min-width: 0;
+}
+
+.review-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-time,
+.review-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.review-time {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.review-state {
+  min-width: 6rem;
+  color: var(--approved);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.review-state.is-pending {
+  color: var(--pending);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.review-state.is-changes {
+  color: var(--changes);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-review-approval-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .review-time,
+  .review-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Review Approval Row demo inside `submissions/examples/basic-review-approval-row-kk/`. This submission introduces a compact CSS-only row for workflow panels, review dashboards, task approvals, and release checklists.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only review approval row that displays a review type icon, review name, helper text, review time, and approved/pending/changes-requested state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-review-approval-row">
  <span class="review-icon is-approved" aria-hidden="true">AP</span>
  <div class="review-copy">
    <strong>Design review</strong>
    <p>Approved by the product design reviewer.</p>
  </div>
  <span class="review-time">8m ago</span>
  <span class="review-state is-approved">Approved</span>
</article>