### PR TITLE
feat: create Animated Toggle with Dark Mode styling #78325

### DIFF
--- a/submissions/examples/css-toggle-animated-dark/README.md
+++ b/submissions/examples/css-toggle-animated-dark/README.md
@@ -1,0 +1,2 @@
+# Animated Toggle (Dark Mode)
+A highly stylized day/night dark mode toggle switch. The thumb animatedly morphs its internal icon from a glowing sun to a crescent moon as it slides.

--- a/submissions/examples/css-toggle-animated-dark/demo.html
+++ b/submissions/examples/css-toggle-animated-dark/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Dark Toggle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <label class="dark-animated-toggle">
+        <input type="checkbox">
+        <div class="dat-track">
+            <div class="dat-thumb">
+                <div class="dat-icon dat-sun"></div>
+                <div class="dat-icon dat-moon"></div>
+            </div>
+        </div>
+    </label>
+</body>
+</html>

--- a/submissions/examples/css-toggle-animated-dark/style.css
+++ b/submissions/examples/css-toggle-animated-dark/style.css
@@ -1,0 +1,13 @@
+:root { --bg: #121212; --track-off: #333; --track-on: #bb86fc; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.dark-animated-toggle { cursor: pointer; }
+.dark-animated-toggle input { display: none; }
+.dat-track { width: 80px; height: 40px; background: var(--track-off); border-radius: 40px; position: relative; transition: background 0.4s ease; box-shadow: inset 0 2px 5px rgba(0,0,0,0.5); }
+.dat-thumb { position: absolute; top: 4px; left: 4px; width: 32px; height: 32px; background: #fff; border-radius: 50%; display: flex; justify-content: center; align-items: center; transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 2px 6px rgba(0,0,0,0.3); overflow: hidden; }
+.dat-icon { position: absolute; width: 16px; height: 16px; border-radius: 50%; transition: all 0.4s; }
+.dat-sun { background: #ffca28; box-shadow: 0 0 10px #ffca28; transform: translateY(0); }
+.dat-moon { background: transparent; box-shadow: inset -4px -4px 0 #121212; transform: translateY(-30px); }
+input:checked + .dat-track { background: var(--track-on); }
+input:checked + .dat-track .dat-thumb { transform: translateX(40px); background: #121212; }
+input:checked + .dat-track .dat-sun { transform: translateY(30px); }
+input:checked + .dat-track .dat-moon { transform: translateY(0); box-shadow: inset -4px -4px 0 #fff; }


### PR DESCRIPTION
**Title:** feat: create Animated Toggle with Dark Mode styling #78325

**Description:**
This PR introduces a highly stylized day/night dark mode toggle switch. The thumb animatedly morphs its internal icon from a glowing sun to a crescent moon as it slides.

Fixes #78325

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-toggle-animated-dark/`
- Engineered a dual-icon slider thumb using an overflow-hidden wrapper, translating the sun out and the moon in dynamically when checked
- Built the crescent moon shape using a transparent background paired with an offset inset `box-shadow`
