### PR TITLE
feat: add basic release channel row demo

### DIFF
--- a/submissions/examples/basic-release-channel-row-kk/README.md
+++ b/submissions/examples/basic-release-channel-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Release Channel Row
+
+## What it does
+
+This submission adds a CSS-only release channel row for rollout dashboards,
+product admin panels, release management pages, and deployment settings.
+
+It shows a channel marker, channel name, helper text, version, rollout share,
+and lifecycle state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a channel marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-release-channel-row">
+  <span class="channel-mark is-stable" aria-hidden="true">ST</span>
+  <div class="channel-copy">
+    <strong>Stable channel</strong>
+    <p>Default release path for all production workspaces.</p>
+  </div>
+  <span class="channel-version">v4.8.2</span>
+  <span class="channel-rollout">100%</span>
+  <span class="channel-state is-stable">Stable</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+product release interfaces. Developers can reuse the same row pattern in release
+dashboards, rollout panels, beta access settings, and deployment consoles while
+keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Stable, beta, and legacy release channel examples
+- Channel marker badges
+- Version metadata
+- Rollout share metadata
+- Lifecycle state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the release channel row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-release-channel-row-kk/demo.html
+++ b/submissions/examples/basic-release-channel-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Release Channel Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Release Channel Row</p>
+          <h1>Release channel rows for product rollout dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing channel name, version, audience,
+            rollout share, and lifecycle status in one compact interface.
+          </p>
+        </header>
+
+        <section class="channel-list" aria-label="Release channel row examples">
+          <article class="basic-release-channel-row">
+            <span class="channel-mark is-stable" aria-hidden="true">ST</span>
+            <div class="channel-copy">
+              <strong>Stable channel</strong>
+              <p>Default release path for all production workspaces.</p>
+            </div>
+            <span class="channel-version">v4.8.2</span>
+            <span class="channel-rollout">100%</span>
+            <span class="channel-state is-stable">Stable</span>
+          </article>
+
+          <article class="basic-release-channel-row">
+            <span class="channel-mark is-beta" aria-hidden="true">BT</span>
+            <div class="channel-copy">
+              <strong>Beta channel</strong>
+              <p>Early access build enabled for opted-in teams.</p>
+            </div>
+            <span class="channel-version">v4.9.0</span>
+            <span class="channel-rollout">18%</span>
+            <span class="channel-state is-beta">Beta</span>
+          </article>
+
+          <article class="basic-release-channel-row">
+            <span class="channel-mark is-legacy" aria-hidden="true">LG</span>
+            <div class="channel-copy">
+              <strong>Legacy channel</strong>
+              <p>Deprecated release path kept only for rollback safety.</p>
+            </div>
+            <span class="channel-version">v3.12.7</span>
+            <span class="channel-rollout">2%</span>
+            <span class="channel-state is-legacy">Legacy</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-release-channel-row"&gt;
+  &lt;span class="channel-mark is-stable" aria-hidden="true"&gt;ST&lt;/span&gt;
+  &lt;div class="channel-copy"&gt;
+    &lt;strong&gt;Stable channel&lt;/strong&gt;
+    &lt;p&gt;Default release path for all production workspaces.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="channel-version"&gt;v4.8.2&lt;/span&gt;
+  &lt;span class="channel-rollout"&gt;100%&lt;/span&gt;
+  &lt;span class="channel-state is-stable"&gt;Stable&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-release-channel-row-kk/style.css
+++ b/submissions/examples/basic-release-channel-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --stable: #86efac;
+  --beta: #93c5fd;
+  --legacy: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--stable);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.channel-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-release-channel-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-release-channel-row + .basic-release-channel-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-release-channel-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.channel-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--stable), #dcfce7);
+}
+
+.channel-mark.is-beta {
+  background: linear-gradient(135deg, var(--beta), #dbeafe);
+}
+
+.channel-mark.is-legacy {
+  background: linear-gradient(135deg, var(--legacy), #f8fafc);
+}
+
+.channel-copy {
+  min-width: 0;
+}
+
+.channel-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.channel-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.channel-version,
+.channel-rollout,
+.channel-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.channel-version,
+.channel-rollout {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.channel-state {
+  color: var(--stable);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.channel-state.is-beta {
+  color: var(--beta);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.channel-state.is-legacy {
+  color: var(--legacy);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-release-channel-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .channel-version,
+  .channel-rollout,
+  .channel-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Release Channel Row demo inside `submissions/examples/basic-release-channel-row-kk/`. This submission introduces a compact CSS-only row for rollout dashboards, product admin panels, release management pages, and deployment settings.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only release channel row that displays a channel marker, channel name, helper text, version, rollout share, and stable/beta/legacy lifecycle state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-release-channel-row">
  <span class="channel-mark is-stable" aria-hidden="true">ST</span>
  <div class="channel-copy">
    <strong>Stable channel</strong>
    <p>Default release path for all production workspaces.</p>
  </div>
  <span class="channel-version">v4.8.2</span>
  <span class="channel-rollout">100%</span>
  <span class="channel-state is-stable">Stable</span>
</article>