### PR TITLE
feat: add basic runbook link row demo

### DIFF
--- a/submissions/examples/basic-runbook-link-row-kk/README.md
+++ b/submissions/examples/basic-runbook-link-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Runbook Link Row
+
+## What it does
+
+This submission adds a CSS-only runbook link row for operations dashboards,
+reliability consoles, service catalogs, and incident readiness pages.
+
+It shows a service marker, service name, helper text, owner team, last review
+state, and documentation health in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a runbook marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-runbook-link-row">
+  <span class="runbook-mark is-verified" aria-hidden="true">OK</span>
+  <div class="runbook-copy">
+    <strong>Payments API</strong>
+    <p>Incident response runbook reviewed by the billing team.</p>
+  </div>
+  <span class="runbook-owner">Billing</span>
+  <span class="runbook-review">Jul 24</span>
+  <span class="runbook-state is-verified">Verified</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+operations and reliability interfaces. Developers can reuse the same row pattern
+in service catalogs, incident readiness dashboards, runbook review queues, and
+on-call admin panels while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Verified, review, and missing runbook examples
+- Runbook marker badges
+- Owner team metadata
+- Last review metadata
+- Documentation health state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the runbook link row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-runbook-link-row-kk/demo.html
+++ b/submissions/examples/basic-runbook-link-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Runbook Link Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Runbook Link Row</p>
+          <h1>Runbook rows for operations and reliability dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing service ownership, runbook
+            review status, linked action, and documentation health.
+          </p>
+        </header>
+
+        <section class="runbook-list" aria-label="Runbook link row examples">
+          <article class="basic-runbook-link-row">
+            <span class="runbook-mark is-verified" aria-hidden="true">OK</span>
+            <div class="runbook-copy">
+              <strong>Payments API</strong>
+              <p>Incident response runbook reviewed by the billing team.</p>
+            </div>
+            <span class="runbook-owner">Billing</span>
+            <span class="runbook-review">Jul 24</span>
+            <span class="runbook-state is-verified">Verified</span>
+          </article>
+
+          <article class="basic-runbook-link-row">
+            <span class="runbook-mark is-stale" aria-hidden="true">RV</span>
+            <div class="runbook-copy">
+              <strong>Search Worker</strong>
+              <p>Recovery steps need review after the queue migration.</p>
+            </div>
+            <span class="runbook-owner">Platform</span>
+            <span class="runbook-review">90 days</span>
+            <span class="runbook-state is-stale">Review</span>
+          </article>
+
+          <article class="basic-runbook-link-row">
+            <span class="runbook-mark is-missing" aria-hidden="true">NO</span>
+            <div class="runbook-copy">
+              <strong>Audit Exporter</strong>
+              <p>No linked recovery guide exists for failed export jobs.</p>
+            </div>
+            <span class="runbook-owner">Security</span>
+            <span class="runbook-review">Missing</span>
+            <span class="runbook-state is-missing">Missing</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-runbook-link-row"&gt;
+  &lt;span class="runbook-mark is-verified" aria-hidden="true"&gt;OK&lt;/span&gt;
+  &lt;div class="runbook-copy"&gt;
+    &lt;strong&gt;Payments API&lt;/strong&gt;
+    &lt;p&gt;Incident response runbook reviewed by the billing team.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="runbook-owner"&gt;Billing&lt;/span&gt;
+  &lt;span class="runbook-review"&gt;Jul 24&lt;/span&gt;
+  &lt;span class="runbook-state is-verified"&gt;Verified&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-runbook-link-row-kk/style.css
+++ b/submissions/examples/basic-runbook-link-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --verified: #86efac;
+  --stale: #facc15;
+  --missing: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1000px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--verified);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.runbook-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-runbook-link-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-runbook-link-row + .basic-runbook-link-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-runbook-link-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.runbook-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--verified), #dcfce7);
+}
+
+.runbook-mark.is-stale {
+  background: linear-gradient(135deg, var(--stale), #fef9c3);
+}
+
+.runbook-mark.is-missing {
+  background: linear-gradient(135deg, var(--missing), #fecaca);
+}
+
+.runbook-copy {
+  min-width: 0;
+}
+
+.runbook-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runbook-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runbook-owner,
+.runbook-review,
+.runbook-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.runbook-owner,
+.runbook-review {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.runbook-state {
+  color: var(--verified);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.runbook-state.is-stale {
+  color: var(--stale);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.runbook-state.is-missing {
+  color: var(--missing);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-runbook-link-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .runbook-owner,
+  .runbook-review,
+  .runbook-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Runbook Link Row demo inside `submissions/examples/basic-runbook-link-row-kk/`. This submission introduces a compact CSS-only row for operations dashboards, reliability consoles, service catalogs, and incident readiness pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only runbook link row that displays a service marker, service name, helper text, owner team, last review date, and verified/review/missing documentation state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-runbook-link-row">
  <span class="runbook-mark is-verified" aria-hidden="true">OK</span>
  <div class="runbook-copy">
    <strong>Payments API</strong>
    <p>Incident response runbook reviewed by the billing team.</p>
  </div>
  <span class="runbook-owner">Billing</span>
  <span class="runbook-review">Jul 24</span>
  <span class="runbook-state is-verified">Verified</span>
</article>