### PR TITLE
feat: create Parallax Dropdown with Minimalist styling (#35719) #79657

### DIFF
--- a/submissions/examples/css-dropdown-parallax-minimalist/README.md
+++ b/submissions/examples/css-dropdown-parallax-minimalist/README.md
@@ -1,0 +1,2 @@
+# Parallax Dropdown (Minimalist)
+A clean, staggered dropdown menu. Uses CSS variables (`--delay`) inline to stagger the cascading entrance of each item, which fall and rotate into place seamlessly.

--- a/submissions/examples/css-dropdown-parallax-minimalist/demo.html
+++ b/submissions/examples/css-dropdown-parallax-minimalist/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parallax Minimalist Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="plx-dd-container">
+        <button class="plx-btn">
+            Filter <i class="ph ph-funnel"></i>
+        </button>
+        <div class="plx-menu">
+            <div class="plx-item-wrap" style="--delay: 0.1s"><a href="#" class="plx-item">Recent</a></div>
+            <div class="plx-item-wrap" style="--delay: 0.2s"><a href="#" class="plx-item">Popular</a></div>
+            <div class="plx-item-wrap" style="--delay: 0.3s"><a href="#" class="plx-item">Trending</a></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-parallax-minimalist/style.css
+++ b/submissions/examples/css-dropdown-parallax-minimalist/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #fafafa; --text: #111; --border: #eaeaea; }
+body { background: var(--bg); display: flex; justify-content: center; padding-top: 15vh; height: 100vh; margin: 0; font-family: -apple-system, sans-serif; }
+.plx-dd-container { position: relative; }
+.plx-btn { background: #fff; color: var(--text); border: 1px solid var(--border); padding: 0.75rem 1.5rem; border-radius: 8px; font-size: 1rem; cursor: pointer; display: flex; align-items: center; gap: 0.75rem; box-shadow: 0 2px 5px rgba(0,0,0,0.02); }
+.plx-menu { position: absolute; top: calc(100% + 5px); left: 0; width: 100%; perspective: 600px; display: flex; flex-direction: column; gap: 4px; pointer-events: none; }
+.plx-item-wrap { overflow: hidden; }
+.plx-item { display: block; background: #fff; color: #555; text-decoration: none; padding: 0.75rem 1rem; border: 1px solid var(--border); border-radius: 6px; transform: translateY(-100%) rotateX(-20deg); opacity: 0; transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1); transition-delay: var(--delay); }
+.plx-item:hover { background: #f5f5f5; color: var(--text); }
+.plx-dd-container:hover .plx-menu { pointer-events: auto; }
+.plx-dd-container:hover .plx-item { transform: translateY(0) rotateX(0); opacity: 1; }


### PR DESCRIPTION
**Title:** feat: create Parallax Dropdown with Minimalist styling (#35719) #79657

**Description:**
This PR introduces a clean, staggered dropdown menu. Uses CSS variables inline to stagger the cascading entrance of each item, which fall and rotate into place seamlessly.

Fixes #79657

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-dropdown-parallax-minimalist/`
- Built out the dropdown container using `perspective: 600px` to allow child links to swing forward in 3D space
- Passed a `--delay` variable inline (`style="--delay: 0.1s"`) to stagger the `.plx-item` transitions on hover, creating a cascading dropdown waterfall
