### PR TITLE
feat: create CSS-only Spinner with Retro styling (#89721) #79622

### DIFF
--- a/submissions/examples/css-spinner-css-only-retro/README.md
+++ b/submissions/examples/css-spinner-css-only-retro/README.md
@@ -1,0 +1,2 @@
+# CSS-only Spinner (Retro)
+A chunky 8-bit arcade loader. It utilizes a `steps(8, end)` animation timing function to mimic low-framerate retro rotation, paired with classic blinking terminal text.

--- a/submissions/examples/css-spinner-css-only-retro/demo.html
+++ b/submissions/examples/css-spinner-css-only-retro/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro CSS-only Spinner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="retro-spin-container">
+        <div class="retro-spinner"></div>
+        <div class="retro-spin-text">LOADING...</div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-spinner-css-only-retro/style.css
+++ b/submissions/examples/css-spinner-css-only-retro/style.css
@@ -1,0 +1,7 @@
+:root { --bg: #0000aa; --text: #ffff55; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Press Start 2P', 'Courier New', monospace; }
+.retro-spin-container { display: flex; flex-direction: column; align-items: center; gap: 1.5rem; }
+.retro-spinner { width: 50px; height: 50px; border: 8px solid #000; border-top-color: var(--text); border-radius: 50%; animation: r-spin 1s steps(8, end) infinite; box-shadow: 4px 4px 0 #000; }
+.retro-spin-text { color: var(--text); text-shadow: 2px 2px 0 #000; font-weight: bold; font-size: 1.2rem; letter-spacing: 2px; animation: r-blink 1s step-end infinite; }
+@keyframes r-spin { 100% { transform: rotate(360deg); } }
+@keyframes r-blink { 50% { opacity: 0; } }


### PR DESCRIPTION
**Title:** feat: create CSS-only Spinner with Retro styling (#89721) #79622

**Description:**
This PR introduces a chunky 8-bit arcade loader. It utilizes a `steps(8, end)` animation timing function to mimic low-framerate retro rotation, paired with classic blinking terminal text.

Fixes #79622

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-spinner-css-only-retro/`
- Bound a `rotate(360deg)` animation to the spinner utilizing the `steps()` timing function instead of linear easing, creating a jagged, frame-by-frame mechanical spin
- Added intense black drop shadows (`4px 4px 0 #000`) and thick borders to maintain the raw pixel art aesthetic
