### PR TITLE
feat: create CSS-only Tooltip with Minimalist styling (#58559) #78597

### DIFF
--- a/submissions/examples/css-tooltip-css-only-minimalist/README.md
+++ b/submissions/examples/css-tooltip-css-only-minimalist/README.md
@@ -1,0 +1,2 @@
+# CSS-only Tooltip (Minimalist)
+A clean, ultra-lightweight tooltip implementation using only CSS pseudo-elements (`::before` for the caret, `::after` for the content) and data attributes.

--- a/submissions/examples/css-tooltip-css-only-minimalist/demo.html
+++ b/submissions/examples/css-tooltip-css-only-minimalist/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist CSS Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tooltip-container">
+        Hover over this <span class="minimal-tooltip" data-tooltip="This is a pure CSS tooltip!">text</span> to see the tooltip.
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-css-only-minimalist/style.css
+++ b/submissions/examples/css-tooltip-css-only-minimalist/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #ffffff; --text: #333333; --tooltip-bg: #111111; --tooltip-text: #ffffff; }
+body { background: var(--bg); color: var(--text); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.tooltip-container { font-size: 1.2rem; }
+.minimal-tooltip { position: relative; display: inline-block; border-bottom: 1px dashed var(--text); cursor: help; }
+.minimal-tooltip::before, .minimal-tooltip::after { position: absolute; opacity: 0; visibility: hidden; transition: all 0.2s ease-in-out; z-index: 10; }
+.minimal-tooltip::before { content: ''; bottom: 100%; left: 50%; transform: translateX(-50%) translateY(5px); border: 6px solid transparent; border-top-color: var(--tooltip-bg); }
+.minimal-tooltip::after { content: attr(data-tooltip); bottom: calc(100% + 12px); left: 50%; transform: translateX(-50%) translateY(5px); background: var(--tooltip-bg); color: var(--tooltip-text); padding: 0.5rem 0.75rem; border-radius: 4px; font-size: 0.875rem; white-space: nowrap; font-weight: 500; box-shadow: 0 4px 6px rgba(0,0,0,0.1); pointer-events: none; }
+.minimal-tooltip:hover::before, .minimal-tooltip:hover::after { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create CSS-only Tooltip with Minimalist styling (#58559) #78597

**Description:**
This PR introduces a clean, ultra-lightweight tooltip implementation using only CSS pseudo-elements and data attributes.

Fixes #78597

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-css-only-minimalist/`
- Designed the tooltip entirely in CSS using `::before` for the structural caret arrow and `::after` parsing `content: attr(data-tooltip)` for the text box
- Triggered a smooth `opacity` and `translateY` reveal animation on `:hover`
