### PR TITLE
feat: add basic sort option row demo

### DIFF
--- a/submissions/examples/basic-sort-option-row-kk/README.md
+++ b/submissions/examples/basic-sort-option-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Sort Option Row
+
+## What it does
+
+This submission adds a CSS-only sort option row for filter panels, settings
+menus, search pages, and list customization screens.
+
+It shows a sort marker, sort label, helper text, order type, preview hint, and
+selected, recommended, or disabled state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a sort marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-sort-option-row">
+  <span class="sort-mark is-selected" aria-hidden="true">AZ</span>
+  <div class="sort-copy">
+    <strong>Name A to Z</strong>
+    <p>Sorts items alphabetically using the visible title.</p>
+  </div>
+  <span class="sort-order">Ascending</span>
+  <span class="sort-preview">A-Z</span>
+  <span class="sort-state is-selected">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+filtering and settings interfaces. Developers can reuse the same row pattern in
+search filters, table settings, list customization panels, and sort menus while
+keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Selected, recommended, and disabled sort examples
+- Sort marker badges
+- Order type metadata
+- Preview hint metadata
+- Sort state styling
+- Long text truncation for compact panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the sort option row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-sort-option-row-kk/demo.html
+++ b/submissions/examples/basic-sort-option-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Sort Option Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Sort Option Row</p>
+          <h1>Simple sort rows for filter and settings panels.</h1>
+          <p class="intro">
+            A CSS-only row component for showing sort label, order type, preview
+            hint, and selected, recommended, or disabled state.
+          </p>
+        </header>
+
+        <section class="sort-list" aria-label="Sort option row examples">
+          <article class="basic-sort-option-row">
+            <span class="sort-mark is-selected" aria-hidden="true">AZ</span>
+            <div class="sort-copy">
+              <strong>Name A to Z</strong>
+              <p>Sorts items alphabetically using the visible title.</p>
+            </div>
+            <span class="sort-order">Ascending</span>
+            <span class="sort-preview">A-Z</span>
+            <span class="sort-state is-selected">Selected</span>
+          </article>
+
+          <article class="basic-sort-option-row">
+            <span class="sort-mark is-recommended" aria-hidden="true">RC</span>
+            <div class="sort-copy">
+              <strong>Most relevant</strong>
+              <p>Recommended for search results and filtered lists.</p>
+            </div>
+            <span class="sort-order">Ranked</span>
+            <span class="sort-preview">Best</span>
+            <span class="sort-state is-recommended">Recommended</span>
+          </article>
+
+          <article class="basic-sort-option-row">
+            <span class="sort-mark is-disabled" aria-hidden="true">OFF</span>
+            <div class="sort-copy">
+              <strong>Recently archived</strong>
+              <p>Disabled because archived items are hidden in this view.</p>
+            </div>
+            <span class="sort-order">Newest</span>
+            <span class="sort-preview">Hidden</span>
+            <span class="sort-state is-disabled">Disabled</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-sort-option-row"&gt;
+  &lt;span class="sort-mark is-selected" aria-hidden="true"&gt;AZ&lt;/span&gt;
+  &lt;div class="sort-copy"&gt;
+    &lt;strong&gt;Name A to Z&lt;/strong&gt;
+    &lt;p&gt;Sorts items alphabetically using the visible title.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="sort-order"&gt;Ascending&lt;/span&gt;
+  &lt;span class="sort-preview"&gt;A-Z&lt;/span&gt;
+  &lt;span class="sort-state is-selected"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-sort-option-row-kk/style.css
+++ b/submissions/examples/basic-sort-option-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --selected: #86efac;
+  --recommended: #93c5fd;
+  --disabled: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--selected);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.sort-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-sort-option-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-sort-option-row + .basic-sort-option-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-sort-option-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.sort-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--selected), #dcfce7);
+}
+
+.sort-mark.is-recommended {
+  background: linear-gradient(135deg, var(--recommended), #dbeafe);
+}
+
+.sort-mark.is-disabled {
+  background: linear-gradient(135deg, var(--disabled), #f8fafc);
+}
+
+.sort-copy {
+  min-width: 0;
+}
+
+.sort-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sort-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sort-order,
+.sort-preview,
+.sort-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.sort-order,
+.sort-preview {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sort-state {
+  color: var(--selected);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.sort-state.is-recommended {
+  color: var(--recommended);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.sort-state.is-disabled {
+  color: var(--disabled);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-sort-option-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .sort-order,
+  .sort-preview,
+  .sort-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Sort Option Row demo inside `submissions/examples/basic-sort-option-row-kk/`. This submission introduces a simple CSS-only row for filter panels, settings menus, search pages, and list customization screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only sort option row that displays a sort marker, sort label, helper text, order type, preview hint, and selected/recommended/disabled state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-sort-option-row">
  <span class="sort-mark is-selected" aria-hidden="true">AZ</span>
  <div class="sort-copy">
    <strong>Name A to Z</strong>
    <p>Sorts items alphabetically using the visible title.</p>
  </div>
  <span class="sort-order">Ascending</span>
  <span class="sort-preview">A-Z</span>
  <span class="sort-state is-selected">Selected</span>
</article>