### PR TITLE
feat: create Animated Dropdown with Gradient styling (#44244) #79612

### DIFF
--- a/submissions/examples/css-dropdown-animated-gradient/README.md
+++ b/submissions/examples/css-dropdown-animated-gradient/README.md
@@ -1,0 +1,2 @@
+# Animated Dropdown (Gradient)
+A stylish dropdown that reveals a glowing gradient border upon hover via a negative inset pseudo-element. The menu drops down with a bouncy 3D scaling effect.

--- a/submissions/examples/css-dropdown-animated-gradient/demo.html
+++ b/submissions/examples/css-dropdown-animated-gradient/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Gradient Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="grad-dd">
+        <button class="grad-dd-btn">
+            Select Option <i class="ph ph-caret-down"></i>
+        </button>
+        <div class="grad-dd-menu">
+            <a href="#">Design</a>
+            <a href="#">Development</a>
+            <a href="#">Marketing</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-animated-gradient/style.css
+++ b/submissions/examples/css-dropdown-animated-gradient/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #1e1e2f; --grad: linear-gradient(135deg, #ff6b6b, #c0392b); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: flex-start; padding-top: 20vh; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.grad-dd { position: relative; display: inline-block; }
+.grad-dd-btn { background: #2a2a40; color: #fff; border: 2px solid transparent; padding: 1rem 2rem; font-size: 1.1rem; border-radius: 8px; cursor: pointer; display: flex; align-items: center; gap: 1rem; transition: 0.3s; background-clip: padding-box; position: relative; z-index: 2; }
+.grad-dd-btn::before { content: ''; position: absolute; inset: -2px; border-radius: 10px; background: var(--grad); z-index: -1; opacity: 0; transition: 0.3s; }
+.grad-dd-btn i { transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.grad-dd-menu { position: absolute; top: calc(100% + 10px); left: 0; width: 100%; background: #2a2a40; border-radius: 8px; overflow: hidden; opacity: 0; visibility: hidden; transform: translateY(-20px) scale(0.95); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); transform-origin: top; box-shadow: 0 10px 30px rgba(0,0,0,0.5); }
+.grad-dd-menu a { display: block; padding: 1rem 1.5rem; color: #fff; text-decoration: none; transition: 0.2s; position: relative; z-index: 1; }
+.grad-dd-menu a:hover { background: rgba(255,255,255,0.1); padding-left: 2rem; }
+.grad-dd:hover .grad-dd-btn::before { opacity: 1; }
+.grad-dd:hover .grad-dd-btn i { transform: rotate(180deg); }
+.grad-dd:hover .grad-dd-menu { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Animated Dropdown with Gradient styling (#44244) #79612

**Description:**
This PR introduces a stylish dropdown that reveals a glowing gradient border upon hover via a negative inset pseudo-element. The menu drops down with a bouncy 3D scaling effect.

Fixes #79612

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-dropdown-animated-gradient/`
- Rendered the button's gradient border by placing an absolutely positioned `::before` element underneath the button utilizing a negative inset (`inset: -2px`)
- Triggered the dropdown menu visibility on `:hover`, utilizing a `cubic-bezier` timing function to scale and translate the menu down naturally from the button's edge
