### PR TITLE
feat: add basic refund status row demo

### DIFF
--- a/submissions/examples/basic-refund-status-row-kk/README.md
+++ b/submissions/examples/basic-refund-status-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Refund Status Row
+
+## What it does
+
+This submission adds a simple CSS-only refund status row for billing history,
+payment support panels, checkout admin screens, and subscription dashboards.
+
+It presents a refund state icon, refund reason, helper text, amount metadata,
+and processing state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a refund icon, copy area, amount label, and state
+pill:
+
+```html
+<article class="basic-refund-status-row">
+  <span class="refund-icon is-processed" aria-hidden="true">OK</span>
+  <div class="refund-copy">
+    <strong>Duplicate payment refund</strong>
+    <p>Refund was processed back to the original payment method.</p>
+  </div>
+  <span class="refund-amount">$49.00</span>
+  <span class="refund-state is-processed">Processed</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+billing and support interfaces. The row can be reused inside payment history,
+refund dashboards, subscription support panels, and checkout admin screens
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Processed, pending, and review refund examples
+- Refund amount metadata
+- Refund processing state pills
+- Long text truncation for refund descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the refund status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-refund-status-row-kk/demo.html
+++ b/submissions/examples/basic-refund-status-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Refund Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Refund Status Row</p>
+          <h1>Refund rows for payment history and billing support panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing refund reason, helper copy,
+            amount metadata, and processing state in billing interfaces.
+          </p>
+        </header>
+
+        <section class="refund-panel" aria-label="Refund status row examples">
+          <article class="basic-refund-status-row">
+            <span class="refund-icon is-processed" aria-hidden="true">OK</span>
+            <div class="refund-copy">
+              <strong>Duplicate payment refund</strong>
+              <p>Refund was processed back to the original payment method.</p>
+            </div>
+            <span class="refund-amount">$49.00</span>
+            <span class="refund-state is-processed">Processed</span>
+          </article>
+
+          <article class="basic-refund-status-row">
+            <span class="refund-icon is-pending" aria-hidden="true">PN</span>
+            <div class="refund-copy">
+              <strong>Plan downgrade credit</strong>
+              <p>Refund is pending bank settlement confirmation.</p>
+            </div>
+            <span class="refund-amount">$18.25</span>
+            <span class="refund-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-refund-status-row">
+            <span class="refund-icon is-failed" aria-hidden="true">FL</span>
+            <div class="refund-copy">
+              <strong>Failed card refund</strong>
+              <p>Original card is unavailable and needs manual review.</p>
+            </div>
+            <span class="refund-amount">$12.80</span>
+            <span class="refund-state is-failed">Review</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-refund-status-row"&gt;
+  &lt;span class="refund-icon is-processed" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="refund-copy"&gt;
+    &lt;strong&gt;Duplicate payment refund&lt;/strong&gt;
+    &lt;p&gt;Refund was processed back to the original payment method.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="refund-amount"&gt;$49.00&lt;/span&gt;
+  &lt;span class="refund-state is-processed"&gt;Processed&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-refund-status-row-kk/style.css
+++ b/submissions/examples/basic-refund-status-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --processed: #86efac;
+  --pending: #93c5fd;
+  --failed: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--processed);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.refund-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-refund-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-refund-status-row + .basic-refund-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-refund-status-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.refund-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.refund-icon.is-pending {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.refund-icon.is-failed {
+  background: linear-gradient(135deg, #fca5a5, #fecaca);
+}
+
+.refund-copy {
+  min-width: 0;
+}
+
+.refund-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.refund-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.refund-amount,
+.refund-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.refund-amount {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.refund-state {
+  min-width: 6rem;
+  color: var(--processed);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.refund-state.is-pending {
+  color: var(--pending);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.refund-state.is-failed {
+  color: var(--failed);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-refund-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .refund-amount,
+  .refund-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Refund Status Row demo inside `submissions/examples/basic-refund-status-row-kk/`. This submission introduces a compact CSS-only row for billing history, payment support panels, checkout admin screens, and subscription dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only refund status row that displays a refund state icon, refund reason, helper text, amount metadata, and processed/pending/review state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-refund-status-row">
  <span class="refund-icon is-processed" aria-hidden="true">OK</span>
  <div class="refund-copy">
    <strong>Duplicate payment refund</strong>
    <p>Refund was processed back to the original payment method.</p>
  </div>
  <span class="refund-amount">$49.00</span>
  <span class="refund-state is-processed">Processed</span>
</article>