### PR TITLE
feat: add basic column visibility row demo

### DIFF
--- a/submissions/examples/basic-column-visibility-row-kk/README.md
+++ b/submissions/examples/basic-column-visibility-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Column Visibility Row
+
+## What it does
+
+This submission adds a CSS-only column visibility row for table settings, data
+grids, admin dashboards, and list customization panels.
+
+It shows a column marker, column name, helper text, data type, position, and
+visible, pinned, or hidden state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a column marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-column-visibility-row">
+  <span class="column-mark is-visible" aria-hidden="true">ON</span>
+  <div class="column-copy">
+    <strong>Customer name</strong>
+    <p>Visible in the default customer table layout.</p>
+  </div>
+  <span class="column-type">Text</span>
+  <span class="column-position">Col 1</span>
+  <span class="column-state is-visible">Visible</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+table and settings interfaces. Developers can reuse the same row pattern in
+column pickers, data grids, admin dashboards, and table customization panels
+while keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Visible, pinned, and hidden column examples
+- Column marker badges
+- Data type metadata
+- Column position metadata
+- Column state styling
+- Long text truncation for compact settings panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the column visibility row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-column-visibility-row-kk/demo.html
+++ b/submissions/examples/basic-column-visibility-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Column Visibility Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Column Visibility Row</p>
+          <h1>Simple rows for table column settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing table column name, data type,
+            position, and visible, pinned, or hidden state.
+          </p>
+        </header>
+
+        <section class="column-list" aria-label="Column visibility row examples">
+          <article class="basic-column-visibility-row">
+            <span class="column-mark is-visible" aria-hidden="true">ON</span>
+            <div class="column-copy">
+              <strong>Customer name</strong>
+              <p>Visible in the default customer table layout.</p>
+            </div>
+            <span class="column-type">Text</span>
+            <span class="column-position">Col 1</span>
+            <span class="column-state is-visible">Visible</span>
+          </article>
+
+          <article class="basic-column-visibility-row">
+            <span class="column-mark is-pinned" aria-hidden="true">PN</span>
+            <div class="column-copy">
+              <strong>Account status</strong>
+              <p>Pinned so the status stays visible while scrolling.</p>
+            </div>
+            <span class="column-type">Badge</span>
+            <span class="column-position">Left</span>
+            <span class="column-state is-pinned">Pinned</span>
+          </article>
+
+          <article class="basic-column-visibility-row">
+            <span class="column-mark is-hidden" aria-hidden="true">OFF</span>
+            <div class="column-copy">
+              <strong>Internal notes</strong>
+              <p>Hidden from the default view to reduce visual clutter.</p>
+            </div>
+            <span class="column-type">Text</span>
+            <span class="column-position">Col 8</span>
+            <span class="column-state is-hidden">Hidden</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-column-visibility-row"&gt;
+  &lt;span class="column-mark is-visible" aria-hidden="true"&gt;ON&lt;/span&gt;
+  &lt;div class="column-copy"&gt;
+    &lt;strong&gt;Customer name&lt;/strong&gt;
+    &lt;p&gt;Visible in the default customer table layout.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="column-type"&gt;Text&lt;/span&gt;
+  &lt;span class="column-position"&gt;Col 1&lt;/span&gt;
+  &lt;span class="column-state is-visible"&gt;Visible&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-column-visibility-row-kk/style.css
+++ b/submissions/examples/basic-column-visibility-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --visible: #86efac;
+  --pinned: #93c5fd;
+  --hidden: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--visible);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.column-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-column-visibility-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-column-visibility-row + .basic-column-visibility-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-column-visibility-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.column-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--visible), #dcfce7);
+}
+
+.column-mark.is-pinned {
+  background: linear-gradient(135deg, var(--pinned), #dbeafe);
+}
+
+.column-mark.is-hidden {
+  background: linear-gradient(135deg, var(--hidden), #f8fafc);
+}
+
+.column-copy {
+  min-width: 0;
+}
+
+.column-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.column-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.column-type,
+.column-position,
+.column-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.column-type,
+.column-position {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.column-state {
+  color: var(--visible);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.column-state.is-pinned {
+  color: var(--pinned);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.column-state.is-hidden {
+  color: var(--hidden);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-column-visibility-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .column-type,
+  .column-position,
+  .column-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Column Visibility Row demo inside `submissions/examples/basic-column-visibility-row-kk/`. This submission introduces a simple CSS-only row for table settings, data grids, admin dashboards, and list customization panels.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only column visibility row that displays a column marker, column name, helper text, data type, position, and visible/pinned/hidden state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-column-visibility-row">
  <span class="column-mark is-visible" aria-hidden="true">ON</span>
  <div class="column-copy">
    <strong>Customer name</strong>
    <p>Visible in the default customer table layout.</p>
  </div>
  <span class="column-type">Text</span>
  <span class="column-position">Col 1</span>
  <span class="column-state is-visible">Visible