### PR TITLE
feat: add basic region failover row demo

### DIFF
--- a/submissions/examples/basic-region-failover-row-kk/README.md
+++ b/submissions/examples/basic-region-failover-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Region Failover Row
+
+## What it does
+
+This submission adds a CSS-only region failover row for infrastructure
+dashboards, deployment panels, status pages, and reliability consoles.
+
+It shows a region marker, region code, helper text, failover role, latency, and
+health state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a region marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-region-failover-row">
+  <span class="region-mark is-primary" aria-hidden="true">US</span>
+  <div class="region-copy">
+    <strong>us-east-1</strong>
+    <p>Primary region serving production traffic normally.</p>
+  </div>
+  <span class="region-role">Primary</span>
+  <span class="region-latency">42 ms</span>
+  <span class="region-state is-primary">Healthy</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+infrastructure and reliability interfaces. Developers can reuse the same row
+pattern in region health dashboards, failover panels, deployment consoles, and
+status pages while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Primary, standby, and degraded region examples
+- Region marker badges
+- Failover role metadata
+- Latency metadata
+- Health state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the region failover row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-region-failover-row-kk/demo.html
+++ b/submissions/examples/basic-region-failover-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Region Failover Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Region Failover Row</p>
+          <h1>Region health rows for infrastructure dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing deployment region, failover
+            role, latency, traffic share, and current health state.
+          </p>
+        </header>
+
+        <section class="region-list" aria-label="Region failover row examples">
+          <article class="basic-region-failover-row">
+            <span class="region-mark is-primary" aria-hidden="true">US</span>
+            <div class="region-copy">
+              <strong>us-east-1</strong>
+              <p>Primary region serving production traffic normally.</p>
+            </div>
+            <span class="region-role">Primary</span>
+            <span class="region-latency">42 ms</span>
+            <span class="region-state is-primary">Healthy</span>
+          </article>
+
+          <article class="basic-region-failover-row">
+            <span class="region-mark is-standby" aria-hidden="true">EU</span>
+            <div class="region-copy">
+              <strong>eu-west-1</strong>
+              <p>Warm standby region ready for automatic failover.</p>
+            </div>
+            <span class="region-role">Standby</span>
+            <span class="region-latency">68 ms</span>
+            <span class="region-state is-standby">Ready</span>
+          </article>
+
+          <article class="basic-region-failover-row">
+            <span class="region-mark is-degraded" aria-hidden="true">AP</span>
+            <div class="region-copy">
+              <strong>ap-south-1</strong>
+              <p>Partial packet loss detected during replication checks.</p>
+            </div>
+            <span class="region-role">Replica</span>
+            <span class="region-latency">184 ms</span>
+            <span class="region-state is-degraded">Degraded</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-region-failover-row"&gt;
+  &lt;span class="region-mark is-primary" aria-hidden="true"&gt;US&lt;/span&gt;
+  &lt;div class="region-copy"&gt;
+    &lt;strong&gt;us-east-1&lt;/strong&gt;
+    &lt;p&gt;Primary region serving production traffic normally.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="region-role"&gt;Primary&lt;/span&gt;
+  &lt;span class="region-latency"&gt;42 ms&lt;/span&gt;
+  &lt;span class="region-state is-primary"&gt;Healthy&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-region-failover-row-kk/style.css
+++ b/submissions/examples/basic-region-failover-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --primary: #86efac;
+  --standby: #93c5fd;
+  --degraded: #facc15;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.region-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-region-failover-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-region-failover-row + .basic-region-failover-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-region-failover-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.region-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.82rem;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--primary), #dcfce7);
+}
+
+.region-mark.is-standby {
+  background: linear-gradient(135deg, var(--standby), #dbeafe);
+}
+
+.region-mark.is-degraded {
+  background: linear-gradient(135deg, var(--degraded), #fef9c3);
+}
+
+.region-copy {
+  min-width: 0;
+}
+
+.region-copy strong {
+  display: block;
+  overflow: hidden;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.region-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.region-role,
+.region-latency,
+.region-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.region-role,
+.region-latency {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.region-state {
+  color: var(--primary);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.region-state.is-standby {
+  color: var(--standby);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.region-state.is-degraded {
+  color: var(--degraded);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-region-failover-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .region-role,
+  .region-latency,
+  .region-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Region Failover Row demo inside `submissions/examples/basic-region-failover-row-kk/`. This submission introduces a compact CSS-only row for infrastructure dashboards, deployment panels, status pages, and reliability consoles.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only region failover row that displays a region marker, region code, helper text, failover role, latency, and primary/standby/degraded health state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-region-failover-row">
  <span class="region-mark is-primary" aria-hidden="true">US</span>
  <div class="region-copy">
    <strong>us-east-1</strong>
    <p>Primary region serving production traffic normally.</p>
  </div>
  <span class="region-role">Primary</span>
  <span class="region-latency">42 ms</span>
  <span class="region-state is-primary">Healthy</span>
</article>