### PR TITLE
feat: create Animated Accordion with Gradient styling (#29013) #79663

### DIFF
--- a/submissions/examples/css-accordion-animated-gradient/README.md
+++ b/submissions/examples/css-accordion-animated-gradient/README.md
@@ -1,0 +1,2 @@
+# Animated Accordion (Gradient)
+A visually stunning accordion. When an item is expanded, its dark background cross-fades into a vibrant CSS linear gradient, illuminating the content within.

--- a/submissions/examples/css-accordion-animated-gradient/demo.html
+++ b/submissions/examples/css-accordion-animated-gradient/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Gradient Accordion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="grad-accordion">
+        <div class="ga-item">
+            <input type="radio" name="ga-acc" id="ga1" checked>
+            <label class="ga-header" for="ga1">Vision</label>
+            <div class="ga-content">
+                <div class="ga-inner">Transforming the web through vibrant, fluid color transitions and flawless state management.</div>
+            </div>
+        </div>
+        <div class="ga-item">
+            <input type="radio" name="ga-acc" id="ga2">
+            <label class="ga-header" for="ga2">Mission</label>
+            <div class="ga-content">
+                <div class="ga-inner">Building performant CSS-only components that reduce Javascript overhead while maximizing aesthetic impact.</div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-accordion-animated-gradient/style.css
+++ b/submissions/examples/css-accordion-animated-gradient/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #111111; --text: #ffffff; --grad1: linear-gradient(45deg, #ff9a9e 0%, #fecfef 99%, #fecfef 100%); --grad2: linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%); --grad3: linear-gradient(to right, #fa709a 0%, #fee140 100%); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.grad-accordion { width: 90%; max-width: 500px; display: flex; flex-direction: column; gap: 1rem; }
+.ga-item { background: #222; border-radius: 12px; overflow: hidden; position: relative; }
+.ga-item::before { content: ''; position: absolute; inset: 0; background: var(--grad1); opacity: 0; transition: opacity 0.5s ease; z-index: 0; }
+.ga-item:nth-child(2)::before { background: var(--grad2); }
+input[type="radio"] { display: none; }
+.ga-header { position: relative; z-index: 1; display: block; padding: 1.5rem; font-size: 1.2rem; font-weight: 700; color: var(--text); cursor: pointer; transition: padding 0.3s ease; }
+.ga-content { position: relative; z-index: 1; max-height: 0; opacity: 0; overflow: hidden; transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1); }
+.ga-inner { padding: 0 1.5rem 1.5rem 1.5rem; color: #fff; font-size: 1rem; line-height: 1.6; text-shadow: 0 1px 2px rgba(0,0,0,0.2); }
+input:checked + .ga-header { padding-bottom: 0.5rem; }
+input:checked ~ .ga-content { max-height: 200px; opacity: 1; }
+input:checked ~ .ga-item::before, input:checked ~ .ga-content, input:checked + .ga-header { z-index: 2; }
+.ga-item:has(input:checked)::before { opacity: 1; }


### PR DESCRIPTION
**Title:** feat: create Animated Accordion with Gradient styling (#29013) #79663

**Description:**
This PR introduces a visually stunning accordion. When an item is expanded, its dark background cross-fades into a vibrant CSS linear gradient, illuminating the content within.

Fixes #79663

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-accordion-animated-gradient/`
- Rendered unique linear gradients on the `::before` pseudo-elements of each accordion item, set to `opacity: 0` by default
- Targeted the `:has(input:checked)::before` state to fade the gradient opacity to 1, effectively illuminating the expanded content block from behind
