### PR TITLE
feat: create Hover Toggle with Neon styling (#69752) #79617

### DIFF
--- a/submissions/examples/css-toggle-hover-neon/README.md
+++ b/submissions/examples/css-toggle-hover-neon/README.md
@@ -1,0 +1,2 @@
+# Hover Toggle (Neon)
+A dark mode toggle that activates its neon pink glow merely on hover, acting as a preview. When fully checked, the thumb slides over and burns bright white with an intense aura.

--- a/submissions/examples/css-toggle-hover-neon/demo.html
+++ b/submissions/examples/css-toggle-hover-neon/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neon Hover Toggle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <label class="neon-hover-toggle">
+        <input type="checkbox">
+        <span class="nht-track">
+            <span class="nht-thumb"></span>
+        </span>
+    </label>
+</body>
+</html>

--- a/submissions/examples/css-toggle-hover-neon/style.css
+++ b/submissions/examples/css-toggle-hover-neon/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #050505; --neon: #ff00ff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.neon-hover-toggle { position: relative; display: inline-block; cursor: pointer; }
+.neon-hover-toggle input { display: none; }
+.nht-track { display: block; width: 90px; height: 40px; border: 2px solid #333; border-radius: 40px; background: #111; transition: all 0.3s; position: relative; }
+.nht-thumb { position: absolute; top: 4px; left: 4px; width: 28px; height: 28px; background: #333; border-radius: 50%; transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.neon-hover-toggle:hover .nht-track { border-color: var(--neon); box-shadow: 0 0 10px rgba(255,0,255,0.3), inset 0 0 10px rgba(255,0,255,0.2); }
+.neon-hover-toggle:hover .nht-thumb { background: var(--neon); box-shadow: 0 0 15px var(--neon); }
+input:checked + .nht-track { border-color: var(--neon); background: rgba(255,0,255,0.1); box-shadow: 0 0 15px rgba(255,0,255,0.5), inset 0 0 15px rgba(255,0,255,0.2); }
+input:checked + .nht-track .nht-thumb { transform: translateX(50px); background: #fff; box-shadow: 0 0 20px #fff, 0 0 40px var(--neon); }


### PR DESCRIPTION
**Title:** feat: create Hover Toggle with Neon styling (#69752) #79617

**Description:**
This PR introduces a dark mode toggle that activates its neon pink glow merely on hover, acting as a preview. When fully checked, the thumb slides over and burns bright white with an intense aura.

Fixes #79617

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-toggle-hover-neon/`
- Designed the inactive track with a subdued `#111` background that lights up dynamically with an inset neon pink box shadow strictly on `:hover`
- Mapped the `:checked` state to turn the thumb completely white while expanding the outer drop shadows to simulate maximum brightness (`0 0 40px var(--neon)`)
