### PR TITLE
feat: add basic contact preference row demo

### DIFF
--- a/submissions/examples/basic-contact-preference-row-kk/README.md
+++ b/submissions/examples/basic-contact-preference-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Contact Preference Row
+
+## What it does
+
+This submission adds a CSS-only contact preference row for profile settings,
+notification pages, account dashboards, and user preference screens.
+
+It shows a preference marker, preference name, helper text, contact method,
+frequency, and active or disabled state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a preference marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-contact-preference-row">
+  <span class="preference-mark is-email" aria-hidden="true">EM</span>
+  <div class="preference-copy">
+    <strong>Email updates</strong>
+    <p>Send product updates to kriti@example.com.</p>
+  </div>
+  <span class="preference-method">Email</span>
+  <span class="preference-frequency">Weekly</span>
+  <span class="preference-state is-email">Active</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+profile and settings interfaces. Developers can reuse the same row pattern in
+notification preferences, account settings, profile pages, and communication
+preference screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Email, SMS, and disabled preference examples
+- Contact method marker badges
+- Method metadata
+- Frequency metadata
+- Preference state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the contact preference row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-contact-preference-row-kk/demo.html
+++ b/submissions/examples/basic-contact-preference-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Contact Preference Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Contact Preference Row</p>
+          <h1>Simple preference rows for profile settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing contact method, destination,
+            frequency, and active or disabled preference state.
+          </p>
+        </header>
+
+        <section class="preference-list" aria-label="Contact preference row examples">
+          <article class="basic-contact-preference-row">
+            <span class="preference-mark is-email" aria-hidden="true">EM</span>
+            <div class="preference-copy">
+              <strong>Email updates</strong>
+              <p>Send product updates to kriti@example.com.</p>
+            </div>
+            <span class="preference-method">Email</span>
+            <span class="preference-frequency">Weekly</span>
+            <span class="preference-state is-email">Active</span>
+          </article>
+
+          <article class="basic-contact-preference-row">
+            <span class="preference-mark is-sms" aria-hidden="true">SM</span>
+            <div class="preference-copy">
+              <strong>Security alerts</strong>
+              <p>Send important login alerts to the verified mobile number.</p>
+            </div>
+            <span class="preference-method">SMS</span>
+            <span class="preference-frequency">Instant</span>
+            <span class="preference-state is-sms">Enabled</span>
+          </article>
+
+          <article class="basic-contact-preference-row">
+            <span class="preference-mark is-disabled" aria-hidden="true">OFF</span>
+            <div class="preference-copy">
+              <strong>Marketing tips</strong>
+              <p>Promotional messages are currently turned off.</p>
+            </div>
+            <span class="preference-method">Email</span>
+            <span class="preference-frequency">None</span>
+            <span class="preference-state is-disabled">Disabled</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-contact-preference-row"&gt;
+  &lt;span class="preference-mark is-email" aria-hidden="true"&gt;EM&lt;/span&gt;
+  &lt;div class="preference-copy"&gt;
+    &lt;strong&gt;Email updates&lt;/strong&gt;
+    &lt;p&gt;Send product updates to kriti@example.com.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="preference-method"&gt;Email&lt;/span&gt;
+  &lt;span class="preference-frequency"&gt;Weekly&lt;/span&gt;
+  &lt;span class="preference-state is-email"&gt;Active&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-contact-preference-row-kk/style.css
+++ b/submissions/examples/basic-contact-preference-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --email: #86efac;
+  --sms: #93c5fd;
+  --disabled: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--email);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.preference-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-contact-preference-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-contact-preference-row + .basic-contact-preference-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-contact-preference-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.preference-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--email), #dcfce7);
+}
+
+.preference-mark.is-sms {
+  background: linear-gradient(135deg, var(--sms), #dbeafe);
+}
+
+.preference-mark.is-disabled {
+  background: linear-gradient(135deg, var(--disabled), #f8fafc);
+}
+
+.preference-copy {
+  min-width: 0;
+}
+
+.preference-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preference-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preference-method,
+.preference-frequency,
+.preference-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.preference-method,
+.preference-frequency {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.preference-state {
+  color: var(--email);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.preference-state.is-sms {
+  color: var(--sms);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.preference-state.is-disabled {
+  color: var(--disabled);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-contact-preference-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .preference-method,
+  .preference-frequency,
+  .preference-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Contact Preference Row demo inside `submissions/examples/basic-contact-preference-row-kk/`. This submission introduces a simple CSS-only row for profile settings, notification pages, account dashboards, and user preference screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only contact preference row that displays a preference marker, preference name, helper text, contact method, frequency, and active/enabled/disabled state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-contact-preference-row">
  <span class="preference-mark is-email" aria-hidden="true">EM</span>
  <div class="preference-copy">
    <strong>Email updates</strong>
    <p>Send product updates to kriti@example.com.</p>
  </div>
  <span class="preference-method">Email</span>
  <span class="preference-frequency">Weekly</span>
  <span class="preference-state is-email">Active</span>
</article>