### PR TITLE
Fix issue 79706

### DIFF
--- a/submissions/examples/css-modal-neumorphic-dark/README.md
+++ b/submissions/examples/css-modal-neumorphic-dark/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Modal (Dark Mode)
+A deep dark mode modal built with soft UI extrusion. Powered entirely by the CSS checkbox hack, featuring smooth 3D scaling and fading transitions.

--- a/submissions/examples/css-modal-neumorphic-dark/demo.html
+++ b/submissions/examples/css-modal-neumorphic-dark/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Dark Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <input type="checkbox" id="neu-modal-toggle" class="nmd-toggle">
+    <div class="nmd-wrapper">
+        <label for="neu-modal-toggle" class="nmd-btn">Open Settings</label>
+    </div>
+
+    <div class="nmd-overlay">
+        <div class="nmd-modal">
+            <h2 class="nmd-title">Preferences</h2>
+            <p class="nmd-desc">Adjust your system settings. Soft UI principles applied to a dark mode palette.</p>
+            <div class="nmd-actions">
+                <label for="neu-modal-toggle" class="nmd-btn-close">Cancel</label>
+                <label for="neu-modal-toggle" class="nmd-btn-save">Save</label>
+            </div>
+        </div>
+        <label for="neu-modal-toggle" class="nmd-backdrop"></label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-modal-neumorphic-dark/style.css
+++ b/submissions/examples/css-modal-neumorphic-dark/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #292d32; --shadow-dark: #1f2226; --shadow-light: #33383e; --text: #a0a5ab; --accent: #4ade80; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: var(--text); }
+.nmd-toggle { display: none; }
+.nmd-btn { padding: 1rem 2rem; border-radius: 50px; background: var(--bg); color: var(--text); font-weight: 600; cursor: pointer; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.3s; user-select: none; }
+.nmd-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.nmd-overlay { position: fixed; inset: 0; display: flex; justify-content: center; align-items: center; z-index: 100; opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+.nmd-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.5); z-index: 1; cursor: pointer; }
+.nmd-modal { position: relative; z-index: 2; background: var(--bg); padding: 2.5rem; border-radius: 20px; width: 90%; max-width: 400px; box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light); transform: translateY(-50px) scale(0.9); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); opacity: 0; }
+.nmd-title { margin-top: 0; color: #fff; font-size: 1.5rem; }
+.nmd-desc { line-height: 1.6; margin-bottom: 2rem; }
+.nmd-actions { display: flex; justify-content: flex-end; gap: 1rem; }
+.nmd-btn-close, .nmd-btn-save { padding: 0.75rem 1.5rem; border-radius: 30px; font-weight: 600; cursor: pointer; box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); transition: all 0.3s; }
+.nmd-btn-save { color: var(--accent); }
+.nmd-btn-close:active, .nmd-btn-save:active { box-shadow: inset 2px 2px 5px var(--shadow-dark), inset -2px -2px 5px var(--shadow-light); }
+.nmd-toggle:checked ~ .nmd-overlay { opacity: 1; pointer-events: auto; }
+.nmd-toggle:checked ~ .nmd-overlay .nmd-modal { transform: translateY(0) scale(1); opacity: 1; }

--- a/submissions/examples/css-navbar-neumorphic-cyberpunk/README.md
+++ b/submissions/examples/css-navbar-neumorphic-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Navbar (Cyberpunk)
+A dark, physical control panel navigation. It fuses the inset/outset extrusion of Neumorphism with the harsh neon color accents and monospace typography of Cyberpunk design.

--- a/submissions/examples/css-navbar-neumorphic-cyberpunk/demo.html
+++ b/submissions/examples/css-navbar-neumorphic-cyberpunk/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Cyberpunk Navbar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nc-nav">
+        <div class="nc-logo">N_CPK</div>
+        <div class="nc-links">
+            <a href="#" class="nc-link">HOME</a>
+            <a href="#" class="nc-link active">GRID</a>
+            <a href="#" class="nc-link">DATA</a>
+        </div>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-navbar-neumorphic-cyberpunk/style.css
+++ b/submissions/examples/css-navbar-neumorphic-cyberpunk/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #1a1a24; --shadow-dark: #121219; --shadow-light: #22222f; --cyan: #00e5ff; --pink: #ff007f; }
+body { background: var(--bg); margin: 0; font-family: 'Courier New', monospace; padding: 2rem; }
+.nc-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; background: var(--bg); border-radius: 12px; box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light); border: 1px solid #2a2a35; }
+.nc-logo { font-size: 1.5rem; font-weight: bold; color: var(--pink); text-shadow: 0 0 10px var(--pink); letter-spacing: 2px; }
+.nc-links { display: flex; gap: 1.5rem; }
+.nc-link { padding: 0.75rem 1.5rem; color: #888; text-decoration: none; border-radius: 8px; font-weight: bold; letter-spacing: 1px; background: var(--bg); box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); transition: all 0.3s; }
+.nc-link:hover { color: var(--cyan); box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); border-bottom: 2px solid var(--cyan); text-shadow: 0 0 8px var(--cyan); }
+.nc-link.active { color: var(--cyan); box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); border-bottom: 2px solid var(--pink); text-shadow: 0 0 8px var(--cyan); }


### PR DESCRIPTION
**Title:** feat: create Neumorphic Navbar with Cyberpunk styling (#43235) #79706

**Description:**
This PR introduces a dark, physical control panel navigation. It fuses the inset/outset extrusion of Neumorphism with the harsh neon color accents and monospace typography of Cyberpunk design.

Fixes #79706

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-navbar-neumorphic-cyberpunk/`
- Built the outer navbar frame using dark-mode Neumorphic outset drop shadows (`8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)`)
- Styled the active navigation links to physically press into the bar via `inset` box shadows while simultaneously lighting up with cyan and pink glowing borders
