### PR TITLE
feat: create Hover Slider with Neumorphism styling (#51433) #78640

### DIFF
--- a/submissions/examples/css-slider-hover-neumorphism/README.md
+++ b/submissions/examples/css-slider-hover-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Hover Slider (Neumorphism)
+A soft UI range slider. The track is inset into the surface, while the thumb sits atop it, elevating and scaling up dynamically on hover.

--- a/submissions/examples/css-slider-hover-neumorphism/demo.html
+++ b/submissions/examples/css-slider-hover-neumorphism/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Hover Slider</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-slider-container">
+        <input type="range" min="0" max="100" value="50" class="neu-slider">
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-slider-hover-neumorphism/style.css
+++ b/submissions/examples/css-slider-hover-neumorphism/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --accent: #4a90e2; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.neu-slider-container { padding: 2rem 3rem; border-radius: 20px; box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light); }
+.neu-slider { -webkit-appearance: none; width: 250px; height: 12px; border-radius: 10px; background: var(--bg); box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); outline: none; padding: 0; margin: 0; transition: box-shadow 0.3s ease; }
+.neu-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 28px; height: 28px; border-radius: 50%; background: var(--bg); box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); cursor: pointer; transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1); border: 2px solid transparent; }
+.neu-slider:hover::-webkit-slider-thumb { box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); border-color: rgba(255,255,255,0.5); transform: scale(1.1); }
+.neu-slider:active::-webkit-slider-thumb { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); border-color: var(--accent); }


### PR DESCRIPTION
**Title:** feat: create Hover Slider with Neumorphism styling (#51433) #78640

**Description:**
This PR introduces a soft UI range slider. The track is inset into the surface, while the thumb sits atop it, elevating and scaling up dynamically on hover.

Fixes #78640

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-slider-hover-neumorphism/`
- Designed the Neumorphic slider track with deep dual inset shadows (`box-shadow: inset 4px...`)
- Styled the custom `::-webkit-slider-thumb` to extrude upwards with outer drop shadows, which dynamically transition to a larger size and subtle border glow on `:hover`
