### PR TITLE
feat: create Glowing Timeline with Pastel styling (#94439) #81382

### DIFF
--- a/submissions/examples/css-timeline-glowing-pastel/README.md
+++ b/submissions/examples/css-timeline-glowing-pastel/README.md
@@ -1,0 +1,2 @@
+# Glowing Timeline (Pastel)
+A warm, inviting vertical stepper. Each timeline node casts a soft pastel-colored glow, and hovering over an item expands the glow radius while illuminating the card's border in the corresponding color.

--- a/submissions/examples/css-timeline-glowing-pastel/demo.html
+++ b/submissions/examples/css-timeline-glowing-pastel/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Pastel Timeline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="gp-timeline">
+        <div class="gp-item">
+            <div class="gp-dot pink"></div>
+            <div class="gp-card">
+                <h4>Registration</h4>
+                <p>Welcome to the platform.</p>
+            </div>
+        </div>
+        <div class="gp-item">
+            <div class="gp-dot purple"></div>
+            <div class="gp-card">
+                <h4>Verification</h4>
+                <p>Account identity confirmed.</p>
+            </div>
+        </div>
+        <div class="gp-item">
+            <div class="gp-dot green"></div>
+            <div class="gp-card">
+                <h4>Activated</h4>
+                <p>Ready to go.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-timeline-glowing-pastel/style.css
+++ b/submissions/examples/css-timeline-glowing-pastel/style.css
@@ -1,0 +1,15 @@
+:root { --bg: #faf9f6; --pink: #ffb7b2; --purple: #cbb2fe; --green: #e2f0cb; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.gp-timeline { position: relative; padding: 2rem 0; width: 90%; max-width: 400px; display: flex; flex-direction: column; gap: 2.5rem; border-left: 2px dashed #ddd; margin-left: 20px; }
+.gp-item { position: relative; padding-left: 3rem; }
+.gp-dot { position: absolute; left: -11px; top: 0; width: 20px; height: 20px; border-radius: 50%; background: #fff; z-index: 2; border: 4px solid; transition: 0.3s; }
+.gp-dot.pink { border-color: var(--pink); box-shadow: 0 0 15px var(--pink); }
+.gp-dot.purple { border-color: var(--purple); box-shadow: 0 0 15px var(--purple); }
+.gp-dot.green { border-color: var(--green); box-shadow: 0 0 15px var(--green); }
+.gp-card { background: #fff; padding: 1.5rem; border-radius: 16px; border: 2px solid transparent; box-shadow: 0 10px 30px rgba(0,0,0,0.03); transition: 0.3s; cursor: default; }
+.gp-card h4 { margin: 0 0 0.5rem 0; color: #555; }
+.gp-card p { margin: 0; color: #888; font-size: 0.9rem; }
+.gp-item:hover .gp-dot { transform: scale(1.3); }
+.gp-item:hover .gp-dot.pink ~ .gp-card { border-color: var(--pink); transform: translateX(5px); box-shadow: 0 10px 20px rgba(255, 183, 178, 0.2); }
+.gp-item:hover .gp-dot.purple ~ .gp-card { border-color: var(--purple); transform: translateX(5px); box-shadow: 0 10px 20px rgba(203, 178, 254, 0.2); }
+.gp-item:hover .gp-dot.green ~ .gp-card { border-color: var(--green); transform: translateX(5px); box-shadow: 0 10px 20px rgba(226, 240, 203, 0.2); }


### PR DESCRIPTION
**Title:** feat: create Glowing Timeline with Pastel styling (#94439) #81382

**Description:**
This PR introduces a warm, inviting vertical stepper. Each timeline node casts a soft pastel-colored glow, and hovering over an item expands the glow radius while illuminating the card's border in the corresponding color.

Fixes #81382

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-timeline-glowing-pastel/`
- Colored the `.gp-dot` node markers using a distinct pastel palette (`--pink`, `--purple`, `--green`), rendering the glow utilizing standard outer `box-shadow` diffusion
- Wired the `.gp-card` to respond to the parent `.gp-item:hover` state utilizing the general sibling combinator (`~`), mapping the correct border color glow on interaction
