### PR TITLE
a11y(switch): toggle aria-checked state submission

### DIFF
--- a/submissions/examples/switch-toggle-aria-checked-sb/README.md
+++ b/submissions/examples/switch-toggle-aria-checked-sb/README.md
@@ -1,0 +1,32 @@
+# Switch Toggle ARIA Checked State
+
+## What does it do?
+A switch widget with `role="switch"` and `aria-checked`, toggled by click and Space/Enter. Emits `onChange(fn)` callbacks and supports an initial checked state.
+
+## How is it used?
+```javascript
+import { SwitchToggle } from './script.js';
+const s = new SwitchToggle(document.getElementById('sw'), { checked: false });
+s.setChecked(true); s.isChecked(); s.toggle();
+s.onChange((on) => { /* update UI */ });
+s.destroy();
+```
+
+## Why is it useful?
+A toggle rendered as a custom control must expose `role="switch"` + `aria-checked` for screen readers, and support Space/Enter for keyboard users. This keeps the semantic state (`aria-checked`) always consistent with the visual state (`is-on` class).
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/switch-toggle-aria-checked-sb/switch.test.js
+```
+- **Happy path**: role=switch + tabindex; aria-checked false initially; setChecked(true) sets aria-checked; click toggles.
+- **Edge cases**: Space/Enter toggle; onChange fires only on actual change; initial checked option; is-on class tracks state.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-switch`), JavaScript (ARIA switch + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click or focus + Space/Enter the switch.
+
+Closes #81911

--- a/submissions/examples/switch-toggle-aria-checked-sb/demo.html
+++ b/submissions/examples/switch-toggle-aria-checked-sb/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Switch Toggle ARIA Checked State</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Switch Toggle ARIA Checked State</h1>
+      <label for="sw">Notifications</label>
+      <button class="ease-switch" id="sw" type="button"></button>
+      <p>State: <code id="state">off</code></p>
+    </main>
+    <script type="module">
+      import { SwitchToggle } from './script.js';
+      const s = new SwitchToggle(document.getElementById('sw'));
+      const stateEl = document.getElementById('state');
+      s.onChange((on) => (stateEl.textContent = on ? 'on' : 'off'));
+      window.__switch = s;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/switch-toggle-aria-checked-sb/script.js
+++ b/submissions/examples/switch-toggle-aria-checked-sb/script.js
@@ -1,0 +1,83 @@
+/**
+ * EaseMotion CSS — Switch Toggle ARIA Checked State
+ * ============================================================
+ * A switch widget with role="switch" and aria-checked, toggled by click
+ * and Space/Enter. Emits onChange(fn) callbacks and supports an initial
+ * checked state.
+ *
+ * API:
+ *   const s = new SwitchToggle(rootEl, { checked });
+ *   s.setChecked(true); s.isChecked(); s.toggle();
+ *   s.onChange(fn); s.destroy();
+ * ============================================================
+ */
+
+export class SwitchToggle {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('SwitchToggle requires a root element');
+    }
+    this.root = root;
+    this._checked = !!options.checked;
+    this._listeners = [];
+
+    this.root.setAttribute('role', 'switch');
+    this.root.setAttribute('tabindex', '0');
+    this._render();
+    this._onClick = this._onClick.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+    this.root.addEventListener('click', this._onClick);
+    this.root.addEventListener('keydown', this._onKeydown);
+  }
+
+  _render() {
+    this.root.setAttribute('aria-checked', String(this._checked));
+    this.root.classList.toggle('is-on', this._checked);
+  }
+
+  _emit() {
+    this._listeners.forEach((fn) => {
+      try { fn(this._checked); } catch { /* listener error */ }
+    });
+  }
+
+  setChecked(checked) {
+    const next = !!checked;
+    if (next === this._checked) return false;
+    this._checked = next;
+    this._render();
+    this._emit();
+    return true;
+  }
+
+  toggle() {
+    return this.setChecked(!this._checked);
+  }
+
+  isChecked() {
+    return this._checked;
+  }
+
+  onChange(fn) {
+    if (typeof fn === 'function') this._listeners.push(fn);
+  }
+
+  _onClick() {
+    this.toggle();
+  }
+
+  _onKeydown(event) {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      this.toggle();
+    }
+  }
+
+  destroy() {
+    this.root.removeEventListener('click', this._onClick);
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this._listeners = [];
+  }
+}
+
+export default SwitchToggle;

--- a/submissions/examples/switch-toggle-aria-checked-sb/style.css
+++ b/submissions/examples/switch-toggle-aria-checked-sb/style.css
@@ -1,0 +1,48 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.ease-switch {
+  position: relative;
+  width: 3rem;
+  height: 1.5rem;
+  border: none;
+  border-radius: 999px;
+  background: #d1d5db;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.ease-switch:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+.ease-switch.is-on {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-switch::after {
+  content: '';
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.15s ease;
+}
+
+.ease-switch.is-on::after {
+  transform: translateX(1.5rem);
+}
+
+code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}

--- a/submissions/examples/switch-toggle-aria-checked-sb/switch.test.js
+++ b/submissions/examples/switch-toggle-aria-checked-sb/switch.test.js
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SwitchToggle } from './script.js';
+
+describe('Switch Toggle ARIA Checked State', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('button');
+    root.className = 'ease-switch';
+    document.body.appendChild(root);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=switch and tabindex=0', () => {
+    const s = new SwitchToggle(root);
+    expect(root.getAttribute('role')).toBe('switch');
+    expect(root.getAttribute('tabindex')).toBe('0');
+    s.destroy();
+  });
+
+  it('aria-checked is false initially', () => {
+    const s = new SwitchToggle(root);
+    expect(root.getAttribute('aria-checked')).toBe('false');
+    expect(s.isChecked()).toBe(false);
+    s.destroy();
+  });
+
+  it('setChecked(true) sets aria-checked=true', () => {
+    const s = new SwitchToggle(root);
+    s.setChecked(true);
+    expect(root.getAttribute('aria-checked')).toBe('true');
+    expect(s.isChecked()).toBe(true);
+    s.destroy();
+  });
+
+  it('click toggles the checked state', () => {
+    const s = new SwitchToggle(root);
+    root.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(s.isChecked()).toBe(true);
+    root.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(s.isChecked()).toBe(false);
+    s.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('Space toggles the checked state', () => {
+    const s = new SwitchToggle(root);
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(s.isChecked()).toBe(true);
+    s.destroy();
+  });
+
+  it('Enter toggles the checked state', () => {
+    const s = new SwitchToggle(root);
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(s.isChecked()).toBe(true);
+    s.destroy();
+  });
+
+  it('onChange fires only when the state actually changes', () => {
+    const s = new SwitchToggle(root);
+    const spy = vi.fn();
+    s.onChange(spy);
+    s.setChecked(true);
+    s.setChecked(true); // no-op
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(true);
+    s.destroy();
+  });
+
+  it('initial checked option is reflected', () => {
+    const s = new SwitchToggle(root, { checked: true });
+    expect(root.getAttribute('aria-checked')).toBe('true');
+    expect(s.isChecked()).toBe(true);
+    s.destroy();
+  });
+
+  it('is-on class tracks the checked state', () => {
+    const s = new SwitchToggle(root);
+    s.setChecked(true);
+    expect(root.classList.contains('is-on')).toBe(true);
+    s.setChecked(false);
+    expect(root.classList.contains('is-on')).toBe(false);
+    s.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a valid root element', () => {
+    expect(() => new SwitchToggle(null)).toThrow(TypeError);
+    expect(() => new SwitchToggle({})).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Switch Toggle ARIA Checked State** accessibility audit (closes #81911). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/switch-toggle-aria-checked-sb/`:
- **`script.js`** — `SwitchToggle`: a switch widget with `role=switch` and `aria-checked`, toggled by click and Space/Enter. Emits `onChange(fn)` callbacks and supports an initial checked state.
- **`switch.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/switch-toggle-aria-checked-sb/switch.test.js
 ✓ switch.test.js (10 tests)
```
- **Happy path**: role=switch + tabindex; aria-checked false initially; setChecked(true) sets aria-checked; click toggles.
- **Edge cases**: Space/Enter toggle; onChange fires only on actual change; initial checked option; is-on class tracks state.
- **Invalid inputs**: throws without root element.

Closes #81911

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._