### PR TITLE
feat: add basic permission request row demo

### DIFF
--- a/submissions/examples/basic-permission-request-row-kk/README.md
+++ b/submissions/examples/basic-permission-request-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Permission Request Row
+
+## What it does
+
+This submission adds a CSS-only permission request row for access review
+screens, admin dashboards, workspace settings, and security panels.
+
+It shows a requester marker, requester name, helper text, permission level,
+request age, and review state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a request marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-permission-request-row">
+  <span class="request-mark is-approved" aria-hidden="true">OK</span>
+  <div class="request-copy">
+    <strong>Meera Iyer</strong>
+    <p>Requested editor access to the product roadmap workspace.</p>
+  </div>
+  <span class="request-level">Editor</span>
+  <span class="request-age">2 hr</span>
+  <span class="request-state is-approved">Approved</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+security and workspace administration interfaces. Developers can reuse the same
+row pattern in access review queues, permission dashboards, admin panels, and
+workspace settings while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Approved, pending, and denied request examples
+- Request marker badges
+- Permission level metadata
+- Request age metadata
+- Review state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the permission request row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-permission-request-row-kk/demo.html
+++ b/submissions/examples/basic-permission-request-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Permission Request Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Permission Request Row</p>
+          <h1>Review rows for access and permission requests.</h1>
+          <p class="intro">
+            A CSS-only row component for showing requester identity, requested
+            resource, permission level, request age, and review state.
+          </p>
+        </header>
+
+        <section class="request-list" aria-label="Permission request row examples">
+          <article class="basic-permission-request-row">
+            <span class="request-mark is-approved" aria-hidden="true">OK</span>
+            <div class="request-copy">
+              <strong>Meera Iyer</strong>
+              <p>Requested editor access to the product roadmap workspace.</p>
+            </div>
+            <span class="request-level">Editor</span>
+            <span class="request-age">2 hr</span>
+            <span class="request-state is-approved">Approved</span>
+          </article>
+
+          <article class="basic-permission-request-row">
+            <span class="request-mark is-pending" aria-hidden="true">RV</span>
+            <div class="request-copy">
+              <strong>Kabir Sethi</strong>
+              <p>Needs admin approval for customer export permissions.</p>
+            </div>
+            <span class="request-level">Admin</span>
+            <span class="request-age">Today</span>
+            <span class="request-state is-pending">Pending</span>
+          </article>
+
+          <article class="basic-permission-request-row">
+            <span class="request-mark is-denied" aria-hidden="true">NO</span>
+            <div class="request-copy">
+              <strong>Anika Rao</strong>
+              <p>Read access denied because the project was archived.</p>
+            </div>
+            <span class="request-level">Viewer</span>
+            <span class="request-age">1 day</span>
+            <span class="request-state is-denied">Denied</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-permission-request-row"&gt;
+  &lt;span class="request-mark is-approved" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="request-copy"&gt;
+    &lt;strong&gt;Meera Iyer&lt;/strong&gt;
+    &lt;p&gt;Requested editor access to the product roadmap workspace.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="request-level"&gt;Editor&lt;/span&gt;
+  &lt;span class="request-age"&gt;2 hr&lt;/span&gt;
+  &lt;span class="request-state is-approved"&gt;Approved&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-permission-request-row-kk/style.css
+++ b/submissions/examples/basic-permission-request-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0c1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --approved: #86efac;
+  --pending: #facc15;
+  --denied: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--approved);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.request-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-permission-request-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-permission-request-row + .basic-permission-request-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-permission-request-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.request-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--approved), #dcfce7);
+}
+
+.request-mark.is-pending {
+  background: linear-gradient(135deg, var(--pending), #fef9c3);
+}
+
+.request-mark.is-denied {
+  background: linear-gradient(135deg, var(--denied), #fecaca);
+}
+
+.request-copy {
+  min-width: 0;
+}
+
+.request-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-level,
+.request-age,
+.request-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.request-level,
+.request-age {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.request-state {
+  color: var(--approved);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.request-state.is-pending {
+  color: var(--pending);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.request-state.is-denied {
+  color: var(--denied);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-permission-request-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .request-level,
+  .request-age,
+  .request-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Permission Request Row demo inside `submissions/examples/basic-permission-request-row-kk/`. This submission introduces a compact CSS-only row for access review screens, admin dashboards, workspace settings, and security panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only permission request row that displays requester identity, requested permission level, request age, helper text, and approved/pending/denied review state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-permission-request-row">
  <span class="request-mark is-approved" aria-hidden="true">OK</span>
  <div class="request-copy">
    <strong>Meera Iyer</strong>
    <p>Requested editor access to the product roadmap workspace.</p>
  </div>
  <span class="request-level">Editor</span>
  <span class="request-age">2 hr</span>
  <span class="request-state is-approved">Approved</span>
</article>