### PR TITLE
feat: create Responsive Navbar with Dark Mode styling (#76259) #78520

### DIFF
--- a/submissions/examples/css-navbar-responsive-dark/README.md
+++ b/submissions/examples/css-navbar-responsive-dark/README.md
@@ -1,0 +1,2 @@
+# Responsive Dark Mode Navbar
+A fully responsive CSS-only navbar optimized for dark mode. Features a hamburger menu on mobile devices using the checkbox hack.

--- a/submissions/examples/css-navbar-responsive-dark/demo.html
+++ b/submissions/examples/css-navbar-responsive-dark/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Navbar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="dark-navbar">
+        <div class="brand">DarkUI</div>
+        <input type="checkbox" id="nav-toggle" class="nav-toggle">
+        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
+        <div class="nav-links">
+            <a href="#">Home</a><a href="#">About</a><a href="#">Services</a><a href="#">Contact</a>
+        </div>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-navbar-responsive-dark/style.css
+++ b/submissions/examples/css-navbar-responsive-dark/style.css
@@ -1,0 +1,19 @@
+:root { --bg: #0f172a; --nav: #1e293b; --text: #f8fafc; --accent: #38bdf8; }
+body { margin: 0; font-family: system-ui; background: var(--bg); color: var(--text); }
+.dark-navbar { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; background: var(--nav); box-shadow: 0 4px 6px rgba(0,0,0,0.3); position: relative; }
+.brand { font-size: 1.5rem; font-weight: bold; color: var(--accent); }
+.nav-links { display: flex; gap: 2rem; }
+.nav-links a { color: var(--text); text-decoration: none; font-weight: 500; transition: color 0.2s; }
+.nav-links a:hover { color: var(--accent); }
+.nav-toggle, .nav-toggle-label { display: none; }
+@media (max-width: 768px) {
+    .nav-toggle-label { display: flex; align-items: center; cursor: pointer; width: 30px; height: 20px; position: relative; }
+    .nav-toggle-label span, .nav-toggle-label span::before, .nav-toggle-label span::after { display: block; background: var(--text); height: 2px; width: 100%; position: absolute; transition: 0.3s; }
+    .nav-toggle-label span::before { content: ''; top: -8px; } .nav-toggle-label span::after { content: ''; bottom: -8px; }
+    .nav-links { position: absolute; top: 100%; left: 0; width: 100%; background: var(--nav); flex-direction: column; gap: 0; max-height: 0; overflow: hidden; transition: max-height 0.3s ease-out; }
+    .nav-links a { padding: 1rem 2rem; border-top: 1px solid rgba(255,255,255,0.05); }
+    .nav-toggle:checked ~ .nav-links { max-height: 300px; }
+    .nav-toggle:checked ~ .nav-toggle-label span { background: transparent; }
+    .nav-toggle:checked ~ .nav-toggle-label span::before { transform: rotate(45deg); top: 0; }
+    .nav-toggle:checked ~ .nav-toggle-label span::after { transform: rotate(-45deg); bottom: 0; }
+}


### PR DESCRIPTION
**Title:** feat: create Responsive Navbar with Dark Mode styling (#76259) #78520

**Description:**
This PR introduces a fully responsive navbar optimized for dark UI themes.

Fixes #78520

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-navbar-responsive-dark/`
- Built a mobile hamburger menu using pure CSS (checkbox hack)
- Implemented smooth dropdown animations and dark mode color variables
