### PR TITLE
feat: add basic webhook secret row demo

### DIFF
--- a/submissions/examples/basic-webhook-secret-row-kk/README.md
+++ b/submissions/examples/basic-webhook-secret-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Webhook Secret Row
+
+## What it does
+
+This submission adds a simple CSS-only webhook secret row for developer
+settings, integration panels, webhook configuration pages, and security tools.
+
+It presents a secret state icon, secret label, masked token value, rotation
+metadata, and signing-secret state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a secret icon, copy area, metadata label, and state
+pill:
+
+```html
+<article class="basic-webhook-secret-row">
+  <span class="secret-icon is-active" aria-hidden="true">SK</span>
+  <div class="secret-copy">
+    <strong>Primary signing secret</strong>
+    <p>whsec_live_********9A3F</p>
+  </div>
+  <span class="secret-meta">90d left</span>
+  <span class="secret-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+developer and security interfaces. The row can be reused inside webhook panels,
+integration settings, signing-secret managers, and security dashboards while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Active, rotating, and expired secret examples
+- Masked token display
+- Rotation timing metadata
+- Secret state pills
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the webhook secret row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-webhook-secret-row-kk/demo.html
+++ b/submissions/examples/basic-webhook-secret-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Webhook Secret Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Webhook Secret Row</p>
+          <h1>Secret rows for webhook and developer settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing masked webhook secrets, helper
+            copy, rotation timing, and signing-secret state in dev panels.
+          </p>
+        </header>
+
+        <section class="secret-panel" aria-label="Webhook secret row examples">
+          <article class="basic-webhook-secret-row">
+            <span class="secret-icon is-active" aria-hidden="true">SK</span>
+            <div class="secret-copy">
+              <strong>Primary signing secret</strong>
+              <p>whsec_live_********9A3F</p>
+            </div>
+            <span class="secret-meta">90d left</span>
+            <span class="secret-state is-active">Active</span>
+          </article>
+
+          <article class="basic-webhook-secret-row">
+            <span class="secret-icon is-rotating" aria-hidden="true">RT</span>
+            <div class="secret-copy">
+              <strong>Rotation secret</strong>
+              <p>whsec_next_********42BC</p>
+            </div>
+            <span class="secret-meta">12h sync</span>
+            <span class="secret-state is-rotating">Rotating</span>
+          </article>
+
+          <article class="basic-webhook-secret-row">
+            <span class="secret-icon is-expired" aria-hidden="true">EX</span>
+            <div class="secret-copy">
+              <strong>Legacy signing secret</strong>
+              <p>whsec_old_********71DD</p>
+            </div>
+            <span class="secret-meta">Expired</span>
+            <span class="secret-state is-expired">Replace</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-webhook-secret-row"&gt;
+  &lt;span class="secret-icon is-active" aria-hidden="true"&gt;SK&lt;/span&gt;
+  &lt;div class="secret-copy"&gt;
+    &lt;strong&gt;Primary signing secret&lt;/strong&gt;
+    &lt;p&gt;whsec_live_********9A3F&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="secret-meta"&gt;90d left&lt;/span&gt;
+  &lt;span class="secret-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-webhook-secret-row-kk/style.css
+++ b/submissions/examples/basic-webhook-secret-row-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --active: #86efac;
+  --rotating: #93c5fd;
+  --expired: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.secret-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-webhook-secret-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-webhook-secret-row + .basic-webhook-secret-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-webhook-secret-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.secret-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.secret-icon.is-rotating {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.secret-icon.is-expired {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.secret-copy {
+  min-width: 0;
+}
+
+.secret-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.secret-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.secret-meta,
+.secret-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.secret-meta {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.secret-state {
+  min-width: 6rem;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.secret-state.is-rotating {
+  color: var(--rotating);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.secret-state.is-expired {
+  color: var(--expired);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-webhook-secret-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .secret-meta,
+  .secret-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Webhook Secret Row demo inside `submissions/examples/basic-webhook-secret-row-kk/`. This submission introduces a compact CSS-only row for developer settings, integration panels, webhook configuration pages, and security tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only webhook secret row that displays a secret state icon, secret label, masked token value, rotation metadata, and active/rotating/expired signing-secret state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-webhook-secret-row">
  <span class="secret-icon is-active" aria-hidden="true">SK</span>
  <div class="secret-copy">
    <strong>Primary signing secret</strong>
    <p>whsec_live_********9A3F</p>
  </div>
  <span class="secret-meta">90d left</span>
  <span class="secret-state is-active">Active</span>
</article>