### PR TITLE
feat: create Animated Tooltip with Neumorphism styling (#60764) #78699

### DIFF
--- a/submissions/examples/css-tooltip-animated-neumorphism/README.md
+++ b/submissions/examples/css-tooltip-animated-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Animated Tooltip (Neumorphism)
+A soft, extruded Neumorphic tooltip that pops into place with a satisfying, slightly bouncy cubic-bezier transition when the host button is hovered.

--- a/submissions/examples/css-tooltip-animated-neumorphism/demo.html
+++ b/submissions/examples/css-tooltip-animated-neumorphism/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Animated Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-tooltip-wrapper">
+        <button class="neu-btn">Hover Me</button>
+        <div class="neu-tooltip">Soft UI Details</div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-animated-neumorphism/style.css
+++ b/submissions/examples/css-tooltip-animated-neumorphism/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #e0e5ec; --shadow-light: #ffffff; --shadow-dark: #a3b1c6; --text: #4a5568; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.neu-tooltip-wrapper { position: relative; display: inline-block; }
+.neu-btn { padding: 1rem 2rem; border: none; background: var(--bg); color: var(--text); font-weight: 600; border-radius: 12px; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); cursor: pointer; transition: all 0.2s; outline: none; }
+.neu-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.neu-tooltip { position: absolute; bottom: calc(100% + 15px); left: 50%; transform: translateX(-50%) translateY(15px); background: var(--bg); color: var(--text); padding: 0.75rem 1.25rem; border-radius: 8px; font-size: 0.875rem; font-weight: 500; white-space: nowrap; box-shadow: 4px 4px 10px var(--shadow-dark), -4px -4px 10px var(--shadow-light); opacity: 0; visibility: hidden; transition: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55); border: 1px solid rgba(255,255,255,0.4); }
+/* The little triangle for the tooltip */
+.neu-tooltip::before { content: ''; position: absolute; bottom: -6px; left: 50%; transform: translateX(-50%) rotate(45deg); width: 12px; height: 12px; background: var(--bg); box-shadow: 4px 4px 5px rgba(163, 177, 198, 0.4); z-index: -1; }
+.neu-tooltip-wrapper:hover .neu-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Animated Tooltip with Neumorphism styling (#60764) #78699

**Description:**
This PR introduces a soft, extruded Neumorphic tooltip that pops into place with a satisfying, slightly bouncy cubic-bezier transition when the host button is hovered.

Fixes #78699

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-animated-neumorphism/`
- Constructed dual shadow palettes (`#ffffff` and `#a3b1c6`) over a cool gray base (`#e0e5ec`) for the Neumorphic structure
- Re-calculated the positioning so the Neumorphic tooltip structure and its attached `::before` caret arrow shadow blends perfectly with the soft UI aesthetic
