### PR TITLE
feat: create Dynamic Popover with Dark Mode styling (#60321) #81408

### DIFF
--- a/submissions/examples/css-popover-dynamic-dark/README.md
+++ b/submissions/examples/css-popover-dynamic-dark/README.md
@@ -1,0 +1,2 @@
+# Dynamic Popover (Dark Mode)
+A crisp, dark-mode sharing dropdown popover. Expanding the popover utilizing `:focus-within` triggers a 180-degree rotation on the trigger icon, and the popover panel scales dynamically from the top-right origin.

--- a/submissions/examples/css-popover-dynamic-dark/demo.html
+++ b/submissions/examples/css-popover-dynamic-dark/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Dark Popover</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="ddp-container">
+        <button class="ddp-btn">Share <i class="ph ph-caret-down"></i></button>
+        <div class="ddp-popover">
+            <a href="#"><i class="ph ph-link"></i> Copy Link</a>
+            <a href="#"><i class="ph ph-twitter-logo"></i> Twitter</a>
+            <a href="#"><i class="ph ph-envelope-simple"></i> Email</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-dynamic-dark/style.css
+++ b/submissions/examples/css-popover-dynamic-dark/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #121212; --surface: #242424; --hover: #333333; --text: #e0e0e0; --accent: #64ffda; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.ddp-container { position: relative; }
+.ddp-btn { padding: 0.75rem 1.5rem; background: var(--surface); color: var(--text); border: 1px solid #444; border-radius: 8px; font-size: 1rem; cursor: pointer; display: flex; align-items: center; gap: 0.5rem; transition: 0.2s; box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
+.ddp-btn:hover { background: var(--hover); border-color: #666; }
+.ddp-btn i { transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.ddp-popover { position: absolute; top: calc(100% + 10px); right: 0; background: var(--surface); border: 1px solid #333; border-radius: 12px; width: 180px; padding: 0.5rem; opacity: 0; visibility: hidden; transform: translateY(-10px) scale(0.95); transform-origin: top right; transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1); box-shadow: 0 10px 25px rgba(0,0,0,0.6); z-index: 10; }
+.ddp-popover a { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; color: var(--text); text-decoration: none; font-size: 0.95rem; border-radius: 8px; transition: 0.2s; }
+.ddp-popover a:hover { background: rgba(100, 255, 218, 0.1); color: var(--accent); }
+.ddp-popover a i { font-size: 1.1rem; }
+.ddp-container:focus-within .ddp-popover { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }
+.ddp-container:focus-within .ddp-btn i { transform: rotate(180deg); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Popover with Dark Mode styling (#60321) #81408

**Description:**
This PR introduces a crisp, dark-mode sharing dropdown popover. Expanding the popover utilizing `:focus-within` triggers a 180-degree rotation on the trigger icon, and the popover panel scales dynamically from the top-right origin.

Fixes #81408

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-dynamic-dark/`
- Altered the CSS `transform-origin` to `top right` to force the popover bubble to expand organically from the corner of the trigger button
- Sequenced an inner `<i>` icon to rotate `180deg` immediately upon the parent container receiving `:focus-within` state
