### PR TITLE
feat: add CSS SVG stroke drawing animation (#74566)

### DIFF
--- a/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/README.md
+++ b/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/README.md
@@ -1,0 +1,27 @@
+# SVG Stroke Drawing Animation
+
+A CSS-only SVG stroke drawing animation that progressively reveals a
+mountain landscape using `stroke-dasharray` and `stroke-dashoffset`.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- Inline SVG illustration
+- Multiple SVG paths
+- Progressive stroke drawing
+- Sequential animations
+- Individual animation delays
+- Opacity transitions
+- Responsive design
+- Accessible SVG markup
+- Reduced-motion support
+- No JavaScript
+- No external libraries
+
+## 📁 Files
+
+```text
+74566-css-svg-stroke-drawing-animation-ks/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/demo.html
+++ b/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/demo.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta
+    name="description"
+    content="CSS-only SVG stroke drawing animation"
+  >
+
+  <title>SVG Stroke Drawing Animation</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section
+      class="animation-card"
+      aria-labelledby="animation-title"
+    >
+
+      <header class="content">
+
+        <p class="eyebrow">
+          EaseMotion CSS
+        </p>
+
+        <h1 id="animation-title">
+          SVG Stroke Drawing
+        </h1>
+
+        <p class="description">
+          A CSS-only SVG illustration that progressively draws
+          itself using stroke animations.
+        </p>
+
+      </header>
+
+
+      <div class="illustration-wrapper">
+
+        <svg
+          class="landscape"
+          viewBox="0 0 800 500"
+          role="img"
+          aria-labelledby="svg-title svg-description"
+        >
+
+          <title id="svg-title">
+            Animated mountain landscape
+          </title>
+
+          <desc id="svg-description">
+            A mountain landscape with a sun, mountains, trees,
+            plants and foreground details progressively drawn
+            using CSS stroke animations.
+          </desc>
+
+
+          <!-- =========================
+               SUN
+          ========================== -->
+
+          <circle
+            class="draw-path sun"
+            pathLength="1"
+            cx="640"
+            cy="115"
+            r="52"
+          />
+
+
+          <!-- =========================
+               SUN RAYS
+          ========================== -->
+
+          <g class="sun-rays">
+
+            <path
+              class="draw-path ray ray-1"
+              pathLength="1"
+              d="M640 45V18"
+            />
+
+            <path
+              class="draw-path ray ray-2"
+              pathLength="1"
+              d="M640 185V212"
+            />
+
+            <path
+              class="draw-path ray ray-3"
+              pathLength="1"
+              d="M570 115H543"
+            />
+
+            <path
+              class="draw-path ray ray-4"
+              pathLength="1"
+              d="M710 115H737"
+            />
+
+            <path
+              class="draw-path ray ray-5"
+              pathLength="1"
+              d="M590 65L571 46"
+            />
+
+            <path
+              class="draw-path ray ray-6"
+              pathLength="1"
+              d="M690 165L709 184"
+            />
+
+            <path
+              class="draw-path ray ray-7"
+              pathLength="1"
+              d="M690 65L709 46"
+            />
+
+            <path
+              class="draw-path ray ray-8"
+              pathLength="1"
+              d="M590 165L571 184"
+            />
+
+          </g>
+
+
+          <!-- =========================
+               BACK MOUNTAIN
+          ========================== -->
+
+          <path
+            class="draw-path mountain back-mountain"
+            pathLength="1"
+            d="M70 385
+               L220 205
+               L310 305
+               L390 215
+               L530 385"
+          />
+
+
+          <!-- =========================
+               FRONT MOUNTAIN
+          ========================== -->
+
+          <path
+            class="draw-path mountain front-mountain"
+            pathLength="1"
+            d="M185 385
+               L350 165
+               L520 385"
+          />
+
+
+          <!-- =========================
+               SNOW CAP
+          ========================== -->
+
+          <path
+            class="draw-path snow"
+            pathLength="1"
+            d="M310 220
+               L350 165
+               L392 220
+               L368 207
+               L350 232
+               L333 207"
+          />
+
+
+          <!-- =========================
+               MOUNTAIN RIDGE
+          ========================== -->
+
+          <path
+            class="draw-path ridge"
+            pathLength="1"
+            d="M70 385
+               L145 330
+               L190 350
+               L250 300
+               L310 345
+               L365 305
+               L425 350
+               L475 315
+               L530 385"
+          />
+
+
+          <!-- =========================
+               GROUND
+          ========================== -->
+
+          <path
+            class="draw-path ground"
+            pathLength="1"
+            d="M55 385H745"
+          />
+
+
+          <!-- =========================
+               LEFT TREE
+          ========================== -->
+
+          <g class="tree left-tree">
+
+            <path
+              class="draw-path tree-trunk"
+              pathLength="1"
+              d="M120 385V320"
+            />
+
+            <path
+              class="draw-path tree-crown"
+              pathLength="1"
+              d="M120 255
+                 L82 320
+                 H102
+                 L72 350
+                 H105
+                 L80 375
+                 H160
+                 L135 350
+                 H168
+                 L138 320
+                 H158
+                 L120 255Z"
+            />
+
+          </g>
+
+
+          <!-- =========================
+               RIGHT TREE
+          ========================== -->
+
+          <g class="tree right-tree">
+
+            <path
+              class="draw-path tree-trunk"
+              pathLength="1"
+              d="M665 385V315"
+            />
+
+            <path
+              class="draw-path tree-crown"
+              pathLength="1"
+              d="M665 250
+                 L625 315
+                 H646
+                 L615 345
+                 H650
+                 L625 375
+                 H705
+                 L680 345
+                 H715
+                 L684 315
+                 H705
+                 L665 250Z"
+            />
+
+          </g>
+
+
+          <!-- =========================
+               FOREGROUND PLANTS
+          ========================== -->
+
+          <path
+            class="draw-path plant plant-one"
+            pathLength="1"
+            d="M240 385
+               C235 365 230 355 218 345
+               M240 385
+               C244 365 251 355 263 348"
+          />
+
+          <path
+            class="draw-path plant plant-two"
+            pathLength="1"
+            d="M565 385
+               C560 365 553 355 542 347
+               M565 385
+               C570 365 578 355 589 349"
+          />
+
+
+          <!-- =========================
+               FOREGROUND
+          ========================== -->
+
+          <path
+            class="draw-path foreground"
+            pathLength="1"
+            d="M55 405
+               C180 385 260 425 390 405
+               C520 385 610 425 745 400"
+          />
+
+        </svg>
+
+      </div>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/style.css
+++ b/submissions/examples/74566-css-svg-stroke-drawing-animation-ks/style.css
@@ -1,0 +1,411 @@
+:root {
+  --page-background: #eef2ff;
+  --card-background: #ffffff;
+  --illustration-start: #f8fafc;
+  --illustration-end: #e0e7ff;
+
+  --text: #172033;
+  --muted: #64748b;
+
+  --stroke: #334155;
+  --mountain: #475569;
+  --nature: #3f6b4f;
+  --sun: #f59e0b;
+
+  --duration: 1.35s;
+  --easing: cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+
+/* ========================================
+   BASE
+======================================== */
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 15% 10%,
+      #ffffff 0,
+      transparent 38%
+    ),
+    var(--page-background);
+}
+
+
+/* ========================================
+   PAGE LAYOUT
+======================================== */
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding: 32px 20px;
+}
+
+.animation-card {
+  width: min(920px, 100%);
+
+  overflow: hidden;
+
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  border-radius: 28px;
+
+  background: var(--card-background);
+
+  box-shadow:
+    0 25px 60px rgba(15, 23, 42, 0.12),
+    0 4px 16px rgba(15, 23, 42, 0.06);
+}
+
+
+/* ========================================
+   CONTENT
+======================================== */
+
+.content {
+  padding: clamp(28px, 5vw, 56px);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+
+  color: #6366f1;
+
+  font-size: 0.8rem;
+  font-weight: 800;
+
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.05;
+
+  letter-spacing: -0.04em;
+}
+
+.description {
+  max-width: 620px;
+
+  margin: 18px 0 0;
+
+  color: var(--muted);
+
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+
+/* ========================================
+   ILLUSTRATION
+======================================== */
+
+.illustration-wrapper {
+  margin: 0 clamp(20px, 5vw, 56px) 56px;
+
+  padding: clamp(16px, 4vw, 32px);
+
+  overflow: hidden;
+
+  border-radius: 22px;
+
+  background:
+    linear-gradient(
+      180deg,
+      var(--illustration-start),
+      var(--illustration-end)
+    );
+}
+
+.landscape {
+  display: block;
+
+  width: 100%;
+  height: auto;
+
+  overflow: visible;
+}
+
+
+/* ========================================
+   SVG STROKE DRAWING
+======================================== */
+
+.draw-path {
+  fill: none;
+
+  stroke: var(--stroke);
+
+  stroke-width: 5;
+
+  stroke-linecap: round;
+  stroke-linejoin: round;
+
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+
+  opacity: 0;
+
+  animation:
+    draw-stroke
+    var(--duration)
+    var(--easing)
+    forwards;
+}
+
+
+/* ========================================
+   SUN
+======================================== */
+
+.sun {
+  stroke: var(--sun);
+  stroke-width: 6;
+
+  animation-delay: 0.1s;
+}
+
+
+/* ========================================
+   SUN RAYS
+======================================== */
+
+.ray {
+  stroke: var(--sun);
+  stroke-width: 4;
+
+  animation-duration: 0.65s;
+}
+
+.ray-1 {
+  animation-delay: 0.45s;
+}
+
+.ray-2 {
+  animation-delay: 0.50s;
+}
+
+.ray-3 {
+  animation-delay: 0.55s;
+}
+
+.ray-4 {
+  animation-delay: 0.60s;
+}
+
+.ray-5 {
+  animation-delay: 0.65s;
+}
+
+.ray-6 {
+  animation-delay: 0.70s;
+}
+
+.ray-7 {
+  animation-delay: 0.75s;
+}
+
+.ray-8 {
+  animation-delay: 0.80s;
+}
+
+
+/* ========================================
+   MOUNTAINS
+======================================== */
+
+.mountain {
+  stroke: var(--mountain);
+}
+
+.back-mountain {
+  animation-delay: 1s;
+}
+
+.front-mountain {
+  stroke-width: 6;
+
+  animation-delay: 1.45s;
+}
+
+.snow {
+  stroke: var(--stroke);
+  stroke-width: 4;
+
+  animation-delay: 1.95s;
+}
+
+.ridge {
+  stroke: var(--mountain);
+  stroke-width: 3.5;
+
+  animation-delay: 2.25s;
+}
+
+
+/* ========================================
+   GROUND
+======================================== */
+
+.ground {
+  stroke: var(--stroke);
+
+  animation-delay: 2.65s;
+}
+
+
+/* ========================================
+   TREES
+======================================== */
+
+.tree-trunk,
+.tree-crown {
+  stroke: var(--nature);
+}
+
+.left-tree .tree-trunk,
+.right-tree .tree-trunk {
+  animation-delay: 2.85s;
+}
+
+.left-tree .tree-crown {
+  animation-delay: 3.05s;
+}
+
+.right-tree .tree-crown {
+  animation-delay: 3.25s;
+}
+
+
+/* ========================================
+   FOREGROUND PLANTS
+======================================== */
+
+.plant {
+  stroke: var(--nature);
+  stroke-width: 3.5;
+}
+
+.plant-one {
+  animation-delay: 3.5s;
+}
+
+.plant-two {
+  animation-delay: 3.6s;
+}
+
+
+/* ========================================
+   FOREGROUND LINE
+======================================== */
+
+.foreground {
+  stroke: var(--stroke);
+  stroke-width: 3;
+
+  animation-delay: 3.8s;
+}
+
+
+/* ========================================
+   DRAWING ANIMATION
+======================================== */
+
+@keyframes draw-stroke {
+  0% {
+    stroke-dashoffset: 1;
+    opacity: 0;
+  }
+
+  12% {
+    opacity: 1;
+  }
+
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}
+
+
+/* ========================================
+   RESPONSIVE DESIGN
+======================================== */
+
+@media (max-width: 640px) {
+  .page {
+    padding: 16px;
+  }
+
+  .animation-card {
+    border-radius: 20px;
+  }
+
+  .content {
+    padding: 24px 18px;
+  }
+
+  .illustration-wrapper {
+    margin: 0 18px 24px;
+    padding: 10px;
+
+    border-radius: 16px;
+  }
+
+  .draw-path {
+    stroke-width: 4;
+  }
+
+  .front-mountain {
+    stroke-width: 5;
+  }
+
+  .ray {
+    stroke-width: 3;
+  }
+
+  .plant {
+    stroke-width: 3;
+  }
+}
+
+
+/* ========================================
+   REDUCED MOTION ACCESSIBILITY
+======================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .draw-path {
+    animation: none;
+
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description

Added a CSS-only SVG stroke drawing animation component for issue #74566.

### Features

* Added an inline SVG mountain landscape illustration.
* Implemented progressive stroke drawing using `stroke-dasharray` and `stroke-dashoffset`.
* Added sequential animation delays for individual SVG elements.
* Added opacity transitions during the drawing animation.
* Added subtle colors for the sun, mountains, and trees.
* Added responsive styling for smaller screens.
* Added `prefers-reduced-motion` support for accessibility.
* Added documentation explaining the implementation and usage.

### Files Added

* `demo.html`
* `style.css`
* `README.md`

No JavaScript or external dependencies are required.

Closes #74566