### PR TITLE
feat: add basic model version row demo

### DIFF
--- a/submissions/examples/basic-model-version-row-kk/README.md
+++ b/submissions/examples/basic-model-version-row-kk/README.md
@@ -1,0 +1,51 @@
+# Basic Model Version Row
+
+## What it does
+
+This submission adds a CSS-only model version row for AI dashboards, release
+management tools, evaluation screens, and product admin panels.
+
+It shows a model version marker, model name, helper text, latency, rollout
+percentage, and lifecycle state in a compact reusable row.
+
+## How to use it
+
+Add the base row class with a version mark, copy area, metric pills, and a
+state pill:
+
+```html
+<article class="basic-model-version-row">
+  <span class="version-mark is-stable" aria-hidden="true">v4</span>
+  <div class="version-copy">
+    <strong>summarizer-core-4.2</strong>
+    <p>Stable production model serving all default workspaces.</p>
+  </div>
+  <span class="version-metric">128 ms</span>
+  <span class="version-rollout">100%</span>
+  <span class="version-state is-stable">Stable</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful for
+modern AI product interfaces. Developers can reuse the same row pattern in
+deployment dashboards, model comparison panels, admin tools, and release
+tracking pages without JavaScript or external dependencies.
+
+## Included features
+
+- Stable, canary, and legacy model examples
+- Version marker badges
+- Latency and rollout metadata pills
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the model version row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-model-version-row-kk/demo.html
+++ b/submissions/examples/basic-model-version-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Model Version Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Model Version Row</p>
+          <h1>Readable version rows for AI model release dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing model name, release channel,
+            latency, rollout percentage, and lifecycle status in one compact UI.
+          </p>
+        </header>
+
+        <section class="version-list" aria-label="Model version row examples">
+          <article class="basic-model-version-row">
+            <span class="version-mark is-stable" aria-hidden="true">v4</span>
+            <div class="version-copy">
+              <strong>summarizer-core-4.2</strong>
+              <p>Stable production model serving all default workspaces.</p>
+            </div>
+            <span class="version-metric">128 ms</span>
+            <span class="version-rollout">100%</span>
+            <span class="version-state is-stable">Stable</span>
+          </article>
+
+          <article class="basic-model-version-row">
+            <span class="version-mark is-canary" aria-hidden="true">v5</span>
+            <div class="version-copy">
+              <strong>summarizer-core-5.0</strong>
+              <p>Canary version enabled for a small evaluation cohort.</p>
+            </div>
+            <span class="version-metric">104 ms</span>
+            <span class="version-rollout">12%</span>
+            <span class="version-state is-canary">Canary</span>
+          </article>
+
+          <article class="basic-model-version-row">
+            <span class="version-mark is-deprecated" aria-hidden="true">v3</span>
+            <div class="version-copy">
+              <strong>summarizer-core-3.8</strong>
+              <p>Legacy model kept available for rollback safety.</p>
+            </div>
+            <span class="version-metric">176 ms</span>
+            <span class="version-rollout">0%</span>
+            <span class="version-state is-deprecated">Legacy</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-model-version-row"&gt;
+  &lt;span class="version-mark is-stable" aria-hidden="true"&gt;v4&lt;/span&gt;
+  &lt;div class="version-copy"&gt;
+    &lt;strong&gt;summarizer-core-4.2&lt;/strong&gt;
+    &lt;p&gt;Stable production model serving all default workspaces.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="version-metric"&gt;128 ms&lt;/span&gt;
+  &lt;span class="version-rollout"&gt;100%&lt;/span&gt;
+  &lt;span class="version-state is-stable"&gt;Stable&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-model-version-row-kk/style.css
+++ b/submissions/examples/basic-model-version-row-kk/style.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --page: #0d1021;
+  --card: rgba(17, 24, 39, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.11);
+  --text: #f8fbff;
+  --muted: #aab4c7;
+  --stable: #8ef0c8;
+  --canary: #f8d56b;
+  --deprecated: #b7c1d7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 15% 18%, rgba(142, 240, 200, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 74%, rgba(248, 213, 107, 0.14), transparent 28%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--stable);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.version-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-model-version-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-model-version-row + .basic-model-version-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-model-version-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(142, 240, 200, 0.72);
+  transform: translateX(4px);
+}
+
+.version-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #06111c;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--stable), #dcfce7);
+}
+
+.version-mark.is-canary {
+  background: linear-gradient(135deg, var(--canary), #fff7c2);
+}
+
+.version-mark.is-deprecated {
+  background: linear-gradient(135deg, var(--deprecated), #eef2ff);
+}
+
+.version-copy {
+  min-width: 0;
+}
+
+.version-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.version-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.version-metric,
+.version-rollout,
+.version-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.version-metric,
+.version-rollout {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.version-state {
+  color: var(--stable);
+  background: rgba(142, 240, 200, 0.12);
+}
+
+.version-state.is-canary {
+  color: var(--canary);
+  background: rgba(248, 213, 107, 0.12);
+}
+
+.version-state.is-deprecated {
+  color: var(--deprecated);
+  background: rgba(183, 193, 215, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 760px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-model-version-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .version-metric,
+  .version-rollout,
+  .version-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Model Version Row demo inside `submissions/examples/basic-model-version-row-kk/`. This submission introduces a compact CSS-only row for AI dashboards, release management tools, evaluation screens, and product admin panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only model version row that displays a model version marker, model name, helper text, latency, rollout percentage, and lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-model-version-row">
  <span class="version-mark is-stable" aria-hidden="true">v4</span>
  <div class="version-copy">
    <strong>summarizer-core-4.2</strong>
    <p>Stable production model serving all default workspaces.</p>
  </div>
  <span class="version-metric">128 ms</span>
  <span class="version-rollout">100%</span>
  <span class="version-state is-stable">Stable</span>
</article>