### PR TITLE
a11y(accordion): aria-expanded attributes submission

### DIFF
--- a/submissions/examples/accordion-aria-expanded-sb/README.md
+++ b/submissions/examples/accordion-aria-expanded-sb/README.md
@@ -1,0 +1,38 @@
+# Accordion ARIA Expanded Attributes
+
+## What does it do?
+Wires accordion header buttons to their panels via `aria-controls` and keeps `aria-expanded` in sync with the open state. Supports single-open (accordion) and multi-open (`allowMultiple`) modes.
+
+## How is it used?
+```html
+<div id="accordion">
+  <button data-accordion-header aria-controls="acc-panel-0">Section 1</button>
+  <div id="acc-panel-0">Content 1</div>
+  <button data-accordion-header aria-controls="acc-panel-1">Section 2</button>
+  <div id="acc-panel-1">Content 2</div>
+</div>
+```
+```javascript
+import { Accordion } from './script.js';
+const a = new Accordion(document.getElementById('accordion'), { allowMultiple: true });
+a.toggle(0); a.expand(1); a.collapse(1); a.isExpanded(0); a.destroy();
+```
+
+## Why is it useful?
+Screen-reader users rely on `aria-expanded` to know whether an accordion section is open, and `role="region"` + `aria-controls` to associate the header with its panel. Without these the accordion is opaque to assistive tech.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/accordion-aria-expanded-sb/accordion.test.js
+```
+- **Happy path**: header role/aria-expanded/tabindex; panel role/aria-hidden; defaultOpen; expand/collapse.
+- **Edge cases**: single-open closes others; allowMultiple keeps others open; click toggles.
+- **Invalid inputs**: throws without root; throws with no headers.
+
+## Tech Stack
+HTML, CSS (expand/collapse + reduced-motion), JavaScript (aria-expanded sync), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click sections.
+
+Closes #81892

--- a/submissions/examples/accordion-aria-expanded-sb/accordion.test.js
+++ b/submissions/examples/accordion-aria-expanded-sb/accordion.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Accordion } from './script.js';
+
+describe('Accordion ARIA Expanded Attributes', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    for (let i = 0; i < 3; i++) {
+      const header = document.createElement('button');
+      header.setAttribute('data-accordion-header', '');
+      header.setAttribute('aria-controls', 'acc-panel-' + i);
+      header.textContent = 'Section ' + (i + 1);
+      root.appendChild(header);
+
+      const panel = document.createElement('div');
+      panel.id = 'acc-panel-' + i;
+      panel.textContent = 'Content ' + (i + 1);
+      root.appendChild(panel);
+    }
+    document.body.appendChild(root);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=button, aria-expanded=false, tabindex=0 on headers', () => {
+    const a = new Accordion(root, { defaultOpen: false });
+    const h = root.querySelector('[data-accordion-header]');
+    expect(h.getAttribute('role')).toBe('button');
+    expect(h.getAttribute('aria-expanded')).toBe('false');
+    expect(h.getAttribute('tabindex')).toBe('0');
+    a.destroy();
+  });
+
+  it('sets role=region and aria-hidden=true on panels', () => {
+    const a = new Accordion(root, { defaultOpen: false });
+    const panel = document.getElementById('acc-panel-0');
+    expect(panel.getAttribute('role')).toBe('region');
+    expect(panel.getAttribute('aria-hidden')).toBe('true');
+    a.destroy();
+  });
+
+  it('defaultOpen expands the first section', () => {
+    const a = new Accordion(root);
+    expect(a.isExpanded(0)).toBe(true);
+    expect(document.getElementById('acc-panel-0').getAttribute('aria-hidden')).toBe('false');
+    a.destroy();
+  });
+
+  it('expand() sets aria-expanded=true and aria-hidden=false', () => {
+    const a = new Accordion(root, { defaultOpen: false });
+    a.expand(1);
+    expect(a.isExpanded(1)).toBe(true);
+    expect(document.getElementById('acc-panel-1').getAttribute('aria-hidden')).toBe('false');
+    a.destroy();
+  });
+
+  it('collapse() sets aria-expanded=false and aria-hidden=true', () => {
+    const a = new Accordion(root);
+    a.collapse(0);
+    expect(a.isExpanded(0)).toBe(false);
+    expect(document.getElementById('acc-panel-0').getAttribute('aria-hidden')).toBe('true');
+    a.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('single-open mode closes others when expanding a new section', () => {
+    const a = new Accordion(root);
+    a.expand(1);
+    expect(a.isExpanded(1)).toBe(true);
+    expect(a.isExpanded(0)).toBe(false);
+    a.destroy();
+  });
+
+  it('allowMultiple keeps other sections open', () => {
+    const a = new Accordion(root, { allowMultiple: true });
+    a.expand(1);
+    expect(a.isExpanded(1)).toBe(true);
+    expect(a.isExpanded(0)).toBe(true);
+    a.destroy();
+  });
+
+  it('clicking a header toggles it', () => {
+    const a = new Accordion(root);
+    const headers = root.querySelectorAll('[data-accordion-header]');
+    headers[1].dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(a.isExpanded(1)).toBe(true);
+    headers[1].dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(a.isExpanded(1)).toBe(false);
+    a.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new Accordion(null)).toThrow(TypeError);
+  });
+
+  it('throws when there are no headers', () => {
+    const empty = document.createElement('div');
+    expect(() => new Accordion(empty)).toThrow(Error);
+  });
+});

--- a/submissions/examples/accordion-aria-expanded-sb/demo.html
+++ b/submissions/examples/accordion-aria-expanded-sb/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Accordion ARIA Expanded Attributes</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo" style="max-width:40rem;margin:2rem auto;padding:0 1.5rem;font-family:system-ui,sans-serif">
+      <h1>Accordion ARIA Expanded Attributes</h1>
+      <div id="accordion">
+        <button data-accordion-header aria-controls="acc-panel-0">Section 1</button>
+        <div id="acc-panel-0">Content 1</div>
+        <button data-accordion-header aria-controls="acc-panel-1">Section 2</button>
+        <div id="acc-panel-1">Content 2</div>
+      </div>
+    </main>
+    <script type="module">
+      import { Accordion } from './script.js';
+      window.__accordion = new Accordion(document.getElementById('accordion'));
+    </script>
+  </body>
+</html>

--- a/submissions/examples/accordion-aria-expanded-sb/script.js
+++ b/submissions/examples/accordion-aria-expanded-sb/script.js
@@ -1,0 +1,100 @@
+/**
+ * EaseMotion CSS — Accordion ARIA Expanded Attributes
+ * ============================================================
+ * Wires accordion header buttons to their panels via aria-controls and
+ * keeps aria-expanded in sync with the open state. Supports single-open
+ * (accordion) and multi-open (allowMultiple) modes.
+ *
+ * API:
+ *   const a = new Accordion(rootEl, { allowMultiple });
+ *   a.toggle(0); a.expand(0); a.collapse(0); a.isExpanded(0); a.destroy();
+ * ============================================================
+ */
+
+export class Accordion {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('Accordion requires a root element');
+    }
+    this.root = root;
+    this.allowMultiple = !!options.allowMultiple;
+    this.headers = Array.from(root.querySelectorAll('[data-accordion-header]'));
+    if (!this.headers.length) {
+      throw new Error('Accordion requires at least one [data-accordion-header]');
+    }
+
+    this._onClick = this._onClick.bind(this);
+    this.root.addEventListener('click', this._onClick);
+
+    this.headers.forEach((header, i) => {
+      header.setAttribute('role', 'button');
+      header.setAttribute('aria-expanded', 'false');
+      header.setAttribute('tabindex', '0');
+      const panel = this._panelFor(header);
+      if (panel) {
+        panel.setAttribute('role', 'region');
+        panel.setAttribute('aria-hidden', 'true');
+        if (!header.getAttribute('aria-controls')) {
+          header.setAttribute('aria-controls', panel.id);
+        }
+      }
+      if (i === 0 && options.defaultOpen !== false) {
+        this.expand(i, { silent: true });
+      }
+    });
+  }
+
+  _panelFor(header) {
+    const id = header.getAttribute('aria-controls');
+    if (!id) return null;
+    return document.getElementById(id);
+  }
+
+  _setExpanded(index, expanded, options = {}) {
+    const header = this.headers[index];
+    if (!header) return false;
+    header.setAttribute('aria-expanded', String(expanded));
+    const panel = this._panelFor(header);
+    if (panel) panel.setAttribute('aria-hidden', String(!expanded));
+    header.classList.toggle('is-open', expanded);
+    if (!options.silent && typeof header.dispatchEvent === 'function') {
+      header.dispatchEvent(new window.Event('toggle', { bubbles: true }));
+    }
+    return true;
+  }
+
+  expand(index, options) {
+    if (!this.allowMultiple && !options?.silent) {
+      this.headers.forEach((h, i) => {
+        if (i !== index) this._setExpanded(i, false, { silent: true });
+      });
+    }
+    return this._setExpanded(index, true, options);
+  }
+
+  collapse(index, options) {
+    return this._setExpanded(index, false, options);
+  }
+
+  toggle(index, options) {
+    return this.isExpanded(index) ? this.collapse(index, options) : this.expand(index, options);
+  }
+
+  isExpanded(index) {
+    const header = this.headers[index];
+    return !!header && header.getAttribute('aria-expanded') === 'true';
+  }
+
+  _onClick(event) {
+    const header = event.target.closest('[data-accordion-header]');
+    if (!header) return;
+    const index = this.headers.indexOf(header);
+    if (index >= 0) this.toggle(index);
+  }
+
+  destroy() {
+    this.root.removeEventListener('click', this._onClick);
+  }
+}
+
+export default Accordion;

--- a/submissions/examples/accordion-aria-expanded-sb/style.css
+++ b/submissions/examples/accordion-aria-expanded-sb/style.css
@@ -1,0 +1,50 @@
+/* ============================================================
+   EaseMotion CSS — Accordion ARIA Expanded Attributes
+   ============================================================ */
+
+[data-accordion-header] {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e5e7eb;
+  border-bottom: none;
+  background: #f9fafb;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+[data-accordion-header]:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: -2px;
+}
+
+[data-accordion-header].is-open {
+  background: #eef2ff;
+}
+
+[data-accordion-header] + [role='region'] {
+  max-height: 0;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-bottom: none;
+  padding: 0 1rem;
+  transition: max-height 0.2s ease, padding 0.2s ease;
+}
+
+[data-accordion-header].is-open + [role='region'] {
+  max-height: 30rem;
+  padding: 0.75rem 1rem;
+}
+
+[data-accordion-header]:last-of-type,
+[data-accordion-header]:last-of-type + [role='region'] {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-accordion-header] + [role='region'] {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Accordion ARIA Expanded Attributes** accessibility audit (closes #81892). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/accordion-aria-expanded-sb/`:
- **`script.js`** — `Accordion`: wires header buttons to panels via `aria-controls` and keeps `aria-expanded` in sync with the open state. Supports single-open and multi-open (`allowMultiple`) modes.
- **`accordion.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/accordion-aria-expanded-sb/accordion.test.js
 ✓ accordion.test.js (10 tests)
```
- **Happy path**: header role/aria-expanded/tabindex; panel role/aria-hidden; defaultOpen; expand/collapse.
- **Edge cases**: single-open closes others; allowMultiple keeps others open; click toggles.
- **Invalid inputs**: throws without root; throws with no headers.

Closes #81892

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._