### PR TITLE
feat: create Hover Tab Bar with Minimalist styling (#71838) #78610

### DIFF
--- a/submissions/examples/css-tab-bar-hover-minimalist/README.md
+++ b/submissions/examples/css-tab-bar-hover-minimalist/README.md
@@ -1,0 +1,2 @@
+# Hover Tab Bar (Minimalist)
+An ultra-clean minimalist tab bar utilizing directional `transform-origin` scaling to create an underline that draws in from the left on hover, and exits to the right.

--- a/submissions/examples/css-tab-bar-hover-minimalist/demo.html
+++ b/submissions/examples/css-tab-bar-hover-minimalist/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Minimalist Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="min-tab-bar">
+        <a href="#" class="min-tab active">Overview</a>
+        <a href="#" class="min-tab">Analytics</a>
+        <a href="#" class="min-tab">Reports</a>
+        <a href="#" class="min-tab">Settings</a>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-hover-minimalist/style.css
+++ b/submissions/examples/css-tab-bar-hover-minimalist/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #ffffff; --text: #666666; --active: #000000; --border: #e5e5e5; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, sans-serif; }
+.min-tab-bar { display: flex; gap: 2rem; border-bottom: 2px solid var(--border); padding: 0 1rem; }
+.min-tab { position: relative; color: var(--text); text-decoration: none; font-size: 1rem; font-weight: 500; padding: 1rem 0; transition: color 0.3s ease; }
+.min-tab::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 100%; height: 2px; background: var(--active); transform: scaleX(0); transform-origin: right; transition: transform 0.4s cubic-bezier(0.86, 0, 0.07, 1); }
+.min-tab:hover { color: var(--active); }
+.min-tab:hover::after { transform: scaleX(1); transform-origin: left; }
+.min-tab.active { color: var(--active); }
+.min-tab.active::after { transform: scaleX(1); }


### PR DESCRIPTION
**Title:** feat: create Hover Tab Bar with Minimalist styling (#71838) #78610

**Description:**
This PR introduces an ultra-clean minimalist tab bar utilizing directional scaling to create an underline that draws in from the left on hover, and exits to the right.

Fixes #78610

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-hover-minimalist/`
- Styled the active indicator bar using a `::after` pseudo-element starting at `transform: scaleX(0)`
- Modulated the `transform-origin` property swapping between `right` on the default state and `left` on the `:hover` state to create the directional sweep animation
