### PR TITLE
feat: create Floating Input Field with Neon styling (#82269) #78675

### DIFF
--- a/submissions/examples/css-input-floating-neon/README.md
+++ b/submissions/examples/css-input-floating-neon/README.md
@@ -1,0 +1,2 @@
+# Floating Input Field (Neon)
+A classic Material Design floating label input but heavily stylized with a dark Cyberpunk/Neon pink aesthetic and glowing underline animations.

--- a/submissions/examples/css-input-floating-neon/demo.html
+++ b/submissions/examples/css-input-floating-neon/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Neon Input</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neon-input-group">
+        <input type="text" id="neon-user" class="neon-input" placeholder=" " required>
+        <label for="neon-user" class="neon-label">Username</label>
+        <div class="neon-border"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-input-floating-neon/style.css
+++ b/submissions/examples/css-input-floating-neon/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #050505; --neon: #ff00ff; --neon-dim: rgba(255, 0, 255, 0.2); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; }
+.neon-input-group { position: relative; width: 300px; margin-top: 2rem; }
+.neon-input { width: 100%; padding: 10px 0; font-size: 1.2rem; color: #fff; background: transparent; border: none; outline: none; border-bottom: 2px solid #333; z-index: 2; position: relative; }
+.neon-label { position: absolute; top: 10px; left: 0; font-size: 1.2rem; color: #666; pointer-events: none; transition: 0.3s ease all; z-index: 1; }
+.neon-border { position: absolute; bottom: 0; left: 0; height: 2px; width: 0; background: var(--neon); transition: 0.3s ease all; box-shadow: 0 0 10px var(--neon); z-index: 3; }
+.neon-input:focus ~ .neon-label, .neon-input:not(:placeholder-shown) ~ .neon-label { top: -20px; font-size: 0.9rem; color: var(--neon); text-shadow: 0 0 5px var(--neon); }
+.neon-input:focus ~ .neon-border { width: 100%; }


### PR DESCRIPTION
**Title:** feat: create Floating Input Field with Neon styling (#82269) #78675

**Description:**
This PR introduces a classic Material Design floating label input but heavily stylized with a dark Cyberpunk/Neon pink aesthetic and glowing underline animations.

Fixes #78675

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-input-floating-neon/`
- Animated the label upward and reduced its font size when the input state is `:focus` or `:not(:placeholder-shown)`
- Paired the floating action with an absolute bottom border that scales its `width` from 0 to 100% carrying an intense `text-shadow` neon glow (`#ff00ff`)
