### PR TITLE
a11y(dropzone): keyboard drag-and-drop submission

### DIFF
--- a/submissions/examples/file-dropzone-keyboard-dnd-sb/README.md
+++ b/submissions/examples/file-dropzone-keyboard-dnd-sb/README.md
@@ -1,0 +1,32 @@
+# File Dropzone Keyboard Drag-and-Drop
+
+## What does it do?
+Makes a file dropzone operable from the keyboard: the zone has `role="button"` + `tabindex="0"`, Enter/Space opens the file picker, and dragging a file over the zone toggles a highlight (with depth-aware enter/leave). Drop and file-picker change events are emitted via `onFile(fn)`.
+
+## How is it used?
+```javascript
+import { DropzoneKeyboard } from './script.js';
+const dz = new DropzoneKeyboard(document.getElementById('dropzone'));
+dz.onFile((files) => { /* handle files */ });
+dz.onHighlight((on) => { /* update UI */ });
+dz.openPicker(); dz.destroy();
+```
+
+## Why is it useful?
+A dropzone that only responds to drag events is unusable for keyboard and screen-reader users. Exposing it as a button with Enter/Space → file picker, plus depth-aware drag highlighting, matches the expected interaction model and prevents flicker when the drag passes over nested children.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/file-dropzone-keyboard-dnd-sb/dropzone.test.js
+```
+- **Happy path**: role=button + tabindex + aria-label; Enter/Space opens picker; dragenter highlights, dragleave clears.
+- **Edge cases**: drop emits files + clears highlight; nested enter/leave keeps highlight until depth 0; onHighlight fires; change emits files; openPicker returns false without input.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-dropzone`), JavaScript (keyboard + DnD), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus the zone and press Enter, or drag a file onto it.
+
+Closes #81909

--- a/submissions/examples/file-dropzone-keyboard-dnd-sb/demo.html
+++ b/submissions/examples/file-dropzone-keyboard-dnd-sb/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>File Dropzone Keyboard Drag-and-Drop</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>File Dropzone Keyboard Drag-and-Drop</h1>
+      <p>Focus the zone and press Enter, or drag a file onto it.</p>
+      <div class="ease-dropzone" id="dropzone">
+        Drop files here or press Enter to browse
+        <input type="file" id="file-input" hidden multiple />
+      </div>
+      <p>Status: <code id="status">idle</code></p>
+    </main>
+    <script type="module">
+      import { DropzoneKeyboard } from './script.js';
+      const dz = new DropzoneKeyboard(document.getElementById('dropzone'));
+      const status = document.getElementById('status');
+      dz.onFile((files) => (status.textContent = files.length + ' file(s) selected'));
+      dz.onHighlight((on) => (status.textContent = on ? 'dragging…' : 'idle'));
+      window.__dz = dz;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/file-dropzone-keyboard-dnd-sb/dropzone.test.js
+++ b/submissions/examples/file-dropzone-keyboard-dnd-sb/dropzone.test.js
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DropzoneKeyboard } from './script.js';
+
+describe('File Dropzone Keyboard Drag-and-Drop', () => {
+  let root, input;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    input = document.createElement('input');
+    input.type = 'file';
+    root = document.createElement('div');
+    root.className = 'ease-dropzone';
+    root.appendChild(input);
+    document.body.appendChild(root);
+  });
+
+  function dragEvent(type, opts = {}) {
+    const ev = new window.Event(type, { bubbles: true });
+    if (type === 'drop') {
+      Object.defineProperty(ev, 'dataTransfer', {
+        value: { files: opts.files || [] },
+      });
+    }
+    return ev;
+  }
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=button, tabindex=0 and an aria-label', () => {
+    const dz = new DropzoneKeyboard(root);
+    expect(root.getAttribute('role')).toBe('button');
+    expect(root.getAttribute('tabindex')).toBe('0');
+    expect(root.getAttribute('aria-label')).toBeTruthy();
+    dz.destroy();
+  });
+
+  it('Enter opens the file picker', () => {
+    const dz = new DropzoneKeyboard(root);
+    const spy = vi.spyOn(input, 'click');
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(spy).toHaveBeenCalled();
+    dz.destroy();
+  });
+
+  it('Space opens the file picker', () => {
+    const dz = new DropzoneKeyboard(root);
+    const spy = vi.spyOn(input, 'click');
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(spy).toHaveBeenCalled();
+    dz.destroy();
+  });
+
+  it('dragenter highlights the zone; dragleave clears it', () => {
+    const dz = new DropzoneKeyboard(root);
+    root.dispatchEvent(dragEvent('dragenter'));
+    expect(root.classList.contains('is-dragover')).toBe(true);
+    root.dispatchEvent(dragEvent('dragleave'));
+    expect(root.classList.contains('is-dragover')).toBe(false);
+    dz.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('drop emits the files via onFile and clears the highlight', () => {
+    const dz = new DropzoneKeyboard(root);
+    const spy = vi.fn();
+    dz.onFile(spy);
+    root.dispatchEvent(dragEvent('dragenter'));
+    const files = [{ name: 'a.txt' }];
+    root.dispatchEvent(dragEvent('drop', { files }));
+    expect(spy).toHaveBeenCalledWith(files);
+    expect(root.classList.contains('is-dragover')).toBe(false);
+    dz.destroy();
+  });
+
+  it('nested dragenter/dragleave keeps highlight until depth reaches 0', () => {
+    const dz = new DropzoneKeyboard(root);
+    root.dispatchEvent(dragEvent('dragenter'));
+    root.dispatchEvent(dragEvent('dragenter'));
+    root.dispatchEvent(dragEvent('dragleave'));
+    expect(root.classList.contains('is-dragover')).toBe(true);
+    root.dispatchEvent(dragEvent('dragleave'));
+    expect(root.classList.contains('is-dragover')).toBe(false);
+    dz.destroy();
+  });
+
+  it('onHighlight fires on dragenter/leave with the new state', () => {
+    const dz = new DropzoneKeyboard(root);
+    const spy = vi.fn();
+    dz.onHighlight(spy);
+    root.dispatchEvent(dragEvent('dragenter'));
+    root.dispatchEvent(dragEvent('dragleave'));
+    expect(spy).toHaveBeenNthCalledWith(1, true);
+    expect(spy).toHaveBeenNthCalledWith(2, false);
+    dz.destroy();
+  });
+
+  it('change on the input emits files via onFile', () => {
+    const dz = new DropzoneKeyboard(root);
+    const spy = vi.fn();
+    dz.onFile(spy);
+    const files = [{ name: 'b.txt' }];
+    Object.defineProperty(input, 'files', { value: files, configurable: true });
+    input.dispatchEvent(new window.Event('change', { bubbles: true }));
+    expect(spy).toHaveBeenCalledWith(files);
+    dz.destroy();
+  });
+
+  it('openPicker() returns false when there is no input', () => {
+    const bare = document.createElement('div');
+    const dz = new DropzoneKeyboard(bare);
+    expect(dz.openPicker()).toBe(false);
+    dz.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a valid root element', () => {
+    expect(() => new DropzoneKeyboard(null)).toThrow(TypeError);
+    expect(() => new DropzoneKeyboard({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/file-dropzone-keyboard-dnd-sb/script.js
+++ b/submissions/examples/file-dropzone-keyboard-dnd-sb/script.js
@@ -1,0 +1,127 @@
+/**
+ * EaseMotion CSS — File Dropzone Keyboard Drag-and-Drop
+ * ============================================================
+ * Makes a file dropzone operable from the keyboard: the dropzone has
+ * role="button" + tabindex="0"; Enter/Space opens the file picker;
+ * dragging a file over the zone toggles a highlight. Drop/cancel events
+ * are emitted via onFile(fn)/onHighlight(fn) callbacks.
+ *
+ * API:
+ *   const dz = new DropzoneKeyboard(rootEl, { input });
+ *   dz.onFile(fn); dz.onHighlight(fn);
+ *   dz.openPicker(); dz.destroy();
+ * ============================================================
+ */
+
+export class DropzoneKeyboard {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('DropzoneKeyboard requires a root element');
+    }
+    this.root = root;
+    this.input = options.input || root.querySelector('input[type="file"]');
+    this._fileListeners = [];
+    this._highlightListeners = [];
+    this._dragDepth = 0;
+
+    this.root.setAttribute('role', 'button');
+    this.root.setAttribute('tabindex', '0');
+    this.root.setAttribute('aria-label', 'Drop files here or press Enter to browse');
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onClick = this._onClick.bind(this);
+    this._onDragEnter = this._onDragEnter.bind(this);
+    this._onDragOver = this._onDragOver.bind(this);
+    this._onDragLeave = this._onDragLeave.bind(this);
+    this._onDrop = this._onDrop.bind(this);
+    this._onChange = this._onChange.bind(this);
+
+    this.root.addEventListener('keydown', this._onKeydown);
+    this.root.addEventListener('click', this._onClick);
+    this.root.addEventListener('dragenter', this._onDragEnter);
+    this.root.addEventListener('dragover', this._onDragOver);
+    this.root.addEventListener('dragleave', this._onDragLeave);
+    this.root.addEventListener('drop', this._onDrop);
+    if (this.input) this.input.addEventListener('change', this._onChange);
+  }
+
+  openPicker() {
+    if (this.input && typeof this.input.click === 'function') {
+      this.input.click();
+      return true;
+    }
+    return false;
+  }
+
+  onFile(fn) {
+    if (typeof fn === 'function') this._fileListeners.push(fn);
+  }
+
+  onHighlight(fn) {
+    if (typeof fn === 'function') this._highlightListeners.push(fn);
+  }
+
+  _emitFiles(files) {
+    if (!files || !files.length) return;
+    this._fileListeners.forEach((fn) => {
+      try { fn(files); } catch { /* listener error */ }
+    });
+  }
+
+  _setHighlight(on) {
+    this.root.classList.toggle('is-dragover', on);
+    this.root.setAttribute('aria-pressed', String(on));
+    this._highlightListeners.forEach((fn) => {
+      try { fn(on); } catch { /* listener error */ }
+    });
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openPicker();
+    }
+  }
+
+  _onClick() {
+    this.openPicker();
+  }
+
+  _onDragEnter(event) {
+    event.preventDefault();
+    this._dragDepth++;
+    this._setHighlight(true);
+  }
+
+  _onDragOver(event) {
+    event.preventDefault();
+  }
+
+  _onDragLeave() {
+    this._dragDepth = Math.max(0, this._dragDepth - 1);
+    if (this._dragDepth === 0) this._setHighlight(false);
+  }
+
+  _onDrop(event) {
+    event.preventDefault();
+    this._dragDepth = 0;
+    this._setHighlight(false);
+    this._emitFiles(event.dataTransfer ? event.dataTransfer.files : null);
+  }
+
+  _onChange() {
+    if (this.input) this._emitFiles(this.input.files);
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this.root.removeEventListener('click', this._onClick);
+    this.root.removeEventListener('dragenter', this._onDragEnter);
+    this.root.removeEventListener('dragover', this._onDragOver);
+    this.root.removeEventListener('dragleave', this._onDragLeave);
+    this.root.removeEventListener('drop', this._onDrop);
+    if (this.input) this.input.removeEventListener('change', this._onChange);
+  }
+}
+
+export default DropzoneKeyboard;

--- a/submissions/examples/file-dropzone-keyboard-dnd-sb/style.css
+++ b/submissions/examples/file-dropzone-keyboard-dnd-sb/style.css
@@ -1,0 +1,38 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-dropzone {
+  display: grid;
+  place-items: center;
+  min-height: 8rem;
+  padding: 1.5rem;
+  text-align: center;
+  border: 2px dashed #d1d5db;
+  border-radius: 0.75rem;
+  background: #f9fafb;
+  color: #6b7280;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.ease-dropzone:focus,
+.ease-dropzone:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ease-dropzone.is-dragover {
+  border-color: var(--ease-color-primary, #6c63ff);
+  background: #eef2ff;
+  color: #1f2937;
+}
+
+code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **File Dropzone Keyboard Drag-and-Drop** accessibility audit (closes #81909). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/file-dropzone-keyboard-dnd-sb/`:
- **`script.js`** — `DropzoneKeyboard`: makes a dropzone operable from the keyboard — `role=button` + `tabindex=0`, Enter/Space opens the file picker, dragging a file over the zone toggles a highlight (depth-aware enter/leave). Drop + change events emit via `onFile(fn)`.
- **`dropzone.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/file-dropzone-keyboard-dnd-sb/dropzone.test.js
 ✓ dropzone.test.js (10 tests)
```
- **Happy path**: role=button + tabindex + aria-label; Enter/Space opens picker; dragenter highlights, dragleave clears.
- **Edge cases**: drop emits files + clears highlight; nested enter/leave keeps highlight until depth 0; onHighlight fires; change emits files; openPicker returns false without input.
- **Invalid inputs**: throws without root element.

Closes #81909

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._