### PR TITLE
feat: add basic file visibility row demo

### DIFF
--- a/submissions/examples/basic-file-visibility-row-kk/README.md
+++ b/submissions/examples/basic-file-visibility-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic File Visibility Row
+
+## What it does
+
+This submission adds a CSS-only file visibility row for file managers, document
+settings, knowledge bases, and sharing dashboards.
+
+It shows a file marker, file name, helper text, visibility scope, access count,
+and private, shared, or public state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a file marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-file-visibility-row">
+  <span class="file-mark is-private" aria-hidden="true">PR</span>
+  <div class="file-copy">
+    <strong>project-budget.xlsx</strong>
+    <p>Only the owner can view or edit this file.</p>
+  </div>
+  <span class="file-scope">Owner</span>
+  <span class="file-access">1 user</span>
+  <span class="file-state is-private">Private</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+file and sharing interfaces. Developers can reuse the same row pattern in file
+settings, document dashboards, knowledge bases, and sharing panels while keeping
+the implementation lightweight and CSS-only.
+
+## Included features
+
+- Private, shared, and public file examples
+- File visibility marker badges
+- Visibility scope metadata
+- Access count metadata
+- File state styling
+- Long text truncation for compact file lists
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the file visibility row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-file-visibility-row-kk/demo.html
+++ b/submissions/examples/basic-file-visibility-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic File Visibility Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic File Visibility Row</p>
+          <h1>Simple visibility rows for file settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing file name, visibility scope,
+            access count, and private, shared, or public state.
+          </p>
+        </header>
+
+        <section class="file-list" aria-label="File visibility row examples">
+          <article class="basic-file-visibility-row">
+            <span class="file-mark is-private" aria-hidden="true">PR</span>
+            <div class="file-copy">
+              <strong>project-budget.xlsx</strong>
+              <p>Only the owner can view or edit this file.</p>
+            </div>
+            <span class="file-scope">Owner</span>
+            <span class="file-access">1 user</span>
+            <span class="file-state is-private">Private</span>
+          </article>
+
+          <article class="basic-file-visibility-row">
+            <span class="file-mark is-shared" aria-hidden="true">SH</span>
+            <div class="file-copy">
+              <strong>design-review.pdf</strong>
+              <p>Shared with selected teammates for feedback.</p>
+            </div>
+            <span class="file-scope">Team</span>
+            <span class="file-access">8 users</span>
+            <span class="file-state is-shared">Shared</span>
+          </article>
+
+          <article class="basic-file-visibility-row">
+            <span class="file-mark is-public" aria-hidden="true">PB</span>
+            <div class="file-copy">
+              <strong>brand-assets.zip</strong>
+              <p>Anyone with the link can view and download this file.</p>
+            </div>
+            <span class="file-scope">Link</span>
+            <span class="file-access">Public</span>
+            <span class="file-state is-public">Public</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-file-visibility-row"&gt;
+  &lt;span class="file-mark is-private" aria-hidden="true"&gt;PR&lt;/span&gt;
+  &lt;div class="file-copy"&gt;
+    &lt;strong&gt;project-budget.xlsx&lt;/strong&gt;
+    &lt;p&gt;Only the owner can view or edit this file.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="file-scope"&gt;Owner&lt;/span&gt;
+  &lt;span class="file-access"&gt;1 user&lt;/span&gt;
+  &lt;span class="file-state is-private"&gt;Private&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-file-visibility-row-kk/style.css
+++ b/submissions/examples/basic-file-visibility-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --private: #86efac;
+  --shared: #93c5fd;
+  --public: #facc15;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--private);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.file-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-file-visibility-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-file-visibility-row + .basic-file-visibility-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-file-visibility-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.file-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--private), #dcfce7);
+}
+
+.file-mark.is-shared {
+  background: linear-gradient(135deg, var(--shared), #dbeafe);
+}
+
+.file-mark.is-public {
+  background: linear-gradient(135deg, var(--public), #fef9c3);
+}
+
+.file-copy {
+  min-width: 0;
+}
+
+.file-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-scope,
+.file-access,
+.file-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.file-scope,
+.file-access {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.file-state {
+  color: var(--private);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.file-state.is-shared {
+  color: var(--shared);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.file-state.is-public {
+  color: var(--public);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-file-visibility-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .file-scope,
+  .file-access,
+  .file-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic File Visibility Row demo inside `submissions/examples/basic-file-visibility-row-kk/`. This submission introduces a simple CSS-only row for file managers, document settings, knowledge bases, and sharing dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only file visibility row that displays a file marker, file name, helper text, visibility scope, access count, and private/shared/public state in one compact layout.

**How does