### PR TITLE
feat: create CSS-only Tab Bar with SaaS Modern styling (#62060) #78524

### DIFF
--- a/submissions/examples/css-tab-bar-saas-modern/README.md
+++ b/submissions/examples/css-tab-bar-saas-modern/README.md
@@ -1,0 +1,2 @@
+# SaaS Modern Tab Bar
+A sleek, pure CSS tab bar component using the radio button hack. Features a smooth sliding indicator and modern SaaS aesthetic.

--- a/submissions/examples/css-tab-bar-saas-modern/demo.html
+++ b/submissions/examples/css-tab-bar-saas-modern/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SaaS Modern Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="dashboard">
+        <div class="tab-container">
+            <input type="radio" id="tab1" name="saas-tabs" checked>
+            <label for="tab1" class="tab-label">Overview</label>
+            
+            <input type="radio" id="tab2" name="saas-tabs">
+            <label for="tab2" class="tab-label">Analytics</label>
+            
+            <input type="radio" id="tab3" name="saas-tabs">
+            <label for="tab3" class="tab-label">Settings</label>
+            
+            <div class="tab-slider"></div>
+            
+            <div class="tab-content-wrapper">
+                <div class="tab-content" id="content1"><h2>Overview</h2><p>Your SaaS dashboard overview goes here.</p></div>
+                <div class="tab-content" id="content2"><h2>Analytics</h2><p>View your latest metrics and charts.</p></div>
+                <div class="tab-content" id="content3"><h2>Settings</h2><p>Manage your account preferences.</p></div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-saas-modern/style.css
+++ b/submissions/examples/css-tab-bar-saas-modern/style.css
@@ -1,0 +1,21 @@
+:root {
+    --bg: #f8fafc;
+    --tab-bg: #ffffff;
+    --text: #64748b;
+    --text-active: #0f172a;
+    --primary: #3b82f6;
+    --shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
+}
+body { background: var(--bg); font-family: system-ui; display: flex; justify-content: center; padding: 3rem; }
+.tab-container { position: relative; background: var(--tab-bg); padding: 1rem; border-radius: 1rem; box-shadow: var(--shadow); width: 100%; max-width: 500px; display: flex; flex-wrap: wrap; }
+input[type="radio"] { display: none; }
+.tab-label { flex: 1; text-align: center; padding: 0.75rem 1rem; cursor: pointer; color: var(--text); font-weight: 500; z-index: 2; transition: color 0.3s; }
+.tab-slider { position: absolute; top: 1rem; left: 1rem; height: 40px; width: calc((100% - 2rem) / 3); background: #eff6ff; border-radius: 0.5rem; z-index: 1; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+#tab1:checked ~ .tab-label[for="tab1"], #tab2:checked ~ .tab-label[for="tab2"], #tab3:checked ~ .tab-label[for="tab3"] { color: var(--primary); }
+#tab1:checked ~ .tab-slider { transform: translateX(0); }
+#tab2:checked ~ .tab-slider { transform: translateX(100%); }
+#tab3:checked ~ .tab-slider { transform: translateX(200%); }
+.tab-content-wrapper { width: 100%; margin-top: 1.5rem; position: relative; }
+.tab-content { display: none; padding: 1rem; color: var(--text-active); animation: fadeIn 0.4s; }
+#tab1:checked ~ .tab-content-wrapper #content1, #tab2:checked ~ .tab-content-wrapper #content2, #tab3:checked ~ .tab-content-wrapper #content3 { display: block; }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }


### PR DESCRIPTION
**Title:** feat: create CSS-only Tab Bar with SaaS Modern styling (#62060) #78524

**Description:**
This PR introduces a pure CSS tab bar component tailored for SaaS dashboards.

Fixes #78524

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-saas-modern/`
- Implemented the radio button hack for pure CSS state management
- Added a smooth sliding background indicator for active tabs
