### PR TITLE
feat: add CSS bundle size threshold dashboard

### DIFF
--- a/submissions/examples/css-bundle-size-threshold-82064/README.md
+++ b/submissions/examples/css-bundle-size-threshold-82064/README.md
@@ -1,0 +1,33 @@
+# CSS Bundle Size Threshold
+
+A responsive CSS-only performance dashboard for visualizing CSS bundle size against a defined performance budget.
+
+## Features
+
+- Current CSS bundle size
+- Maximum bundle size threshold
+- Remaining performance budget
+- Bundle usage percentage
+- Visual size progress indicator
+- Threshold validation status
+- Performance budget information
+- Responsive layout
+- Smooth hover interactions
+- Reduced-motion support
+- No JavaScript or external dependencies
+
+## Example Metrics
+
+| Metric | Value |
+|---|---:|
+| Current Bundle | 42 KB |
+| Maximum Threshold | 100 KB |
+| Remaining Budget | 58 KB |
+| Budget Usage | 42% |
+
+## Performance Threshold
+
+The example uses a maximum CSS bundle size of:
+
+```text
+100 KB

--- a/submissions/examples/css-bundle-size-threshold-82064/demo.html
+++ b/submissions/examples/css-bundle-size-threshold-82064/demo.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Bundle Size Threshold</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="dashboard">
+
+    <header class="hero">
+      <span class="badge">EASEMOTION CSS • PERFORMANCE</span>
+
+      <h1>CSS Bundle<br><span>Size Threshold</span></h1>
+
+      <p>
+        A lightweight performance dashboard for monitoring
+        stylesheet size against defined performance budgets.
+      </p>
+    </header>
+
+    <section class="status-card">
+      <div class="status-icon">✓</div>
+
+      <div class="status-content">
+        <span class="label">BUNDLE STATUS</span>
+        <h2>Performance Budget Passed</h2>
+        <p>
+          Current CSS bundle remains below the configured
+          size threshold.
+        </p>
+      </div>
+
+      <span class="status">PASS</span>
+    </section>
+
+    <section class="metrics">
+
+      <article class="metric">
+        <span>CURRENT SIZE</span>
+        <strong>42 KB</strong>
+        <small>Compressed stylesheet</small>
+      </article>
+
+      <article class="metric">
+        <span>MAXIMUM SIZE</span>
+        <strong>100 KB</strong>
+        <small>Configured threshold</small>
+      </article>
+
+      <article class="metric">
+        <span>REMAINING</span>
+        <strong>58 KB</strong>
+        <small>Available budget</small>
+      </article>
+
+      <article class="metric">
+        <span>USAGE</span>
+        <strong>42%</strong>
+        <small>Of total budget</small>
+      </article>
+
+    </section>
+
+    <section class="bundle-card">
+
+      <div class="section-heading">
+        <div>
+          <span class="label">BUNDLE ANALYSIS</span>
+          <h2>CSS Size Overview</h2>
+        </div>
+
+        <span class="size-tag">42 KB / 100 KB</span>
+      </div>
+
+      <div class="progress">
+        <span class="progress-fill"></span>
+      </div>
+
+      <div class="scale">
+        <span>0 KB</span>
+        <span>50 KB</span>
+        <span>100 KB</span>
+      </div>
+
+      <div class="threshold">
+        <div>
+          <span class="dot current"></span>
+          <span>Current bundle</span>
+        </div>
+
+        <div>
+          <span class="dot limit"></span>
+          <span>Maximum threshold</span>
+        </div>
+      </div>
+
+    </section>
+
+    <section class="checks">
+
+      <div class="section-heading">
+        <div>
+          <span class="label">THRESHOLD VALIDATION</span>
+          <h2>Performance Checks</h2>
+        </div>
+      </div>
+
+      <article class="check">
+        <div class="check-icon">✓</div>
+
+        <div class="check-info">
+          <strong>Bundle size within limit</strong>
+          <span>42 KB is below the 100 KB threshold</span>
+        </div>
+
+        <span class="check-status">PASS</span>
+      </article>
+
+      <article class="check">
+        <div class="check-icon">✓</div>
+
+        <div class="check-info">
+          <strong>CSS payload optimized</strong>
+          <span>Current usage is below 50% of the budget</span>
+        </div>
+
+        <span class="check-status">PASS</span>
+      </article>
+
+      <article class="check warning">
+        <div class="check-icon">!</div>
+
+        <div class="check-info">
+          <strong>Warning threshold</strong>
+          <span>Warning begins when usage exceeds 80 KB</span>
+        </div>
+
+        <span class="check-status">READY</span>
+      </article>
+
+    </section>
+
+    <section class="budget-card">
+
+      <div>
+        <span class="label">PERFORMANCE BUDGET</span>
+        <h2>100 KB Maximum</h2>
+        <p>
+          Keeping CSS bundles within a defined budget helps
+          maintain predictable loading performance.
+        </p>
+      </div>
+
+      <div class="budget-value">
+        <strong>42%</strong>
+        <span>USED</span>
+      </div>
+
+    </section>
+
+    <footer>
+      CSS Bundle Size Threshold • Performance Budget • EaseMotion CSS
+    </footer>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/css-bundle-size-threshold-82064/style.css
+++ b/submissions/examples/css-bundle-size-threshold-82064/style.css
@@ -1,0 +1,421 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #080c18;
+  --surface: #11172a;
+  --surface-light: #19213a;
+  --text: #f5f7ff;
+  --muted: #8c96ad;
+  --accent: #7c5cff;
+  --accent-light: #b7aaff;
+  --success: #35d49a;
+  --warning: #f2b84b;
+  --border: rgba(255, 255, 255, 0.08);
+}
+
+body {
+  min-height: 100vh;
+  padding: 40px 20px;
+  color: var(--text);
+  font-family: Inter, Arial, sans-serif;
+  background:
+    radial-gradient(
+      circle at 10% 0%,
+      rgba(124, 92, 255, 0.2),
+      transparent 35%
+    ),
+    radial-gradient(
+      circle at 90% 100%,
+      rgba(53, 212, 154, 0.08),
+      transparent 30%
+    ),
+    var(--bg);
+}
+
+.dashboard {
+  width: min(100%, 950px);
+  margin: auto;
+}
+
+.hero {
+  margin-bottom: 30px;
+}
+
+.badge {
+  display: inline-block;
+  margin-bottom: 18px;
+  padding: 7px 12px;
+  border: 1px solid rgba(124, 92, 255, 0.4);
+  border-radius: 20px;
+  color: var(--accent-light);
+  background: rgba(124, 92, 255, 0.08);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 1.5px;
+}
+
+.hero h1 {
+  margin-bottom: 18px;
+  font-size: clamp(44px, 8vw, 76px);
+  line-height: 0.95;
+  letter-spacing: -3px;
+}
+
+.hero h1 span {
+  color: var(--accent-light);
+}
+
+.hero p {
+  max-width: 650px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.status-card,
+.bundle-card,
+.checks,
+.budget-card {
+  padding: 24px;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background:
+    linear-gradient(
+      135deg,
+      var(--surface),
+      var(--surface-light)
+    );
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+
+.status-card {
+  display: flex;
+  align-items: center;
+  gap: 17px;
+}
+
+.status-icon {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  color: #06150f;
+  background: var(--success);
+  font-size: 24px;
+  font-weight: 900;
+  box-shadow: 0 0 30px rgba(53, 212, 154, 0.2);
+}
+
+.status-content {
+  flex: 1;
+}
+
+.label {
+  color: #9da7be;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 1.5px;
+}
+
+.status-content h2,
+.section-heading h2,
+.budget-card h2 {
+  margin: 5px 0;
+  font-size: 19px;
+}
+
+.status-content p,
+.budget-card p {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.status,
+.check-status {
+  padding: 7px 11px;
+  border-radius: 20px;
+  color: var(--success);
+  background: rgba(53, 212, 154, 0.1);
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 13px;
+  margin-bottom: 16px;
+}
+
+.metric {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(17, 23, 42, 0.85);
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.metric:hover {
+  transform: translateY(-5px);
+  border-color: rgba(124, 92, 255, 0.45);
+}
+
+.metric span {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.metric strong {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 27px;
+}
+
+.metric small {
+  color: #69748d;
+  font-size: 10px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.size-tag {
+  padding: 7px 11px;
+  border-radius: 8px;
+  color: var(--accent-light);
+  background: rgba(124, 92, 255, 0.1);
+  font-family: monospace;
+  font-size: 10px;
+}
+
+.progress {
+  height: 16px;
+  overflow: hidden;
+  border-radius: 20px;
+  background: #242b3f;
+}
+
+.progress-fill {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      90deg,
+      var(--accent),
+      var(--success)
+    );
+  box-shadow: 0 0 20px rgba(53, 212, 154, 0.2);
+}
+
+.scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 9px;
+  color: #68738b;
+  font-family: monospace;
+  font-size: 9px;
+}
+
+.threshold {
+  display: flex;
+  gap: 25px;
+  margin-top: 22px;
+}
+
+.threshold div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.dot.current {
+  background: var(--success);
+}
+
+.dot.limit {
+  background: var(--warning);
+}
+
+.checks {
+  display: grid;
+  gap: 10px;
+}
+
+.checks .section-heading {
+  margin-bottom: 8px;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 15px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.check:hover {
+  transform: translateX(5px);
+  border-color: rgba(124, 92, 255, 0.4);
+}
+
+.check-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  color: #06150f;
+  background: var(--success);
+  font-size: 14px;
+  font-weight: 900;
+}
+
+.check-info {
+  flex: 1;
+}
+
+.check-info strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+
+.check-info span {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.warning .check-icon {
+  color: #211504;
+  background: var(--warning);
+}
+
+.warning .check-status {
+  color: var(--warning);
+  background: rgba(242, 184, 75, 0.1);
+}
+
+.budget-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+}
+
+.budget-card p {
+  max-width: 600px;
+}
+
+.budget-value {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 110px;
+  height: 110px;
+  flex-shrink: 0;
+  border: 1px solid rgba(53, 212, 154, 0.3);
+  border-radius: 50%;
+  background: rgba(53, 212, 154, 0.06);
+}
+
+.budget-value strong {
+  color: var(--success);
+  font-size: 28px;
+}
+
+.budget-value span {
+  color: var(--muted);
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+footer {
+  padding: 18px;
+  color: #657087;
+  text-align: center;
+  font-size: 10px;
+}
+
+@media (max-width: 800px) {
+  .metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 25px 14px;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .status,
+  .check-status {
+    display: none;
+  }
+
+  .status-card {
+    align-items: flex-start;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .budget-card {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .budget-value {
+    width: 90px;
+    height: 90px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Added a responsive **CSS Bundle Size Threshold** component that visually represents stylesheet size, performance budget usage, threshold validation, and optimization status.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A CSS-only performance dashboard for visualizing CSS bundle size against a defined performance threshold.

**How does a developer use it?**

```html
<link rel="stylesheet" href="style.css">

<main class="dashboard">
  <!-- Add the dashboard markup from demo.html -->
</main>

**Why does it fit EaseMotion CSS?**

The component uses lightweight, human-readable CSS with responsive layouts, visual performance indicators, CSS custom properties, and subtle transitions without external dependencies.
---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [*] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The submission is fully self-contained inside
submissions/examples/css-bundle-size-threshold-82064/.

Only demo.html, style.css, and README.md were added.
No changes were made to core/ or components/.

Closes #82064

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
