### PR TITLE
a11y: Add accessibility audit and Form Input Associated Label Attribute Audit (enhancement) #81954

### DIFF
--- a/submissions/examples/a11y-form-input-label-association-enhancement/README.md
+++ b/submissions/examples/a11y-form-input-label-association-enhancement/README.md
@@ -1,0 +1,16 @@
+# Accessible Form Input Label Association (Enhancement)
+
+A highly accessible, WCAG 2.1 AA compliant Form component designed to demonstrate the rigorous implementation of explicit labels, descriptive associations, and high-visibility keyboard focus.
+
+## Accessibility Features
+
+- **Explicit Label Association**: Every `<input>` and `<textarea>` is strictly paired with a `<label>`. This is achieved by ensuring the `for` attribute on the label perfectly matches the `id` of the input. This is critical for screen readers (which read the label when the input is focused) and provides a larger clickable area for mouse users.
+- **Accessible Descriptions**: Form fields with instructional text utilize the `aria-describedby` attribute, pointing to the `id` of the helper text `<div>`. This ensures screen readers announce the helper text immediately after the label when the user focuses the field.
+- **Required State Semantics**: Required fields use the standard HTML5 `required` attribute coupled with `aria-required="true"`. The visual asterisk (`*`) is hidden from screen readers using `aria-hidden="true"` to prevent annoying "star" vocalizations.
+- **Input Types**: Utilizes appropriate HTML5 input types (`type="email"`, `type="text"`) to trigger correct mobile keyboards and native browser validation.
+- **State Announcements (aria-live)**: Uses an `aria-live="polite"` region to announce to screen readers when the form has been successfully submitted.
+- **Focus Management**: A highly visible focus ring is implemented across all inputs (using `box-shadow` and `border-color`) and the submit button (`:focus-visible` with `outline-offset`), fulfilling the WCAG Focus Visible requirement.
+- **Forced Colors Support**: Includes robust `@media (forced-colors: active)` styling to map borders, backgrounds, and text variables directly to operating system high-contrast colors (`Canvas`, `CanvasText`, `Highlight`). The focus state falls back to a strict `outline` in this mode since `box-shadow` is often discarded by high contrast themes.
+
+## Usage
+Include `demo.html` and `style.css` in your project. Ensure the provided JavaScript is attached to handle the `aria-live` submission announcement.

--- a/submissions/examples/a11y-form-input-label-association-enhancement/demo.html
+++ b/submissions/examples/a11y-form-input-label-association-enhancement/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Form with Explicit Labels (Enhancement)</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <main class="container">
+        <h1>Accessible Form Submission</h1>
+        <p>Use the Tab key to navigate between form fields. Screen readers will correctly announce each field due to strict <code>for</code>/<code>id</code> attribute association.</p>
+        
+        <form class="a11y-form" onsubmit="handleFormSubmit(event)">
+            
+            <!-- Standard Text Input -->
+            <div class="form-group">
+                <!-- Explicit label association using 'for' attribute -->
+                <label for="full-name" class="form-label">Full Name <span class="required" aria-hidden="true">*</span></label>
+                <!-- Explicit 'id' matches the 'for' attribute, 'aria-required' communicates mandatory status -->
+                <input type="text" id="full-name" name="full-name" class="form-input" aria-required="true" required>
+            </div>
+
+            <!-- Email Input -->
+            <div class="form-group">
+                <label for="email-address" class="form-label">Email Address <span class="required" aria-hidden="true">*</span></label>
+                <!-- Input types enhance mobile keyboard and auto-validation -->
+                <input type="email" id="email-address" name="email-address" class="form-input" aria-required="true" required>
+            </div>
+
+            <!-- Descriptive Input Group -->
+            <div class="form-group">
+                <label for="bio" class="form-label">Short Biography</label>
+                <!-- aria-describedby connects the input to its instructional text -->
+                <textarea id="bio" name="bio" class="form-input" rows="4" aria-describedby="bio-help"></textarea>
+                <div id="bio-help" class="form-help-text">Please keep it under 150 words.</div>
+            </div>
+
+            <!-- Submit Button -->
+            <button type="submit" class="form-submit">Submit Profile</button>
+
+            <!-- Live region for announcing interactions -->
+            <div aria-live="polite" class="sr-only" id="announcer"></div>
+        </form>
+
+    </main>
+
+    <script>
+        function handleFormSubmit(event) {
+            event.preventDefault();
+            
+            // Announce success to screen readers
+            const announcer = document.getElementById('announcer');
+            announcer.innerText = "Form submitted successfully. Thank you!";
+            
+            // Visual feedback (resetting the form)
+            event.target.reset();
+        }
+    </script>
+</body>
+</html>

--- a/submissions/examples/a11y-form-input-label-association-enhancement/style.css
+++ b/submissions/examples/a11y-form-input-label-association-enhancement/style.css
@@ -1,0 +1,172 @@
+:root {
+    --form-bg: #ffffff;
+    --form-border: #cbd5e1;
+    --form-border-focus: #2563eb;
+    --text-label: #1e293b;
+    --text-input: #0f172a;
+    --text-help: #64748b;
+    --text-error: #ef4444;
+    --btn-bg: #2563eb;
+    --btn-text: #ffffff;
+    --btn-hover: #1d4ed8;
+    --focus-ring: #3b82f6;
+    
+    --bg-main: #f8fafc;
+}
+
+/* Forced Colors (High Contrast Mode) */
+@media (forced-colors: active) {
+    :root {
+        --form-bg: Canvas;
+        --form-border: CanvasText;
+        --form-border-focus: Highlight;
+        --text-label: CanvasText;
+        --text-input: CanvasText;
+        --text-help: CanvasText;
+        --text-error: CanvasText;
+        --btn-bg: Highlight;
+        --btn-text: HighlightText;
+        --btn-hover: Highlight;
+        --focus-ring: CanvasText;
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-main);
+    color: var(--text-label);
+    padding: 2rem;
+    line-height: 1.5;
+}
+
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+h1 {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+}
+
+/* 
+   Form Layout
+*/
+.a11y-form {
+    background-color: var(--form-bg);
+    padding: 2rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    margin-top: 1.5rem;
+}
+
+.form-group {
+    margin-bottom: 1.5rem;
+}
+
+/* 
+   Labels
+*/
+.form-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--text-label);
+}
+
+.required {
+    color: var(--text-error);
+}
+
+.form-help-text {
+    font-size: 0.875rem;
+    color: var(--text-help);
+    margin-top: 0.375rem;
+}
+
+/* 
+   Inputs & Textareas
+*/
+.form-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-family: inherit;
+    color: var(--text-input);
+    background-color: var(--form-bg);
+    border: 1px solid var(--form-border);
+    border-radius: 0.375rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-input:hover {
+    border-color: #94a3b8;
+}
+
+/* Focus Management */
+.form-input:focus {
+    outline: none;
+    border-color: var(--form-border-focus);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+@media (forced-colors: active) {
+    .form-input:focus {
+        outline: 2px solid Highlight;
+        outline-offset: 2px;
+        box-shadow: none;
+    }
+}
+
+/* 
+   Submit Button
+*/
+.form-submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--btn-text);
+    background-color: var(--btn-bg);
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    width: 100%;
+}
+
+.form-submit:hover {
+    background-color: var(--btn-hover);
+}
+
+.form-submit:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+    .form-submit {
+        border: 1px solid CanvasText;
+    }
+}
+
+/* 
+   Screen Reader Only Utility
+*/
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}


### PR DESCRIPTION


**Title:** a11y: Add accessibility audit and Form Input Associated Label Attribute Audit (enhancement) #81954

**Description:**
This PR introduces a highly accessible, WCAG 2.1 AA compliant Form component designed to demonstrate the rigorous implementation of explicit labels, descriptive associations, and high-visibility keyboard focus.

Fixes #81954

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/a11y-form-input-label-association-enhancement/`
- Implemented **Explicit Label Association**: Every `<input>` and `<textarea>` is strictly paired with a `<label>`. The `for` attribute on the label perfectly matches the `id` of the input, making it fully readable by screen readers and providing a larger clickable area for mouse users
- Built **Accessible Descriptions**: Form fields with instructional text utilize the `aria-describedby` attribute, pointing to the `id` of the helper text `<div>`, ensuring screen readers announce the helper text immediately after the label
- Configured **Required State Semantics**: Required fields use the standard HTML5 `required` attribute coupled with `aria-required="true"`. The visual asterisk (`*`) is hidden from screen readers using `aria-hidden="true"` to prevent annoying "star" vocalizations
- Added **Input Types**: Utilized appropriate HTML5 input types (`type="email"`, `type="text"`) to trigger correct mobile keyboards and native browser validation
- Designed **State Announcements (aria-live)**: Uses an `aria-live="polite"` region to announce to screen readers when the form has been successfully submitted
- Engineered **Focus Management & High Contrast**: A highly visible focus ring is implemented across all inputs and the submit button, fulfilling the WCAG Focus Visible requirement. Added robust `@media (forced-colors: active)` styling to map colors directly to OS-level High Contrast themes, including a fallback strictly to `outline` for inputs since `box-shadow` is often discarded in this mode
