### PR TITLE
feat: create Dynamic Tooltip with Neumorphism styling (#72706) #79702

### DIFF
--- a/submissions/examples/css-tooltip-dynamic-neumorphism/README.md
+++ b/submissions/examples/css-tooltip-dynamic-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Dynamic Tooltip (Neumorphism)
+A soft-UI physical tooltip. The trigger button presses inward on hover utilizing an inset shadow, which subsequently pops the tooltip panel out to the side with a sweeping 3D rotation.

--- a/submissions/examples/css-tooltip-dynamic-neumorphism/demo.html
+++ b/submissions/examples/css-tooltip-dynamic-neumorphism/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Neumorphic Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="dn-container">
+        <button class="dn-btn"><i class="ph ph-info"></i></button>
+        <div class="dn-tooltip">
+            <strong>System Info</strong>
+            <p>All core services are fully operational.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-dynamic-neumorphism/style.css
+++ b/submissions/examples/css-tooltip-dynamic-neumorphism/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.dn-container { position: relative; display: inline-block; }
+.dn-btn { width: 50px; height: 50px; border-radius: 50%; border: none; background: var(--bg); color: var(--text); font-size: 1.5rem; cursor: pointer; display: flex; justify-content: center; align-items: center; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: all 0.3s; }
+.dn-container:hover .dn-btn { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); color: var(--accent); }
+.dn-tooltip { position: absolute; left: calc(100% + 20px); top: 50%; transform: translateY(-50%) scale(0.8) rotateX(20deg); transform-origin: left center; background: var(--bg); padding: 1rem 1.5rem; border-radius: 12px; width: 200px; opacity: 0; visibility: hidden; transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light); z-index: 10; pointer-events: none; }
+.dn-tooltip strong { display: block; color: var(--text); margin-bottom: 0.5rem; font-size: 0.95rem; }
+.dn-tooltip p { margin: 0; color: #718096; font-size: 0.85rem; line-height: 1.4; }
+.dn-container:hover .dn-tooltip { opacity: 1; visibility: visible; transform: translateY(-50%) scale(1) rotateX(0); pointer-events: auto; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Tooltip with Neumorphism styling (#72706) #79702

**Description:**
This PR introduces a soft-UI physical tooltip. The trigger button presses inward on hover utilizing an inset shadow, which subsequently pops the tooltip panel out to the side with a sweeping 3D rotation.

Fixes #79702

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-dynamic-neumorphism/`
- Styled the circular trigger button with Neumorphic outset shadows that dynamically invert to `inset` when hovered
- Attached a 3D entrance to the tooltip element by defaulting it to `transform: rotateX(20deg) scale(0.8)` and springing it flat to `rotateX(0)` when activated
