### PR TITLE
feat: add basic alert route row demo

### DIFF
--- a/submissions/examples/basic-alert-route-row-kk/README.md
+++ b/submissions/examples/basic-alert-route-row-kk/README.md
@@ -1,0 +1,53 @@
+# Basic Alert Route Row
+
+## What it does
+
+This submission adds a CSS-only alert route row for monitoring settings,
+operations dashboards, on-call consoles, and reliability admin pages.
+
+It shows a route marker, alert destination, helper text, channel type,
+escalation delay, and routing health state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a route marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-alert-route-row">
+  <span class="route-mark is-active" aria-hidden="true">ON</span>
+  <div class="route-copy">
+    <strong>Critical production incidents</strong>
+    <p>Routes urgent alerts to the platform on-call team.</p>
+  </div>
+  <span class="route-channel">Pager</span>
+  <span class="route-delay">0 min</span>
+  <span class="route-state is-active">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+monitoring and reliability interfaces. Developers can reuse the same row pattern
+in alert routing settings, escalation dashboards, on-call admin panels, and
+incident readiness screens while keeping the implementation lightweight and
+CSS-only.
+
+## Included features
+
+- Active, muted, and broken alert route examples
+- Route marker badges
+- Channel type metadata
+- Escalation delay metadata
+- Routing health state styling
+- Long text truncation for compact dashboards
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the alert route row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-alert-route-row-kk/demo.html
+++ b/submissions/examples/basic-alert-route-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Alert Route Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Alert Route Row</p>
+          <h1>Alert routing rows for monitoring settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing alert destination, owner team,
+            escalation delay, channel type, and routing health state.
+          </p>
+        </header>
+
+        <section class="route-list" aria-label="Alert route row examples">
+          <article class="basic-alert-route-row">
+            <span class="route-mark is-active" aria-hidden="true">ON</span>
+            <div class="route-copy">
+              <strong>Critical production incidents</strong>
+              <p>Routes urgent alerts to the platform on-call team.</p>
+            </div>
+            <span class="route-channel">Pager</span>
+            <span class="route-delay">0 min</span>
+            <span class="route-state is-active">Active</span>
+          </article>
+
+          <article class="basic-alert-route-row">
+            <span class="route-mark is-muted" aria-hidden="true">MT</span>
+            <div class="route-copy">
+              <strong>Staging deployment warnings</strong>
+              <p>Muted during the scheduled release validation window.</p>
+            </div>
+            <span class="route-channel">Slack</span>
+            <span class="route-delay">15 min</span>
+            <span class="route-state is-muted">Muted</span>
+          </article>
+
+          <article class="basic-alert-route-row">
+            <span class="route-mark is-broken" aria-hidden="true">ER</span>
+            <div class="route-copy">
+              <strong>Billing export failures</strong>
+              <p>Webhook destination is unavailable and needs repair.</p>
+            </div>
+            <span class="route-channel">Webhook</span>
+            <span class="route-delay">Retry</span>
+            <span class="route-state is-broken">Broken</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-alert-route-row"&gt;
+  &lt;span class="route-mark is-active" aria-hidden="true"&gt;ON&lt;/span&gt;
+  &lt;div class="route-copy"&gt;
+    &lt;strong&gt;Critical production incidents&lt;/strong&gt;
+    &lt;p&gt;Routes urgent alerts to the platform on-call team.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="route-channel"&gt;Pager&lt;/span&gt;
+  &lt;span class="route-delay"&gt;0 min&lt;/span&gt;
+  &lt;span class="route-state is-active"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-alert-route-row-kk/style.css
+++ b/submissions/examples/basic-alert-route-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --active: #86efac;
+  --route-muted: #facc15;
+  --broken: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(250, 204, 21, 0.12), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1000px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--active);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.route-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-alert-route-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-alert-route-row + .basic-alert-route-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-alert-route-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.route-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--active), #dcfce7);
+}
+
+.route-mark.is-muted {
+  background: linear-gradient(135deg, var(--route-muted), #fef9c3);
+}
+
+.route-mark.is-broken {
+  background: linear-gradient(135deg, var(--broken), #fecaca);
+}
+
+.route-copy {
+  min-width: 0;
+}
+
+.route-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.route-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.route-channel,
+.route-delay,
+.route-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.route-channel,
+.route-delay {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.route-state {
+  color: var(--active);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.route-state.is-muted {
+  color: var(--route-muted);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.route-state.is-broken {
+  color: var(--broken);
+  background: rgba(252, 165, 165, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-alert-route-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .route-channel,
+  .route-delay,
+  .route-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Alert Route Row demo inside `submissions/examples/basic-alert-route-row-kk/`. This submission introduces a compact CSS-only row for monitoring settings, operations dashboards, on-call consoles, and reliability admin pages.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only alert route row that displays a route marker, alert destination, helper text, channel type, escalation delay, and active/muted/broken routing health state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-alert-route-row">
  <span class="route-mark is-active" aria-hidden="true">ON</span>
  <div class="route-copy">
    <strong>Critical production incidents</strong>
    <p>Routes urgent alerts to the platform on-call team.</p>
  </div>
  <span class="route-channel">Pager</span>
  <span class="route-delay">0 min</span>
  <span class="route-state is-active">Active</span>
</article>