### PR TITLE
feat: add basic invite link row demo

### DIFF
--- a/submissions/examples/basic-invite-link-row-kk/README.md
+++ b/submissions/examples/basic-invite-link-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Invite Link Row
+
+## What it does
+
+This submission adds a CSS-only invite link row for workspace settings, team
+management dashboards, admin panels, and access control screens.
+
+It shows an invite marker, invite label, helper text, default role, usage count,
+and lifecycle state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with an invite marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-invite-link-row">
+  <span class="invite-mark is-active" aria-hidden="true">IN</span>
+  <div class="invite-copy">
+    <strong>Design team invite</strong>
+    <p>Reusable onboarding link for product designers.</p>
+  </div>
+  <span class="invite-role">Editor</span>
+  <span class="invite-usage">12 used</span>
+  <span class="invite-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+workspace administration interfaces. Developers can reuse the same row pattern
+in team settings, access control dashboards, invite management panels, and
+onboarding flows while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Active, expiring, and disabled invite examples
+- Invite marker badges
+- Default role metadata
+- Usage count metadata
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the invite link row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-invite-link-row-kk/demo.html
+++ b/submissions/examples/basic-invite-link-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Invite Link Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Invite Link Row</p>
+          <h1>Invite link rows for workspace access settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing invite links, default role,
+            expiry window, usage count, and lifecycle state in one compact UI.
+          </p>
+        </header>
+
+        <section class="invite-list" aria-label="Invite link row examples">
+          <article class="basic-invite-link-row">
+            <span class="invite-mark is-active" aria-hidden="true">IN</span>
+            <div class="invite-copy">
+              <strong>Design team invite</strong>
+              <p>Reusable onboarding link for product designers.</p>
+            </div>
+            <span class="invite-role">Editor</span>
+            <span class="invite-usage">12 used</span>
+            <span class="invite-state is-active">Active</span>
+          </article>
+
+          <article class="basic-invite-link-row">
+            <span class="invite-mark is-expiring" aria-hidden="true">24</span>
+            <div class="invite-copy">
+              <strong>Partner review link</strong>
+              <p>Temporary access link for external review partners.</p>
+            </div>
+            <span class="invite-role">Viewer</span>
+            <span class="invite-usage">3 used</span>
+            <span class="invite-state is-expiring">Expires Soon</span>
+          </article>
+
+          <article class="basic-invite-link-row">
+            <span class="invite-mark is-disabled" aria-hidden="true">OFF</span>
+            <div class="invite-copy">
+              <strong>Legacy campaign invite</strong>
+              <p>Disabled after the campaign workspace was archived.</p>
+            </div>
+            <span class="invite-role">Guest</span>
+            <span class="invite-usage">0 used</span>
+            <span class="invite-state is-disabled">Disabled</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-invite-link-row"&gt;
+  &lt;span class="invite-mark is-active" aria-hidden="true"&gt;IN&lt;/span&gt;
+  &lt;div class="invite-copy"&gt;
+    &lt;strong&gt;Design team invite&lt;/strong&gt;
+    &lt;p&gt;Reusable onboarding link for product designers.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="invite-role"&gt;Editor&lt;/span&gt;
+  &lt;span class="invite-usage"&gt;12 used&lt;/span&gt;
+  &lt;span class="invite-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-invite-link-row-kk/style.css
+++ b/submissions/examples/basic-invite-link-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --active: #86efac;
+  --expiring: #facc15;
+  --disabled: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.invite-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-invite-link-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-invite-link-row + .basic-invite-link-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-invite-link-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.invite-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--active), #dcfce7);
+}
+
+.invite-mark.is-expiring {
+  background: linear-gradient(135deg, var(--expiring), #fef9c3);
+}
+
+.invite-mark.is-disabled {
+  background: linear-gradient(135deg, var(--disabled), #f8fafc);
+}
+
+.invite-copy {
+  min-width: 0;
+}
+
+.invite-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invite-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invite-role,
+.invite-usage,
+.invite-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.invite-role,
+.invite-usage {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.invite-state {
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.invite-state.is-expiring {
+  color: var(--expiring);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.invite-state.is-disabled {
+  color: var(--disabled);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-invite-link-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .invite-role,
+  .invite-usage,
+  .invite-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Invite Link Row demo inside `submissions/examples/basic-invite-link-row-kk/`. This submission introduces a compact CSS-only row for workspace settings, team management dashboards, admin panels, and access control screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only invite link row that displays an invite marker, invite label, helper text, default role, usage count, and active/expiring/disabled lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-invite-link-row">
  <span class="invite-mark is-active" aria-hidden="true">IN</span>
  <div class="invite-copy">
    <strong>Design team invite</strong>
    <p>Reusable onboarding link for product designers.</p>
  </div>
  <span class="invite-role">Editor</span>
  <span class="invite-usage">12 used</span>
  <span class="invite-state is-active">Active</span>
</article>