### PR TITLE
feat: add basic dns record row demo

### DIFF
--- a/submissions/examples/basic-dns-record-row-kk/README.md
+++ b/submissions/examples/basic-dns-record-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic DNS Record Row
+
+## What it does
+
+This submission adds a CSS-only DNS record row for hosting dashboards, domain
+settings, deployment panels, and site configuration pages.
+
+It shows a DNS record type, host, target value, TTL, and verification state in
+one compact reusable row.
+
+## How to use it
+
+Add the base row class with a DNS type badge, copy area, target metadata, TTL,
+and state pill:
+
+```html
+<article class="basic-dns-record-row">
+  <span class="dns-type is-verified">A</span>
+  <div class="dns-copy">
+    <strong>@</strong>
+    <p>76.76.21.21 points the root domain to production hosting.</p>
+  </div>
+  <span class="dns-target">76.76.21.21</span>
+  <span class="dns-ttl">Auto</span>
+  <span class="dns-state is-verified">Verified</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+developer and hosting interfaces. Developers can reuse the same row pattern in
+domain settings, DNS verification panels, deployment dashboards, and site setup
+screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Verified, pending, and error DNS record examples
+- DNS type badges
+- Host and target metadata
+- TTL metadata pill
+- Verification state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the DNS record row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-dns-record-row-kk/demo.html
+++ b/submissions/examples/basic-dns-record-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic DNS Record Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic DNS Record Row</p>
+          <h1>Compact DNS record rows for hosting dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing record type, host, target value,
+            TTL, and verification state inside domain settings panels.
+          </p>
+        </header>
+
+        <section class="dns-list" aria-label="DNS record row examples">
+          <article class="basic-dns-record-row">
+            <span class="dns-type is-verified">A</span>
+            <div class="dns-copy">
+              <strong>@</strong>
+              <p>76.76.21.21 points the root domain to production hosting.</p>
+            </div>
+            <span class="dns-target">76.76.21.21</span>
+            <span class="dns-ttl">Auto</span>
+            <span class="dns-state is-verified">Verified</span>
+          </article>
+
+          <article class="basic-dns-record-row">
+            <span class="dns-type is-pending">C</span>
+            <div class="dns-copy">
+              <strong>www</strong>
+              <p>Alias record is waiting for propagation checks.</p>
+            </div>
+            <span class="dns-target">cname.host.app</span>
+            <span class="dns-ttl">1 hr</span>
+            <span class="dns-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-dns-record-row">
+            <span class="dns-type is-error">MX</span>
+            <div class="dns-copy">
+              <strong>mail</strong>
+              <p>Mail routing is blocked by an incorrect priority value.</p>
+            </div>
+            <span class="dns-target">mx.mailbox.local</span>
+            <span class="dns-ttl">30 min</span>
+            <span class="dns-state is-error">Fix Needed</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-dns-record-row"&gt;
+  &lt;span class="dns-type is-verified"&gt;A&lt;/span&gt;
+  &lt;div class="dns-copy"&gt;
+    &lt;strong&gt;@&lt;/strong&gt;
+    &lt;p&gt;76.76.21.21 points the root domain to production hosting.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="dns-target"&gt;76.76.21.21&lt;/span&gt;
+  &lt;span class="dns-ttl"&gt;Auto&lt;/span&gt;
+  &lt;span class="dns-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-dns-record-row-kk/style.css
+++ b/submissions/examples/basic-dns-record-row-kk/style.css
@@ -1,0 +1,209 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --verified: #86efac;
+  --pending: #facc15;
+  --error: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1020px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--verified);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.dns-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-dns-record-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(8rem, auto) auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-dns-record-row + .basic-dns-record-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-dns-record-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.dns-type {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.82rem;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--verified), #dcfce7);
+}
+
+.dns-type.is-pending {
+  background: linear-gradient(135deg, var(--pending), #fef9c3);
+}
+
+.dns-type.is-error {
+  background: linear-gradient(135deg, var(--error), #fecaca);
+}
+
+.dns-copy {
+  min-width: 0;
+}
+
+.dns-copy strong {
+  display: block;
+  overflow: hidden;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dns-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dns-target,
+.dns-ttl,
+.dns-state {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.dns-target {
+  min-width: 9rem;
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dns-ttl {
+  min-width: 4.8rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dns-state {
+  min-width: 6.6rem;
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.dns-state.is-pending {
+  color: var(--pending);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.dns-state.is-error {
+  color: var(--error);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 820px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-dns-record-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .dns-target,
+  .dns-ttl,
+  .dns-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic DNS Record Row demo inside `submissions/examples/basic-dns-record-row-kk/`. This submission introduces a compact CSS-only row for hosting dashboards, domain settings, deployment panels, and site configuration pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only DNS record row that displays a DNS record type, host, target value, TTL, and verified/pending/fix-needed state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-dns-record-row">
  <span class="dns-type is-verified">A</span>
  <div class="dns-copy">
    <strong>@</strong>
    <p>76.76.21.21 points the root domain to production hosting.</p>
  </div>
  <span class="dns-target">76.76.21.21</span>
  <span class="dns-ttl">Auto</span>
  <span class="dns-state is-verified">Verified</span>
</article>