### PR TITLE
feat: create Glassmorphism Slider with Cyberpunk styling (#76343) #78546

### DIFF
--- a/submissions/examples/css-slider-glassmorphism-cyberpunk/README.md
+++ b/submissions/examples/css-slider-glassmorphism-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Glassmorphism Slider (Cyberpunk)
+A unique slider control bridging the gap between frosted glass aesthetics and harsh angular cyberpunk elements.

--- a/submissions/examples/css-slider-glassmorphism-cyberpunk/demo.html
+++ b/submissions/examples/css-slider-glassmorphism-cyberpunk/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyber-Glass Slider</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="slider-wrapper">
+        <label>POWER_OUTPUT</label>
+        <input type="range" min="0" max="100" value="50" class="cg-slider">
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-slider-glassmorphism-cyberpunk/style.css
+++ b/submissions/examples/css-slider-glassmorphism-cyberpunk/style.css
@@ -1,0 +1,7 @@
+:root { --cyan: #00f0ff; --glass: rgba(0, 240, 255, 0.1); }
+body { background: #050505; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; }
+.slider-wrapper { background: var(--glass); backdrop-filter: blur(8px); padding: 2rem; border-radius: 4px; border: 1px solid rgba(0,240,255,0.3); box-shadow: 0 0 20px rgba(0,240,255,0.1); width: 80%; max-width: 400px; text-align: center; }
+label { color: var(--cyan); font-weight: bold; display: block; margin-bottom: 1.5rem; letter-spacing: 2px; }
+.cg-slider { -webkit-appearance: none; width: 100%; height: 6px; background: rgba(255,255,255,0.1); outline: none; border-radius: 3px; }
+.cg-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 16px; height: 24px; background: var(--cyan); cursor: pointer; clip-path: polygon(0 0, 100% 10%, 100% 100%, 0 90%); box-shadow: 0 0 10px var(--cyan); transition: transform 0.2s; }
+.cg-slider::-webkit-slider-thumb:hover { transform: scale(1.2); }


### PR DESCRIPTION
**Title:** feat: create Glassmorphism Slider with Cyberpunk styling (#76343) #78546

**Description:**
This PR introduces a unique `<input type="range">` slider control bridging the gap between frosted glass aesthetics and harsh angular cyberpunk elements.

Fixes #78546

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-slider-glassmorphism-cyberpunk/`
- Housed the slider inside a `backdrop-filter: blur(8px)` wrapper emitting a subtle cyan glow
- Re-styled the `::-webkit-slider-thumb` with a custom `clip-path` angular polygon and intense cyan `box-shadow`
