### PR TITLE
feat: add neumorphic-toggle switch set component

### DIFF
--- a/submissions/examples/neumorphic-toggle/README.md
+++ b/submissions/examples/neumorphic-toggle/README.md
@@ -1,0 +1,37 @@
+# Neumorphic Toggle Switch Set
+
+A set of soft-UI (neumorphic) toggle switches with a smooth sliding thumb that glows purple when active. Pure HTML and CSS — no JavaScript required.
+
+## Features
+
+- 🎛️ Soft neumorphic shadows (dual light/dark inset+outset shadow) on both the row container and the toggle itself
+- ✨ Thumb slides with a springy easing curve and glows on activation
+- ⌨️ Keyboard-focusable with a visible focus ring
+- 📱 Responsive by default — fixed compact size fits any layout
+- ♿ Respects `prefers-reduced-motion`
+- 🧩 Pure HTML + CSS — no JavaScript dependencies
+
+## Usage
+
+```html
+<label class="neu-toggle">
+  <input type="checkbox" />
+  <span class="neu-toggle-track"><span class="neu-toggle-thumb"></span></span>
+</label>
+```
+
+Add `checked` to the `<input>` to have a toggle start in the "on" position. Works as a real checkbox, so it's form-submittable and screen-reader accessible.
+
+## Why it fits EaseMotion CSS
+
+The slide and glow are handled entirely by `:checked` + the general sibling combinator plus `transition`/`transform`, no JavaScript. Class names stay simple and readable (`neu-toggle`, `neu-toggle-track`, `neu-toggle-thumb`).
+
+## Files
+
+- `demo.html` — three example toggle rows in a settings-style list
+- `style.css` — all styles, neumorphic shadows, and animations
+- `README.md` — this file
+
+## Notes
+
+Neumorphism relies on matching the shadow colors closely to the background color for the soft-embossed look — if you change `.toggle-row`'s background, update the shadow colors in `style.css` to match (typically a slightly darker and slightly lighter shade of the base background).

--- a/submissions/examples/neumorphic-toggle/demo.html
+++ b/submissions/examples/neumorphic-toggle/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neumorphic Toggle Switches — Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <div class="toggle-list">
+    <div class="toggle-row">
+      <span class="toggle-row-label">Push notifications</span>
+      <label class="neu-toggle">
+        <input type="checkbox" checked />
+        <span class="neu-toggle-track"><span class="neu-toggle-thumb"></span></span>
+      </label>
+    </div>
+
+    <div class="toggle-row">
+      <span class="toggle-row-label">Dark mode</span>
+      <label class="neu-toggle">
+        <input type="checkbox" />
+        <span class="neu-toggle-track"><span class="neu-toggle-thumb"></span></span>
+      </label>
+    </div>
+
+    <div class="toggle-row">
+      <span class="toggle-row-label">Auto-save</span>
+      <label class="neu-toggle">
+        <input type="checkbox" checked />
+        <span class="neu-toggle-track"><span class="neu-toggle-thumb"></span></span>
+      </label>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-toggle/style.css
+++ b/submissions/examples/neumorphic-toggle/style.css
@@ -1,0 +1,104 @@
+/* ============================================
+   Neumorphic Toggle Switch Set
+   Pure CSS — no JavaScript required
+   ============================================ */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+  background: #1e2128;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.toggle-list {
+  width: 100%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: #1e2128;
+  box-shadow: 8px 8px 16px #16181d, -8px -8px 16px #262a33;
+}
+
+.toggle-row-label {
+  font-size: 0.88rem;
+  color: #d3d6db;
+  font-weight: 500;
+}
+
+/* ---------- Neumorphic toggle ---------- */
+.neu-toggle {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.neu-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.neu-toggle-track {
+  display: block;
+  width: 52px;
+  height: 28px;
+  border-radius: 999px;
+  background: #1e2128;
+  box-shadow: inset 4px 4px 8px #16181d, inset -4px -4px 8px #262a33;
+  transition: background 0.3s ease;
+}
+
+.neu-toggle-thumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 4px;
+  border-radius: 50%;
+  background: #1e2128;
+  box-shadow: 3px 3px 6px #16181d, -3px -3px 6px #262a33;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.3s ease;
+}
+
+/* Checked state: thumb slides and glows purple */
+.neu-toggle input:checked ~ .neu-toggle-track .neu-toggle-thumb {
+  transform: translateX(24px);
+  background: linear-gradient(135deg, #6c5ce7, #a29bfe);
+  box-shadow: 0 0 10px rgba(108, 92, 231, 0.6);
+}
+
+.neu-toggle input:checked ~ .neu-toggle-track {
+  box-shadow: inset 4px 4px 8px #16181d, inset -4px -4px 8px #262a33,
+    0 0 0 1px rgba(108, 92, 231, 0.15);
+}
+
+/* Keyboard focus ring */
+.neu-toggle input:focus-visible ~ .neu-toggle-track {
+  outline: 2px solid #6c5ce7;
+  outline-offset: 2px;
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .neu-toggle-thumb,
+  .neu-toggle-track {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a set of neumorphic (soft-UI) toggle switches with a springy sliding thumb and purple glow when active, built with pure HTML and CSS.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>` structure and links `style.css`
- Real `<input type="checkbox">` driving `:checked` sibling selectors — accessible and form-submittable
- `prefers-reduced-motion` removes the slide/glow transitions

## Feature Description

Adds a reusable neumorphic toggle switch component.

Level: Beginner

@SAPTARSHI-coder Please review the submission whenever you get a chance.

@github-actions Please validate the submission.