### PR TITLE
feat: create Responsive Accordion with Neumorphism styling (#85563) #79667

### DIFF
--- a/submissions/examples/css-accordion-responsive-neumorphism/README.md
+++ b/submissions/examples/css-accordion-responsive-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Responsive Accordion (Neumorphism)
+A soft-UI accordion utilizing the checkbox hack. Expanding an item elegantly shifts its container from an outset shadow drop to a recessed inset shadow, making it feel physically indented.

--- a/submissions/examples/css-accordion-responsive-neumorphism/demo.html
+++ b/submissions/examples/css-accordion-responsive-neumorphism/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Responsive Accordion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="neu-accordion">
+        <div class="neu-acc-item">
+            <input type="checkbox" id="neu-acc1" class="neu-acc-input">
+            <label class="neu-acc-header" for="neu-acc1">
+                Design System
+                <span class="neu-acc-icon"></span>
+            </label>
+            <div class="neu-acc-content">
+                <p>A collection of reusable components built with soft UI principles to create cohesive, extruded interfaces.</p>
+            </div>
+        </div>
+        <div class="neu-acc-item">
+            <input type="checkbox" id="neu-acc2" class="neu-acc-input">
+            <label class="neu-acc-header" for="neu-acc2">
+                Accessibility
+                <span class="neu-acc-icon"></span>
+            </label>
+            <div class="neu-acc-content">
+                <p>Ensure adequate contrast ratios in Neumorphic designs, as the subtle shadows can be difficult for visually impaired users to perceive.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-accordion-responsive-neumorphism/style.css
+++ b/submissions/examples/css-accordion-responsive-neumorphism/style.css
@@ -1,0 +1,17 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.neu-accordion { width: 90%; max-width: 600px; display: flex; flex-direction: column; gap: 1.5rem; }
+.neu-acc-item { background: var(--bg); border-radius: 15px; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); overflow: hidden; transition: all 0.3s ease; }
+.neu-acc-input { display: none; }
+.neu-acc-header { display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 1.5rem; font-size: 1.1rem; font-weight: 600; color: var(--text); cursor: pointer; user-select: none; transition: color 0.3s ease; }
+.neu-acc-icon { position: relative; width: 24px; height: 24px; border-radius: 50%; box-shadow: inset 2px 2px 5px var(--shadow-dark), inset -2px -2px 5px var(--shadow-light); transition: all 0.3s; }
+.neu-acc-icon::before { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 10px; height: 2px; background: var(--text); transition: all 0.3s; }
+.neu-acc-icon::after { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 2px; height: 10px; background: var(--text); transition: all 0.3s; }
+.neu-acc-content { max-height: 0; opacity: 0; padding: 0 1.5rem; overflow: hidden; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); }
+.neu-acc-content p { color: #718096; line-height: 1.6; margin-top: 0; padding-bottom: 1.25rem; }
+.neu-acc-input:checked + .neu-acc-header { color: var(--accent); }
+.neu-acc-input:checked + .neu-acc-header .neu-acc-icon { box-shadow: 2px 2px 5px var(--shadow-dark), -2px -2px 5px var(--shadow-light); }
+.neu-acc-input:checked + .neu-acc-header .neu-acc-icon::before { background: var(--accent); }
+.neu-acc-input:checked + .neu-acc-header .neu-acc-icon::after { transform: translate(-50%, -50%) rotate(90deg); background: var(--accent); opacity: 0; }
+.neu-acc-input:checked ~ .neu-acc-content { max-height: 200px; opacity: 1; }
+.neu-acc-input:checked ~ .neu-acc-item { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }


### PR DESCRIPTION

**Title:** feat: create Responsive Accordion with Neumorphism styling (#85563) #79667

**Description:**
This PR introduces a soft-UI accordion utilizing the checkbox hack. Expanding an item elegantly shifts its container from an outset shadow drop to a recessed inset shadow, making it feel physically indented.

Fixes #79667

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-accordion-responsive-neumorphism/`
- Rendered the accordion item bodies utilizing Neumorphic dual box-shadows (`6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light)`)
- Mapped the `:checked` state to swap the entire container shadow to `inset`, simulating a button press while simultaneously transitioning the expand icon from a '+' to a '-'
