### PR TITLE
feat: add basic theme preference row demo

### DIFF
--- a/submissions/examples/basic-theme-preference-row-kk/README.md
+++ b/submissions/examples/basic-theme-preference-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Theme Preference Row
+
+## What it does
+
+This submission adds a CSS-only theme preference row for appearance settings,
+profile pages, account dashboards, and personalization screens.
+
+It shows a theme marker, theme name, helper text, display mode, sync behavior,
+and selected or suggested state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a theme marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-theme-preference-row">
+  <span class="theme-mark is-light" aria-hidden="true">LT</span>
+  <div class="theme-copy">
+    <strong>Light theme</strong>
+    <p>Bright interface mode for daytime reading.</p>
+  </div>
+  <span class="theme-mode">Light</span>
+  <span class="theme-sync">Manual</span>
+  <span class="theme-state is-light">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+appearance and profile settings interfaces. Developers can reuse the same row
+pattern in theme pickers, account settings, personalization panels, and user
+preference screens while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Light, dark, and system theme examples
+- Theme marker badges
+- Display mode metadata
+- Sync behavior metadata
+- Theme preference state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the theme preference row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-theme-preference-row-kk/demo.html
+++ b/submissions/examples/basic-theme-preference-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Theme Preference Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Theme Preference Row</p>
+          <h1>Simple theme rows for appearance settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing theme name, display mode,
+            sync behavior, and active or suggested preference state.
+          </p>
+        </header>
+
+        <section class="theme-list" aria-label="Theme preference row examples">
+          <article class="basic-theme-preference-row">
+            <span class="theme-mark is-light" aria-hidden="true">LT</span>
+            <div class="theme-copy">
+              <strong>Light theme</strong>
+              <p>Bright interface mode for daytime reading.</p>
+            </div>
+            <span class="theme-mode">Light</span>
+            <span class="theme-sync">Manual</span>
+            <span class="theme-state is-light">Selected</span>
+          </article>
+
+          <article class="basic-theme-preference-row">
+            <span class="theme-mark is-dark" aria-hidden="true">DK</span>
+            <div class="theme-copy">
+              <strong>Dark theme</strong>
+              <p>Low-glare interface mode for focused work.</p>
+            </div>
+            <span class="theme-mode">Dark</span>
+            <span class="theme-sync">Manual</span>
+            <span class="theme-state is-dark">Available</span>
+          </article>
+
+          <article class="basic-theme-preference-row">
+            <span class="theme-mark is-system" aria-hidden="true">SY</span>
+            <div class="theme-copy">
+              <strong>System theme</strong>
+              <p>Automatically follows the device appearance setting.</p>
+            </div>
+            <span class="theme-mode">Auto</span>
+            <span class="theme-sync">System</span>
+            <span class="theme-state is-system">Suggested</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-theme-preference-row"&gt;
+  &lt;span class="theme-mark is-light" aria-hidden="true"&gt;LT&lt;/span&gt;
+  &lt;div class="theme-copy"&gt;
+    &lt;strong&gt;Light theme&lt;/strong&gt;
+    &lt;p&gt;Bright interface mode for daytime reading.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="theme-mode"&gt;Light&lt;/span&gt;
+  &lt;span class="theme-sync"&gt;Manual&lt;/span&gt;
+  &lt;span class="theme-state is-light"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-theme-preference-row-kk/style.css
+++ b/submissions/examples/basic-theme-preference-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --light: #fde68a;
+  --dark: #93c5fd;
+  --system: #86efac;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(253, 230, 138, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--system);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.theme-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-theme-preference-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-theme-preference-row + .basic-theme-preference-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-theme-preference-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.theme-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--light), #fef9c3);
+}
+
+.theme-mark.is-dark {
+  background: linear-gradient(135deg, var(--dark), #dbeafe);
+}
+
+.theme-mark.is-system {
+  background: linear-gradient(135deg, var(--system), #dcfce7);
+}
+
+.theme-copy {
+  min-width: 0;
+}
+
+.theme-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-mode,
+.theme-sync,
+.theme-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.theme-mode,
+.theme-sync {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.theme-state {
+  color: var(--light);
+  background: rgba(253, 230, 138, 0.12);
+}
+
+.theme-state.is-dark {
+  color: var(--dark);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.theme-state.is-system {
+  color: var(--system);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-theme-preference-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .theme-mode,
+  .theme-sync,
+  .theme-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Theme Preference Row demo inside `submissions/examples/basic-theme-preference-row-kk/`. This submission introduces a simple CSS-only row for appearance settings, profile pages, account dashboards, and personalization screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only theme preference row that displays a theme marker, theme name, helper text, display mode, sync behavior, and selected/available/suggested state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-theme-preference-row">
  <span class="theme-mark is-light" aria-hidden="true">LT</span>
  <div class="theme-copy">
    <strong>Light theme</strong>
    <p>Bright interface mode for daytime reading.</p>
  </div>
  <span class="theme-mode">Light</span>
  <span class="theme-sync">Manual</span>
  <span class="theme-state is-light">Selected</span>
</article>