### PR TITLE
feat: create Responsive Modal with Glassmorphism styling (#71123) #78673

### DIFF
--- a/submissions/examples/css-modal-responsive-glassmorphism/README.md
+++ b/submissions/examples/css-modal-responsive-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Responsive Modal (Glassmorphism)
+A fully responsive, pure CSS modal utilizing a checkbox hack for state management and an elegant backdrop-filter to blur the surrounding context.

--- a/submissions/examples/css-modal-responsive-glassmorphism/demo.html
+++ b/submissions/examples/css-modal-responsive-glassmorphism/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass Responsive Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="bg-scene">
+        <label for="modal-toggle" class="open-btn">Open Glass Modal</label>
+        
+        <input type="checkbox" id="modal-toggle" class="modal-toggle">
+        <div class="modal-backdrop">
+            <div class="glass-modal">
+                <label for="modal-toggle" class="close-btn">&times;</label>
+                <h2>Glassmorphism</h2>
+                <p>This modal scales beautifully on mobile devices and utilizes a backdrop filter to blur the vibrant background beneath it.</p>
+                <button class="action-btn">Accept</button>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-modal-responsive-glassmorphism/style.css
+++ b/submissions/examples/css-modal-responsive-glassmorphism/style.css
@@ -1,0 +1,17 @@
+:root { --glass: rgba(255,255,255,0.2); --border: rgba(255,255,255,0.3); }
+body { margin: 0; font-family: system-ui, sans-serif; }
+.bg-scene { min-height: 100vh; background: linear-gradient(45deg, #a18cd1 0%, #fbc2eb 100%); display: flex; justify-content: center; align-items: center; padding: 1rem; }
+.open-btn { background: #fff; color: #a18cd1; padding: 1rem 2rem; border-radius: 99px; font-weight: bold; cursor: pointer; box-shadow: 0 4px 15px rgba(0,0,0,0.1); transition: transform 0.2s; }
+.open-btn:hover { transform: translateY(-2px); }
+.modal-toggle { display: none; }
+.modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.2); display: flex; justify-content: center; align-items: center; opacity: 0; pointer-events: none; transition: opacity 0.3s; padding: 1rem; z-index: 100; }
+.glass-modal { background: var(--glass); backdrop-filter: blur(15px); -webkit-backdrop-filter: blur(15px); border: 1px solid var(--border); border-radius: 1.5rem; padding: 2.5rem; width: 100%; max-width: 500px; color: #fff; position: relative; transform: translateY(50px); transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25); }
+.close-btn { position: absolute; top: 1rem; right: 1.5rem; font-size: 2rem; cursor: pointer; opacity: 0.7; transition: opacity 0.2s; }
+.close-btn:hover { opacity: 1; }
+.glass-modal h2 { margin: 0 0 1rem 0; font-size: 1.75rem; text-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.glass-modal p { line-height: 1.6; margin-bottom: 2rem; opacity: 0.9; }
+.action-btn { width: 100%; background: #fff; color: #a18cd1; border: none; padding: 1rem; border-radius: 0.75rem; font-size: 1rem; font-weight: bold; cursor: pointer; transition: background 0.2s; }
+.action-btn:hover { background: #f8f9fa; }
+.modal-toggle:checked ~ .modal-backdrop { opacity: 1; pointer-events: auto; }
+.modal-toggle:checked ~ .modal-backdrop .glass-modal { transform: translateY(0); }
+@media (max-width: 480px) { .glass-modal { padding: 1.5rem; } }


### PR DESCRIPTION
**Title:** feat: create Responsive Modal with Glassmorphism styling (#71123) #78673

**Description:**
This PR introduces a fully responsive, pure CSS modal utilizing a checkbox hack for state management and an elegant backdrop-filter to blur the surrounding context.

Fixes #78673

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-modal-responsive-glassmorphism/`
- Managed open/close states natively via an invisible `<input type="checkbox">` toggled by styled `<label>` elements acting as buttons
- Applied deep 15px `backdrop-filter` blurring to the modal card on top of a fixed `rgba(0,0,0,0.2)` semi-transparent overlay backdrop
