### PR TITLE
a11y(tooltip): aria-describedby link submission

### DIFF
--- a/submissions/examples/tooltip-aria-describedby-sb/README.md
+++ b/submissions/examples/tooltip-aria-describedby-sb/README.md
@@ -1,0 +1,30 @@
+# Tooltip ARIA Describedby Link
+
+## What does it do?
+Wires a trigger element's `aria-describedby` to a tooltip element with `role="tooltip"`, and shows/hides it on focus/blur and mouseenter/mouseleave.
+
+## How is it used?
+```javascript
+import { TooltipAria } from './script.js';
+const t = new TooltipAria(triggerEl, tooltipEl);
+t.show(); t.hide(); t.destroy();
+```
+
+## Why is it useful?
+For a tooltip to be announced by screen readers, the trigger must reference it via `aria-describedby` and the tooltip must carry `role="tooltip"`. This also gates visibility on focus (keyboard) and hover (mouse), so both input methods expose the tooltip.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/tooltip-aria-describedby-sb/tooltip.test.js
+```
+- **Happy path**: role=tooltip + aria-describedby set; reuses existing id; hidden initially; focus shows / blur hides.
+- **Edge cases**: mouseenter/mouseleave; show()/hide(); destroy() removes aria-describedby.
+- **Invalid inputs**: throws without valid elements.
+
+## Tech Stack
+HTML, CSS (`ease-tooltip`), JavaScript (focus/hover + ARIA), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus or hover the button.
+
+Closes #81901

--- a/submissions/examples/tooltip-aria-describedby-sb/demo.html
+++ b/submissions/examples/tooltip-aria-describedby-sb/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tooltip ARIA Describedby Link</title>
+    <link rel="stylesheet" href="../../../components/tooltips.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Tooltip ARIA Describedby Link</h1>
+      <p>
+        <button id="btn" aria-describedby="">Delete</button>
+        <span class="ease-tooltip" id="tip">Removes the item permanently.</span>
+      </p>
+    </main>
+    <script type="module">
+      import { TooltipAria } from './script.js';
+      window.__tip = new TooltipAria(document.getElementById('btn'), document.getElementById('tip'));
+    </script>
+  </body>
+</html>

--- a/submissions/examples/tooltip-aria-describedby-sb/script.js
+++ b/submissions/examples/tooltip-aria-describedby-sb/script.js
@@ -1,0 +1,77 @@
+/**
+ * EaseMotion CSS — Tooltip ARIA Describedby Link
+ * ============================================================
+ * Wires a trigger element's `aria-describedby` to a tooltip element with
+ * role="tooltip", and shows/hides it on focus/blur and mouseenter/mouseleave.
+ * The tooltip id is generated if missing and reused on re-init.
+ *
+ * API:
+ *   const t = new TooltipAria(triggerEl, tooltipEl);
+ *   t.show(); t.hide(); t.destroy();
+ * ============================================================
+ */
+
+let _seq = 0;
+
+export class TooltipAria {
+  constructor(trigger, tooltip) {
+    if (!trigger || !tooltip || typeof trigger.addEventListener !== 'function') {
+      throw new TypeError('TooltipAria requires a trigger and a tooltip element');
+    }
+    this.trigger = trigger;
+    this.tooltip = tooltip;
+    this.tooltip.setAttribute('role', 'tooltip');
+    if (!this.tooltip.id) {
+      this.tooltip.id = 'ease-tooltip-' + ++_seq;
+    }
+    this.trigger.setAttribute('aria-describedby', this.tooltip.id);
+    this._shown = false;
+    this._onFocusIn = this._onFocusIn.bind(this);
+    this._onFocusOut = this._onFocusOut.bind(this);
+    this._onEnter = this._onEnter.bind(this);
+    this._onLeave = this._onLeave.bind(this);
+    this.trigger.addEventListener('focus', this._onFocusIn);
+    this.trigger.addEventListener('blur', this._onFocusOut);
+    this.trigger.addEventListener('mouseenter', this._onEnter);
+    this.trigger.addEventListener('mouseleave', this._onLeave);
+    this.hide();
+  }
+
+  show() {
+    this._shown = true;
+    this.tooltip.setAttribute('data-visible', 'true');
+  }
+
+  hide() {
+    this._shown = false;
+    this.tooltip.setAttribute('data-visible', 'false');
+  }
+
+  _onFocusIn() {
+    this.show();
+  }
+
+  _onFocusOut() {
+    this.hide();
+  }
+
+  _onEnter() {
+    this.show();
+  }
+
+  _onLeave() {
+    this.hide();
+  }
+
+  destroy() {
+    this.trigger.removeEventListener('focus', this._onFocusIn);
+    this.trigger.removeEventListener('blur', this._onFocusOut);
+    this.trigger.removeEventListener('mouseenter', this._onEnter);
+    this.trigger.removeEventListener('mouseleave', this._onLeave);
+    if (this.trigger.getAttribute('aria-describedby') === this.tooltip.id) {
+      this.trigger.removeAttribute('aria-describedby');
+    }
+  }
+}
+
+export default TooltipAria;

--- a/submissions/examples/tooltip-aria-describedby-sb/style.css
+++ b/submissions/examples/tooltip-aria-describedby-sb/style.css
@@ -1,0 +1,28 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+.ease-tooltip {
+  position: absolute;
+  margin-top: 0.25rem;
+  padding: 0.35rem 0.5rem;
+  background: #111827;
+  color: #fff;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.ease-tooltip[data-visible='false'] {
+  display: none;
+}

--- a/submissions/examples/tooltip-aria-describedby-sb/tooltip.test.js
+++ b/submissions/examples/tooltip-aria-describedby-sb/tooltip.test.js
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TooltipAria } from './script.js';
+
+describe('Tooltip ARIA Describedby Link', () => {
+  let trigger, tooltip;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    trigger = document.createElement('button');
+    tooltip = document.createElement('span');
+    tooltip.textContent = 'More info';
+    document.body.append(trigger, tooltip);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=tooltip and links aria-describedby', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    expect(tooltip.getAttribute('role')).toBe('tooltip');
+    expect(trigger.getAttribute('aria-describedby')).toBe(tooltip.id);
+    expect(tooltip.id).toBeTruthy();
+    t.destroy();
+  });
+
+  it('reuses an existing tooltip id for aria-describedby', () => {
+    tooltip.id = 'custom-tip';
+    const t = new TooltipAria(trigger, tooltip);
+    expect(trigger.getAttribute('aria-describedby')).toBe('custom-tip');
+    t.destroy();
+  });
+
+  it('is hidden initially', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    expect(tooltip.getAttribute('data-visible')).toBe('false');
+    t.destroy();
+  });
+
+  it('focus shows the tooltip; blur hides it', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    trigger.dispatchEvent(new window.Event('focus'));
+    expect(tooltip.getAttribute('data-visible')).toBe('true');
+    trigger.dispatchEvent(new window.Event('blur'));
+    expect(tooltip.getAttribute('data-visible')).toBe('false');
+    t.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('mouseenter shows the tooltip; mouseleave hides it', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    trigger.dispatchEvent(new window.MouseEvent('mouseenter'));
+    expect(tooltip.getAttribute('data-visible')).toBe('true');
+    trigger.dispatchEvent(new window.MouseEvent('mouseleave'));
+    expect(tooltip.getAttribute('data-visible')).toBe('false');
+    t.destroy();
+  });
+
+  it('show()/hide() toggle the visible state', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    t.show();
+    expect(tooltip.getAttribute('data-visible')).toBe('true');
+    t.hide();
+    expect(tooltip.getAttribute('data-visible')).toBe('false');
+    t.destroy();
+  });
+
+  it('destroy() removes aria-describedby it set', () => {
+    const t = new TooltipAria(trigger, tooltip);
+    t.destroy();
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without valid elements', () => {
+    expect(() => new TooltipAria(null, tooltip)).toThrow(TypeError);
+    expect(() => new TooltipAria(trigger, null)).toThrow(TypeError);
+    expect(() => new TooltipAria({}, {})).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Tooltip ARIA Describedby Link** accessibility audit (closes #81901). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/tooltip-aria-describedby-sb/`:
- **`script.js`** — `TooltipAria`: wires a trigger's `aria-describedby` to a tooltip with `role=tooltip`, and shows/hides it on focus/blur and mouseenter/mouseleave.
- **`tooltip.test.js`** — 8 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/tooltip-aria-describedby-sb/tooltip.test.js
 ✓ tooltip.test.js (8 tests)
```
- **Happy path**: role=tooltip + aria-describedby set; reuses existing id; hidden initially; focus shows / blur hides.
- **Edge cases**: mouseenter/mouseleave; show()/hide(); destroy() removes aria-describedby.
- **Invalid inputs**: throws without valid elements.

Closes #81901

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._