### PR TITLE
feat: create Hover Progress Bar with Dark Mode styling (#98523) #78550

### DIFF
--- a/submissions/examples/css-progress-bar-hover-dark/README.md
+++ b/submissions/examples/css-progress-bar-hover-dark/README.md
@@ -1,0 +1,2 @@
+# Hover Progress Bar (Dark Mode)
+A sleek dark mode progress bar that illuminates the fill track and summons a smoothly translating percentage tooltip strictly when hovered.

--- a/submissions/examples/css-progress-bar-hover-dark/demo.html
+++ b/submissions/examples/css-progress-bar-hover-dark/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Hover Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dark-progress-wrapper">
+        <div class="dark-progress-bar" style="--progress: 75%;">
+            <div class="dp-fill"></div>
+            <div class="dp-tooltip">75%</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-progress-bar-hover-dark/style.css
+++ b/submissions/examples/css-progress-bar-hover-dark/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #121212; --track: #2a2a2a; --fill: #bb86fc; --text: #e0e0e0; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.dark-progress-wrapper { width: 80%; max-width: 400px; padding: 2rem 0; }
+.dark-progress-bar { position: relative; height: 16px; background: var(--track); border-radius: 8px; cursor: pointer; border: 1px solid #333; }
+.dp-fill { position: absolute; top: 0; left: 0; height: 100%; width: var(--progress); background: var(--fill); border-radius: 8px; transition: filter 0.3s ease; }
+.dp-tooltip { position: absolute; left: var(--progress); top: -35px; transform: translateX(-50%) translateY(10px); background: #333; color: var(--text); padding: 4px 8px; border-radius: 4px; font-size: 0.8rem; opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); pointer-events: none; }
+.dp-tooltip::after { content: ''; position: absolute; bottom: -4px; left: 50%; transform: translateX(-50%) rotate(45deg); width: 8px; height: 8px; background: #333; z-index: -1; }
+.dark-progress-bar:hover .dp-fill { filter: brightness(1.2) drop-shadow(0 0 8px rgba(187,134,252,0.5)); }
+.dark-progress-bar:hover .dp-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Hover Progress Bar with Dark Mode styling (#98523) #78550

**Description:**
This PR introduces a sleek dark mode progress bar that illuminates the fill track and summons a smoothly translating percentage tooltip strictly when hovered.

Fixes #78550

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-progress-bar-hover-dark/`
- Applied a brightness filter (`brightness(1.2) drop-shadow(...)`) to the `.dp-fill` element triggered on hover
- Engineered a tooltip that relies on CSS variables (`--progress: 75%`) for dynamic absolute positioning, sliding into view using a `cubic-bezier` timing function
