### PR TITLE
a11y(command-palette): ARIA combobox role submission

### DIFF
--- a/submissions/examples/command-palette-aria-combobox-sb/README.md
+++ b/submissions/examples/command-palette-aria-combobox-sb/README.md
@@ -1,0 +1,36 @@
+# Command Palette ARIA Combobox Role
+
+## What does it do?
+Implements the ARIA 1.2 combobox pattern for a command palette: `role="combobox"` + `aria-expanded` + `aria-controls` + `aria-activedescendant` on the search input, `role="listbox"` on the results, and `role="option"` + `aria-selected` on each result, with full keyboard nav (ArrowUp/Down/Enter).
+
+## How is it used?
+```javascript
+import { CommandPalette } from './script.js';
+const cp = new CommandPalette(inputEl, listboxEl, [
+  { id: 'open', label: 'Open file' },
+  { id: 'save', label: 'Save' },
+]);
+cp.filter('op');          // filter + set activedescendant
+cp.move(1);               // move active option
+cp.selectActive();        // → selected item
+cp.destroy();
+```
+
+## Why is it useful?
+A screen-reader-accessible command palette must announce the active option via `aria-activedescendant` and expose the listbox/options roles. This keeps the input focused while moving through results, which is the correct combobox semantics.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/command-palette-aria-combobox-sb/command-palette.test.js
+```
+- **Happy path**: combobox role + aria-expanded; filter renders role=option; aria-activedescendant on active; ArrowDown/Up cyclic move.
+- **Edge cases**: aria-selected only on active; no matches → expanded=false + no activedescendant; typing filters.
+- **Invalid inputs**: non-array/label-less items ignored; move with no matches → -1; selectActive null when inactive; throws without elements.
+
+## Tech Stack
+HTML, CSS (`ease-command-palette-*`), JavaScript (ARIA combobox + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, type, and use arrow keys.
+
+Closes #81897

--- a/submissions/examples/command-palette-aria-combobox-sb/command-palette.test.js
+++ b/submissions/examples/command-palette-aria-combobox-sb/command-palette.test.js
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CommandPalette } from './script.js';
+
+describe('Command Palette ARIA Combobox Role', () => {
+  let input, listbox;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    input = document.createElement('input');
+    input.type = 'text';
+    listbox = document.createElement('div');
+    listbox.id = 'cmd-list';
+    document.body.append(input, listbox);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets combobox role and aria-expanded=false initially', () => {
+    const cp = new CommandPalette(input, listbox);
+    expect(input.getAttribute('role')).toBe('combobox');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(input.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(listbox.getAttribute('role')).toBe('listbox');
+    cp.destroy();
+  });
+
+  it('filter("te") renders only matching options as role=option', () => {
+    const cp = new CommandPalette(input, listbox, [
+      { id: 'a', label: 'Settings' },
+      { id: 'b', label: 'Theme' },
+      { id: 'c', label: 'Help' },
+    ]);
+    cp.filter('t');
+    expect(listbox.querySelectorAll('[role="option"]')).toHaveLength(2);
+    cp.destroy();
+  });
+
+  it('sets aria-activedescendant to the active option id', () => {
+    const cp = new CommandPalette(input, listbox, [{ id: 'x', label: 'Text' }]);
+    cp.filter('tex');
+    expect(input.getAttribute('aria-activedescendant')).toBe('x');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+    cp.destroy();
+  });
+
+  it('ArrowDown/ArrowUp move the active option cyclically', () => {
+    const cp = new CommandPalette(input, listbox, [
+      { id: '1', label: 'Open' },
+      { id: '2', label: 'Save' },
+      { id: '3', label: 'Close' },
+    ]);
+    cp.filter(''); // all 3
+    expect(cp.activeIndex).toBe(0);
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    expect(cp.activeIndex).toBe(1);
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    expect(cp.activeIndex).toBe(0);
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    expect(cp.activeIndex).toBe(2); // wraps
+    cp.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('aria-selected is true only on the active option', () => {
+    const cp = new CommandPalette(input, listbox, [{ id: '1', label: 'Open' }, { id: '2', label: 'Save' }]);
+    cp.filter('');
+    cp.move(1);
+    const opts = listbox.querySelectorAll('[role="option"]');
+    expect(opts[1].getAttribute('aria-selected')).toBe('true');
+    expect(opts[0].getAttribute('aria-selected')).toBe('false');
+    cp.destroy();
+  });
+
+  it('no matches → aria-expanded=false, no activedescendant', () => {
+    const cp = new CommandPalette(input, listbox, [{ id: '1', label: 'Open' }]);
+    cp.filter('zzz');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
+    expect(cp.activeIndex).toBe(-1);
+    cp.destroy();
+  });
+
+  it('typing fires input → filter updates the listbox', () => {
+    const cp = new CommandPalette(input, listbox, [{ id: '1', label: 'Save' }, { id: '2', label: 'Edit' }]);
+    input.value = 'sa';
+    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(listbox.querySelectorAll('[role="option"]')).toHaveLength(1);
+    cp.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('setItems ignores non-array / items without a label', () => {
+    const cp = new CommandPalette(input, listbox);
+    cp.setItems('nope');
+    expect(cp.items).toHaveLength(0);
+    cp.setItems([{ id: '1' }, { label: 'ok' }]);
+    expect(cp.items).toHaveLength(1);
+    cp.destroy();
+  });
+
+  it('move() with no matches returns -1', () => {
+    const cp = new CommandPalette(input, listbox);
+    expect(cp.move(1)).toBe(-1);
+    cp.destroy();
+  });
+
+  it('selectActive() returns null when nothing is active', () => {
+    const cp = new CommandPalette(input, listbox);
+    expect(cp.selectActive()).toBeNull();
+    cp.destroy();
+  });
+
+  it('throws without valid elements', () => {
+    expect(() => new CommandPalette(null, listbox)).toThrow(TypeError);
+    expect(() => new CommandPalette(input, {})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/command-palette-aria-combobox-sb/demo.html
+++ b/submissions/examples/command-palette-aria-combobox-sb/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Command Palette ARIA Combobox</title>
+    <link rel="stylesheet" href="../../../components/command-palette.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Command Palette ARIA Combobox Role</h1>
+      <div class="ease-command-palette">
+        <input class="ease-command-palette-search" id="cp-input" placeholder="Type a command…" />
+        <div class="ease-command-palette-content" id="cp-list" role="listbox"></div>
+      </div>
+    </main>
+    <script type="module">
+      import { CommandPalette } from './script.js';
+      const cp = new CommandPalette(document.getElementById('cp-input'), document.getElementById('cp-list'), [
+        { id: 'open', label: 'Open file' },
+        { id: 'save', label: 'Save' },
+        { id: 'theme', label: 'Toggle theme' },
+        { id: 'settings', label: 'Settings' },
+      ]);
+      window.__cp = cp;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/command-palette-aria-combobox-sb/script.js
+++ b/submissions/examples/command-palette-aria-combobox-sb/script.js
@@ -1,0 +1,124 @@
+/**
+ * EaseMotion CSS — Command Palette ARIA Combobox Role
+ * ============================================================
+ * Implements the ARIA 1.2 combobox pattern for a command palette: the search
+ * input has role="combobox", aria-expanded, aria-controls, and aria-activedescendant;
+ * the listbox has role="listbox"; options have role="option" + aria-selected.
+ *
+ * API:
+ *   const cp = new CommandPalette(inputEl, listEl, options);
+ *   cp.setItems([{ id, label }, ...]);
+ *   cp.filter('te');   // returns matches, updates listbox + activedescendant
+ *   cp.move(1 | -1);   // moves active option
+ *   cp.selectActive(); // returns selected item
+ *   cp.destroy();
+ * ============================================================
+ */
+
+export class CommandPalette {
+  constructor(input, listbox, options = []) {
+    if (!input || !listbox || typeof input.addEventListener !== 'function') {
+      throw new TypeError('CommandPalette requires an input and a listbox element');
+    }
+    this.input = input;
+    this.listbox = listbox;
+    this.items = [];
+    this.matches = [];
+    this.activeIndex = -1;
+
+    this.input.setAttribute('role', 'combobox');
+    this.input.setAttribute('aria-expanded', 'false');
+    this.input.setAttribute('autocomplete', 'off');
+    this.input.setAttribute('aria-haspopup', 'listbox');
+    this.listbox.setAttribute('role', 'listbox');
+
+    this._onInput = this._onInput.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+    this.input.addEventListener('input', this._onInput);
+    this.input.addEventListener('keydown', this._onKeydown);
+
+    if (Array.isArray(options) && options.length) this.setItems(options);
+  }
+
+  setItems(items) {
+    if (!Array.isArray(items)) return;
+    this.items = items
+      .filter((it) => it && typeof it.label === 'string')
+      .map((it, i) => ({ id: it.id != null ? String(it.id) : 'cmd-' + i, label: it.label }));
+    this.filter(this.input.value || '');
+  }
+
+  filter(query) {
+    const q = typeof query === 'string' ? query.trim().toLowerCase() : '';
+    this.matches = q
+      ? this.items.filter((it) => it.label.toLowerCase().includes(q))
+      : this.items.slice();
+    this.activeIndex = this.matches.length ? 0 : -1;
+    this._render();
+    return this.matches;
+  }
+
+  _render() {
+    this.listbox.innerHTML = '';
+    this.matches.forEach((item, i) => {
+      const opt = document.createElement('div');
+      opt.className = 'ease-command-palette-item' + (i === this.activeIndex ? ' ease-command-palette-item-active' : '');
+      opt.setAttribute('role', 'option');
+      opt.setAttribute('id', item.id);
+      opt.setAttribute('aria-selected', String(i === this.activeIndex));
+      opt.textContent = item.label;
+      this.listbox.appendChild(opt);
+    });
+    const expanded = this.matches.length > 0;
+    this.input.setAttribute('aria-expanded', String(expanded));
+    if (expanded && this.activeIndex >= 0) {
+      this.input.setAttribute('aria-controls', this.listbox.id || '');
+      this.input.setAttribute('aria-activedescendant', this.matches[this.activeIndex].id);
+    } else {
+      this.input.removeAttribute('aria-activedescendant');
+      this.input.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  move(delta) {
+    if (!Number.isFinite(delta) || !this.matches.length) return -1;
+    let next = this.activeIndex + (delta > 0 ? 1 : -1);
+    next = (next + this.matches.length) % this.matches.length;
+    this.activeIndex = next;
+    this._render();
+    return this.activeIndex;
+  }
+
+  selectActive() {
+    if (this.activeIndex < 0 || this.activeIndex >= this.matches.length) return null;
+    return this.matches[this.activeIndex];
+  }
+
+  _onInput() {
+    this.filter(this.input.value);
+  }
+
+  _onKeydown(event) {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.move(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.move(-1);
+        break;
+      case 'Enter':
+        event.preventDefault();
+        this.selectActive();
+        break;
+    }
+  }
+
+  destroy() {
+    this.input.removeEventListener('input', this._onInput);
+    this.input.removeEventListener('keydown', this._onKeydown);
+  }
+}
+
+export default CommandPalette;

--- a/submissions/examples/command-palette-aria-combobox-sb/style.css
+++ b/submissions/examples/command-palette-aria-combobox-sb/style.css
@@ -1,0 +1,36 @@
+.demo {
+  max-width: 32rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-command-palette {
+  position: relative;
+}
+
+.ease-command-palette-search {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+.ease-command-palette-content {
+  margin-top: 0.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #fff;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+}
+
+.ease-command-palette-item {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.ease-command-palette-item-active {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Command Palette ARIA Combobox Role** accessibility audit (closes #81897). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/command-palette-aria-combobox-sb/`:
- **`script.js`** — `CommandPalette` implementing the ARIA 1.2 combobox pattern: `role=combobox` + `aria-expanded` + `aria-controls` + `aria-activedescendant` on the search input, `role=listbox` on the results, `role=option` + `aria-selected` on each result, with full keyboard nav (ArrowUp/Down/Enter).
- **`command-palette.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/command-palette-aria-combobox-sb/command-palette.test.js
 ✓ command-palette.test.js (11 tests)
```
- **Happy path**: combobox role + aria-expanded; filter renders role=option; aria-activedescendant on active; ArrowDown/Up cyclic move.
- **Edge cases**: aria-selected only on active; no matches → expanded=false + no activedescendant; typing filters.
- **Invalid inputs**: non-array/label-less items ignored; move with no matches → -1; selectActive null when inactive; throws without elements.

Closes #81897

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._