### PR TITLE
a11y(toast): aria-live region submission

### DIFF
--- a/submissions/examples/toast-notification-aria-live-sb/README.md
+++ b/submissions/examples/toast-notification-aria-live-sb/README.md
@@ -1,0 +1,34 @@
+# Toast Notification ARIA Live Region
+
+## What does it do?
+Announces toast notifications via an `aria-live` region so screen-reader users hear them without moving focus. Polite by default, assertive when `{ politeness: 'assertive' }`. Toasts auto-dismiss after a timeout.
+
+## How is it used?
+```html
+<div id="toast-region"></div>
+```
+```javascript
+import { ToastRegion } from './script.js';
+const t = new ToastRegion(document.getElementById('toast-region'));
+t.show('Saved!', { politeness: 'polite', timeout: 3000 });
+t.clear(); t.destroy();
+```
+
+## Why is it useful?
+Toast notifications are visual feedback that screen-reader users miss unless they're announced via an `aria-live` region. Using `aria-live="polite"` (or `assertive` for urgent toasts) plus `aria-atomic="true"` ensures the full message is read once.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/toast-notification-aria-live-sb/toast.test.js
+```
+- **Happy path**: role=status + aria-live + aria-atomic on region; show creates toast with message; returns id; auto-dismisses after timeout.
+- **Edge cases**: assertive toggles aria-live; timeout=0 keeps until dismissed; clear removes all; destroy clears timers + toasts.
+- **Invalid inputs**: throws without root; rejects empty/non-string messages.
+
+## Tech Stack
+HTML, CSS (toast styling + reduced-motion), JavaScript (aria-live + timers), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click the button.
+
+Closes #81894

--- a/submissions/examples/toast-notification-aria-live-sb/demo.html
+++ b/submissions/examples/toast-notification-aria-live-sb/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Toast Notification ARIA Live Region</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo">
+      <h1>Toast Notification ARIA Live Region</h1>
+      <button type="button" id="btn">Show toast</button>
+    </main>
+    <div id="toast-region"></div>
+    <script type="module">
+      import { ToastRegion } from './script.js';
+      const t = new ToastRegion(document.getElementById('toast-region'));
+      document.getElementById('btn').addEventListener('click', () => {
+        t.show('Saved successfully', { politeness: 'polite', timeout: 3000 });
+      });
+      window.__toast = t;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/toast-notification-aria-live-sb/script.js
+++ b/submissions/examples/toast-notification-aria-live-sb/script.js
@@ -1,0 +1,85 @@
+/**
+ * EaseMotion CSS — Toast Notification ARIA Live Region
+ * ============================================================
+ * Announces toast notifications via an aria-live region so screen-reader
+ * users hear them without moving focus. Polite by default, assertive
+ * when { politeness: 'assertive' }. Toasts auto-dismiss after a timeout.
+ *
+ * API:
+ *   const t = new ToastRegion(rootEl);
+ *   t.show('Saved!', { politeness: 'polite', timeout: 3000 });
+ *   t.clear(); t.destroy();
+ * ============================================================ */
+
+export class ToastRegion {
+  constructor(root, options = {}) {
+    if (!root || typeof root.appendChild !== 'function') {
+      throw new TypeError('ToastRegion requires a root element');
+    }
+    this.root = root;
+    this.defaultPoliteness = options.politeness || 'polite';
+    this.defaultTimeout = options.timeout || 4000;
+
+    this.root.setAttribute('role', 'status');
+    this.root.setAttribute('aria-live', this.defaultPoliteness);
+    this.root.setAttribute('aria-atomic', 'true');
+    this.root.classList.add('ease-toast-region');
+    this.root.setAttribute('tabindex', '-1');
+    this._idSeq = 0;
+    this._timers = new Map();
+  }
+
+  show(message, options = {}) {
+    if (typeof message !== 'string' || !message.trim()) {
+      throw new TypeError('ToastRegion.show requires a non-empty message string');
+    }
+    const politeness = options.politeness || this.defaultPoliteness;
+    const timeout = options.timeout ?? this.defaultTimeout;
+
+    // Politeness can change per-toast by toggling aria-live before content.
+    this.root.setAttribute('aria-live', politeness);
+
+    const toast = document.createElement('div');
+    toast.className = 'ease-toast';
+    toast.id = 'ease-toast-' + (++this._idSeq);
+    toast.setAttribute('role', 'status');
+    toast.textContent = message;
+    this.root.appendChild(toast);
+
+    if (timeout > 0) {
+      const timer = setTimeout(() => this._remove(toast), timeout);
+      this._timers.set(toast.id, timer);
+    }
+    return toast.id;
+  }
+
+  _remove(toast) {
+    if (!toast || !toast.parentNode) return;
+    if (this._timers.has(toast.id)) {
+      clearTimeout(this._timers.get(toast.id));
+      this._timers.delete(toast.id);
+    }
+    toast.parentNode.removeChild(toast);
+  }
+
+  dismiss(id) {
+    const toast = id ? this.root.querySelector('#' + id.replace(/[^A-Za-z0-9_-]/g, '')) : null;
+    if (toast) this._remove(toast);
+  }
+
+  clear() {
+    Array.from(this.root.querySelectorAll('.ease-toast')).forEach((t) => this._remove(t));
+  }
+
+  count() {
+    return this.root.querySelectorAll('.ease-toast').length;
+  }
+
+  destroy() {
+    this._timers.forEach((t) => clearTimeout(t));
+    this._timers.clear();
+    this.clear();
+  }
+}
+
+export default ToastRegion;

--- a/submissions/examples/toast-notification-aria-live-sb/style.css
+++ b/submissions/examples/toast-notification-aria-live-sb/style.css
@@ -1,0 +1,35 @@
+/* ============================================================
+   EaseMotion CSS — Toast Notification ARIA Live Region
+   ============================================================ */
+
+.ease-toast-region {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 200;
+  pointer-events: none;
+}
+
+.ease-toast {
+  pointer-events: auto;
+  background: #1f2937;
+  color: #f9fafb;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.25);
+  font-size: 0.95rem;
+  max-width: 24rem;
+  animation: ease-toast-in 0.2s ease;
+}
+
+@keyframes ease-toast-in {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast { animation: none !important; }
+}

--- a/submissions/examples/toast-notification-aria-live-sb/toast.test.js
+++ b/submissions/examples/toast-notification-aria-live-sb/toast.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ToastRegion } from './script.js';
+
+describe('Toast Notification ARIA Live Region', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.id = 'toast-region';
+    document.body.appendChild(root);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  it('sets role=status, aria-live=polite, aria-atomic=true on the region', () => {
+    const t = new ToastRegion(root);
+    expect(root.getAttribute('role')).toBe('status');
+    expect(root.getAttribute('aria-live')).toBe('polite');
+    expect(root.getAttribute('aria-atomic')).toBe('true');
+    t.destroy();
+  });
+
+  it('show() creates a toast element with the message', () => {
+    const t = new ToastRegion(root);
+    const id = t.show('Saved!');
+    const toast = document.getElementById(id);
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe('Saved!');
+    expect(toast.getAttribute('role')).toBe('status');
+    t.destroy();
+  });
+
+  it('show() returns the toast id', () => {
+    const t = new ToastRegion(root);
+    const id = t.show('Hello');
+    expect(typeof id).toBe('string');
+    expect(id).toMatch(/^ease-toast-\d+$/);
+    t.destroy();
+  });
+
+  it('toast auto-dismisses after the timeout', () => {
+    const t = new ToastRegion(root, { timeout: 3000 });
+    t.show('Bye');
+    expect(t.count()).toBe(1);
+    vi.advanceTimersByTime(3000);
+    expect(t.count()).toBe(0);
+    t.destroy();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it('assertive politeness toggles aria-live', () => {
+    const t = new ToastRegion(root);
+    t.show('Warning', { politeness: 'assertive' });
+    expect(root.getAttribute('aria-live')).toBe('assertive');
+    t.destroy();
+  });
+
+  it('timeout=0 keeps the toast until manually dismissed', () => {
+    const t = new ToastRegion(root);
+    const id = t.show('Stays', { timeout: 0 });
+    vi.advanceTimersByTime(999999);
+    expect(t.count()).toBe(1);
+    t.dismiss(id);
+    expect(t.count()).toBe(0);
+    t.destroy();
+  });
+
+  it('clear() removes all toasts', () => {
+    const t = new ToastRegion(root);
+    t.show('A');
+    t.show('B');
+    t.show('C');
+    expect(t.count()).toBe(3);
+    t.clear();
+    expect(t.count()).toBe(0);
+    t.destroy();
+  });
+
+  it('destroy() clears timers and toasts', () => {
+    const t = new ToastRegion(root);
+    t.show('A', { timeout: 5000 });
+    t.show('B', { timeout: 10000 });
+    t.destroy();
+    expect(t.count()).toBe(0);
+  });
+
+  // ── Invalid inputs ───────────────────────────────────────────────
+
+  it('throws without a root element', () => {
+    expect(() => new ToastRegion(null)).toThrow(TypeError);
+    expect(() => new ToastRegion({})).toThrow(TypeError);
+  });
+
+  it('show() rejects empty/non-string messages', () => {
+    const t = new ToastRegion(root);
+    expect(() => t.show('')).toThrow(TypeError);
+    expect(() => t.show(null)).toThrow(TypeError);
+    t.destroy();
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Toast Notification ARIA Live Region** accessibility audit (closes #81894). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/toast-notification-aria-live-sb/`:
- **`script.js`** — `ToastRegion`: announces toast notifications via an `aria-live` region so screen-reader users hear them without moving focus. Polite by default, assertive when `{ politeness: 'assertive' }`. Toasts auto-dismiss after a timeout.
- **`toast.test.js`** — 10 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/toast-notification-aria-live-sb/toast.test.js
 ✓ toast.test.js (10 tests)
```
- **Happy path**: role=status + aria-live + aria-atomic on region; show creates toast with message; returns id; auto-dismisses after timeout.
- **Edge cases**: assertive toggles aria-live; timeout=0 keeps until dismissed; clear removes all; destroy clears timers + toasts.
- **Invalid inputs**: throws without root; rejects empty/non-string messages.

Closes #81894

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._