### PR TITLE
a11y(cards): high contrast mode submission

### DIFF
--- a/submissions/examples/cards-high-contrast-sb/README.md
+++ b/submissions/examples/cards-high-contrast-sb/README.md
@@ -1,0 +1,36 @@
+# Cards High Contrast Mode
+
+## What does it do?
+Ensures card surfaces, text, muted text, and borders meet WCAG AA contrast (≥4.5:1 text, ≥3:1 UI) in normal, forced-colors, and Windows high-contrast (`-ms-high-contrast`) modes.
+
+## How is it used?
+```html
+<link rel="stylesheet" href="style.css" />
+<article class="ease-card">
+  <h2 class="ease-card__title">Card title</h2>
+  <p class="ease-card__body">Body text.</p>
+</article>
+```
+```javascript
+import { applyCardContrast } from './script.js';
+applyCardContrast();
+```
+
+## Why is it useful?
+Cards commonly use soft grays that vanish or merge with the background in high-contrast themes. Pinning a verified palette plus forced-colors fallbacks keeps the card legible for low-vision users.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/cards-high-contrast-sb/cards.test.js
+```
+- **Happy path**: tokens exported; text/bg ≥4.5:1; muted/bg ≥4.5:1; border/bg ≥3:1.
+- **Edge cases**: applyCardContrast sets tokens on root and custom root.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-card` + forced-colors media queries), JavaScript (contrast math), EaseMotion CSS.
+
+## Preview
+Open `demo.html` (toggle forced-colors / Windows High Contrast to see the fallback).
+
+Closes #81917

--- a/submissions/examples/cards-high-contrast-sb/cards.test.js
+++ b/submissions/examples/cards-high-contrast-sb/cards.test.js
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { applyCardContrast, CARD_CONTRAST_TOKENS } from './script.js';
+
+const hexToRgb = (hex) => {
+  const n = parseInt(hex.replace('#', ''), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+};
+
+const luminance = ([r, g, b]) => 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+function ratio(fg, bg) {
+  const a = [fg, bg].map((c) => {
+    const v = Math.min(Math.max(0, c), 255) / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  const lighter = Math.max(a[0], a[1]);
+  const darker = Math.min(a[0], a[1]);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('Cards High Contrast Mode', () => {
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('exports contrast tokens for bg, text, muted, border', () => {
+    expect(CARD_CONTRAST_TOKENS['--ease-card-bg']).toBeTruthy();
+    expect(CARD_CONTRAST_TOKENS['--ease-card-text']).toBeTruthy();
+    expect(CARD_CONTRAST_TOKENS['--ease-card-muted']).toBeTruthy();
+    expect(CARD_CONTRAST_TOKENS['--ease-card-border']).toBeTruthy();
+  });
+
+  it('card text vs bg meets WCAG AA (≥4.5:1)', () => {
+    const r = ratio(
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-text'])),
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-bg'])),
+    );
+    expect(r).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('card muted text vs bg meets WCAG AA (≥4.5:1)', () => {
+    const r = ratio(
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-muted'])),
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-bg'])),
+    );
+    expect(r).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('card border vs bg meets WCAG AA for UI (≥3:1)', () => {
+    const r = ratio(
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-border'])),
+      luminance(hexToRgb(CARD_CONTRAST_TOKENS['--ease-card-bg'])),
+    );
+    expect(r).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('applyCardContrast sets all tokens on the root', () => {
+    document.documentElement.style.cssText = '';
+    applyCardContrast();
+    const style = getComputedStyle(document.documentElement);
+    expect(style.getPropertyValue('--ease-card-text').trim()).toBe(
+      CARD_CONTRAST_TOKENS['--ease-card-text'],
+    );
+    expect(style.getPropertyValue('--ease-card-border').trim()).toBe(
+      CARD_CONTRAST_TOKENS['--ease-card-border'],
+    );
+  });
+
+  it('applyCardContrast targets a custom root', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    applyCardContrast(el);
+    expect(el.style.getPropertyValue('--ease-card-bg')).toBe(
+      CARD_CONTRAST_TOKENS['--ease-card-bg'],
+    );
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('applyCardContrast throws without a root element', () => {
+    expect(() => applyCardContrast(null)).toThrow(TypeError);
+    expect(() => applyCardContrast({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/cards-high-contrast-sb/demo.html
+++ b/submissions/examples/cards-high-contrast-sb/demo.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cards High Contrast Mode</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Cards High Contrast Mode</h1>
+      <article class="ease-card">
+        <h2 class="ease-card__title">Card title</h2>
+        <p class="ease-card__body">Card body text stays legible in forced-colors and Windows high-contrast modes.</p>
+      </article>
+    </main>
+    <script type="module">
+      import { applyCardContrast } from './script.js';
+      applyCardContrast();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/cards-high-contrast-sb/script.js
+++ b/submissions/examples/cards-high-contrast-sb/script.js
@@ -1,0 +1,26 @@
+/**
+ * EaseMotion CSS — Cards High Contrast Mode
+ * ============================================================
+ * Ensures card surfaces and borders meet WCAG AA contrast in normal and
+ * forced-colors / Windows high-contrast modes. Exposes the contrast
+ * tokens and a small helper to apply them to a root element.
+ * ============================================================
+ */
+
+export const CARD_CONTRAST_TOKENS = {
+  '--ease-card-bg': '#ffffff',
+  '--ease-card-text': '#111827',
+  '--ease-card-border': '#111827',
+  '--ease-card-muted': '#374151',
+  '--ease-card-surface': '#f3f4f6',
+};
+
+export function applyCardContrast(root = document.documentElement) {
+  if (!root || typeof root.style !== 'object') {
+    throw new TypeError('applyCardContrast requires a root element');
+  }
+  Object.entries(CARD_CONTRAST_TOKENS).forEach(([k, v]) => {
+    root.style.setProperty(k, v);
+  });
+  return root;
+}

--- a/submissions/examples/cards-high-contrast-sb/style.css
+++ b/submissions/examples/cards-high-contrast-sb/style.css
@@ -1,0 +1,65 @@
+/* ============================================================
+   EaseMotion CSS — Cards High Contrast Mode
+   Base palette meets WCAG AA; forced-colors / -ms-high-contrast keep
+   card text and borders legible in Windows HC modes.
+   ============================================================ */
+
+:root {
+  --ease-card-bg: #ffffff;
+  --ease-card-text: #111827;    /* gray-900 on white ≈ 16:1 */
+  --ease-card-border: #111827;
+  --ease-card-muted: #374151;   /* gray-700 on white ≈ 8.6:1 */
+  --ease-card-surface: #f3f4f6;
+}
+
+.ease-card {
+  background: var(--ease-card-bg);
+  color: var(--ease-card-text);
+  border: 2px solid var(--ease-card-border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+.ease-card__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ease-card-text);
+}
+
+.ease-card__body {
+  margin: 0;
+  color: var(--ease-card-muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.ease-card--surface {
+  background: var(--ease-card-surface);
+}
+
+/* Windows high-contrast (legacy Edge/IE) */
+@media screen and (-ms-high-contrast: active) {
+  .ease-card {
+    background: window;
+    color: windowText;
+    border-color: windowText;
+  }
+  .ease-card__title,
+  .ease-card__body {
+    color: windowText;
+  }
+}
+
+/* CSS Forced Colors (modern browsers) */
+@media (forced-colors: active) {
+  .ease-card {
+    background: Canvas;
+    color: CanvasText;
+    border-color: CanvasText;
+  }
+  .ease-card__title,
+  .ease-card__body {
+    color: CanvasText;
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Cards High Contrast Mode** accessibility audit (closes #81917). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/cards-high-contrast-sb/`:
- **`style.css`** — `.ease-card` palette verified to meet WCAG AA (≥4.5:1 text/muted, ≥3:1 border) plus `@media (forced-colors: active)` and `@media (-ms-high-contrast: active)` fallbacks.
- **`script.js`** — `applyCardContrast()` and `CARD_CONTRAST_TOKENS`.
- **`cards.test.js`** — 7 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/cards-high-contrast-sb/cards.test.js
 ✓ cards.test.js (7 tests)
```
- **Happy path**: tokens exported; text/bg ≥4.5:1; muted/bg ≥4.5:1; border/bg ≥3:1.
- **Edge cases**: applyCardContrast sets tokens on root and custom root.
- **Invalid inputs**: throws without root element.

Closes #81917

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._