### PR TITLE
feat: create Animated Carousel with Minimalist styling (#21711) #78676

### DIFF
--- a/submissions/examples/css-carousel-animated-minimalist/README.md
+++ b/submissions/examples/css-carousel-animated-minimalist/README.md
@@ -1,0 +1,2 @@
+# Animated Carousel (Minimalist)
+A sleek, Apple-style 3D coverflow carousel built entirely with CSS radio button state logic, featuring scale and translate transitions.

--- a/submissions/examples/css-carousel-animated-minimalist/demo.html
+++ b/submissions/examples/css-carousel-animated-minimalist/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimal Animated Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="min-carousel">
+        <input type="radio" name="slider" id="s1" checked>
+        <input type="radio" name="slider" id="s2">
+        <input type="radio" name="slider" id="s3">
+        
+        <div class="cards">
+            <label for="s1" id="card1" class="card">
+                <h2>01</h2>
+                <p>Minimalist Design</p>
+            </label>
+            <label for="s2" id="card2" class="card">
+                <h2>02</h2>
+                <p>Pure CSS Logic</p>
+            </label>
+            <label for="s3" id="card3" class="card">
+                <h2>03</h2>
+                <p>Smooth Transitions</p>
+            </label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-animated-minimalist/style.css
+++ b/submissions/examples/css-carousel-animated-minimalist/style.css
@@ -1,0 +1,20 @@
+:root { --bg: #f5f5f7; --card-bg: #ffffff; --text: #1d1d1f; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; overflow: hidden; }
+.min-carousel { width: 100%; max-width: 800px; height: 400px; position: relative; display: flex; justify-content: center; align-items: center; }
+input[type="radio"] { display: none; }
+.cards { position: relative; width: 300px; height: 400px; perspective: 1000px; }
+.card { position: absolute; width: 100%; height: 100%; left: 0; top: 0; background: var(--card-bg); border-radius: 20px; padding: 2rem; box-sizing: border-box; display: flex; flex-direction: column; justify-content: center; align-items: center; box-shadow: 0 10px 30px rgba(0,0,0,0.05); transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.5s; cursor: pointer; text-align: center; color: var(--text); }
+.card h2 { font-size: 4rem; margin: 0 0 1rem 0; font-weight: 300; color: #e5e5e7; }
+.card p { font-size: 1.25rem; margin: 0; font-weight: 500; }
+/* State: Card 1 Selected */
+#s1:checked ~ .cards #card1 { transform: translateX(0) scale(1); opacity: 1; z-index: 3; }
+#s1:checked ~ .cards #card2 { transform: translateX(40%) scale(0.85); opacity: 0.6; z-index: 2; }
+#s1:checked ~ .cards #card3 { transform: translateX(-40%) scale(0.85); opacity: 0.6; z-index: 2; }
+/* State: Card 2 Selected */
+#s2:checked ~ .cards #card2 { transform: translateX(0) scale(1); opacity: 1; z-index: 3; }
+#s2:checked ~ .cards #card3 { transform: translateX(40%) scale(0.85); opacity: 0.6; z-index: 2; }
+#s2:checked ~ .cards #card1 { transform: translateX(-40%) scale(0.85); opacity: 0.6; z-index: 2; }
+/* State: Card 3 Selected */
+#s3:checked ~ .cards #card3 { transform: translateX(0) scale(1); opacity: 1; z-index: 3; }
+#s3:checked ~ .cards #card1 { transform: translateX(40%) scale(0.85); opacity: 0.6; z-index: 2; }
+#s3:checked ~ .cards #card2 { transform: translateX(-40%) scale(0.85); opacity: 0.6; z-index: 2; }


### PR DESCRIPTION
**Title:** feat: create Animated Carousel with Minimalist styling (#21711) #78676

**Description:**
This PR introduces a sleek, Apple-style 3D coverflow carousel built entirely with CSS radio button state logic, featuring scale and translate transitions.

Fixes #78676

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-animated-minimalist/`
- Engineered state management purely via `<input type="radio">` tags and the `~` general sibling combinator
- Styled smooth 3D offsets where inactive side cards step back via `scale(0.85)` and `translateX(40%)` while reducing opacity to guide user focus to the center card
