### PR TITLE
feat: create Neumorphic Hero Section with Glassmorphism styling (#40971) #79665

### DIFF
--- a/submissions/examples/css-hero-neumorphic-glassmorphism/README.md
+++ b/submissions/examples/css-hero-neumorphic-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Hero Section (Glassmorphism)
+A unique hybrid design. Fuses ambient glassmorphism blurred background orbs with a Neumorphic outer container box-shadow, creating a soft, translucent frosted panel.

--- a/submissions/examples/css-hero-neumorphic-glassmorphism/demo.html
+++ b/submissions/examples/css-hero-neumorphic-glassmorphism/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Glass Hero</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ng-hero-bg">
+        <div class="ng-orb orb-a"></div>
+        <div class="ng-orb orb-b"></div>
+        <div class="ng-hero-card">
+            <h1>Soft Meets Glass</h1>
+            <p>Experience the ultimate fusion of soft Neumorphic extrusion and deep frosted Glassmorphism blurs.</p>
+            <button class="ng-btn">Discover</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-hero-neumorphic-glassmorphism/style.css
+++ b/submissions/examples/css-hero-neumorphic-glassmorphism/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; }
+body { margin: 0; font-family: system-ui, sans-serif; background: var(--bg); overflow: hidden; }
+.ng-hero-bg { position: relative; height: 100vh; display: flex; justify-content: center; align-items: center; padding: 2rem; }
+.ng-orb { position: absolute; border-radius: 50%; filter: blur(40px); z-index: 1; }
+.orb-a { width: 300px; height: 300px; background: #ff9a9e; top: 10%; left: 20%; animation: float 10s infinite alternate ease-in-out; }
+.orb-b { width: 400px; height: 400px; background: #a18cd1; bottom: 5%; right: 15%; animation: float 12s infinite alternate-reverse ease-in-out; }
+.ng-hero-card { position: relative; z-index: 2; max-width: 700px; padding: 4rem; border-radius: 30px; text-align: center; /* The Fusion */ background: rgba(224, 229, 236, 0.4); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border: 2px solid rgba(255, 255, 255, 0.5); box-shadow: 15px 15px 30px rgba(163, 177, 198, 0.4), -15px -15px 30px rgba(255, 255, 255, 0.6); }
+.ng-hero-card h1 { font-size: 3.5rem; color: #2d3748; margin-top: 0; letter-spacing: -1px; text-shadow: 2px 2px 4px rgba(255,255,255,0.8); }
+.ng-hero-card p { font-size: 1.25rem; color: #4a5568; line-height: 1.6; margin-bottom: 2.5rem; }
+.ng-btn { background: var(--bg); color: #4a90e2; font-size: 1.1rem; font-weight: bold; padding: 1rem 2.5rem; border: none; border-radius: 50px; cursor: pointer; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.3s; }
+.ng-btn:hover { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); color: #2b6cb0; }
+@keyframes float { 0% { transform: translateY(0); } 100% { transform: translateY(50px); } }


### PR DESCRIPTION

**Title:** feat: create Neumorphic Hero Section with Glassmorphism styling (#40971) #79665

**Description:**
This PR introduces a unique hybrid design. Fuses ambient glassmorphism blurred background orbs with a Neumorphic outer container box-shadow, creating a soft, translucent frosted panel.

Fixes #79665

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-hero-neumorphic-glassmorphism/`
- Designed slow-floating animated background orbs rendered completely soft via `filter: blur(40px)`
- Styled the main content card using `backdrop-filter: blur(20px)` to pull the background through, but finalized the outer edges with classic Neumorphic soft shadows (`15px 15px 30px...`)
