### PR TITLE
feat: create Glowing Drawer with Retro Pixel styling (#14591) #81419

### DIFF
--- a/submissions/examples/css-drawer-glowing-retro-pixel/README.md
+++ b/submissions/examples/css-drawer-glowing-retro-pixel/README.md
@@ -1,0 +1,2 @@
+# Glowing Drawer (Retro Pixel)
+A chunky 8-bit arcade drawer. The drawer slides in from the right using a jagged `steps()` animation function to mimic low framerates, heavily styled with green terminal glows.

--- a/submissions/examples/css-drawer-glowing-retro-pixel/demo.html
+++ b/submissions/examples/css-drawer-glowing-retro-pixel/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Pixel Drawer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <input type="checkbox" id="rp-drawer-toggle" class="rp-toggle">
+    <div class="rp-layout">
+        <label for="rp-drawer-toggle" class="rp-btn">START</label>
+        <p class="rp-text">Insert Coin...</p>
+    </div>
+    
+    <div class="rp-drawer">
+        <div class="rp-header">
+            <h2>INVENTORY</h2>
+            <label for="rp-drawer-toggle" class="rp-close">[X]</label>
+        </div>
+        <div class="rp-items">
+            <a href="#">> WEAPONS</a>
+            <a href="#">> ARMOR</a>
+            <a href="#">> POTIONS</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-drawer-glowing-retro-pixel/style.css
+++ b/submissions/examples/css-drawer-glowing-retro-pixel/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #000; --green: #33ff00; }
+body { background: var(--bg); margin: 0; font-family: 'Press Start 2P', monospace; color: var(--green); overflow-x: hidden; }
+.rp-toggle { display: none; }
+.rp-layout { padding: 2rem; text-align: center; }
+.rp-btn { display: inline-block; padding: 1rem 2rem; border: 4px solid var(--green); background: #000; color: var(--green); cursor: pointer; text-shadow: 0 0 5px var(--green); box-shadow: 0 0 10px var(--green), inset 0 0 10px var(--green); transition: 0.1s; }
+.rp-btn:active { transform: translate(4px, 4px); box-shadow: none; }
+.rp-text { margin-top: 2rem; animation: rp-blink 1s steps(2, start) infinite; }
+.rp-drawer { position: fixed; top: 0; right: -400px; width: 350px; height: 100vh; background: #000; border-left: 6px solid var(--green); transition: right 0.3s steps(10, end); box-shadow: -10px 0 20px rgba(51,255,0,0.2); padding: 2rem; box-sizing: border-box; }
+.rp-header { display: flex; justify-content: space-between; border-bottom: 4px dashed var(--green); padding-bottom: 1rem; margin-bottom: 2rem; }
+.rp-header h2 { margin: 0; font-size: 1.2rem; text-shadow: 0 0 8px var(--green); }
+.rp-close { cursor: pointer; transition: 0.2s; }
+.rp-close:hover { color: #fff; text-shadow: 0 0 8px #fff; }
+.rp-items a { display: block; color: var(--green); text-decoration: none; padding: 1rem 0; font-size: 1rem; transition: 0.2s; }
+.rp-items a:hover { background: var(--green); color: #000; padding-left: 1rem; }
+.rp-toggle:checked ~ .rp-drawer { right: 0; }
+@keyframes rp-blink { to { visibility: hidden; } }


### PR DESCRIPTION
**Title:** feat: create Glowing Drawer with Retro Pixel styling (#14591) #81419

**Description:**
This PR introduces a chunky 8-bit arcade drawer. The drawer slides in from the right using a jagged `steps()` animation function to mimic low framerates, heavily styled with green terminal glows.

Fixes #81419

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-drawer-glowing-retro-pixel/`
- Wired the primary drawer `.rp-drawer` slide transition using `steps(10, end)` to simulate an old mechanical computer loading state
- Designed the UI elements utilizing solid green `#33ff00` borders and text-shadows over a pitch-black background
