### PR TITLE
feat: create Glowing Popover with Pastel styling (#21369) #81409

### DIFF
--- a/submissions/examples/css-popover-glowing-pastel/README.md
+++ b/submissions/examples/css-popover-glowing-pastel/README.md
@@ -1,0 +1,2 @@
+# Glowing Popover (Pastel)
+A welcoming, perfectly rounded help-tip popover. It casts a soft pink pastel glow onto the page and triggers its entry animation utilizing `:focus-within` for improved accessibility.

--- a/submissions/examples/css-popover-glowing-pastel/demo.html
+++ b/submissions/examples/css-popover-glowing-pastel/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Pastel Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="gpp-container">
+        <button class="gpp-trigger">?</button>
+        <div class="gpp-popover">
+            <div class="gpp-header">Help Tip</div>
+            <div class="gpp-body">Pastel colors provide a soft, welcoming aesthetic without overwhelming contrast.</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-glowing-pastel/style.css
+++ b/submissions/examples/css-popover-glowing-pastel/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #fdfbf7; --pastel-purple: #cbb2fe; --pastel-pink: #ffc4e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.gpp-container { position: relative; }
+.gpp-trigger { width: 40px; height: 40px; border-radius: 50%; background: #fff; border: 2px solid var(--pastel-purple); color: var(--pastel-purple); font-weight: bold; font-size: 1.2rem; cursor: pointer; transition: 0.3s; box-shadow: 0 4px 10px rgba(203, 178, 254, 0.3); }
+.gpp-trigger:hover { background: var(--pastel-purple); color: #fff; transform: translateY(-2px); box-shadow: 0 8px 15px rgba(203, 178, 254, 0.5); }
+.gpp-popover { position: absolute; bottom: calc(100% + 15px); left: 50%; transform: translateX(-50%) translateY(10px); width: 220px; background: #fff; border-radius: 16px; border: 2px solid var(--pastel-pink); padding: 1rem; opacity: 0; visibility: hidden; transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); box-shadow: 0 15px 30px rgba(255, 196, 225, 0.4), inset 0 0 20px rgba(255, 196, 225, 0.2); z-index: 10; text-align: center; }
+.gpp-popover::after { content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%); border-width: 8px; border-style: solid; border-color: var(--pastel-pink) transparent transparent transparent; }
+.gpp-header { font-weight: 700; color: #555; margin-bottom: 0.5rem; }
+.gpp-body { color: #777; font-size: 0.9rem; line-height: 1.4; }
+.gpp-container:focus-within .gpp-popover { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Glowing Popover with Pastel styling (#21369) #81409

**Description:**
This PR introduces a welcoming, perfectly rounded help-tip popover. It casts a soft pink pastel glow onto the page and triggers its entry animation utilizing `:focus-within` for improved accessibility.

Fixes #81409

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-glowing-pastel/`
- Bound the popover visibility state purely to CSS `:focus-within` on the parent container, ensuring mobile and keyboard accessibility
- Designed the bubble utilizing thick borders and heavy inset/outset drop shadows colored with `--pastel-pink` (`#ffc4e1`)
