### PR TITLE
Fix issue 78686

### DIFF
--- a/submissions/examples/css-accordion-css-only-saas-modern/README.md
+++ b/submissions/examples/css-accordion-css-only-saas-modern/README.md
@@ -1,0 +1,2 @@
+# CSS-only Accordion (SaaS Modern)
+A crisp, professional accordion perfect for SaaS FAQs or settings. Built entirely with the checkbox hack and featuring a clean cross-to-minus animated icon.

--- a/submissions/examples/css-accordion-css-only-saas-modern/demo.html
+++ b/submissions/examples/css-accordion-css-only-saas-modern/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SaaS CSS-only Accordion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="saas-accordion">
+        <div class="saas-acc-item">
+            <input type="checkbox" id="acc1" class="saas-acc-input">
+            <label class="saas-acc-header" for="acc1">
+                <span>Billing Cycle</span>
+                <div class="saas-acc-icon"></div>
+            </label>
+            <div class="saas-acc-content">
+                <p>Your billing cycle is calculated monthly from the date you upgraded your workspace. Unused minutes do not roll over.</p>
+            </div>
+        </div>
+        <div class="saas-acc-item">
+            <input type="checkbox" id="acc2" class="saas-acc-input">
+            <label class="saas-acc-header" for="acc2">
+                <span>Team Seats</span>
+                <div class="saas-acc-icon"></div>
+            </label>
+            <div class="saas-acc-content">
+                <p>You can add up to 10 members on the Pro plan. Enterprise plans offer unlimited seats.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-accordion-css-only-saas-modern/style.css
+++ b/submissions/examples/css-accordion-css-only-saas-modern/style.css
@@ -1,0 +1,18 @@
+:root { --bg: #f8fafc; --surface: #ffffff; --border: #e2e8f0; --text: #1e293b; --text-muted: #64748b; --primary: #3b82f6; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, -apple-system, sans-serif; }
+.saas-accordion { width: 100%; max-width: 500px; background: var(--surface); border-radius: 12px; border: 1px solid var(--border); box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05); overflow: hidden; }
+.saas-acc-item { border-bottom: 1px solid var(--border); }
+.saas-acc-item:last-child { border-bottom: none; }
+.saas-acc-input { display: none; }
+.saas-acc-header { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 1.5rem; font-weight: 500; color: var(--text); cursor: pointer; transition: background 0.2s; }
+.saas-acc-header:hover { background: #f1f5f9; }
+.saas-acc-icon { width: 20px; height: 20px; position: relative; }
+.saas-acc-icon::before, .saas-acc-icon::after { content: ''; position: absolute; background: var(--text-muted); transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.saas-acc-icon::before { top: 9px; left: 2px; width: 16px; height: 2px; }
+.saas-acc-icon::after { top: 2px; left: 9px; width: 2px; height: 16px; }
+.saas-acc-content { max-height: 0; overflow: hidden; opacity: 0; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); padding: 0 1.5rem; }
+.saas-acc-content p { margin: 0; padding-bottom: 1.25rem; color: var(--text-muted); line-height: 1.6; }
+.saas-acc-input:checked + .saas-acc-header { color: var(--primary); }
+.saas-acc-input:checked + .saas-acc-header .saas-acc-icon::before { transform: rotate(180deg); background: var(--primary); }
+.saas-acc-input:checked + .saas-acc-header .saas-acc-icon::after { transform: rotate(90deg); background: var(--primary); }
+.saas-acc-input:checked ~ .saas-acc-content { max-height: 150px; opacity: 1; padding-top: 0.5rem; }

--- a/submissions/examples/css-sidebar-dynamic-dark/README.md
+++ b/submissions/examples/css-sidebar-dynamic-dark/README.md
@@ -1,0 +1,2 @@
+# Dynamic Sidebar (Dark Mode)
+A deeply styled dark mode vertical navigation sidebar. It leverages a hidden checkbox to transition smoothly between a collapsed icon-only state and a fully expanded text state.

--- a/submissions/examples/css-sidebar-dynamic-dark/demo.html
+++ b/submissions/examples/css-sidebar-dynamic-dark/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Dark Sidebar</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <input type="checkbox" id="sidebar-toggle" class="sidebar-toggle">
+    <nav class="dark-sidebar">
+        <label for="sidebar-toggle" class="sb-menu-btn">
+            <i class="ph ph-list"></i>
+        </label>
+        <div class="sb-links">
+            <a href="#" class="sb-link active"><i class="ph ph-squares-four"></i><span class="sb-text">Dashboard</span></a>
+            <a href="#" class="sb-link"><i class="ph ph-users"></i><span class="sb-text">Team</span></a>
+            <a href="#" class="sb-link"><i class="ph ph-chart-pie-slice"></i><span class="sb-text">Analytics</span></a>
+            <a href="#" class="sb-link"><i class="ph ph-gear"></i><span class="sb-text">Settings</span></a>
+        </div>
+    </nav>
+    <main class="main-content">
+        <h1>Dark Mode Dashboard</h1>
+        <p>Click the menu icon to dynamically expand and collapse the sidebar using pure CSS.</p>
+    </main>
+</body>
+</html>

--- a/submissions/examples/css-sidebar-dynamic-dark/style.css
+++ b/submissions/examples/css-sidebar-dynamic-dark/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #0f0f13; --sidebar-bg: #18181f; --text: #e2e8f0; --accent: #8b5cf6; --border: #272730; }
+body { background: var(--bg); color: var(--text); display: flex; margin: 0; font-family: system-ui, sans-serif; height: 100vh; overflow: hidden; }
+.sidebar-toggle { display: none; }
+.dark-sidebar { width: 70px; background: var(--sidebar-bg); border-right: 1px solid var(--border); transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1); display: flex; flex-direction: column; overflow: hidden; white-space: nowrap; }
+.sb-menu-btn { padding: 1.5rem; color: var(--text); font-size: 1.5rem; cursor: pointer; display: block; border-bottom: 1px solid var(--border); transition: color 0.2s; }
+.sb-menu-btn:hover { color: var(--accent); }
+.sb-links { padding-top: 1rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.sb-link { display: flex; align-items: center; padding: 0.75rem 1.5rem; color: #94a3b8; text-decoration: none; font-weight: 500; transition: all 0.2s; border-left: 3px solid transparent; }
+.sb-link i { font-size: 1.5rem; min-width: 24px; }
+.sb-text { margin-left: 1.5rem; opacity: 0; transition: opacity 0.2s; }
+.sb-link:hover { background: rgba(139, 92, 246, 0.1); color: var(--text); border-left-color: rgba(139, 92, 246, 0.5); }
+.sb-link.active { background: rgba(139, 92, 246, 0.15); color: var(--accent); border-left-color: var(--accent); }
+.sidebar-toggle:checked ~ .dark-sidebar { width: 240px; }
+.sidebar-toggle:checked ~ .dark-sidebar .sb-text { opacity: 1; transition-delay: 0.1s; }
+.main-content { flex: 1; padding: 3rem; transition: padding 0.3s; }
+.main-content h1 { margin-top: 0; font-weight: 600; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Sidebar with Dark Mode styling (#55112) #78686

**Description:**
This PR introduces a deeply styled dark mode vertical navigation sidebar. It leverages a hidden checkbox to transition smoothly between a collapsed icon-only state and a fully expanded text state.

Fixes #78686

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-sidebar-dynamic-dark/`
- Bound the sidebar state logic to a `.sidebar-toggle` checkbox hack activated via the top hamburger menu icon
- Configured a dynamic CSS `width` transition from `70px` to `240px` and sequenced an `opacity` reveal on the text labels utilizing a `transition-delay` for a polished feel
