### PR TITLE
feat: add basic date format row demo

### DIFF
--- a/submissions/examples/basic-date-format-row-kk/README.md
+++ b/submissions/examples/basic-date-format-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Date Format Row
+
+## What it does
+
+This submission adds a CSS-only date format row for profile settings, account
+dashboards, localization panels, and preference screens.
+
+It shows a date format marker, format label, helper text, region hint, example
+output, and selected or disabled state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a format marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-date-format-row">
+  <span class="format-mark is-selected" aria-hidden="true">IN</span>
+  <div class="format-copy">
+    <strong>DD MMM YYYY</strong>
+    <p>Displays dates as 14 Aug 2026 for readable regional settings.</p>
+  </div>
+  <span class="format-region">India</span>
+  <span class="format-example">14 Aug</span>
+  <span class="format-state is-selected">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+profile and localization settings. Developers can reuse the same row pattern in
+account preferences, regional settings, admin panels, and onboarding flows while
+keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Selected, available, and disabled date format examples
+- Date format marker badges
+- Region metadata
+- Example output metadata
+- Format preference state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the date format row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-date-format-row-kk/demo.html
+++ b/submissions/examples/basic-date-format-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Date Format Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Date Format Row</p>
+          <h1>Simple date format rows for profile settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing date format labels, example
+            output, region hint, and selected or disabled preference state.
+          </p>
+        </header>
+
+        <section class="format-list" aria-label="Date format row examples">
+          <article class="basic-date-format-row">
+            <span class="format-mark is-selected" aria-hidden="true">IN</span>
+            <div class="format-copy">
+              <strong>DD MMM YYYY</strong>
+              <p>Displays dates as 14 Aug 2026 for readable regional settings.</p>
+            </div>
+            <span class="format-region">India</span>
+            <span class="format-example">14 Aug</span>
+            <span class="format-state is-selected">Selected</span>
+          </article>
+
+          <article class="basic-date-format-row">
+            <span class="format-mark is-regional" aria-hidden="true">US</span>
+            <div class="format-copy">
+              <strong>MMM DD, YYYY</strong>
+              <p>Displays dates as Aug 14, 2026 for US-style interfaces.</p>
+            </div>
+            <span class="format-region">US</span>
+            <span class="format-example">Aug 14</span>
+            <span class="format-state is-regional">Available</span>
+          </article>
+
+          <article class="basic-date-format-row">
+            <span class="format-mark is-disabled" aria-hidden="true">ISO</span>
+            <div class="format-copy">
+              <strong>YYYY-MM-DD</strong>
+              <p>Technical ISO format hidden for non-admin workspaces.</p>
+            </div>
+            <span class="format-region">System</span>
+            <span class="format-example">2026-08-14</span>
+            <span class="format-state is-disabled">Disabled</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-date-format-row"&gt;
+  &lt;span class="format-mark is-selected" aria-hidden="true"&gt;IN&lt;/span&gt;
+  &lt;div class="format-copy"&gt;
+    &lt;strong&gt;DD MMM YYYY&lt;/strong&gt;
+    &lt;p&gt;Displays dates as 14 Aug 2026 for readable regional settings.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="format-region"&gt;India&lt;/span&gt;
+  &lt;span class="format-example"&gt;14 Aug&lt;/span&gt;
+  &lt;span class="format-state is-selected"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-date-format-row-kk/style.css
+++ b/submissions/examples/basic-date-format-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --selected: #86efac;
+  --regional: #93c5fd;
+  --disabled: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--selected);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.format-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-date-format-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-date-format-row + .basic-date-format-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-date-format-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.format-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--selected), #dcfce7);
+}
+
+.format-mark.is-regional {
+  background: linear-gradient(135deg, var(--regional), #dbeafe);
+}
+
+.format-mark.is-disabled {
+  background: linear-gradient(135deg, var(--disabled), #f8fafc);
+}
+
+.format-copy {
+  min-width: 0;
+}
+
+.format-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.format-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.format-region,
+.format-example,
+.format-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.format-region,
+.format-example {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.format-state {
+  color: var(--selected);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.format-state.is-regional {
+  color: var(--regional);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.format-state.is-disabled {
+  color: var(--disabled);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-date-format-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .format-region,
+  .format-example,
+  .format-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Date Format Row demo inside `submissions/examples/basic-date-format-row-kk/`. This submission introduces a simple CSS-only row for profile settings, account dashboards, localization panels, and preference screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only date format row that displays a date format marker, format label, helper text, region hint, example output, and selected/available/disabled preference state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-date-format-row">
  <span class="format-mark is-selected" aria-hidden="true">IN</span>
  <div class="format-copy">
    <strong>DD MMM YYYY</strong>
    <p>Displays dates as 14 Aug 2026 for readable regional settings.</p>
  </div>
  <span class="format-region">India</span>
  <span class="format-example">14 Aug</span>
  <span class="format-state is-selected">Selected</span>
</article>