### PR TITLE
a11y(range): aria-valuetext slider submission

### DIFF
--- a/submissions/examples/range-slider-aria-valuetext-sb/README.md
+++ b/submissions/examples/range-slider-aria-valuetext-sb/README.md
@@ -1,0 +1,32 @@
+# Range Slider ARIA Valuetext
+
+## What does it do?
+Keeps a range input's `aria-valuenow` and `aria-valuetext` in sync with its value. `aria-valuetext` is a human-readable label (e.g. "3 of 5" or "Medium") computed from a formatter, so screen readers announce meaning rather than just a number.
+
+## How is it used?
+```javascript
+import { RangeAria } from './script.js';
+const r = new RangeAria(inputEl, {
+  formatter: (v) => ['Off', 'Low', 'Medium', 'High'][v],
+});
+r.setValue(2); r.getValue(); r.getValuetext(); r.destroy();
+```
+
+## Why is it useful?
+A native range input announces its numeric value, which is meaningless for stepped/labelled scales (volume levels, font sizes). Setting `aria-valuetext` lets screen readers say "Medium" instead of "2", improving comprehension.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/range-slider-aria-valuetext-sb/range.test.js
+```
+- **Happy path**: role=slider + aria-valuemin/max/now; default valuetext "value of max"; custom formatter; input event re-renders.
+- **Edge cases**: setValue clamps above max/below min; formatter that throws falls back to raw value; defaults min=0/max=100; getValuetext.
+- **Invalid inputs**: setValue rejects non-finite; throws without input.
+
+## Tech Stack
+HTML, CSS, JavaScript (ARIA slider + formatter), EaseMotion CSS.
+
+## Preview
+Open `demo.html` and drag the slider.
+
+Closes #81913

--- a/submissions/examples/range-slider-aria-valuetext-sb/demo.html
+++ b/submissions/examples/range-slider-aria-valuetext-sb/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Range Slider ARIA Valuetext</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Range Slider ARIA Valuetext</h1>
+      <label for="vol">Volume</label>
+      <input type="range" id="vol" min="0" max="3" value="0" />
+      <p>Announced: <code id="label">Off</code></p>
+    </main>
+    <script type="module">
+      import { RangeAria } from './script.js';
+      const r = new RangeAria(document.getElementById('vol'), {
+        formatter: (v) => ['Off', 'Low', 'Medium', 'High'][v],
+      });
+      const label = document.getElementById('label');
+      r.onChange = (fn) => document.getElementById('vol').addEventListener('input', () => fn(r.getValuetext()));
+      document.getElementById('vol').addEventListener('input', () => (label.textContent = r.getValuetext()));
+      window.__range = r;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/range-slider-aria-valuetext-sb/range.test.js
+++ b/submissions/examples/range-slider-aria-valuetext-sb/range.test.js
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RangeAria } from './script.js';
+
+describe('Range Slider ARIA Valuetext', () => {
+  let input;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    input = document.createElement('input');
+    input.type = 'range';
+    input.min = '0';
+    input.max = '5';
+    input.value = '0';
+    document.body.appendChild(input);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=slider and aria-valuemin/max/now', () => {
+    const r = new RangeAria(input);
+    expect(input.getAttribute('role')).toBe('slider');
+    expect(input.getAttribute('aria-valuemin')).toBe('0');
+    expect(input.getAttribute('aria-valuemax')).toBe('5');
+    expect(input.getAttribute('aria-valuenow')).toBe('0');
+    r.destroy();
+  });
+
+  it('aria-valuetext defaults to "value of max"', () => {
+    const r = new RangeAria(input);
+    r.setValue(3);
+    expect(input.getAttribute('aria-valuetext')).toBe('3 of 5');
+    r.destroy();
+  });
+
+  it('a custom formatter controls aria-valuetext', () => {
+    const r = new RangeAria(input, {
+      formatter: (v) => ['Off', 'Low', 'Medium', 'High'][v] || 'High',
+    });
+    r.setValue(2);
+    expect(input.getAttribute('aria-valuetext')).toBe('Medium');
+    r.destroy();
+  });
+
+  it('input event re-renders aria-valuenow/valuetext', () => {
+    const r = new RangeAria(input);
+    input.value = '4';
+    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(input.getAttribute('aria-valuenow')).toBe('4');
+    expect(input.getAttribute('aria-valuetext')).toBe('4 of 5');
+    r.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('setValue clamps above max and below min', () => {
+    const r = new RangeAria(input);
+    r.setValue(99);
+    expect(r.getValue()).toBe(5);
+    r.setValue(-10);
+    expect(r.getValue()).toBe(0);
+    r.destroy();
+  });
+
+  it('a formatter that throws falls back to the raw value', () => {
+    const r = new RangeAria(input, { formatter: () => { throw new Error('boom'); } });
+    r.setValue(2);
+    expect(input.getAttribute('aria-valuetext')).toBe('2');
+    r.destroy();
+  });
+
+  it('defaults min=0/max=100 when attributes are missing', () => {
+    const bare = document.createElement('input');
+    bare.type = 'range';
+    bare.value = '50';
+    const r = new RangeAria(bare);
+    expect(bare.getAttribute('aria-valuemin')).toBe('0');
+    expect(bare.getAttribute('aria-valuemax')).toBe('100');
+    r.destroy();
+  });
+
+  it('getValuetext returns the current aria-valuetext', () => {
+    const r = new RangeAria(input);
+    r.setValue(1);
+    expect(r.getValuetext()).toBe('1 of 5');
+    r.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('setValue rejects non-finite values', () => {
+    const r = new RangeAria(input);
+    expect(r.setValue(NaN)).toBe(false);
+    expect(r.setValue('abc')).toBe(false);
+    expect(r.getValue()).toBe(0);
+    r.destroy();
+  });
+
+  it('throws without an input element', () => {
+    expect(() => new RangeAria(null)).toThrow(TypeError);
+    expect(() => new RangeAria({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/range-slider-aria-valuetext-sb/script.js
+++ b/submissions/examples/range-slider-aria-valuetext-sb/script.js
@@ -1,0 +1,76 @@
+/**
+ * EaseMotion CSS — Range Slider ARIA Valuetext
+ * ============================================================
+ * Keeps a range input's aria-valuenow and aria-valuetext in sync with its
+ * value. aria-valuetext is a human-readable label (e.g. "3 of 5") computed
+ * from a formatter, so screen readers announce meaning, not just a number.
+ *
+ * API:
+ *   const r = new RangeAria(inputEl, { formatter });
+ *   r.setValue(3); r.getValue(); r.destroy();
+ * ============================================================
+ */
+
+export class RangeAria {
+  constructor(input, options = {}) {
+    if (!input || typeof input.addEventListener !== 'function') {
+      throw new TypeError('RangeAria requires an input element');
+    }
+    this.input = input;
+    this.formatter =
+      typeof options.formatter === 'function'
+        ? options.formatter
+        : (value, min, max) => value + ' of ' + max;
+    this.min = input.hasAttribute('min') && Number.isFinite(Number(input.min)) ? Number(input.min) : 0;
+    this.max = input.hasAttribute('max') && Number.isFinite(Number(input.max)) ? Number(input.max) : 100;
+    this.input.setAttribute('role', 'slider');
+    this._render();
+    this._onInput = this._onInput.bind(this);
+    this.input.addEventListener('input', this._onInput);
+  }
+
+  _render() {
+    const value = this._rawValue();
+    this.input.setAttribute('aria-valuenow', String(value));
+    this.input.setAttribute('aria-valuemin', String(this.min));
+    this.input.setAttribute('aria-valuemax', String(this.max));
+    let text;
+    try {
+      text = String(this.formatter(value, this.min, this.max));
+    } catch {
+      text = String(value);
+    }
+    this.input.setAttribute('aria-valuetext', text);
+  }
+
+  _rawValue() {
+    const v = Number(this.input.value);
+    return Number.isFinite(v) ? v : this.min;
+  }
+
+  _onInput() {
+    this._render();
+  }
+
+  setValue(value) {
+    if (!Number.isFinite(value)) return false;
+    const clamped = Math.min(this.max, Math.max(this.min, value));
+    this.input.value = clamped;
+    this._render();
+    return true;
+  }
+
+  getValue() {
+    return this._rawValue();
+  }
+
+  getValuetext() {
+    return this.input.getAttribute('aria-valuetext');
+  }
+
+  destroy() {
+    this.input.removeEventListener('input', this._onInput);
+  }
+}
+
+export default RangeAria;

--- a/submissions/examples/range-slider-aria-valuetext-sb/style.css
+++ b/submissions/examples/range-slider-aria-valuetext-sb/style.css
@@ -1,0 +1,17 @@
+.demo {
+  max-width: 40rem;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+input[type='range'] {
+  width: 100%;
+  accent-color: var(--ease-color-primary, #6c63ff);
+}
+
+code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Range Slider ARIA Valuetext** accessibility audit (closes #81913). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/range-slider-aria-valuetext-sb/`:
- **`script.js`** — `RangeAria`: keeps a range input's `aria-valuenow` and `aria-valuetext` in sync with its value. `aria-valuetext` is a human-readable label (e.g. "3 of 5" or "Medium") computed from a formatter, so screen readers announce meaning rather than just a number.
- **`range.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/range-slider-aria-valuetext-sb/range.test.js
 ✓ range.test.js (10 tests)
```
- **Happy path**: role=slider + aria-valuemin/max/now; default valuetext "value of max"; custom formatter; input event re-renders.
- **Edge cases**: setValue clamps above max/below min; formatter that throws falls back to raw value; defaults min=0/max=100; getValuetext.
- **Invalid inputs**: setValue rejects non-finite; throws without input.

Closes #81913

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._