### PR TITLE
a11y(modal): focus trap submission

### DIFF
--- a/submissions/examples/modal-focus-trap-sb/README.md
+++ b/submissions/examples/modal-focus-trap-sb/README.md
@@ -1,0 +1,39 @@
+# Modal Component Focus Trap
+
+## What does it do?
+A modal dialog that traps focus within itself (Tab/Shift+Tab cycle between focusables), moves focus into the dialog on open, restores focus to the trigger on close, and closes on Escape + backdrop click.
+
+## How is it used?
+```html
+<div id="modal" class="ease-modal">
+  <div class="ease-modal__dialog" tabindex="-1">
+    <button id="close">Close</button>
+    <input />
+  </div>
+</div>
+<button id="open">Open</button>
+```
+```javascript
+import { Modal } from './script.js';
+const m = new Modal(document.getElementById('modal'), { trigger: document.getElementById('open') });
+m.open(); m.close(); m.isOpen(); m.destroy();
+```
+
+## Why is it useful?
+A focus trap prevents keyboard users from tabbing out of the dialog into the hidden page behind it (an ARIA Authoring Practices requirement for `aria-modal="true"`). Restoring focus on close returns the user to their place.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/modal-focus-trap-sb/modal.test.js
+```
+- **Happy path**: role=dialog + aria-modal; open toggles hidden + aria-hidden; open moves focus to first focusable; Escape closes.
+- **Edge cases**: close restores saved focus; Tab wraps last→first; Shift+Tab wraps first→last; trigger opens; backdrop closes.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (overlay), JavaScript (focus trap + Escape), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click Open, Tab around, press Escape.
+
+Closes #81886

--- a/submissions/examples/modal-focus-trap-sb/demo.html
+++ b/submissions/examples/modal-focus-trap-sb/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Modal Component Focus Trap</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Modal Component Focus Trap</h1>
+      <button type="button" id="open">Open modal</button>
+      <div id="modal" class="ease-modal">
+        <div class="ease-modal__dialog" tabindex="-1">
+          <p>Focus is trapped here. Tab cycles; Escape closes.</p>
+          <button type="button" id="close">Close</button>
+          <label>Name <input id="field" /></label>
+        </div>
+      </div>
+    </main>
+    <script type="module">
+      import { Modal } from './script.js';
+      const m = new Modal(document.getElementById('modal'), {
+        trigger: document.getElementById('open'),
+      });
+      document.getElementById('close').addEventListener('click', () => m.close());
+      window.__modal = m;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/modal-focus-trap-sb/modal.test.js
+++ b/submissions/examples/modal-focus-trap-sb/modal.test.js
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Modal } from './script.js';
+
+describe('Modal Component Focus Trap', () => {
+  let root, trigger;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.id = 'modal';
+    root.innerHTML = '<button id="close">Close</button><input id="field" />';
+    trigger = document.createElement('button');
+    trigger.id = 'open';
+    document.body.appendChild(trigger);
+    document.body.appendChild(root);
+  });
+
+  function keydown(key, shiftKey = false) {
+    document.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key, shiftKey, bubbles: true }),
+    );
+  }
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=dialog and aria-modal=true, hidden initially', () => {
+    const m = new Modal(root);
+    expect(root.getAttribute('role')).toBe('dialog');
+    expect(root.getAttribute('aria-modal')).toBe('true');
+    expect(root.hasAttribute('hidden')).toBe(true);
+    m.destroy();
+  });
+
+  it('open() removes hidden and sets aria-hidden=false', () => {
+    const m = new Modal(root);
+    m.open();
+    expect(m.isOpen()).toBe(true);
+    expect(root.hasAttribute('hidden')).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    m.destroy();
+  });
+
+  it('open() moves focus to the first focusable element', () => {
+    const m = new Modal(root);
+    const close = document.getElementById('close');
+    const spy = vi.spyOn(close, 'focus');
+    m.open();
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('Escape closes the modal', () => {
+    const m = new Modal(root);
+    m.open();
+    keydown('Escape');
+    expect(m.isOpen()).toBe(false);
+    m.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('close() restores focus to the saved element', () => {
+    const m = new Modal(root, { trigger });
+    trigger.focus();
+    m.open();
+    const spy = vi.spyOn(trigger, 'focus');
+    m.close();
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('Tab on last focusable wraps to first', () => {
+    const m = new Modal(root);
+    m.open();
+    const field = document.getElementById('field');
+    field.focus();
+    const first = document.getElementById('close');
+    const spy = vi.spyOn(first, 'focus');
+    keydown('Tab');
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('Shift+Tab on first focusable wraps to last', () => {
+    const m = new Modal(root);
+    m.open();
+    const first = document.getElementById('close');
+    first.focus();
+    const last = document.getElementById('field');
+    const spy = vi.spyOn(last, 'focus');
+    keydown('Tab', true);
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('clicking the trigger opens the modal', () => {
+    const m = new Modal(root, { trigger });
+    trigger.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(m.isOpen()).toBe(true);
+    m.destroy();
+  });
+
+  it('backdrop click (event target === root) closes the modal', () => {
+    const m = new Modal(root);
+    m.open();
+    root.dispatchEvent(new window.MouseEvent('mousedown', { bubbles: true }));
+    expect(m.isOpen()).toBe(false);
+    m.destroy();
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new Modal(null)).toThrow(TypeError);
+    expect(() => new Modal({})).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/modal-focus-trap-sb/script.js
+++ b/submissions/examples/modal-focus-trap-sb/script.js
@@ -1,0 +1,124 @@
+/**
+ * EaseMotion CSS — Modal Component Focus Trap
+ * ============================================================
+ * A modal dialog that traps focus within itself (Tab/Shift+Tab cycle),
+ * moves focus into the dialog on open, restores focus to the trigger on
+ * close, and closes on Escape + backdrop click.
+ *
+ * API:
+ *   const m = new Modal(rootEl, { trigger });
+ *   m.open(); m.close(); m.isOpen(); m.destroy();
+ * ============================================================ */
+
+export class Modal {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('Modal requires a root element');
+    }
+    this.root = root;
+    this.trigger = options.trigger || null;
+    this._open = false;
+    this._savedFocus = null;
+
+    this.root.setAttribute('role', 'dialog');
+    this.root.setAttribute('aria-modal', 'true');
+    this.root.setAttribute('hidden', '');
+    this.root.classList.add('ease-modal');
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onTrigger = this._onTrigger.bind(this);
+    this._onBackdrop = this._onBackdrop.bind(this);
+    document.addEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.addEventListener('click', this._onTrigger);
+    this.root.addEventListener('mousedown', this._onBackdrop);
+  }
+
+  _focusables() {
+    return Array.from(
+      this.root.querySelectorAll(
+        'a[href],button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  }
+
+  open() {
+    if (this._open) return false;
+    this._open = true;
+    this._savedFocus = document.activeElement;
+    this.root.removeAttribute('hidden');
+    this.root.classList.add('is-open');
+    this.root.setAttribute('aria-hidden', 'false');
+    const focusables = this._focusables();
+    if (focusables.length && typeof focusables[0].focus === 'function') {
+      focusables[0].focus();
+    } else if (typeof this.root.focus === 'function') {
+      this.root.focus();
+    }
+    return true;
+  }
+
+  close() {
+    if (!this._open) return false;
+    this._open = false;
+    this.root.setAttribute('hidden', '');
+    this.root.classList.remove('is-open');
+    this.root.setAttribute('aria-hidden', 'true');
+    if (this._savedFocus && typeof this._savedFocus.focus === 'function') {
+      this._savedFocus.focus();
+    }
+    return true;
+  }
+
+  toggle() {
+    return this._open ? this.close() : this.open();
+  }
+
+  isOpen() {
+    return this._open;
+  }
+
+  _onKeydown(event) {
+    if (!this._open) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+    if (event.key === 'Tab') {
+      const focusables = this._focusables();
+      if (!focusables.length) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first || !this.root.contains(document.activeElement)) {
+          event.preventDefault();
+          if (typeof last.focus === 'function') last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault();
+          if (typeof first.focus === 'function') first.focus();
+        }
+      }
+    }
+  }
+
+  _onTrigger() {
+    this.open();
+  }
+
+  _onBackdrop(event) {
+    if (event.target === this.root) this.close();
+  }
+
+  destroy() {
+    document.removeEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.removeEventListener('click', this._onTrigger);
+    this.root.removeEventListener('mousedown', this._onBackdrop);
+  }
+}
+
+export default Modal;

--- a/submissions/examples/modal-focus-trap-sb/style.css
+++ b/submissions/examples/modal-focus-trap-sb/style.css
@@ -1,0 +1,34 @@
+/* ============================================================
+   EaseMotion CSS — Modal Component Focus Trap
+   ============================================================ */
+
+.ease-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+}
+
+.ease-modal[hidden] {
+  display: none !important;
+}
+
+.ease-modal.is-open {
+  display: flex;
+}
+
+.ease-modal__dialog {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 32rem;
+  width: calc(100% - 2rem);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+}
+
+.ease-modal__dialog:focus-visible {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Modal Component Focus Trap** accessibility audit (closes #81886). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/modal-focus-trap-sb/`:
- **`script.js`** — `Modal`: traps focus within the dialog (Tab/Shift+Tab cycle between focusables), moves focus into the dialog on open, restores focus to the trigger on close, and closes on Escape + backdrop click.
- **`modal.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/modal-focus-trap-sb/modal.test.js
 ✓ modal.test.js (10 tests)
```
- **Happy path**: role=dialog + aria-modal; open toggles hidden + aria-hidden; open moves focus to first focusable; Escape closes.
- **Edge cases**: close restores saved focus; Tab wraps last→first; Shift+Tab wraps first→last; trigger opens; backdrop closes.
- **Invalid inputs**: throws without root element.

Closes #81886

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._