### PR TITLE
feat: add basic status filter row demo

### DIFF
--- a/submissions/examples/basic-status-filter-row-kk/README.md
+++ b/submissions/examples/basic-status-filter-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Status Filter Row
+
+## What it does
+
+This submission adds a CSS-only status filter row for dashboards, filter panels,
+settings menus, and list views.
+
+It shows a filter marker, filter name, helper text, item count, scope, and
+selected, active, or archived state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with a filter marker, copy area, metadata pills, and a
+state pill:
+
+```html
+<article class="basic-status-filter-row">
+  <span class="filter-mark is-selected" aria-hidden="true">ALL</span>
+  <div class="filter-copy">
+    <strong>All items</strong>
+    <p>Shows every item across active and archived states.</p>
+  </div>
+  <span class="filter-count">248</span>
+  <span class="filter-scope">Global</span>
+  <span class="filter-state is-selected">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful for common
+dashboard and filtering interfaces. Developers can reuse the same row pattern in
+filter drawers, table views, admin dashboards, and settings panels while keeping
+the implementation lightweight and CSS-only.
+
+## Included features
+
+- Selected, active, and archived filter examples
+- Filter marker badges
+- Item count metadata
+- Scope metadata
+- Filter state styling
+- Long text truncation for compact panels
+- Subtle hover slide and side accent
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the status filter row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-status-filter-row-kk/demo.html
+++ b/submissions/examples/basic-status-filter-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Status Filter Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Status Filter Row</p>
+          <h1>Simple filter rows for dashboard lists.</h1>
+          <p class="intro">
+            A CSS-only row component for showing filter name, item count, scope,
+            and selected, active, or archived state.
+          </p>
+        </header>
+
+        <section class="filter-list" aria-label="Status filter row examples">
+          <article class="basic-status-filter-row">
+            <span class="filter-mark is-selected" aria-hidden="true">ALL</span>
+            <div class="filter-copy">
+              <strong>All items</strong>
+              <p>Shows every item across active and archived states.</p>
+            </div>
+            <span class="filter-count">248</span>
+            <span class="filter-scope">Global</span>
+            <span class="filter-state is-selected">Selected</span>
+          </article>
+
+          <article class="basic-status-filter-row">
+            <span class="filter-mark is-active" aria-hidden="true">ON</span>
+            <div class="filter-copy">
+              <strong>Active items</strong>
+              <p>Shows only currently active records in the workspace.</p>
+            </div>
+            <span class="filter-count">214</span>
+            <span class="filter-scope">Live</span>
+            <span class="filter-state is-active">Active</span>
+          </article>
+
+          <article class="basic-status-filter-row">
+            <span class="filter-mark is-archived" aria-hidden="true">AR</span>
+            <div class="filter-copy">
+              <strong>Archived items</strong>
+              <p>Shows items hidden from the default dashboard view.</p>
+            </div>
+            <span class="filter-count">34</span>
+            <span class="filter-scope">Stored</span>
+            <span class="filter-state is-archived">Archived</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-status-filter-row"&gt;
+  &lt;span class="filter-mark is-selected" aria-hidden="true"&gt;ALL&lt;/span&gt;
+  &lt;div class="filter-copy"&gt;
+    &lt;strong&gt;All items&lt;/strong&gt;
+    &lt;p&gt;Shows every item across active and archived states.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="filter-count"&gt;248&lt;/span&gt;
+  &lt;span class="filter-scope"&gt;Global&lt;/span&gt;
+  &lt;span class="filter-state is-selected"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-status-filter-row-kk/style.css
+++ b/submissions/examples/basic-status-filter-row-kk/style.css
@@ -1,0 +1,200 @@
+:root {
+  color-scheme: dark;
+  --page: #0b1020;
+  --card: rgba(15, 23, 42, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.1);
+  --text: #f8fbff;
+  --muted: #a8b3c6;
+  --selected: #86efac;
+  --active: #93c5fd;
+  --archived: #cbd5e1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(134, 239, 172, 0.14), transparent 28%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 30%),
+    linear-gradient(145deg, #070914, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--selected);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 17ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.filter-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-status-filter-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-status-filter-row + .basic-status-filter-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-status-filter-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 3px 0 0 rgba(134, 239, 172, 0.72);
+  transform: translateX(4px);
+}
+
+.filter-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 17px;
+  color: #07111f;
+  font-size: 0.74rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--selected), #dcfce7);
+}
+
+.filter-mark.is-active {
+  background: linear-gradient(135deg, var(--active), #dbeafe);
+}
+
+.filter-mark.is-archived {
+  background: linear-gradient(135deg, var(--archived), #f8fafc);
+}
+
+.filter-copy {
+  min-width: 0;
+}
+
+.filter-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-count,
+.filter-scope,
+.filter-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 5.8rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.filter-count,
+.filter-scope {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.filter-state {
+  color: var(--selected);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.filter-state.is-active {
+  color: var(--active);
+  background: rgba(147, 197, 253, 0.12);
+}
+
+.filter-state.is-archived {
+  color: var(--archived);
+  background: rgba(203, 213, 225, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 780px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-status-filter-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .filter-count,
+  .filter-scope,
+  .filter-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Status Filter Row demo inside `submissions/examples/basic-status-filter-row-kk/`. This submission introduces a simple CSS-only row for dashboards, filter panels, settings menus, and list views.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only status filter row that displays a filter marker, filter name, helper text, item count, scope, and selected/active/archived state in one compact layout.

**How does a developer use it?**

```html
<article class="basic-status-filter-row">
  <span class="filter-mark is-selected" aria-hidden="true">ALL</span>
  <div class="filter-copy">
    <strong>All items</strong>
    <p>Shows every item across active and archived states.</p>
  </div>
  <span class="filter-count">248</span>
  <span class="filter-scope">Global</span>
  <span class="filter-state is-selected">Selected</span>
</article>