### PR TITLE
test(toast): add Toast Queue Manager module + auto-dismiss timer tests

### DIFF
--- a/core/toast.js
+++ b/core/toast.js
@@ -1,0 +1,176 @@
+/**
+ * EaseMotion CSS — Toast Queue Manager
+ * ============================================================
+ * Opt-in toast queue with per-toast auto-dismiss timer.
+ *
+ * Markup (the CSS lives in components/toast.css):
+ *   <div class="ease-toast-region" data-toast-region></div>
+ *
+ * API (global, opt-in — the script self-initialises on load):
+ *   window.EaseToast.push({ message, title?, type?, duration?, id? })
+ *   window.EaseToast.dismiss(id)
+ *   window.EaseToast.clear()
+ *
+ * The queue is capped (default 5). Each toast auto-dismisses after its
+ * `duration` (default 4000ms; 0 keeps it until manually dismissed). Invalid
+ * inputs (empty message, non-finite/non-positive duration other than 0) are
+ * rejected without mutating the queue.
+ * ============================================================
+ */
+(function () {
+  'use strict';
+
+  var DEFAULT_DURATION = 4000;
+  var MAX_QUEUE = 5;
+
+  var VALID_TYPES = {
+    success: 'ease-toast-success',
+    danger: 'ease-toast-danger',
+    warning: 'ease-toast-warning',
+    info: 'ease-toast-info',
+  };
+
+  function resolveRegion() {
+    var region = document.querySelector('[data-toast-region]');
+    if (!region) {
+      region = document.createElement('div');
+      region.setAttribute('data-toast-region', '');
+      region.className = 'ease-toast-region';
+      document.body.appendChild(region);
+    }
+    return region;
+  }
+
+  function typeClass(type) {
+    return VALID_TYPES[type] || '';
+  }
+
+  function isFiniteNumber(value) {
+    return typeof value === 'number' && isFinite(value);
+  }
+
+  // Map of id -> timeout handle so timers can be cancelled on manual dismiss.
+  var timers = {};
+
+  var EaseToast = {
+    _queue: [],
+
+    /**
+     * Push a toast onto the queue.
+     * @param {object} options
+     *   message  string (required)
+     *   title    string (optional)
+     *   type     'success'|'danger'|'warning'|'info' (optional)
+     *   duration number ms, default 4000; 0 = sticky (no auto-dismiss)
+     *   id       string/number (optional, dedupes re-pushes of the same id)
+     * @returns {string|null} the toast id, or null if rejected.
+     */
+    push: function (options) {
+      if (!options || typeof options !== 'object') return null;
+      var message = options.message;
+      if (typeof message !== 'string' || message.trim() === '') return null;
+
+      var duration = options.duration;
+      if (duration === undefined) {
+        duration = DEFAULT_DURATION;
+      } else if (!isFiniteNumber(duration) || duration < 0) {
+        return null;
+      }
+
+      var id = options.id != null ? String(options.id) : 'ease-toast-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+
+      // Dedup: a toast with the same id already in the queue is a no-op.
+      if (this._queue.indexOf(id) !== -1) return id;
+
+      // Enforce the queue cap by dismissing the oldest entry.
+      while (this._queue.length >= MAX_QUEUE) {
+        var oldest = this._queue[0];
+        this.dismiss(oldest);
+      }
+
+      var region = resolveRegion();
+
+      var el = document.createElement('div');
+      el.className = 'ease-toast ease-toast-enter ' + typeClass(options.type);
+      el.setAttribute('data-toast-id', id);
+      el.setAttribute('role', 'status');
+      el.setAttribute('aria-live', 'polite');
+
+      var body = document.createElement('div');
+      body.className = 'ease-toast-body';
+      if (options.title) {
+        var strong = document.createElement('strong');
+        strong.textContent = String(options.title);
+        body.appendChild(strong);
+      }
+      var p = document.createElement('p');
+      p.textContent = message;
+      body.appendChild(p);
+      el.appendChild(body);
+
+      var self = this;
+      el.addEventListener('click', function () {
+        self.dismiss(id);
+      });
+
+      region.appendChild(el);
+      this._queue.push(id);
+
+      if (duration > 0) {
+        timers[id] = setTimeout(function () {
+          self.dismiss(id);
+        }, duration);
+      }
+
+      return id;
+    },
+
+    /**
+     * Dismiss a toast by id, cancelling any pending auto-dismiss timer.
+     */
+    dismiss: function (id) {
+      if (id == null) return false;
+      id = String(id);
+      var idx = this._queue.indexOf(id);
+      if (idx === -1) return false;
+
+      this._queue.splice(idx, 1);
+
+      if (timers[id]) {
+        clearTimeout(timers[id]);
+        delete timers[id];
+      }
+
+      var region = document.querySelector('[data-toast-region]');
+      var el = region && region.querySelector('[data-toast-id="' + CSS.escape(id) + '"]');
+      if (el && el.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+      return true;
+    },
+
+    /**
+     * Clear every toast in the queue.
+     */
+    clear: function () {
+      var ids = this._queue.slice();
+      for (var i = 0; i < ids.length; i++) {
+        this.dismiss(ids[i]);
+      }
+    },
+
+    /**
+     * Read-only queue length (exposed for tests / debugging).
+     */
+    size: function () {
+      return this._queue.length;
+    },
+  };
+
+  if (typeof window !== 'undefined') {
+    window.EaseToast = EaseToast;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = EaseToast;
+  }
+})();

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+/**
+ * EaseMotion CSS — Toast Queue Manager Unit Tests
+ * ============================================================
+ * Tests for core/toast.js (Toast Queue Manager Auto-Dismiss Timer).
+ * Run: npm test
+ * ============================================================
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const toastScript = fs.readFileSync(path.resolve(__dirname, '../core/toast.js'), 'utf8');
+
+function loadToastModule() {
+  // Run the IIFE in the current jsdom context; it attaches window.EaseToast.
+  // eslint-disable-next-line no-new-func
+  new Function(toastScript)();
+}
+
+describe('Toast Queue Manager — core/toast.js', () => {
+  let EaseToast;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    window.CSS = window.CSS || {};
+    window.CSS.escape = (val) => String(val).replace(/"/g, '\\"');
+    loadToastModule();
+    EaseToast = window.EaseToast;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.EaseToast;
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('push() adds a toast element to the region and returns its id', () => {
+    const id = EaseToast.push({ message: 'Saved successfully' });
+    expect(id).toBeTruthy();
+    const el = document.querySelector('[data-toast-id="' + id + '"]');
+    expect(el).not.toBeNull();
+    expect(el.classList.contains('ease-toast')).toBe(true);
+    expect(el.textContent).toContain('Saved successfully');
+    expect(EaseToast.size()).toBe(1);
+  });
+
+  it('auto-dismisses the toast after the configured duration', () => {
+    EaseToast.push({ message: 'Hello', duration: 2000 });
+    expect(EaseToast.size()).toBe(1);
+    expect(document.querySelectorAll('.ease-toast')).toHaveLength(1);
+
+    vi.advanceTimersByTime(1999);
+    expect(EaseToast.size()).toBe(1);
+
+    vi.advanceTimersByTime(1);
+    expect(EaseToast.size()).toBe(0);
+    expect(document.querySelectorAll('.ease-toast')).toHaveLength(0);
+  });
+
+  it('uses the default duration of 4000ms when none is given', () => {
+    EaseToast.push({ message: 'Default' });
+    vi.advanceTimersByTime(3999);
+    expect(EaseToast.size()).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  it('renders an optional title and applies the type modifier class', () => {
+    const id = EaseToast.push({ message: 'Done', title: 'Success', type: 'success' });
+    const el = document.querySelector('[data-toast-id="' + id + '"]');
+    expect(el.classList.contains('ease-toast-success')).toBe(true);
+    const strong = el.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong.textContent).toBe('Success');
+  });
+
+  it('clicking a toast dismisses it before the timer fires', () => {
+    const id = EaseToast.push({ message: 'Click me', duration: 5000 });
+    const el = document.querySelector('[data-toast-id="' + id + '"]');
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(EaseToast.size()).toBe(0);
+    // Advancing past the original duration must not error or re-dismiss.
+    vi.advanceTimersByTime(6000);
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('creates a region container when none exists', () => {
+    expect(document.querySelector('[data-toast-region]')).toBeNull();
+    EaseToast.push({ message: 'No region yet' });
+    expect(document.querySelector('[data-toast-region]')).not.toBeNull();
+  });
+
+  it('caps the queue at the maximum and dismisses the oldest toast', () => {
+    const first = EaseToast.push({ message: 'first', duration: 0 });
+    EaseToast.push({ message: 'second', duration: 0 });
+    EaseToast.push({ message: 'third', duration: 0 });
+    EaseToast.push({ message: 'fourth', duration: 0 });
+    EaseToast.push({ message: 'fifth', duration: 0 });
+    expect(EaseToast.size()).toBe(5);
+
+    const sixth = EaseToast.push({ message: 'sixth', duration: 0 });
+    expect(EaseToast.size()).toBe(5);
+    // The oldest (first) should have been evicted.
+    expect(EaseToast.dismiss(first)).toBe(false);
+    expect(EaseToast.dismiss(sixth)).toBe(true);
+  });
+
+  it('does not auto-dismiss a sticky (duration: 0) toast', () => {
+    EaseToast.push({ message: 'Sticky', duration: 0 });
+    vi.advanceTimersByTime(60000);
+    expect(EaseToast.size()).toBe(1);
+  });
+
+  it('dedupes re-pushing the same explicit id without adding a duplicate', () => {
+    const id = EaseToast.push({ message: 'one', id: 'X', duration: 0 });
+    expect(EaseToast.size()).toBe(1);
+    const again = EaseToast.push({ message: 'two', id: 'X', duration: 0 });
+    expect(again).toBe(id);
+    expect(EaseToast.size()).toBe(1);
+    expect(document.querySelectorAll('.ease-toast')).toHaveLength(1);
+  });
+
+  it('clear() removes every queued toast', () => {
+    EaseToast.push({ message: 'a', duration: 0 });
+    EaseToast.push({ message: 'b', duration: 0 });
+    EaseToast.push({ message: 'c', duration: 0 });
+    EaseToast.clear();
+    expect(EaseToast.size()).toBe(0);
+    expect(document.querySelectorAll('.ease-toast')).toHaveLength(0);
+  });
+
+  it('dismiss() cancels the pending auto-dismiss timer', () => {
+    const id = EaseToast.push({ message: 'timer', duration: 3000 });
+    EaseToast.dismiss(id);
+    // No pending timers should remain for this toast.
+    const pending = vi.getTimerCount();
+    expect(pending).toBe(0);
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('rejects a push with no message', () => {
+    expect(EaseToast.push({})).toBeNull();
+    expect(EaseToast.push({ message: '   ' })).toBeNull();
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  it('rejects a push with a non-object argument', () => {
+    expect(EaseToast.push(null)).toBeNull();
+    expect(EaseToast.push(undefined)).toBeNull();
+    expect(EaseToast.push('text')).toBeNull();
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  it('rejects a non-number duration', () => {
+    expect(EaseToast.push({ message: 'x', duration: 'soon' })).toBeNull();
+    expect(EaseToast.push({ message: 'x', duration: NaN })).toBeNull();
+    expect(EaseToast.push({ message: 'x', duration: Infinity })).toBeNull();
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  it('rejects a negative duration', () => {
+    expect(EaseToast.push({ message: 'x', duration: -1 })).toBeNull();
+    expect(EaseToast.size()).toBe(0);
+  });
+
+  it('dismiss() on an unknown id returns false and is a no-op', () => {
+    expect(EaseToast.dismiss('nope')).toBe(false);
+    expect(EaseToast.dismiss(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

The framework ships interactive `core/` modules (`modal.js`, `tabs.js`, `reveal.js`) with Vitest specs in `tests/`, but there was **no Toast Queue Manager JS module** — only the `components/toast.css` styling. This PR adds the module and its Vitest coverage for the **Toast Queue Manager Auto-Dismiss Timer**.

### `core/toast.js` — new module
Opt-in IIFE matching the `core/*.js` pattern, exposing `window.EaseToast`:
- `push({ message, title?, type?, duration?, id? })` — renders a toast using the existing `ease-toast-*` classes
- `dismiss(id)` / `clear()` / `size()`
- Queue cap (default 5, evicts oldest), per-toast `setTimeout` auto-dismiss (default 4000ms; `0` = sticky), **timer cancellation on manual dismiss**, id dedup

### `tests/toast.test.js` — new spec (16 tests, all passing)
Following the `tests/modal.test.js` convention (jsdom, `fs.readFileSync` + run the IIFE) with `vi.useFakeTimers`:

**Happy path**
- `push()` renders an element and returns its id
- auto-dismisses after the configured duration (boundary check at duration−1)
- default 4000ms duration
- optional title + type modifier class
- click-to-dismiss before the timer fires (no double-dismiss)

**Edge cases**
- auto-creates the `[data-toast-region]` container when absent
- queue cap evicts the oldest toast
- sticky (`duration: 0`) toast never auto-dismisses
- id dedup: re-pushing the same id is a no-op
- `clear()` empties the queue
- `dismiss()` cancels the pending timer (`vi.getTimerCount() === 0`)

**Invalid inputs**
- empty/whitespace message → `null`
- non-object argument (`null`/`undefined`/string) → `null`
- non-number duration (`'soon'`/`NaN`/`Infinity`) → `null`
- negative duration → `null`
- `dismiss()` on an unknown/null id → `false`

```
npx vitest run tests/toast.test.js
 ✓ tests/toast.test.js (16 tests)
 Test Files  1 passed (1) | Tests 16 passed (16)
```

Closes #81985

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._