### PR TITLE
test(rating): mouse hover star highlight submission

### DIFF
--- a/submissions/examples/rating-hover-star-highlight-sb/README.md
+++ b/submissions/examples/rating-hover-star-highlight-sb/README.md
@@ -1,0 +1,31 @@
+# Rating Component Mouse Hover Star Highlight
+
+## What does it do?
+Highlights stars from 1 up to the hovered index on `mouseenter`, clears the hover highlight on `mouseleave`, and keeps a committed `setRating()` value visible when not hovering.
+
+## How is it used?
+```javascript
+import { RatingHover } from './script.js';
+const r = new RatingHover(document.getElementById('rating'), { stars: 5 });
+r.setRating(3); // commits a value
+r.destroy();
+```
+
+## Why is it useful?
+A usable star rating should preview on hover without committing, and fall back to the committed value after hover leaves. This keeps hover and committed state separate so they don't clobber each other, and syncs `aria-checked`.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/rating-hover-star-highlight-sb/rating.test.js
+```
+- **Happy path**: builds N stars; mouseenter highlights up to index; mouseleave clears; setRating persists.
+- **Edge cases**: hover overrides committed visually; aria-checked only on committed; default 5 stars.
+- **Invalid inputs**: setRating rejects out-of-range/non-number; invalid hover index ignored; throws without container.
+
+## Tech Stack
+HTML, CSS, JavaScript (mouseenter/leave + ARIA radiogroup), EaseMotion CSS.
+
+## Preview
+Open `demo.html` and hover the stars.
+
+Closes #82012

--- a/submissions/examples/rating-hover-star-highlight-sb/demo.html
+++ b/submissions/examples/rating-hover-star-highlight-sb/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Rating Mouse Hover Star Highlight</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Rating Mouse Hover Star Highlight</h1>
+      <p>Hover the stars — they highlight up to the cursor without committing a selection.</p>
+      <div class="ease-rating" id="rating"></div>
+    </main>
+    <script type="module">
+      import { RatingHover } from './script.js';
+      window.__r = new RatingHover(document.getElementById('rating'), { stars: 5 });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/rating-hover-star-highlight-sb/rating.test.js
+++ b/submissions/examples/rating-hover-star-highlight-sb/rating.test.js
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RatingHover } from './script.js';
+
+describe('Rating Component Mouse Hover Star Highlight', () => {
+  let container;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('builds the configured number of stars', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    expect(r.stars).toHaveLength(5);
+    expect(container.querySelectorAll('.ease-rating-star')).toHaveLength(5);
+  });
+
+  it('mouseenter highlights stars up to the hovered index', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r.stars[3].dispatchEvent(new window.MouseEvent('mouseenter', { bubbles: false }));
+    const active = container.querySelectorAll('.ease-rating-star.is-active');
+    expect(active).toHaveLength(4);
+    r.destroy();
+  });
+
+  it('mouseleave clears the hover highlight', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r.stars[2].dispatchEvent(new window.MouseEvent('mouseenter'));
+    container.dispatchEvent(new window.MouseEvent('mouseleave'));
+    expect(container.querySelectorAll('.ease-rating-star.is-hovered')).toHaveLength(0);
+    r.destroy();
+  });
+
+  it('setRating commits a value that persists after hover clears', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r.setRating(3);
+    r.stars[4].dispatchEvent(new window.MouseEvent('mouseenter'));
+    container.dispatchEvent(new window.MouseEvent('mouseleave'));
+    expect(container.querySelectorAll('.ease-rating-star.is-active')).toHaveLength(3);
+    r.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('hover overrides the committed value visually while hovering', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r.setRating(4);
+    r.stars[1].dispatchEvent(new window.MouseEvent('mouseenter'));
+    expect(container.querySelectorAll('.ease-rating-star.is-active')).toHaveLength(2);
+    r.destroy();
+  });
+
+  it('marks aria-checked only on the committed star', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r.setRating(3);
+    expect(r.stars[2].getAttribute('aria-checked')).toBe('true');
+    expect(r.stars[0].getAttribute('aria-checked')).toBe('false');
+    r.destroy();
+  });
+
+  it('uses a default of 5 stars', () => {
+    const r = new RatingHover(container);
+    expect(r.stars).toHaveLength(5);
+    r.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('setRating rejects out-of-range / non-number values', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    expect(r.setRating(-1)).toBe(false);
+    expect(r.setRating(6)).toBe(false);
+    expect(r.setRating(NaN)).toBe(false);
+    expect(r.rating).toBe(0);
+    r.destroy();
+  });
+
+  it('mouseenter with an invalid index is ignored', () => {
+    const r = new RatingHover(container, { stars: 5 });
+    r._onStarEnter(99);
+    expect(r.hover).toBe(0);
+    r.destroy();
+  });
+
+  it('throws without a valid container', () => {
+    expect(() => new RatingHover(null)).toThrow(TypeError);
+    expect(() => new RatingHover({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/rating-hover-star-highlight-sb/script.js
+++ b/submissions/examples/rating-hover-star-highlight-sb/script.js
@@ -1,0 +1,81 @@
+/**
+ * EaseMotion CSS — Rating Component Mouse Hover Star Highlight
+ * ============================================================
+ * Highlights the stars from 1 up to the hovered index on `mouseenter`, and
+ * clears the hover highlight on `mouseleave`, without committing a selection.
+ *
+ * API:
+ *   const r = new RatingHover(containerEl, { stars });
+ *   r.setRating(n);   // committed value
+ *   r.destroy();
+ * ============================================================
+ */
+
+export class RatingHover {
+  constructor(container, options = {}) {
+    if (!container || typeof container.appendChild !== 'function') {
+      throw new TypeError('RatingHover requires a container element');
+    }
+    this.container = container;
+    this.maxStars = Number.isFinite(options.stars) && options.stars > 0 ? Math.floor(options.stars) : 5;
+    this.rating = 0;
+    this.hover = 0;
+    this.stars = [];
+    this._onStarEnter = this._onStarEnter.bind(this);
+    this._onLeave = this._onLeave.bind(this);
+    this._build();
+  }
+
+  _build() {
+    this.container.setAttribute('role', 'radiogroup');
+    this.container.setAttribute('aria-label', 'Rating');
+    for (let i = 1; i <= this.maxStars; i++) {
+      const star = document.createElement('span');
+      star.className = 'ease-rating-star';
+      star.setAttribute('data-index', String(i));
+      star.setAttribute('role', 'radio');
+      star.setAttribute('aria-checked', 'false');
+      star.addEventListener('mouseenter', () => this._onStarEnter(i));
+      this.container.appendChild(star);
+      this.stars.push(star);
+    }
+    this.container.addEventListener('mouseleave', this._onLeave);
+    this._render();
+  }
+
+  _onStarEnter(index) {
+    if (!Number.isFinite(index) || index < 1 || index > this.maxStars) return;
+    this.hover = index;
+    this._render();
+  }
+
+  _onLeave() {
+    this.hover = 0;
+    this._render();
+  }
+
+  _render() {
+    const active = this.hover || this.rating;
+    for (let i = 0; i < this.stars.length; i++) {
+      const filled = i < active;
+      this.stars[i].classList.toggle('is-active', filled);
+      this.stars[i].classList.toggle('is-hovered', this.hover > 0 && i < this.hover);
+      this.stars[i].setAttribute('aria-checked', String(i + 1 === this.rating));
+    }
+  }
+
+  setRating(n) {
+    if (!Number.isFinite(n) || n < 0 || n > this.maxStars) return false;
+    this.rating = Math.floor(n);
+    this._render();
+    return true;
+  }
+
+  destroy() {
+    this.container.removeEventListener('mouseleave', this._onLeave);
+    this.stars.forEach((s) => s.replaceWith(s.cloneNode(false)));
+    this.container.innerHTML = '';
+  }
+}
+
+export default RatingHover;

--- a/submissions/examples/rating-hover-star-highlight-sb/style.css
+++ b/submissions/examples/rating-hover-star-highlight-sb/style.css
@@ -1,0 +1,30 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-rating {
+  display: inline-flex;
+  gap: 0.25rem;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.ease-rating-star {
+  cursor: pointer;
+  color: #d1d5db;
+}
+
+.ease-rating-star::before {
+  content: '★';
+}
+
+.ease-rating-star.is-active {
+  color: #f59e0b;
+}
+
+.ease-rating-star.is-hovered {
+  transform: scale(1.1);
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Rating Component Mouse Hover Star Highlight** edge-case test (closes #82012). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/rating-hover-star-highlight-sb/`:
- **`script.js`** — `RatingHover`: highlights stars up to the hovered index on `mouseenter`, clears the hover highlight on `mouseleave`, and keeps a committed `setRating()` value visible when not hovering. Uses an ARIA `radiogroup`/`radio` with `aria-checked` on the committed star.
- **`rating.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/rating-hover-star-highlight-sb/rating.test.js
 ✓ rating.test.js (10 tests)
```
- **Happy path**: builds N stars; mouseenter highlights up to index; mouseleave clears; setRating persists.
- **Edge cases**: hover overrides committed visually; aria-checked only on committed; default 5 stars.
- **Invalid inputs**: setRating rejects out-of-range/non-number; invalid hover index ignored; throws without container.

Closes #82012

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._