### PR TITLE
feat: add basic queue status row demo

### DIFF
--- a/submissions/examples/basic-queue-status-row-kk/README.md
+++ b/submissions/examples/basic-queue-status-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Queue Status Row
+
+## What it does
+
+This submission adds a simple CSS-only queue status row for admin dashboards,
+background job panels, task processors, and operational tools.
+
+It presents a queue state icon, job name, helper text, position or progress
+metadata, and processing state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a queue icon, copy area, metadata label, and state
+pill:
+
+```html
+<article class="basic-queue-status-row">
+  <span class="queue-icon is-waiting" aria-hidden="true">WT</span>
+  <div class="queue-copy">
+    <strong>Image optimization</strong>
+    <p>Waiting for a worker to compress uploaded media.</p>
+  </div>
+  <span class="queue-meta">#12</span>
+  <span class="queue-state is-waiting">Waiting</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+admin and operational interfaces. The row can be reused inside background job
+panels, queue dashboards, task processors, and system tools while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Waiting, processing, and blocked queue examples
+- Position and progress metadata
+- Queue state pills
+- Long text truncation for job descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the queue status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-queue-status-row-kk/demo.html
+++ b/submissions/examples/basic-queue-status-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Queue Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Queue Status Row</p>
+          <h1>Queue rows for background jobs and task processors.</h1>
+          <p class="intro">
+            A CSS-only row component for showing queued jobs, helper copy,
+            queue position, and processing state in admin dashboards.
+          </p>
+        </header>
+
+        <section class="queue-panel" aria-label="Queue status row examples">
+          <article class="basic-queue-status-row">
+            <span class="queue-icon is-waiting" aria-hidden="true">WT</span>
+            <div class="queue-copy">
+              <strong>Image optimization</strong>
+              <p>Waiting for a worker to compress uploaded media.</p>
+            </div>
+            <span class="queue-meta">#12</span>
+            <span class="queue-state is-waiting">Waiting</span>
+          </article>
+
+          <article class="basic-queue-status-row">
+            <span class="queue-icon is-processing" aria-hidden="true">PR</span>
+            <div class="queue-copy">
+              <strong>Email campaign send</strong>
+              <p>Currently processing recipients in small batches.</p>
+            </div>
+            <span class="queue-meta">72%</span>
+            <span class="queue-state is-processing">Processing</span>
+          </article>
+
+          <article class="basic-queue-status-row">
+            <span class="queue-icon is-blocked" aria-hidden="true">BL</span>
+            <div class="queue-copy">
+              <strong>Report generation</strong>
+              <p>Blocked until the missing dataset source reconnects.</p>
+            </div>
+            <span class="queue-meta">Hold</span>
+            <span class="queue-state is-blocked">Blocked</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-queue-status-row"&gt;
+  &lt;span class="queue-icon is-waiting" aria-hidden="true"&gt;WT&lt;/span&gt;
+  &lt;div class="queue-copy"&gt;
+    &lt;strong&gt;Image optimization&lt;/strong&gt;
+    &lt;p&gt;Waiting for a worker to compress uploaded media.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="queue-meta"&gt;#12&lt;/span&gt;
+  &lt;span class="queue-state is-waiting"&gt;Waiting&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-queue-status-row-kk/style.css
+++ b/submissions/examples/basic-queue-status-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --waiting: #93c5fd;
+  --processing: #86efac;
+  --blocked: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(147, 197, 253, 0.16), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(134, 239, 172, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--waiting);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.queue-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-queue-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-queue-status-row + .basic-queue-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-queue-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(147, 197, 253, 0.72);
+  transform: translateX(4px);
+}
+
+.queue-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.queue-icon.is-processing {
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.queue-icon.is-blocked {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.queue-copy {
+  min-width: 0;
+}
+
+.queue-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-meta,
+.queue-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.queue-meta {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.queue-state {
+  min-width: 6rem;
+  color: var(--waiting);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.queue-state.is-processing {
+  color: var(--processing);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.queue-state.is-blocked {
+  color: var(--blocked);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-queue-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .queue-meta,
+  .queue-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Queue Status Row demo inside `submissions/examples/basic-queue-status-row-kk/`. This submission introduces a compact CSS-only row for admin dashboards, background job panels, task processors, and operational tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only queue status row that displays a queue state icon, job name, helper text, position or progress metadata, and waiting/processing/blocked state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-queue-status-row">
  <span class="queue-icon is-waiting" aria-hidden="true">WT</span>
  <div class="queue-copy">
    <strong>Image optimization</strong>
    <p>Waiting for a worker to compress uploaded media.</p>
  </div>
  <span class="queue-meta">#12</span>
  <span class="queue-state is-waiting">Waiting</span>
</article>