### PR TITLE
feat: create Parallax Loader with Material Design styling (#41244) #78623

### DIFF
--- a/submissions/examples/css-loader-parallax-material/README.md
+++ b/submissions/examples/css-loader-parallax-material/README.md
@@ -1,0 +1,2 @@
+# Parallax Loader (Material Design)
+A 3D stacked loader rotating on a tilted axis. Features Material Design colors and a pulsing animation that morphs the layers from rounded squares to circles.

--- a/submissions/examples/css-loader-parallax-material/demo.html
+++ b/submissions/examples/css-loader-parallax-material/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Parallax Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="mat-parallax-loader">
+        <div class="mat-layer layer-1"></div>
+        <div class="mat-layer layer-2"></div>
+        <div class="mat-layer layer-3"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-loader-parallax-material/style.css
+++ b/submissions/examples/css-loader-parallax-material/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #fafafa; --p1: #6200ea; --p2: #03dac6; --p3: #b00020; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; perspective: 800px; }
+.mat-parallax-loader { position: relative; width: 120px; height: 120px; transform-style: preserve-3d; animation: spin-3d 4s linear infinite; }
+.mat-layer { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border-radius: 12px; box-shadow: 0 4px 10px rgba(0,0,0,0.15); opacity: 0.8; }
+.layer-1 { background: var(--p1); transform: translateZ(-30px) rotate45deg; animation: pulse-mat 2s infinite alternate; }
+.layer-2 { background: var(--p2); transform: translateZ(0px) rotate(45deg); animation: pulse-mat 2s infinite alternate 0.6s; }
+.layer-3 { background: var(--p3); transform: translateZ(30px) rotate(45deg); animation: pulse-mat 2s infinite alternate 1.2s; }
+@keyframes spin-3d { 0% { transform: rotateX(60deg) rotateZ(0deg); } 100% { transform: rotateX(60deg) rotateZ(360deg); } }
+@keyframes pulse-mat { 0% { border-radius: 12px; transform: scale(0.8) translateZ(calc(var(--z)*1px)) rotate(45deg); } 100% { border-radius: 50%; transform: scale(1.1) translateZ(calc(var(--z)*1.5px)) rotate(45deg); } }


### PR DESCRIPTION


**Title:** feat: create Parallax Loader with Material Design styling (#41244) #78623

**Description:**
This PR introduces a 3D stacked loader rotating on a tilted axis. Features Material Design colors and a pulsing animation that morphs the layers from rounded squares to circles.

Fixes #78623

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-loader-parallax-material/`
- Implemented three absolute layers utilizing classic MD colors (`#6200ea`, `#03dac6`, `#b00020`)
- Configured a complex 3D CSS animation spinning the container via `rotateX(60deg) rotateZ(...)` while the individual layers pulse and morph their `border-radius` independently
