### PR TITLE
feat: create Interactive Carousel with Dark Mode styling (#86321) #81396

### DIFF
--- a/submissions/examples/css-carousel-interactive-dark/README.md
+++ b/submissions/examples/css-carousel-interactive-dark/README.md
@@ -1,0 +1,2 @@
+# Interactive Carousel (Dark Mode)
+A dark mode carousel utilizing left and right arrow controls. It leverages complex CSS sibling selectors to conditionally display the correct "next" and "previous" label overlays based on the active slide state.

--- a/submissions/examples/css-carousel-interactive-dark/demo.html
+++ b/submissions/examples/css-carousel-interactive-dark/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Dark Carousel</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="id-carousel">
+        <input type="radio" name="id-slide" id="id1" checked>
+        <input type="radio" name="id-slide" id="id2">
+        <input type="radio" name="id-slide" id="id3">
+        
+        <div class="id-container">
+            <div class="id-track">
+                <div class="id-card">
+                    <i class="ph ph-moon"></i>
+                    <h3>Night Mode</h3>
+                    <p>Easier on the eyes.</p>
+                </div>
+                <div class="id-card">
+                    <i class="ph ph-star"></i>
+                    <h3>Favorites</h3>
+                    <p>Save for later.</p>
+                </div>
+                <div class="id-card">
+                    <i class="ph ph-bell"></i>
+                    <h3>Alerts</h3>
+                    <p>Stay updated.</p>
+                </div>
+            </div>
+            
+            <div class="id-controls">
+                <!-- Previous Arrows -->
+                <label for="id3" class="id-prev id-p1"><i class="ph ph-caret-left"></i></label>
+                <label for="id1" class="id-prev id-p2"><i class="ph ph-caret-left"></i></label>
+                <label for="id2" class="id-prev id-p3"><i class="ph ph-caret-left"></i></label>
+                <!-- Next Arrows -->
+                <label for="id2" class="id-next id-n1"><i class="ph ph-caret-right"></i></label>
+                <label for="id3" class="id-next id-n2"><i class="ph ph-caret-right"></i></label>
+                <label for="id1" class="id-next id-n3"><i class="ph ph-caret-right"></i></label>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-interactive-dark/style.css
+++ b/submissions/examples/css-carousel-interactive-dark/style.css
@@ -1,0 +1,21 @@
+:root { --bg: #121212; --surface: #1e1e1e; --accent: #4ade80; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; color: #fff; }
+.id-carousel { width: 100%; max-width: 400px; position: relative; }
+input[type="radio"] { display: none; }
+.id-container { position: relative; overflow: hidden; border-radius: 16px; background: var(--surface); padding: 3rem 0; box-shadow: 0 10px 30px rgba(0,0,0,0.5); border: 1px solid #333; }
+.id-track { display: flex; width: 300%; transition: transform 0.5s ease-in-out; }
+.id-card { width: 33.333%; display: flex; flex-direction: column; align-items: center; text-align: center; }
+.id-card i { font-size: 4rem; color: var(--accent); margin-bottom: 1rem; filter: drop-shadow(0 0 10px rgba(74, 222, 128, 0.5)); }
+.id-card h3 { margin: 0 0 0.5rem 0; font-size: 1.5rem; }
+.id-card p { margin: 0; color: #888; }
+#id1:checked ~ .id-container .id-track { transform: translateX(0); }
+#id2:checked ~ .id-container .id-track { transform: translateX(-33.333%); }
+#id3:checked ~ .id-container .id-track { transform: translateX(-66.666%); }
+.id-prev, .id-next { position: absolute; top: 50%; transform: translateY(-50%); width: 40px; height: 40px; background: #333; border-radius: 50%; display: flex; justify-content: center; align-items: center; cursor: pointer; transition: 0.3s; opacity: 0; pointer-events: none; }
+.id-prev:hover, .id-next:hover { background: var(--accent); color: #000; }
+.id-prev { left: 10px; }
+.id-next { right: 10px; }
+/* Logic for showing correct arrows based on checked state */
+#id1:checked ~ .id-container .id-p1, #id1:checked ~ .id-container .id-n1 { opacity: 1; pointer-events: auto; }
+#id2:checked ~ .id-container .id-p2, #id2:checked ~ .id-container .id-n2 { opacity: 1; pointer-events: auto; }
+#id3:checked ~ .id-container .id-p3, #id3:checked ~ .id-container .id-n3 { opacity: 1; pointer-events: auto; }


### PR DESCRIPTION
**Title:** feat: create Interactive Carousel with Dark Mode styling (#86321) #81396

**Description:**
This PR introduces a dark mode carousel utilizing left and right arrow controls. It leverages complex CSS sibling selectors to conditionally display the correct "next" and "previous" label overlays based on the active slide state.

Fixes #81396

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-interactive-dark/`
- Replaced standard pagination dots with interactive left/right caret arrows (`.id-prev`, `.id-next`) linked to the corresponding `<input type="radio">` states
- Configured a complex logic tree in CSS (`#id1:checked ~ .id-container .id-n1 { opacity: 1; pointer-events: auto; }`) to guarantee the correct directional labels are actionable
