### PR TITLE
a11y(tab): arrow key navigation submission

### DIFF
--- a/submissions/examples/tab-component-arrow-key-nav-sb/README.md
+++ b/submissions/examples/tab-component-arrow-key-nav-sb/README.md
@@ -1,0 +1,38 @@
+# Tab Component Arrow Key Navigation
+
+## What does it do?
+A tablist where Left/Right (or Up/Down when `aria-orientation="vertical"`) arrows move focus between tabs, Home/End jump to first/last, and the active tab uses roving tabindex (`tabindex=0`, others `-1`). Activating a tab shows its panel (`aria-controls`/`aria-labelledby` + `aria-hidden`).
+
+## How is it used?
+```html
+<div role="tablist" id="tabs">
+  <button role="tab" aria-controls="panel-1">First</button>
+  <button role="tab" aria-controls="panel-2">Second</button>
+</div>
+<div role="tabpanel" id="panel-1">Panel one</div>
+<div role="tabpanel" id="panel-2">Panel two</div>
+```
+```javascript
+import { TabNav } from './script.js';
+const t = new TabNav(document.getElementById('tabs'));
+t.select(2); t.getActive(); t.destroy();
+```
+
+## Why is it useful?
+The WAI-ARIA tabs pattern requires arrow-key navigation (not Tab) to move between tabs, with Home/End shortcuts. Roving tabindex keeps the tablist a single tab stop.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/tab-component-arrow-key-nav-sb/tab.test.js
+```
+- **Happy path**: first tab aria-selected + tabindex=0; active panel shown; ArrowRight/Left move focus.
+- **Edge cases**: wraps last↔first; Home/End; click selects; vertical orientation uses Up/Down.
+- **Invalid inputs**: throws without root; throws with no tabs.
+
+## Tech Stack
+HTML, CSS, JavaScript (roving tabindex + arrow keys), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus a tab, use arrow keys.
+
+Closes #81890

--- a/submissions/examples/tab-component-arrow-key-nav-sb/demo.html
+++ b/submissions/examples/tab-component-arrow-key-nav-sb/demo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tab Component Arrow Key Navigation</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo" style="max-width:40rem;margin:2rem auto;padding:0 1.5rem;font-family:system-ui,sans-serif">
+      <h1>Tab Component Arrow Key Navigation</h1>
+      <div role="tablist" id="tabs">
+        <button role="tab" id="tab-1" aria-controls="panel-1">First</button>
+        <button role="tab" id="tab-2" aria-controls="panel-2">Second</button>
+        <button role="tab" id="tab-3" aria-controls="panel-3">Third</button>
+      </div>
+      <div id="panel-1" role="tabpanel" aria-labelledby="tab-1">Panel one.</div>
+      <div id="panel-2" role="tabpanel" aria-labelledby="tab-2">Panel two.</div>
+      <div id="panel-3" role="tabpanel" aria-labelledby="tab-3">Panel three.</div>
+    </main>
+    <script type="module">
+      import { TabNav } from './script.js';
+      window.__tabs = new TabNav(document.getElementById('tabs'));
+    </script>
+  </body>
+</html>

--- a/submissions/examples/tab-component-arrow-key-nav-sb/script.js
+++ b/submissions/examples/tab-component-arrow-key-nav-sb/script.js
@@ -1,0 +1,110 @@
+/**
+ * EaseMotion CSS — Tab Component Arrow Key Navigation
+ * ============================================================
+ * A tablist where Left/Right (or Up/Down) arrows move focus between
+ * tabs, Home/End jump to the first/last tab, and the active tab gets
+ * aria-selected=true + tabindex=0 (roving tabindex). Activating a tab
+ * shows its associated tabpanel (aria-controls/aria-labelledby link).
+ *
+ * API:
+ *   const t = new TabNav(rootEl);
+ *   t.select(2); t.getActive(); t.destroy();
+ * ============================================================
+ */
+
+export class TabNav {
+  constructor(root) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('TabNav requires a root element');
+    }
+    this.root = root;
+    this.tabs = Array.from(root.querySelectorAll('[role="tab"]'));
+    if (!this.tabs.length) {
+      throw new Error('TabNav requires at least one [role="tab"] element');
+    }
+    this.active = 0;
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onClick = this._onClick.bind(this);
+    this.root.addEventListener('keydown', this._onKeydown);
+    this.root.addEventListener('click', this._onClick);
+
+    this.tabs.forEach((tab, i) => {
+      tab.setAttribute('aria-selected', String(i === this.active));
+      tab.setAttribute('tabindex', i === this.active ? '0' : '-1');
+    });
+    this._showPanel(this.active);
+  }
+
+  _showPanel(index) {
+    this.active = index;
+    this.tabs.forEach((tab, i) => {
+      const selected = i === index;
+      tab.setAttribute('aria-selected', String(selected));
+      tab.setAttribute('tabindex', selected ? '0' : '-1');
+      tab.classList.toggle('is-active', selected);
+      const panelId = tab.getAttribute('aria-controls');
+      if (panelId) {
+        const panel = document.getElementById(panelId);
+        if (panel) panel.setAttribute('aria-hidden', String(!selected));
+      }
+    });
+  }
+
+  select(index) {
+    if (index < 0 || index >= this.tabs.length) return false;
+    this._showPanel(index);
+    if (typeof this.tabs[index].focus === 'function') this.tabs[index].focus();
+    return true;
+  }
+
+  getActive() {
+    return this.active;
+  }
+
+  _focus(index) {
+    const i = (index + this.tabs.length) % this.tabs.length;
+    this._showPanel(i);
+    if (typeof this.tabs[i].focus === 'function') this.tabs[i].focus();
+  }
+
+  _onKeydown(event) {
+    const horizontal = this.root.getAttribute('aria-orientation') !== 'vertical';
+    const next = horizontal ? 'ArrowRight' : 'ArrowDown';
+    const prev = horizontal ? 'ArrowLeft' : 'ArrowUp';
+    switch (event.key) {
+      case next:
+        event.preventDefault();
+        this._focus(this.active + 1);
+        break;
+      case prev:
+        event.preventDefault();
+        this._focus(this.active - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this._focus(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        this._focus(this.tabs.length - 1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  _onClick(event) {
+    const tab = event.target.closest('[role="tab"]');
+    if (!tab) return;
+    const index = this.tabs.indexOf(tab);
+    if (index >= 0) this.select(index);
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this.root.removeEventListener('click', this._onClick);
+  }
+}
+
+export default TabNav;

--- a/submissions/examples/tab-component-arrow-key-nav-sb/style.css
+++ b/submissions/examples/tab-component-arrow-key-nav-sb/style.css
@@ -1,0 +1,40 @@
+/* ============================================================
+   EaseMotion CSS — Tab Component Arrow Key Navigation
+   ============================================================ */
+
+[role='tablist'] {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+[role='tab'] {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-weight: 600;
+  color: #6b7280;
+  cursor: pointer;
+  border-radius: 0.5rem 0.5rem 0 0;
+}
+
+[role='tab']:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: -2px;
+}
+
+[role='tab'].is-active {
+  color: #1f2937;
+  border-bottom: 2px solid var(--ease-color-primary, #6c63ff);
+  margin-bottom: -2px;
+}
+
+[role='tabpanel'][aria-hidden='true'] {
+  display: none;
+}
+
+[role='tabpanel'] {
+  padding: 1rem 0;
+}

--- a/submissions/examples/tab-component-arrow-key-nav-sb/tab.test.js
+++ b/submissions/examples/tab-component-arrow-key-nav-sb/tab.test.js
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TabNav } from './script.js';
+
+describe('Tab Component Arrow Key Navigation', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.setAttribute('role', 'tablist');
+    for (let i = 0; i < 3; i++) {
+      const tab = document.createElement('button');
+      tab.setAttribute('role', 'tab');
+      tab.setAttribute('aria-controls', 'panel-' + i);
+      tab.textContent = 'Tab ' + (i + 1);
+      root.appendChild(tab);
+
+      const panel = document.createElement('div');
+      panel.id = 'panel-' + i;
+      panel.setAttribute('role', 'tabpanel');
+      panel.textContent = 'Panel ' + (i + 1);
+      document.body.appendChild(panel);
+    }
+    document.body.appendChild(root);
+  });
+
+  function press(key, target = root) {
+    target.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('marks the first tab aria-selected and tabindex=0, others -1', () => {
+    const t = new TabNav(root);
+    const tabs = root.querySelectorAll('[role="tab"]');
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0].getAttribute('tabindex')).toBe('0');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1].getAttribute('tabindex')).toBe('-1');
+    t.destroy();
+  });
+
+  it('shows the active panel (aria-hidden=false) and hides others', () => {
+    const t = new TabNav(root);
+    expect(document.getElementById('panel-0').getAttribute('aria-hidden')).toBe('false');
+    expect(document.getElementById('panel-1').getAttribute('aria-hidden')).toBe('true');
+    t.destroy();
+  });
+
+  it('ArrowRight moves focus to the next tab', () => {
+    const t = new TabNav(root);
+    const tabs = root.querySelectorAll('[role="tab"]');
+    const spy = vi.spyOn(tabs[1], 'focus');
+    press('ArrowRight', tabs[0]);
+    expect(t.getActive()).toBe(1);
+    expect(spy).toHaveBeenCalled();
+    t.destroy();
+  });
+
+  it('ArrowLeft moves focus to the previous tab', () => {
+    const t = new TabNav(root);
+    t.select(2);
+    const tabs = root.querySelectorAll('[role="tab"]');
+    const spy = vi.spyOn(tabs[1], 'focus');
+    press('ArrowLeft', tabs[2]);
+    expect(t.getActive()).toBe(1);
+    expect(spy).toHaveBeenCalled();
+    t.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('ArrowRight wraps from the last tab to the first', () => {
+    const t = new TabNav(root);
+    t.select(2);
+    press('ArrowRight', root.querySelectorAll('[role="tab"]')[2]);
+    expect(t.getActive()).toBe(0);
+    t.destroy();
+  });
+
+  it('ArrowLeft wraps from the first tab to the last', () => {
+    const t = new TabNav(root);
+    press('ArrowLeft', root.querySelectorAll('[role="tab"]')[0]);
+    expect(t.getActive()).toBe(2);
+    t.destroy();
+  });
+
+  it('Home jumps to the first tab, End to the last', () => {
+    const t = new TabNav(root);
+    t.select(1);
+    press('Home', root.querySelectorAll('[role="tab"]')[1]);
+    expect(t.getActive()).toBe(0);
+    press('End', root.querySelectorAll('[role="tab"]')[0]);
+    expect(t.getActive()).toBe(2);
+    t.destroy();
+  });
+
+  it('clicking a tab selects it', () => {
+    const t = new TabNav(root);
+    const tabs = root.querySelectorAll('[role="tab"]');
+    tabs[2].dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(t.getActive()).toBe(2);
+    expect(tabs[2].getAttribute('aria-selected')).toBe('true');
+    t.destroy();
+  });
+
+  it('vertical orientation uses ArrowDown/ArrowUp', () => {
+    root.setAttribute('aria-orientation', 'vertical');
+    const t = new TabNav(root);
+    const tabs = root.querySelectorAll('[role="tab"]');
+    press('ArrowDown', tabs[0]);
+    expect(t.getActive()).toBe(1);
+    press('ArrowUp', tabs[1]);
+    expect(t.getActive()).toBe(0);
+    t.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new TabNav(null)).toThrow(TypeError);
+  });
+
+  it('throws when there are no tab elements', () => {
+    const empty = document.createElement('div');
+    empty.setAttribute('role', 'tablist');
+    expect(() => new TabNav(empty)).toThrow(Error);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Tab Component Arrow Key Navigation** accessibility audit (closes #81890). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/tab-component-arrow-key-nav-sb/`:
- **`script.js`** — `TabNav`: arrow-key navigation (Left/Right or Up/Down for `aria-orientation="vertical"`), Home/End shortcuts, and roving tabindex. Activating a tab shows its panel via `aria-controls`/`aria-hidden`.
- **`tab.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/tab-component-arrow-key-nav-sb/tab.test.js
 ✓ tab.test.js (11 tests)
```
- **Happy path**: first tab aria-selected + tabindex=0; active panel shown; ArrowRight/Left move focus.
- **Edge cases**: wraps last↔first; Home/End; click selects; vertical orientation uses Up/Down.
- **Invalid inputs**: throws without root; throws with no tabs.

Closes #81890

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._