### PR TITLE
Fix issue 79710

### DIFF
--- a/submissions/examples/css-modal-neumorphic-dark/README.md
+++ b/submissions/examples/css-modal-neumorphic-dark/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Modal (Dark Mode)
+A deep dark mode modal built with soft UI extrusion. Powered entirely by the CSS checkbox hack, featuring smooth 3D scaling and fading transitions.

--- a/submissions/examples/css-modal-neumorphic-dark/demo.html
+++ b/submissions/examples/css-modal-neumorphic-dark/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Dark Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <input type="checkbox" id="neu-modal-toggle" class="nmd-toggle">
+    <div class="nmd-wrapper">
+        <label for="neu-modal-toggle" class="nmd-btn">Open Settings</label>
+    </div>
+
+    <div class="nmd-overlay">
+        <div class="nmd-modal">
+            <h2 class="nmd-title">Preferences</h2>
+            <p class="nmd-desc">Adjust your system settings. Soft UI principles applied to a dark mode palette.</p>
+            <div class="nmd-actions">
+                <label for="neu-modal-toggle" class="nmd-btn-close">Cancel</label>
+                <label for="neu-modal-toggle" class="nmd-btn-save">Save</label>
+            </div>
+        </div>
+        <label for="neu-modal-toggle" class="nmd-backdrop"></label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-modal-neumorphic-dark/style.css
+++ b/submissions/examples/css-modal-neumorphic-dark/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #292d32; --shadow-dark: #1f2226; --shadow-light: #33383e; --text: #a0a5ab; --accent: #4ade80; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: var(--text); }
+.nmd-toggle { display: none; }
+.nmd-btn { padding: 1rem 2rem; border-radius: 50px; background: var(--bg); color: var(--text); font-weight: 600; cursor: pointer; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.3s; user-select: none; }
+.nmd-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.nmd-overlay { position: fixed; inset: 0; display: flex; justify-content: center; align-items: center; z-index: 100; opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+.nmd-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.5); z-index: 1; cursor: pointer; }
+.nmd-modal { position: relative; z-index: 2; background: var(--bg); padding: 2.5rem; border-radius: 20px; width: 90%; max-width: 400px; box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light); transform: translateY(-50px) scale(0.9); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); opacity: 0; }
+.nmd-title { margin-top: 0; color: #fff; font-size: 1.5rem; }
+.nmd-desc { line-height: 1.6; margin-bottom: 2rem; }
+.nmd-actions { display: flex; justify-content: flex-end; gap: 1rem; }
+.nmd-btn-close, .nmd-btn-save { padding: 0.75rem 1.5rem; border-radius: 30px; font-weight: 600; cursor: pointer; box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); transition: all 0.3s; }
+.nmd-btn-save { color: var(--accent); }
+.nmd-btn-close:active, .nmd-btn-save:active { box-shadow: inset 2px 2px 5px var(--shadow-dark), inset -2px -2px 5px var(--shadow-light); }
+.nmd-toggle:checked ~ .nmd-overlay { opacity: 1; pointer-events: auto; }
+.nmd-toggle:checked ~ .nmd-overlay .nmd-modal { transform: translateY(0) scale(1); opacity: 1; }

--- a/submissions/examples/css-navbar-hover-retro/README.md
+++ b/submissions/examples/css-navbar-hover-retro/README.md
@@ -1,0 +1,2 @@
+# Hover Navbar (Retro)
+A chunky 8-bit style navigation bar. Features hard black drop-shadows and a sweeping hot-pink background fill on hover that scales from right to left.

--- a/submissions/examples/css-navbar-hover-retro/demo.html
+++ b/submissions/examples/css-navbar-hover-retro/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hover Navbar Retro</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="retro-nav">
+        <div class="rn-logo">ARCADE</div>
+        <div class="rn-links">
+            <a href="#" class="rn-link">GAMES</a>
+            <a href="#" class="rn-link">HIGHSCORES</a>
+            <a href="#" class="rn-link">SHOP</a>
+        </div>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-navbar-hover-retro/style.css
+++ b/submissions/examples/css-navbar-hover-retro/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #f4f4f4; --primary: #ff0055; --text: #111; }
+body { background: var(--bg); margin: 0; font-family: 'Courier New', monospace; padding: 2rem; }
+.retro-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border: 4px solid var(--text); background: #fff; box-shadow: 6px 6px 0 var(--text); }
+.rn-logo { font-size: 1.5rem; font-weight: 900; letter-spacing: 2px; color: var(--text); }
+.rn-links { display: flex; gap: 2rem; }
+.rn-link { color: var(--text); text-decoration: none; font-weight: bold; font-size: 1.1rem; padding: 0.5rem 1rem; border: 2px solid transparent; transition: all 0.2s; position: relative; }
+.rn-link::before { content: ''; position: absolute; inset: 0; background: var(--primary); z-index: -1; transform: scaleX(0); transform-origin: right; transition: transform 0.3s cubic-bezier(0.65, 0.05, 0.36, 1); }
+.rn-link:hover { color: #fff; border-color: var(--text); box-shadow: 4px 4px 0 var(--text); transform: translate(-2px, -2px); }
+.rn-link:hover::before { transform: scaleX(1); transform-origin: left; }


### PR DESCRIPTION
**Title:** feat: create Hover Navbar with Retro styling (#91052) #79710

**Description:**
This PR introduces a chunky 8-bit style navigation bar. Features hard black drop-shadows and a sweeping hot-pink background fill on hover that scales from right to left.

Fixes #79710

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-navbar-hover-retro/`
- Rendered thick borders and sharp `box-shadow: 6px 6px 0 var(--text)` to match classic pixel-art aesthetics
- Powered the hover link animation via a `::before` pseudo-element that translates its `transform-origin` dynamically to sweep across the button bounds
