### PR TITLE
Fix issue 78555

### DIFF
--- a/submissions/examples/css-toggle-responsive-glassmorphism/README.md
+++ b/submissions/examples/css-toggle-responsive-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Responsive Toggle (Glassmorphism)
+A frosted glass toggle switch. Features standard checkbox hack state management, `backdrop-filter` blurring, and an active stretch animation on the thumb.

--- a/submissions/examples/css-toggle-responsive-glassmorphism/demo.html
+++ b/submissions/examples/css-toggle-responsive-glassmorphism/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass Toggle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="glass-bg-scene">
+        <label class="glass-toggle">
+            <input type="checkbox" class="gt-input">
+            <span class="gt-track">
+                <span class="gt-thumb"></span>
+            </span>
+        </label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-toggle-responsive-glassmorphism/style.css
+++ b/submissions/examples/css-toggle-responsive-glassmorphism/style.css
@@ -1,0 +1,11 @@
+:root { --glass: rgba(255,255,255,0.2); --border: rgba(255,255,255,0.4); --active: #4ade80; }
+body { margin: 0; font-family: system-ui; }
+.glass-bg-scene { height: 100vh; background: url('https://picsum.photos/1000/1000?blur=2') center/cover; display: flex; justify-content: center; align-items: center; }
+.glass-toggle { cursor: pointer; display: inline-flex; align-items: center; }
+.gt-input { display: none; }
+.gt-track { width: 70px; height: 36px; background: var(--glass); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 2px solid var(--border); border-radius: 99px; position: relative; transition: all 0.3s ease; box-shadow: inset 0 2px 4px rgba(0,0,0,0.1), 0 4px 6px rgba(0,0,0,0.1); }
+.gt-thumb { position: absolute; top: 2px; left: 2px; width: 28px; height: 28px; background: #fff; border-radius: 50%; box-shadow: 0 2px 5px rgba(0,0,0,0.2); transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.gt-input:checked + .gt-track { background: rgba(74, 222, 128, 0.4); border-color: var(--active); }
+.gt-input:checked + .gt-track .gt-thumb { transform: translateX(34px); background: #fff; }
+.gt-input:active + .gt-track .gt-thumb { width: 36px; }
+.gt-input:checked:active + .gt-track .gt-thumb { transform: translateX(26px); }


### PR DESCRIPTION
**Title:** feat: create Responsive Toggle with Glassmorphism styling (#43095) #78555

**Description:**
This PR introduces a frosted glass toggle switch. Features standard checkbox hack state management, backdrop-filter blurring, and an active stretch animation on the thumb.

Fixes #78555

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-toggle-responsive-glassmorphism/`
- Styled the toggle track with `backdrop-filter: blur(10px)` over a frosted white background (`rgba(255,255,255,0.2)`)
- Mapped state changes to an invisible `<input type="checkbox">` and applied dynamic width changes (`width: 36px`) on the `:active` state to make the thumb feel tactile and squishy
