### PR TITLE
feat: create CSS-only Navbar with Retro styling (#14132) #78568

### DIFF
--- a/submissions/examples/css-navbar-css-only-retro/README.md
+++ b/submissions/examples/css-navbar-css-only-retro/README.md
@@ -1,0 +1,2 @@
+# CSS-only Navbar (Retro)
+A classic 8-bit retro styled navbar. It features bulky MS-DOS era borders, an authentic pixel font, and a pure CSS mobile dropdown utilizing the checkbox hack.

--- a/submissions/examples/css-navbar-css-only-retro/demo.html
+++ b/submissions/examples/css-navbar-css-only-retro/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro CSS Navbar</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+</head>
+<body>
+    <nav class="retro-nav">
+        <div class="logo">8-BIT</div>
+        <input type="checkbox" id="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <div class="menu">
+            <a href="#">START</a>
+            <a href="#">OPTIONS</a>
+            <a href="#">EXIT</a>
+        </div>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-navbar-css-only-retro/style.css
+++ b/submissions/examples/css-navbar-css-only-retro/style.css
@@ -1,0 +1,15 @@
+:root { --bg: #2b2b2b; --nav-bg: #c0c0c0; --border-dark: #808080; --border-light: #ffffff; --text: #000000; --hover: #000080; }
+body { background: var(--bg); margin: 0; font-family: 'Press Start 2P', cursive; padding: 2rem; }
+.retro-nav { display: flex; justify-content: space-between; align-items: center; background: var(--nav-bg); padding: 1rem 2rem; box-shadow: inset -2px -2px 0px var(--border-dark), inset 2px 2px 0px var(--border-light); border: 4px solid #000; }
+.logo { font-size: 1.5rem; color: var(--text); }
+input[type="checkbox"] { display: none; }
+.menu-icon { display: none; font-size: 2rem; cursor: pointer; }
+.menu { display: flex; gap: 2rem; }
+.menu a { text-decoration: none; color: var(--text); font-size: 1rem; padding: 0.5rem; }
+.menu a:hover { background: var(--hover); color: #fff; }
+@media (max-width: 768px) {
+    .menu-icon { display: block; }
+    .menu { display: none; position: absolute; top: 80px; left: 2rem; right: 2rem; background: var(--nav-bg); flex-direction: column; gap: 0; box-shadow: inset -2px -2px 0px var(--border-dark), inset 2px 2px 0px var(--border-light); border: 4px solid #000; z-index: 10; }
+    .menu a { padding: 1rem; border-bottom: 2px solid var(--border-dark); }
+    #menu-toggle:checked ~ .menu { display: flex; }
+}


### PR DESCRIPTION
**Title:** feat: create CSS-only Navbar with Retro styling (#14132) #78568

**Description:**
This PR introduces a classic 8-bit retro styled navbar. It features bulky MS-DOS era borders, an authentic pixel font, and a pure CSS mobile dropdown.

Fixes #78568

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-navbar-css-only-retro/`
- Designed authentic 90s-style borders using heavily contrasting `box-shadow: inset` lines
- Engineered a pure CSS mobile hamburger menu utilizing the checkbox hack (`<input type="checkbox">` + `~ .menu`)
