### PR TITLE
feat: create Interactive Slider with Neon styling (#12378) #78552

### DIFF
--- a/submissions/examples/css-slider-interactive-neon/README.md
+++ b/submissions/examples/css-slider-interactive-neon/README.md
@@ -1,0 +1,2 @@
+# Interactive Neon Slider
+A custom `<input type="range">` styled with pure CSS to emit a powerful neon glow using intense drop shadows and active scaling.

--- a/submissions/examples/css-slider-interactive-neon/demo.html
+++ b/submissions/examples/css-slider-interactive-neon/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Neon Slider</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="slider-container">
+        <input type="range" min="0" max="100" value="50" class="neon-slider">
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-slider-interactive-neon/style.css
+++ b/submissions/examples/css-slider-interactive-neon/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #090a0f; --neon-pink: #ff007f; --neon-blue: #00f0ff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.slider-container { width: 80%; max-width: 400px; position: relative; }
+.neon-slider { -webkit-appearance: none; width: 100%; height: 8px; border-radius: 4px; background: rgba(255,255,255,0.1); outline: none; transition: background 0.3s; }
+.neon-slider:hover { background: rgba(255,255,255,0.2); }
+.neon-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 24px; height: 24px; border-radius: 50%; background: #fff; cursor: pointer; box-shadow: 0 0 15px var(--neon-pink), 0 0 30px var(--neon-blue); border: 2px solid var(--neon-pink); transition: transform 0.2s, box-shadow 0.2s; }
+.neon-slider::-webkit-slider-thumb:hover { transform: scale(1.2); box-shadow: 0 0 25px var(--neon-pink), 0 0 50px var(--neon-blue); }
+.neon-slider:active::-webkit-slider-thumb { transform: scale(0.9); }
+/* Firefox support */
+.neon-slider::-moz-range-thumb { width: 24px; height: 24px; border-radius: 50%; background: #fff; cursor: pointer; box-shadow: 0 0 15px var(--neon-pink), 0 0 30px var(--neon-blue); border: 2px solid var(--neon-pink); transition: transform 0.2s; }


### PR DESCRIPTION
**Title:** feat: create Interactive Slider with Neon styling (#12378) #78552

**Description:**
This PR introduces a custom-styled `<input type="range">` component that emits a powerful dual-tone neon glow.

Fixes #78552

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-slider-interactive-neon/`
- Used `-webkit-appearance: none` and `::-webkit-slider-thumb` to completely override the default browser slider UI
- Layered intense drop shadows in neon pink and cyan to create a glowing effect that scales dynamically on hover/active states
