### PR TITLE
feat: add basic backup snapshot row demo

### DIFF
--- a/submissions/examples/basic-backup-snapshot-row-kk/README.md
+++ b/submissions/examples/basic-backup-snapshot-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Backup Snapshot Row
+
+## What it does
+
+This submission adds a CSS-only backup snapshot row for admin dashboards,
+storage tools, recovery panels, and infrastructure status pages.
+
+It shows a snapshot marker, backup name, timestamp helper text, storage target,
+backup size, and lifecycle status in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a snapshot mark, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-backup-snapshot-row">
+  <span class="snapshot-mark is-complete" aria-hidden="true">OK</span>
+  <div class="snapshot-copy">
+    <strong>workspace-nightly-042</strong>
+    <p>Completed today at 02:15 AM with no skipped files.</p>
+  </div>
+  <span class="snapshot-target">S3 East</span>
+  <span class="snapshot-size">8.4 GB</span>
+  <span class="snapshot-state is-complete">Complete</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is human-readable, composable, and useful for
+common admin and infrastructure interfaces. Developers can reuse the same row
+pattern in backup logs, recovery dashboards, storage panels, and system health
+screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Complete, scheduled, and failed backup examples
+- Snapshot marker badges
+- Storage target metadata
+- Backup size metadata
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the backup snapshot row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-backup-snapshot-row-kk/demo.html
+++ b/submissions/examples/basic-backup-snapshot-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Backup Snapshot Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Backup Snapshot Row</p>
+          <h1>Compact backup status rows for admin dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing snapshot name, timestamp,
+            storage target, backup size, and current state in one readable row.
+          </p>
+        </header>
+
+        <section class="snapshot-list" aria-label="Backup snapshot row examples">
+          <article class="basic-backup-snapshot-row">
+            <span class="snapshot-mark is-complete" aria-hidden="true">OK</span>
+            <div class="snapshot-copy">
+              <strong>workspace-nightly-042</strong>
+              <p>Completed today at 02:15 AM with no skipped files.</p>
+            </div>
+            <span class="snapshot-target">S3 East</span>
+            <span class="snapshot-size">8.4 GB</span>
+            <span class="snapshot-state is-complete">Complete</span>
+          </article>
+
+          <article class="basic-backup-snapshot-row">
+            <span class="snapshot-mark is-scheduled" aria-hidden="true">UP</span>
+            <div class="snapshot-copy">
+              <strong>billing-database-daily</strong>
+              <p>Queued for the next maintenance window.</p>
+            </div>
+            <span class="snapshot-target">Cold Store</span>
+            <span class="snapshot-size">3.1 GB</span>
+            <span class="snapshot-state is-scheduled">Scheduled</span>
+          </article>
+
+          <article class="basic-backup-snapshot-row">
+            <span class="snapshot-mark is-failed" aria-hidden="true">ER</span>
+            <div class="snapshot-copy">
+              <strong>media-library-weekly</strong>
+              <p>Failed because the remote storage token expired.</p>
+            </div>
+            <span class="snapshot-target">Archive</span>
+            <span class="snapshot-size">21 GB</span>
+            <span class="snapshot-state is-failed">Failed</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-backup-snapshot-row"&gt;
+  &lt;span class="snapshot-mark is-complete" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="snapshot-copy"&gt;
+    &lt;strong&gt;workspace-nightly-042&lt;/strong&gt;
+    &lt;p&gt;Completed today at 02:15 AM with no skipped files.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="snapshot-target"&gt;S3 East&lt;/span&gt;
+  &lt;span class="snapshot-size"&gt;8.4 GB&lt;/span&gt;
+  &lt;span class="snapshot-state is-complete"&gt;Complete&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-backup-snapshot-row-kk/style.css
+++ b/submissions/examples/basic-backup-snapshot-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0d1220;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f9fbff;
+  --muted: #aab5c7;
+  --complete: #8df0bb;
+  --scheduled: #93c5fd;
+  --failed: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 16% 20%, rgba(141, 240, 187, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 76%, rgba(147, 197, 253, 0.14), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 990px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--complete);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.snapshot-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-backup-snapshot-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-backup-snapshot-row + .basic-backup-snapshot-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-backup-snapshot-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(141, 240, 187, 0.72);
+  transform: translateX(4px);
+}
+
+.snapshot-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--complete), #dcfce7);
+}
+
+.snapshot-mark.is-scheduled {
+  background: linear-gradient(135deg, var(--scheduled), #dbeafe);
+}
+
+.snapshot-mark.is-failed {
+  background: linear-gradient(135deg, var(--failed), #fecaca);
+}
+
+.snapshot-copy {
+  min-width: 0;
+}
+
+.snapshot-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snapshot-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snapshot-target,
+.snapshot-size,
+.snapshot-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.4rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.snapshot-target,
+.snapshot-size {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.snapshot-state {
+  color: var(--complete);
+  background: rgba(141, 240, 187, 0.12);
+}
+
+.snapshot-state.is-scheduled {
+  color: var(--scheduled);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.snapshot-state.is-failed {
+  color: var(--failed);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-backup-snapshot-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .snapshot-target,
+  .snapshot-size,
+  .snapshot-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Backup Snapshot Row demo inside `submissions/examples/basic-backup-snapshot-row-kk/`. This submission introduces a compact CSS-only row for admin dashboards, storage tools, recovery panels, and infrastructure status pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only backup snapshot row that displays a snapshot marker, backup name, timestamp helper text, storage target, backup size, and lifecycle status in one compact layout.

**How does a developer use it?**

```html
<article class="basic-backup-snapshot-row">
  <span class="snapshot-mark is-complete" aria-hidden="true">OK</span>
  <div class="snapshot-copy">
    <strong>workspace-nightly-042</strong>
    <p>Completed today at 02:15 AM with no skipped files.</p>
  </div>
  <span class="snapshot-target">S3 East</span>
  <span class="snapshot-size">8.4 GB</span>
  <span class="snapshot-state is-complete">Complete</span>
</article>