### PR TITLE
feat: add split-text-hero cascading reveal component

### DIFF
--- a/submissions/examples/split-text-hero/README.md
+++ b/submissions/examples/split-text-hero/README.md
@@ -1,0 +1,41 @@
+# Split-Text Hero Heading Reveal Animation
+
+A hero heading where each word cascades in with a staggered fade-and-rise animation, followed by the subheading. Pure HTML and CSS — no JavaScript required.
+
+## Features
+
+- ✨ Each word animates in independently with an increasing delay, creating a cascading reveal
+- 🎨 Easily highlight specific words with an accent color (see word 2 & 3 in the demo)
+- 📝 Subheading fades in after the heading finishes
+- 📱 Responsive — heading font size scales down on small screens
+- ♿ Respects `prefers-reduced-motion` (all text appears instantly, fully visible)
+- 🧩 Pure HTML + CSS — no JavaScript dependencies
+
+## Usage
+
+Wrap each word of your heading in its own `.hero-word` span:
+
+```html
+<h1 class="hero-heading">
+  <span class="hero-word">Build</span>
+  <span class="hero-word">beautiful</span>
+  <span class="hero-word">interfaces.</span>
+</h1>
+<p class="hero-sub">Your subheading here.</p>
+```
+
+Each word's `animation-delay` is set via `:nth-child` in `style.css` — add more `:nth-child(N)` rules with increasing delays if your heading has more words than the default five.
+
+## Why it fits EaseMotion CSS
+
+The cascade is achieved purely with `@keyframes` and staggered `animation-delay` per word — no JavaScript text-splitting library required, since the words are just written as separate `<span>` elements in the markup.
+
+## Files
+
+- `demo.html` — an example hero section with a 5-word heading and subheading
+- `style.css` — all styles and the cascading reveal animation
+- `README.md` — this file
+
+## Notes
+
+For headings with a variable/dynamic number of words (e.g. CMS-driven content), you'd generate the `.hero-word` spans and their delays in your app's templating layer — the animation technique itself stays pure CSS either way.

--- a/submissions/examples/split-text-hero/demo.html
+++ b/submissions/examples/split-text-hero/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split-Text Hero Reveal — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <section class="hero">
+    <!--
+      Each word is wrapped in its own span so it can animate in
+      independently with a staggered delay, creating a cascading
+      reveal effect with pure CSS.
+    -->
+    <h1 class="hero-heading">
+      <span class="hero-word">Build</span>
+      <span class="hero-word">beautiful</span>
+      <span class="hero-word">interfaces</span>
+      <span class="hero-word">without</span>
+      <span class="hero-word">JavaScript.</span>
+    </h1>
+    <p class="hero-sub">A pure CSS component library for modern web animation.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/split-text-hero/style.css
+++ b/submissions/examples/split-text-hero/style.css
@@ -1,0 +1,95 @@
+/* ============================================
+   Split-Text Hero Heading Reveal Animation
+   Pure CSS — no JavaScript required
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: #0f1115;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.hero {
+  max-width: 640px;
+  text-align: center;
+}
+
+/* ---------- Heading ---------- */
+.hero-heading {
+  margin: 0 0 16px;
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #e6e8eb;
+  line-height: 1.25;
+}
+
+/* Each word is an inline-block so transforms apply per-word,
+   with a small gap so wrapping looks natural. */
+.hero-word {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: word-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  margin-right: 0.28em;
+}
+
+.hero-word:nth-child(1) { animation-delay: 0.05s; }
+.hero-word:nth-child(2) { animation-delay: 0.15s; color: #a29bfe; }
+.hero-word:nth-child(3) { animation-delay: 0.25s; color: #a29bfe; }
+.hero-word:nth-child(4) { animation-delay: 0.35s; }
+.hero-word:nth-child(5) { animation-delay: 0.45s; }
+
+@keyframes word-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ---------- Subheading ---------- */
+.hero-sub {
+  font-size: 1rem;
+  color: #8a8f98;
+  margin: 0;
+
+  opacity: 0;
+  animation: sub-in 0.6s ease forwards;
+  animation-delay: 0.6s;
+}
+
+@keyframes sub-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 480px) {
+  .hero-heading {
+    font-size: 1.6rem;
+  }
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .hero-word,
+  .hero-sub {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a split-text hero heading where each word cascades in with a staggered fade-and-rise animation, built with pure HTML and CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` structure and links `style.css`
- Each word is a separate `<span>` with `:nth-child`-based `animation-delay`
- `prefers-reduced-motion` shows all text immediately, fully visible

## Feature Description

Adds a reusable cascading word-reveal hero heading animation.

Level: Beginner

@SAPTARSHI-coder Please review the submission whenever you get a chance.

@github-actions Please validate the submission.