### PR TITLE
feat: create Animated Input Field with Cyberpunk styling (#65260) #79611

### DIFF
--- a/submissions/examples/css-input-animated-cyberpunk/README.md
+++ b/submissions/examples/css-input-animated-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Animated Input Field (Cyberpunk)
+A dystopian terminal input. Features a bouncy floating label and an animated underline that stretches to 100% on focus, followed by a frantic skewing glitch animation.

--- a/submissions/examples/css-input-animated-cyberpunk/demo.html
+++ b/submissions/examples/css-input-animated-cyberpunk/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Animated Input</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cyber-input-group">
+        <input type="text" class="cyber-input" required>
+        <span class="cyber-label">ACCESS_CODE</span>
+        <div class="cyber-glitch-bar"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-input-animated-cyberpunk/style.css
+++ b/submissions/examples/css-input-animated-cyberpunk/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #000000; --primary: #fcee0a; --cyan: #0ff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; color: #fff; }
+.cyber-input-group { position: relative; width: 300px; margin-top: 2rem; }
+.cyber-input { width: 100%; background: transparent; border: none; border-bottom: 2px solid #555; color: var(--primary); padding: 10px 0; font-size: 1.2rem; font-family: inherit; outline: none; transition: border-color 0.3s; z-index: 2; position: relative; }
+.cyber-label { position: absolute; top: 10px; left: 0; color: #888; font-size: 1.2rem; pointer-events: none; transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55); z-index: 1; letter-spacing: 2px; }
+.cyber-glitch-bar { position: absolute; bottom: 0; left: 0; width: 0; height: 2px; background: var(--cyan); transition: width 0.3s ease; z-index: 3; box-shadow: 0 0 10px var(--cyan); }
+.cyber-input:focus ~ .cyber-label, .cyber-input:valid ~ .cyber-label { top: -25px; font-size: 0.8rem; color: var(--primary); }
+.cyber-input:focus ~ .cyber-glitch-bar { width: 100%; animation: c-glitch 2s infinite linear alternate-reverse; }
+@keyframes c-glitch { 0%, 100% { transform: skewX(0deg); } 20% { transform: skewX(-20deg); } 40% { transform: skewX(20deg); } }


### PR DESCRIPTION
**Title:** feat: create Animated Input Field with Cyberpunk styling (#65260) #79611

**Description:**
This PR introduces a dystopian terminal input. Features a bouncy floating label and an animated underline that stretches to 100% on focus, followed by a frantic skewing glitch animation.

Fixes #79611

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-input-animated-cyberpunk/`
- Floated the `ACCESS_CODE` label dynamically utilizing the `:focus` and `:valid` state selectors
- Wired an aggressive, looping CSS keyframe animation (`c-glitch`) that rapidly `skewX` the active cyan underline back and forth to mimic a corrupted monitor
