### PR TITLE
feat: add CSS-only Neon modal #79766

### DIFF
--- a/submissions/examples/79766-css-modal-neon/README.md
+++ b/submissions/examples/79766-css-modal-neon/README.md
@@ -1,0 +1,25 @@
+# CSS-only Modal with Neon Styling
+
+A responsive, futuristic modal component built entirely with HTML and CSS. The modal uses the URL fragment `:target` technique, so no JavaScript or external dependency is required.
+
+## ✨ Features
+
+- Pure HTML and CSS
+- Zero JavaScript dependencies
+- Neon cyber-inspired visual design
+- CSS-only open and close interaction
+- Smooth modal entrance animation
+- Neon glow effects
+- Responsive across desktop, tablet and mobile
+- Keyboard-friendly links and focus states
+- `prefers-reduced-motion` support
+- Semantic dialog markup
+- Reusable CSS custom properties
+
+## 📁 Structure
+
+```text
+79766-css-modal-neon/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/79766-css-modal-neon/demo.html
+++ b/submissions/examples/79766-css-modal-neon/demo.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="CSS-only responsive modal with neon styling."
+  >
+
+  <title>CSS-only Neon Modal</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+    <section class="hero" aria-labelledby="page-title">
+
+      <span class="eyebrow">
+        EASEMOTION / MODAL
+      </span>
+
+      <h1 id="page-title">
+        Neon modal,
+        <span>zero JavaScript.</span>
+      </h1>
+
+      <p>
+        A responsive CSS-only modal component with
+        neon glow effects, smooth transitions,
+        keyboard-friendly controls, and a dark
+        futuristic interface.
+      </p>
+
+      <a
+        class="open-modal"
+        href="#neon-modal"
+        aria-haspopup="dialog"
+      >
+        Open Neon Modal
+        <span aria-hidden="true">↗</span>
+      </a>
+
+    </section>
+
+    <section
+      class="feature-grid"
+      aria-label="Modal features"
+    >
+
+      <article class="feature-card">
+        <span class="feature-icon" aria-hidden="true">
+          ✦
+        </span>
+
+        <h2>CSS Only</h2>
+
+        <p>
+          The modal state is controlled with the
+          URL fragment and CSS selectors.
+        </p>
+      </article>
+
+      <article class="feature-card">
+        <span class="feature-icon" aria-hidden="true">
+          ◈
+        </span>
+
+        <h2>Neon Glow</h2>
+
+        <p>
+          Layered shadows, gradients and borders
+          create a futuristic visual treatment.
+        </p>
+      </article>
+
+      <article class="feature-card">
+        <span class="feature-icon" aria-hidden="true">
+          ◎
+        </span>
+
+        <h2>Responsive</h2>
+
+        <p>
+          The modal adapts smoothly across desktop,
+          tablet and mobile screen sizes.
+        </p>
+      </article>
+
+    </section>
+  </main>
+
+
+  <!-- CSS-only Modal -->
+  <div
+    class="modal"
+    id="neon-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+    aria-describedby="modal-description"
+  >
+
+    <a
+      class="modal-backdrop"
+      href="#"
+      aria-label="Close modal"
+    ></a>
+
+    <div class="modal-window">
+
+      <div class="modal-top-line" aria-hidden="true"></div>
+
+      <div class="modal-header">
+
+        <div class="modal-symbol" aria-hidden="true">
+          ⚡
+        </div>
+
+        <a
+          class="modal-close"
+          href="#"
+          aria-label="Close modal"
+        >
+          ×
+        </a>
+
+      </div>
+
+      <span class="modal-label">
+        SYSTEM MESSAGE
+      </span>
+
+      <h2 id="modal-title">
+        Neon interface activated.
+      </h2>
+
+      <p id="modal-description">
+        This modal is built entirely with HTML and
+        CSS. No external JavaScript dependency is
+        required to open or close the interface.
+      </p>
+
+      <div class="modal-status">
+        <span class="status-dot" aria-hidden="true"></span>
+
+        <span>
+          Component ready
+        </span>
+      </div>
+
+      <div class="modal-actions">
+
+        <a
+          class="modal-primary"
+          href="#"
+        >
+          Continue
+        </a>
+
+        <a
+          class="modal-secondary"
+          href="#"
+        >
+          Cancel
+        </a>
+
+      </div>
+
+      <p class="modal-note">
+        Press the close control or select the backdrop
+        to return to the page.
+      </p>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/79766-css-modal-neon/style.css
+++ b/submissions/examples/79766-css-modal-neon/style.css
@@ -1,0 +1,943 @@
+:root {
+  --em-bg: #070812;
+  --em-bg-soft: #0d1020;
+
+  --em-surface: #101426;
+  --em-surface-light: #151a30;
+
+  --em-text: #f4f7ff;
+  --em-muted: #9ca6c5;
+  --em-subtle: #68718e;
+
+  --em-neon: #00f5d4;
+  --em-neon-alt: #8b5cf6;
+  --em-neon-pink: #ff3cac;
+
+  --em-border:
+    rgba(0, 245, 212, 0.18);
+
+  --em-glow:
+    0 0 18px rgba(0, 245, 212, 0.25);
+
+  --em-glow-strong:
+    0 0 30px rgba(0, 245, 212, 0.38);
+
+  --em-shadow:
+    0 30px 80px
+    rgba(0, 0, 0, 0.55);
+
+  --em-radius-xl: 28px;
+  --em-radius-lg: 20px;
+  --em-radius-md: 14px;
+
+  --em-transition:
+    280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+
+  margin: 0;
+
+  color: var(--em-text);
+
+  background:
+    radial-gradient(
+      circle at 15% 15%,
+      rgba(0, 245, 212, 0.08),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 85% 75%,
+      rgba(139, 92, 246, 0.12),
+      transparent 30rem
+    ),
+    var(--em-bg);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+body::before {
+  position: fixed;
+
+  inset: 0;
+
+  z-index: -1;
+
+  background-image:
+    linear-gradient(
+      rgba(255, 255, 255, 0.025) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.025) 1px,
+      transparent 1px
+    );
+
+  background-size: 40px 40px;
+
+  content: "";
+  pointer-events: none;
+}
+
+a {
+  color: inherit;
+}
+
+.page {
+  width: min(1000px, 100%);
+
+  margin: 0 auto;
+
+  padding:
+    clamp(60px, 10vw, 110px)
+    20px;
+}
+
+.hero {
+  max-width: 700px;
+
+  margin:
+    0 auto
+    clamp(50px, 8vw, 75px);
+
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-flex;
+
+  padding: 8px 13px;
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.22);
+
+  border-radius: 999px;
+
+  color: var(--em-neon);
+
+  background:
+    rgba(0, 245, 212, 0.055);
+
+  box-shadow:
+    var(--em-glow);
+
+  font-size: 0.58rem;
+  font-weight: 800;
+
+  letter-spacing: 0.13em;
+}
+
+.hero h1 {
+  margin: 22px 0 0;
+
+  font-size:
+    clamp(3rem, 7vw, 5.5rem);
+
+  line-height: 0.94;
+
+  letter-spacing: -0.07em;
+}
+
+.hero h1 span {
+  display: block;
+
+  color: var(--em-neon);
+
+  text-shadow:
+    0 0 25px
+    rgba(0, 245, 212, 0.28);
+}
+
+.hero p {
+  max-width: 620px;
+
+  margin: 25px auto 0;
+
+  color: var(--em-muted);
+
+  font-size: 0.9rem;
+
+  line-height: 1.8;
+}
+
+.open-modal {
+  display: inline-flex;
+
+  align-items: center;
+
+  gap: 12px;
+
+  margin-top: 30px;
+
+  padding:
+    14px 20px;
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.5);
+
+  border-radius: 12px;
+
+  color: var(--em-neon);
+
+  background:
+    rgba(0, 245, 212, 0.06);
+
+  box-shadow:
+    var(--em-glow);
+
+  text-decoration: none;
+
+  font-size: 0.74rem;
+  font-weight: 800;
+
+  transition:
+    transform var(--em-transition),
+    background var(--em-transition),
+    box-shadow var(--em-transition);
+}
+
+.open-modal:hover {
+  transform:
+    translateY(-4px);
+
+  background:
+    rgba(0, 245, 212, 0.11);
+
+  box-shadow:
+    var(--em-glow-strong);
+}
+
+.open-modal:focus-visible {
+  outline:
+    2px solid
+    var(--em-neon);
+
+  outline-offset: 5px;
+}
+
+.feature-grid {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 14px;
+}
+
+.feature-card {
+  position: relative;
+
+  padding: 25px;
+
+  overflow: hidden;
+
+  border:
+    1px solid
+    var(--em-border);
+
+  border-radius: var(--em-radius-lg);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(21, 26, 48, 0.9),
+      rgba(11, 14, 29, 0.9)
+    );
+
+  box-shadow:
+    0 18px 45px
+    rgba(0, 0, 0, 0.25);
+
+  transition:
+    transform var(--em-transition),
+    border-color var(--em-transition),
+    box-shadow var(--em-transition);
+}
+
+.feature-card::before {
+  position: absolute;
+
+  top: -60px;
+  right: -50px;
+
+  width: 120px;
+  height: 120px;
+
+  border-radius: 50%;
+
+  background:
+    var(--em-neon);
+
+  filter: blur(55px);
+
+  opacity: 0.06;
+
+  content: "";
+
+  transition:
+    opacity var(--em-transition);
+}
+
+.feature-card:hover {
+  transform:
+    translateY(-6px);
+
+  border-color:
+    rgba(0, 245, 212, 0.32);
+
+  box-shadow:
+    0 20px 50px
+    rgba(0, 245, 212, 0.08);
+}
+
+.feature-card:hover::before {
+  opacity: 0.16;
+}
+
+.feature-icon {
+  display: grid;
+
+  width: 42px;
+  height: 42px;
+
+  place-items: center;
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.2);
+
+  border-radius: 12px;
+
+  color: var(--em-neon);
+
+  background:
+    rgba(0, 245, 212, 0.06);
+
+  box-shadow:
+    var(--em-glow);
+
+  font-size: 1rem;
+}
+
+.feature-card h2 {
+  margin: 20px 0 8px;
+
+  font-size: 1rem;
+
+  letter-spacing: -0.02em;
+}
+
+.feature-card p {
+  margin: 0;
+
+  color: var(--em-muted);
+
+  font-size: 0.68rem;
+
+  line-height: 1.7;
+}
+
+/*
+  CSS-only modal
+
+  The modal becomes visible when its ID is targeted:
+
+  #neon-modal:target
+
+  Opening:
+  href="#neon-modal"
+
+  Closing:
+  href="#"
+*/
+
+.modal {
+  position: fixed;
+
+  inset: 0;
+
+  z-index: 1000;
+
+  display: grid;
+
+  padding:
+    20px;
+
+  place-items: center;
+
+  visibility: hidden;
+
+  opacity: 0;
+
+  pointer-events: none;
+
+  transition:
+    opacity var(--em-transition),
+    visibility var(--em-transition);
+}
+
+.modal:target {
+  visibility: visible;
+
+  opacity: 1;
+
+  pointer-events: auto;
+}
+
+.modal-backdrop {
+  position: absolute;
+
+  inset: 0;
+
+  background:
+    rgba(3, 5, 14, 0.82);
+
+  backdrop-filter:
+    blur(9px);
+
+  cursor: default;
+}
+
+.modal-window {
+  position: relative;
+
+  width: min(560px, 100%);
+
+  max-height:
+    calc(100vh - 40px);
+
+  overflow: auto;
+
+  padding:
+    clamp(27px, 5vw, 42px);
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.35);
+
+  border-radius: var(--em-radius-xl);
+
+  background:
+    linear-gradient(
+      145deg,
+      #141a31,
+      #0b0e1c
+    );
+
+  box-shadow:
+    var(--em-shadow),
+    0 0 0 1px
+    rgba(139, 92, 246, 0.08),
+    0 0 45px
+    rgba(0, 245, 212, 0.12);
+
+  transform:
+    translateY(25px)
+    scale(0.96);
+
+  transition:
+    transform var(--em-transition);
+}
+
+.modal:target .modal-window {
+  transform:
+    translateY(0)
+    scale(1);
+}
+
+.modal-window::before {
+  position: absolute;
+
+  top: -90px;
+  left: 15%;
+
+  width: 180px;
+  height: 180px;
+
+  border-radius: 50%;
+
+  background:
+    var(--em-neon);
+
+  filter: blur(80px);
+
+  opacity: 0.12;
+
+  content: "";
+
+  pointer-events: none;
+}
+
+.modal-window::after {
+  position: absolute;
+
+  right: -90px;
+  bottom: -100px;
+
+  width: 200px;
+  height: 200px;
+
+  border-radius: 50%;
+
+  background:
+    var(--em-neon-alt);
+
+  filter: blur(90px);
+
+  opacity: 0.1;
+
+  content: "";
+
+  pointer-events: none;
+}
+
+.modal-top-line {
+  position: absolute;
+
+  top: 0;
+  right: 12%;
+  left: 12%;
+
+  height: 2px;
+
+  border-radius: 0 0 5px 5px;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      var(--em-neon),
+      var(--em-neon-pink),
+      transparent
+    );
+
+  box-shadow:
+    0 0 14px
+    rgba(0, 245, 212, 0.7);
+}
+
+.modal-header {
+  position: relative;
+
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+}
+
+.modal-symbol {
+  display: grid;
+
+  width: 52px;
+  height: 52px;
+
+  place-items: center;
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.32);
+
+  border-radius: 15px;
+
+  color: var(--em-neon);
+
+  background:
+    rgba(0, 245, 212, 0.07);
+
+  box-shadow:
+    var(--em-glow);
+
+  font-size: 1.25rem;
+
+  animation:
+    neonPulse 2.4s ease-in-out infinite;
+}
+
+@keyframes neonPulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 12px
+      rgba(0, 245, 212, 0.2);
+  }
+
+  50% {
+    box-shadow:
+      0 0 28px
+      rgba(0, 245, 212, 0.42);
+  }
+}
+
+.modal-close {
+  display: grid;
+
+  width: 40px;
+  height: 40px;
+
+  place-items: center;
+
+  border:
+    1px solid
+    rgba(255, 255, 255, 0.1);
+
+  border-radius: 11px;
+
+  color: var(--em-muted);
+
+  background:
+    rgba(255, 255, 255, 0.035);
+
+  text-decoration: none;
+
+  font-size: 1.4rem;
+
+  line-height: 1;
+
+  transition:
+    color var(--em-transition),
+    border-color var(--em-transition),
+    background var(--em-transition),
+    transform var(--em-transition);
+}
+
+.modal-close:hover {
+  color: var(--em-neon);
+
+  border-color:
+    rgba(0, 245, 212, 0.4);
+
+  background:
+    rgba(0, 245, 212, 0.07);
+
+  transform:
+    rotate(90deg);
+}
+
+.modal-close:focus-visible {
+  outline:
+    2px solid
+    var(--em-neon);
+
+  outline-offset: 4px;
+}
+
+.modal-label {
+  display: inline-block;
+
+  margin-top: 27px;
+
+  color: var(--em-neon);
+
+  font-size: 0.56rem;
+  font-weight: 900;
+
+  letter-spacing: 0.15em;
+}
+
+.modal-window h2 {
+  margin:
+    10px 0 0;
+
+  font-size:
+    clamp(1.7rem, 5vw, 2.5rem);
+
+  line-height: 1.05;
+
+  letter-spacing: -0.05em;
+
+  text-shadow:
+    0 0 20px
+    rgba(0, 245, 212, 0.14);
+}
+
+.modal-window > p {
+  color: var(--em-muted);
+
+  font-size: 0.77rem;
+
+  line-height: 1.8;
+}
+
+.modal-status {
+  display: inline-flex;
+
+  align-items: center;
+
+  gap: 9px;
+
+  margin-top: 12px;
+
+  padding:
+    8px 11px;
+
+  border:
+    1px solid
+    rgba(0, 245, 212, 0.13);
+
+  border-radius: 999px;
+
+  color: #a9f9eb;
+
+  background:
+    rgba(0, 245, 212, 0.045);
+
+  font-size: 0.6rem;
+  font-weight: 700;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+
+  border-radius: 50%;
+
+  background:
+    var(--em-neon);
+
+  box-shadow:
+    0 0 10px
+    var(--em-neon);
+
+  animation:
+    statusBlink 1.6s ease-in-out infinite;
+}
+
+@keyframes statusBlink {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+.modal-actions {
+  display: flex;
+
+  flex-wrap: wrap;
+
+  gap: 10px;
+
+  margin-top: 27px;
+}
+
+.modal-primary,
+.modal-secondary {
+  display: inline-flex;
+
+  min-height: 43px;
+
+  align-items: center;
+
+  justify-content: center;
+
+  padding:
+    0 17px;
+
+  border-radius: 11px;
+
+  text-decoration: none;
+
+  font-size: 0.65rem;
+  font-weight: 800;
+
+  transition:
+    transform var(--em-transition),
+    box-shadow var(--em-transition),
+    background var(--em-transition),
+    border-color var(--em-transition);
+}
+
+.modal-primary {
+  border:
+    1px solid
+    var(--em-neon);
+
+  color: #061313;
+
+  background:
+    var(--em-neon);
+
+  box-shadow:
+    var(--em-glow);
+}
+
+.modal-primary:hover {
+  transform:
+    translateY(-3px);
+
+  box-shadow:
+    0 0 25px
+    rgba(0, 245, 212, 0.4);
+}
+
+.modal-secondary {
+  border:
+    1px solid
+    rgba(255, 255, 255, 0.12);
+
+  color: var(--em-muted);
+
+  background:
+    rgba(255, 255, 255, 0.035);
+}
+
+.modal-secondary:hover {
+  transform:
+    translateY(-3px);
+
+  color: var(--em-text);
+
+  border-color:
+    rgba(0, 245, 212, 0.3);
+
+  background:
+    rgba(0, 245, 212, 0.06);
+}
+
+.modal-primary:focus-visible,
+.modal-secondary:focus-visible {
+  outline:
+    2px solid
+    var(--em-neon);
+
+  outline-offset: 4px;
+}
+
+.modal-note {
+  margin-bottom: 0;
+
+  color: var(--em-subtle) !important;
+
+  font-size: 0.57rem !important;
+
+  line-height: 1.6 !important;
+}
+
+@media (max-width: 720px) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card {
+    display: grid;
+
+    grid-template-columns: auto 1fr;
+
+    column-gap: 15px;
+  }
+
+  .feature-card h2 {
+    margin:
+      3px 0 5px;
+  }
+
+  .feature-card p {
+    grid-column: 2;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    padding:
+      50px 14px 70px;
+  }
+
+  .hero h1 {
+    font-size: 3rem;
+  }
+
+  .hero p {
+    font-size: 0.78rem;
+  }
+
+  .open-modal {
+    width: 100%;
+
+    justify-content: center;
+  }
+
+  .modal {
+    padding:
+      12px;
+  }
+
+  .modal-window {
+    max-height:
+      calc(100vh - 24px);
+
+    padding:
+      25px 20px;
+
+    border-radius: 21px;
+  }
+
+  .modal-symbol {
+    width: 46px;
+    height: 46px;
+  }
+
+  .modal-window h2 {
+    font-size: 1.7rem;
+  }
+
+  .modal-actions {
+    flex-direction: column;
+  }
+
+  .modal-primary,
+  .modal-secondary {
+    width: 100%;
+  }
+}
+
+@media (max-width: 380px) {
+  .feature-card {
+    display: block;
+  }
+
+  .feature-card h2 {
+    margin-top: 15px;
+  }
+
+  .feature-card p {
+    margin-top: 7px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR implements a new **CSS-only Modal with Neon styling** for issue #79766.

It is a critical issue for expanding the EaseMotion CSS component collection with a reusable, responsive, futuristic modal component that does not depend on JavaScript.

## ✨ Features

- Added CSS-only modal component
- Implemented modal state using the `:target` pseudo-class
- Added neon glow styling
- Added layered gradients and shadows
- Added smooth entrance and hover transitions
- Added responsive desktop, tablet and mobile layouts
- Added keyboard-focusable controls
- Added visible `:focus-visible` states
- Added `prefers-reduced-motion` support
- Zero external JavaScript dependencies
- Added reusable CSS design tokens

## ♿ Accessibility

- Added semantic dialog attributes
- Added `aria-modal`
- Added `aria-labelledby`
- Added `aria-describedby`
- Added descriptive close labels
- Added keyboard focus states
- Added reduced-motion support

## 📱 Responsive Design

The modal adapts to:

- Desktop
- Tablet
- Mobile

Action buttons stack vertically on smaller screens for better usability.

## 📁 Files Added

- `demo.html`
- `style.css`
- `README.md`

## 🧪 Testing

Designed for modern:

- Chrome
- Firefox
- Safari
- Edge

## Issue

Closes #79766