### PR TITLE
feat: create Dynamic Drawer with Material Design styling (#56096) #81417

### DIFF
--- a/submissions/examples/css-drawer-dynamic-material-design/README.md
+++ b/submissions/examples/css-drawer-dynamic-material-design/README.md
@@ -1,0 +1,2 @@
+# Dynamic Drawer (Material Design)
+A classic Google Material Design navigation drawer. Features standard elevation shadows, a user profile header block, and a fully interactive scrim overlay.

--- a/submissions/examples/css-drawer-dynamic-material-design/demo.html
+++ b/submissions/examples/css-drawer-dynamic-material-design/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Dynamic Drawer</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <input type="checkbox" id="md-drawer-toggle" class="md-toggle">
+    
+    <header class="md-appbar">
+        <label for="md-drawer-toggle" class="md-menu-btn"><i class="ph ph-list"></i></label>
+        <h1>Material App</h1>
+    </header>
+    
+    <div class="md-drawer">
+        <div class="md-drawer-header">
+            <div class="md-avatar">U</div>
+            <div class="md-user-info">
+                <strong>User Name</strong>
+                <span>user@example.com</span>
+            </div>
+        </div>
+        <div class="md-nav">
+            <a href="#" class="md-nav-item active"><i class="ph ph-inbox"></i> Inbox</a>
+            <a href="#" class="md-nav-item"><i class="ph ph-star"></i> Starred</a>
+            <a href="#" class="md-nav-item"><i class="ph ph-paper-plane-tilt"></i> Sent</a>
+            <div class="md-divider"></div>
+            <a href="#" class="md-nav-item"><i class="ph ph-gear"></i> Settings</a>
+        </div>
+    </div>
+    <label for="md-drawer-toggle" class="md-overlay"></label>
+</body>
+</html>

--- a/submissions/examples/css-drawer-dynamic-material-design/style.css
+++ b/submissions/examples/css-drawer-dynamic-material-design/style.css
@@ -1,0 +1,22 @@
+:root { --bg: #fafafa; --primary: #6200ea; --surface: #ffffff; --text: #333; }
+body { background: var(--bg); margin: 0; font-family: Roboto, system-ui, sans-serif; color: var(--text); overflow-x: hidden; }
+.md-toggle { display: none; }
+.md-appbar { display: flex; align-items: center; gap: 1.5rem; background: var(--primary); color: #fff; padding: 1rem 1.5rem; box-shadow: 0 2px 4px rgba(0,0,0,0.2); position: sticky; top: 0; z-index: 5; }
+.md-menu-btn { font-size: 1.5rem; cursor: pointer; display: flex; align-items: center; border-radius: 50%; padding: 0.5rem; transition: background 0.3s; }
+.md-menu-btn:hover { background: rgba(255,255,255,0.1); }
+.md-appbar h1 { margin: 0; font-size: 1.25rem; font-weight: 500; }
+.md-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.32); opacity: 0; pointer-events: none; transition: opacity 0.3s; z-index: 10; }
+.md-drawer { position: fixed; top: 0; left: -320px; width: 300px; height: 100vh; background: var(--surface); box-shadow: 0 8px 10px -5px rgba(0,0,0,0.2), 0 16px 24px 2px rgba(0,0,0,0.14), 0 6px 30px 5px rgba(0,0,0,0.12); transition: left 0.3s cubic-bezier(0.0, 0.0, 0.2, 1); z-index: 20; display: flex; flex-direction: column; }
+.md-drawer-header { padding: 2rem 1.5rem 1rem 1.5rem; border-bottom: 1px solid #e0e0e0; background: #f5f5f5; }
+.md-avatar { width: 64px; height: 64px; border-radius: 50%; background: var(--primary); color: #fff; display: flex; justify-content: center; align-items: center; font-size: 2rem; margin-bottom: 1rem; }
+.md-user-info strong { display: block; font-weight: 500; }
+.md-user-info span { color: #666; font-size: 0.85rem; }
+.md-nav { padding: 0.5rem 0; flex: 1; overflow-y: auto; }
+.md-nav-item { display: flex; align-items: center; gap: 1rem; padding: 0.75rem 1.5rem; color: #444; text-decoration: none; font-weight: 500; transition: background 0.2s; }
+.md-nav-item i { font-size: 1.25rem; color: #666; }
+.md-nav-item:hover { background: rgba(0,0,0,0.04); }
+.md-nav-item.active { background: rgba(98, 0, 234, 0.08); color: var(--primary); border-top-right-radius: 30px; border-bottom-right-radius: 30px; margin-right: 1rem; }
+.md-nav-item.active i { color: var(--primary); }
+.md-divider { height: 1px; background: #e0e0e0; margin: 0.5rem 0; }
+.md-toggle:checked ~ .md-drawer { left: 0; }
+.md-toggle:checked ~ .md-overlay { opacity: 1; pointer-events: auto; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Drawer with Material Design styling (#56096) #81417

**Description:**
This PR introduces a classic Google Material Design navigation drawer. Features standard elevation shadows, a user profile header block, and a fully interactive scrim overlay.

Fixes #81417

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-drawer-dynamic-material-design/`
- Structured the drawer panel mirroring official Material specs, including standard padding, typography, and the `.md-user-info` block
- Applied deep elevation shadows (`0 16px 24px 2px rgba(0,0,0,0.14)`) to separate the drawer depth from the underlying application content
