### PR TITLE
feat: create Glowing Progress Bar with Retro styling (#25207) #78715

### DIFF
--- a/submissions/examples/css-progress-bar-glowing-retro/README.md
+++ b/submissions/examples/css-progress-bar-glowing-retro/README.md
@@ -1,0 +1,2 @@
+# Glowing Progress Bar (Retro)
+An outrun/synthwave inspired progress bar. It uses harsh cyan borders with intense magenta fills, topped with a pulsing bright-white leading edge.

--- a/submissions/examples/css-progress-bar-glowing-retro/demo.html
+++ b/submissions/examples/css-progress-bar-glowing-retro/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Retro Progress</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="glow-retro-wrapper">
+        <div class="glow-retro-track">
+            <div class="glow-retro-fill"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-progress-bar-glowing-retro/style.css
+++ b/submissions/examples/css-progress-bar-glowing-retro/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #090014; --magenta: #ff00ff; --cyan: #00ffff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.glow-retro-wrapper { width: 80%; max-width: 500px; padding: 2rem; background: #111; border: 1px solid #333; border-radius: 8px; box-shadow: inset 0 0 20px rgba(0,0,0,0.8); }
+.glow-retro-track { width: 100%; height: 20px; background: #000; border: 2px solid var(--cyan); box-shadow: 0 0 10px rgba(0, 255, 255, 0.3), inset 0 0 10px rgba(0, 255, 255, 0.3); border-radius: 4px; overflow: hidden; position: relative; }
+.glow-retro-fill { height: 100%; width: 60%; background: var(--magenta); box-shadow: 0 0 15px var(--magenta), inset 0 0 10px #fff; animation: glow-pulse 2s ease-in-out infinite alternate; position: relative; }
+.glow-retro-fill::after { content: ''; position: absolute; top: 0; right: 0; bottom: 0; width: 10px; background: #fff; box-shadow: 0 0 15px #fff; }
+@keyframes glow-pulse { 0% { opacity: 0.8; filter: brightness(1); } 100% { opacity: 1; filter: brightness(1.3); } }


### PR DESCRIPTION
**Title:** feat: create Glowing Progress Bar with Retro styling (#25207) #78715

**Description:**
This PR introduces an outrun/synthwave inspired progress bar. It uses harsh cyan borders with intense magenta fills, topped with a pulsing bright-white leading edge.

Fixes #78715

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-progress-bar-glowing-retro/`
- Stacked overlapping `box-shadow` styles across the track and fill bar to create an intense blooming neon glow
- Added a `::after` element mapped to the right edge of the fill bar to simulate a searing hot leading edge (`box-shadow: 0 0 15px #fff`)
