### PR TITLE
Fix issue 78598

### DIFF
--- a/submissions/examples/css-dropdown-floating-pastel/README.md
+++ b/submissions/examples/css-dropdown-floating-pastel/README.md
@@ -1,0 +1,2 @@
+# Floating Dropdown (Pastel)
+A soft, CSS-only floating dropdown menu. It leverages `visibility` and `opacity` alongside a `transform: translateY` to create a smooth, floating entrance animation on hover.

--- a/submissions/examples/css-dropdown-floating-pastel/demo.html
+++ b/submissions/examples/css-dropdown-floating-pastel/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pastel Floating Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dropdown-wrapper">
+        <button class="dropdown-trigger">Select Option ▼</button>
+        <ul class="dropdown-menu">
+            <li><a href="#">🍓 Strawberry</a></li>
+            <li><a href="#">🍋 Lemon</a></li>
+            <li><a href="#">🍇 Grape</a></li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-floating-pastel/style.css
+++ b/submissions/examples/css-dropdown-floating-pastel/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #fef7f2; --primary: #ffd1dc; --text: #594a4e; --menu-bg: #ffffff; --hover: #fcf1f3; }
+body { background: var(--bg); display: flex; justify-content: center; padding-top: 100px; height: 100vh; margin: 0; font-family: 'Segoe UI', Tahoma, sans-serif; }
+.dropdown-wrapper { position: relative; display: inline-block; }
+.dropdown-trigger { background: var(--primary); color: var(--text); border: none; padding: 1rem 2rem; font-size: 1rem; font-weight: 600; border-radius: 99px; cursor: pointer; box-shadow: 0 4px 14px rgba(255, 209, 220, 0.6); transition: transform 0.2s; }
+.dropdown-trigger:hover { transform: translateY(-2px); }
+.dropdown-menu { position: absolute; top: 120%; left: 50%; transform: translateX(-50%) translateY(10px); width: 200px; background: var(--menu-bg); border-radius: 16px; padding: 0.5rem 0; margin: 0; list-style: none; box-shadow: 0 10px 25px rgba(0,0,0,0.05); opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.dropdown-wrapper:hover .dropdown-menu, .dropdown-wrapper:focus-within .dropdown-menu { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }
+.dropdown-menu li a { display: block; padding: 0.75rem 1.5rem; color: var(--text); text-decoration: none; transition: background 0.2s; }
+.dropdown-menu li a:hover { background: var(--hover); }

--- a/submissions/examples/css-dropdown-morphing-dark/README.md
+++ b/submissions/examples/css-dropdown-morphing-dark/README.md
@@ -1,0 +1,2 @@
+# Morphing Dropdown (Dark Mode)
+A highly interactive dropdown where the trigger button smoothly morphs its border-radius and the menu expands via an animated `clip-path: inset()` reveal.

--- a/submissions/examples/css-dropdown-morphing-dark/demo.html
+++ b/submissions/examples/css-dropdown-morphing-dark/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morphing Dark Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="morph-dropdown">
+        <button class="md-trigger">Settings</button>
+        <div class="md-menu">
+            <a href="#">Profile</a>
+            <a href="#">Security</a>
+            <a href="#">Log Out</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-morphing-dark/style.css
+++ b/submissions/examples/css-dropdown-morphing-dark/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #0f172a; --btn-bg: #1e293b; --menu-bg: #0f172a; --text: #f8fafc; --accent: #38bdf8; }
+body { background: var(--bg); display: flex; justify-content: center; padding-top: 100px; height: 100vh; margin: 0; font-family: system-ui; }
+.morph-dropdown { position: relative; }
+.md-trigger { background: var(--btn-bg); color: var(--text); border: 1px solid #334155; padding: 0.75rem 2rem; border-radius: 99px; font-size: 1rem; cursor: pointer; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); z-index: 2; position: relative; }
+.md-menu { position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 100%; min-width: 150px; background: var(--menu-bg); border: 1px solid #334155; border-radius: 16px; opacity: 0; visibility: hidden; z-index: 1; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); padding-top: 3rem; padding-bottom: 0.5rem; display: flex; flex-direction: column; clip-path: inset(0 20% 100% 20% round 99px); }
+.morph-dropdown:hover .md-trigger { border-radius: 16px 16px 0 0; background: var(--menu-bg); border-color: transparent; }
+.morph-dropdown:hover .md-menu { opacity: 1; visibility: visible; clip-path: inset(0 0 0 0 round 16px); box-shadow: 0 10px 25px rgba(0,0,0,0.5); }
+.md-menu a { color: #cbd5e1; text-decoration: none; padding: 0.75rem 1.5rem; transition: color 0.2s, background 0.2s; }
+.md-menu a:hover { color: var(--accent); background: rgba(56, 189, 248, 0.1); }


### PR DESCRIPTION
**Title:** feat: create Morphing Dropdown with Dark Mode styling (#81890) #78598

**Description:**
This PR introduces a highly interactive dropdown where the trigger button smoothly morphs its border-radius and the menu expands via an animated `clip-path: inset()` reveal.

Fixes #78598

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-dropdown-morphing-dark/`
- Animated the pill-shaped button (`border-radius: 99px`) to morph into a flat-bottomed tab (`border-radius: 16px 16px 0 0`) when hovered
- Revealed the absolute positioned menu seamlessly utilizing `clip-path: inset(...)` for a performant, liquid-like masking animation
