### PR TITLE
feat: add basic compliance evidence row demo

### DIFF
--- a/submissions/examples/basic-compliance-evidence-row-kk/README.md
+++ b/submissions/examples/basic-compliance-evidence-row-kk/README.md
@@ -1,0 +1,50 @@
+# Basic Compliance Evidence Row
+
+## What it does
+
+This submission adds a simple CSS-only compliance evidence row for audit
+dashboards, control review panels, security questionnaires, and compliance
+workspaces.
+
+It presents an evidence type icon, evidence name, helper text, control mapping,
+and review state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an evidence icon, copy area, control label, and
+state pill:
+
+```html
+<article class="basic-compliance-evidence-row">
+  <span class="evidence-icon is-approved" aria-hidden="true">SOC</span>
+  <div class="evidence-copy">
+    <strong>Access review export</strong>
+    <p>Mapped to quarterly access control evidence.</p>
+  </div>
+  <span class="evidence-meta">AC-02</span>
+  <span class="evidence-state is-approved">Approved</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+security and compliance interfaces. The row can be reused inside audit panels,
+control review dashboards, evidence libraries, and compliance workspaces while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Approved, review, and expiring evidence examples
+- Control mapping metadata
+- Evidence review state pills
+- Long text truncation for evidence descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the compliance evidence row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-compliance-evidence-row-kk/demo.html
+++ b/submissions/examples/basic-compliance-evidence-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Compliance Evidence Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Compliance Evidence Row</p>
+          <h1>Evidence rows for audit and compliance review panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing uploaded evidence, control
+            mapping, helper copy, review timing, and compliance state.
+          </p>
+        </header>
+
+        <section class="evidence-panel" aria-label="Compliance evidence row examples">
+          <article class="basic-compliance-evidence-row">
+            <span class="evidence-icon is-approved" aria-hidden="true">SOC</span>
+            <div class="evidence-copy">
+              <strong>Access review export</strong>
+              <p>Mapped to quarterly access control evidence.</p>
+            </div>
+            <span class="evidence-meta">AC-02</span>
+            <span class="evidence-state is-approved">Approved</span>
+          </article>
+
+          <article class="basic-compliance-evidence-row">
+            <span class="evidence-icon is-review" aria-hidden="true">ISO</span>
+            <div class="evidence-copy">
+              <strong>Vendor risk checklist</strong>
+              <p>Needs reviewer sign-off before the audit package is complete.</p>
+            </div>
+            <span class="evidence-meta">VR-11</span>
+            <span class="evidence-state is-review">Review</span>
+          </article>
+
+          <article class="basic-compliance-evidence-row">
+            <span class="evidence-icon is-expiring" aria-hidden="true">PCI</span>
+            <div class="evidence-copy">
+              <strong>Encryption certificate</strong>
+              <p>Evidence expires soon and should be refreshed.</p>
+            </div>
+            <span class="evidence-meta">CR-04</span>
+            <span class="evidence-state is-expiring">Expiring</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-compliance-evidence-row"&gt;
+  &lt;span class="evidence-icon is-approved" aria-hidden="true"&gt;SOC&lt;/span&gt;
+  &lt;div class="evidence-copy"&gt;
+    &lt;strong&gt;Access review export&lt;/strong&gt;
+    &lt;p&gt;Mapped to quarterly access control evidence.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="evidence-meta"&gt;AC-02&lt;/span&gt;
+  &lt;span class="evidence-state is-approved"&gt;Approved&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-compliance-evidence-row-kk/style.css
+++ b/submissions/examples/basic-compliance-evidence-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --approved: #86efac;
+  --review: #93c5fd;
+  --expiring: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--approved);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.evidence-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-compliance-evidence-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-compliance-evidence-row + .basic-compliance-evidence-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-compliance-evidence-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.evidence-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.evidence-icon.is-review {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.evidence-icon.is-expiring {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.evidence-copy {
+  min-width: 0;
+}
+
+.evidence-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evidence-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evidence-meta,
+.evidence-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.evidence-meta {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.evidence-state {
+  min-width: 6rem;
+  color: var(--approved);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.evidence-state.is-review {
+  color: var(--review);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.evidence-state.is-expiring {
+  color: var(--expiring);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-compliance-evidence-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .evidence-meta,
+  .evidence-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Compliance Evidence Row demo inside `submissions/examples/basic-compliance-evidence-row-kk/`. This submission introduces a compact CSS-only row for audit dashboards, control review panels, security questionnaires, and compliance workspaces.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only compliance evidence row that displays an evidence type icon, evidence name, helper text, control mapping, and approved/review/expiring state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-compliance-evidence-row">
  <span class="evidence-icon is-approved" aria-hidden="true">SOC</span>
  <div class="evidence-copy">
    <strong>Access review export</strong>
    <p>Mapped to quarterly access control evidence.</p>
  </div>
  <span class="evidence-meta">AC-02</span>
  <span class="evidence-state is-approved">Approved</span>
</article>