### PR TITLE
Fix issue 79705

### DIFF
--- a/submissions/examples/css-carousel-floating-dark/README.md
+++ b/submissions/examples/css-carousel-floating-dark/README.md
@@ -1,0 +1,2 @@
+# Floating Carousel (Dark Mode)
+A dark mode slider component. Inactive slides shrink into the background while the active slide physically elevates toward the user with an intense drop shadow.

--- a/submissions/examples/css-carousel-floating-dark/demo.html
+++ b/submissions/examples/css-carousel-floating-dark/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Dark Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fd-carousel">
+        <input type="radio" name="fd-slide" id="fd1" checked>
+        <input type="radio" name="fd-slide" id="fd2">
+        <input type="radio" name="fd-slide" id="fd3">
+        
+        <div class="fd-container">
+            <div class="fd-track">
+                <div class="fd-card"><h3>Slide 1</h3><p>Deep dark floating space.</p></div>
+                <div class="fd-card"><h3>Slide 2</h3><p>Smooth shadow transitions.</p></div>
+                <div class="fd-card"><h3>Slide 3</h3><p>CSS-only interactions.</p></div>
+            </div>
+        </div>
+        
+        <div class="fd-nav">
+            <label for="fd1"></label>
+            <label for="fd2"></label>
+            <label for="fd3"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-floating-dark/style.css
+++ b/submissions/examples/css-carousel-floating-dark/style.css
@@ -1,0 +1,19 @@
+:root { --bg: #121212; --surface: #1e1e1e; --accent: #bb86fc; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: #fff; }
+.fd-carousel { width: 90%; max-width: 600px; display: flex; flex-direction: column; align-items: center; gap: 2rem; }
+input[type="radio"] { display: none; }
+.fd-container { width: 100%; overflow: hidden; padding: 2rem 0; perspective: 1000px; }
+.fd-track { display: flex; width: 300%; transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+.fd-card { width: 33.333%; padding: 3rem; box-sizing: border-box; background: var(--surface); border-radius: 20px; box-shadow: 0 10px 30px rgba(0,0,0,0.5); transform: scale(0.9) translateY(10px); opacity: 0.5; transition: all 0.6s cubic-bezier(0.16, 1, 0.3, 1); }
+.fd-card h3 { color: var(--accent); margin-top: 0; font-size: 1.5rem; }
+#fd1:checked ~ .fd-container .fd-track { transform: translateX(0); }
+#fd2:checked ~ .fd-container .fd-track { transform: translateX(-33.333%); }
+#fd3:checked ~ .fd-container .fd-track { transform: translateX(-66.666%); }
+#fd1:checked ~ .fd-container .fd-card:nth-child(1),
+#fd2:checked ~ .fd-container .fd-card:nth-child(2),
+#fd3:checked ~ .fd-container .fd-card:nth-child(3) { transform: scale(1) translateY(-10px); opacity: 1; box-shadow: 0 20px 40px rgba(0,0,0,0.8); }
+.fd-nav { display: flex; gap: 1rem; }
+.fd-nav label { width: 12px; height: 12px; border-radius: 50%; background: #444; cursor: pointer; transition: 0.3s; }
+#fd1:checked ~ .fd-nav label:nth-child(1),
+#fd2:checked ~ .fd-nav label:nth-child(2),
+#fd3:checked ~ .fd-nav label:nth-child(3) { background: var(--accent); transform: scale(1.3); box-shadow: 0 0 10px var(--accent); }

--- a/submissions/examples/css-modal-neumorphic-dark/README.md
+++ b/submissions/examples/css-modal-neumorphic-dark/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Modal (Dark Mode)
+A deep dark mode modal built with soft UI extrusion. Powered entirely by the CSS checkbox hack, featuring smooth 3D scaling and fading transitions.

--- a/submissions/examples/css-modal-neumorphic-dark/demo.html
+++ b/submissions/examples/css-modal-neumorphic-dark/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Dark Modal</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <input type="checkbox" id="neu-modal-toggle" class="nmd-toggle">
+    <div class="nmd-wrapper">
+        <label for="neu-modal-toggle" class="nmd-btn">Open Settings</label>
+    </div>
+
+    <div class="nmd-overlay">
+        <div class="nmd-modal">
+            <h2 class="nmd-title">Preferences</h2>
+            <p class="nmd-desc">Adjust your system settings. Soft UI principles applied to a dark mode palette.</p>
+            <div class="nmd-actions">
+                <label for="neu-modal-toggle" class="nmd-btn-close">Cancel</label>
+                <label for="neu-modal-toggle" class="nmd-btn-save">Save</label>
+            </div>
+        </div>
+        <label for="neu-modal-toggle" class="nmd-backdrop"></label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-modal-neumorphic-dark/style.css
+++ b/submissions/examples/css-modal-neumorphic-dark/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #292d32; --shadow-dark: #1f2226; --shadow-light: #33383e; --text: #a0a5ab; --accent: #4ade80; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: var(--text); }
+.nmd-toggle { display: none; }
+.nmd-btn { padding: 1rem 2rem; border-radius: 50px; background: var(--bg); color: var(--text); font-weight: 600; cursor: pointer; box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light); transition: all 0.3s; user-select: none; }
+.nmd-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); }
+.nmd-overlay { position: fixed; inset: 0; display: flex; justify-content: center; align-items: center; z-index: 100; opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+.nmd-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.5); z-index: 1; cursor: pointer; }
+.nmd-modal { position: relative; z-index: 2; background: var(--bg); padding: 2.5rem; border-radius: 20px; width: 90%; max-width: 400px; box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light); transform: translateY(-50px) scale(0.9); transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); opacity: 0; }
+.nmd-title { margin-top: 0; color: #fff; font-size: 1.5rem; }
+.nmd-desc { line-height: 1.6; margin-bottom: 2rem; }
+.nmd-actions { display: flex; justify-content: flex-end; gap: 1rem; }
+.nmd-btn-close, .nmd-btn-save { padding: 0.75rem 1.5rem; border-radius: 30px; font-weight: 600; cursor: pointer; box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); transition: all 0.3s; }
+.nmd-btn-save { color: var(--accent); }
+.nmd-btn-close:active, .nmd-btn-save:active { box-shadow: inset 2px 2px 5px var(--shadow-dark), inset -2px -2px 5px var(--shadow-light); }
+.nmd-toggle:checked ~ .nmd-overlay { opacity: 1; pointer-events: auto; }
+.nmd-toggle:checked ~ .nmd-overlay .nmd-modal { transform: translateY(0) scale(1); opacity: 1; }


### PR DESCRIPTION
**Title:** feat: create Floating Carousel with Dark Mode styling (#60119) #79705

**Description:**
This PR introduces a dark mode slider component. Inactive slides shrink into the background while the active slide physically elevates toward the user with an intense drop shadow.

Fixes #79705

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-floating-dark/`
- Applied `perspective: 1000px` to the parent container to allow 3D depth scaling
- Built a CSS-only slider mapped to hidden radio buttons, where the `:checked` slide expands utilizing `transform: scale(1) translateY(-10px)` and casts a heavy `box-shadow` to float above the inactive siblings
