### PR TITLE
feat: add basic bookmark status row demo

### DIFF
--- a/submissions/examples/basic-bookmark-status-row-kk/README.md
+++ b/submissions/examples/basic-bookmark-status-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Bookmark Status Row
+
+## What it does
+
+This submission adds a CSS-only bookmark status row for saved content lists,
+learning dashboards, knowledge bases, and reading apps.
+
+It shows a bookmark marker, title, helper text, collection, last updated detail,
+and saved, shared, or archived state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a bookmark marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-bookmark-status-row">
+  <span class="bookmark-mark is-saved" aria-hidden="true">SV</span>
+  <div class="bookmark-copy">
+    <strong>Frontend animation checklist</strong>
+    <p>Saved to the design systems collection.</p>
+  </div>
+  <span class="bookmark-collection">Design</span>
+  <span class="bookmark-updated">Today</span>
+  <span class="bookmark-state is-saved">Saved</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+content and profile interfaces. Developers can reuse the same row pattern in
+saved article lists, learning collections, bookmarks pages, and knowledge bases
+while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Saved, shared, and archived bookmark examples
+- Bookmark marker badges
+- Collection metadata
+- Last updated metadata
+- Bookmark state styling
+- Long text truncation for compact lists
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the bookmark status row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-bookmark-status-row-kk/demo.html
+++ b/submissions/examples/basic-bookmark-status-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Bookmark Status Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Bookmark Status Row</p>
+          <h1>Simple bookmark rows for saved content lists.</h1>
+          <p class="intro">
+            A CSS-only row component for showing bookmark title, collection,
+            last updated detail, and saved, shared, or archived state.
+          </p>
+        </header>
+
+        <section class="bookmark-list" aria-label="Bookmark status row examples">
+          <article class="basic-bookmark-status-row">
+            <span class="bookmark-mark is-saved" aria-hidden="true">SV</span>
+            <div class="bookmark-copy">
+              <strong>Frontend animation checklist</strong>
+              <p>Saved to the design systems collection.</p>
+            </div>
+            <span class="bookmark-collection">Design</span>
+            <span class="bookmark-updated">Today</span>
+            <span class="bookmark-state is-saved">Saved</span>
+          </article>
+
+          <article class="basic-bookmark-status-row">
+            <span class="bookmark-mark is-shared" aria-hidden="true">SH</span>
+            <div class="bookmark-copy">
+              <strong>CSS grid layout notes</strong>
+              <p>Shared with the learning group for review.</p>
+            </div>
+            <span class="bookmark-collection">CSS</span>
+            <span class="bookmark-updated">2 days</span>
+            <span class="bookmark-state is-shared">Shared</span>
+          </article>
+
+          <article class="basic-bookmark-status-row">
+            <span class="bookmark-mark is-archived" aria-hidden="true">AR</span>
+            <div class="bookmark-copy">
+              <strong>Old onboarding resource</strong>
+              <p>Archived after the guide was replaced by a newer version.</p>
+            </div>
+            <span class="bookmark-collection">Archive</span>
+            <span class="bookmark-updated">May 12</span>
+            <span class="bookmark-state is-archived">Archived</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-bookmark-status-row"&gt;
+  &lt;span class="bookmark-mark is-saved" aria-hidden="true"&gt;SV&lt;/span&gt;
+  &lt;div class="bookmark-copy"&gt;
+    &lt;strong&gt;Frontend animation checklist&lt;/strong&gt;
+    &lt;p&gt;Saved to the design systems collection.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="bookmark-collection"&gt;Design&lt;/span&gt;
+  &lt;span class="bookmark-updated"&gt;Today&lt;/span&gt;
+  &lt;span class="bookmark-state is-saved"&gt;Saved&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-bookmark-status-row-kk/style.css
+++ b/submissions/examples/basic-bookmark-status-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --saved: #86efac;
+  --shared: #93c5fd;
+  --archived: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--saved);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.bookmark-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-bookmark-status-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-bookmark-status-row + .basic-bookmark-status-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-bookmark-status-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.bookmark-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--saved), #dcfce7);
+}
+
+.bookmark-mark.is-shared {
+  background: linear-gradient(135deg, var(--shared), #dbeafe);
+}
+
+.bookmark-mark.is-archived {
+  background: linear-gradient(135deg, var(--archived), #f8fafc);
+}
+
+.bookmark-copy {
+  min-width: 0;
+}
+
+.bookmark-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bookmark-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bookmark-collection,
+.bookmark-updated,
+.bookmark-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.bookmark-collection,
+.bookmark-updated {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bookmark-state {
+  color: var(--saved);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.bookmark-state.is-shared {
+  color: var(--shared);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.bookmark-state.is-archived {
+  color: var(--archived);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-bookmark-status-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .bookmark-collection,
+  .bookmark-updated,
+  .bookmark-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Bookmark Status Row demo inside `submissions/examples/basic-bookmark-status-row-kk/`. This submission introduces a simple CSS-only row for saved content lists, learning dashboards, knowledge bases, and reading apps.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only bookmark status row that displays a bookmark marker, title, helper text, collection, last updated detail, and saved/shared/archived state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-bookmark-status-row">
  <span class="bookmark-mark is-saved" aria-hidden="true">SV</span>
  <div class="bookmark-copy">
    <strong>Frontend animation checklist</strong>
    <p>Saved to the design systems collection.</p>
  </div>
  <span class="bookmark-collection">Design</span>
  <span class="bookmark-updated">Today</span>
  <span class="bookmark-state is-saved">Saved</span>
</article>