### PR TITLE
feat: add basic build artifact row demo

### DIFF
--- a/submissions/examples/basic-build-artifact-row-kk/README.md
+++ b/submissions/examples/basic-build-artifact-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Build Artifact Row
+
+## What it does
+
+This submission adds a simple CSS-only build artifact row for CI/CD dashboards,
+release download panels, deployment tools, and developer workflows.
+
+It presents an artifact type icon, artifact name, helper text, file size or
+progress metadata, and artifact state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an artifact icon, copy area, size label, and state
+pill:
+
+```html
+<article class="basic-build-artifact-row">
+  <span class="artifact-icon is-ready" aria-hidden="true">ZIP</span>
+  <div class="artifact-copy">
+    <strong>frontend-dist.zip</strong>
+    <p>Production bundle generated from the latest main build.</p>
+  </div>
+  <span class="artifact-size">18.4 MB</span>
+  <span class="artifact-state is-ready">Ready</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+developer and release interfaces. The row can be reused inside build pages,
+download drawers, CI artifact lists, and deployment dashboards while staying
+lightweight and CSS-only.
+
+## Included features
+
+- Ready, uploading, and expiring artifact examples
+- File size and progress metadata
+- Artifact state pills
+- Long text truncation for artifact descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the build artifact row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-build-artifact-row-kk/demo.html
+++ b/submissions/examples/basic-build-artifact-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Build Artifact Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Build Artifact Row</p>
+          <h1>Artifact rows for CI/CD and release download panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing build artifact name, helper
+            copy, file size, retention note, and artifact state in dev tools.
+          </p>
+        </header>
+
+        <section class="artifact-panel" aria-label="Build artifact row examples">
+          <article class="basic-build-artifact-row">
+            <span class="artifact-icon is-ready" aria-hidden="true">ZIP</span>
+            <div class="artifact-copy">
+              <strong>frontend-dist.zip</strong>
+              <p>Production bundle generated from the latest main build.</p>
+            </div>
+            <span class="artifact-size">18.4 MB</span>
+            <span class="artifact-state is-ready">Ready</span>
+          </article>
+
+          <article class="basic-build-artifact-row">
+            <span class="artifact-icon is-uploading" aria-hidden="true">MAP</span>
+            <div class="artifact-copy">
+              <strong>sourcemaps.tar</strong>
+              <p>Debug maps are uploading to the release archive.</p>
+            </div>
+            <span class="artifact-size">42%</span>
+            <span class="artifact-state is-uploading">Uploading</span>
+          </article>
+
+          <article class="basic-build-artifact-row">
+            <span class="artifact-icon is-expiring" aria-hidden="true">LOG</span>
+            <div class="artifact-copy">
+              <strong>test-report.log</strong>
+              <p>Retained for review and scheduled to expire soon.</p>
+            </div>
+            <span class="artifact-size">6.8 MB</span>
+            <span class="artifact-state is-expiring">Expires</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-build-artifact-row"&gt;
+  &lt;span class="artifact-icon is-ready" aria-hidden="true"&gt;ZIP&lt;/span&gt;
+  &lt;div class="artifact-copy"&gt;
+    &lt;strong&gt;frontend-dist.zip&lt;/strong&gt;
+    &lt;p&gt;Production bundle generated from the latest main build.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="artifact-size"&gt;18.4 MB&lt;/span&gt;
+  &lt;span class="artifact-state is-ready"&gt;Ready&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-build-artifact-row-kk/style.css
+++ b/submissions/examples/basic-build-artifact-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --ready: #86efac;
+  --uploading: #93c5fd;
+  --expiring: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--ready);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.artifact-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-build-artifact-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-build-artifact-row + .basic-build-artifact-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-build-artifact-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.artifact-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.artifact-icon.is-uploading {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.artifact-icon.is-expiring {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.artifact-copy {
+  min-width: 0;
+}
+
+.artifact-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-size,
+.artifact-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.artifact-size {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.artifact-state {
+  min-width: 6rem;
+  color: var(--ready);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.artifact-state.is-uploading {
+  color: var(--uploading);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.artifact-state.is-expiring {
+  color: var(--expiring);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-build-artifact-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .artifact-size,
+  .artifact-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Build Artifact Row demo inside `submissions/examples/basic-build-artifact-row-kk/`. This submission introduces a compact CSS-only row for CI/CD dashboards, release download panels, deployment tools, and developer workflows.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only build artifact row that displays an artifact type icon, artifact name, helper text, file size or progress metadata, and ready/uploading/expiring artifact state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-build-artifact-row">
  <span class="artifact-icon is-ready" aria-hidden="true">ZIP</span>
  <div class="artifact-copy">
    <strong>frontend-dist.zip</strong>
    <p>Production bundle generated from the latest main build.</p>
  </div>
  <span class="artifact-size">18.4 MB</span>
  <span class="artifact-state is-ready">Ready</span>
</article>