### PR TITLE
feat: create Floating Pagination with Pastel styling (#83642) #79666

### DIFF
--- a/submissions/examples/css-pagination-floating-pastel/README.md
+++ b/submissions/examples/css-pagination-floating-pastel/README.md
@@ -1,0 +1,2 @@
+# Floating Pagination (Pastel)
+A dreamy pastel pagination bar. Items physically float upwards on hover, while the active page remains perpetually elevated with an indicator dot anchored below it.

--- a/submissions/examples/css-pagination-floating-pastel/demo.html
+++ b/submissions/examples/css-pagination-floating-pastel/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Pastel Pagination</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="pastel-float-pag">
+        <a href="#" class="pfp-btn">&lt;</a>
+        <a href="#" class="pfp-item">1</a>
+        <a href="#" class="pfp-item active">2</a>
+        <a href="#" class="pfp-item">3</a>
+        <a href="#" class="pfp-btn">&gt;</a>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pagination-floating-pastel/style.css
+++ b/submissions/examples/css-pagination-floating-pastel/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #fdfbf7; --shadow: rgba(255, 183, 178, 0.4); --active: #ffb7b2; --hover: #ffdac1; --text: #555; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.pastel-float-pag { display: flex; gap: 1rem; padding: 1.5rem 2.5rem; background: #fff; border-radius: 50px; box-shadow: 0 10px 30px rgba(0,0,0,0.03); }
+.pfp-item, .pfp-btn { display: flex; justify-content: center; align-items: center; width: 45px; height: 45px; border-radius: 50%; color: var(--text); text-decoration: none; font-weight: 600; background: #fff; transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); position: relative; }
+.pfp-item:hover, .pfp-btn:hover { transform: translateY(-8px); background: var(--hover); color: #fff; box-shadow: 0 12px 20px var(--shadow); }
+.pfp-item.active { background: var(--active); color: #fff; transform: translateY(-12px) scale(1.1); box-shadow: 0 15px 25px var(--shadow); pointer-events: none; }
+.pfp-item.active::after { content: ''; position: absolute; bottom: -15px; left: 50%; transform: translateX(-50%); width: 6px; height: 6px; border-radius: 50%; background: var(--active); }


### PR DESCRIPTION
**Title:** feat: create Floating Pagination with Pastel styling (#83642) #79666

**Description:**
This PR introduces a dreamy pastel pagination bar. Items physically float upwards on hover, while the active page remains perpetually elevated with an indicator dot anchored below it.

Fixes #79666

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-pagination-floating-pastel/`
- Built a minimal rounded pill container holding crisp circular pagination links
- Applied `transform: translateY(-8px)` combined with a soft pink drop shadow on hover, and locked the `.active` item at `translateY(-12px) scale(1.1)` for strong visual hierarchy
