### PR TITLE
feat: add basic dataset source row demo

### DIFF
--- a/submissions/examples/basic-dataset-source-row-kk/README.md
+++ b/submissions/examples/basic-dataset-source-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Dataset Source Row
+
+## What it does
+
+This submission adds a simple CSS-only dataset source row for analytics pages,
+data import settings, admin dashboards, and reporting tools.
+
+It presents a source type icon, source name, helper text, sync metadata, and
+source state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a source icon, copy area, sync label, and state
+pill:
+
+```html
+<article class="basic-dataset-source-row">
+  <span class="source-icon is-csv" aria-hidden="true">CSV</span>
+  <div class="source-copy">
+    <strong>Sales upload</strong>
+    <p>Imported from a spreadsheet uploaded by the finance team.</p>
+  </div>
+  <span class="source-sync">12m ago</span>
+  <span class="source-state is-ready">Ready</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+analytics and admin interfaces. The row can be reused inside import settings,
+dataset cards, reporting panels, and data source dashboards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- CSV, API, and manual source examples
+- Ready, live, and review state pills
+- Last sync or source status metadata
+- Long text truncation for source descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the dataset source row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-dataset-source-row-kk/demo.html
+++ b/submissions/examples/basic-dataset-source-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Dataset Source Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Dataset Source Row</p>
+          <h1>Source rows for analytics and import settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing dataset source type, helper
+            copy, last sync metadata, and source status in admin dashboards.
+          </p>
+        </header>
+
+        <section class="source-panel" aria-label="Dataset source row examples">
+          <article class="basic-dataset-source-row">
+            <span class="source-icon is-csv" aria-hidden="true">CSV</span>
+            <div class="source-copy">
+              <strong>Sales upload</strong>
+              <p>Imported from a spreadsheet uploaded by the finance team.</p>
+            </div>
+            <span class="source-sync">12m ago</span>
+            <span class="source-state is-ready">Ready</span>
+          </article>
+
+          <article class="basic-dataset-source-row">
+            <span class="source-icon is-api" aria-hidden="true">API</span>
+            <div class="source-copy">
+              <strong>Product events</strong>
+              <p>Connected through a live analytics API integration.</p>
+            </div>
+            <span class="source-sync">Live</span>
+            <span class="source-state is-live">Live</span>
+          </article>
+
+          <article class="basic-dataset-source-row">
+            <span class="source-icon is-manual" aria-hidden="true">MAN</span>
+            <div class="source-copy">
+              <strong>Research notes</strong>
+              <p>Manual entries need review before publishing.</p>
+            </div>
+            <span class="source-sync">Draft</span>
+            <span class="source-state is-draft">Review</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-dataset-source-row"&gt;
+  &lt;span class="source-icon is-csv" aria-hidden="true"&gt;CSV&lt;/span&gt;
+  &lt;div class="source-copy"&gt;
+    &lt;strong&gt;Sales upload&lt;/strong&gt;
+    &lt;p&gt;Imported from a spreadsheet uploaded by the finance team.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="source-sync"&gt;12m ago&lt;/span&gt;
+  &lt;span class="source-state is-ready"&gt;Ready&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-dataset-source-row-kk/style.css
+++ b/submissions/examples/basic-dataset-source-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --csv: #86efac;
+  --api: #93c5fd;
+  --manual: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--csv);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.source-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-dataset-source-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-dataset-source-row + .basic-dataset-source-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-dataset-source-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.source-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.source-icon.is-api {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.source-icon.is-manual {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.source-copy {
+  min-width: 0;
+}
+
+.source-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-sync,
+.source-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.source-sync {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.source-state {
+  min-width: 5.8rem;
+  color: var(--csv);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.source-state.is-live {
+  color: var(--api);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.source-state.is-draft {
+  color: var(--manual);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-dataset-source-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .source-sync,
+  .source-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Dataset Source Row demo inside `submissions/examples/basic-dataset-source-row-kk/`. This submission introduces a compact CSS-only row for analytics pages, data import settings, admin dashboards, and reporting tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only dataset source row that displays a source type icon, source name, helper text, sync metadata, and ready/live/review state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-dataset-source-row">
  <span class="source-icon is-csv" aria-hidden="true">CSV</span>
  <div class="source-copy">
    <strong>Sales upload</strong>
    <p>Imported from a spreadsheet uploaded by the finance team.</p>
  </div>
  <span class="source-sync">12m ago</span>
  <span class="source-state is-ready">Ready</span>
</article>