### PR TITLE
feat: add basic plan entitlement row demo

### DIFF
--- a/submissions/examples/basic-plan-entitlement-row-kk/README.md
+++ b/submissions/examples/basic-plan-entitlement-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Plan Entitlement Row
+
+## What it does
+
+This submission adds a CSS-only plan entitlement row for pricing pages, billing
+dashboards, upgrade screens, and SaaS admin panels.
+
+It shows a feature marker, feature name, helper text, plan tier, usage
+allowance, and entitlement state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a feature marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-plan-entitlement-row">
+  <span class="entitlement-mark is-included" aria-hidden="true">OK</span>
+  <div class="entitlement-copy">
+    <strong>Team workspaces</strong>
+    <p>Included in the current plan with unlimited project members.</p>
+  </div>
+  <span class="entitlement-tier">Pro</span>
+  <span class="entitlement-limit">Unlimited</span>
+  <span class="entitlement-state is-included">Included</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+SaaS billing and product interfaces. Developers can reuse the same row pattern
+in pricing tables, upgrade pages, billing settings, and plan comparison screens
+while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Included, limited, and locked entitlement examples
+- Feature marker badges
+- Plan tier metadata
+- Usage allowance metadata
+- Entitlement state styling
+- Long text truncation for compact billing panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the plan entitlement row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-plan-entitlement-row-kk/demo.html
+++ b/submissions/examples/basic-plan-entitlement-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Plan Entitlement Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Plan Entitlement Row</p>
+          <h1>Plan feature rows for billing and upgrade screens.</h1>
+          <p class="intro">
+            A CSS-only row component for showing feature entitlement, plan tier,
+            usage allowance, billing impact, and availability state.
+          </p>
+        </header>
+
+        <section class="entitlement-list" aria-label="Plan entitlement row examples">
+          <article class="basic-plan-entitlement-row">
+            <span class="entitlement-mark is-included" aria-hidden="true">OK</span>
+            <div class="entitlement-copy">
+              <strong>Team workspaces</strong>
+              <p>Included in the current plan with unlimited project members.</p>
+            </div>
+            <span class="entitlement-tier">Pro</span>
+            <span class="entitlement-limit">Unlimited</span>
+            <span class="entitlement-state is-included">Included</span>
+          </article>
+
+          <article class="basic-plan-entitlement-row">
+            <span class="entitlement-mark is-limited" aria-hidden="true">50</span>
+            <div class="entitlement-copy">
+              <strong>Automation runs</strong>
+              <p>Limited monthly allowance before overage billing applies.</p>
+            </div>
+            <span class="entitlement-tier">Growth</span>
+            <span class="entitlement-limit">50k/mo</span>
+            <span class="entitlement-state is-limited">Limited</span>
+          </article>
+
+          <article class="basic-plan-entitlement-row">
+            <span class="entitlement-mark is-locked" aria-hidden="true">UP</span>
+            <div class="entitlement-copy">
+              <strong>Advanced audit exports</strong>
+              <p>Available after upgrading to the enterprise security package.</p>
+            </div>
+            <span class="entitlement-tier">Enterprise</span>
+            <span class="entitlement-limit">Upgrade</span>
+            <span class="entitlement-state is-locked">Locked</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-plan-entitlement-row"&gt;
+  &lt;span class="entitlement-mark is-included" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="entitlement-copy"&gt;
+    &lt;strong&gt;Team workspaces&lt;/strong&gt;
+    &lt;p&gt;Included in the current plan with unlimited project members.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="entitlement-tier"&gt;Pro&lt;/span&gt;
+  &lt;span class="entitlement-limit"&gt;Unlimited&lt;/span&gt;
+  &lt;span class="entitlement-state is-included"&gt;Included&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-plan-entitlement-row-kk/style.css
+++ b/submissions/examples/basic-plan-entitlement-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --included: #86efac;
+  --limited: #facc15;
+  --locked: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1000px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--included);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.entitlement-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-plan-entitlement-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-plan-entitlement-row + .basic-plan-entitlement-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-plan-entitlement-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.entitlement-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--included), #dcfce7);
+}
+
+.entitlement-mark.is-limited {
+  background: linear-gradient(135deg, var(--limited), #fef9c3);
+}
+
+.entitlement-mark.is-locked {
+  background: linear-gradient(135deg, var(--locked), #f8fafc);
+}
+
+.entitlement-copy {
+  min-width: 0;
+}
+
+.entitlement-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entitlement-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entitlement-tier,
+.entitlement-limit,
+.entitlement-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.entitlement-tier,
+.entitlement-limit {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.entitlement-state {
+  color: var(--included);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.entitlement-state.is-limited {
+  color: var(--limited);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.entitlement-state.is-locked {
+  color: var(--locked);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-plan-entitlement-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .entitlement-tier,
+  .entitlement-limit,
+  .entitlement-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Plan Entitlement Row demo inside `submissions/examples/basic-plan-entitlement-row-kk/`. This submission introduces a compact CSS-only row for pricing pages, billing dashboards, upgrade screens, and SaaS admin panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only plan entitlement row that displays a feature marker, feature name, helper text, plan tier, usage allowance, and included/limited/locked entitlement state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-plan-entitlement-row">
  <span class="entitlement-mark is-included" aria-hidden="true">OK</span>
  <div class="entitlement-copy">
    <strong>Team workspaces</strong>
    <p>Included in the current plan with unlimited project members.</p>
  </div>
  <span class="entitlement-tier">Pro</span>
  <span class="entitlement-limit">Unlimited</span>
  <span class="entitlement-state is-included">Included</span>
</article>