### PR TITLE
feat: create Floating Drawer with Glassmorphism styling (#55899) #81413

### DIFF
--- a/submissions/examples/css-drawer-floating-glassmorphism/README.md
+++ b/submissions/examples/css-drawer-floating-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Floating Drawer (Glassmorphism)
+A stunning floating sidebar. Rather than pinning to the absolute edge of the screen, the drawer floats with a margin, fully rendered in frosted glass over an ambient background gradient orb.

--- a/submissions/examples/css-drawer-floating-glassmorphism/demo.html
+++ b/submissions/examples/css-drawer-floating-glassmorphism/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Glass Drawer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fg-scene">
+        <div class="fg-bg-orb"></div>
+        <input type="checkbox" id="fg-drawer-toggle" class="fg-toggle">
+        
+        <label for="fg-drawer-toggle" class="fg-btn">Toggle Glass Drawer</label>
+        
+        <div class="fg-drawer">
+            <div class="fg-drawer-inner">
+                <h2>Navigation</h2>
+                <a href="#">Home</a>
+                <a href="#">About</a>
+                <a href="#">Services</a>
+                <a href="#">Contact</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-drawer-floating-glassmorphism/style.css
+++ b/submissions/examples/css-drawer-floating-glassmorphism/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #e2e8f0; --glass: rgba(255, 255, 255, 0.4); --border: rgba(255, 255, 255, 0.6); }
+body { background: var(--bg); margin: 0; font-family: system-ui, sans-serif; overflow-x: hidden; }
+.fg-scene { position: relative; height: 100vh; display: flex; justify-content: center; align-items: center; }
+.fg-bg-orb { position: absolute; width: 400px; height: 400px; background: linear-gradient(45deg, #3b82f6, #ec4899); border-radius: 50%; filter: blur(60px); z-index: 0; animation: fg-float 10s infinite alternate; }
+.fg-toggle { display: none; }
+.fg-btn { position: relative; z-index: 10; padding: 1rem 2rem; background: var(--glass); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border: 1px solid var(--border); border-radius: 50px; cursor: pointer; font-weight: 600; color: #334155; box-shadow: 0 4px 6px rgba(0,0,0,0.05); transition: 0.3s; }
+.fg-btn:hover { background: rgba(255,255,255,0.6); transform: translateY(-2px); }
+.fg-drawer { position: fixed; top: 20px; left: -320px; bottom: 20px; width: 300px; z-index: 20; transition: left 0.5s cubic-bezier(0.4, 0, 0.2, 1); }
+.fg-drawer-inner { height: 100%; background: var(--glass); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border: 1px solid var(--border); border-radius: 24px; box-shadow: 10px 10px 30px rgba(0,0,0,0.1); padding: 2rem; box-sizing: border-box; }
+.fg-drawer-inner h2 { color: #1e293b; margin-top: 0; margin-bottom: 2rem; }
+.fg-drawer-inner a { display: block; padding: 1rem; color: #475569; text-decoration: none; font-weight: 500; border-radius: 12px; transition: 0.3s; margin-bottom: 0.5rem; }
+.fg-drawer-inner a:hover { background: rgba(255,255,255,0.5); transform: translateX(5px); color: #0f172a; }
+.fg-toggle:checked ~ .fg-drawer { left: 20px; }
+@keyframes fg-float { 100% { transform: translate(50px, 50px); } }


### PR DESCRIPTION
**Title:** feat: create Floating Drawer with Glassmorphism styling (#55899) #81413

**Description:**
This PR introduces a stunning floating sidebar. Rather than pinning to the absolute edge of the screen, the drawer floats with a margin, fully rendered in frosted glass over an ambient background gradient orb.

Fixes #81413

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-drawer-floating-glassmorphism/`
- Placed the drawer inset from the viewport edge using `top: 20px`, `bottom: 20px`, and heavy `border-radius: 24px` to achieve a floating panel aesthetic
- Coated the drawer container in an intense `backdrop-filter: blur(20px)` and overlaid it atop an animated, blurred ambient light orb (`.fg-bg-orb`)
