### PR TITLE
docs: add Claymorphism Sidebar accessibility guide

### DIFF
--- a/submissions/docs/claymorphism-sidebar-accessibility/README.md
+++ b/submissions/docs/claymorphism-sidebar-accessibility/README.md
@@ -1,0 +1,217 @@
+# Claymorphism Sidebar – Accessibility Integration
+
+A reusable claymorphism-style sidebar with navigation and accessibility considerations.
+
+## Features
+
+* Claymorphism visual style
+* Semantic HTML structure
+* Keyboard-friendly navigation
+* Visible focus states
+* Accessible sidebar label
+* CSS custom properties
+* Responsive layout
+* Reduced-motion support
+
+## Basic Usage
+
+```html
+<aside
+  class="clay-sidebar"
+  aria-label="Main navigation">
+
+  <nav aria-label="Primary navigation">
+    <ul class="clay-sidebar__menu">
+      <li>
+        <a class="clay-sidebar__link" href="#home">
+          Home
+        </a>
+      </li>
+
+      <li>
+        <a class="clay-sidebar__link" href="#profile">
+          Profile
+        </a>
+      </li>
+    </ul>
+  </nav>
+
+</aside>
+```
+
+## Class Naming Convention
+
+The component uses a base class with BEM-style elements and modifiers.
+
+### Base Class
+
+```text
+.clay-sidebar
+```
+
+Defines the main sidebar component.
+
+### Elements
+
+```text
+.clay-sidebar__header
+.clay-sidebar__close
+.clay-sidebar__menu
+.clay-sidebar__link
+```
+
+These classes represent parts of the sidebar.
+
+### Modifier
+
+```text
+.clay-sidebar__link--active
+```
+
+The modifier indicates the currently active navigation item.
+
+## CSS Custom Properties
+
+The component exposes variables for customization.
+
+```css
+:root {
+  --clay-sidebar-bg: #e8e8e8;
+  --clay-sidebar-text: #222;
+  --clay-sidebar-accent: #7c5cff;
+  --clay-sidebar-radius: 24px;
+  --clay-sidebar-padding: 24px;
+}
+```
+
+You can override them:
+
+```css
+.clay-sidebar {
+  --clay-sidebar-bg: #f0e6ff;
+  --clay-sidebar-text: #302040;
+  --clay-sidebar-accent: #6d3fd1;
+  --clay-sidebar-radius: 20px;
+}
+```
+
+## Accessibility
+
+Use semantic HTML for the sidebar.
+
+```html
+<aside aria-label="Main navigation">
+  <nav aria-label="Primary navigation">
+    ...
+  </nav>
+</aside>
+```
+
+This helps screen-reader users understand the purpose of the navigation.
+
+## Keyboard Navigation
+
+Navigation links should remain normal `<a>` elements so they can be reached using the keyboard.
+
+Users should be able to:
+
+* Press `Tab` to move between interactive elements.
+* Press `Shift + Tab` to move backward.
+* Press `Enter` to activate a focused link.
+* Use the close button when the sidebar is opened as an interactive drawer.
+
+Do not remove the browser's focus indicator.
+
+## Focus Styles
+
+The sidebar provides a visible focus state:
+
+```css
+.clay-sidebar__link:focus-visible {
+  outline: 3px solid var(--clay-sidebar-accent);
+  outline-offset: 2px;
+}
+```
+
+This makes keyboard focus easier to identify.
+
+## Sidebar Toggle Accessibility
+
+If JavaScript is used to open and close the sidebar, the toggle button should expose its state.
+
+```html
+<button
+  type="button"
+  aria-controls="main-sidebar"
+  aria-expanded="false">
+  Open Menu
+</button>
+```
+
+When the sidebar opens:
+
+```html
+aria-expanded="true"
+```
+
+When it closes:
+
+```html
+aria-expanded="false"
+```
+
+The `aria-expanded` value should always match the actual sidebar state.
+
+## Close Button
+
+The close button should have an accessible name.
+
+```html
+<button
+  type="button"
+  aria-label="Close navigation">
+  &times;
+</button>
+```
+
+## Reduced Motion
+
+Respect users who prefer reduced motion.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+```
+
+## Responsive Design
+
+The sidebar should remain usable on smaller screens.
+
+```css
+@media (max-width: 600px) {
+  .clay-sidebar {
+    width: min(280px, 90vw);
+  }
+}
+```
+
+## Usage Checklist
+
+* Use semantic `<aside>` and `<nav>` elements.
+* Give navigation landmarks accessible names.
+* Keep navigation links keyboard accessible.
+* Provide visible `:focus-visible` styles.
+* Keep `aria-expanded` synchronized with the sidebar state.
+* Give icon-only buttons accessible names.
+* Respect `prefers-reduced-motion`.
+* Do not place non-interactive elements in the tab order.
+
+## License
+
+This documentation is provided as part of the EaseMotion-css project.

--- a/submissions/docs/claymorphism-sidebar-accessibility/demo.html
+++ b/submissions/docs/claymorphism-sidebar-accessibility/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claymorphism Sidebar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<button
+ class="sidebar-toggle"
+ type="button"
+ aria-controls="main-sidebar"
+ aria-expanded="false">
+Open Menu </button>
+
+  <aside
+    id="main-sidebar"
+    class="clay-sidebar"
+    aria-label="Main navigation">
+
+```
+<div class="clay-sidebar__header">
+  <h2>Navigation</h2>
+
+  <button
+    class="clay-sidebar__close"
+    type="button"
+    aria-label="Close navigation">
+    &times;
+  </button>
+</div>
+
+<nav aria-label="Primary navigation">
+  <ul class="clay-sidebar__menu">
+    <li>
+      <a class="clay-sidebar__link clay-sidebar__link--active"
+         href="#home">
+        Home
+      </a>
+    </li>
+
+    <li>
+      <a class="clay-sidebar__link" href="#profile">
+        Profile
+      </a>
+    </li>
+
+    <li>
+      <a class="clay-sidebar__link" href="#settings">
+        Settings
+      </a>
+    </li>
+
+    <li>
+      <a class="clay-sidebar__link" href="#help">
+        Help
+      </a>
+    </li>
+  </ul>
+</nav>
+```
+
+  </aside>
+
+</body>
+</html>

--- a/submissions/docs/claymorphism-sidebar-accessibility/style.css
+++ b/submissions/docs/claymorphism-sidebar-accessibility/style.css
@@ -1,0 +1,102 @@
+:root {
+    --clay-sidebar-bg: #e8e8e8;
+    --clay-sidebar-text: #222;
+    --clay-sidebar-accent: #7c5cff;
+    --clay-sidebar-shadow:
+    8px 8px 16px rgba(0, 0, 0, 0.15),
+    -8px -8px 16px rgba(255, 255, 255, 0.8);
+    --clay-sidebar-radius: 24px;
+    --clay-sidebar-padding: 24px;
+    }
+    
+    * {
+      box-sizing: border-box;
+      }
+    
+    body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Arial, sans-serif;
+    background: #f4f4f4;
+    color: var(--clay-sidebar-text);
+    }
+    
+    .clay-sidebar {
+    width: 280px;
+    min-height: 100vh;
+    padding: var(--clay-sidebar-padding);
+    background: var(--clay-sidebar-bg);
+    border-radius: 0 var(--clay-sidebar-radius) var(--clay-sidebar-radius) 0;
+    box-shadow: var(--clay-sidebar-shadow);
+    }
+    
+    .clay-sidebar__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    }
+    
+    .clay-sidebar__header h2 {
+    margin: 0;
+    }
+    
+    .clay-sidebar__close,
+    .sidebar-toggle {
+    border: 0;
+    cursor: pointer;
+    border-radius: 12px;
+    padding: 10px 14px;
+    background: var(--clay-sidebar-bg);
+    color: var(--clay-sidebar-text);
+    box-shadow: var(--clay-sidebar-shadow);
+    }
+    
+    .clay-sidebar__menu {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    }
+    
+    .clay-sidebar__link {
+    display: block;
+    padding: 12px 16px;
+    color: var(--clay-sidebar-text);
+    text-decoration: none;
+    border-radius: 14px;
+    }
+    
+    .clay-sidebar__link:hover,
+    .clay-sidebar__link:focus-visible {
+    outline: 3px solid var(--clay-sidebar-accent);
+    outline-offset: 2px;
+    }
+    
+    .clay-sidebar__link--active {
+    background: var(--clay-sidebar-accent);
+    color: #fff;
+    }
+    
+    .sidebar-toggle {
+    margin: 24px;
+    }
+    
+    @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+    scroll-behavior: auto;
+    transition: none !important;
+    animation: none !important;
+    }
+    }
+    
+    @media (max-width: 600px) {
+    .clay-sidebar {
+    width: min(280px, 90vw);
+    }
+    }
+    


### PR DESCRIPTION
## Description

Added comprehensive documentation for the Claymorphism Sidebar accessibility integration.

## Changes

* Added copy-paste HTML example
* Added CSS styling example
* Documented BEM-style class naming
* Documented modifier classes
* Documented CSS custom property overrides
* Added accessibility guidance
* Added keyboard navigation guidance
* Added focus-state guidance
* Added sidebar toggle accessibility guidance
* Added reduced-motion support
* Added responsive usage guidance

## Testing

* Verified Markdown structure
* Verified HTML structure
* Verified CSS syntax
* Ran `git diff --check`

Closes #81650
