### PR TITLE
Fix issue 78553

### DIFF
--- a/submissions/examples/css-input-morphing-glassmorphism/README.md
+++ b/submissions/examples/css-input-morphing-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Morphing Input Field (Glassmorphism)
+A search input that starts as a compact circular glass button and morphs smoothly into a full-width search bar upon receiving focus.

--- a/submissions/examples/css-input-morphing-glassmorphism/demo.html
+++ b/submissions/examples/css-input-morphing-glassmorphism/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Morphing Glass Input</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="mgl-bg">
+        <div class="mgl-wrapper">
+            <input type="text" class="mgl-input" placeholder="Search...">
+            <div class="mgl-icon"><i class="ph ph-magnifying-glass"></i></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-input-morphing-glassmorphism/style.css
+++ b/submissions/examples/css-input-morphing-glassmorphism/style.css
@@ -1,0 +1,10 @@
+:root { --glass: rgba(255,255,255,0.15); --border: rgba(255,255,255,0.3); }
+body { margin: 0; font-family: system-ui; }
+.mgl-bg { height: 100vh; display: flex; justify-content: center; align-items: center; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
+.mgl-wrapper { position: relative; display: flex; align-items: center; }
+.mgl-input { width: 50px; height: 50px; padding: 0; border: 1px solid var(--border); border-radius: 25px; background: var(--glass); color: #fff; outline: none; font-size: 1.1rem; backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1); cursor: pointer; color: transparent; }
+.mgl-input::placeholder { color: transparent; }
+.mgl-icon { position: absolute; right: 15px; color: #fff; font-size: 1.25rem; pointer-events: none; transition: transform 0.5s ease; }
+.mgl-input:focus { width: 300px; padding: 0 40px 0 20px; cursor: text; color: #fff; border-color: rgba(255,255,255,0.6); box-shadow: 0 10px 20px rgba(0,0,0,0.2); }
+.mgl-input:focus::placeholder { color: rgba(255,255,255,0.7); }
+.mgl-input:focus + .mgl-icon { transform: rotate(90deg) scale(0.9); opacity: 0.8; }


### PR DESCRIPTION
**Title:** feat: create Morphing Input Field with Glassmorphism styling (#60480) #78553

**Description:**
This PR introduces a search input that starts as a compact circular glass button and morphs smoothly into a full-width search bar upon receiving focus.

Fixes #78553

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-input-morphing-glassmorphism/`
- Designed the default state as a perfect circle (`width: 50px; height: 50px`) using deep glassmorphism blurs (`backdrop-filter: blur(10px)`)
- Expanded the input to `width: 300px` on `:focus`, smoothly transitioning the border-radius and dynamically rotating the search icon 90 degrees out of the way
