### PR TITLE
Fix issue 78561

### DIFF
--- a/submissions/examples/css-card-floating-neon/README.md
+++ b/submissions/examples/css-card-floating-neon/README.md
@@ -1,0 +1,2 @@
+# Floating Card (Neon)
+A dark mode card that physically tilts and floats on hover while emitting a blurred neon pink aura from behind via a pseudo-element.

--- a/submissions/examples/css-card-floating-neon/demo.html
+++ b/submissions/examples/css-card-floating-neon/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Neon Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neon-card">
+        <div class="nc-content">
+            <h2>Neon Floating</h2>
+            <p>Hover over this card to see it float and emit a glowing neon aura.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-card-floating-neon/style.css
+++ b/submissions/examples/css-card-floating-neon/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #090a0f; --neon: #ff0055; --surface: #111; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; color: #fff; }
+.neon-card { position: relative; width: 300px; padding: 2rem; background: var(--surface); border-radius: 12px; border: 1px solid #333; transition: all 0.4s ease; transform-style: preserve-3d; }
+.neon-card::before { content: ''; position: absolute; inset: -2px; background: var(--neon); border-radius: 14px; z-index: -1; opacity: 0; filter: blur(15px); transition: opacity 0.4s ease; }
+.neon-card:hover { transform: translateY(-15px) rotateX(10deg) rotateY(10deg); border-color: var(--neon); box-shadow: 0 15px 30px rgba(0,0,0,0.8); }
+.neon-card:hover::before { opacity: 0.8; }
+.nc-content h2 { margin-top: 0; color: var(--neon); text-shadow: 0 0 5px var(--neon); letter-spacing: 1px; }
+.nc-content p { color: #aaa; line-height: 1.6; }

--- a/submissions/examples/css-tooltip-neumorphic-minimalist/README.md
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Tooltip (Minimalist)
+A clean, soft-UI tooltip implementation. The tooltip box and its directional caret are seamlessly blended together using Neumorphic shadow palettes.

--- a/submissions/examples/css-tooltip-neumorphic-minimalist/demo.html
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-tt-container">
+        <button class="neu-tt-btn">Info</button>
+        <div class="neu-tt-box">
+            Verified Account
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-neumorphic-minimalist/style.css
+++ b/submissions/examples/css-tooltip-neumorphic-minimalist/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #e6e9ef; --shadow-dark: #b8c1d1; --shadow-light: #ffffff; --text: #505a69; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.neu-tt-container { position: relative; display: inline-block; }
+.neu-tt-btn { background: var(--bg); color: var(--text); border: none; padding: 1rem 2rem; font-size: 1rem; font-weight: 600; border-radius: 50px; cursor: pointer; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.2s; outline: none; }
+.neu-tt-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.neu-tt-box { position: absolute; bottom: 130%; left: 50%; transform: translateX(-50%) scale(0.9); background: var(--bg); color: var(--text); padding: 0.75rem 1.5rem; border-radius: 12px; font-size: 0.875rem; font-weight: 500; white-space: nowrap; box-shadow: 4px 4px 10px var(--shadow-dark), -4px -4px 10px var(--shadow-light); opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1); pointer-events: none; }
+.neu-tt-box::after { content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%) translateY(-50%) rotate(45deg); width: 12px; height: 12px; background: var(--bg); box-shadow: 4px 4px 5px rgba(184, 193, 209, 0.5); z-index: -1; }
+.neu-tt-container:hover .neu-tt-box { opacity: 1; visibility: visible; transform: translateX(-50%) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Floating Card with Neon styling (#55631) #78561

**Description:**
This PR introduces a dark mode card that physically tilts and floats on hover while emitting a blurred neon pink aura from behind.

Fixes #78561

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-card-floating-neon/`
- Rendered the neon glow utilizing an absolutely positioned `::before` pseudo-element with `filter: blur(15px)` mapped behind the main card
- Triggered a physical lift animation on `:hover` using `transform: translateY(-15px) rotateX(10deg) rotateY(10deg)` combined with `transform-style: preserve-3d`
