### PR TITLE
feat: create Floating Tab Bar with Material Design styling (#56682) #78557

### DIFF
--- a/submissions/examples/css-tab-bar-floating-material/README.md
+++ b/submissions/examples/css-tab-bar-floating-material/README.md
@@ -1,0 +1,2 @@
+# Floating Tab Bar (Material Design)
+A pure CSS, mobile-first floating tab bar using Material Design principles. Features animated icons, text reveals, and a sliding active indicator.

--- a/submissions/examples/css-tab-bar-floating-material/demo.html
+++ b/submissions/examples/css-tab-bar-floating-material/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Material Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+</head>
+<body>
+    <div class="floating-tab-bar">
+        <input type="radio" id="mtab1" name="mtabs" checked>
+        <label for="mtab1" class="mtab"><i class="material-icons">home</i><span>Home</span></label>
+        
+        <input type="radio" id="mtab2" name="mtabs">
+        <label for="mtab2" class="mtab"><i class="material-icons">search</i><span>Search</span></label>
+        
+        <input type="radio" id="mtab3" name="mtabs">
+        <label for="mtab3" class="mtab"><i class="material-icons">notifications</i><span>Alerts</span></label>
+        
+        <input type="radio" id="mtab4" name="mtabs">
+        <label for="mtab4" class="mtab"><i class="material-icons">person</i><span>Profile</span></label>
+        
+        <div class="m-indicator"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-floating-material/style.css
+++ b/submissions/examples/css-tab-bar-floating-material/style.css
@@ -1,0 +1,15 @@
+:root { --primary: #6200ee; --bg: #f5f5f5; --surface: #ffffff; --text: #000000; --text-inactive: #757575; }
+body { margin: 0; background: var(--bg); font-family: 'Roboto', sans-serif; display: flex; justify-content: center; height: 100vh; align-items: flex-end; padding-bottom: 2rem; }
+.floating-tab-bar { position: relative; background: var(--surface); display: flex; padding: 0.5rem; border-radius: 2rem; box-shadow: 0 8px 24px rgba(0,0,0,0.12); width: 90%; max-width: 400px; }
+.floating-tab-bar input[type="radio"] { display: none; }
+.mtab { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 0.5rem; cursor: pointer; color: var(--text-inactive); z-index: 2; transition: color 0.3s; }
+.mtab i { font-size: 1.5rem; margin-bottom: 0.2rem; transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.mtab span { font-size: 0.75rem; font-weight: 500; opacity: 0; transform: translateY(10px); transition: all 0.3s; }
+.m-indicator { position: absolute; top: 0.5rem; left: 0.5rem; width: calc((100% - 1rem) / 4); height: calc(100% - 1rem); background: rgba(98, 0, 238, 0.1); border-radius: 1.5rem; z-index: 1; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+#mtab1:checked ~ .mtab[for="mtab1"], #mtab2:checked ~ .mtab[for="mtab2"], #mtab3:checked ~ .mtab[for="mtab3"], #mtab4:checked ~ .mtab[for="mtab4"] { color: var(--primary); }
+#mtab1:checked ~ .mtab[for="mtab1"] i, #mtab2:checked ~ .mtab[for="mtab2"] i, #mtab3:checked ~ .mtab[for="mtab3"] i, #mtab4:checked ~ .mtab[for="mtab4"] i { transform: translateY(-5px); }
+#mtab1:checked ~ .mtab[for="mtab1"] span, #mtab2:checked ~ .mtab[for="mtab2"] span, #mtab3:checked ~ .mtab[for="mtab3"] span, #mtab4:checked ~ .mtab[for="mtab4"] span { opacity: 1; transform: translateY(0); }
+#mtab1:checked ~ .m-indicator { transform: translateX(0); }
+#mtab2:checked ~ .m-indicator { transform: translateX(100%); }
+#mtab3:checked ~ .m-indicator { transform: translateX(200%); }
+#mtab4:checked ~ .m-indicator { transform: translateX(300%); }


### PR DESCRIPTION


**Title:** feat: create Floating Tab Bar with Material Design styling (#56682) #78557

**Description:**
This PR introduces a pure CSS, mobile-first floating tab bar heavily inspired by Material Design principles.

Fixes #78557

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-floating-material/`
- Implemented standard Material Icons and elevation box-shadows
- Created smooth CSS transforms that reveal text and translate icons upwards when a tab is actively selected via the radio button hack
