### PR TITLE
feat: add basic oauth app row demo

### DIFF
--- a/submissions/examples/basic-oauth-app-row-kk/README.md
+++ b/submissions/examples/basic-oauth-app-row-kk/README.md
@@ -1,0 +1,53 @@
+# Basic OAuth App Row
+
+## What it does
+
+This submission adds a CSS-only OAuth app row for security settings pages,
+connected app dashboards, admin panels, and access review screens.
+
+It shows an app marker, app name, helper text, granted scope count, last used
+time, and authorization state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an app marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-oauth-app-row">
+  <span class="oauth-mark is-approved" aria-hidden="true">GH</span>
+  <div class="oauth-copy">
+    <strong>GitHub Sync</strong>
+    <p>Approved by workspace admin for repository automation.</p>
+  </div>
+  <span class="oauth-scopes">4 scopes</span>
+  <span class="oauth-used">Today</span>
+  <span class="oauth-state is-approved">Approved</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+security and admin interfaces. Developers can reuse the same row pattern in
+connected app settings, access review dashboards, workspace security pages, and
+OAuth permission screens while keeping the implementation lightweight and
+CSS-only.
+
+## Included features
+
+- Approved, review, and revoked OAuth app examples
+- App initial marker badges
+- Scope count metadata
+- Last used metadata
+- Authorization state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the OAuth app row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-oauth-app-row-kk/demo.html
+++ b/submissions/examples/basic-oauth-app-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic OAuth App Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic OAuth App Row</p>
+          <h1>Connected app rows for security settings pages.</h1>
+          <p class="intro">
+            A CSS-only row component for showing OAuth app name, owner, granted
+            scopes, last used time, and authorization status in one compact UI.
+          </p>
+        </header>
+
+        <section class="oauth-list" aria-label="OAuth app row examples">
+          <article class="basic-oauth-app-row">
+            <span class="oauth-mark is-approved" aria-hidden="true">GH</span>
+            <div class="oauth-copy">
+              <strong>GitHub Sync</strong>
+              <p>Approved by workspace admin for repository automation.</p>
+            </div>
+            <span class="oauth-scopes">4 scopes</span>
+            <span class="oauth-used">Today</span>
+            <span class="oauth-state is-approved">Approved</span>
+          </article>
+
+          <article class="basic-oauth-app-row">
+            <span class="oauth-mark is-review" aria-hidden="true">BI</span>
+            <div class="oauth-copy">
+              <strong>BI Exporter</strong>
+              <p>New permission request needs security review.</p>
+            </div>
+            <span class="oauth-scopes">7 scopes</span>
+            <span class="oauth-used">Pending</span>
+            <span class="oauth-state is-review">Review</span>
+          </article>
+
+          <article class="basic-oauth-app-row">
+            <span class="oauth-mark is-revoked" aria-hidden="true">CI</span>
+            <div class="oauth-copy">
+              <strong>Legacy CI Bot</strong>
+              <p>Access was revoked after token rotation cleanup.</p>
+            </div>
+            <span class="oauth-scopes">2 scopes</span>
+            <span class="oauth-used">38 days</span>
+            <span class="oauth-state is-revoked">Revoked</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-oauth-app-row"&gt;
+  &lt;span class="oauth-mark is-approved" aria-hidden="true"&gt;GH&lt;/span&gt;
+  &lt;div class="oauth-copy"&gt;
+    &lt;strong&gt;GitHub Sync&lt;/strong&gt;
+    &lt;p&gt;Approved by workspace admin for repository automation.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="oauth-scopes"&gt;4 scopes&lt;/span&gt;
+  &lt;span class="oauth-used"&gt;Today&lt;/span&gt;
+  &lt;span class="oauth-state is-approved"&gt;Approved&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-oauth-app-row-kk/style.css
+++ b/submissions/examples/basic-oauth-app-row-kk/style.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: dark;
+  --page: #0c1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --approved: #86efac;
+  --review: #facc15;
+  --revoked: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--approved);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.oauth-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-oauth-app-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-oauth-app-row + .basic-oauth-app-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-oauth-app-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.oauth-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.82rem;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--approved), #dcfce7);
+}
+
+.oauth-mark.is-review {
+  background: linear-gradient(135deg, var(--review), #fef9c3);
+}
+
+.oauth-mark.is-revoked {
+  background: linear-gradient(135deg, var(--revoked), #fecaca);
+}
+
+.oauth-copy {
+  min-width: 0;
+}
+
+.oauth-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.oauth-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.oauth-scopes,
+.oauth-used,
+.oauth-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.oauth-scopes,
+.oauth-used {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.oauth-state {
+  color: var(--approved);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.oauth-state.is-review {
+  color: var(--review);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.oauth-state.is-revoked {
+  color: var(--revoked);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-oauth-app-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .oauth-scopes,
+  .oauth-used,
+  .oauth-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic OAuth App Row demo inside `submissions/examples/basic-oauth-app-row-kk/`. This submission introduces a compact CSS-only row for security settings pages, connected app dashboards, admin panels, and access review screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only OAuth app row that displays an app marker, app name, helper text, granted scope count, last used time, and approved/review/revoked authorization state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-oauth-app-row">
  <span class="oauth-mark is-approved" aria-hidden="true">GH</span>
  <div class="oauth-copy">
    <strong>GitHub Sync</strong>
    <p>Approved by workspace admin for repository automation.</p>
  </div>
  <span class="oauth-scopes">4 scopes</span>
  <span class="oauth-used">Today</span>
  <span class="oauth-state is-approved">Approved</span>
</article>