### PR TITLE
feat: create Dynamic Popover with SaaS Modern styling (#69437) #81405

### DIFF
--- a/submissions/examples/css-popover-dynamic-saas-modern/README.md
+++ b/submissions/examples/css-popover-dynamic-saas-modern/README.md
@@ -1,0 +1,2 @@
+# Dynamic Popover (SaaS Modern)
+A highly polished B2B SaaS popover menu. It features an incredibly crisp dropdown animation, meticulously defined borders, inner panel padding, and semantic action buttons typical of modern web dashboards.

--- a/submissions/examples/css-popover-dynamic-saas-modern/demo.html
+++ b/submissions/examples/css-popover-dynamic-saas-modern/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SaaS Modern Popover</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="sm-popover-container">
+        <button class="sm-trigger">
+            <span>Filter</span>
+            <i class="ph ph-faders"></i>
+        </button>
+        <div class="sm-popover">
+            <div class="sm-header">
+                <h3>View Options</h3>
+            </div>
+            <div class="sm-body">
+                <label class="sm-checkbox">
+                    <input type="checkbox" checked>
+                    <span>Show inactive users</span>
+                </label>
+                <label class="sm-checkbox">
+                    <input type="checkbox">
+                    <span>Group by department</span>
+                </label>
+            </div>
+            <div class="sm-footer">
+                <button class="sm-btn sm-btn-ghost">Reset</button>
+                <button class="sm-btn sm-btn-primary">Apply</button>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-dynamic-saas-modern/style.css
+++ b/submissions/examples/css-popover-dynamic-saas-modern/style.css
@@ -1,0 +1,17 @@
+:root { --bg: #f8fafc; --text: #334155; --primary: #2563eb; --border: #e2e8f0; --surface: #ffffff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, sans-serif; color: var(--text); }
+.sm-popover-container { position: relative; }
+.sm-trigger { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); color: var(--text); font-size: 0.9rem; font-weight: 500; cursor: pointer; transition: all 0.2s; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.sm-trigger:hover { border-color: #cbd5e1; background: #f1f5f9; }
+.sm-popover { position: absolute; top: calc(100% + 8px); left: 0; width: 280px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); opacity: 0; visibility: hidden; transform: translateY(-10px) scale(0.98); transform-origin: top left; transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1); z-index: 10; }
+.sm-header { padding: 1rem; border-bottom: 1px solid var(--border); }
+.sm-header h3 { margin: 0; font-size: 0.9rem; font-weight: 600; color: #0f172a; }
+.sm-body { padding: 1rem; display: flex; flex-direction: column; gap: 0.75rem; }
+.sm-checkbox { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; cursor: pointer; }
+.sm-footer { padding: 0.75rem 1rem; background: #f8fafc; border-top: 1px solid var(--border); border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; display: flex; justify-content: flex-end; gap: 0.5rem; }
+.sm-btn { padding: 0.4rem 0.75rem; font-size: 0.8rem; font-weight: 500; border-radius: 4px; cursor: pointer; border: 1px solid transparent; transition: 0.2s; }
+.sm-btn-ghost { background: transparent; color: var(--text); }
+.sm-btn-ghost:hover { background: #e2e8f0; }
+.sm-btn-primary { background: var(--primary); color: #fff; }
+.sm-btn-primary:hover { background: #1d4ed8; }
+.sm-popover-container:focus-within .sm-popover { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Popover with SaaS Modern styling (#69437) #81405

**Description:**
This PR introduces a highly polished B2B SaaS popover menu. It features an incredibly crisp dropdown animation, meticulously defined borders, inner panel padding, and semantic action buttons typical of modern web dashboards.

Fixes #81405

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-dynamic-saas-modern/`
- Bound the `.sm-popover` to a `:focus-within` pseudoclass trigger on the parent container, creating a robust, JavaScript-free interaction state
- Structured the popover utilizing distinct `.sm-header`, `.sm-body`, and `.sm-footer` regions with subtle gray background contrast to match modern dashboard aesthetics
