### PR TITLE
feat: create 3D Badge with Neumorphism styling (#48441) #78565

### DIFF
--- a/submissions/examples/css-badge-3d-neumorphism/README.md
+++ b/submissions/examples/css-badge-3d-neumorphism/README.md
@@ -1,0 +1,2 @@
+# 3D Badge (Neumorphism)
+A soft-UI Neumorphic badge that seamlessly transitions from an extruded 3D state to an inset pressed state upon hovering.

--- a/submissions/examples/css-badge-3d-neumorphism/demo.html
+++ b/submissions/examples/css-badge-3d-neumorphism/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Neumorphic Badge</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-badge">
+        <span class="icon">★</span> PREMIUM
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-badge-3d-neumorphism/style.css
+++ b/submissions/examples/css-badge-3d-neumorphism/style.css
@@ -1,0 +1,6 @@
+:root { --bg: #e0e5ec; --shadow-light: #ffffff; --shadow-dark: #a3b1c6; --text: #4a5568; --accent: #f6ad55; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui; }
+.neu-badge { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: var(--bg); color: var(--text); font-weight: 700; font-size: 1.1rem; border-radius: 9999px; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.3s ease; border: 1px solid rgba(255,255,255,0.2); }
+.neu-badge:hover { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); color: var(--accent); }
+.icon { color: var(--accent); font-size: 1.25rem; }
+.neu-badge:hover .icon { transform: scale(1.1); }


### PR DESCRIPTION
**Title:** feat: create 3D Badge with Neumorphism styling (#48441) #78565

**Description:**
This PR introduces a soft-UI Neumorphic badge that seamlessly transitions from an extruded 3D state to an inset pressed state upon hovering.

Fixes #78565

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-badge-3d-neumorphism/`
- Styled the resting state with a dual `box-shadow` (light/dark) projecting outward to create a physical pill-shape extrusion
- Inverted the shadows to `inset` on `:hover` to provide a satisfying, tactile physical press interaction
