### PR TITLE
feat: create Glowing Tooltip with Pastel styling (#39105) #79704

### DIFF
--- a/submissions/examples/css-tooltip-glowing-pastel/README.md
+++ b/submissions/examples/css-tooltip-glowing-pastel/README.md
@@ -1,0 +1,2 @@
+# Glowing Tooltip (Pastel)
+A highly visible but extremely soft tooltip. It uses thick borders and aggressive box-shadows colored in soft pastel pinks and greens to glow gently without blinding the user.

--- a/submissions/examples/css-tooltip-glowing-pastel/demo.html
+++ b/submissions/examples/css-tooltip-glowing-pastel/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Pastel Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="gp-container">
+        <button class="gp-btn">Hover for details</button>
+        <div class="gp-tooltip">
+            <span class="gp-text">A soft, glowing notification with pastel hues.</span>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-glowing-pastel/style.css
+++ b/submissions/examples/css-tooltip-glowing-pastel/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #fdfbf7; --pastel-pink: #ffb7b2; --pastel-blue: #e2f0cb; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.gp-container { position: relative; display: inline-block; }
+.gp-btn { padding: 0.75rem 2rem; border-radius: 50px; background: #fff; border: 2px solid var(--pastel-pink); color: #555; font-weight: bold; cursor: pointer; transition: all 0.3s; }
+.gp-btn:hover { background: var(--pastel-pink); color: #fff; box-shadow: 0 5px 15px rgba(255, 183, 178, 0.4); }
+.gp-tooltip { position: absolute; bottom: calc(100% + 15px); left: 50%; transform: translateX(-50%) translateY(10px); background: #fff; border: 2px solid var(--pastel-blue); padding: 1rem; border-radius: 12px; width: 220px; text-align: center; opacity: 0; visibility: hidden; transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); box-shadow: 0 10px 25px rgba(226, 240, 203, 0.6), inset 0 0 10px rgba(226, 240, 203, 0.4); }
+.gp-tooltip::after { content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%); border-width: 8px; border-style: solid; border-color: var(--pastel-blue) transparent transparent transparent; }
+.gp-text { color: #666; font-size: 0.9rem; line-height: 1.4; }
+.gp-container:hover .gp-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Glowing Tooltip with Pastel styling (#39105) #79704

**Description:**
This PR introduces a highly visible but extremely soft tooltip. It uses thick borders and aggressive box-shadows colored in soft pastel pinks and greens to glow gently without blinding the user.

Fixes #79704

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-glowing-pastel/`
- Designed the tooltip bubble featuring a combination of thick solid borders and matching inset/outset drop shadows rendered in `--pastel-blue`
- Triggered the tooltip entry animation on `:hover` using a sequenced `transform: translateY(0)` combined with an opacity fade
