### PR TITLE
feat: create Neumorphic Accordion with Retro styling (#47217) #78529

### DIFF
--- a/submissions/examples/css-accordion-neumorphic-retro/README.md
+++ b/submissions/examples/css-accordion-neumorphic-retro/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Accordion (Retro)
+A secondary variant of the Retro Neumorphic Accordion, utilizing checkboxes instead of radio buttons to allow multiple panels to remain open simultaneously.

--- a/submissions/examples/css-accordion-neumorphic-retro/demo.html
+++ b/submissions/examples/css-accordion-neumorphic-retro/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Neumorphic Accordion (Variant 2)</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="retro-neu-acc">
+        <div class="acc-card">
+            <input type="checkbox" id="rn1">
+            <label for="rn1">System Config</label>
+            <div class="acc-body"><p>Configuration options loaded.</p></div>
+        </div>
+        <div class="acc-card">
+            <input type="checkbox" id="rn2">
+            <label for="rn2">Hardware Specs</label>
+            <div class="acc-body"><p>64MB RAM installed.</p></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-accordion-neumorphic-retro/style.css
+++ b/submissions/examples/css-accordion-neumorphic-retro/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #d9d4c1; --shadow-dark: #b8b19e; --shadow-light: #fefcf1; --text: #594d41; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; }
+.retro-neu-acc { width: 90%; max-width: 400px; display: flex; flex-direction: column; gap: 1.5rem; }
+.acc-card { position: relative; }
+input[type="checkbox"] { display: none; }
+label { display: block; padding: 1rem 1.5rem; background: var(--bg); color: var(--text); font-weight: bold; cursor: pointer; border-radius: 8px; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: all 0.2s; border: 1px solid rgba(255,255,255,0.4); text-transform: uppercase; }
+label:hover { transform: translateY(-2px); }
+.acc-body { max-height: 0; overflow: hidden; background: var(--bg); border-radius: 8px; margin-top: 0.5rem; box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); transition: max-height 0.4s ease; }
+.acc-body p { padding: 1rem 1.5rem; margin: 0; color: #4a3f33; }
+input:checked + label { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); transform: translateY(2px); }
+input:checked + label + .acc-body { max-height: 200px; }


### PR DESCRIPTION
**Title:** feat: create Neumorphic Accordion with Retro styling (#47217) #78529

**Description:**
This PR introduces a secondary variant of the Retro Neumorphic Accordion, utilizing checkboxes instead of radio buttons to allow multiple panels to remain open simultaneously.

Fixes #78529

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-accordion-neumorphic-retro/`
- Applied a brutalist Windows 95 beige color palette (`#d9d4c1`) combined with chunky neumorphic shadows
- Powered state management purely via `<input type="checkbox">` elements, triggering `max-height` transitions on sibling `.acc-body` elements
