### PR TITLE
a11y(rating): star keypress selection submission

### DIFF
--- a/submissions/examples/rating-star-keypress-sb/README.md
+++ b/submissions/examples/rating-star-keypress-sb/README.md
@@ -1,0 +1,30 @@
+# Rating Component Star Keypress Selection
+
+## What does it do?
+Adds full keyboard support to a star rating: ArrowRight/Up increases the preview, ArrowLeft/Down decreases it, Enter/Space commits the selection. The container exposes `role="slider"` with `aria-valuenow/min/max`.
+
+## How is it used?
+```javascript
+import { RatingKeys } from './script.js';
+const r = new RatingKeys(document.getElementById('rating'), { stars: 5 });
+r.setValue(3); r.getValue(); r.destroy();
+```
+
+## Why is it useful?
+A mouse-only rating is unusable for keyboard and screen-reader users. Exposing it as a `slider` with arrow-key preview + Enter/Space commit matches the expected interaction model and announces the value via `aria-valuenow`.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/rating-star-keypress-sb/rating.test.js
+```
+- **Happy path**: role=slider + aria valuemin/max/now; ArrowRight increases preview; ArrowLeft decreases; Enter commits.
+- **Edge cases**: ArrowUp/Down; Space commits; preview clamps at max/0; Enter with no preview keeps value.
+- **Invalid inputs**: setValue rejects out-of-range/non-number; throws without container.
+
+## Tech Stack
+HTML, CSS, JavaScript (keyboard + ARIA slider), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus the rating, use arrows + Enter/Space.
+
+Closes #81905

--- a/submissions/examples/rating-star-keypress-sb/demo.html
+++ b/submissions/examples/rating-star-keypress-sb/demo.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Rating Star Keypress Selection</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Rating Star Keypress Selection</h1>
+      <p>Focus the rating, then use ←/→/↑/↓ to preview and Enter/Space to commit.</p>
+      <div class="ease-rating" id="rating" tabindex="0"></div>
+    </main>
+    <script type="module">
+      import { RatingKeys } from './script.js';
+      window.__rk = new RatingKeys(document.getElementById('rating'), { stars: 5 });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/rating-star-keypress-sb/rating.test.js
+++ b/submissions/examples/rating-star-keypress-sb/rating.test.js
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RatingKeys } from './script.js';
+
+describe('Rating Component Star Keypress Selection', () => {
+  let container;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.setAttribute('tabindex', '0');
+    document.body.appendChild(container);
+  });
+
+  function key(k) {
+    container.dispatchEvent(new window.KeyboardEvent('keydown', { key: k, bubbles: true }));
+  }
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=slider with aria-valuemin/max/now', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    expect(container.getAttribute('role')).toBe('slider');
+    expect(container.getAttribute('aria-valuemin')).toBe('0');
+    expect(container.getAttribute('aria-valuemax')).toBe('5');
+    expect(container.getAttribute('aria-valuenow')).toBe('0');
+    r.destroy();
+  });
+
+  it('ArrowRight increases the preview', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    key('ArrowRight');
+    expect(r.preview).toBe(1);
+    expect(container.querySelectorAll('.is-active')).toHaveLength(1);
+    r.destroy();
+  });
+
+  it('ArrowLeft decreases the preview', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    r.setValue(3);
+    key('ArrowLeft');
+    expect(r.preview).toBe(2);
+    r.destroy();
+  });
+
+  it('Enter commits the previewed value to the value', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    key('ArrowRight');
+    key('ArrowRight');
+    key('Enter');
+    expect(r.getValue()).toBe(2);
+    expect(container.getAttribute('aria-valuenow')).toBe('2');
+    r.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('ArrowUp also increases; ArrowDown decreases', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    key('ArrowUp');
+    expect(r.preview).toBe(1);
+    key('ArrowDown');
+    expect(r.preview).toBe(0);
+    r.destroy();
+  });
+
+  it('Space commits the previewed value', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    key('ArrowRight');
+    key('ArrowRight');
+    key('ArrowRight');
+    key(' ');
+    expect(r.getValue()).toBe(3);
+    r.destroy();
+  });
+
+  it('preview clamps at max and 0', () => {
+    const r = new RatingKeys(container, { stars: 3 });
+    key('ArrowRight');
+    key('ArrowRight');
+    key('ArrowRight');
+    key('ArrowRight');
+    expect(r.preview).toBe(3);
+    key('ArrowLeft');
+    key('ArrowLeft');
+    key('ArrowLeft');
+    key('ArrowLeft');
+    expect(r.preview).toBe(0);
+    r.destroy();
+  });
+
+  it('Enter with no preview commits the current value unchanged', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    r.setValue(4);
+    key('Enter');
+    expect(r.getValue()).toBe(4);
+    r.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('setValue rejects out-of-range / non-number', () => {
+    const r = new RatingKeys(container, { stars: 5 });
+    expect(r.setValue(-1)).toBe(false);
+    expect(r.setValue(6)).toBe(false);
+    expect(r.setValue(NaN)).toBe(false);
+    expect(r.getValue()).toBe(0);
+    r.destroy();
+  });
+
+  it('throws without a valid container', () => {
+    expect(() => new RatingKeys(null)).toThrow(TypeError);
+    expect(() => new RatingKeys({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/rating-star-keypress-sb/script.js
+++ b/submissions/examples/rating-star-keypress-sb/script.js
@@ -1,0 +1,90 @@
+/**
+ * EaseMotion CSS — Rating Component Star Keypress Selection
+ * ============================================================
+ * Adds full keyboard support to a star rating: ArrowRight/Up increases the
+ * preview, ArrowLeft/Down decreases it, Enter/Space commits the selection.
+ * The container exposes role=slider with aria-valuenow/min/max.
+ *
+ * API:
+ *   const r = new RatingKeys(containerEl, { stars });
+ *   r.setValue(n); r.getValue(); r.destroy();
+ * ============================================================
+ */
+
+export class RatingKeys {
+  constructor(container, options = {}) {
+    if (!container || typeof container.addEventListener !== 'function') {
+      throw new TypeError('RatingKeys requires a container element');
+    }
+    this.container = container;
+    this.maxStars = Number.isFinite(options.stars) && options.stars > 0 ? Math.floor(options.stars) : 5;
+    this.value = 0;
+    this.preview = 0;
+    this.container.setAttribute('role', 'slider');
+    this.container.setAttribute('aria-label', 'Rating');
+    this.container.setAttribute('aria-valuemin', '0');
+    this.container.setAttribute('aria-valuemax', String(this.maxStars));
+    this.container.setAttribute('aria-valuenow', '0');
+    this.container.setAttribute('tabindex', '0');
+    this._onKeydown = this._onKeydown.bind(this);
+    this.container.addEventListener('keydown', this._onKeydown);
+    this._render();
+  }
+
+  _render() {
+    const active = this.preview || this.value;
+    this.container.setAttribute('aria-valuenow', String(this.value));
+    this.container.textContent = '';
+    for (let i = 1; i <= this.maxStars; i++) {
+      const star = document.createElement('span');
+      star.className = 'ease-rating-star' + (i <= active ? ' is-active' : '');
+      star.textContent = '★';
+      this.container.appendChild(star);
+    }
+  }
+
+  _change(delta) {
+    let next = (this.preview || this.value) + delta;
+    next = Math.min(this.maxStars, Math.max(0, next));
+    this.preview = next;
+    this._render();
+  }
+
+  _onKeydown(event) {
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        event.preventDefault();
+        this._change(1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        event.preventDefault();
+        this._change(-1);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        this.setValue(this.preview || this.value);
+        break;
+    }
+  }
+
+  setValue(n) {
+    if (!Number.isFinite(n) || n < 0 || n > this.maxStars) return false;
+    this.value = Math.floor(n);
+    this.preview = this.value;
+    this._render();
+    return true;
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  destroy() {
+    this.container.removeEventListener('keydown', this._onKeydown);
+  }
+}
+
+export default RatingKeys;

--- a/submissions/examples/rating-star-keypress-sb/style.css
+++ b/submissions/examples/rating-star-keypress-sb/style.css
@@ -1,0 +1,28 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-rating {
+  display: inline-flex;
+  gap: 0.25rem;
+  font-size: 2rem;
+  line-height: 1;
+  outline: none;
+}
+
+.ease-rating:focus {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.ease-rating-star {
+  color: #d1d5db;
+}
+
+.ease-rating-star.is-active {
+  color: #f59e0b;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Rating Component Star Keypress Selection** accessibility audit (closes #81905). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/rating-star-keypress-sb/`:
- **`script.js`** — `RatingKeys`: full keyboard support — ArrowRight/Up increases the preview, ArrowLeft/Down decreases it, Enter/Space commits. Container exposes `role=slider` with `aria-valuenow/min/max`.
- **`rating.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/rating-star-keypress-sb/rating.test.js
 ✓ rating.test.js (10 tests)
```
- **Happy path**: role=slider + aria valuemin/max/now; ArrowRight increases preview; ArrowLeft decreases; Enter commits.
- **Edge cases**: ArrowUp/Down; Space commits; preview clamps at max/0; Enter with no preview keeps value.
- **Invalid inputs**: setValue rejects out-of-range/non-number; throws without container.

Closes #81905

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._