### PR TITLE
test(dropdown): click-outside dismiss listener submission

### DIFF
--- a/submissions/examples/dropdown-click-outside-dismiss-sb/README.md
+++ b/submissions/examples/dropdown-click-outside-dismiss-sb/README.md
@@ -1,0 +1,33 @@
+# Dropdown Click-Outside Dismiss Listener
+
+## What does it do?
+Toggles a dropdown menu open/closed and dismisses it when a click lands **outside** the menu (or on Escape). Keeps `aria-expanded` in sync on the trigger.
+
+## How is it used?
+```javascript
+import { DropdownToggle } from './script.js';
+const d = new DropdownToggle(
+  document.getElementById('dd-btn'),
+  document.getElementById('dd-menu'),
+);
+// d.toggle() / d.open() / d.close() / d.destroy()
+```
+
+## Why is it useful?
+A common dropdown need: close on outside-click + Escape, without leaking document listeners after removal. This controller captures the document click in the capture phase so it works alongside nested handlers, and `destroy()` cleanly detaches all listeners.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/dropdown-click-outside-dismiss-sb/dropdown.test.js
+```
+- **Happy path**: toggle opens/closes; open()/close() set `aria-expanded`; button click toggles.
+- **Edge cases**: outside click closes; inside click does not; Escape closes + refocuses; close-on-closed is a no-op; `destroy()` stops outside-click closing.
+- **Invalid inputs**: throws `TypeError` for missing/non-element args.
+
+## Tech Stack
+HTML, CSS, JavaScript (capture-phase listener + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click the trigger, then click outside or press Escape.
+
+Closes #81996

--- a/submissions/examples/dropdown-click-outside-dismiss-sb/demo.html
+++ b/submissions/examples/dropdown-click-outside-dismiss-sb/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dropdown Click-Outside Dismiss Listener</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Dropdown Click-Outside Dismiss Listener</h1>
+      <div class="ease-dropdown" id="dd">
+        <button class="ease-dropdown-trigger" id="dd-btn" aria-haspopup="true" aria-expanded="false">Options ▾</button>
+        <div class="ease-dropdown-menu" id="dd-menu" data-open="false">
+          <a href="#" class="ease-dropdown-item">Edit</a>
+          <a href="#" class="ease-dropdown-item">Duplicate</a>
+          <a href="#" class="ease-dropdown-item">Delete</a>
+        </div>
+      </div>
+    </main>
+    <script type="module">
+      import { DropdownToggle } from './script.js';
+      const d = new DropdownToggle(document.getElementById('dd-btn'), document.getElementById('dd-menu'));
+      window.__dd = d;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/dropdown-click-outside-dismiss-sb/dropdown.test.js
+++ b/submissions/examples/dropdown-click-outside-dismiss-sb/dropdown.test.js
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DropdownToggle } from './script.js';
+
+describe('Dropdown Click-Outside Dismiss Listener', () => {
+  let button, menu;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    button = document.createElement('button');
+    menu = document.createElement('div');
+    menu.className = 'ease-dropdown-menu';
+    document.body.append(button, menu);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('toggle() opens and closes the menu', () => {
+    const d = new DropdownToggle(button, menu);
+    d.toggle();
+    expect(d.isOpen).toBe(true);
+    expect(menu.getAttribute('data-open')).toBe('true');
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    d.toggle();
+    expect(d.isOpen).toBe(false);
+    expect(menu.getAttribute('data-open')).toBe('false');
+    d.destroy();
+  });
+
+  it('open()/close() set aria-expanded correctly', () => {
+    const d = new DropdownToggle(button, menu);
+    d.open();
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    d.close();
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    d.destroy();
+  });
+
+  it('clicking the button toggles the menu', () => {
+    const d = new DropdownToggle(button, menu);
+    button.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(d.isOpen).toBe(true);
+    d.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('clicking outside the menu closes it', () => {
+    const d = new DropdownToggle(button, menu);
+    d.open();
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(d.isOpen).toBe(false);
+    d.destroy();
+  });
+
+  it('clicking inside the menu does not close it', () => {
+    const d = new DropdownToggle(button, menu);
+    d.open();
+    const item = document.createElement('a');
+    menu.appendChild(item);
+    item.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(d.isOpen).toBe(true);
+    d.destroy();
+  });
+
+  it('Escape closes the open menu and refocuses the button', () => {
+    const d = new DropdownToggle(button, menu);
+    d.open();
+    const focusSpy = vi.spyOn(button, 'focus');
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(d.isOpen).toBe(false);
+    expect(focusSpy).toHaveBeenCalled();
+    d.destroy();
+  });
+
+  it('close() on an already-closed menu is a no-op returning false', () => {
+    const d = new DropdownToggle(button, menu);
+    expect(d.close()).toBe(false);
+    d.destroy();
+  });
+
+  it('destroy() removes listeners so outside clicks no longer close', () => {
+    const d = new DropdownToggle(button, menu);
+    d.destroy();
+    d.isOpen = true; // simulate a stale state
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(d.isOpen).toBe(true); // listener gone, stays true
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without valid elements', () => {
+    expect(() => new DropdownToggle(null, menu)).toThrow(TypeError);
+    expect(() => new DropdownToggle(button, null)).toThrow(TypeError);
+    expect(() => new DropdownToggle({}, {})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/dropdown-click-outside-dismiss-sb/script.js
+++ b/submissions/examples/dropdown-click-outside-dismiss-sb/script.js
@@ -1,0 +1,75 @@
+/**
+ * EaseMotion CSS — Dropdown Click-Outside Dismiss Listener
+ * ============================================================
+ * Toggles a `.ease-dropdown-menu` open/closed and dismisses it when a click
+ * lands outside the dropdown (or on Escape). Mirrors the markup in components/.
+ *
+ * API:
+ *   const d = new DropdownToggle(buttonEl, menuEl);
+ *   d.toggle(); d.open(); d.close(); d.destroy();
+ * ============================================================
+ */
+
+export class DropdownToggle {
+  constructor(button, menu) {
+    if (!button || !menu || typeof button.addEventListener !== 'function') {
+      throw new TypeError('DropdownToggle requires a button and a menu element');
+    }
+    this.button = button;
+    this.menu = menu;
+    this.isOpen = false;
+    this._onButtonClick = this._onButtonClick.bind(this);
+    this._onDocumentClick = this._onDocumentClick.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+    this.button.addEventListener('click', this._onButtonClick);
+    document.addEventListener('click', this._onDocumentClick, true);
+    document.addEventListener('keydown', this._onKeydown);
+  }
+
+  _onButtonClick(event) {
+    event.stopPropagation();
+    this.toggle();
+  }
+
+  _onDocumentClick(event) {
+    if (!this.isOpen) return;
+    const target = event.target;
+    if (target instanceof Node && (this.menu.contains(target) || this.button.contains(target))) {
+      return;
+    }
+    this.close();
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Escape' && this.isOpen) {
+      this.close();
+      this.button.focus();
+    }
+  }
+
+  open() {
+    this.isOpen = true;
+    this.menu.setAttribute('data-open', 'true');
+    this.button.setAttribute('aria-expanded', 'true');
+  }
+
+  close() {
+    if (!this.isOpen) return false;
+    this.isOpen = false;
+    this.menu.setAttribute('data-open', 'false');
+    this.button.setAttribute('aria-expanded', 'false');
+    return true;
+  }
+
+  toggle() {
+    this.isOpen ? this.close() : this.open();
+  }
+
+  destroy() {
+    this.button.removeEventListener('click', this._onButtonClick);
+    document.removeEventListener('click', this._onDocumentClick, true);
+    document.removeEventListener('keydown', this._onKeydown);
+  }
+}
+
+export default DropdownToggle;

--- a/submissions/examples/dropdown-click-outside-dismiss-sb/style.css
+++ b/submissions/examples/dropdown-click-outside-dismiss-sb/style.css
@@ -1,0 +1,46 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-dropdown-trigger {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.ease-dropdown-menu {
+  position: absolute;
+  min-width: 10rem;
+  margin-top: 0.25rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  padding: 0.25rem 0;
+  display: none;
+}
+
+.ease-dropdown-menu[data-open='true'] {
+  display: block;
+}
+
+.ease-dropdown-item {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: #111827;
+  text-decoration: none;
+}
+
+.ease-dropdown-item:hover {
+  background: #f3f4f6;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Dropdown Menu Click Outside Dismiss Listener** edge-case test (closes #81996). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/dropdown-click-outside-dismiss-sb/`:
- **`script.js`** — `DropdownToggle`: toggles a menu open/closed and dismisses it on **click-outside** (capture-phase document listener) and **Escape**, keeping `aria-expanded` in sync on the trigger and refocusing the trigger on Escape.
- **`dropdown.test.js`** — 9 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/dropdown-click-outside-dismiss-sb/dropdown.test.js
 ✓ dropdown.test.js (9 tests)
```
- **Happy path**: toggle opens/closes; open()/close() set `aria-expanded`; button click toggles.
- **Edge cases**: outside click closes; inside click does not; Escape closes + refocuses; close-on-closed no-op; `destroy()` stops outside-click closing.
- **Invalid inputs**: throws `TypeError` for missing/non-element args.

Closes #81996

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._