### PR TITLE
feat: create Dynamic Popover with Claymorphism styling (#13450) #81412

### DIFF
--- a/submissions/examples/css-popover-dynamic-claymorphism/README.md
+++ b/submissions/examples/css-popover-dynamic-claymorphism/README.md
@@ -1,0 +1,2 @@
+# Dynamic Popover (Claymorphism)
+A fluffy, deeply extruded 3D popover utilizing Claymorphism principles. It relies on a combination of inner and outer shadows to create a playful, rounded pill-like aesthetic.

--- a/submissions/examples/css-popover-dynamic-claymorphism/demo.html
+++ b/submissions/examples/css-popover-dynamic-claymorphism/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Claymorphism Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="clay-popover-container">
+        <button class="clay-btn">Tap Me</button>
+        <div class="clay-popover">
+            <h3>Clay Popover</h3>
+            <p>Soft, fluffy, and perfectly rounded 3D UI elements.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-dynamic-claymorphism/style.css
+++ b/submissions/examples/css-popover-dynamic-claymorphism/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #f2f2f2; --clay: #ffffff; --inner-shadow: rgba(0, 0, 0, 0.1); --outer-shadow: rgba(0, 0, 0, 0.15); --highlight: rgba(255, 255, 255, 1); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.clay-popover-container { position: relative; display: inline-block; }
+.clay-btn { padding: 1rem 2.5rem; border: none; border-radius: 30px; font-size: 1.1rem; font-weight: 700; color: #555; background: var(--clay); cursor: pointer; box-shadow: 8px 8px 16px var(--outer-shadow), -8px -8px 16px var(--highlight), inset -4px -4px 8px var(--inner-shadow), inset 4px 4px 8px var(--highlight); transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.clay-btn:active { box-shadow: 2px 2px 4px var(--outer-shadow), -2px -2px 4px var(--highlight), inset -2px -2px 4px var(--inner-shadow), inset 2px 2px 4px var(--highlight); transform: scale(0.95); }
+.clay-popover { position: absolute; bottom: calc(100% + 20px); left: 50%; transform: translateX(-50%) translateY(20px) scale(0.8); background: var(--clay); padding: 1.5rem; border-radius: 24px; width: 250px; text-align: center; opacity: 0; visibility: hidden; transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); box-shadow: 12px 12px 24px var(--outer-shadow), -12px -12px 24px var(--highlight), inset -6px -6px 12px var(--inner-shadow), inset 6px 6px 12px var(--highlight); z-index: 10; }
+.clay-popover h3 { margin: 0 0 0.5rem 0; color: #333; }
+.clay-popover p { margin: 0; color: #777; line-height: 1.5; font-size: 0.95rem; }
+.clay-popover-container:focus-within .clay-popover { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Popover with Claymorphism styling (#13450) #81412

**Description:**
This PR introduces a fluffy, deeply extruded 3D popover utilizing Claymorphism principles. It relies on a combination of inner and outer shadows to create a playful, rounded pill-like aesthetic.

Fixes #81412

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-dynamic-claymorphism/`
- Constructed the soft UI popover utilizing a multi-layered `box-shadow` strategy: outer shadows drop depth behind it, while intense `inset` highlights curve the borders upward
- Triggered the popover via a pure-CSS `:focus-within` pseudoclass, allowing the bubble to spring outward using a bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` transition curve
