### PR TITLE
feat: create CSS-only Button with Cyberpunk styling (#10466) #78573

### DIFF
--- a/submissions/examples/css-button-css-only-cyberpunk/README.md
+++ b/submissions/examples/css-button-css-only-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# CSS-only Button (Cyberpunk)
+A pure CSS Cyberpunk button featuring angular `clip-path` borders and a high-contrast text glitch animation triggered on hover.

--- a/submissions/examples/css-button-css-only-cyberpunk/demo.html
+++ b/submissions/examples/css-button-css-only-cyberpunk/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk CSS Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <button class="cybr-btn">
+        <span class="cybr-text">CONNECT</span>
+        <span class="cybr-glitch" aria-hidden="true">CONNECT</span>
+    </button>
+</body>
+</html>

--- a/submissions/examples/css-button-css-only-cyberpunk/style.css
+++ b/submissions/examples/css-button-css-only-cyberpunk/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #050505; --neon-yellow: #fcee0a; --neon-cyan: #00f0ff; --neon-red: #ff003c; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; }
+.cybr-btn { position: relative; padding: 1rem 3rem; background: var(--neon-yellow); color: #000; border: none; font-size: 1.5rem; font-weight: bold; text-transform: uppercase; letter-spacing: 2px; cursor: pointer; clip-path: polygon(15px 0, 100% 0, 100% calc(100% - 15px), calc(100% - 15px) 100%, 0 100%, 0 15px); transition: background 0.2s; }
+.cybr-btn:hover { background: var(--neon-cyan); }
+.cybr-btn::after { content: ''; position: absolute; bottom: -5px; right: 0; width: 40px; height: 5px; background: var(--neon-red); }
+.cybr-glitch { display: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: var(--neon-cyan); padding: 1rem 3rem; color: #000; text-shadow: 2px 0 var(--neon-red), -2px 0 var(--neon-yellow); clip-path: polygon(0 0, 100% 0, 100% 100%, 0% 100%); }
+.cybr-btn:hover .cybr-glitch { display: block; animation: cybr-glitch-anim 0.25s infinite; }
+@keyframes cybr-glitch-anim { 0% { clip-path: polygon(0 2%, 100% 2%, 100% 5%, 0 5%); transform: translate(-2px, 2px); } 50% { clip-path: polygon(0 40%, 100% 40%, 100% 45%, 0 45%); transform: translate(2px, -2px); } 100% { clip-path: polygon(0 80%, 100% 80%, 100% 85%, 0 85%); transform: translate(0); } }


### PR DESCRIPTION
**Title:** feat: create CSS-only Button with Cyberpunk styling (#10466) #78573

**Description:**
This PR introduces a pure CSS Cyberpunk button featuring angular borders and a high-contrast text glitch animation triggered on hover.

Fixes #78573

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-button-css-only-cyberpunk/`
- Implemented `clip-path: polygon(...)` to cut the corners of the button, mimicking the angular UI found in cyberpunk aesthetics
- Created a pure CSS text glitch effect using a duplicate hidden span (`.cybr-glitch`) that rapidly animates its `clip-path` and `transform` via `@keyframes cybr-glitch-anim` when the button is hovered
