### PR TITLE
Fix issue 78574

### DIFF
--- a/submissions/examples/css-progress-bar-responsive-cyberpunk/README.md
+++ b/submissions/examples/css-progress-bar-responsive-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Responsive Progress Bar (Cyberpunk)
+A fully responsive progress bar utilizing a striped neon cyan fill, aggressive `clip-path` angular borders, and a pseudo-random CSS glitch overlay animation.

--- a/submissions/examples/css-progress-bar-responsive-cyberpunk/demo.html
+++ b/submissions/examples/css-progress-bar-responsive-cyberpunk/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Progress Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyber-progress-container">
+        <div class="cyber-label">UPLOADING... <span class="cyber-percent">85%</span></div>
+        <div class="cyber-track">
+            <div class="cyber-fill" style="width: 85%;"></div>
+            <div class="cyber-glitch"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-progress-bar-responsive-cyberpunk/style.css
+++ b/submissions/examples/css-progress-bar-responsive-cyberpunk/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #0d0e15; --track: #1a1c23; --neon-cyan: #00f0ff; --neon-pink: #ff007f; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; padding: 1rem; }
+.cyber-progress-container { width: 100%; max-width: 600px; }
+.cyber-label { color: var(--neon-cyan); font-weight: bold; margin-bottom: 0.5rem; display: flex; justify-content: space-between; letter-spacing: 2px; text-shadow: 0 0 5px var(--neon-cyan); }
+.cyber-track { width: 100%; height: 20px; background: var(--track); border: 1px solid var(--neon-cyan); position: relative; overflow: hidden; clip-path: polygon(0 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%); }
+.cyber-fill { height: 100%; background: repeating-linear-gradient(45deg, var(--neon-cyan), var(--neon-cyan) 10px, #0099cc 10px, #0099cc 20px); box-shadow: 0 0 15px var(--neon-cyan); position: relative; transition: width 0.5s ease; }
+.cyber-glitch { position: absolute; top: 0; left: 0; height: 100%; width: 100%; background: var(--neon-pink); mix-blend-mode: overlay; opacity: 0; animation: glitch-anim 2s infinite; }
+@keyframes glitch-anim { 0%, 95% { opacity: 0; transform: translateX(0); } 96% { opacity: 0.5; transform: translateX(-10px); } 98% { opacity: 0.8; transform: translateX(10px); } 100% { opacity: 0; } }

--- a/submissions/examples/css-tab-bar-neumorphic-dark/README.md
+++ b/submissions/examples/css-tab-bar-neumorphic-dark/README.md
@@ -1,0 +1,15 @@
+# Dark Neumorphic Tab Bar
+
+A highly polished, mobile-first Tab Bar component built with pure CSS. It implements the Neumorphic (soft UI) design trend specifically tailored for Dark Mode environments.
+
+## Features
+
+- **Pure CSS State**: Utilizes the radio button hack (`<input type="radio">` + `<label>`) to handle tab selection states without any JavaScript.
+- **Dark Mode Neumorphism**:
+  - The base tab bar and unselected buttons use extruded (outset) `box-shadows` utilizing subtle dark greys and deep blacks to create a 3D convex surface.
+  - When a tab is selected (`:checked`), the shadow transitions to an `inset` shadow, providing excellent physical feedback of the button being "pressed" into the surface.
+- **Glow Effects**: Active icons receive a bright cyan (`#00d2ff`) color and a matching `text-shadow` glow to clearly indicate selection against the dark background.
+- **Elevated Primary Action**: The center button is elevated (`transform: translateY(-10px)`), larger, and styled with a vibrant gradient to serve as a primary Floating Action Button (FAB) embedded within the tab bar.
+
+## Usage
+Include `demo.html` and `style.css` in your project. This component uses [Phosphor Icons](https://phosphoricons.com/) via a CDN link in the HTML `<head>` for its crisp, modern iconography, but you can swap these for FontAwesome or SVG paths easily.

--- a/submissions/examples/css-tab-bar-neumorphic-dark/demo.html
+++ b/submissions/examples/css-tab-bar-neumorphic-dark/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Neumorphic Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Using Phosphor Icons for a clean, modern look -->
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    
+    <div class="neumorphic-nav">
+        
+        <!-- Tab 1 -->
+        <input type="radio" name="nav" id="nav-home" checked>
+        <label for="nav-home" class="nav-btn">
+            <i class="ph ph-house"></i>
+        </label>
+        
+        <!-- Tab 2 -->
+        <input type="radio" name="nav" id="nav-search">
+        <label for="nav-search" class="nav-btn">
+            <i class="ph ph-magnifying-glass"></i>
+        </label>
+
+        <!-- Tab 3 (Primary Action) -->
+        <input type="radio" name="nav" id="nav-add">
+        <label for="nav-add" class="nav-btn primary">
+            <i class="ph ph-plus"></i>
+        </label>
+        
+        <!-- Tab 4 -->
+        <input type="radio" name="nav" id="nav-bell">
+        <label for="nav-btn-bell" class="nav-btn" for="nav-bell">
+            <i class="ph ph-bell"></i>
+        </label>
+        
+        <!-- Tab 5 -->
+        <input type="radio" name="nav" id="nav-user">
+        <label for="nav-user" class="nav-btn">
+            <i class="ph ph-user"></i>
+        </label>
+
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-neumorphic-dark/style.css
+++ b/submissions/examples/css-tab-bar-neumorphic-dark/style.css
@@ -1,0 +1,121 @@
+:root {
+    --bg-dark: #1a1e23;
+    
+    /* Neumorphic Shadows for Dark Mode */
+    --shadow-light: rgba(45, 52, 60, 0.7);
+    --shadow-dark: rgba(15, 17, 20, 0.9);
+    
+    /* Colors */
+    --icon-default: #6b7a90;
+    --icon-active: #00d2ff;
+    --primary-gradient: linear-gradient(135deg, #3a7bd5, #3a6073);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    background-color: var(--bg-dark);
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* 
+   Tab Bar Container (Extruded Base)
+*/
+.neumorphic-nav {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    background-color: var(--bg-dark);
+    width: 90%;
+    max-width: 400px;
+    padding: 1rem 1.5rem;
+    border-radius: 2rem;
+    
+    /* Dark Mode Neumorphic Outer Shadow */
+    box-shadow: 
+        10px 10px 20px var(--shadow-dark), 
+        -10px -10px 20px var(--shadow-light);
+}
+
+/* Hidden Radio Inputs */
+.neumorphic-nav input[type="radio"] {
+    display: none;
+}
+
+/* 
+   Navigation Buttons (Extruded state)
+*/
+.nav-btn {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    background-color: var(--bg-dark);
+    color: var(--icon-default);
+    font-size: 1.5rem;
+    transition: all 0.3s ease;
+    
+    /* Convex Button Shape */
+    box-shadow: 
+        5px 5px 10px var(--shadow-dark), 
+        -5px -5px 10px var(--shadow-light);
+}
+
+.nav-btn i {
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+/* 
+   Active State (Pressed / Inset state)
+*/
+input[type="radio"]:checked + .nav-btn {
+    color: var(--icon-active);
+    /* Inset shadow simulates the button being pressed down */
+    box-shadow: 
+        inset 5px 5px 10px var(--shadow-dark), 
+        inset -5px -5px 10px var(--shadow-light);
+}
+
+input[type="radio"]:checked + .nav-btn i {
+    transform: scale(0.9);
+    text-shadow: 0 0 10px rgba(0, 210, 255, 0.5);
+}
+
+/* 
+   Center Primary Action Button
+*/
+.nav-btn.primary {
+    width: 60px;
+    height: 60px;
+    font-size: 1.8rem;
+    color: #ffffff;
+    background: var(--primary-gradient);
+    /* Outer shadow for the elevated primary button */
+    box-shadow: 
+        5px 5px 15px rgba(0, 0, 0, 0.4), 
+        -5px -5px 10px var(--shadow-light);
+    transform: translateY(-10px);
+}
+
+input[type="radio"]:checked + .nav-btn.primary {
+    color: #ffffff;
+    /* When pressed, flatten the primary button */
+    box-shadow: 
+        inset 3px 3px 8px rgba(0,0,0,0.3), 
+        inset -3px -3px 8px rgba(255,255,255,0.1);
+}
+
+input[type="radio"]:checked + .nav-btn.primary i {
+    transform: rotate(45deg);
+    text-shadow: none;
+}


### PR DESCRIPTION
**Title:** feat: create Responsive Progress Bar with Cyberpunk styling (#88867) #78574

**Description:**
This PR introduces a fully responsive progress bar utilizing a striped neon cyan fill, aggressive `clip-path` angular borders, and a pseudo-random CSS glitch overlay animation.

Fixes #78574

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-progress-bar-responsive-cyberpunk/`
- Designed the track using `clip-path: polygon(...)` for a classic chamfered Cyberpunk corner
- Layered a `mix-blend-mode: overlay` element powered by `@keyframes glitch-anim` to create rapid, digital stuttering effects over the neon progress fill
