### PR TITLE
feat: add basic feature deprecation row demo

### DIFF
--- a/submissions/examples/basic-feature-deprecation-row-kk/README.md
+++ b/submissions/examples/basic-feature-deprecation-row-kk/README.md
@@ -1,0 +1,53 @@
+# Basic Feature Deprecation Row
+
+## What it does
+
+This submission adds a CSS-only feature deprecation row for product dashboards,
+admin panels, release planning pages, and migration tracking screens.
+
+It shows a feature marker, feature name, migration hint, sunset date, usage
+count, and lifecycle state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a feature marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-feature-deprecation-row">
+  <span class="deprecation-mark is-scheduled" aria-hidden="true">90</span>
+  <div class="deprecation-copy">
+    <strong>Legacy CSV importer</strong>
+    <p>Scheduled for removal after migration to bulk uploader.</p>
+  </div>
+  <span class="deprecation-date">Nov 12</span>
+  <span class="deprecation-usage">128 users</span>
+  <span class="deprecation-state is-scheduled">Sunsetting</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+product and release management interfaces. Developers can reuse the same row
+pattern in deprecation dashboards, migration plans, product admin pages, and
+feature lifecycle screens while keeping the implementation lightweight and
+CSS-only.
+
+## Included features
+
+- Preferred, sunsetting, and retired feature examples
+- Feature lifecycle marker badges
+- Sunset date metadata
+- Usage count metadata
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the feature deprecation row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-feature-deprecation-row-kk/demo.html
+++ b/submissions/examples/basic-feature-deprecation-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Feature Deprecation Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Feature Deprecation Row</p>
+          <h1>Lifecycle rows for feature sunset planning.</h1>
+          <p class="intro">
+            A CSS-only row component for showing feature status, migration hints,
+            sunset timing, usage count, and deprecation state in one compact UI.
+          </p>
+        </header>
+
+        <section class="deprecation-list" aria-label="Feature deprecation row examples">
+          <article class="basic-feature-deprecation-row">
+            <span class="deprecation-mark is-active" aria-hidden="true">ON</span>
+            <div class="deprecation-copy">
+              <strong>New analytics explorer</strong>
+              <p>Recommended replacement for legacy dashboard reports.</p>
+            </div>
+            <span class="deprecation-date">Active</span>
+            <span class="deprecation-usage">842 users</span>
+            <span class="deprecation-state is-active">Preferred</span>
+          </article>
+
+          <article class="basic-feature-deprecation-row">
+            <span class="deprecation-mark is-scheduled" aria-hidden="true">90</span>
+            <div class="deprecation-copy">
+              <strong>Legacy CSV importer</strong>
+              <p>Scheduled for removal after migration to bulk uploader.</p>
+            </div>
+            <span class="deprecation-date">Nov 12</span>
+            <span class="deprecation-usage">128 users</span>
+            <span class="deprecation-state is-scheduled">Sunsetting</span>
+          </article>
+
+          <article class="basic-feature-deprecation-row">
+            <span class="deprecation-mark is-retired" aria-hidden="true">OFF</span>
+            <div class="deprecation-copy">
+              <strong>Classic billing page</strong>
+              <p>Retired after all accounts moved to the unified billing center.</p>
+            </div>
+            <span class="deprecation-date">Retired</span>
+            <span class="deprecation-usage">0 users</span>
+            <span class="deprecation-state is-retired">Retired</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-feature-deprecation-row"&gt;
+  &lt;span class="deprecation-mark is-scheduled" aria-hidden="true"&gt;90&lt;/span&gt;
+  &lt;div class="deprecation-copy"&gt;
+    &lt;strong&gt;Legacy CSV importer&lt;/strong&gt;
+    &lt;p&gt;Scheduled for removal after migration to bulk uploader.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="deprecation-date"&gt;Nov 12&lt;/span&gt;
+  &lt;span class="deprecation-usage"&gt;128 users&lt;/span&gt;
+  &lt;span class="deprecation-state is-scheduled"&gt;Sunsetting&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-feature-deprecation-row-kk/style.css
+++ b/submissions/examples/basic-feature-deprecation-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --active: #86efac;
+  --scheduled: #facc15;
+  --retired: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1020px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.deprecation-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-feature-deprecation-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-feature-deprecation-row + .basic-feature-deprecation-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-feature-deprecation-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.deprecation-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--active), #dcfce7);
+}
+
+.deprecation-mark.is-scheduled {
+  background: linear-gradient(135deg, var(--scheduled), #fef9c3);
+}
+
+.deprecation-mark.is-retired {
+  background: linear-gradient(135deg, var(--retired), #f8fafc);
+}
+
+.deprecation-copy {
+  min-width: 0;
+}
+
+.deprecation-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deprecation-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deprecation-date,
+.deprecation-usage,
+.deprecation-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.deprecation-date,
+.deprecation-usage {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.deprecation-state {
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.deprecation-state.is-scheduled {
+  color: var(--scheduled);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.deprecation-state.is-retired {
+  color: var(--retired);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-feature-deprecation-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .deprecation-date,
+  .deprecation-usage,
+  .deprecation-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Feature Deprecation Row demo inside `submissions/examples/basic-feature-deprecation-row-kk/`. This submission introduces a compact CSS-only row for product dashboards, admin panels, release planning pages, and migration tracking screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only feature deprecation row that displays a feature marker, feature name, migration hint, sunset date, usage count, and preferred/sunsetting/retired lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-feature-deprecation-row">
  <span class="deprecation-mark is-scheduled" aria-hidden="true">90</span>
  <div class="deprecation-copy">
    <strong>Legacy CSV importer</strong>
    <p>Scheduled for removal after migration to bulk uploader.</p>
  </div>
  <span class="deprecation-date">Nov 12</span>
  <span class="deprecation-usage">128 users</span>
  <span class="deprecation-state is-scheduled">Sunsetting</span>
</article>