### PR TITLE
a11y(pulse): reduced motion guard submission

### DIFF
--- a/submissions/examples/pulse-reduced-motion-sb/README.md
+++ b/submissions/examples/pulse-reduced-motion-sb/README.md
@@ -1,0 +1,30 @@
+# Pulse Animation Reduced Motion
+
+## What does it do?
+Adds a `prefers-reduced-motion` guard to pulse (attention) animations. When reduced motion is enabled, the pulse is replaced by a static, high-visibility outline ring so the affordance stays discoverable without movement.
+
+## How is it used?
+```javascript
+import { PulseMotion } from './script.js';
+const p = new PulseMotion(document.getElementById('target'));
+p.start(); p.stop(); p.isPulsing(); p.isReducedMotion(); p.destroy();
+```
+
+## Why is it useful?
+Continuous pulsing can cause vestibular distress for motion-sensitive users. Honoring `prefers-reduced-motion` by substituting a static ring keeps the element noticeable without animation.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/pulse-reduced-motion-sb/pulse.test.js
+```
+- **Happy path**: ease-pulse class added; start adds animating class; stop removes both.
+- **Edge cases**: start/stop are no-ops when already in that state; reduced motion uses static ring; destroy removes all classes.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (`ease-pulse` + `@media prefers-reduced-motion`), JavaScript (matchMedia), EaseMotion CSS.
+
+## Preview
+Open `demo.html`. Set OS reduced motion and reload to see the static ring.
+
+Closes #81921

--- a/submissions/examples/pulse-reduced-motion-sb/demo.html
+++ b/submissions/examples/pulse-reduced-motion-sb/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pulse Animation Reduced Motion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Pulse Animation Reduced Motion</h1>
+      <p>A pulse that becomes a static ring when reduced motion is on.</p>
+      <button type="button" id="btn">Toggle pulse</button>
+      <span id="target" style="display:inline-block;padding:0.5rem 1rem;background:#eef2ff;border-radius:0.5rem;">Watch me</span>
+      <script type="module">
+        import { PulseMotion } from './script.js';
+        const p = new PulseMotion(document.getElementById('target'));
+        const btn = document.getElementById('btn');
+        btn.addEventListener('click', () => (p.isPulsing() ? p.stop() : p.start()));
+        p.start();
+        window.__pulse = p;
+      </script>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/pulse-reduced-motion-sb/pulse.test.js
+++ b/submissions/examples/pulse-reduced-motion-sb/pulse.test.js
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PulseMotion } from './script.js';
+
+describe('Pulse Animation Reduced Motion', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('span');
+    document.body.appendChild(root);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('adds the ease-pulse class', () => {
+    const p = new PulseMotion(root);
+    expect(root.classList.contains('ease-pulse')).toBe(true);
+    p.destroy();
+  });
+
+  it('start() adds the animating class by default', () => {
+    const p = new PulseMotion(root);
+    p.start();
+    expect(p.isPulsing()).toBe(true);
+    expect(root.classList.contains('ease-pulse--animating')).toBe(true);
+    p.destroy();
+  });
+
+  it('stop() removes both animating and static classes', () => {
+    const p = new PulseMotion(root);
+    p.start();
+    p.stop();
+    expect(p.isPulsing()).toBe(false);
+    expect(root.classList.contains('ease-pulse--animating')).toBe(false);
+    p.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('start() is a no-op when already pulsing', () => {
+    const p = new PulseMotion(root);
+    p.start();
+    expect(p.start()).toBe(false);
+    p.destroy();
+  });
+
+  it('stop() is a no-op when not pulsing', () => {
+    const p = new PulseMotion(root);
+    expect(p.stop()).toBe(false);
+    p.destroy();
+  });
+
+  it('reduced motion uses a static ring instead of animation', () => {
+    window.matchMedia = () => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    });
+    const p = new PulseMotion(root);
+    p.start();
+    expect(p.isReducedMotion()).toBe(true);
+    expect(root.classList.contains('ease-pulse--static')).toBe(true);
+    expect(root.classList.contains('ease-pulse--animating')).toBe(false);
+    p.destroy();
+    delete window.matchMedia;
+  });
+
+  it('destroy() removes all pulse classes', () => {
+    const p = new PulseMotion(root);
+    p.start();
+    p.destroy();
+    expect(root.className).toBe('');
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new PulseMotion(null)).toThrow(TypeError);
+    expect(() => new PulseMotion({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/pulse-reduced-motion-sb/script.js
+++ b/submissions/examples/pulse-reduced-motion-sb/script.js
@@ -1,0 +1,60 @@
+/**
+ * EaseMotion CSS — Pulse Animation Reduced Motion
+ * ============================================================
+ * Adds a prefers-reduced-motion guard to pulse (attention) animations.
+ * When reduced motion is enabled, the pulse is replaced by a static,
+ * high-visibility ring so the affordance is still discoverable without
+ * movement.
+ *
+ * API:
+ *   const p = new PulseMotion(rootEl);
+ *   p.start(); p.stop(); p.isReducedMotion(); p.destroy();
+ * ============================================================
+ */
+
+export class PulseMotion {
+  constructor(root) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('PulseMotion requires a root element');
+    }
+    this.root = root;
+    this._pulsing = false;
+    this._mq = typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : { matches: false };
+    this.root.classList.add('ease-pulse');
+  }
+
+  isReducedMotion() {
+    return this._mq && this._mq.matches;
+  }
+
+  start() {
+    if (this._pulsing) return false;
+    this._pulsing = true;
+    if (this.isReducedMotion()) {
+      this.root.classList.add('ease-pulse--static');
+    } else {
+      this.root.classList.add('ease-pulse--animating');
+    }
+    return true;
+  }
+
+  stop() {
+    if (!this._pulsing) return false;
+    this._pulsing = false;
+    this.root.classList.remove('ease-pulse--animating', 'ease-pulse--static');
+    return true;
+  }
+
+  isPulsing() {
+    return this._pulsing;
+  }
+
+  destroy() {
+    this.stop();
+    this.root.classList.remove('ease-pulse');
+  }
+}
+
+export default PulseMotion;

--- a/submissions/examples/pulse-reduced-motion-sb/style.css
+++ b/submissions/examples/pulse-reduced-motion-sb/style.css
@@ -1,0 +1,32 @@
+/* ============================================================
+   EaseMotion CSS — Pulse Animation Reduced Motion
+   Base: scale/opacity keyframes. Guarded by prefers-reduced-motion
+   which swaps the animation for a static high-visibility ring.
+   ============================================================ */
+
+.ease-pulse {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-pulse--animating {
+  animation: ease-pulse-anim 1.4s ease-in-out infinite;
+}
+
+.ease-pulse--static {
+  outline: 3px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+@keyframes ease-pulse-anim {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.08); opacity: 0.7; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-pulse--animating {
+    animation: none !important;
+    outline: 3px solid var(--ease-color-primary, #6c63ff);
+    outline-offset: 2px;
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Pulse Animation Reduced Motion** accessibility audit (closes #81921). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/pulse-reduced-motion-sb/`:
- **`script.js`** — `PulseMotion`: adds a `prefers-reduced-motion` guard to pulse (attention) animations. When reduced motion is enabled the pulse is replaced by a static, high-visibility outline ring so the affordance stays discoverable without movement.
- **`pulse.test.js`** — 8 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/pulse-reduced-motion-sb/pulse.test.js
 ✓ pulse.test.js (8 tests)
```
- **Happy path**: ease-pulse class added; start adds animating class; stop removes both.
- **Edge cases**: start/stop are no-ops when already in that state; reduced motion uses static ring; destroy removes all classes.
- **Invalid inputs**: throws without root element.

Closes #81921

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._