### PR TITLE
feat: add basic certificate expiry row demo

### DIFF
--- a/submissions/examples/basic-certificate-expiry-row-kk/README.md
+++ b/submissions/examples/basic-certificate-expiry-row-kk/README.md
@@ -1,0 +1,49 @@
+# Basic Certificate Expiry Row
+
+## What it does
+
+This submission adds a simple CSS-only certificate expiry row for security
+dashboards, domain health panels, TLS settings, and infrastructure tools.
+
+It presents a certificate state icon, domain name, helper text, expiry metadata,
+and certificate state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a certificate icon, copy area, expiry label, and
+state pill:
+
+```html
+<article class="basic-certificate-expiry-row">
+  <span class="certificate-icon is-valid" aria-hidden="true">TLS</span>
+  <div class="certificate-copy">
+    <strong>app.example.com</strong>
+    <p>Certificate is valid and trusted by all monitored browsers.</p>
+  </div>
+  <span class="certificate-date">82d left</span>
+  <span class="certificate-state is-valid">Valid</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+security and infrastructure interfaces. The row can be reused inside TLS
+settings, domain health cards, certificate dashboards, and deployment tools
+while staying lightweight and CSS-only.
+
+## Included features
+
+- Valid, renewing, and expiring certificate examples
+- Expiry metadata label
+- Certificate state pills
+- Long text truncation for certificate descriptions
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the certificate expiry row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-certificate-expiry-row-kk/demo.html
+++ b/submissions/examples/basic-certificate-expiry-row-kk/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Certificate Expiry Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Certificate Expiry Row</p>
+          <h1>Certificate rows for security and domain health panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing certificate name, domain helper
+            copy, expiry metadata, and TLS certificate state in dashboards.
+          </p>
+        </header>
+
+        <section class="certificate-panel" aria-label="Certificate expiry row examples">
+          <article class="basic-certificate-expiry-row">
+            <span class="certificate-icon is-valid" aria-hidden="true">TLS</span>
+            <div class="certificate-copy">
+              <strong>app.example.com</strong>
+              <p>Certificate is valid and trusted by all monitored browsers.</p>
+            </div>
+            <span class="certificate-date">82d left</span>
+            <span class="certificate-state is-valid">Valid</span>
+          </article>
+
+          <article class="basic-certificate-expiry-row">
+            <span class="certificate-icon is-renewing" aria-hidden="true">REN</span>
+            <div class="certificate-copy">
+              <strong>api.example.com</strong>
+              <p>Automatic renewal is in progress through DNS validation.</p>
+            </div>
+            <span class="certificate-date">14d left</span>
+            <span class="certificate-state is-renewing">Renewing</span>
+          </article>
+
+          <article class="basic-certificate-expiry-row">
+            <span class="certificate-icon is-expiring" aria-hidden="true">EXP</span>
+            <div class="certificate-copy">
+              <strong>docs.example.com</strong>
+              <p>Certificate expires soon and needs manual review.</p>
+            </div>
+            <span class="certificate-date">3d left</span>
+            <span class="certificate-state is-expiring">Expiring</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-certificate-expiry-row"&gt;
+  &lt;span class="certificate-icon is-valid" aria-hidden="true"&gt;TLS&lt;/span&gt;
+  &lt;div class="certificate-copy"&gt;
+    &lt;strong&gt;app.example.com&lt;/strong&gt;
+    &lt;p&gt;Certificate is valid and trusted by all monitored browsers.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="certificate-date"&gt;82d left&lt;/span&gt;
+  &lt;span class="certificate-state is-valid"&gt;Valid&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-certificate-expiry-row-kk/style.css
+++ b/submissions/examples/basic-certificate-expiry-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0a1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.05);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a2adbf;
+  --valid: #86efac;
+  --renewing: #93c5fd;
+  --expiring: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(134, 239, 172, 0.15), transparent 28%),
+    radial-gradient(circle at 86% 82%, rgba(147, 197, 253, 0.12), transparent 30%),
+    linear-gradient(145deg, #070a14, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 940px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 30px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--valid);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.certificate-panel,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-certificate-expiry-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-certificate-expiry-row + .basic-certificate-expiry-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-certificate-expiry-row:hover {
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.certificate-icon {
+  display: grid;
+  width: 2.9rem;
+  height: 2.9rem;
+  place-items: center;
+  border-radius: 16px;
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  color: #07111f;
+  background: linear-gradient(135deg, #86efac, #bbf7d0);
+}
+
+.certificate-icon.is-renewing {
+  background: linear-gradient(135deg, #93c5fd, #dbeafe);
+}
+
+.certificate-icon.is-expiring {
+  background: linear-gradient(135deg, #fbbf24, #fde68a);
+}
+
+.certificate-copy {
+  min-width: 0;
+}
+
+.certificate-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.certificate-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.certificate-date,
+.certificate-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.certificate-date {
+  min-width: 5rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.certificate-state {
+  min-width: 6rem;
+  color: var(--valid);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.certificate-state.is-renewing {
+  color: var(--renewing);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.certificate-state.is-expiring {
+  color: var(--expiring);
+  background: rgba(251, 191, 36, 0.13);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 700px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-certificate-expiry-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .certificate-date,
+  .certificate-state {
+    margin-left: 3.75rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Certificate Expiry Row demo inside `submissions/examples/basic-certificate-expiry-row-kk/`. This submission introduces a compact CSS-only row for security dashboards, domain health panels, TLS settings, and infrastructure tools.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only certificate expiry row that displays a certificate state icon, domain name, helper text, expiry metadata, and valid/renewing/expiring certificate state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-certificate-expiry-row">
  <span class="certificate-icon is-valid" aria-hidden="true">TLS</span>
  <div class="certificate-copy">
    <strong>app.example.com</strong>
    <p>Certificate is valid and trusted by all monitored browsers.</p>
  </div>
  <span class="certificate-date">82d left</span>
  <span class="certificate-state is-valid">Valid</span>
</article>