### PR TITLE
a11y(carousel): autoplay pause on focus submission

### DIFF
--- a/submissions/examples/carousel-pause-on-focus-sb/README.md
+++ b/submissions/examples/carousel-pause-on-focus-sb/README.md
@@ -1,0 +1,32 @@
+# Carousel Autoplay Pause on Focus
+
+## What does it do?
+Pauses carousel autoplay while any slide or control inside the carousel is focused (via `focusin`/`focusout` on the root), and resumes autoplay when focus leaves the carousel entirely.
+
+## How is it used?
+```javascript
+import { CarouselPause } from './script.js';
+const c = new CarouselPause(document.getElementById('carousel'), { interval: 3000 });
+c.play(); c.pause(); c.next(); c.isPaused();
+c.onPauseChange((paused) => { /* update UI */ });
+c.destroy();
+```
+
+## Why is it useful?
+Auto-advancing carousels are a WCAG 2.2.2 concern: moving content must pause when a user interacts with it. Pausing on focus (not just hover) covers keyboard users, who never trigger mouseenter, so the carousel stays still while they read a slide.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/carousel-pause-on-focus-sb/carousel.test.js
+```
+- **Happy path**: starts playing; pauses on focusin; resumes on focusout; aria-hidden only false on active; next() cycles.
+- **Edge cases**: no re-pause when already paused; focusout to inner element keeps paused; onPauseChange fires on pause/resume; pause() clears timer.
+- **Invalid inputs**: works with no slides; throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-carousel*`), JavaScript (focusin/focusout + timers), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, Tab into a slide, and watch the status flip to paused.
+
+Closes #81907

--- a/submissions/examples/carousel-pause-on-focus-sb/carousel.test.js
+++ b/submissions/examples/carousel-pause-on-focus-sb/carousel.test.js
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CarouselPause } from './script.js';
+
+describe('Carousel Autoplay Pause on Focus', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.className = 'ease-carousel';
+    for (let i = 0; i < 3; i++) {
+      const slide = document.createElement('div');
+      slide.className = 'ease-carousel-slide';
+      slide.setAttribute('tabindex', '0');
+      slide.textContent = 'Slide ' + (i + 1);
+      root.appendChild(slide);
+    }
+    document.body.appendChild(root);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('starts playing and pauses on focusin', () => {
+    const c = new CarouselPause(root, { interval: 1000 });
+    expect(c.isPaused()).toBe(false);
+    root.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
+    expect(c.isPaused()).toBe(true);
+    c.destroy();
+  });
+
+  it('resumes when focus leaves the carousel', () => {
+    const c = new CarouselPause(root, { interval: 1000 });
+    root.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
+    expect(c.isPaused()).toBe(true);
+    root.dispatchEvent(
+      new window.FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }),
+    );
+    expect(c.isPaused()).toBe(false);
+    c.destroy();
+  });
+
+  it('marks the active slide aria-hidden=false and others true', () => {
+    const c = new CarouselPause(root);
+    const slides = root.querySelectorAll('.ease-carousel-slide');
+    expect(slides[0].getAttribute('aria-hidden')).toBe('false');
+    expect(slides[1].getAttribute('aria-hidden')).toBe('true');
+    c.destroy();
+  });
+
+  it('next() advances the active slide cyclically', () => {
+    const c = new CarouselPause(root);
+    c.next();
+    expect(c.index).toBe(1);
+    const slides = root.querySelectorAll('.ease-carousel-slide');
+    expect(slides[1].getAttribute('aria-hidden')).toBe('false');
+    c.next();
+    c.next();
+    expect(c.index).toBe(0);
+    c.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('does not re-pause if already paused', () => {
+    const c = new CarouselPause(root);
+    c.pause();
+    const before = c.isPaused();
+    root.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
+    expect(c.isPaused()).toBe(before);
+    c.destroy();
+  });
+
+  it('focusout to another element inside the root keeps it paused', () => {
+    const c = new CarouselPause(root);
+    root.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
+    const inner = root.querySelector('.ease-carousel-slide');
+    root.dispatchEvent(
+      new window.FocusEvent('focusout', { bubbles: true, relatedTarget: inner }),
+    );
+    expect(c.isPaused()).toBe(true);
+    c.destroy();
+  });
+
+  it('onPauseChange fires with the new state on pause and resume', () => {
+    const c = new CarouselPause(root);
+    const spy = vi.fn();
+    c.onPauseChange(spy);
+    c.pause();
+    c.play();
+    expect(spy).toHaveBeenNthCalledWith(1, true);
+    expect(spy).toHaveBeenNthCalledWith(2, false);
+    c.destroy();
+  });
+
+  it('pause() clears the scheduled timer', () => {
+    const c = new CarouselPause(root, { interval: 1000 });
+    c.play();
+    c.pause();
+    expect(c._timer).toBeNull();
+    c.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('works with a root that has no slides', () => {
+    const empty = document.createElement('div');
+    const c = new CarouselPause(empty);
+    expect(() => c.next()).not.toThrow();
+    c.destroy();
+  });
+
+  it('throws without a valid root element', () => {
+    expect(() => new CarouselPause(null)).toThrow(TypeError);
+    expect(() => new CarouselPause({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/carousel-pause-on-focus-sb/demo.html
+++ b/submissions/examples/carousel-pause-on-focus-sb/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Carousel Pause on Focus</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Carousel Pause on Focus</h1>
+      <p>Autoplay pauses while any slide or control is focused.</p>
+      <div class="ease-carousel" id="carousel">
+        <div class="ease-carousel-slide" tabindex="0">Slide 1</div>
+        <div class="ease-carousel-slide" tabindex="0">Slide 2</div>
+        <div class="ease-carousel-slide" tabindex="0">Slide 3</div>
+      </div>
+      <p>Status: <code id="status">playing</code></p>
+    </main>
+    <script type="module">
+      import { CarouselPause } from './script.js';
+      const c = new CarouselPause(document.getElementById('carousel'), { interval: 3000 });
+      const statusEl = document.getElementById('status');
+      const sync = () => (statusEl.textContent = c.isPaused() ? 'paused' : 'playing');
+      c.onPauseChange(sync); sync();
+      window.__carousel = c;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/carousel-pause-on-focus-sb/script.js
+++ b/submissions/examples/carousel-pause-on-focus-sb/script.js
@@ -1,0 +1,109 @@
+/**
+ * EaseMotion CSS — Carousel Autoplay Pause on Focus
+ * ============================================================
+ * Pauses autoplay while any slide or control inside the carousel is focused
+ * (focusin/focusout on the carousel root), and resumes when focus leaves.
+ *
+ * API:
+ *   const c = new CarouselPause(rootEl, { interval });
+ *   c.play(); c.pause(); c.next(); c.isPaused();
+ *   c.onPauseChange(fn);   // fn(true|false) on pause/resume
+ *   c.destroy();
+ * ============================================================
+ */
+
+export class CarouselPause {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('CarouselPause requires a root element');
+    }
+    this.root = root;
+    this.interval = Number.isFinite(options.interval) && options.interval > 0 ? options.interval : 4000;
+    this.slides = Array.from(root.querySelectorAll('[class*="slide"]'));
+    this.index = 0;
+    this._timer = null;
+    this._paused = false;
+    this._listeners = [];
+    this._onFocusIn = this._onFocusIn.bind(this);
+    this._onFocusOut = this._onFocusOut.bind(this);
+    this.root.setAttribute('role', 'region');
+    this.root.setAttribute('aria-roledescription', 'carousel');
+    this.root.addEventListener('focusin', this._onFocusIn);
+    this.root.addEventListener('focusout', this._onFocusOut);
+    this._render();
+  }
+
+  _render() {
+    this.slides.forEach((slide, i) => {
+      slide.setAttribute('aria-hidden', String(i !== this.index));
+      if (i === this.index) {
+        slide.classList.add('is-active');
+      } else {
+        slide.classList.remove('is-active');
+      }
+    });
+  }
+
+  _notify() {
+    this._listeners.forEach((fn) => {
+      try { fn(this._paused); } catch { /* listener error */ }
+    });
+  }
+
+  _onFocusIn() {
+    if (this._paused) return;
+    this.pause();
+  }
+
+  _onFocusOut(event) {
+    if (!this.root.contains(event.relatedTarget)) {
+      this.play();
+    }
+  }
+
+  _schedule() {
+    if (this._timer) clearTimeout(this._timer);
+    if (this._paused) return;
+    this._timer = setTimeout(() => {
+      this.next();
+      this._schedule();
+    }, this.interval);
+  }
+
+  pause() {
+    if (this._paused) return;
+    this._paused = true;
+    if (this._timer) { clearTimeout(this._timer); this._timer = null; }
+    this._notify();
+  }
+
+  play() {
+    if (!this._paused) return;
+    this._paused = false;
+    this._schedule();
+    this._notify();
+  }
+
+  next() {
+    if (!this.slides.length) return;
+    this.index = (this.index + 1) % this.slides.length;
+    this._render();
+  }
+
+  isPaused() {
+    return this._paused;
+  }
+
+  onPauseChange(fn) {
+    if (typeof fn === 'function') this._listeners.push(fn);
+  }
+
+  destroy() {
+    if (this._timer) clearTimeout(this._timer);
+    this.root.removeEventListener('focusin', this._onFocusIn);
+    this.root.removeEventListener('focusout', this._onFocusOut);
+    this._listeners = [];
+  }
+}
+
+export default CarouselPause;

--- a/submissions/examples/carousel-pause-on-focus-sb/style.css
+++ b/submissions/examples/carousel-pause-on-focus-sb/style.css
@@ -1,0 +1,38 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-carousel {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+
+.ease-carousel-slide {
+  flex: 1 0 33%;
+  min-height: 6rem;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  opacity: 0.45;
+  transition: opacity 0.2s ease;
+}
+
+.ease-carousel-slide.is-active {
+  opacity: 1;
+  border-color: var(--ease-color-primary, #6c63ff);
+}
+
+code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Carousel Autoplay Pause on Focus** accessibility audit (closes #81907). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/carousel-pause-on-focus-sb/`:
- **`script.js`** — `CarouselPause`: pauses autoplay while any slide/control inside the carousel is focused (`focusin`/`focusout` on the root) and resumes when focus leaves the carousel entirely.
- **`carousel.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/carousel-pause-on-focus-sb/carousel.test.js
 ✓ carousel.test.js (10 tests)
```
- **Happy path**: starts playing; pauses on focusin; resumes on focusout; aria-hidden only false on active; next() cycles.
- **Edge cases**: no re-pause when already paused; focusout to inner element keeps paused; onPauseChange fires on pause/resume; pause() clears timer.
- **Invalid inputs**: works with no slides; throws without root element.

Closes #81907

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._