### PR TITLE
feat: add basic data residency row demo

### DIFF
--- a/submissions/examples/basic-data-residency-row-v2-kk/README.md
+++ b/submissions/examples/basic-data-residency-row-v2-kk/README.md
@@ -1,0 +1,50 @@
+# Basic Data Residency Row
+
+## What it does
+
+This submission adds a simple CSS-only data residency row for workspace
+settings, compliance panels, enterprise admin pages, and region configuration
+screens.
+
+It presents a region icon, region name, helper text, residency scope, and
+hosting state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a region icon, copy area, scope label, and state
+pill:
+
+```html
+<article class="basic-data-residency-row">
+  <span class="residency-icon is-active" aria-hidden="true">US</span>
+  <div class="residency-copy">
+    <strong>United States region</strong>
+    <p>Primary workspace data is stored in US data centers.</p>
+  </div>
+  <span class="residency-scope">Primary</span>
+  <span class="residency-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+enterprise settings interfaces. The row can be reused inside region selectors,
+compliance dashboards, workspace settings, and data residency panels while
+staying lightweight and CSS-only.
+
+## Included features
+
+- Active, migrating, and restricted region examples
+- Residency scope metadata
+- Hosting state pills
+- Long text truncation for region descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the data residency row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-data-residency-row-v2-kk/demo.html
+++ b/submissions/examples/basic-data-residency-row-v2-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Data Residency Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Data Residency Row</p>
+          <h1>Region rows for workspace and compliance settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing data region, helper copy,
+            residency scope, and hosting state in admin dashboards.
+          </p>
+        </header>
+
+        <section class="residency-panel" aria-label="Data residency row examples">
+          <article class="basic-data-residency-row">
+            <span class="residency-icon is-active" aria-hidden="true">US</span>
+            <div class="residency-copy">
+              <strong>United States region</strong>
+              <p>Primary workspace data is stored in US data centers.</p>
+            </div>
+            <span class="residency-scope">Primary</span>
+            <span class="residency-state is-active">Active</span>
+          </article>
+
+          <article class="basic-data-residency-row">
+            <span class="residency-icon is-moving" aria-hidden="true">EU</span>
+            <div class="residency-copy">
+              <strong>European Union region</strong>
+              <p>Migration is scheduled for compliance alignment.</p>
+            </div>
+            <span class="residency-scope">Moving</span>
+            <span class="residency-state is-moving">Migrating</span>
+          </article>
+
+          <article class="basic-data-residency-row">
+            <span class="residency-icon is-locked" aria-hidden="true">AP</span>
+            <div class="residency-copy">
+              <strong>Asia Pacific region</strong>
+              <p>Region is restricted until enterprise controls are enabled.</p>
+            </div>
+            <span class="residency-scope">Locked</span>
+            <span class="residency-state is-locked">Restricted</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-data-residency-row"&gt;
+  &lt;span class="residency-icon is-active" aria-hidden="true"&gt;US&lt;/span&gt;
+  &lt;div class="residency-copy"&gt;
+    &lt;strong&gt;United States region&lt;/strong&gt;
+    &lt;p&gt;Primary workspace data is stored in US data centers.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="residency-scope"&gt;Primary&lt;/span&gt;
+  &lt;span class="residency-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-data-residency-row-v2-kk/style.css
+++ b/submissions/examples/basic-data-residency-row-v2-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --active: #86efac;
+  --moving: #93c5fd;
+  --locked: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 960px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.residency-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-data-residency-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-data-residency-row + .basic-data-residency-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-data-residency-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.residency-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.residency-icon.is-moving {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.residency-icon.is-locked {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.residency-copy {
+  min-width: 0;
+}
+
+.residency-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.residency-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.residency-scope,
+.residency-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.residency-scope {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.residency-state {
+  min-width: 6rem;
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.residency-state.is-moving {
+  color: var(--moving);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.residency-state.is-locked {
+  color: var(--locked);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-data-residency-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .residency-scope,
+  .residency-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Data Residency Row demo inside `submissions/examples/basic-data-residency-row-v2-kk/`. This submission introduces a compact CSS-only row for workspace settings, compliance panels, enterprise admin pages, and region configuration screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only data residency row that displays a region icon, region name, helper text, residency scope, and active/migrating/restricted hosting state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-data-residency-row">
  <span class="residency-icon is-active" aria-hidden="true">US</span>
  <div class="residency-copy">
    <strong>United States region</strong>
    <p>Primary workspace data is stored in US data centers.</p>
  </div>
  <span class="residency-scope">Primary</span>
  <span class="residency-state is-active">Active</span>
</article>