### PR TITLE
Fix issue 78545

### DIFF
--- a/submissions/examples/css-button-hover-material/README.md
+++ b/submissions/examples/css-button-hover-material/README.md
@@ -1,0 +1,2 @@
+# Material Design Hover Button
+A classic Material Design button replicating the physical ink ripple effect and elevation shadow changes using pure CSS pseudo-elements and animations.

--- a/submissions/examples/css-button-hover-material/demo.html
+++ b/submissions/examples/css-button-hover-material/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Hover Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <button class="md-btn"><span>Submit Data</span></button>
+</body>
+</html>

--- a/submissions/examples/css-button-hover-material/style.css
+++ b/submissions/examples/css-button-hover-material/style.css
@@ -1,0 +1,8 @@
+:root { --md-primary: #1976d2; --md-primary-light: #42a5f5; --bg: #f5f5f5; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: Roboto, sans-serif; }
+.md-btn { position: relative; background: var(--md-primary); color: #fff; border: none; padding: 1rem 2rem; font-size: 1rem; font-weight: 500; text-transform: uppercase; letter-spacing: 1px; border-radius: 4px; box-shadow: 0 3px 1px -2px rgba(0,0,0,0.2), 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12); cursor: pointer; overflow: hidden; transition: box-shadow 0.2s, transform 0.2s; }
+.md-btn:hover { box-shadow: 0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12); transform: translateY(-1px); }
+.md-btn:active { box-shadow: 0 5px 5px -3px rgba(0,0,0,0.2), 0 8px 10px 1px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12); transform: translateY(1px); }
+.md-btn::after { content: ''; position: absolute; top: 50%; left: 50%; width: 5px; height: 5px; background: rgba(255,255,255,0.5); opacity: 0; border-radius: 100%; transform: scale(1) translate(-50%, -50%); transform-origin: 50% 50%; }
+.md-btn:focus:not(:active)::after { animation: ripple 1s ease-out; }
+@keyframes ripple { 0% { transform: scale(0) translate(-50%, -50%); opacity: 0.5; } 100% { transform: scale(40) translate(-50%, -50%); opacity: 0; } }

--- a/submissions/examples/css-carousel-glassmorphism-glassmorphism/README.md
+++ b/submissions/examples/css-carousel-glassmorphism-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Glassmorphism Carousel
+A CSS-only carousel featuring floating glassmorphism panels overlaid on sliding background images.

--- a/submissions/examples/css-carousel-glassmorphism-glassmorphism/demo.html
+++ b/submissions/examples/css-carousel-glassmorphism-glassmorphism/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="carousel-container">
+        <input type="radio" name="carousel" id="slide1" checked>
+        <input type="radio" name="carousel" id="slide2">
+        <input type="radio" name="carousel" id="slide3">
+        
+        <div class="slides">
+            <div class="slide slide-1">
+                <div class="glass-panel"><h3>Slide 1</h3><p>Beautiful frosted glass effect.</p></div>
+            </div>
+            <div class="slide slide-2">
+                <div class="glass-panel"><h3>Slide 2</h3><p>Pure CSS transitions.</p></div>
+            </div>
+            <div class="slide slide-3">
+                <div class="glass-panel"><h3>Slide 3</h3><p>Responsive layout.</p></div>
+            </div>
+        </div>
+        
+        <div class="controls">
+            <label for="slide1" class="control-btn"></label>
+            <label for="slide2" class="control-btn"></label>
+            <label for="slide3" class="control-btn"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-glassmorphism-glassmorphism/style.css
+++ b/submissions/examples/css-carousel-glassmorphism-glassmorphism/style.css
@@ -1,0 +1,16 @@
+:root { --glass: rgba(255,255,255,0.2); }
+body { margin: 0; background: linear-gradient(45deg, #ff9a9e 0%, #fecfef 99%, #fecfef 100%); display: flex; justify-content: center; align-items: center; height: 100vh; font-family: system-ui; }
+.carousel-container { position: relative; width: 80%; max-width: 600px; height: 300px; border-radius: 1rem; overflow: hidden; box-shadow: 0 10px 30px rgba(0,0,0,0.1); }
+input[type="radio"] { display: none; }
+.slides { display: flex; width: 300%; height: 100%; transition: transform 0.5s ease-in-out; }
+.slide { width: 33.333%; display: flex; justify-content: center; align-items: center; background-size: cover; background-position: center; }
+.slide-1 { background-image: url('https://picsum.photos/800/400?1'); }
+.slide-2 { background-image: url('https://picsum.photos/800/400?2'); }
+.slide-3 { background-image: url('https://picsum.photos/800/400?3'); }
+.glass-panel { background: var(--glass); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); padding: 2rem; border-radius: 1rem; border: 1px solid rgba(255,255,255,0.3); color: #fff; text-align: center; text-shadow: 0 2px 4px rgba(0,0,0,0.3); }
+#slide1:checked ~ .slides { transform: translateX(0); }
+#slide2:checked ~ .slides { transform: translateX(-33.333%); }
+#slide3:checked ~ .slides { transform: translateX(-66.666%); }
+.controls { position: absolute; bottom: 1rem; left: 50%; transform: translateX(-50%); display: flex; gap: 0.5rem; }
+.control-btn { width: 12px; height: 12px; border-radius: 50%; background: rgba(255,255,255,0.5); cursor: pointer; transition: background 0.3s; }
+#slide1:checked ~ .controls .control-btn:nth-child(1), #slide2:checked ~ .controls .control-btn:nth-child(2), #slide3:checked ~ .controls .control-btn:nth-child(3) { background: #fff; box-shadow: 0 0 8px rgba(255,255,255,0.8); }

--- a/submissions/examples/css-floating-card-dark/README.md
+++ b/submissions/examples/css-floating-card-dark/README.md
@@ -1,0 +1,2 @@
+# Floating Card (Dark Mode)
+A sleek dark mode card component that utilizes a `cubic-bezier` float animation and a radial gradient blur to create a dynamic hover aura.

--- a/submissions/examples/css-floating-card-dark/demo.html
+++ b/submissions/examples/css-floating-card-dark/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Dark Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dark-card">
+        <div class="card-glow"></div>
+        <div class="card-content">
+            <h2>Pro Plan</h2>
+            <p>$19 / month</p>
+            <button>Upgrade Now</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-floating-card-dark/style.css
+++ b/submissions/examples/css-floating-card-dark/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #0f172a; --card-bg: #1e293b; --text: #f8fafc; --accent: #8b5cf6; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui; }
+.dark-card { position: relative; width: 300px; padding: 2rem; border-radius: 1.5rem; background: var(--card-bg); color: var(--text); box-shadow: 0 10px 30px -5px rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.05); transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); z-index: 2; }
+.dark-card:hover { transform: translateY(-10px); }
+.card-glow { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: radial-gradient(circle at 50% 0%, var(--accent), transparent 60%); opacity: 0; border-radius: 1.5rem; z-index: -1; transition: opacity 0.4s; filter: blur(20px); }
+.dark-card:hover .card-glow { opacity: 0.5; }
+.card-content h2 { margin-top: 0; }
+.card-content button { background: var(--accent); color: #fff; border: none; padding: 0.75rem 1.5rem; border-radius: 0.5rem; font-weight: bold; cursor: pointer; width: 100%; transition: background 0.2s; }
+.card-content button:hover { background: #7c3aed; }


### PR DESCRIPTION
**Title:** feat: create Glassmorphism Carousel with Glassmorphism styling (#82614) #78545

**Description:**
This PR introduces a CSS-only image carousel featuring floating glassmorphism panels overlaid on sliding background images.

Fixes #78545

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-glassmorphism-glassmorphism/`
- Engineered a CSS carousel that translates its container (`transform: translateX`) based on radio button state
- Overlaid informational panels using `backdrop-filter: blur(10px)` with semi-transparent white borders
