### PR TITLE
feat: add basic license seat row demo

### DIFF
--- a/submissions/examples/basic-license-seat-row-kk/README.md
+++ b/submissions/examples/basic-license-seat-row-kk/README.md
@@ -1,0 +1,51 @@
+# Basic License Seat Row
+
+## What it does
+
+This submission adds a CSS-only license seat row for SaaS admin panels,
+workspace settings, billing pages, and team management dashboards.
+
+It shows a user avatar, seat owner, role, recent activity, and seat lifecycle
+state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an avatar, copy area, metadata pills, and a state
+pill:
+
+```html
+<article class="basic-license-seat-row">
+  <span class="seat-avatar is-active" aria-hidden="true">AM</span>
+  <div class="seat-copy">
+    <strong>Aarav Mehta</strong>
+    <p>Product workspace admin with full billing access.</p>
+  </div>
+  <span class="seat-role">Admin</span>
+  <span class="seat-activity">Today</span>
+  <span class="seat-state is-active">Assigned</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+SaaS admin interfaces. Developers can reuse the same row pattern in billing
+settings, workspace member lists, team dashboards, and license management
+screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Assigned, invited, and inactive seat examples
+- Initial avatar markers
+- Role and activity metadata pills
+- Seat lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the license seat row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-license-seat-row-kk/demo.html
+++ b/submissions/examples/basic-license-seat-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic License Seat Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic License Seat Row</p>
+          <h1>Simple seat management rows for SaaS admin panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing assigned seats, pending invites,
+            inactive users, workspace metadata, and recent activity in one row.
+          </p>
+        </header>
+
+        <section class="seat-list" aria-label="License seat row examples">
+          <article class="basic-license-seat-row">
+            <span class="seat-avatar is-active" aria-hidden="true">AM</span>
+            <div class="seat-copy">
+              <strong>Aarav Mehta</strong>
+              <p>Product workspace admin with full billing access.</p>
+            </div>
+            <span class="seat-role">Admin</span>
+            <span class="seat-activity">Today</span>
+            <span class="seat-state is-active">Assigned</span>
+          </article>
+
+          <article class="basic-license-seat-row">
+            <span class="seat-avatar is-invited" aria-hidden="true">NS</span>
+            <div class="seat-copy">
+              <strong>Nisha Shah</strong>
+              <p>Invite sent for the design review workspace.</p>
+            </div>
+            <span class="seat-role">Editor</span>
+            <span class="seat-activity">Pending</span>
+            <span class="seat-state is-invited">Invited</span>
+          </article>
+
+          <article class="basic-license-seat-row">
+            <span class="seat-avatar is-inactive" aria-hidden="true">RK</span>
+            <div class="seat-copy">
+              <strong>Rohan Kapoor</strong>
+              <p>Inactive seat ready for reassignment or removal.</p>
+            </div>
+            <span class="seat-role">Viewer</span>
+            <span class="seat-activity">42 days</span>
+            <span class="seat-state is-inactive">Inactive</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-license-seat-row"&gt;
+  &lt;span class="seat-avatar is-active" aria-hidden="true"&gt;AM&lt;/span&gt;
+  &lt;div class="seat-copy"&gt;
+    &lt;strong&gt;Aarav Mehta&lt;/strong&gt;
+    &lt;p&gt;Product workspace admin with full billing access.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="seat-role"&gt;Admin&lt;/span&gt;
+  &lt;span class="seat-activity"&gt;Today&lt;/span&gt;
+  &lt;span class="seat-state is-active"&gt;Assigned&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-license-seat-row-kk/style.css
+++ b/submissions/examples/basic-license-seat-row-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0c1020;
+  --card: rgba(17, 24, 39, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --active: #86efac;
+  --invited: #facc15;
+  --inactive: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 16% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 80%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.seat-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-license-seat-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-license-seat-row + .basic-license-seat-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-license-seat-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.seat-avatar {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.82rem;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--active), #dcfce7);
+}
+
+.seat-avatar.is-invited {
+  background: linear-gradient(135deg, var(--invited), #fef9c3);
+}
+
+.seat-avatar.is-inactive {
+  background: linear-gradient(135deg, var(--inactive), #f8fafc);
+}
+
+.seat-copy {
+  min-width: 0;
+}
+
+.seat-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seat-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seat-role,
+.seat-activity,
+.seat-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.4rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.seat-role,
+.seat-activity {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.seat-state {
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.seat-state.is-invited {
+  color: var(--invited);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.seat-state.is-inactive {
+  color: var(--inactive);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-license-seat-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .seat-role,
+  .seat-activity,
+  .seat-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic License Seat Row demo inside `submissions/examples/basic-license-seat-row-kk/`. This submission introduces a compact CSS-only row for SaaS admin panels, workspace settings, billing pages, and team management dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only license seat row that displays a user avatar, seat owner, role, recent activity, and assigned/invited/inactive lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-license-seat-row">
  <span class="seat-avatar is-active" aria-hidden="true">AM</span>
  <div class="seat-copy">
    <strong>Aarav Mehta</strong>
    <p>Product workspace admin with full billing access.</p>
  </div>
  <span class="seat-role">Admin</span>
  <span class="seat-activity">Today</span>
  <span class="seat-state is-active">Assigned</span>
</article>