### PR TITLE
feat: create Animated Carousel with Neumorphism styling (#75749) #81387

### DIFF
--- a/submissions/examples/css-carousel-animated-neumorphism/README.md
+++ b/submissions/examples/css-carousel-animated-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Animated Carousel (Neumorphism)
+A soft-UI physical dial carousel. The slider window acts as a deeply inset circular recess, while the radio indicators physically press into the surface when activated to reveal a blue accent.

--- a/submissions/examples/css-carousel-animated-neumorphism/demo.html
+++ b/submissions/examples/css-carousel-animated-neumorphism/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Animated Carousel</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="nm-carousel">
+        <input type="radio" name="nm-slide" id="nm1" checked>
+        <input type="radio" name="nm-slide" id="nm2">
+        <input type="radio" name="nm-slide" id="nm3">
+        
+        <div class="nm-viewport">
+            <div class="nm-track">
+                <div class="nm-slide"><i class="ph ph-headphones"></i></div>
+                <div class="nm-slide"><i class="ph ph-speaker-hifi"></i></div>
+                <div class="nm-slide"><i class="ph ph-microphone"></i></div>
+            </div>
+        </div>
+        
+        <div class="nm-controls">
+            <label for="nm1"></label>
+            <label for="nm2"></label>
+            <label for="nm3"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-animated-neumorphism/style.css
+++ b/submissions/examples/css-carousel-animated-neumorphism/style.css
@@ -1,0 +1,19 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.nm-carousel { width: 300px; padding: 2rem; border-radius: 30px; background: var(--bg); box-shadow: 12px 12px 24px var(--shadow-dark), -12px -12px 24px var(--shadow-light); display: flex; flex-direction: column; align-items: center; gap: 2rem; }
+input[type="radio"] { display: none; }
+.nm-viewport { width: 200px; height: 200px; border-radius: 50%; background: var(--bg); box-shadow: inset 8px 8px 16px var(--shadow-dark), inset -8px -8px 16px var(--shadow-light); overflow: hidden; position: relative; }
+.nm-track { display: flex; width: 300%; height: 100%; transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1); }
+.nm-slide { width: 33.333%; height: 100%; display: flex; justify-content: center; align-items: center; }
+.nm-slide i { font-size: 5rem; color: var(--text); opacity: 0.5; transition: 0.6s; transform: scale(0.8); }
+#nm1:checked ~ .nm-viewport .nm-track { transform: translateX(0); }
+#nm2:checked ~ .nm-viewport .nm-track { transform: translateX(-33.333%); }
+#nm3:checked ~ .nm-viewport .nm-track { transform: translateX(-66.666%); }
+#nm1:checked ~ .nm-viewport .nm-slide:nth-child(1) i,
+#nm2:checked ~ .nm-viewport .nm-slide:nth-child(2) i,
+#nm3:checked ~ .nm-viewport .nm-slide:nth-child(3) i { color: var(--accent); opacity: 1; transform: scale(1); }
+.nm-controls { display: flex; gap: 1.5rem; }
+.nm-controls label { width: 20px; height: 20px; border-radius: 50%; background: var(--bg); box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); cursor: pointer; transition: 0.3s; }
+#nm1:checked ~ .nm-controls label:nth-child(1),
+#nm2:checked ~ .nm-controls label:nth-child(2),
+#nm3:checked ~ .nm-controls label:nth-child(3) { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); background: var(--accent); }


### PR DESCRIPTION
**Title:** feat: create Animated Carousel with Neumorphism styling (#75749) #81387

**Description:**
This PR introduces a soft-UI physical dial carousel. The slider window acts as a deeply inset circular recess, while the radio indicators physically press into the surface when activated to reveal a blue accent.

Fixes #81387

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-animated-neumorphism/`
- Rendered the primary `.nm-viewport` utilizing extreme `border-radius: 50%` and heavy `inset` shadows to simulate a drilled-out mechanical housing
- Attached an opacity fade and scaling animation (`scale(0.8)` to `scale(1)`) to the icon graphics as they enter the visible inset ring
