### PR TITLE
feat: create Hover Tab Bar with Material Design styling (#73259) #78705

### DIFF
--- a/submissions/examples/css-tab-bar-hover-material/README.md
+++ b/submissions/examples/css-tab-bar-hover-material/README.md
@@ -1,0 +1,2 @@
+# Hover Tab Bar (Material Design)
+A sleek Material Design 3 inspired tab bar. Icons translate upwards on hover while labels smoothly fade in beneath them, backed by a classic radial highlight.

--- a/submissions/examples/css-tab-bar-hover-material/demo.html
+++ b/submissions/examples/css-tab-bar-hover-material/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Hover Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="material-tab-bar">
+        <a href="#" class="mat-tab active">
+            <i class="ph ph-house"></i>
+            <span>Home</span>
+        </a>
+        <a href="#" class="mat-tab">
+            <i class="ph ph-magnifying-glass"></i>
+            <span>Search</span>
+        </a>
+        <a href="#" class="mat-tab">
+            <i class="ph ph-bell"></i>
+            <span>Alerts</span>
+        </a>
+        <a href="#" class="mat-tab">
+            <i class="ph ph-user"></i>
+            <span>Profile</span>
+        </a>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-hover-material/style.css
+++ b/submissions/examples/css-tab-bar-hover-material/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #f5f5f5; --surface: #ffffff; --primary: #6200ee; --text-muted: #757575; --hover-bg: rgba(98, 0, 238, 0.08); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: flex-end; padding-bottom: 2rem; height: 100vh; margin: 0; font-family: 'Roboto', sans-serif; }
+.material-tab-bar { display: flex; justify-content: space-between; align-items: center; background: var(--surface); width: 100%; max-width: 400px; padding: 0.5rem; border-radius: 2rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); }
+.mat-tab { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.25rem; flex: 1; padding: 0.5rem; color: var(--text-muted); text-decoration: none; border-radius: 1.5rem; transition: background 0.3s, color 0.3s; position: relative; overflow: hidden; }
+.mat-tab i { font-size: 1.5rem; z-index: 2; transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
+.mat-tab span { font-size: 0.75rem; font-weight: 500; z-index: 2; opacity: 0; transform: translateY(10px); transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); position: absolute; bottom: 0.5rem; }
+.mat-tab::before { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(0); width: 100%; padding-bottom: 100%; border-radius: 50%; background: var(--hover-bg); transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1); z-index: 1; }
+.mat-tab:hover::before, .mat-tab.active::before { transform: translate(-50%, -50%) scale(1.5); }
+.mat-tab:hover i, .mat-tab.active i { transform: translateY(-8px); color: var(--primary); }
+.mat-tab:hover span, .mat-tab.active span { opacity: 1; transform: translateY(0); color: var(--primary); }


### PR DESCRIPTION
**Title:** feat: create Hover Tab Bar with Material Design styling (#73259) #78705

**Description:**
This PR introduces a sleek Material Design 3 inspired tab bar. Icons translate upwards on hover while labels smoothly fade in beneath them, backed by a classic radial highlight.

Fixes #78705

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-hover-material/`
- Implemented the classic MD3 pill-shaped surface elevation (`box-shadow: 0 4px 6px -1px rgba(...)`)
- Created a pure CSS expanding radial ripple background using the `::before` pseudo-element expanding from `scale(0)` to `scale(1.5)`
