### PR TITLE
feat: add basic cache status row demo

### DIFF
--- a/submissions/examples/basic-cache-status-row-kk/README.md
+++ b/submissions/examples/basic-cache-status-row-kk/README.md
@@ -1,0 +1,48 @@
+# Basic Cache Status Row
+
+## What it does
+
+This submission adds a simple CSS-only cache status row for CDN dashboards,
+performance settings, developer panels, and deployment tools.
+
+It presents a cache layer icon, cache target name, helper text, TTL metadata,
+and freshness state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a cache icon, copy area, TTL label, and state pill:
+
+```html
+<article class="basic-cache-status-row">
+  <span class="cache-icon is-fresh" aria-hidden="true">FR</span>
+  <div class="cache-copy">
+    <strong>Homepage cache</strong>
+    <p>Fresh edge response served from the nearest CDN region.</p>
+  </div>
+  <span class="cache-ttl">15m TTL</span>
+  <span class="cache-state is-fresh">Fresh</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+developer and performance interfaces. The row can be reused inside CDN settings,
+cache panels, deployment dashboards, and performance monitoring cards while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Fresh, revalidating, and stale cache examples
+- TTL metadata label
+- Freshness state pills
+- Long text truncation for cache descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the cache status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-cache-status-row-kk/demo.html
+++ b/submissions/examples/basic-cache-status-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Cache Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Cache Status Row</p>
+          <h1>Cache rows for CDN and performance dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing cache layer, helper copy, TTL
+            metadata, and freshness state in developer settings.
+          </p>
+        </header>
+
+        <section class="cache-panel" aria-label="Cache status row examples">
+          <article class="basic-cache-status-row">
+            <span class="cache-icon is-fresh" aria-hidden="true">FR</span>
+            <div class="cache-copy">
+              <strong>Homepage cache</strong>
+              <p>Fresh edge response served from the nearest CDN region.</p>
+            </div>
+            <span class="cache-ttl">15m TTL</span>
+            <span class="cache-state is-fresh">Fresh</span>
+          </article>
+
+          <article class="basic-cache-status-row">
+            <span class="cache-icon is-revalidating" aria-hidden="true">RV</span>
+            <div class="cache-copy">
+              <strong>Product API cache</strong>
+              <p>Serving cached data while a background refresh runs.</p>
+            </div>
+            <span class="cache-ttl">2m left</span>
+            <span class="cache-state is-revalidating">Revalidating</span>
+          </article>
+
+          <article class="basic-cache-status-row">
+            <span class="cache-icon is-stale" aria-hidden="true">ST</span>
+            <div class="cache-copy">
+              <strong>Search index cache</strong>
+              <p>Cache is stale and should be purged before release.</p>
+            </div>
+            <span class="cache-ttl">Expired</span>
+            <span class="cache-state is-stale">Stale</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-cache-status-row"&gt;
+  &lt;span class="cache-icon is-fresh" aria-hidden="true"&gt;FR&lt;/span&gt;
+  &lt;div class="cache-copy"&gt;
+    &lt;strong&gt;Homepage cache&lt;/strong&gt;
+    &lt;p&gt;Fresh edge response served from the nearest CDN region.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="cache-ttl"&gt;15m TTL&lt;/span&gt;
+  &lt;span class="cache-state is-fresh"&gt;Fresh&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-cache-status-row-kk/style.css
+++ b/submissions/examples/basic-cache-status-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --fresh: #86efac;
+  --revalidating: #93c5fd;
+  --stale: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--fresh);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.cache-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-cache-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-cache-status-row + .basic-cache-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-cache-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.cache-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.cache-icon.is-revalidating {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.cache-icon.is-stale {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.cache-copy {
+  min-width: 0;
+}
+
+.cache-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cache-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cache-ttl,
+.cache-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.cache-ttl {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.cache-state {
+  min-width: 6.4rem;
+  color: var(--fresh);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.cache-state.is-revalidating {
+  color: var(--revalidating);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.cache-state.is-stale {
+  color: var(--stale);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-cache-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .cache-ttl,
+  .cache-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Cache Status Row demo inside `submissions/examples/basic-cache-status-row-kk/`. This submission introduces a compact CSS-only row for CDN dashboards, performance settings, developer panels, and deployment tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only cache status row that displays a cache layer icon, cache target name, helper text, TTL metadata, and fresh/revalidating/stale freshness state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-cache-status-row">
  <span class="cache-icon is-fresh" aria-hidden="true">FR</span>
  <div class="cache-copy">
    <strong>Homepage cache</strong>
    <p>Fresh edge response served from the nearest CDN region.</p>
  </div>
  <span class="cache-ttl">15m TTL</span>
  <span class="cache-state is-fresh">Fresh</span>
</article>