### PR TITLE
test(toast): Toast Queue Manager with auto-dismiss timer

### DIFF
--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/README.md
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/README.md
@@ -1,0 +1,41 @@
+# Toast Queue Manager — Auto-Dismiss Timer
+
+## What does it do?
+A self-contained Toast Queue Manager that schedules a per-toast **auto-dismiss timer**. Each toast is appended to a region element and removed from the DOM when its timer fires or when dismissed early. The queue is capped (the oldest toast is evicted), re-pushes of the same id are deduped, and dismissing a toast cancels its pending timer so it can't fire later.
+
+## How is it used?
+1. **Include files**: link `../../../components/toast.css` and `style.css`, then import `script.js` as an ES module (see `demo.html`).
+2. **Create the manager** with a container element:
+   ```javascript
+   import { ToastQueueManager } from './script.js';
+   const toasts = new ToastQueueManager(document.getElementById('toast-region'), {
+     maxQueue: 5,
+     defaultDuration: 4000, // ms; 0 = sticky
+   });
+   ```
+3. **Push toasts**:
+   ```javascript
+   toasts.push({ message: 'Saved', title: 'Success', type: 'success', duration: 2000 });
+   toasts.push({ message: 'Sticky alert', type: 'danger', duration: 0 }); // stays until dismissed
+   ```
+4. **Dismiss / clear**: `toasts.dismiss(id)`, `toasts.clear()`. Clicking a toast also dismisses it.
+
+## Why is it useful?
+Auto-dismissing toasts are a common UX pattern, but doing it safely needs queue bounds (so the screen isn't flooded), idempotent re-pushes (so retries don't stack duplicates), and timer cancellation on early dismiss (so a cleared toast doesn't fire a stale `setTimeout`). This submission demonstrates all three, plus validation that rejects invalid inputs (empty message, non-finite/negative duration).
+
+## Testing
+A Vitest spec accompanies the module — 17 tests covering the happy path, edge cases, and invalid inputs:
+```bash
+npx vitest run submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
+```
+- **Happy path**: push renders an element; auto-dismiss after duration (boundary at duration−1); default + custom `defaultDuration`; title + type class; click-to-dismiss before the timer.
+- **Edge cases**: `maxQueue` cap evicts oldest; sticky (`duration: 0`); id dedup; `clear()`; `dismiss()` cancels the timer (`vi.getTimerCount() === 0`).
+- **Invalid inputs**: empty/whitespace message; non-object arg; non-number (`'soon'`/`NaN`/`Infinity`) and negative duration; unknown-id dismiss; constructor without a container throws `TypeError`.
+
+## Tech Stack
+- HTML, CSS (EaseMotion `ease-toast-*` classes), JavaScript (ES module, DOM manipulation, `setTimeout`).
+
+## Preview
+Open `demo.html` in a browser and click the buttons to push auto-dismissing toasts.
+
+Closes #81985

--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/demo.html
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Toast Queue Manager — Auto-Dismiss Timer</title>
+    <link rel="stylesheet" href="../../../components/toast.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Toast Queue Manager — Auto-Dismiss Timer</h1>
+      <p>
+        A queue manager that schedules a per-toast auto-dismiss timer, caps the
+        queue (oldest is evicted), dedups by id, and cancels the timer when a
+        toast is dismissed early (click a toast to dismiss it).
+      </p>
+
+      <div class="controls">
+        <button data-toast="info" data-title="Heads up" data-duration="4000">Info (4s)</button>
+        <button data-toast="success" data-title="Saved" data-duration="2000">Success (2s)</button>
+        <button data-toast="warning" data-title="Careful" data-duration="6000">Warning (6s)</button>
+        <button data-toast="danger" data-title="Failed" data-duration="0">Danger (sticky)</button>
+        <button id="clear-btn">Clear all</button>
+      </div>
+
+      <!-- The region the manager renders toasts into. -->
+      <div class="ease-toast-fixed-bottom-right" data-toast-region id="toast-region"></div>
+    </main>
+
+    <script type="module">
+      import { ToastQueueManager } from './script.js';
+
+      const region = document.getElementById('toast-region');
+      const toasts = new ToastQueueManager(region, { maxQueue: 5, defaultDuration: 4000 });
+
+      document.querySelectorAll('.controls [data-toast]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          toasts.push({
+            type: btn.dataset.toast,
+            title: btn.dataset.title,
+            message: 'This toast auto-dismisses after ' + (btn.dataset.duration || '4000') + 'ms.',
+            duration: Number(btn.dataset.duration),
+          });
+        });
+      });
+
+      document.getElementById('clear-btn').addEventListener('click', () => toasts.clear());
+    </script>
+  </body>
+</html>

--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/script.js
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/script.js
@@ -1,0 +1,128 @@
+/**
+ * EaseMotion CSS — Toast Queue Manager with Auto-Dismiss Timer
+ * ============================================================
+ * A self-contained submission demonstrating a toast queue manager that
+ * schedules a per-toast auto-dismiss timer, caps the queue, dedups by id,
+ * and cancels the timer when a toast is dismissed early.
+ *
+ * Uses the framework's `ease-toast-*` classes from components/toast.css.
+ *
+ * API (the manager is framework-agnostic — it takes a container element):
+ *   const toasts = new ToastQueueManager(regionEl, { maxQueue, defaultDuration });
+ *   const id = toasts.push({ message, title?, type?, duration?, id? });
+ *   toasts.dismiss(id);
+ *   toasts.clear();
+ *   toasts.size();
+ *
+ * Exported as an ES module so the accompanying Vitest spec can import it.
+ * ============================================================
+ */
+
+export class ToastQueueManager {
+  constructor(region, options = {}) {
+    if (!region || typeof region.appendChild !== 'function') {
+      throw new TypeError('ToastQueueManager requires a container element');
+    }
+    this.region = region;
+    this.maxQueue = Number.isFinite(options.maxQueue) && options.maxQueue > 0 ? options.maxQueue : 5;
+    this.defaultDuration =
+      Number.isFinite(options.defaultDuration) && options.defaultDuration >= 0
+        ? options.defaultDuration
+        : 4000;
+    this._queue = [];
+    this._timers = {};
+  }
+
+  static VALID_TYPES = {
+    success: 'ease-toast-success',
+    danger: 'ease-toast-danger',
+    warning: 'ease-toast-warning',
+    info: 'ease-toast-info',
+  };
+
+  _typeClass(type) {
+    return ToastQueueManager.VALID_TYPES[type] || '';
+  }
+
+  push(options) {
+    if (!options || typeof options !== 'object') return null;
+    const { message } = options;
+    if (typeof message !== 'string' || message.trim() === '') return null;
+
+    let duration = options.duration;
+    if (duration === undefined) {
+      duration = this.defaultDuration;
+    } else if (!Number.isFinite(duration) || duration < 0) {
+      return null;
+    }
+
+    const id =
+      options.id != null
+        ? String(options.id)
+        : 'ease-toast-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+
+    if (this._queue.indexOf(id) !== -1) return id;
+
+    while (this._queue.length >= this.maxQueue) {
+      this.dismiss(this._queue[0]);
+    }
+
+    const el = document.createElement('div');
+    el.className = 'ease-toast ease-toast-enter ' + this._typeClass(options.type);
+    el.setAttribute('data-toast-id', id);
+    el.setAttribute('role', 'status');
+    el.setAttribute('aria-live', 'polite');
+
+    const body = document.createElement('div');
+    body.className = 'ease-toast-body';
+    if (options.title) {
+      const strong = document.createElement('strong');
+      strong.textContent = String(options.title);
+      body.appendChild(strong);
+    }
+    const p = document.createElement('p');
+    p.textContent = message;
+    body.appendChild(p);
+    el.appendChild(body);
+
+    el.addEventListener('click', () => this.dismiss(id));
+    this.region.appendChild(el);
+    this._queue.push(id);
+
+    if (duration > 0) {
+      this._timers[id] = setTimeout(() => this.dismiss(id), duration);
+    }
+    return id;
+  }
+
+  dismiss(id) {
+    if (id == null) return false;
+    id = String(id);
+    const idx = this._queue.indexOf(id);
+    if (idx === -1) return false;
+
+    this._queue.splice(idx, 1);
+
+    if (this._timers[id]) {
+      clearTimeout(this._timers[id]);
+      delete this._timers[id];
+    }
+
+    const el = this.region.querySelector('[data-toast-id="' + CSS.escape(id) + '"]');
+    if (el && el.parentNode) {
+      el.parentNode.removeChild(el);
+    }
+    return true;
+  }
+
+  clear() {
+    const ids = this._queue.slice();
+    for (const id of ids) this.dismiss(id);
+  }
+
+  size() {
+    return this._queue.length;
+  }
+}
+
+export default ToastQueueManager;

--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/style.css
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/style.css
@@ -1,0 +1,48 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo p {
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.controls button {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--ease-color-primary, #6c63ff);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  background: #fff;
+  color: var(--ease-color-primary, #6c63ff);
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.controls button:hover {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+.controls #clear-btn {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.controls #clear-btn:hover {
+  background: #ef4444;
+  color: #fff;
+}

--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+/**
+ * Toast Queue Manager — Auto-Dismiss Timer — Vitest unit tests
+ * Run: npx vitest run submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
+ *
+ * Covers happy path, edge cases, and invalid inputs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ToastQueueManager } from './script.js';
+
+describe('ToastQueueManager — auto-dismiss timer', () => {
+  let region;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.CSS = window.CSS || {};
+    window.CSS.escape = (val) => String(val).replace(/"/g, '\\"');
+    region = document.createElement('div');
+    region.setAttribute('data-toast-region', '');
+    document.body.appendChild(region);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('push() adds a toast element and returns its id', () => {
+    const t = new ToastQueueManager(region);
+    const id = t.push({ message: 'Saved successfully' });
+    expect(id).toBeTruthy();
+    const el = region.querySelector('[data-toast-id="' + id + '"]');
+    expect(el).not.toBeNull();
+    expect(el.classList.contains('ease-toast')).toBe(true);
+    expect(el.textContent).toContain('Saved successfully');
+    expect(t.size()).toBe(1);
+  });
+
+  it('auto-dismisses the toast after the configured duration', () => {
+    const t = new ToastQueueManager(region);
+    t.push({ message: 'Hello', duration: 2000 });
+    expect(t.size()).toBe(1);
+    vi.advanceTimersByTime(1999);
+    expect(t.size()).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(t.size()).toBe(0);
+    expect(region.querySelectorAll('.ease-toast')).toHaveLength(0);
+  });
+
+  it('uses the default duration of 4000ms when none is given', () => {
+    const t = new ToastQueueManager(region);
+    t.push({ message: 'Default' });
+    vi.advanceTimersByTime(3999);
+    expect(t.size()).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(t.size()).toBe(0);
+  });
+
+  it('honours a custom defaultDuration option', () => {
+    const t = new ToastQueueManager(region, { defaultDuration: 1000 });
+    t.push({ message: 'Custom' });
+    vi.advanceTimersByTime(999);
+    expect(t.size()).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(t.size()).toBe(0);
+  });
+
+  it('renders an optional title and applies the type modifier class', () => {
+    const t = new ToastQueueManager(region);
+    const id = t.push({ message: 'Done', title: 'Success', type: 'success' });
+    const el = region.querySelector('[data-toast-id="' + id + '"]');
+    expect(el.classList.contains('ease-toast-success')).toBe(true);
+    const strong = el.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong.textContent).toBe('Success');
+  });
+
+  it('clicking a toast dismisses it before the timer fires', () => {
+    const t = new ToastQueueManager(region);
+    const id = t.push({ message: 'Click me', duration: 5000 });
+    const el = region.querySelector('[data-toast-id="' + id + '"]');
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(t.size()).toBe(0);
+    vi.advanceTimersByTime(6000);
+    expect(t.size()).toBe(0);
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('caps the queue at maxQueue and dismisses the oldest toast', () => {
+    const t = new ToastQueueManager(region, { maxQueue: 3 });
+    const first = t.push({ message: 'first', duration: 0 });
+    t.push({ message: 'second', duration: 0 });
+    t.push({ message: 'third', duration: 0 });
+    expect(t.size()).toBe(3);
+
+    const sixth = t.push({ message: 'fourth', duration: 0 });
+    expect(t.size()).toBe(3);
+    expect(t.dismiss(first)).toBe(false); // evicted
+    expect(t.dismiss(sixth)).toBe(true);
+  });
+
+  it('does not auto-dismiss a sticky (duration: 0) toast', () => {
+    const t = new ToastQueueManager(region);
+    t.push({ message: 'Sticky', duration: 0 });
+    vi.advanceTimersByTime(60000);
+    expect(t.size()).toBe(1);
+  });
+
+  it('dedupes re-pushing the same explicit id without adding a duplicate', () => {
+    const t = new ToastQueueManager(region);
+    const id = t.push({ message: 'one', id: 'X', duration: 0 });
+    expect(t.size()).toBe(1);
+    const again = t.push({ message: 'two', id: 'X', duration: 0 });
+    expect(again).toBe(id);
+    expect(t.size()).toBe(1);
+    expect(region.querySelectorAll('.ease-toast')).toHaveLength(1);
+  });
+
+  it('clear() removes every queued toast', () => {
+    const t = new ToastQueueManager(region);
+    t.push({ message: 'a', duration: 0 });
+    t.push({ message: 'b', duration: 0 });
+    t.push({ message: 'c', duration: 0 });
+    t.clear();
+    expect(t.size()).toBe(0);
+    expect(region.querySelectorAll('.ease-toast')).toHaveLength(0);
+  });
+
+  it('dismiss() cancels the pending auto-dismiss timer', () => {
+    const t = new ToastQueueManager(region);
+    const id = t.push({ message: 'timer', duration: 3000 });
+    t.dismiss(id);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('rejects a push with no message', () => {
+    const t = new ToastQueueManager(region);
+    expect(t.push({})).toBeNull();
+    expect(t.push({ message: '   ' })).toBeNull();
+    expect(t.size()).toBe(0);
+  });
+
+  it('rejects a push with a non-object argument', () => {
+    const t = new ToastQueueManager(region);
+    expect(t.push(null)).toBeNull();
+    expect(t.push(undefined)).toBeNull();
+    expect(t.push('text')).toBeNull();
+    expect(t.size()).toBe(0);
+  });
+
+  it('rejects a non-number duration', () => {
+    const t = new ToastQueueManager(region);
+    expect(t.push({ message: 'x', duration: 'soon' })).toBeNull();
+    expect(t.push({ message: 'x', duration: NaN })).toBeNull();
+    expect(t.push({ message: 'x', duration: Infinity })).toBeNull();
+    expect(t.size()).toBe(0);
+  });
+
+  it('rejects a negative duration', () => {
+    const t = new ToastQueueManager(region);
+    expect(t.push({ message: 'x', duration: -1 })).toBeNull();
+    expect(t.size()).toBe(0);
+  });
+
+  it('dismiss() on an unknown id returns false and is a no-op', () => {
+    const t = new ToastQueueManager(region);
+    expect(t.dismiss('nope')).toBe(false);
+    expect(t.dismiss(null)).toBe(false);
+  });
+
+  it('throws when constructed without a container element', () => {
+    expect(() => new ToastQueueManager(null)).toThrow(TypeError);
+    expect(() => new ToastQueueManager({})).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission demonstrating a **Toast Queue Manager with Auto-Dismiss Timer** (closes #81985). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/`:
- **`script.js`** — `ToastQueueManager` ES module. Schedules a per-toast `setTimeout` auto-dismiss timer, caps the queue (evicts oldest), dedups by id, and **cancels the timer on early dismiss**. Validates inputs (empty message, non-finite/negative duration are rejected). Uses the framework's `ease-toast-*` classes from `components/toast.css`.
- **`toast-queue-manager.test.js`** — 17 Vitest tests covering the **happy path**, **edge cases**, and **invalid inputs** (all passing).
- **`demo.html`**, **`style.css`**, **`README.md`** — runnable demo + docs.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
 ✓ toast-queue-manager.test.js (17 tests)
```
- **Happy path**: push renders element + returns id; auto-dismiss after duration (boundary at duration−1); default 4000ms; custom `defaultDuration`; title + type class; click-to-dismiss before timer.
- **Edge cases**: `maxQueue` cap evicts oldest; sticky `duration: 0`; id dedup; `clear()`; `dismiss()` cancels timer (`vi.getTimerCount() === 0`).
- **Invalid inputs**: empty/whitespace message; non-object arg; non-number (`'soon'`/`NaN`/`Infinity`) and negative duration; unknown-id dismiss; constructor without a container throws `TypeError`.

`(Note: the repo's vitest.config.js restricts `npm test` to `tests/**/*.test.js`, so this submission's spec is run with an explicit include, matching the pattern of the other `.test.js` files under `submissions/examples/`.)`

Closes #81985

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._