### PR TITLE
a11y(slide): reduced motion guard submission

### DIFF
--- a/submissions/examples/slide-reduced-motion-sb/README.md
+++ b/submissions/examples/slide-reduced-motion-sb/README.md
@@ -1,0 +1,30 @@
+# Slide Animation Reduced Motion
+
+## What does it do?
+Adds a `prefers-reduced-motion` guard to slide-in/slide-out animations. When the user has reduced motion enabled, the slide panel appears instantly (no transform/opacity transition) instead of animating.
+
+## How is it used?
+```javascript
+import { SlideMotion } from './script.js';
+const s = new SlideMotion(document.getElementById('panel'), { direction: 'right' });
+s.show(); s.hide(); s.toggle(); s.isReducedMotion(); s.destroy();
+```
+
+## Why is it useful?
+Slide transitions can trigger vestibular discomfort for users with motion sensitivity. Honoring `prefers-reduced-motion` by disabling the transition (while still toggling visibility and `aria-hidden`) keeps the component usable.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/slide-reduced-motion-sb/slide.test.js
+```
+- **Happy path**: ease-slide + direction class; starts hidden; show/hide toggle aria-hidden + is-visible.
+- **Edge cases**: toggle flips; Escape hides; reduced motion sets transition:none; defaults left.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-slide` + `@media prefers-reduced-motion`), JavaScript (matchMedia), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click Toggle. Set OS reduced motion and reload to see the instant show.
+
+Closes #81919

--- a/submissions/examples/slide-reduced-motion-sb/demo.html
+++ b/submissions/examples/slide-reduced-motion-sb/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Slide Animation Reduced Motion</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      .demo { max-width: 40rem; margin: 2rem auto; padding: 0 1.5rem; font-family: system-ui, sans-serif; }
+      .ease-slide { background: #eef2ff; border: 1px solid #c7d2fe; padding: 1rem; border-radius: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Slide Animation Reduced Motion</h1>
+      <button type="button" id="btn">Toggle panel</button>
+      <div id="panel" hidden>Slide panel content</div>
+      <script type="module">
+        import { SlideMotion } from './script.js';
+        const p = new SlideMotion(document.getElementById('panel'));
+        document.getElementById('btn').addEventListener('click', () => p.toggle());
+        window.__slide = p;
+      </script>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/slide-reduced-motion-sb/script.js
+++ b/submissions/examples/slide-reduced-motion-sb/script.js
@@ -1,0 +1,74 @@
+/**
+ * EaseMotion CSS — Slide Animation Reduced Motion
+ * ============================================================
+ * Adds a prefers-reduced-motion guard to slide-in/slide-out animations.
+ * When the user has reduced motion enabled, the slide is shown instantly
+ * (no transform/opacity transition) instead of animating.
+ *
+ * API:
+ *   const s = new SlideMotion(rootEl, { direction });
+ *   s.show(); s.hide(); s.isReducedMotion(); s.destroy();
+ * ============================================================
+ */
+
+export class SlideMotion {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('SlideMotion requires a root element');
+    }
+    this.root = root;
+    this.direction = options.direction || 'left';
+    this._visible = false;
+    this._onKeydown = this._onKeydown.bind(this);
+
+    this.root.setAttribute('aria-hidden', 'true');
+    this.root.classList.add('ease-slide', 'ease-slide--' + this.direction);
+    this._mq = typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : { matches: false };
+    this.root.addEventListener('keydown', this._onKeydown);
+  }
+
+  isReducedMotion() {
+    return this._mq && this._mq.matches;
+  }
+
+  show() {
+    this._visible = true;
+    this.root.setAttribute('aria-hidden', 'false');
+    this.root.classList.add('is-visible');
+    this.root.style.transition = this.isReducedMotion() ? 'none' : '';
+    if (this.isReducedMotion()) {
+      this.root.style.transform = 'none';
+      this.root.style.opacity = '1';
+    }
+  }
+
+  hide() {
+    this._visible = false;
+    this.root.setAttribute('aria-hidden', 'true');
+    this.root.classList.remove('is-visible');
+    if (this.isReducedMotion()) {
+      this.root.style.transform = '';
+      this.root.style.opacity = '';
+    }
+  }
+
+  toggle() {
+    return this._visible ? this.hide() : this.show();
+  }
+
+  isVisible() {
+    return this._visible;
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Escape') this.hide();
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+  }
+}
+
+export default SlideMotion;

--- a/submissions/examples/slide-reduced-motion-sb/slide.test.js
+++ b/submissions/examples/slide-reduced-motion-sb/slide.test.js
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SlideMotion } from './script.js';
+
+describe('Slide Animation Reduced Motion', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.id = 'panel';
+    document.body.appendChild(root);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('adds ease-slide class and direction modifier', () => {
+    const s = new SlideMotion(root, { direction: 'right' });
+    expect(root.classList.contains('ease-slide')).toBe(true);
+    expect(root.classList.contains('ease-slide--right')).toBe(true);
+    s.destroy();
+  });
+
+  it('starts hidden with aria-hidden=true', () => {
+    const s = new SlideMotion(root);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(s.isVisible()).toBe(false);
+    s.destroy();
+  });
+
+  it('show() sets aria-hidden=false and is-visible class', () => {
+    const s = new SlideMotion(root);
+    s.show();
+    expect(s.isVisible()).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(root.classList.contains('is-visible')).toBe(true);
+    s.destroy();
+  });
+
+  it('hide() sets aria-hidden=true and removes is-visible', () => {
+    const s = new SlideMotion(root);
+    s.show();
+    s.hide();
+    expect(s.isVisible()).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(root.classList.contains('is-visible')).toBe(false);
+    s.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('toggle() flips visibility', () => {
+    const s = new SlideMotion(root);
+    s.toggle();
+    expect(s.isVisible()).toBe(true);
+    s.toggle();
+    expect(s.isVisible()).toBe(false);
+    s.destroy();
+  });
+
+  it('Escape hides the panel', () => {
+    const s = new SlideMotion(root);
+    s.show();
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(s.isVisible()).toBe(false);
+    s.destroy();
+  });
+
+  it('reduced motion sets transition to none on show()', () => {
+    const fakeMq = { matches: true, addEventListener: () => {}, removeEventListener: () => {} };
+    window.matchMedia = () => fakeMq;
+    const s = new SlideMotion(root);
+    s.show();
+    expect(s.isReducedMotion()).toBe(true);
+    expect(root.style.transition).toBe('none');
+    expect(root.style.transform).toBe('none');
+    expect(root.style.opacity).toBe('1');
+    s.destroy();
+    delete window.matchMedia;
+  });
+
+  it('defaults to left direction', () => {
+    const s = new SlideMotion(root);
+    expect(root.classList.contains('ease-slide--left')).toBe(true);
+    s.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new SlideMotion(null)).toThrow(TypeError);
+    expect(() => new SlideMotion({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/slide-reduced-motion-sb/style.css
+++ b/submissions/examples/slide-reduced-motion-sb/style.css
@@ -1,0 +1,31 @@
+/* ============================================================
+   EaseMotion CSS — Slide Animation Reduced Motion
+   Base: transform + opacity transition. Guarded by
+   prefers-reduced-motion so the panel appears instantly.
+   ============================================================ */
+
+.ease-slide {
+  transform: translateX(-100%);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  will-change: transform, opacity;
+}
+
+.ease-slide--right {
+  transform: translateX(100%);
+}
+
+.ease-slide.is-visible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-slide,
+  .ease-slide--right,
+  .ease-slide.is-visible {
+    transition: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Slide Animation Reduced Motion** accessibility audit (closes #81919). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/slide-reduced-motion-sb/`:
- **`script.js`** — `SlideMotion`: adds a `prefers-reduced-motion` guard to slide-in/slide-out animations. When reduced motion is enabled the panel appears instantly (`transition: none`, no transform/opacity animation) while still toggling `aria-hidden`.
- **`slide.test.js`** — 9 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/slide-reduced-motion-sb/slide.test.js
 ✓ slide.test.js (9 tests)
```
- **Happy path**: ease-slide + direction class; starts hidden; show/hide toggle aria-hidden + is-visible.
- **Edge cases**: toggle flips; Escape hides; reduced motion sets transition:none; defaults left.
- **Invalid inputs**: throws without root element.

Closes #81919

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._