### PR TITLE
Fix issue 78601

### DIFF
--- a/submissions/examples/css-breadcrumb-dynamic-neon/README.md
+++ b/submissions/examples/css-breadcrumb-dynamic-neon/README.md
@@ -1,0 +1,2 @@
+# Dynamic Breadcrumb (Neon)
+A dark, cyberpunk-inspired breadcrumb navigation featuring glowing active states and crisp neon hover transitions.

--- a/submissions/examples/css-breadcrumb-dynamic-neon/demo.html
+++ b/submissions/examples/css-breadcrumb-dynamic-neon/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Neon Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="neon-breadcrumb">
+        <a href="#" class="b-item">SYSTEM</a>
+        <a href="#" class="b-item">USERS</a>
+        <a href="#" class="b-item active">ADMIN</a>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-dynamic-neon/style.css
+++ b/submissions/examples/css-breadcrumb-dynamic-neon/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #0a0a0a; --neon: #00ffcc; --neon-dim: rgba(0, 255, 204, 0.2); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; }
+.neon-breadcrumb { display: flex; gap: 0.5rem; background: #111; padding: 1rem 2rem; border-radius: 8px; border: 1px solid #333; }
+.b-item { position: relative; color: #666; text-decoration: none; padding: 0.5rem 1rem; font-weight: bold; letter-spacing: 1px; transition: all 0.3s; }
+.b-item:not(:last-child)::after { content: '/'; position: absolute; right: -10px; color: #333; }
+.b-item:hover { color: var(--neon); text-shadow: 0 0 10px var(--neon); }
+.b-item.active { color: #fff; background: var(--neon-dim); border-radius: 4px; box-shadow: 0 0 15px var(--neon-dim); border: 1px solid var(--neon); text-shadow: 0 0 5px var(--neon); }

--- a/submissions/examples/css-dropdown-floating-pastel/README.md
+++ b/submissions/examples/css-dropdown-floating-pastel/README.md
@@ -1,0 +1,2 @@
+# Floating Dropdown (Pastel)
+A soft, CSS-only floating dropdown menu. It leverages `visibility` and `opacity` alongside a `transform: translateY` to create a smooth, floating entrance animation on hover.

--- a/submissions/examples/css-dropdown-floating-pastel/demo.html
+++ b/submissions/examples/css-dropdown-floating-pastel/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pastel Floating Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dropdown-wrapper">
+        <button class="dropdown-trigger">Select Option ▼</button>
+        <ul class="dropdown-menu">
+            <li><a href="#">🍓 Strawberry</a></li>
+            <li><a href="#">🍋 Lemon</a></li>
+            <li><a href="#">🍇 Grape</a></li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-floating-pastel/style.css
+++ b/submissions/examples/css-dropdown-floating-pastel/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #fef7f2; --primary: #ffd1dc; --text: #594a4e; --menu-bg: #ffffff; --hover: #fcf1f3; }
+body { background: var(--bg); display: flex; justify-content: center; padding-top: 100px; height: 100vh; margin: 0; font-family: 'Segoe UI', Tahoma, sans-serif; }
+.dropdown-wrapper { position: relative; display: inline-block; }
+.dropdown-trigger { background: var(--primary); color: var(--text); border: none; padding: 1rem 2rem; font-size: 1rem; font-weight: 600; border-radius: 99px; cursor: pointer; box-shadow: 0 4px 14px rgba(255, 209, 220, 0.6); transition: transform 0.2s; }
+.dropdown-trigger:hover { transform: translateY(-2px); }
+.dropdown-menu { position: absolute; top: 120%; left: 50%; transform: translateX(-50%) translateY(10px); width: 200px; background: var(--menu-bg); border-radius: 16px; padding: 0.5rem 0; margin: 0; list-style: none; box-shadow: 0 10px 25px rgba(0,0,0,0.05); opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.dropdown-wrapper:hover .dropdown-menu, .dropdown-wrapper:focus-within .dropdown-menu { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }
+.dropdown-menu li a { display: block; padding: 0.75rem 1.5rem; color: var(--text); text-decoration: none; transition: background 0.2s; }
+.dropdown-menu li a:hover { background: var(--hover); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Breadcrumb with Neon styling (#83744) #78601

**Description:**
This PR introduces a dark, cyberpunk-inspired breadcrumb navigation featuring glowing active states and crisp neon hover transitions.

Fixes #78601

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-breadcrumb-dynamic-neon/`
- Utilized an intense neon cyan (`#00ffcc`) for highlights against a harsh black/grey (`#0a0a0a`) background
- Enhanced the `.active` and `:hover` states with `text-shadow` and `box-shadow` to simulate light emitting from the links
