### PR TITLE
feat: create Neumorphic Carousel with Neumorphism styling (#93364) #78547

### DIFF
--- a/submissions/examples/css-carousel-neumorphic-neumorphism/README.md
+++ b/submissions/examples/css-carousel-neumorphic-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Carousel (Neumorphism)
+A CSS-only carousel leveraging soft UI inset/outset shadows. Uses radio buttons to translate the slides and applies pressed Neumorphic states to the active control dots.

--- a/submissions/examples/css-carousel-neumorphic-neumorphism/demo.html
+++ b/submissions/examples/css-carousel-neumorphic-neumorphism/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-carousel">
+        <input type="radio" name="neu-slides" id="slide1" checked>
+        <input type="radio" name="neu-slides" id="slide2">
+        <input type="radio" name="neu-slides" id="slide3">
+        
+        <div class="neu-slides-container">
+            <div class="neu-slide">
+                <div class="neu-card">Slide 1</div>
+            </div>
+            <div class="neu-slide">
+                <div class="neu-card">Slide 2</div>
+            </div>
+            <div class="neu-slide">
+                <div class="neu-card">Slide 3</div>
+            </div>
+        </div>
+        
+        <div class="neu-controls">
+            <label for="slide1" class="neu-dot"></label>
+            <label for="slide2" class="neu-dot"></label>
+            <label for="slide3" class="neu-dot"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-neumorphic-neumorphism/style.css
+++ b/submissions/examples/css-carousel-neumorphic-neumorphism/style.css
@@ -1,0 +1,15 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --accent: #4a90e2; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.neu-carousel { width: 400px; padding: 2rem; border-radius: 20px; box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light); overflow: hidden; position: relative; }
+input[type="radio"] { display: none; }
+.neu-slides-container { display: flex; width: 300%; transition: transform 0.5s cubic-bezier(0.25, 1, 0.5, 1); }
+.neu-slide { width: 33.333%; padding: 1rem; box-sizing: border-box; }
+.neu-card { height: 200px; display: flex; justify-content: center; align-items: center; font-size: 1.5rem; color: #555; background: var(--bg); border-radius: 15px; box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.neu-controls { display: flex; justify-content: center; gap: 1rem; margin-top: 1.5rem; }
+.neu-dot { width: 16px; height: 16px; border-radius: 50%; background: var(--bg); box-shadow: 2px 2px 5px var(--shadow-dark), -2px -2px 5px var(--shadow-light); cursor: pointer; transition: all 0.3s; }
+#slide1:checked ~ .neu-slides-container { transform: translateX(0); }
+#slide2:checked ~ .neu-slides-container { transform: translateX(-33.333%); }
+#slide3:checked ~ .neu-slides-container { transform: translateX(-66.666%); }
+#slide1:checked ~ .neu-controls label:nth-child(1),
+#slide2:checked ~ .neu-controls label:nth-child(2),
+#slide3:checked ~ .neu-controls label:nth-child(3) { box-shadow: inset 2px 2px 5px var(--shadow-dark), inset -2px -2px 5px var(--shadow-light); background: var(--accent); }


### PR DESCRIPTION

**Title:** feat: create Neumorphic Carousel with Neumorphism styling (#93364) #78547

**Description:**
This PR introduces a CSS-only carousel leveraging soft UI inset/outset shadows. Uses radio buttons to translate the slides and applies pressed Neumorphic states to the active control dots.

Fixes #78547

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-neumorphic-neumorphism/`
- Bound carousel slider logic natively using `<input type="radio">` tags and the `~` sibling combinator to apply `transform: translateX(...)` on the slide container
- Styled the active pagination dots to invert their drop shadows to `box-shadow: inset...` appearing physically pressed into the surface
