### PR TITLE
feat: create 3D Carousel with Neon styling (#42854) #78718

### DIFF
--- a/submissions/examples/css-carousel-3d-neon/README.md
+++ b/submissions/examples/css-carousel-3d-neon/README.md
@@ -1,0 +1,2 @@
+# 3D Carousel (Neon)
+A rotating 3D hexagon carousel built using `perspective` and `transform-style: preserve-3d`. Each card panel features intense cyan neon glows and rotates around a central Z-axis point.

--- a/submissions/examples/css-carousel-3d-neon/demo.html
+++ b/submissions/examples/css-carousel-3d-neon/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Neon Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neon-scene">
+        <div class="neon-carousel">
+            <div class="n-item n1">1</div>
+            <div class="n-item n2">2</div>
+            <div class="n-item n3">3</div>
+            <div class="n-item n4">4</div>
+            <div class="n-item n5">5</div>
+            <div class="n-item n6">6</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-3d-neon/style.css
+++ b/submissions/examples/css-carousel-3d-neon/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #090a0f; --neon: #0ff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; perspective: 1000px; font-family: 'Courier New', monospace; }
+.neon-scene { position: relative; width: 200px; height: 200px; transform-style: preserve-3d; }
+.neon-carousel { width: 100%; height: 100%; position: absolute; transform-style: preserve-3d; animation: n-spin 15s infinite linear; }
+.n-item { position: absolute; width: 180px; height: 120px; background: rgba(0, 255, 255, 0.1); border: 2px solid var(--neon); box-shadow: 0 0 15px rgba(0, 255, 255, 0.5), inset 0 0 10px rgba(0, 255, 255, 0.3); color: var(--neon); text-shadow: 0 0 5px var(--neon); font-size: 2rem; font-weight: bold; display: flex; justify-content: center; align-items: center; left: 10px; top: 40px; }
+.n1 { transform: rotateY(0deg) translateZ(250px); }
+.n2 { transform: rotateY(60deg) translateZ(250px); }
+.n3 { transform: rotateY(120deg) translateZ(250px); }
+.n4 { transform: rotateY(180deg) translateZ(250px); }
+.n5 { transform: rotateY(240deg) translateZ(250px); }
+.n6 { transform: rotateY(300deg) translateZ(250px); }
+@keyframes n-spin { from { transform: rotateY(0deg); } to { transform: rotateY(360deg); } }


### PR DESCRIPTION
**Title:** feat: create 3D Carousel with Neon styling (#42854) #78718

**Description:**
This PR introduces a rotating 3D hexagon carousel built using `perspective` and `transform-style: preserve-3d`. Each card panel features intense cyan neon glows and rotates around a central Z-axis point.

Fixes #78718

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-3d-neon/`
- Set up a master container utilizing `perspective: 1000px` to project physical depth onto the child cards
- Positioned six identical cards evenly around a 360-degree radial axis utilizing `rotateY` increments (0, 60, 120, etc.) combined with `translateZ(250px)` to push them outward into the hexagon shape
