### PR TITLE
test(masonry): column calc resize listener submission

### DIFF
--- a/submissions/examples/masonry-resize-listener-sb/README.md
+++ b/submissions/examples/masonry-resize-listener-sb/README.md
@@ -1,0 +1,35 @@
+# Masonry Column Calculation Resize Listener
+
+## What does it do?
+Computes the number of CSS columns for `.ease-masonry` from the container width and a minimum column width, then recalculates on `window resize` via a debounced listener. Mirrors the responsive behaviour in `components/masonry.css` (1 col mobile, 2 tablet, 3+ desktop).
+
+## How is it used?
+```javascript
+import { MasonryColumns } from './script.js';
+const m = new MasonryColumns(document.getElementById('grid'), {
+  minColumnWidth: 320, // px per column
+  gap: 16,             // px between columns
+  debounceMs: 150,     // resize debounce
+});
+// m.computeColumns() sets --ease-masonry-columns + data-masonry-columns
+m.destroy(); // detach the listener
+```
+
+## Why is it useful?
+CSS `columns` alone can't always recompute on container-driven layout changes (e.g. flex/grid parents). This listener keeps the masonry column count in sync with the live container width, debounced to avoid layout thrash.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/masonry-resize-listener-sb/masonry.test.js
+```
+- **Happy path**: 1 column when too narrow; increases with width; accounts for gap; constructor applies `--ease-masonry-columns`.
+- **Edge cases**: debounced recalc after resize; no recalc before debounce; `destroy()` removes listener.
+- **Invalid inputs**: non-finite/negative width → 1; non-finite/negative minColumnWidth → 1; negative gap coerced to 0; constructor without element throws `TypeError`.
+
+## Tech Stack
+HTML, CSS (`ease-masonry`), JavaScript (resize listener + debounce), EaseMotion CSS.
+
+## Preview
+Open `demo.html` and resize the browser window.
+
+Closes #82016

--- a/submissions/examples/masonry-resize-listener-sb/demo.html
+++ b/submissions/examples/masonry-resize-listener-sb/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Masonry Column Calculation Resize Listener</title>
+    <link rel="stylesheet" href="../../../components/masonry.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Masonry Column Calculation Resize Listener</h1>
+      <p>Resize the window — the column count recalculates (debounced) and updates <code>--ease-masonry-columns</code>.</p>
+      <div class="ease-masonry" id="grid">
+        <div class="ease-masonry-item">1</div>
+        <div class="ease-masonry-item">2</div>
+        <div class="ease-masonry-item">3</div>
+        <div class="ease-masonry-item">4</div>
+        <div class="ease-masonry-item">5</div>
+        <div class="ease-masonry-item">6</div>
+      </div>
+    </main>
+    <script type="module">
+      import { MasonryColumns } from './script.js';
+      const m = new MasonryColumns(document.getElementById('grid'), { minColumnWidth: 320, gap: 16 });
+      window.__masonry = m;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/masonry-resize-listener-sb/masonry.test.js
+++ b/submissions/examples/masonry-resize-listener-sb/masonry.test.js
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { calcColumns, MasonryColumns } from './script.js';
+
+describe('Masonry Column Calculation Resize Listener', () => {
+  let el;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    el = document.createElement('div');
+    Object.defineProperty(el, 'clientWidth', { configurable: true, value: 960 });
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('calcColumns returns 1 column when the container is narrower than min', () => {
+    expect(calcColumns(200, 320, 16)).toBe(1);
+  });
+
+  it('calcColumns increases with available width', () => {
+    expect(calcColumns(320, 320, 0)).toBe(1);
+    expect(calcColumns(640, 320, 0)).toBe(2);
+    expect(calcColumns(960, 320, 0)).toBe(3);
+  });
+
+  it('accounts for the gap when computing columns', () => {
+    // 2 cols: 2*320 + 1*16 = 656 <= 660 ; 3 cols: 3*320 + 2*16 = 992 > 660
+    expect(calcColumns(660, 320, 16)).toBe(2);
+  });
+
+  it('the constructor applies the computed columns to the element', () => {
+    const m = new MasonryColumns(el, { minColumnWidth: 320, gap: 0 });
+    expect(el.getAttribute('data-masonry-columns')).toBe('3');
+    expect(el.style.getPropertyValue('--ease-masonry-columns')).toBe('3');
+    m.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('recalculates columns after a debounced resize', () => {
+    const m = new MasonryColumns(el, { minColumnWidth: 320, gap: 0, debounceMs: 100 });
+    Object.defineProperty(el, 'clientWidth', { configurable: true, value: 1280 });
+    window.dispatchEvent(new window.Event('resize'));
+    // not yet (debounced)
+    expect(el.getAttribute('data-masonry-columns')).toBe('3');
+    vi.advanceTimersByTime(100);
+    expect(el.getAttribute('data-masonry-columns')).toBe('4');
+    m.destroy();
+  });
+
+  it('does not recalc before the debounce window elapses', () => {
+    const m = new MasonryColumns(el, { minColumnWidth: 320, gap: 0, debounceMs: 100 });
+    Object.defineProperty(el, 'clientWidth', { configurable: true, value: 1280 });
+    window.dispatchEvent(new window.Event('resize'));
+    vi.advanceTimersByTime(99);
+    expect(el.getAttribute('data-masonry-columns')).toBe('3');
+    m.destroy();
+  });
+
+  it('destroy() detaches the resize listener', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const m = new MasonryColumns(el);
+    m.destroy();
+    expect(removeSpy).toHaveBeenCalled();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('calcColumns returns 1 for non-finite/negative width', () => {
+    expect(calcColumns(NaN, 320, 0)).toBe(1);
+    expect(calcColumns(-1, 320, 0)).toBe(1);
+    expect(calcColumns(0, 320, 0)).toBe(1);
+  });
+
+  it('calcColumns returns 1 for non-finite/negative minColumnWidth', () => {
+    expect(calcColumns(960, NaN, 0)).toBe(1);
+    expect(calcColumns(960, -1, 0)).toBe(1);
+  });
+
+  it('calcColumns coerces a negative gap to 0', () => {
+    expect(calcColumns(640, 320, -10)).toBe(2);
+  });
+
+  it('the constructor throws without a valid element', () => {
+    expect(() => new MasonryColumns(null)).toThrow(TypeError);
+    expect(() => new MasonryColumns({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/masonry-resize-listener-sb/script.js
+++ b/submissions/examples/masonry-resize-listener-sb/script.js
@@ -1,0 +1,69 @@
+/**
+ * EaseMotion CSS — Masonry Column Calculation Resize Listener
+ * ============================================================
+ * Computes the number of CSS columns for `.ease-masonry` from the container
+ * width and a minimum column width, and recalculates on window resize via a
+ * debounced listener. Mirrors the responsive behaviour in components/masonry.css.
+ *
+ * API:
+ *   const m = new MasonryColumns(el, { minColumnWidth, gap });
+ *   m.computeColumns(); // returns the new column count
+ *   m.destroy();        // detaches the resize listener
+ * ============================================================
+ */
+
+export function calcColumns(containerWidth, minColumnWidth, gap = 0) {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return 1;
+  if (!Number.isFinite(minColumnWidth) || minColumnWidth <= 0) return 1;
+  if (!Number.isFinite(gap) || gap < 0) gap = 0;
+  let columns = 1;
+  while ((columns + 1) * minColumnWidth + columns * gap <= containerWidth) {
+    columns++;
+  }
+  return Math.max(1, Math.floor(columns));
+}
+
+export class MasonryColumns {
+  constructor(element, options = {}) {
+    if (!element || typeof element.clientWidth === 'undefined') {
+      throw new TypeError('MasonryColumns requires an element with clientWidth');
+    }
+    this.element = element;
+    this.minColumnWidth = Number.isFinite(options.minColumnWidth) && options.minColumnWidth > 0
+      ? options.minColumnWidth
+      : 320;
+    this.gap = Number.isFinite(options.gap) && options.gap >= 0 ? options.gap : 16;
+    this.debounceMs = Number.isFinite(options.debounceMs) && options.debounceMs >= 0
+      ? options.debounceMs
+      : 150;
+    this._timeout = null;
+    this._onResize = this._onResize.bind(this);
+    window.addEventListener('resize', this._onResize);
+    this.computeColumns();
+  }
+
+  computeColumns() {
+    const count = calcColumns(this.element.clientWidth, this.minColumnWidth, this.gap);
+    this.element.style.setProperty('--ease-masonry-columns', String(count));
+    this.element.setAttribute('data-masonry-columns', String(count));
+    return count;
+  }
+
+  _onResize() {
+    if (this._timeout) clearTimeout(this._timeout);
+    this._timeout = setTimeout(() => {
+      this._timeout = null;
+      this.computeColumns();
+    }, this.debounceMs);
+  }
+
+  destroy() {
+    if (this._timeout) {
+      clearTimeout(this._timeout);
+      this._timeout = null;
+    }
+    window.removeEventListener('resize', this._onResize);
+  }
+}
+
+export default MasonryColumns;

--- a/submissions/examples/masonry-resize-listener-sb/style.css
+++ b/submissions/examples/masonry-resize-listener-sb/style.css
@@ -1,0 +1,26 @@
+.demo {
+  max-width: 64rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.demo h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.demo code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}
+
+.ease-masonry-item {
+  break-inside: avoid-column;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  background: var(--ease-color-surface, #fff);
+  border-radius: var(--ease-radius-md, 0.5rem);
+  box-shadow: var(--ease-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.1));
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Masonry Column Calculation Resize Listener** edge-case test (closes #82016). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/masonry-resize-listener-sb/`:
- **`script.js`** — `calcColumns()` + `MasonryColumns` class: computes the column count from the container width + min column width + gap, and recalculates on a **debounced** `window resize` listener (mirrors the responsive behaviour in `components/masonry.css`). Validates inputs (non-finite/negative width or minColumnWidth → 1, negative gap coerced to 0).
- **`masonry.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`** — runnable demo + docs.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/masonry-resize-listener-sb/masonry.test.js
 ✓ masonry.test.js (11 tests)
```
- **Happy path**: 1 col when too narrow; increases with width; accounts for gap; constructor applies `--ease-masonry-columns`.
- **Edge cases**: debounced recalc after resize; no recalc before debounce; `destroy()` detaches listener.
- **Invalid inputs**: non-finite/negative width → 1; non-finite/negative minColumnWidth → 1; negative gap → 0; constructor without element throws `TypeError`.

Closes #82016

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._