### PR TITLE
feat: add basic backup status row demo

### DIFF
--- a/submissions/examples/basic-backup-status-row-v2-kk/README.md
+++ b/submissions/examples/basic-backup-status-row-v2-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Backup Status Row
+
+## What it does
+
+This submission adds a simple CSS-only backup status row for admin settings,
+restore panels, system safety dashboards, and workspace backup screens.
+
+It presents a backup type icon, backup name, helper text, size or progress
+metadata, and backup state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a backup icon, copy area, size label, and state
+pill:
+
+```html
+<article class="basic-backup-status-row">
+  <span class="backup-icon is-complete" aria-hidden="true">OK</span>
+  <div class="backup-copy">
+    <strong>Daily workspace backup</strong>
+    <p>Snapshot completed successfully at 2:00 AM.</p>
+  </div>
+  <span class="backup-size">4.2 GB</span>
+  <span class="backup-state is-complete">Complete</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+admin and reliability interfaces. The row can be reused inside backup settings,
+restore panels, system dashboards, and workspace safety pages while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Completed, running, and failed backup examples
+- Size and progress metadata
+- Backup state pills
+- Long text truncation for backup descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the backup status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-backup-status-row-v2-kk/demo.html
+++ b/submissions/examples/basic-backup-status-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Backup Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Backup Status Row</p>
+          <h1>Backup rows for restore and system safety panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing backup status, snapshot type,
+            restore point, size, and action state in admin settings.
+          </p>
+        </header>
+
+        <section class="backup-panel" aria-label="Backup status row examples">
+          <article class="basic-backup-status-row">
+            <span class="backup-icon is-complete" aria-hidden="true">OK</span>
+            <div class="backup-copy">
+              <strong>Daily workspace backup</strong>
+              <p>Snapshot completed successfully at 2:00 AM.</p>
+            </div>
+            <span class="backup-size">4.2 GB</span>
+            <span class="backup-state is-complete">Complete</span>
+          </article>
+
+          <article class="basic-backup-status-row">
+            <span class="backup-icon is-running" aria-hidden="true">RN</span>
+            <div class="backup-copy">
+              <strong>Database backup</strong>
+              <p>Backup is running and preparing restore metadata.</p>
+            </div>
+            <span class="backup-size">62%</span>
+            <span class="backup-state is-running">Running</span>
+          </article>
+
+          <article class="basic-backup-status-row">
+            <span class="backup-icon is-failed" aria-hidden="true">ER</span>
+            <div class="backup-copy">
+              <strong>Media archive backup</strong>
+              <p>Retry needed because the previous upload timed out.</p>
+            </div>
+            <span class="backup-size">8.9 GB</span>
+            <span class="backup-state is-failed">Retry</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-backup-status-row"&gt;
+  &lt;span class="backup-icon is-complete" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="backup-copy"&gt;
+    &lt;strong&gt;Daily workspace backup&lt;/strong&gt;
+    &lt;p&gt;Snapshot completed successfully at 2:00 AM.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="backup-size"&gt;4.2 GB&lt;/span&gt;
+  &lt;span class="backup-state is-complete"&gt;Complete&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-backup-status-row-v2-kk/style.css
+++ b/submissions/examples/basic-backup-status-row-v2-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a0f1d;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --complete: #86efac;
+  --running: #93c5fd;
+  --failed: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Lucida Sans", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--complete);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.backup-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-backup-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-backup-status-row + .basic-backup-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-backup-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.backup-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.backup-icon.is-running {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.backup-icon.is-failed {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.backup-copy {
+  min-width: 0;
+}
+
+.backup-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backup-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backup-size,
+.backup-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.backup-size {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.backup-state {
+  min-width: 6rem;
+  color: var(--complete);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.backup-state.is-running {
+  color: var(--running);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.backup-state.is-failed {
+  color: var(--failed);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-backup-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .backup-size,
+  .backup-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Backup Status Row demo inside `submissions/examples/basic-backup-status-row-v2-kk/`. This submission introduces a compact CSS-only row for admin settings, restore panels, system safety dashboards, and workspace backup screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only backup status row that displays a backup type icon, backup name, helper text, size or progress metadata, and completed/running/failed state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-backup-status-row">
  <span class="backup-icon is-complete" aria-hidden="true">OK</span>
  <div class="backup-copy">
    <strong>Daily workspace backup</strong>
    <p>Snapshot completed successfully at 2:00 AM.</p>
  </div>
  <span class="backup-size">4.2 GB</span>
  <span class="backup-state is-complete">Complete</span>
</article>