### PR TITLE
feat: create Dynamic Tooltip with Minimalist styling (#58751) #78605

### DIFF
--- a/submissions/examples/css-tooltip-dynamic-minimalist/README.md
+++ b/submissions/examples/css-tooltip-dynamic-minimalist/README.md
@@ -1,0 +1,2 @@
+# Dynamic Tooltip (Minimalist)
+A highly minimal, ultra-clean tooltip that utilizes a dynamic spring-like `cubic-bezier` scaling animation to pop out directly from the target element.

--- a/submissions/examples/css-tooltip-dynamic-minimalist/demo.html
+++ b/submissions/examples/css-tooltip-dynamic-minimalist/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Minimalist Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dyn-tooltip-container">
+        <button class="dyn-target" data-info="System optimal. No errors detected.">Status Check</button>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-dynamic-minimalist/style.css
+++ b/submissions/examples/css-tooltip-dynamic-minimalist/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #ffffff; --text: #111111; --tooltip-bg: #f3f4f6; --tooltip-text: #374151; --border: #e5e7eb; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.dyn-tooltip-container { position: relative; }
+.dyn-target { padding: 0.75rem 1.5rem; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; font-size: 1rem; transition: background 0.2s; }
+.dyn-target:hover { background: #fafafa; }
+.dyn-target::after { content: attr(data-info); position: absolute; bottom: 130%; left: 50%; transform: translateX(-50%) scale(0.8); background: var(--tooltip-bg); color: var(--tooltip-text); padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.875rem; white-space: nowrap; opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1); border: 1px solid var(--border); pointer-events: none; transform-origin: bottom center; }
+.dyn-target:hover::after { opacity: 1; visibility: visible; transform: translateX(-50%) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Tooltip with Minimalist styling (#58751) #78605

**Description:**
This PR introduces a highly minimal, ultra-clean tooltip that utilizes a dynamic spring-like `cubic-bezier` scaling animation to pop out directly from the target element.

Fixes #78605

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-dynamic-minimalist/`
- Engineered a lightweight tooltip utilizing only a `::after` pseudo-element reading from `data-info="..."`
- Applied a satisfying bouncy transition using `transform: scale(...)` with `transform-origin: bottom center` to anchor the pop-up effect naturally to the button
