### PR TITLE
a11y(menu): roving tabindex menuitem focus submission

### DIFF
--- a/submissions/examples/dropdown-menu-aria-focus-sb/README.md
+++ b/submissions/examples/dropdown-menu-aria-focus-sb/README.md
@@ -1,0 +1,32 @@
+# Dropdown Menu ARIA Menuitem Focus
+
+## What does it do?
+Implements a keyboard-navigable menu with `role="menu"`, `role="menuitem"` items, and **roving tabindex** (only the active item has `tabindex=0`). Arrow keys move focus, Home/End jump to first/last, and Escape closes the menu and returns focus to the trigger.
+
+## How is it used?
+```javascript
+import { MenuFocus } from './script.js';
+const m = new MenuFocus(document.getElementById('menu'), {
+  trigger: document.getElementById('trigger'),
+});
+m.open(); m.close(); m.destroy();
+```
+
+## Why is it useful?
+Roving tabindex is the recommended ARIA menu pattern: it keeps Tab reserved for leaving the menu while arrow keys navigate within it. This gives screen-reader users predictable focus behaviour.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/dropdown-menu-aria-focus-sb/menu.test.js
+```
+- **Happy path**: role=menu/menuitem set; only active item has tabindex=0; ArrowDown moves focus + tabindex; ArrowUp wraps.
+- **Edge cases**: Home/End jump; Escape closes + returns focus to trigger; open() sets aria-expanded.
+- **Invalid inputs**: empty menu handled; throws without menu element.
+
+## Tech Stack
+HTML, CSS, JavaScript (roving tabindex + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click the trigger, then use arrow/Home/End/Escape.
+
+Closes #81899

--- a/submissions/examples/dropdown-menu-aria-focus-sb/demo.html
+++ b/submissions/examples/dropdown-menu-aria-focus-sb/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dropdown Menu ARIA Menuitem Focus</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Dropdown Menu ARIA Menuitem Focus</h1>
+      <button id="trigger">Options</button>
+      <div class="ease-menu" id="menu">
+        <div data-menuitem>Edit</div>
+        <div data-menuitem>Duplicate</div>
+        <div data-menuitem>Delete</div>
+      </div>
+    </main>
+    <script type="module">
+      import { MenuFocus } from './script.js';
+      const m = new MenuFocus(document.getElementById('menu'), {
+        trigger: document.getElementById('trigger'),
+      });
+      document.getElementById('trigger').addEventListener('click', () => m.open());
+      window.__menu = m;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/dropdown-menu-aria-focus-sb/menu.test.js
+++ b/submissions/examples/dropdown-menu-aria-focus-sb/menu.test.js
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MenuFocus } from './script.js';
+
+describe('Dropdown Menu ARIA Menuitem Focus', () => {
+  let menu;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    menu = document.createElement('div');
+    ['Edit', 'Duplicate', 'Delete'].forEach((label) => {
+      const item = document.createElement('div');
+      item.setAttribute('data-menuitem', '');
+      item.textContent = label;
+      menu.appendChild(item);
+    });
+    document.body.appendChild(menu);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=menu on the container and role=menuitem on items', () => {
+    const m = new MenuFocus(menu);
+    expect(menu.getAttribute('role')).toBe('menu');
+    menu.querySelectorAll('[data-menuitem]').forEach((item) => {
+      expect(item.getAttribute('role')).toBe('menuitem');
+    });
+    m.destroy();
+  });
+
+  it('only the active item has tabindex=0 (roving tabindex)', () => {
+    const m = new MenuFocus(menu);
+    const tabs = Array.from(menu.querySelectorAll('[data-menuitem]')).map((i) =>
+      i.getAttribute('tabindex'),
+    );
+    expect(tabs).toEqual(['0', '-1', '-1']);
+    m.destroy();
+  });
+
+  it('ArrowDown moves focus to the next item and updates tabindex', () => {
+    const m = new MenuFocus(menu);
+    menu.querySelectorAll('[data-menuitem]')[0].focus();
+    vi.spyOn(menu.querySelectorAll('[data-menuitem]')[1], 'focus');
+    menu.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(m.activeIndex).toBe(1);
+    const tabs = Array.from(menu.querySelectorAll('[data-menuitem]')).map((i) =>
+      i.getAttribute('tabindex'),
+    );
+    expect(tabs).toEqual(['-1', '0', '-1']);
+    m.destroy();
+  });
+
+  it('ArrowUp wraps from first to last', () => {
+    const m = new MenuFocus(menu);
+    menu.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(m.activeIndex).toBe(2);
+    m.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('Home/End jump to first/last', () => {
+    const m = new MenuFocus(menu);
+    menu.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(m.activeIndex).toBe(2);
+    menu.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(m.activeIndex).toBe(0);
+    m.destroy();
+  });
+
+  it('Escape closes the menu and returns focus to the trigger', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    const m = new MenuFocus(menu, { trigger });
+    const spy = vi.spyOn(trigger, 'focus');
+    menu.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(menu.getAttribute('aria-expanded')).toBe('false');
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('open() sets aria-expanded=true and focuses the active item', () => {
+    const m = new MenuFocus(menu);
+    const spy = vi.spyOn(menu.querySelectorAll('[data-menuitem]')[0], 'focus');
+    m.open();
+    expect(menu.getAttribute('aria-expanded')).toBe('true');
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('works with an empty menu (no items)', () => {
+    const empty = document.createElement('div');
+    const m = new MenuFocus(empty);
+    expect(m.items).toHaveLength(0);
+    expect(() => m.open()).not.toThrow();
+    m.destroy();
+  });
+
+  it('throws without a valid menu element', () => {
+    expect(() => new MenuFocus(null)).toThrow(TypeError);
+    expect(() => new MenuFocus({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/dropdown-menu-aria-focus-sb/script.js
+++ b/submissions/examples/dropdown-menu-aria-focus-sb/script.js
@@ -1,0 +1,87 @@
+/**
+ * EaseMotion CSS — Dropdown Menu ARIA Menuitem Focus (roving tabindex)
+ * ============================================================
+ * A menu widget with role="menu", items role="menuitem", and arrow-key
+ * roving tabindex: only one item holds tabindex=0, the rest tabindex=-1.
+ * Home/End jump to first/last; Escape closes and returns focus to the trigger.
+ *
+ * API:
+ *   const m = new MenuFocus(menuEl, { trigger });
+ *   m.open(); m.close(); m.destroy();
+ * ============================================================
+ */
+
+export class MenuFocus {
+  constructor(menu, options = {}) {
+    if (!menu || typeof menu.addEventListener !== 'function') {
+      throw new TypeError('MenuFocus requires a menu element');
+    }
+    this.menu = menu;
+    this.trigger = options.trigger || null;
+    this.menu.setAttribute('role', 'menu');
+    this.items = Array.from(menu.querySelectorAll('[data-menuitem]'));
+    this.activeIndex = 0;
+    this._onKeydown = this._onKeydown.bind(this);
+    this.menu.addEventListener('keydown', this._onKeydown);
+    this._refresh();
+  }
+
+  _refresh() {
+    if (!this.items.length) return;
+    this.activeIndex = Math.min(this.activeIndex, this.items.length - 1);
+    this.items.forEach((item, i) => {
+      item.setAttribute('role', 'menuitem');
+      item.setAttribute('tabindex', i === this.activeIndex ? '0' : '-1');
+    });
+  }
+
+  _focus(index) {
+    if (!this.items.length) return;
+    this.activeIndex = (index + this.items.length) % this.items.length;
+    this._refresh();
+    this.items[this.activeIndex].focus();
+  }
+
+  _onKeydown(event) {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this._focus(this.activeIndex + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this._focus(this.activeIndex - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this._focus(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        this._focus(this.items.length - 1);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  open() {
+    this.menu.setAttribute('aria-expanded', 'true');
+    this._refresh();
+    if (this.items[this.activeIndex]) this.items[this.activeIndex].focus();
+  }
+
+  close() {
+    this.menu.setAttribute('aria-expanded', 'false');
+    if (this.trigger && typeof this.trigger.focus === 'function') this.trigger.focus();
+  }
+
+  destroy() {
+    this.menu.removeEventListener('keydown', this._onKeydown);
+    this.items.forEach((item) => item.setAttribute('tabindex', '0'));
+  }
+}
+
+export default MenuFocus;

--- a/submissions/examples/dropdown-menu-aria-focus-sb/style.css
+++ b/submissions/examples/dropdown-menu-aria-focus-sb/style.css
@@ -1,0 +1,27 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-menu {
+  display: inline-block;
+  min-width: 10rem;
+  margin-top: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #fff;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+}
+
+.ease-menu [data-menuitem] {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.ease-menu [data-menuitem]:focus,
+.ease-menu [data-menuitem]:hover {
+  background: #f3f4f6;
+  outline: none;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Dropdown Menu ARIA Menuitem Focus** accessibility audit (closes #81899). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/dropdown-menu-aria-focus-sb/`:
- **`script.js`** — `MenuFocus`: keyboard-navigable menu with `role=menu`, `role=menuitem` items, and **roving tabindex** (only the active item has `tabindex=0`). Arrow keys move focus, Home/End jump to first/last, Escape closes and returns focus to the trigger.
- **`menu.test.js`** — 9 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/dropdown-menu-aria-focus-sb/menu.test.js
 ✓ menu.test.js (9 tests)
```
- **Happy path**: role=menu/menuitem set; only active item has tabindex=0; ArrowDown moves focus + tabindex; ArrowUp wraps.
- **Edge cases**: Home/End jump; Escape closes + returns focus to trigger; open() sets aria-expanded.
- **Invalid inputs**: empty menu handled; throws without menu element.

Closes #81899

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._