### PR TITLE
feat: create 3D Progress Bar with Cyberpunk styling (#95820) #78587

### DIFF
--- a/submissions/examples/css-progress-bar-3d-cyberpunk/README.md
+++ b/submissions/examples/css-progress-bar-3d-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# 3D Progress Bar (Cyberpunk)
+A purely CSS-driven 3D isometric progress bar utilizing `perspective`, `transform-style: preserve-3d`, and extruded side panels via pseudo-elements to create a holographic cyberpunk gauge.

--- a/submissions/examples/css-progress-bar-3d-cyberpunk/demo.html
+++ b/submissions/examples/css-progress-bar-3d-cyberpunk/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Cyberpunk Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="p3d-container">
+        <div class="p3d-bar">
+            <div class="p3d-fill" style="width: 70%;"></div>
+        </div>
+        <div class="p3d-glow"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-progress-bar-3d-cyberpunk/style.css
+++ b/submissions/examples/css-progress-bar-3d-cyberpunk/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #000; --bar-bg: #1a1a1a; --neon-cyan: #0ff; --neon-pink: #f0f; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; perspective: 800px; }
+.p3d-container { position: relative; width: 80%; max-width: 500px; transform: rotateX(45deg) rotateZ(-15deg); transform-style: preserve-3d; }
+.p3d-bar { width: 100%; height: 30px; background: var(--bar-bg); border: 2px solid var(--neon-cyan); position: relative; transform-style: preserve-3d; box-shadow: inset 0 0 10px rgba(0,255,255,0.2); }
+.p3d-bar::before { content: ''; position: absolute; top: 100%; left: -2px; width: calc(100% + 4px); height: 20px; background: #055; transform-origin: top; transform: rotateX(-90deg); border-left: 2px solid var(--neon-cyan); border-right: 2px solid var(--neon-cyan); border-bottom: 2px solid var(--neon-cyan); }
+.p3d-fill { height: 100%; background: linear-gradient(90deg, var(--neon-pink), var(--neon-cyan)); box-shadow: 0 0 20px var(--neon-cyan); position: relative; }
+.p3d-glow { position: absolute; top: 150%; left: 0; width: 100%; height: 30px; background: var(--neon-cyan); filter: blur(30px); opacity: 0.5; transform: rotateX(90deg) translateZ(-50px); }


### PR DESCRIPTION
**Title:** feat: create 3D Progress Bar with Cyberpunk styling (#95820) #78587

**Description:**
This PR introduces a purely CSS-driven 3D isometric progress bar utilizing `perspective` and extruded side panels to create a holographic cyberpunk gauge.

Fixes #78587

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-progress-bar-3d-cyberpunk/`
- Configured a 3D isometric layout utilizing `transform: rotateX(45deg) rotateZ(-15deg)` paired with `transform-style: preserve-3d`
- Built physical depth using a precisely hinged `::before` pseudo-element representing the floor of the progress bar, illuminated by a blurred `.p3d-glow` shadow beneath it
