### PR TITLE
feat: create 3D sidebar with dark mode styling for #78559

### DIFF
--- a/submissions/examples/78559-3d-sidebar-dark-mode/README.md
+++ b/submissions/examples/78559-3d-sidebar-dark-mode/README.md
@@ -1,0 +1,46 @@
+# 3D Sidebar - Dark Mode
+
+A responsive 3D-inspired sidebar and dashboard interface with light and dark mode support.
+
+## Features
+
+- 3D-inspired sidebar depth
+- Responsive desktop and mobile layouts
+- Dark/light mode toggle
+- Theme persistence with `localStorage`
+- Mobile sidebar navigation
+- Dashboard statistics
+- Activity chart
+- Recent projects section
+- Recent messages section
+- Accessible labels and focus states
+- Reduced-motion support
+- No external dependencies
+
+## Files
+
+- `demo.html` - Complete sidebar and dashboard markup
+- `style.css` - Responsive 3D styling and themes
+
+## Usage
+
+Open `demo.html` in a modern browser.
+
+Use the menu button on smaller screens to open or close the sidebar.
+
+Use the Dark Mode control in the sidebar to switch themes.
+
+The selected theme is stored with `localStorage`.
+
+## Responsive Behavior
+
+On smaller screens:
+
+- The sidebar slides in from the left.
+- A mobile menu button becomes visible.
+- Dashboard cards stack vertically.
+- Charts and panels adapt to the available width.
+
+## Accessibility
+
+The component uses semantic navigation markup, accessible labels, visible keyboard focus states, and `prefers-reduced-motion` support.

--- a/submissions/examples/78559-3d-sidebar-dark-mode/demo.html
+++ b/submissions/examples/78559-3d-sidebar-dark-mode/demo.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="Responsive 3D Sidebar with Dark Mode"
+  >
+
+  <title>3D Sidebar - Dark Mode</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="app-shell">
+
+    <input
+      type="checkbox"
+      id="sidebar-toggle"
+      class="sidebar-toggle"
+      aria-label="Toggle sidebar"
+    >
+
+    <label
+      for="sidebar-toggle"
+      class="mobile-menu"
+      aria-label="Open sidebar"
+    >
+      <span></span>
+      <span></span>
+      <span></span>
+    </label>
+
+    <aside class="sidebar" aria-label="Main sidebar">
+
+      <div class="sidebar-brand">
+        <div class="brand-mark">E</div>
+
+        <div class="brand-copy">
+          <strong>EaseUI</strong>
+          <span>Dashboard</span>
+        </div>
+      </div>
+
+      <div class="sidebar-profile">
+        <div class="avatar">AK</div>
+
+        <div>
+          <strong>Alex Kumar</strong>
+          <span>Frontend Designer</span>
+        </div>
+      </div>
+
+      <nav class="navigation">
+        <p class="nav-heading">MAIN</p>
+
+        <a href="#dashboard" class="nav-item active">
+          <span class="nav-icon">⌂</span>
+          <span>Dashboard</span>
+        </a>
+
+        <a href="#analytics" class="nav-item">
+          <span class="nav-icon">◫</span>
+          <span>Analytics</span>
+        </a>
+
+        <a href="#projects" class="nav-item">
+          <span class="nav-icon">▣</span>
+          <span>Projects</span>
+        </a>
+
+        <a href="#messages" class="nav-item">
+          <span class="nav-icon">✉</span>
+          <span>Messages</span>
+          <span class="badge">4</span>
+        </a>
+
+        <p class="nav-heading">MANAGE</p>
+
+        <a href="#settings" class="nav-item">
+          <span class="nav-icon">⚙</span>
+          <span>Settings</span>
+        </a>
+
+        <a href="#help" class="nav-item">
+          <span class="nav-icon">?</span>
+          <span>Help Center</span>
+        </a>
+      </nav>
+
+      <div class="sidebar-bottom">
+        <button
+          type="button"
+          class="theme-button"
+          id="theme-toggle"
+          aria-pressed="false"
+        >
+          <span class="theme-symbol" aria-hidden="true">☼</span>
+
+          <span class="theme-text">Dark Mode</span>
+
+          <span class="switch-indicator" aria-hidden="true">
+            <span></span>
+          </span>
+        </button>
+
+        <a href="#logout" class="logout-link">
+          <span class="nav-icon">↪</span>
+          <span>Log out</span>
+        </a>
+      </div>
+
+    </aside>
+
+    <main class="content">
+
+      <header class="content-header">
+        <div>
+          <span class="section-label">OVERVIEW</span>
+          <h1>Good morning, Alex 👋</h1>
+          <p>Here’s what’s happening with your workspace today.</p>
+        </div>
+
+        <button type="button" class="notification-button" aria-label="Notifications">
+          <span>◔</span>
+          <i></i>
+        </button>
+      </header>
+
+      <section class="stats-grid" id="dashboard">
+
+        <article class="stat-card">
+          <span class="stat-label">TOTAL PROJECTS</span>
+          <strong>24</strong>
+          <span class="stat-change positive">+12.5%</span>
+        </article>
+
+        <article class="stat-card">
+          <span class="stat-label">ACTIVE TASKS</span>
+          <strong>128</strong>
+          <span class="stat-change positive">+8.2%</span>
+        </article>
+
+        <article class="stat-card">
+          <span class="stat-label">COMPLETED</span>
+          <strong>86%</strong>
+          <span class="stat-change positive">+4.8%</span>
+        </article>
+
+      </section>
+
+      <section class="dashboard-grid">
+
+        <article class="panel analytics-panel" id="analytics">
+          <div class="panel-heading">
+            <div>
+              <span class="section-label">ACTIVITY</span>
+              <h2>Weekly performance</h2>
+            </div>
+
+            <button type="button" class="period-button">
+              This week ▾
+            </button>
+          </div>
+
+          <div class="chart">
+            <div class="chart-labels">
+              <span>100</span>
+              <span>75</span>
+              <span>50</span>
+              <span>25</span>
+              <span>0</span>
+            </div>
+
+            <div class="chart-area">
+              <div class="grid-line line-1"></div>
+              <div class="grid-line line-2"></div>
+              <div class="grid-line line-3"></div>
+              <div class="grid-line line-4"></div>
+
+              <div class="bars">
+                <div class="bar" style="--height: 42%;"></div>
+                <div class="bar" style="--height: 58%;"></div>
+                <div class="bar" style="--height: 49%;"></div>
+                <div class="bar active" style="--height: 78%;"></div>
+                <div class="bar" style="--height: 65%;"></div>
+                <div class="bar" style="--height: 88%;"></div>
+                <div class="bar" style="--height: 72%;"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="days">
+            <span>Mon</span>
+            <span>Tue</span>
+            <span>Wed</span>
+            <span>Thu</span>
+            <span>Fri</span>
+            <span>Sat</span>
+            <span>Sun</span>
+          </div>
+        </article>
+
+        <article class="panel project-panel" id="projects">
+          <div class="panel-heading">
+            <div>
+              <span class="section-label">PROJECTS</span>
+              <h2>Recent work</h2>
+            </div>
+
+            <a href="#projects" class="view-link">View all</a>
+          </div>
+
+          <div class="project-list">
+
+            <div class="project-row">
+              <div class="project-dot purple"></div>
+
+              <div class="project-info">
+                <strong>Dashboard Redesign</strong>
+                <span>Updated 2 hours ago</span>
+              </div>
+
+              <span class="progress">82%</span>
+            </div>
+
+            <div class="project-row">
+              <div class="project-dot blue"></div>
+
+              <div class="project-info">
+                <strong>Mobile App</strong>
+                <span>Updated yesterday</span>
+              </div>
+
+              <span class="progress">64%</span>
+            </div>
+
+            <div class="project-row">
+              <div class="project-dot green"></div>
+
+              <div class="project-info">
+                <strong>Landing Page</strong>
+                <span>Updated 2 days ago</span>
+              </div>
+
+              <span class="progress">91%</span>
+            </div>
+
+          </div>
+        </article>
+
+      </section>
+
+      <section class="bottom-grid">
+
+        <article class="panel messages-panel" id="messages">
+          <div class="panel-heading">
+            <div>
+              <span class="section-label">MESSAGES</span>
+              <h2>Recent conversations</h2>
+            </div>
+
+            <span class="message-count">4 new</span>
+          </div>
+
+          <div class="message-row">
+            <div class="mini-avatar">RM</div>
+
+            <div class="message-info">
+              <strong>Riya Mehta</strong>
+              <span>Can you review the latest design?</span>
+            </div>
+
+            <time datetime="2026-08-14T08:00">08:00</time>
+          </div>
+
+          <div class="message-row">
+            <div class="mini-avatar">SK</div>
+
+            <div class="message-info">
+              <strong>Sam Khan</strong>
+              <span>The new dashboard is ready.</span>
+            </div>
+
+            <time datetime="2026-08-14T07:30">07:30</time>
+          </div>
+
+          <div class="message-row">
+            <div class="mini-avatar">NP</div>
+
+            <div class="message-info">
+              <strong>Nina Patel</strong>
+              <span>Let’s sync up this afternoon.</span>
+            </div>
+
+            <time datetime="2026-08-14T06:15">06:15</time>
+          </div>
+        </article>
+
+        <article class="panel quick-panel">
+          <span class="section-label">QUICK ACTION</span>
+
+          <h2>Create something new</h2>
+
+          <p>
+            Start a fresh project and bring your next idea to life.
+          </p>
+
+          <a href="#new-project" class="primary-button">
+            + New Project
+          </a>
+        </article>
+
+      </section>
+
+    </main>
+  </div>
+
+  <script>
+    const themeToggle = document.getElementById("theme-toggle");
+    const themeSymbol = document.querySelector(".theme-symbol");
+    const themeText = document.querySelector(".theme-text");
+
+    function applyTheme(theme) {
+      const isDark = theme === "dark";
+
+      document.body.classList.toggle("dark", isDark);
+
+      themeToggle.setAttribute(
+        "aria-pressed",
+        String(isDark)
+      );
+
+      themeSymbol.textContent = isDark ? "☾" : "☼";
+      themeText.textContent = isDark ? "Light Mode" : "Dark Mode";
+    }
+
+    const savedTheme = localStorage.getItem("easeui-sidebar-theme");
+
+    if (savedTheme === "dark" || savedTheme === "light") {
+      applyTheme(savedTheme);
+    }
+
+    themeToggle.addEventListener("click", () => {
+      const nextTheme = document.body.classList.contains("dark")
+        ? "light"
+        : "dark";
+
+      applyTheme(nextTheme);
+
+      localStorage.setItem(
+        "easeui-sidebar-theme",
+        nextTheme
+      );
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/78559-3d-sidebar-dark-mode/style.css
+++ b/submissions/examples/78559-3d-sidebar-dark-mode/style.css
@@ -1,0 +1,1217 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --page-bg: #edf1f8;
+  --surface: #ffffff;
+  --surface-soft: #f5f7fb;
+  --sidebar: #f9fbff;
+
+  --text: #172033;
+  --muted: #748098;
+
+  --primary: #635bff;
+  --primary-soft: rgba(99, 91, 255, 0.11);
+
+  --border: #e2e7f0;
+
+  --sidebar-shadow: rgba(47, 57, 82, 0.14);
+  --card-shadow: rgba(31, 41, 61, 0.08);
+  --card-shadow-dark: rgba(31, 41, 61, 0.15);
+
+  --positive: #28a875;
+  --purple: #8b5cf6;
+  --blue: #3b82f6;
+  --green: #22c55e;
+}
+
+body.dark {
+  --page-bg: #0b1020;
+  --surface: #131a2d;
+  --surface-soft: #182139;
+  --sidebar: #10172a;
+
+  --text: #f3f6ff;
+  --muted: #9aa6c1;
+
+  --primary: #8c84ff;
+  --primary-soft: rgba(140, 132, 255, 0.12);
+
+  --border: #27314a;
+
+  --sidebar-shadow: rgba(0, 0, 0, 0.35);
+  --card-shadow: rgba(0, 0, 0, 0.2);
+  --card-shadow-dark: rgba(0, 0, 0, 0.3);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+  background: var(--page-bg);
+
+  transition:
+    background-color 220ms ease,
+    color 220ms ease;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+/* =========================
+   Sidebar
+   ========================= */
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+
+  width: 280px;
+  height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+
+  padding: 26px 20px;
+
+  background: var(--sidebar);
+
+  border-right: 1px solid var(--border);
+
+  box-shadow:
+    14px 0 32px var(--sidebar-shadow),
+    6px 0 0 rgba(255, 255, 255, 0.24);
+
+  transform: perspective(1200px) rotateY(0deg);
+  transform-origin: left center;
+
+  transition:
+    transform 260ms ease,
+    background-color 220ms ease;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  padding: 0 8px;
+}
+
+.brand-mark {
+  display: grid;
+
+  width: 42px;
+  height: 42px;
+
+  place-items: center;
+
+  border-radius: 12px;
+
+  color: white;
+  background: linear-gradient(
+    145deg,
+    var(--primary),
+    #8b83ff
+  );
+
+  box-shadow:
+    0 8px 18px rgba(99, 91, 255, 0.25),
+    inset 1px 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand-copy strong {
+  font-size: 1rem;
+  letter-spacing: -0.03em;
+}
+
+.brand-copy span {
+  color: var(--muted);
+  font-size: 0.67rem;
+  font-weight: 600;
+}
+
+.sidebar-profile {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+
+  margin: 30px 0 26px;
+  padding: 14px;
+
+  border: 1px solid var(--border);
+  border-radius: 16px;
+
+  background: var(--surface);
+
+  box-shadow:
+    6px 6px 14px var(--card-shadow-dark),
+    -5px -5px 12px rgba(255, 255, 255, 0.7);
+}
+
+body.dark .sidebar-profile {
+  box-shadow:
+    6px 6px 14px var(--card-shadow-dark),
+    -4px -4px 12px rgba(255, 255, 255, 0.02);
+}
+
+.avatar,
+.mini-avatar {
+  display: grid;
+
+  place-items: center;
+
+  flex-shrink: 0;
+
+  border-radius: 50%;
+
+  color: white;
+
+  background:
+    linear-gradient(
+      145deg,
+      #7c74ff,
+      #4f46e5
+    );
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.sidebar-profile > div:last-child {
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sidebar-profile strong {
+  overflow: hidden;
+
+  font-size: 0.78rem;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.sidebar-profile span {
+  overflow: hidden;
+
+  color: var(--muted);
+
+  font-size: 0.65rem;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.navigation {
+  display: flex;
+  flex-direction: column;
+
+  gap: 5px;
+}
+
+.nav-heading {
+  margin: 5px 10px 8px;
+
+  color: var(--muted);
+
+  font-size: 0.61rem;
+  font-weight: 850;
+  letter-spacing: 0.15em;
+}
+
+.nav-heading:not(:first-child) {
+  margin-top: 23px;
+}
+
+.nav-item {
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  min-height: 46px;
+
+  padding: 0 13px;
+
+  border-radius: 12px;
+
+  color: var(--muted);
+
+  font-size: 0.78rem;
+  font-weight: 700;
+
+  transition:
+    transform 160ms ease,
+    color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.nav-item:hover {
+  color: var(--text);
+
+  background: var(--primary-soft);
+
+  transform: translateX(3px);
+}
+
+.nav-item.active {
+  color: var(--primary);
+
+  background: var(--primary-soft);
+
+  box-shadow:
+    inset 4px 0 0 var(--primary),
+    0 6px 14px rgba(99, 91, 255, 0.07);
+}
+
+.nav-icon {
+  display: grid;
+
+  width: 25px;
+  height: 25px;
+
+  place-items: center;
+
+  flex-shrink: 0;
+
+  border-radius: 8px;
+
+  font-size: 0.86rem;
+}
+
+.nav-item.active .nav-icon {
+  background: rgba(99, 91, 255, 0.12);
+}
+
+.badge {
+  margin-left: auto;
+
+  min-width: 21px;
+  height: 21px;
+
+  display: grid;
+  place-items: center;
+
+  border-radius: 7px;
+
+  color: var(--primary);
+
+  background: var(--primary-soft);
+
+  font-size: 0.61rem;
+  font-weight: 850;
+}
+
+.sidebar-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  margin-top: auto;
+}
+
+.theme-button {
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  min-height: 45px;
+
+  padding: 0 12px;
+
+  border: 1px solid var(--border);
+  border-radius: 12px;
+
+  color: var(--text);
+  background: var(--surface);
+
+  cursor: pointer;
+
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.theme-button:hover,
+.theme-button:focus-visible {
+  transform: translateY(-2px);
+
+  border-color: var(--primary);
+
+  background: var(--primary-soft);
+
+  outline: none;
+}
+
+.theme-symbol {
+  color: var(--primary);
+  font-size: 1rem;
+}
+
+.theme-text {
+  font-size: 0.73rem;
+  font-weight: 700;
+}
+
+.switch-indicator {
+  width: 31px;
+  height: 17px;
+
+  margin-left: auto;
+
+  padding: 2px;
+
+  border-radius: 999px;
+
+  background: var(--border);
+
+  transition: background-color 180ms ease;
+}
+
+.switch-indicator span {
+  display: block;
+
+  width: 13px;
+  height: 13px;
+
+  border-radius: 50%;
+
+  background: var(--surface);
+
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.18);
+
+  transition: transform 180ms ease;
+}
+
+body.dark .switch-indicator {
+  background: var(--primary);
+}
+
+body.dark .switch-indicator span {
+  transform: translateX(14px);
+}
+
+.logout-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  min-height: 45px;
+
+  padding: 0 13px;
+
+  border-radius: 12px;
+
+  color: var(--muted);
+
+  font-size: 0.78rem;
+  font-weight: 700;
+
+  transition:
+    color 160ms ease,
+    background-color 160ms ease;
+}
+
+.logout-link:hover {
+  color: #e05252;
+
+  background: rgba(224, 82, 82, 0.08);
+}
+
+/* =========================
+   Main
+   ========================= */
+
+.content {
+  min-height: 100vh;
+
+  margin-left: 280px;
+
+  padding: 42px clamp(24px, 4vw, 60px);
+}
+
+.content-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  gap: 24px;
+}
+
+.section-label {
+  display: block;
+
+  margin-bottom: 7px;
+
+  color: var(--primary);
+
+  font-size: 0.6rem;
+  font-weight: 850;
+  letter-spacing: 0.16em;
+}
+
+.content-header h1 {
+  font-size: clamp(1.7rem, 4vw, 2.5rem);
+
+  letter-spacing: -0.045em;
+}
+
+.content-header p {
+  margin-top: 8px;
+
+  color: var(--muted);
+
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.notification-button {
+  position: relative;
+
+  display: grid;
+
+  width: 43px;
+  height: 43px;
+
+  place-items: center;
+
+  border: 1px solid var(--border);
+  border-radius: 12px;
+
+  color: var(--text);
+  background: var(--surface);
+
+  cursor: pointer;
+
+  box-shadow:
+    5px 5px 12px var(--card-shadow),
+    -4px -4px 10px rgba(255, 255, 255, 0.7);
+}
+
+body.dark .notification-button {
+  box-shadow:
+    5px 5px 12px var(--card-shadow),
+    -4px -4px 10px rgba(255, 255, 255, 0.02);
+}
+
+.notification-button span {
+  font-size: 1rem;
+}
+
+.notification-button i {
+  position: absolute;
+
+  top: 8px;
+  right: 9px;
+
+  width: 6px;
+  height: 6px;
+
+  border-radius: 50%;
+
+  background: #ef4444;
+
+  box-shadow: 0 0 0 3px var(--surface);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+
+  gap: 18px;
+
+  margin-top: 32px;
+}
+
+.stat-card {
+  position: relative;
+
+  min-height: 140px;
+
+  padding: 22px;
+
+  border: 1px solid var(--border);
+  border-radius: 18px;
+
+  background: var(--surface);
+
+  box-shadow:
+    10px 10px 22px var(--card-shadow),
+    -7px -7px 18px rgba(255, 255, 255, 0.68);
+
+  overflow: hidden;
+}
+
+body.dark .stat-card,
+body.dark .panel {
+  box-shadow:
+    10px 10px 22px var(--card-shadow),
+    -5px -5px 16px rgba(255, 255, 255, 0.018);
+}
+
+.stat-card::after {
+  content: "";
+
+  position: absolute;
+
+  right: -25px;
+  bottom: -35px;
+
+  width: 120px;
+  height: 120px;
+
+  border-radius: 50%;
+
+  background: var(--primary-soft);
+}
+
+.stat-label {
+  color: var(--muted);
+
+  font-size: 0.61rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+}
+
+.stat-card strong {
+  display: block;
+
+  margin-top: 14px;
+
+  font-size: 2rem;
+
+  letter-spacing: -0.05em;
+}
+
+.stat-change {
+  display: inline-block;
+
+  margin-top: 8px;
+
+  font-size: 0.67rem;
+  font-weight: 800;
+}
+
+.stat-change.positive {
+  color: var(--positive);
+}
+
+.dashboard-grid,
+.bottom-grid {
+  display: grid;
+
+  gap: 18px;
+}
+
+.dashboard-grid {
+  grid-template-columns: 1.35fr 1fr;
+
+  margin-top: 18px;
+}
+
+.bottom-grid {
+  grid-template-columns: 1.25fr 0.75fr;
+
+  margin-top: 18px;
+}
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+
+  background: var(--surface);
+
+  box-shadow:
+    10px 10px 22px var(--card-shadow),
+    -7px -7px 18px rgba(255, 255, 255, 0.68);
+
+  overflow: hidden;
+}
+
+.analytics-panel,
+.project-panel,
+.messages-panel {
+  min-height: 350px;
+
+  padding: 24px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  gap: 16px;
+}
+
+.panel-heading h2 {
+  font-size: 1rem;
+
+  letter-spacing: -0.025em;
+}
+
+.period-button {
+  padding: 8px 10px;
+
+  border: 1px solid var(--border);
+  border-radius: 9px;
+
+  color: var(--muted);
+  background: var(--surface);
+
+  font-size: 0.65rem;
+  font-weight: 700;
+
+  cursor: pointer;
+}
+
+.chart {
+  display: flex;
+
+  height: 230px;
+
+  margin-top: 24px;
+}
+
+.chart-labels {
+  width: 35px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  padding-bottom: 21px;
+
+  color: var(--muted);
+
+  font-size: 0.57rem;
+}
+
+.chart-area {
+  position: relative;
+
+  flex: 1;
+
+  border-left: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.grid-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+
+  border-top: 1px dashed var(--border);
+}
+
+.line-1 {
+  top: 0;
+}
+
+.line-2 {
+  top: 25%;
+}
+
+.line-3 {
+  top: 50%;
+}
+
+.line-4 {
+  top: 75%;
+}
+
+.bars {
+  position: absolute;
+  inset: 0;
+
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+
+  gap: 15px;
+
+  padding: 0 15px;
+}
+
+.bar {
+  position: relative;
+
+  width: min(42px, 10%);
+
+  height: var(--height);
+
+  border-radius: 8px 8px 2px 2px;
+
+  background:
+    linear-gradient(
+      180deg,
+      rgba(99, 91, 255, 0.22),
+      rgba(99, 91, 255, 0.06)
+    );
+
+  border: 1px solid rgba(99, 91, 255, 0.09);
+}
+
+.bar.active {
+  background:
+    linear-gradient(
+      180deg,
+      var(--primary),
+      rgba(99, 91, 255, 0.35)
+    );
+
+  box-shadow:
+    0 8px 20px rgba(99, 91, 255, 0.2);
+}
+
+.days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+
+  margin-left: 35px;
+
+  color: var(--muted);
+
+  font-size: 0.58rem;
+
+  text-align: center;
+}
+
+.project-list {
+  display: grid;
+
+  margin-top: 25px;
+}
+
+.project-row {
+  display: flex;
+  align-items: center;
+
+  gap: 12px;
+
+  padding: 15px 0;
+
+  border-bottom: 1px solid var(--border);
+}
+
+.project-row:last-child {
+  border-bottom: 0;
+}
+
+.project-dot {
+  width: 9px;
+  height: 9px;
+
+  border-radius: 50%;
+
+  flex-shrink: 0;
+}
+
+.project-dot.purple {
+  background: var(--purple);
+}
+
+.project-dot.blue {
+  background: var(--blue);
+}
+
+.project-dot.green {
+  background: var(--green);
+}
+
+.project-info {
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+
+  gap: 4px;
+
+  flex: 1;
+}
+
+.project-info strong {
+  overflow: hidden;
+
+  font-size: 0.74rem;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.project-info span {
+  color: var(--muted);
+
+  font-size: 0.6rem;
+}
+
+.progress {
+  color: var(--primary);
+
+  font-size: 0.67rem;
+  font-weight: 850;
+}
+
+.view-link,
+.message-count {
+  color: var(--primary);
+
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.message-row {
+  display: flex;
+  align-items: center;
+
+  gap: 12px;
+
+  padding: 15px 0;
+
+  border-bottom: 1px solid var(--border);
+}
+
+.message-row:last-child {
+  border-bottom: 0;
+}
+
+.mini-avatar {
+  width: 36px;
+  height: 36px;
+
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.message-info {
+  min-width: 0;
+
+  flex: 1;
+
+  display: flex;
+  flex-direction: column;
+
+  gap: 3px;
+}
+
+.message-info strong {
+  font-size: 0.71rem;
+}
+
+.message-info span {
+  overflow: hidden;
+
+  color: var(--muted);
+
+  font-size: 0.6rem;
+
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.message-row time {
+  color: var(--muted);
+
+  font-size: 0.56rem;
+}
+
+.quick-panel {
+  min-height: 250px;
+
+  padding: 28px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  background:
+    radial-gradient(
+      circle at 85% 20%,
+      rgba(99, 91, 255, 0.13),
+      transparent 30%
+    ),
+    var(--surface);
+}
+
+.quick-panel h2 {
+  max-width: 280px;
+
+  margin-top: 7px;
+
+  font-size: clamp(1.4rem, 3vw, 2rem);
+
+  line-height: 1.08;
+
+  letter-spacing: -0.04em;
+}
+
+.quick-panel p {
+  max-width: 310px;
+
+  margin-top: 10px;
+
+  color: var(--muted);
+
+  font-size: 0.75rem;
+  line-height: 1.65;
+}
+
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: max-content;
+
+  min-height: 42px;
+
+  margin-top: 20px;
+  padding: 0 16px;
+
+  border-radius: 10px;
+
+  color: white;
+
+  background: var(--primary);
+
+  font-size: 0.7rem;
+  font-weight: 800;
+
+  box-shadow:
+    0 9px 20px rgba(99, 91, 255, 0.22);
+
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-2px);
+
+  box-shadow:
+    0 13px 25px rgba(99, 91, 255, 0.28);
+
+  outline: none;
+}
+
+/* =========================
+   Mobile
+   ========================= */
+
+.sidebar-toggle {
+  display: none;
+}
+
+.mobile-menu {
+  display: none;
+}
+
+@media (max-width: 1050px) {
+  .sidebar {
+    width: 250px;
+  }
+
+  .content {
+    margin-left: 250px;
+
+    padding-inline: 28px;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bottom-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .mobile-menu {
+    position: fixed;
+    top: 17px;
+    right: 18px;
+    z-index: 150;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    gap: 5px;
+
+    width: 43px;
+    height: 43px;
+
+    border: 1px solid var(--border);
+    border-radius: 12px;
+
+    background: var(--surface);
+
+    cursor: pointer;
+
+    box-shadow:
+      6px 6px 14px var(--card-shadow),
+      -4px -4px 10px rgba(255, 255, 255, 0.68);
+  }
+
+  .mobile-menu span {
+    width: 18px;
+    height: 2px;
+
+    margin: 0 auto;
+
+    border-radius: 999px;
+
+    background: var(--text);
+
+    transition:
+      transform 180ms ease,
+      opacity 180ms ease;
+  }
+
+  .sidebar {
+    transform: translateX(-105%);
+  }
+
+  .sidebar-toggle:checked ~ .sidebar {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle:checked + .mobile-menu span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+
+  .sidebar-toggle:checked + .mobile-menu span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .sidebar-toggle:checked + .mobile-menu span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  .content {
+    margin-left: 0;
+
+    padding:
+      80px
+      20px
+      30px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .content {
+    padding-inline: 15px;
+  }
+
+  .content-header {
+    padding-right: 48px;
+  }
+
+  .content-header h1 {
+    font-size: 1.6rem;
+  }
+
+  .content-header p {
+    font-size: 0.74rem;
+  }
+
+  .analytics-panel,
+  .project-panel,
+  .messages-panel {
+    padding: 18px;
+  }
+
+  .chart {
+    height: 195px;
+  }
+
+  .bars {
+    gap: 8px;
+    padding-inline: 8px;
+  }
+
+  .bar {
+    width: 10%;
+  }
+
+  .panel-heading {
+    align-items: center;
+  }
+
+  .period-button {
+    font-size: 0.58rem;
+  }
+
+  .quick-panel {
+    padding: 22px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  body,
+  .sidebar,
+  .nav-item,
+  .theme-button,
+  .primary-button,
+  .mobile-menu span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue to add a reusable 3D Sidebar component with Dark Mode styling.

This PR introduces a responsive dashboard sidebar with 3D-inspired depth, theme switching, mobile navigation, dashboard panels, and persistent dark-mode preferences.

## Changes

- Added 3D-inspired responsive sidebar
- Added light/dark mode switching
- Added persistent theme preference
- Added mobile sidebar navigation
- Added dashboard statistics and panels
- Added responsive layout
- Added accessible navigation and focus states
- Added reduced-motion support
- Added component documentation

## Testing

- Tested desktop sidebar
- Tested mobile sidebar
- Tested dark/light mode
- Verified theme persistence
- Tested responsive dashboard layout
- Verified reduced-motion behavior
- Verified with `git diff --cached --check`

Closes #78559