### PR TITLE
feat: add basic cron job row demo

### DIFF
--- a/submissions/examples/basic-cron-job-row-kk/README.md
+++ b/submissions/examples/basic-cron-job-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Cron Job Row
+
+## What it does
+
+This submission adds a CSS-only cron job row for scheduler dashboards,
+automation panels, infrastructure tools, and admin monitoring pages.
+
+It shows a job marker, job name, helper text, cron schedule, last run timing,
+and current lifecycle state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a job marker, copy area, metadata pills, and a state
+pill:
+
+```html
+<article class="basic-cron-job-row">
+  <span class="cron-mark is-complete" aria-hidden="true">OK</span>
+  <div class="cron-copy">
+    <strong>nightly-report-sync</strong>
+    <p>Runs every night to refresh analytics exports.</p>
+  </div>
+  <span class="cron-schedule">0 2 * * *</span>
+  <span class="cron-last-run">12 min ago</span>
+  <span class="cron-state is-complete">Complete</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+developer and infrastructure dashboards. Developers can reuse the same row
+pattern in scheduler logs, automation tools, admin panels, and job monitoring
+screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Complete, active, and paused cron job examples
+- Job marker badges
+- Cron expression metadata
+- Last run timing metadata
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the cron job row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-cron-job-row-kk/demo.html
+++ b/submissions/examples/basic-cron-job-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Cron Job Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Cron Job Row</p>
+          <h1>Readable scheduler rows for automation dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing recurring job names, schedules,
+            last run timing, and current state in one compact interface.
+          </p>
+        </header>
+
+        <section class="cron-list" aria-label="Cron job row examples">
+          <article class="basic-cron-job-row">
+            <span class="cron-mark is-complete" aria-hidden="true">OK</span>
+            <div class="cron-copy">
+              <strong>nightly-report-sync</strong>
+              <p>Runs every night to refresh analytics exports.</p>
+            </div>
+            <span class="cron-schedule">0 2 * * *</span>
+            <span class="cron-last-run">12 min ago</span>
+            <span class="cron-state is-complete">Complete</span>
+          </article>
+
+          <article class="basic-cron-job-row">
+            <span class="cron-mark is-running" aria-hidden="true">ON</span>
+            <div class="cron-copy">
+              <strong>invoice-reminder-worker</strong>
+              <p>Currently sending renewal reminders to active accounts.</p>
+            </div>
+            <span class="cron-schedule">*/15 * * * *</span>
+            <span class="cron-last-run">Running</span>
+            <span class="cron-state is-running">Active</span>
+          </article>
+
+          <article class="basic-cron-job-row">
+            <span class="cron-mark is-paused" aria-hidden="true">II</span>
+            <div class="cron-copy">
+              <strong>legacy-cache-cleanup</strong>
+              <p>Paused while storage migration checks are reviewed.</p>
+            </div>
+            <span class="cron-schedule">0 */6 * * *</span>
+            <span class="cron-last-run">3 days ago</span>
+            <span class="cron-state is-paused">Paused</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-cron-job-row"&gt;
+  &lt;span class="cron-mark is-complete" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="cron-copy"&gt;
+    &lt;strong&gt;nightly-report-sync&lt;/strong&gt;
+    &lt;p&gt;Runs every night to refresh analytics exports.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="cron-schedule"&gt;0 2 * * *&lt;/span&gt;
+  &lt;span class="cron-last-run"&gt;12 min ago&lt;/span&gt;
+  &lt;span class="cron-state is-complete"&gt;Complete&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-cron-job-row-kk/style.css
+++ b/submissions/examples/basic-cron-job-row-kk/style.css
@@ -1,0 +1,204 @@
+:root {
+  color-scheme: dark;
+  --page: #0d1020;
+  --card: rgba(17, 24, 39, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --complete: #8df0bb;
+  --running: #93c5fd;
+  --paused: #facc15;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(141, 240, 187, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1000px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--complete);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.cron-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-cron-job-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-cron-job-row + .basic-cron-job-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-cron-job-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(141, 240, 187, 0.72);
+  transform: translateX(4px);
+}
+
+.cron-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--complete), #dcfce7);
+}
+
+.cron-mark.is-running {
+  background: linear-gradient(135deg, var(--running), #dbeafe);
+}
+
+.cron-mark.is-paused {
+  background: linear-gradient(135deg, var(--paused), #fef9c3);
+}
+
+.cron-copy {
+  min-width: 0;
+}
+
+.cron-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cron-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cron-schedule,
+.cron-last-run,
+.cron-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.cron-schedule {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+.cron-schedule,
+.cron-last-run {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.cron-state {
+  color: var(--complete);
+  background: rgba(141, 240, 187, 0.12);
+}
+
+.cron-state.is-running {
+  color: var(--running);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.cron-state.is-paused {
+  color: var(--paused);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-cron-job-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .cron-schedule,
+  .cron-last-run,
+  .cron-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Cron Job Row demo inside `submissions/examples/basic-cron-job-row-kk/`. This submission introduces a compact CSS-only row for scheduler dashboards, automation panels, infrastructure tools, and admin monitoring pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only cron job row that displays a job marker, job name, helper text, cron schedule, last run timing, and complete/active/paused lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-cron-job-row">
  <span class="cron-mark is-complete" aria-hidden="true">OK</span>
  <div class="cron-copy">
    <strong>nightly-report-sync</strong>
    <p>Runs every night to refresh analytics exports.</p>
  </div>
  <span class="cron-schedule">0 2 * * *</span>
  <span class="cron-last-run">12 min ago</span>
  <span class="cron-state is-complete">Complete</span>
</article>