### PR TITLE
feat: create Glassmorphism Progress Bar with Dark Mode styling (#61675) #78711

### DIFF
--- a/submissions/examples/css-progress-bar-glassmorphism-dark/README.md
+++ b/submissions/examples/css-progress-bar-glassmorphism-dark/README.md
@@ -1,0 +1,2 @@
+# Glassmorphism Progress Bar (Dark Mode)
+A deep dark mode frosted glass panel featuring a progress bar filled with a vibrant gradient. It includes an infinite shimmering reflection animation across the fill area.

--- a/submissions/examples/css-progress-bar-glassmorphism-dark/demo.html
+++ b/submissions/examples/css-progress-bar-glassmorphism-dark/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glass Dark Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="glass-dark-scene">
+        <div class="glass-dark-panel">
+            <div class="gd-label">Syncing... <span>82%</span></div>
+            <div class="gd-track">
+                <div class="gd-fill"></div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-progress-bar-glassmorphism-dark/style.css
+++ b/submissions/examples/css-progress-bar-glassmorphism-dark/style.css
@@ -1,0 +1,11 @@
+:root { --glass: rgba(255, 255, 255, 0.05); --border: rgba(255, 255, 255, 0.1); --fill: linear-gradient(90deg, #38bdf8, #818cf8); }
+body { margin: 0; font-family: system-ui; background: #0f172a; display: flex; justify-content: center; align-items: center; height: 100vh; }
+.glass-dark-scene { position: relative; width: 100%; display: flex; justify-content: center; }
+.glass-dark-scene::before { content: ''; position: absolute; width: 300px; height: 300px; background: #818cf8; border-radius: 50%; filter: blur(100px); opacity: 0.2; top: -100px; left: 20%; z-index: 0; }
+.glass-dark-panel { position: relative; z-index: 1; width: 350px; background: var(--glass); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); border: 1px solid var(--border); padding: 2rem; border-radius: 20px; box-shadow: 0 20px 40px rgba(0,0,0,0.4); }
+.gd-label { display: flex; justify-content: space-between; color: #cbd5e1; font-weight: 500; margin-bottom: 1rem; font-size: 0.9rem; }
+.gd-label span { color: #fff; font-weight: 700; }
+.gd-track { width: 100%; height: 8px; background: rgba(0,0,0,0.3); border-radius: 4px; overflow: hidden; box-shadow: inset 0 1px 3px rgba(0,0,0,0.5); }
+.gd-fill { height: 100%; width: 82%; background: var(--fill); border-radius: 4px; position: relative; overflow: hidden; }
+.gd-fill::after { content: ''; position: absolute; top: 0; left: -100%; width: 50%; height: 100%; background: linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent); animation: gd-shimmer 2s infinite; }
+@keyframes gd-shimmer { 100% { left: 200%; } }


### PR DESCRIPTION

**Title:** feat: create Glassmorphism Progress Bar with Dark Mode styling (#61675) #78711

**Description:**
This PR introduces a deep dark mode frosted glass panel featuring a progress bar filled with a vibrant gradient. It includes an infinite shimmering reflection animation across the fill area.

Fixes #78711

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-progress-bar-glassmorphism-dark/`
- Built an ambient background using a massive blurred orb (`filter: blur(100px)`) placed beneath the `backdrop-filter` glass panel
- Layered a `linear-gradient` sweep animation over the progress fill bar using a sliding `::after` pseudo-element to create a premium metallic shine effect
