### PR TITLE
docs: document animated button usage and composition

### DIFF
--- a/submissions/docs/animated-button-usage/README.md
+++ b/submissions/docs/animated-button-usage/README.md
@@ -1,0 +1,57 @@
+# Animated Button — Usage Documentation
+
+## What this documents
+This is a usage guide for EaseMotion CSS's animated button system: the base `ease-btn` class combined with color, shape, and motion modifier classes. This is documentation for the framework's existing button utilities, not a new component.
+
+## Quick Start
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/dist/easemotion.min.css">
+
+<button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-fade-in ease-delay-200">
+  Get Started →
+</button>
+```
+
+## Composition guide
+
+| Step | Class | What it does |
+|---|---|---|
+| 1 | `ease-btn` | **Required.** Base button styling (padding, font, border-radius) |
+| 2 | `ease-btn-primary` | Accent color fill (optional — omit for the neutral default) |
+| 3 | `ease-btn-pill` | Fully rounded, pill-shaped corners |
+| 4 | `ease-hover-grow` | Scales up slightly on hover |
+| 4 | `ease-hover-lift` | Lifts up with a shadow on hover (alternative to grow) |
+| 5 | `ease-fade-in` | Fades the button in on page load/scroll into view |
+| 5 | `ease-slide-up` | Slides up while fading in (alternative entrance to fade-in) |
+| 6 | `ease-delay-100` / `200` / `300` | Staggers the entrance animation start, useful when multiple animated elements appear together |
+
+Classes are additive — stack as many as needed. Only `ease-btn` is required; every other class is an optional modifier.
+
+## Common patterns
+
+**Simple primary CTA:**
+```html
+<button class="ease-btn ease-btn-primary">Submit</button>
+```
+
+**Pill-shaped hero CTA with entrance animation:**
+```html
+<button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-fade-in">
+  Get Started →
+</button>
+```
+
+**Staggered button group** (each button enters slightly after the previous):
+```html
+<button class="ease-btn ease-fade-in ease-delay-100">One</button>
+<button class="ease-btn ease-fade-in ease-delay-200">Two</button>
+<button class="ease-btn ease-fade-in ease-delay-300">Three</button>
+```
+
+## Accessibility
+All entrance and hover animations respect `prefers-reduced-motion` — motion-sensitive users see buttons in their final state immediately, with hover feedback limited to non-motion cues (color/shadow) where the framework's core styles apply this.
+
+## Files
+- `demo.html` — interactive usage guide showing each composition step live, with copyable code snippets
+- `style.css` — demo page styling, plus minimal illustrative versions of the documented classes (the real implementations ship in EaseMotion's core `easemotion.css`)
+- `README.md` — this file

--- a/submissions/docs/animated-button-usage/demo.html
+++ b/submissions/docs/animated-button-usage/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EaseMotion CSS — Animated Button Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <main class="demo-wrap">
+    <h1>Animated Button — Usage Guide</h1>
+    <p class="intro">
+      EaseMotion CSS ships a composable button system: a base <code>ease-btn</code>
+      class combined with color, shape, and animation modifier classes. Every
+      class name reads like plain English — no memorization required.
+    </p>
+
+    <section>
+      <h2>1. Base button</h2>
+      <p>Every animated button starts with the base <code>ease-btn</code> class.</p>
+      <button class="ease-btn">Default Button</button>
+      <pre><code>&lt;button class="ease-btn"&gt;Default Button&lt;/button&gt;</code></pre>
+    </section>
+
+    <section>
+      <h2>2. Color variants</h2>
+      <p>Add <code>ease-btn-primary</code> for the accent-colored variant.</p>
+      <button class="ease-btn ease-btn-primary">Primary Button</button>
+      <pre><code>&lt;button class="ease-btn ease-btn-primary"&gt;Primary Button&lt;/button&gt;</code></pre>
+    </section>
+
+    <section>
+      <h2>3. Shape modifiers</h2>
+      <p>Stack <code>ease-btn-pill</code> for fully rounded corners.</p>
+      <button class="ease-btn ease-btn-primary ease-btn-pill">Pill Button</button>
+      <pre><code>&lt;button class="ease-btn ease-btn-primary ease-btn-pill"&gt;Pill Button&lt;/button&gt;</code></pre>
+    </section>
+
+    <section>
+      <h2>4. Hover animations</h2>
+      <p>Layer a hover-motion class to make the button react on hover.</p>
+      <div class="btn-row">
+        <button class="ease-btn ease-btn-primary ease-hover-grow">Hover Grow</button>
+        <button class="ease-btn ease-btn-primary ease-hover-lift">Hover Lift</button>
+      </div>
+      <pre><code>&lt;button class="ease-btn ease-btn-primary ease-hover-grow"&gt;Hover Grow&lt;/button&gt;
+&lt;button class="ease-btn ease-btn-primary ease-hover-lift"&gt;Hover Lift&lt;/button&gt;</code></pre>
+    </section>
+
+    <section>
+      <h2>5. Entrance animation</h2>
+      <p>
+        Add <code>ease-fade-in</code> (or <code>ease-slide-up</code>) so the button
+        animates in on page load, optionally combined with a
+        <code>ease-delay-*</code> class to stagger it after other elements.
+      </p>
+      <button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-fade-in ease-delay-200">
+        Get Started →
+      </button>
+      <pre><code>&lt;button class="ease-btn ease-btn-primary ease-btn-pill ease-hover-grow ease-fade-in ease-delay-200"&gt;
+  Get Started →
+&lt;/button&gt;</code></pre>
+    </section>
+
+    <section>
+      <h2>Full composition reference</h2>
+      <table>
+        <thead>
+          <tr><th>Class</th><th>Purpose</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>ease-btn</code></td><td>Base button styling (required)</td></tr>
+          <tr><td><code>ease-btn-primary</code></td><td>Accent color variant</td></tr>
+          <tr><td><code>ease-btn-pill</code></td><td>Fully rounded corners</td></tr>
+          <tr><td><code>ease-hover-grow</code></td><td>Scales up slightly on hover</td></tr>
+          <tr><td><code>ease-hover-lift</code></td><td>Lifts with shadow on hover</td></tr>
+          <tr><td><code>ease-fade-in</code></td><td>Fades in on load/scroll into view</td></tr>
+          <tr><td><code>ease-slide-up</code></td><td>Slides up while fading in on load</td></tr>
+          <tr><td><code>ease-delay-100</code> / <code>200</code> / <code>300</code></td><td>Staggers the entrance animation start time</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/animated-button-usage/style.css
+++ b/submissions/docs/animated-button-usage/style.css
@@ -1,0 +1,140 @@
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #f5f7fa;
+  font-family: system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.demo-wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 50px 24px 80px;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 10px;
+}
+
+.intro {
+  color: #94a3b8;
+  margin-bottom: 40px;
+}
+
+section {
+  margin-bottom: 40px;
+  padding-bottom: 30px;
+  border-bottom: 1px solid #1e293b;
+}
+
+h2 {
+  font-size: 1.1rem;
+  margin-bottom: 8px;
+}
+
+section p {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+code {
+  background: rgba(56, 189, 248, 0.1);
+  color: #38bdf8;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+pre {
+  background: #14141c;
+  border: 1px solid #23273a;
+  border-radius: 10px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  margin-top: 16px;
+}
+
+pre code {
+  background: none;
+  color: #cbd5e1;
+  padding: 0;
+}
+
+.btn-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid #1e293b;
+}
+
+th {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+/* Minimal illustrative styling for the ease-btn family, since this demo
+   documents usage rather than redefining the framework's own core CSS
+   (which ships separately as easemotion.css) */
+.ease-btn {
+  display: inline-block;
+  padding: 10px 22px;
+  border: 1px solid #334155;
+  background: #1e293b;
+  color: #f5f7fa;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.ease-btn-primary {
+  background: #6366f1;
+  border-color: #6366f1;
+}
+
+.ease-btn-pill {
+  border-radius: 999px;
+}
+
+.ease-hover-grow:hover {
+  transform: scale(1.06);
+}
+
+.ease-hover-lift:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.35);
+}
+
+@keyframes ease-fade-in-anim {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.ease-fade-in {
+  animation: ease-fade-in-anim 0.6s ease forwards;
+}
+
+.ease-delay-100 { animation-delay: 0.1s; }
+.ease-delay-200 { animation-delay: 0.2s; }
+.ease-delay-300 { animation-delay: 0.3s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-btn, .ease-fade-in {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #78712

## Pull Request Description
Adds usage documentation for EaseMotion CSS's animated button system — the base `ease-btn` class combined with its color, shape, hover-animation, and entrance-animation modifier classes (`ease-btn-primary`, `ease-btn-pill`, `ease-hover-grow`, `ease-hover-lift`, `ease-fade-in`, `ease-slide-up`, `ease-delay-*`). Includes an interactive step-by-step demo with copyable code snippets and a full class-reference table.

---

## Type of Change
- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist
- [x] All changes are inside `submissions/` (`submissions/docs/animated-button-usage/`)
- [x] Includes `demo.html` — interactive usage guide
- [x] Includes `style.css` — demo styling
- [x] Includes `README.md` — full documentation
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**

---

## What this documents
This documents EaseMotion's existing animated button classes (confirmed against the framework's own README and public demo site) rather than proposing a new component: `ease-btn`, `ease-btn-primary`, `ease-btn-pill`, `ease-hover-grow`, `ease-hover-lift`, `ease-fade-in`, `ease-slide-up`, and the `ease-delay-*` stagger utilities.

**Content included:**
- A composition guide showing how each class layers onto the base `ease-btn`
- Live, working examples for each step (base → color → shape → hover → entrance)
- A full class-reference table
- Common real-world patterns (simple CTA, pill hero CTA, staggered button groups)
- Accessibility notes on `prefers-reduced-motion`

---

## Demo
- [x] Demo added (`demo.html` — interactive step-by-step guide with copyable snippets)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
`style.css` includes minimal illustrative versions of the documented `ease-*` classes so the demo renders correctly standalone without a dependency on the core bundle — the README notes these are illustrative only, since the real implementations ship in `easemotion.css`. Happy to adjust if you'd prefer the demo to link directly to the CDN bundle instead.