### PR TITLE
docs: add advanced Pastel Pagination guide

### DIFF
--- a/submissions/docs/pastel-pagination-advanced/README.md
+++ b/submissions/docs/pastel-pagination-advanced/README.md
@@ -1,0 +1,222 @@
+# Pastel Pagination — Advanced Styling
+
+A customizable pastel-style pagination component with responsive design, CSS variable overrides, keyboard-friendly focus states, and accessibility support.
+
+## Features
+
+* Pastel visual design
+* Advanced CSS customization
+* Active and disabled states
+* Previous and next controls
+* Responsive layout
+* Keyboard focus support
+* Reduced-motion support
+* CSS custom properties
+* Semantic pagination navigation
+
+## Basic HTML
+
+```html
+<nav
+  class="pastel-pagination"
+  aria-label="Pagination"
+>
+  <a class="pastel-pagination__item" href="#">1</a>
+
+  <a
+    class="pastel-pagination__item pastel-pagination__item--active"
+    href="#"
+    aria-current="page"
+  >
+    2
+  </a>
+
+  <a class="pastel-pagination__item" href="#">3</a>
+</nav>
+```
+
+## Class Naming Convention
+
+The component follows a block-element-modifier naming pattern.
+
+### Block
+
+```text
+pastel-pagination
+```
+
+The main pagination container.
+
+### Element
+
+```text
+pastel-pagination__item
+```
+
+Represents an individual pagination control.
+
+### Modifiers
+
+```text
+pastel-pagination__item--active
+pastel-pagination__item--disabled
+pastel-pagination__item--previous
+pastel-pagination__item--next
+pastel-pagination--rounded
+```
+
+Modifiers change the appearance or behavior of the component.
+
+## Advanced Styling
+
+The rounded modifier can be added to the pagination container:
+
+```html
+<nav class="pastel-pagination pastel-pagination--rounded">
+```
+
+This changes the pagination items to a pill-shaped appearance.
+
+## CSS Variable Overrides
+
+The component can be customized using CSS custom properties.
+
+```css
+.pastel-pagination {
+  --pagination-bg: #f0f8ff;
+  --pagination-text: #4a5568;
+  --pagination-hover: #d9f0ff;
+  --pagination-active: #7db7e8;
+  --pagination-active-text: #ffffff;
+  --pagination-border: #b9d9f2;
+  --pagination-radius: 16px;
+  --pagination-gap: 10px;
+}
+```
+
+### Available Variables
+
+| Variable                   | Purpose                |
+| -------------------------- | ---------------------- |
+| `--pagination-bg`          | Background color       |
+| `--pagination-text`        | Text color             |
+| `--pagination-hover`       | Hover background       |
+| `--pagination-active`      | Active page background |
+| `--pagination-active-text` | Active page text       |
+| `--pagination-border`      | Border color           |
+| `--pagination-shadow`      | Item shadow            |
+| `--pagination-radius`      | Border radius          |
+| `--pagination-gap`         | Space between items    |
+
+## Accessibility
+
+Use a semantic `<nav>` element with an accessible label:
+
+```html
+<nav aria-label="Pagination">
+```
+
+The current page should use:
+
+```html
+aria-current="page"
+```
+
+Example:
+
+```html
+<a
+  class="pastel-pagination__item pastel-pagination__item--active"
+  href="#"
+  aria-current="page"
+>
+  2
+</a>
+```
+
+Previous and next controls should have accessible names:
+
+```html
+<a
+  class="pastel-pagination__item pastel-pagination__item--previous"
+  href="#"
+  aria-label="Previous page"
+>
+  &laquo;
+</a>
+```
+
+## Keyboard Interaction
+
+Pagination links are naturally keyboard accessible because they use `<a>` elements.
+
+Users can:
+
+* Press `Tab` to move between pagination controls.
+* Press `Shift + Tab` to move backward.
+* Press `Enter` to activate a focused link.
+
+The `:focus-visible` style provides a visible focus indicator.
+
+```css
+.pastel-pagination__item:focus-visible {
+  outline: 3px solid #9b7bb5;
+  outline-offset: 3px;
+}
+```
+
+## Reduced Motion
+
+The component respects users who prefer reduced motion:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .pastel-pagination__item {
+    transition: none;
+  }
+}
+```
+
+## Responsive Design
+
+On smaller screens, pagination controls become smaller while remaining usable.
+
+```css
+@media (max-width: 600px) {
+  .pastel-pagination__item {
+    min-width: 36px;
+    height: 36px;
+  }
+}
+```
+
+## Recommended Structure
+
+```text
+pastel-pagination-advanced/
+├── index.html
+├── style.css
+└── README.md
+```
+
+## Usage
+
+1. Copy `index.html`.
+2. Copy `style.css`.
+3. Link the stylesheet in your HTML.
+4. Add the pagination markup.
+5. Customize the CSS variables as required.
+
+## Accessibility Checklist
+
+* Use `<nav>` for pagination navigation.
+* Provide an `aria-label`.
+* Mark the current page with `aria-current="page"`.
+* Give previous/next controls accessible labels.
+* Keep visible keyboard focus indicators.
+* Avoid removing focus outlines.
+* Respect `prefers-reduced-motion`.
+
+## Browser Support
+
+The component uses standard HTML and CSS features and works in modern browsers.

--- a/submissions/docs/pastel-pagination-advanced/demo.html
+++ b/submissions/docs/pastel-pagination-advanced/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pastel Pagination - Advanced Styling</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <main class="demo">
+    <h1>Pastel Pagination</h1>
+    <p>Advanced styling and customization example.</p>
+
+    <nav
+      class="pastel-pagination pastel-pagination--rounded"
+      aria-label="Pagination"
+    >
+      <a
+        class="pastel-pagination__item pastel-pagination__item--previous"
+        href="#"
+        aria-label="Previous page"
+      >
+        &laquo;
+      </a>
+
+      <a class="pastel-pagination__item" href="#">1</a>
+
+      <a
+        class="pastel-pagination__item pastel-pagination__item--active"
+        href="#"
+        aria-current="page"
+      >
+        2
+      </a>
+
+      <a class="pastel-pagination__item" href="#">3</a>
+      <a class="pastel-pagination__item" href="#">4</a>
+
+      <span class="pastel-pagination__item pastel-pagination__item--disabled">
+        ...
+      </span>
+
+      <a class="pastel-pagination__item" href="#">10</a>
+
+      <a
+        class="pastel-pagination__item pastel-pagination__item--next"
+        href="#"
+        aria-label="Next page"
+      >
+        &raquo;
+      </a>
+    </nav>
+  </main>
+
+</body>
+</html>

--- a/submissions/docs/pastel-pagination-advanced/style.css
+++ b/submissions/docs/pastel-pagination-advanced/style.css
@@ -1,0 +1,139 @@
+:root {
+    --pagination-bg: #fff4f8;
+    --pagination-text: #6b5b73;
+    --pagination-hover: #ffd6e7;
+    --pagination-active: #f5a6c7;
+    --pagination-active-text: #ffffff;
+    --pagination-border: #f3c6d9;
+    --pagination-shadow: 0 6px 18px rgba(190, 120, 150, 0.15);
+    --pagination-radius: 12px;
+    --pagination-gap: 8px;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    font-family: Arial, sans-serif;
+    background: #fffafd;
+    color: #4f4255;
+  }
+  
+  .demo {
+    text-align: center;
+    padding: 40px 20px;
+  }
+  
+  .demo h1 {
+    margin-bottom: 8px;
+  }
+  
+  .demo p {
+    margin-bottom: 28px;
+    color: #756878;
+  }
+  
+  /* Base pagination component */
+  .pastel-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--pagination-gap);
+    list-style: none;
+  }
+  
+  /* Pagination item */
+  .pastel-pagination__item {
+    min-width: 42px;
+    height: 42px;
+    padding: 0 12px;
+  
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  
+    text-decoration: none;
+    color: var(--pagination-text);
+  
+    background: var(--pagination-bg);
+    border: 1px solid var(--pagination-border);
+    border-radius: var(--pagination-radius);
+  
+    box-shadow: var(--pagination-shadow);
+  
+    transition:
+      background-color 0.2s ease,
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  
+  /* Hover state */
+  .pastel-pagination__item:hover:not(
+    .pastel-pagination__item--active,
+    .pastel-pagination__item--disabled
+  ) {
+    background: var(--pagination-hover);
+    transform: translateY(-2px);
+  }
+  
+  /* Active modifier */
+  .pastel-pagination__item--active {
+    background: var(--pagination-active);
+    color: var(--pagination-active-text);
+    border-color: var(--pagination-active);
+    font-weight: 700;
+  }
+  
+  /* Disabled modifier */
+  .pastel-pagination__item--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  
+  /* Previous / Next modifiers */
+  .pastel-pagination__item--previous,
+  .pastel-pagination__item--next {
+    font-weight: 700;
+  }
+  
+  /* Keyboard focus */
+  .pastel-pagination__item:focus-visible {
+    outline: 3px solid #9b7bb5;
+    outline-offset: 3px;
+  }
+  
+  /* Rounded modifier */
+  .pastel-pagination--rounded {
+    --pagination-radius: 999px;
+  }
+  
+  /* Responsive styling */
+  @media (max-width: 600px) {
+    .pastel-pagination {
+      gap: 5px;
+    }
+  
+    .pastel-pagination__item {
+      min-width: 36px;
+      height: 36px;
+      padding: 0 9px;
+      font-size: 14px;
+    }
+  }
+  
+  /* Respect reduced-motion preferences */
+  @media (prefers-reduced-motion: reduce) {
+    .pastel-pagination__item {
+      transition: none;
+    }
+  
+    .pastel-pagination__item:hover {
+      transform: none;
+    }
+  }


### PR DESCRIPTION
# docs: add advanced Pastel Pagination guide

## Description

This PR adds comprehensive documentation for the **Pastel Pagination – Advanced Styling** component.

### Changes

* Added copy-paste HTML markup examples.
* Added CSS styling examples for advanced customization.
* Documented CSS class naming conventions and modifier classes.
* Documented custom CSS variable overrides.
* Added accessibility guidance.
* Added keyboard interaction guidance.
* Included usage examples for integrating the component.

## Issue

Closes #81643

## Checklist

* [x] Documentation added
* [x] HTML examples included
* [x] CSS examples included
* [x] Accessibility guidance included
* [x] Keyboard interaction guidance included
* [x] Markdown formatting checked
* [x] Changes tested locally
