### PR TITLE
feat: create Neumorphic Accordion with Retro styling (#53828) #78540

### DIFF
--- a/submissions/examples/css-accordion-neumorphic-retro/README.md
+++ b/submissions/examples/css-accordion-neumorphic-retro/README.md
@@ -1,0 +1,15 @@
+# Retro Neumorphic Accordion
+
+A pure CSS accordion component that combines the soft, tactile UI of **Neumorphism** with the aesthetic charm of **Retro computing**. It utilizes the classic hidden radio button hack to maintain state without a single line of JavaScript.
+
+## Features
+
+- **Pure CSS State Management**: Uses `<input type="radio">` and the `:checked` pseudo-class along with the general sibling combinator (`~`) to animate the opening and closing of accordion panels.
+- **Dynamic Neumorphism**:
+  - The accordion headers start with an **extruded** outer shadow (`box-shadow`), making them look like raised buttons.
+  - When clicked (`:checked`), the shadow transitions to an **inset** shadow (`box-shadow: inset ...`), giving the satisfying visual feedback of a physical button being pressed down.
+- **Retro Aesthetic**: Uses a warm, vintage beige color palette (`#e0d8c3`), a punchy retro orange accent (`#f05d23`), and the `VT323` pixel font from Google Fonts to evoke nostalgic 80s/90s computing vibes.
+- **Smooth Animations**: The content area expands gracefully using a `max-height` transition combined with a `cubic-bezier` timing function, while the text inside fades and slides up.
+
+## Usage
+Include `demo.html` and `style.css` in your project. If you want the accordions to behave independently (multiple can be open at once), change `type="radio"` to `type="checkbox"` in the HTML and remove the `name="retro-accordion"` attribute.

--- a/submissions/examples/css-accordion-neumorphic-retro/demo.html
+++ b/submissions/examples/css-accordion-neumorphic-retro/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Neumorphic Accordion</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+</head>
+<body>
+
+    <main class="accordion-container">
+        
+        <h1 class="accordion-title">FAQ_SYSTEM_V1.0</h1>
+
+        <div class="accordion">
+            
+            <!-- Accordion Item 1 -->
+            <div class="accordion-item">
+                <input type="radio" id="acc-1" name="retro-accordion" class="accordion-trigger" checked>
+                <label for="acc-1" class="accordion-header">
+                    <span class="header-text">What is Neumorphism?</span>
+                    <span class="header-icon"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner">
+                        <p>> Neumorphism (soft UI) is a design style that uses highlights and shadows to make elements look like they are extruded from or pressed into the background. Combined with this retro palette, it gives a unique tactile feel.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Accordion Item 2 -->
+            <div class="accordion-item">
+                <input type="radio" id="acc-2" name="retro-accordion" class="accordion-trigger">
+                <label for="acc-2" class="accordion-header">
+                    <span class="header-text">Is this pure CSS?</span>
+                    <span class="header-icon"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner">
+                        <p>> Yes! This entire accordion relies on the hidden radio button hack. The `:checked` pseudo-class controls the max-height and inner shadow transitions.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Accordion Item 3 -->
+            <div class="accordion-item">
+                <input type="radio" id="acc-3" name="retro-accordion" class="accordion-trigger">
+                <label for="acc-3" class="accordion-header">
+                    <span class="header-text">System Requirements</span>
+                    <span class="header-icon"></span>
+                </label>
+                <div class="accordion-content">
+                    <div class="content-inner">
+                        <p>> Compatible with all modern browsers. No JavaScript required. Optimal viewing experienced at 640x480 resolution (just kidding, it is fully responsive!).</p>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/css-accordion-neumorphic-retro/style.css
+++ b/submissions/examples/css-accordion-neumorphic-retro/style.css
@@ -1,0 +1,157 @@
+:root {
+    /* Retro Neumorphic Palette */
+    --bg-color: #e0d8c3; /* Classic retro beige */
+    --shadow-light: #ffffff;
+    --shadow-dark: #b8b19e;
+    
+    --text-primary: #3c3831;
+    --accent-color: #f05d23; /* Retro orange/coral */
+    
+    --border-radius: 12px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'VT323', monospace;
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    padding: 2rem 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+/* Container */
+.accordion-container {
+    width: 100%;
+    max-width: 600px;
+}
+
+.accordion-title {
+    font-size: 2.5rem;
+    text-align: center;
+    margin-bottom: 2rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    text-shadow: 2px 2px 0px rgba(255,255,255,0.7);
+}
+
+.accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+/* Accordion Item */
+.accordion-item {
+    position: relative;
+}
+
+/* Hidden Radio Input */
+.accordion-trigger {
+    display: none;
+}
+
+/* 
+   Header / Label (Extruded Neumorphism)
+*/
+.accordion-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    font-size: 1.5rem;
+    cursor: pointer;
+    background: var(--bg-color);
+    border-radius: var(--border-radius);
+    /* Neumorphic outer shadow */
+    box-shadow: 6px 6px 12px var(--shadow-dark),
+               -6px -6px 12px var(--shadow-light);
+    transition: all 0.3s ease;
+    user-select: none;
+}
+
+.accordion-header:hover {
+    color: var(--accent-color);
+}
+
+/* Active State (Pressed Neumorphism) */
+.accordion-trigger:checked + .accordion-header {
+    color: var(--accent-color);
+    /* Transition to inner shadow to look pressed */
+    box-shadow: inset 4px 4px 8px var(--shadow-dark),
+                inset -4px -4px 8px var(--shadow-light);
+}
+
+/* Custom Icon */
+.header-icon {
+    position: relative;
+    width: 16px;
+    height: 16px;
+    transition: transform 0.3s ease;
+}
+
+.header-icon::before,
+.header-icon::after {
+    content: '';
+    position: absolute;
+    background-color: currentColor;
+    border-radius: 2px;
+}
+
+.header-icon::before {
+    top: 0; left: 6px;
+    width: 4px; height: 16px;
+}
+
+.header-icon::after {
+    top: 6px; left: 0;
+    width: 16px; height: 4px;
+}
+
+.accordion-trigger:checked + .accordion-header .header-icon {
+    transform: rotate(45deg);
+}
+
+/* 
+   Content Area (Smooth Expansion)
+*/
+.accordion-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.content-inner {
+    padding: 1rem 1.5rem;
+    font-size: 1.25rem;
+    line-height: 1.6;
+    margin-top: 1rem;
+    background: var(--bg-color);
+    border-radius: var(--border-radius);
+    /* Subtle pressed inset for content */
+    box-shadow: inset 4px 4px 8px var(--shadow-dark),
+                inset -4px -4px 8px var(--shadow-light);
+}
+
+.content-inner p {
+    margin: 0;
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: all 0.3s ease 0.1s;
+}
+
+/* Expand content when radio is checked */
+.accordion-trigger:checked ~ .accordion-content {
+    max-height: 400px; /* Arbitrary large height */
+}
+
+.accordion-trigger:checked ~ .accordion-content .content-inner p {
+    opacity: 1;
+    transform: translateY(0);
+}


### PR DESCRIPTION
**Title:** feat: create Neumorphic Accordion with Retro styling (#53828) #78540

**Description:**
This PR introduces a pure CSS accordion component that masterfully combines the soft, tactile UI of **Neumorphism** with the aesthetic charm of **Retro computing**. It utilizes the classic hidden radio button hack to maintain state without any JavaScript.

Fixes #78540

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-accordion-neumorphic-retro/`
- Implemented **Pure CSS State Management**: Uses `<input type="radio">` and the `:checked` pseudo-class alongside the general sibling combinator (`~`) to control the opening and closing of accordion panels seamlessly
- Engineered **Dynamic Neumorphism**:
  - The accordion headers start with an **extruded** outer shadow (`box-shadow`), making them look like raised physical buttons
  - When clicked (`:checked`), the shadow smoothly transitions to an **inset** shadow, delivering satisfying visual feedback of a physical button being pressed into the page
- Designed **Retro Aesthetic**: Uses a warm, vintage beige color palette (`#e0d8c3`), a punchy retro orange accent (`#f05d23`), and the `VT323` pixel font from Google Fonts to evoke nostalgic 80s/90s computing vibes
- Added **Smooth Animations**: The content area expands gracefully using a `max-height` transition combined with a `cubic-bezier` timing function, while the text inside elegantly fades and slides into view
