### PR TITLE
feat: add basic cdn cache rule row demo

### DIFF
--- a/submissions/examples/basic-cdn-cache-rule-row-kk/README.md
+++ b/submissions/examples/basic-cdn-cache-rule-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic CDN Cache Rule Row
+
+## What it does
+
+This submission adds a CSS-only CDN cache rule row for hosting dashboards,
+performance settings, deployment panels, and edge configuration screens.
+
+It shows a cache marker, path pattern, helper text, cache behavior, TTL, and
+rule health state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a cache marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-cdn-cache-rule-row">
+  <span class="cache-mark is-enabled" aria-hidden="true">ON</span>
+  <div class="cache-copy">
+    <strong>/assets/*</strong>
+    <p>Static assets are cached globally with immutable headers.</p>
+  </div>
+  <span class="cache-behavior">Cache</span>
+  <span class="cache-ttl">30 days</span>
+  <span class="cache-state is-enabled">Enabled</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+hosting and performance interfaces. Developers can reuse the same row pattern in
+CDN settings, cache rule editors, deployment dashboards, and edge configuration
+screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Enabled, bypass, and review cache rule examples
+- Cache rule marker badges
+- Cache behavior metadata
+- TTL metadata
+- Rule health state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the CDN cache rule row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-cdn-cache-rule-row-kk/demo.html
+++ b/submissions/examples/basic-cdn-cache-rule-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic CDN Cache Rule Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic CDN Cache Rule Row</p>
+          <h1>Cache rule rows for performance dashboards.</h1>
+          <p class="intro">
+            A CSS-only row component for showing CDN path rules, cache behavior,
+            TTL, hit ratio, and rule health in one compact interface.
+          </p>
+        </header>
+
+        <section class="cache-list" aria-label="CDN cache rule row examples">
+          <article class="basic-cdn-cache-rule-row">
+            <span class="cache-mark is-enabled" aria-hidden="true">ON</span>
+            <div class="cache-copy">
+              <strong>/assets/*</strong>
+              <p>Static assets are cached globally with immutable headers.</p>
+            </div>
+            <span class="cache-behavior">Cache</span>
+            <span class="cache-ttl">30 days</span>
+            <span class="cache-state is-enabled">Enabled</span>
+          </article>
+
+          <article class="basic-cdn-cache-rule-row">
+            <span class="cache-mark is-bypass" aria-hidden="true">BY</span>
+            <div class="cache-copy">
+              <strong>/api/auth/*</strong>
+              <p>Authentication endpoints bypass edge cache for fresh responses.</p>
+            </div>
+            <span class="cache-behavior">Bypass</span>
+            <span class="cache-ttl">0 sec</span>
+            <span class="cache-state is-bypass">Bypass</span>
+          </article>
+
+          <article class="basic-cdn-cache-rule-row">
+            <span class="cache-mark is-warning" aria-hidden="true">RV</span>
+            <div class="cache-copy">
+              <strong>/reports/*.pdf</strong>
+              <p>Low hit ratio suggests this rule should be reviewed.</p>
+            </div>
+            <span class="cache-behavior">Private</span>
+            <span class="cache-ttl">5 min</span>
+            <span class="cache-state is-warning">Review</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-cdn-cache-rule-row"&gt;
+  &lt;span class="cache-mark is-enabled" aria-hidden="true"&gt;ON&lt;/span&gt;
+  &lt;div class="cache-copy"&gt;
+    &lt;strong&gt;/assets/*&lt;/strong&gt;
+    &lt;p&gt;Static assets are cached globally with immutable headers.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="cache-behavior"&gt;Cache&lt;/span&gt;
+  &lt;span class="cache-ttl"&gt;30 days&lt;/span&gt;
+  &lt;span class="cache-state is-enabled"&gt;Enabled&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-cdn-cache-rule-row-kk/style.css
+++ b/submissions/examples/basic-cdn-cache-rule-row-kk/style.css
@@ -1,0 +1,201 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --enabled: #86efac;
+  --bypass: #93c5fd;
+  --warning: #facc15;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 1000px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--enabled);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.15rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.cache-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-cdn-cache-rule-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-cdn-cache-rule-row + .basic-cdn-cache-rule-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-cdn-cache-rule-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.cache-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--enabled), #dcfce7);
+}
+
+.cache-mark.is-bypass {
+  background: linear-gradient(135deg, var(--bypass), #dbeafe);
+}
+
+.cache-mark.is-warning {
+  background: linear-gradient(135deg, var(--warning), #fef9c3);
+}
+
+.cache-copy {
+  min-width: 0;
+}
+
+.cache-copy strong {
+  display: block;
+  overflow: hidden;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cache-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cache-behavior,
+.cache-ttl,
+.cache-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.cache-behavior,
+.cache-ttl {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.cache-state {
+  color: var(--enabled);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.cache-state.is-bypass {
+  color: var(--bypass);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.cache-state.is-warning {
+  color: var(--warning);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-cdn-cache-rule-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .cache-behavior,
+  .cache-ttl,
+  .cache-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic CDN Cache Rule Row demo inside `submissions/examples/basic-cdn-cache-rule-row-kk/`. This submission introduces a compact CSS-only row for hosting dashboards, performance settings, deployment panels, and edge configuration screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only CDN cache rule row that displays a cache marker, path pattern, helper text, cache behavior, TTL, and enabled/bypass/review rule health state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-cdn-cache-rule-row">
  <span class="cache-mark is-enabled" aria-hidden="true">ON</span>
  <div class="cache-copy">
    <strong>/assets/*</strong>
    <p>Static assets are cached globally with immutable headers.</p>
  </div>
  <span class="cache-behavior">Cache</span>
  <span class="cache-ttl">30 days</span>
  <span class="cache-state is-enabled">Enabled</span>
</article>