### PR TITLE
feat: create 3D Pagination with Neon styling (#45360) #78549

### DIFF
--- a/submissions/examples/css-pagination-3d-neon/README.md
+++ b/submissions/examples/css-pagination-3d-neon/README.md
@@ -1,0 +1,2 @@
+# 3D Pagination (Neon)
+A cyberpunk-inspired pagination block. Each button exists in 3D space, physically depressing when active, and lifting with a glowing neon border on hover.

--- a/submissions/examples/css-pagination-3d-neon/demo.html
+++ b/submissions/examples/css-pagination-3d-neon/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Neon Pagination</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neon-pagination">
+        <a href="#" class="np-btn">&lt;</a>
+        <a href="#" class="np-btn">1</a>
+        <a href="#" class="np-btn active">2</a>
+        <a href="#" class="np-btn">3</a>
+        <a href="#" class="np-btn">&gt;</a>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pagination-3d-neon/style.css
+++ b/submissions/examples/css-pagination-3d-neon/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #050505; --neon: #0ff; --surface: #111; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; perspective: 600px; }
+.neon-pagination { display: flex; gap: 1rem; transform-style: preserve-3d; }
+.np-btn { display: flex; justify-content: center; align-items: center; width: 40px; height: 40px; background: var(--surface); color: #555; text-decoration: none; font-weight: bold; font-size: 1.2rem; border: 1px solid #333; position: relative; transition: all 0.3s; transform-style: preserve-3d; }
+.np-btn::before { content: ''; position: absolute; top: 100%; left: -1px; width: calc(100% + 2px); height: 8px; background: #000; transform-origin: top; transform: rotateX(-90deg); border: 1px solid #333; border-top: none; transition: all 0.3s; }
+.np-btn:hover { color: var(--neon); text-shadow: 0 0 5px var(--neon); transform: translateY(-5px) rotateX(15deg); border-color: var(--neon); box-shadow: 0 10px 20px rgba(0,255,255,0.2); }
+.np-btn:hover::before { border-color: var(--neon); background: #055; }
+.np-btn.active { color: #fff; background: rgba(0,255,255,0.1); border-color: var(--neon); box-shadow: 0 0 15px rgba(0,255,255,0.4), inset 0 0 10px rgba(0,255,255,0.2); transform: translateZ(-10px); }
+.np-btn.active::before { height: 4px; }


### PR DESCRIPTION
**Title:** feat: create 3D Pagination with Neon styling (#45360) #78549

**Description:**
This PR introduces a cyberpunk-inspired pagination block. Each button exists in 3D space, physically depressing when active, and lifting with a glowing neon border on hover.

Fixes #78549

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-pagination-3d-neon/`
- Transformed the anchor tags into 3D objects mapping the bottom edge panel utilizing `transform: rotateX(-90deg)`
- Linked the hover states to a `translateY(-5px) rotateX(15deg)` shift paired with intense cyan drop shadows
