### PR TITLE
feat: create Animated Carousel with Cyberpunk styling (#34217) #81389

### DIFF
--- a/submissions/examples/css-carousel-animated-cyberpunk/README.md
+++ b/submissions/examples/css-carousel-animated-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Animated Carousel (Cyberpunk)
+A gritty, high-contrast slider heavily inspired by Cyberpunk UI. It features harsh neon colors, chromatic aberration text-shadows, and a jarring `steps()` transition to simulate digital stutter.

--- a/submissions/examples/css-carousel-animated-cyberpunk/demo.html
+++ b/submissions/examples/css-carousel-animated-cyberpunk/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Animated Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cp-carousel">
+        <input type="radio" name="cp-slide" id="cp1" checked>
+        <input type="radio" name="cp-slide" id="cp2">
+        <input type="radio" name="cp-slide" id="cp3">
+        
+        <div class="cp-viewport">
+            <div class="cp-track">
+                <div class="cp-slide">
+                    <div class="cp-glitch" data-text="SYSTEM">SYSTEM</div>
+                    <p>Core operational.</p>
+                </div>
+                <div class="cp-slide">
+                    <div class="cp-glitch" data-text="NETWORK">NETWORK</div>
+                    <p>Uplink established.</p>
+                </div>
+                <div class="cp-slide">
+                    <div class="cp-glitch" data-text="BREACH">BREACH</div>
+                    <p>Security compromised.</p>
+                </div>
+            </div>
+        </div>
+        
+        <div class="cp-nav">
+            <label for="cp1">SYS</label>
+            <label for="cp2">NET</label>
+            <label for="cp3">BRC</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-animated-cyberpunk/style.css
+++ b/submissions/examples/css-carousel-animated-cyberpunk/style.css
@@ -1,0 +1,19 @@
+:root { --bg: #0d0d12; --yellow: #fcee0a; --cyan: #00f0ff; --pink: #ff003c; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', monospace; color: #fff; }
+.cp-carousel { width: 100%; max-width: 500px; border: 2px solid var(--cyan); padding: 2rem; position: relative; box-shadow: 0 0 20px rgba(0, 240, 255, 0.2); }
+.cp-carousel::before { content: 'CAROUSEL_v2.0'; position: absolute; top: -10px; left: 20px; background: var(--bg); padding: 0 10px; color: var(--yellow); font-size: 0.8rem; letter-spacing: 2px; }
+input[type="radio"] { display: none; }
+.cp-viewport { overflow: hidden; margin-bottom: 2rem; border-left: 4px solid var(--pink); padding-left: 1rem; }
+.cp-track { display: flex; width: 300%; transition: transform 0.1s steps(5, end); }
+.cp-slide { width: 33.333%; }
+.cp-glitch { font-size: 3rem; font-weight: bold; position: relative; color: #fff; text-shadow: 2px 0 var(--cyan), -2px 0 var(--pink); letter-spacing: 4px; }
+.cp-slide p { color: var(--yellow); margin-top: 0.5rem; text-transform: uppercase; font-size: 0.9rem; }
+#cp1:checked ~ .cp-viewport .cp-track { transform: translateX(0); }
+#cp2:checked ~ .cp-viewport .cp-track { transform: translateX(-33.333%); }
+#cp3:checked ~ .cp-viewport .cp-track { transform: translateX(-66.666%); }
+.cp-nav { display: flex; gap: 1rem; }
+.cp-nav label { padding: 0.5rem 1rem; background: transparent; border: 1px solid var(--cyan); color: var(--cyan); cursor: pointer; transition: 0s; font-size: 0.8rem; text-transform: uppercase; }
+.cp-nav label:hover { background: rgba(0, 240, 255, 0.2); }
+#cp1:checked ~ .cp-nav label:nth-child(1),
+#cp2:checked ~ .cp-nav label:nth-child(2),
+#cp3:checked ~ .cp-nav label:nth-child(3) { background: var(--yellow); border-color: var(--yellow); color: #000; box-shadow: 4px 4px 0 var(--pink); transform: translate(-4px, -4px); }


### PR DESCRIPTION
**Title:** feat: create Animated Carousel with Cyberpunk styling (#34217) #81389

**Description:**
This PR introduces a gritty, high-contrast slider heavily inspired by Cyberpunk UI. It features harsh neon colors, chromatic aberration text-shadows, and a jarring `steps()` transition to simulate digital stutter.

Fixes #81389

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-animated-cyberpunk/`
- Styled the active navigation buttons utilizing a jarring `box-shadow: 4px 4px 0 var(--pink)` hard-shadow aesthetic combined with negative translations
- Forcibly overrode standard smooth easing with `transition: transform 0.1s steps(5, end)` to create a mechanical, glitch-like slide movement
