### PR TITLE
feat: create Floating Timeline with Claymorphism styling (#41905) #81385

### DIFF
--- a/submissions/examples/css-timeline-floating-claymorphism/README.md
+++ b/submissions/examples/css-timeline-floating-claymorphism/README.md
@@ -1,0 +1,2 @@
+# Floating Timeline (Claymorphism)
+A beautifully soft and fluffy vertical timeline. Every element, including the central connecting line, utilizes complex inner and outer inset shadows to form pill-like 3D clay extrusions.

--- a/submissions/examples/css-timeline-floating-claymorphism/demo.html
+++ b/submissions/examples/css-timeline-floating-claymorphism/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Claymorphism Timeline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="clay-timeline">
+        <div class="clay-node">
+            <div class="clay-marker">1</div>
+            <div class="clay-content">
+                <h3>Ideation</h3>
+                <p>Brainstorming features.</p>
+            </div>
+        </div>
+        <div class="clay-node">
+            <div class="clay-marker">2</div>
+            <div class="clay-content">
+                <h3>Design</h3>
+                <p>Creating soft UI mocks.</p>
+            </div>
+        </div>
+        <div class="clay-node">
+            <div class="clay-marker">3</div>
+            <div class="clay-content">
+                <h3>Deploy</h3>
+                <p>Shipping to production.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-timeline-floating-claymorphism/style.css
+++ b/submissions/examples/css-timeline-floating-claymorphism/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #f4f6f9; --clay: #ffffff; --inner-shadow: rgba(0, 0, 0, 0.08); --outer-shadow: rgba(0, 0, 0, 0.12); --highlight: rgba(255, 255, 255, 1); --accent: #ff7b93; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.clay-timeline { position: relative; padding: 2rem 0; width: 90%; max-width: 400px; display: flex; flex-direction: column; gap: 3rem; }
+.clay-timeline::before { content: ''; position: absolute; left: 24px; top: 0; bottom: 0; width: 8px; background: var(--clay); border-radius: 4px; box-shadow: inset -2px -2px 4px var(--inner-shadow), inset 2px 2px 4px var(--highlight); }
+.clay-node { display: flex; gap: 2rem; position: relative; z-index: 1; align-items: flex-start; }
+.clay-marker { width: 56px; height: 56px; border-radius: 50%; background: var(--clay); display: flex; justify-content: center; align-items: center; font-weight: bold; color: var(--accent); font-size: 1.2rem; flex-shrink: 0; box-shadow: 8px 8px 16px var(--outer-shadow), -8px -8px 16px var(--highlight), inset -4px -4px 8px var(--inner-shadow), inset 4px 4px 8px var(--highlight); transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.clay-content { background: var(--clay); padding: 1.5rem; border-radius: 20px; box-shadow: 12px 12px 24px var(--outer-shadow), -12px -12px 24px var(--highlight), inset -6px -6px 12px var(--inner-shadow), inset 6px 6px 12px var(--highlight); transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.clay-content h3 { margin: 0 0 0.5rem 0; color: #444; }
+.clay-content p { margin: 0; color: #777; font-size: 0.95rem; }
+.clay-node:hover .clay-marker { transform: scale(1.1); }
+.clay-node:hover .clay-content { transform: translateX(10px); }


### PR DESCRIPTION
**Title:** feat: create Floating Timeline with Claymorphism styling (#41905) #81385

**Description:**
This PR introduces a beautifully soft and fluffy vertical timeline. Every element, including the central connecting line, utilizes complex inner and outer inset shadows to form pill-like 3D clay extrusions.

Fixes #81385

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-timeline-floating-claymorphism/`
- Designed the timeline stem utilizing a `::before` pseudo-element styled with `box-shadow: inset -2px -2px 4px var(--inner-shadow)` to look physically stamped into the page
- Applied bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` hover transitions to both the node marker (scaling up) and the content card (shifting right)
