### PR TITLE
feat: create Responsive Popover with Material Design styling (#71144)…

### DIFF
--- a/submissions/examples/css-popover-responsive-material-design/README.md
+++ b/submissions/examples/css-popover-responsive-material-design/README.md
@@ -1,0 +1,2 @@
+# Responsive Popover (Material Design)
+A classic Google Material Design Floating Action Button (FAB) that triggers a popover menu. The menu scales up along the Y-axis from the trigger point, while the FAB physically rotates to form a close icon (`x`).

--- a/submissions/examples/css-popover-responsive-material-design/demo.html
+++ b/submissions/examples/css-popover-responsive-material-design/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="md-popover-container">
+        <button class="md-fab">+</button>
+        <div class="md-popover">
+            <div class="md-menu">
+                <a href="#">Add Document</a>
+                <a href="#">Upload File</a>
+                <a href="#">Create Folder</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-responsive-material-design/style.css
+++ b/submissions/examples/css-popover-responsive-material-design/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #f5f5f5; --primary: #6200ea; --surface: #ffffff; --text: #333; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; }
+.md-popover-container { position: relative; }
+.md-fab { width: 56px; height: 56px; border-radius: 50%; background: var(--primary); color: #fff; border: none; font-size: 2rem; cursor: pointer; box-shadow: 0 3px 5px -1px rgba(0,0,0,0.2), 0 6px 10px 0 rgba(0,0,0,0.14), 0 1px 18px 0 rgba(0,0,0,0.12); transition: background 0.3s, transform 0.2s; display: flex; justify-content: center; align-items: center; line-height: 1; }
+.md-fab:hover { background: #7c4dff; }
+.md-popover { position: absolute; bottom: calc(100% + 16px); right: 0; background: var(--surface); border-radius: 4px; box-shadow: 0 5px 5px -3px rgba(0,0,0,0.2), 0 8px 10px 1px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12); opacity: 0; visibility: hidden; transform: scaleY(0.5); transform-origin: bottom right; transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1); width: 200px; overflow: hidden; z-index: 10; }
+.md-menu { padding: 8px 0; }
+.md-menu a { display: block; padding: 12px 16px; color: var(--text); text-decoration: none; font-size: 0.95rem; font-weight: 500; transition: background 0.2s; }
+.md-menu a:hover { background: rgba(0,0,0,0.04); }
+.md-popover-container:focus-within .md-popover { opacity: 1; visibility: visible; transform: scaleY(1); }
+.md-popover-container:focus-within .md-fab { transform: rotate(45deg); }


### PR DESCRIPTION
**Title:** feat: create Responsive Popover with Material Design styling (#71144) #81404

**Description:**
This PR introduces a classic Google Material Design Floating Action Button (FAB) that triggers a popover menu. The menu scales up along the Y-axis from the trigger point, while the FAB physically rotates to form a close icon (`x`).

Fixes #81404

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-responsive-material-design/`
- Designed the core FAB using heavy Material drop shadows (`0 6px 10px 0 rgba(0,0,0,0.14)`) and linked its state to rotate `45deg` on interaction
- Animated the popup panel utilizing `transform: scaleY(0)` expanding to `scaleY(1)` anchored at `transform-origin: bottom right`
