### PR TITLE
feat: create 3D Tab Bar with Minimalist styling (#83442) #78697

### DIFF
--- a/submissions/examples/css-tab-bar-3d-minimalist/README.md
+++ b/submissions/examples/css-tab-bar-3d-minimalist/README.md
@@ -1,0 +1,2 @@
+# 3D Tab Bar (Minimalist)
+A clean, structural tab bar. Inactive tabs are physically rotated backwards along the X-axis `rotateX(30deg)`, while the active tab springs upright and scales to full size on selection.

--- a/submissions/examples/css-tab-bar-3d-minimalist/demo.html
+++ b/submissions/examples/css-tab-bar-3d-minimalist/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Minimalist Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="m3d-tabs">
+        <input type="radio" name="m3d" id="t1" checked>
+        <label for="t1" class="m3d-tab">Home</label>
+        
+        <input type="radio" name="m3d" id="t2">
+        <label for="t2" class="m3d-tab">Profile</label>
+        
+        <input type="radio" name="m3d" id="t3">
+        <label for="t3" class="m3d-tab">Settings</label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-3d-minimalist/style.css
+++ b/submissions/examples/css-tab-bar-3d-minimalist/style.css
@@ -1,0 +1,6 @@
+:root { --bg: #f0f0f0; --text: #888; --active: #111; --surface: #ffffff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, sans-serif; perspective: 800px; }
+.m3d-tabs { display: flex; gap: 1rem; transform-style: preserve-3d; }
+input[type="radio"] { display: none; }
+.m3d-tab { background: var(--surface); padding: 1rem 2.5rem; border-radius: 8px 8px 0 0; color: var(--text); font-weight: 600; cursor: pointer; transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); transform-origin: bottom; transform: rotateX(30deg) translateY(10px) scale(0.95); box-shadow: 0 -5px 15px rgba(0,0,0,0.05); }
+input[type="radio"]:checked + .m3d-tab { color: var(--active); transform: rotateX(0deg) translateY(0) scale(1); box-shadow: 0 -10px 20px rgba(0,0,0,0.1); z-index: 10; border-bottom: 2px solid var(--active); }


### PR DESCRIPTION
**Title:** feat: create 3D Tab Bar with Minimalist styling (#83442) #78697

**Description:**
This PR introduces a clean, structural tab bar. Inactive tabs are physically rotated backwards along the X-axis, while the active tab springs upright and scales to full size on selection.

Fixes #78697

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-3d-minimalist/`
- Managed active states natively through CSS utilizing hidden `<input type="radio">` toggles
- Applied `transform-origin: bottom` to anchor the tabs to the baseline, allowing them to lean backwards via `rotateX(30deg)` when inactive
