### PR TITLE
feat: create Parallax Sidebar with Minimalist styling (#84765) #78701

### DIFF
--- a/submissions/examples/css-sidebar-parallax-minimalist/README.md
+++ b/submissions/examples/css-sidebar-parallax-minimalist/README.md
@@ -1,0 +1,2 @@
+# Parallax Sidebar (Minimalist)
+A highly refined, minimalist vertical sidebar. When hovered, the entire sidebar container tilts slightly using 3D perspective while the icons physically lift off the surface (`translateZ`).

--- a/submissions/examples/css-sidebar-parallax-minimalist/demo.html
+++ b/submissions/examples/css-sidebar-parallax-minimalist/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Parallax Sidebar</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="app-layout">
+        <nav class="parallax-sidebar">
+            <div class="sidebar-inner">
+                <a href="#" class="sb-item"><i class="ph ph-squares-four"></i></a>
+                <a href="#" class="sb-item active"><i class="ph ph-chart-line-up"></i></a>
+                <a href="#" class="sb-item"><i class="ph ph-folder"></i></a>
+                <a href="#" class="sb-item"><i class="ph ph-gear"></i></a>
+            </div>
+        </nav>
+        <main class="content">
+            <h1>Dashboard</h1>
+            <p>Hovering over the sidebar shifts the icons via perspective and translateZ, giving a subtle 3D parallax effect against the crisp white background.</p>
+        </main>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-sidebar-parallax-minimalist/style.css
+++ b/submissions/examples/css-sidebar-parallax-minimalist/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #f3f4f6; --surface: #ffffff; --text: #1f2937; --active: #000000; }
+body { background: var(--bg); margin: 0; font-family: system-ui, sans-serif; }
+.app-layout { display: flex; height: 100vh; }
+.parallax-sidebar { width: 80px; background: var(--surface); border-right: 1px solid #e5e7eb; display: flex; justify-content: center; padding: 2rem 0; perspective: 400px; }
+.sidebar-inner { display: flex; flex-direction: column; gap: 2rem; transform-style: preserve-3d; transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1); }
+.parallax-sidebar:hover .sidebar-inner { transform: rotateY(15deg); }
+.sb-item { display: flex; justify-content: center; align-items: center; width: 48px; height: 48px; border-radius: 12px; color: #9ca3af; text-decoration: none; font-size: 1.5rem; transition: all 0.3s ease; transform: translateZ(10px); }
+.sb-item:hover { color: var(--text); background: #f9fafb; transform: translateZ(25px) scale(1.1); box-shadow: -5px 5px 15px rgba(0,0,0,0.05); }
+.sb-item.active { color: var(--surface); background: var(--active); box-shadow: -4px 8px 12px rgba(0,0,0,0.15); transform: translateZ(20px); }
+.content { padding: 3rem; flex: 1; }
+h1 { margin: 0 0 1rem 0; color: var(--text); }
+p { color: #4b5563; max-width: 600px; line-height: 1.6; }


### PR DESCRIPTION
**Title:** feat: create Parallax Sidebar with Minimalist styling (#84765) #78701

**Description:**
This PR introduces a highly refined, minimalist vertical sidebar. When hovered, the entire sidebar container tilts slightly using 3D perspective while the icons physically lift off the surface.

Fixes #78701

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-sidebar-parallax-minimalist/`
- Configured the sidebar wrapper with `perspective: 400px` and `transform-style: preserve-3d`
- Triggered `rotateY(15deg)` on the container upon hover, and bumped up individual `.sb-item` elements on the Z-axis (`translateZ(25px)`) for a clean, paper-like 3D depth effect
