### PR TITLE
feat: create Responsive Stepper with Neumorphism styling (#79218) #81363

### DIFF
--- a/submissions/examples/css-stepper-responsive-neumorphism/README.md
+++ b/submissions/examples/css-stepper-responsive-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Responsive Stepper (Neumorphism)
+A soft-UI progress stepper. The inactive nodes and container utilize soft outer shadows, while the active node presses into the page using inset shadows. On mobile, the flex layout dynamically pivots to a vertical stepper track.

--- a/submissions/examples/css-stepper-responsive-neumorphism/demo.html
+++ b/submissions/examples/css-stepper-responsive-neumorphism/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Responsive Stepper</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="nm-stepper">
+        <input type="radio" name="nm-step" id="nm-step1" checked>
+        <input type="radio" name="nm-step" id="nm-step2">
+        <input type="radio" name="nm-step" id="nm-step3">
+
+        <div class="nm-progress-bar">
+            <div class="nm-progress-fill"></div>
+        </div>
+
+        <div class="nm-steps-container">
+            <label for="nm-step1" class="nm-step-item">
+                <div class="nm-step-circle"><i class="ph ph-user"></i></div>
+                <span>Account</span>
+            </label>
+            <label for="nm-step2" class="nm-step-item">
+                <div class="nm-step-circle"><i class="ph ph-map-pin"></i></div>
+                <span>Address</span>
+            </label>
+            <label for="nm-step3" class="nm-step-item">
+                <div class="nm-step-circle"><i class="ph ph-credit-card"></i></div>
+                <span>Payment</span>
+            </label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-stepper-responsive-neumorphism/style.css
+++ b/submissions/examples/css-stepper-responsive-neumorphism/style.css
@@ -1,0 +1,28 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.nm-stepper { width: 90%; max-width: 600px; padding: 3rem 2rem; border-radius: 24px; background: var(--bg); box-shadow: 10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light); position: relative; }
+input[type="radio"] { display: none; }
+.nm-progress-bar { position: absolute; top: 4.5rem; left: 15%; width: 70%; height: 8px; border-radius: 4px; background: var(--bg); box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); z-index: 1; }
+.nm-progress-fill { height: 100%; border-radius: 4px; background: var(--accent); width: 0%; transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 0 10px rgba(66, 153, 225, 0.5); }
+.nm-steps-container { display: flex; justify-content: space-between; position: relative; z-index: 2; }
+.nm-step-item { display: flex; flex-direction: column; align-items: center; gap: 1rem; cursor: pointer; width: 33.333%; }
+.nm-step-circle { width: 50px; height: 50px; border-radius: 50%; background: var(--bg); display: flex; justify-content: center; align-items: center; font-size: 1.5rem; color: var(--text); box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: all 0.3s; }
+.nm-step-item span { font-weight: 600; color: #718096; transition: 0.3s; font-size: 0.9rem; }
+#nm-step1:checked ~ .nm-progress-bar .nm-progress-fill { width: 0%; }
+#nm-step2:checked ~ .nm-progress-bar .nm-progress-fill { width: 50%; }
+#nm-step3:checked ~ .nm-progress-bar .nm-progress-fill { width: 100%; }
+#nm-step1:checked ~ .nm-steps-container label:nth-child(1) .nm-step-circle,
+#nm-step2:checked ~ .nm-steps-container label:nth-child(2) .nm-step-circle,
+#nm-step3:checked ~ .nm-steps-container label:nth-child(3) .nm-step-circle { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); color: var(--accent); }
+#nm-step1:checked ~ .nm-steps-container label:nth-child(1) span,
+#nm-step2:checked ~ .nm-steps-container label:nth-child(2) span,
+#nm-step3:checked ~ .nm-steps-container label:nth-child(3) span { color: var(--text); }
+@media (max-width: 480px) {
+    .nm-steps-container { flex-direction: column; align-items: flex-start; gap: 2rem; }
+    .nm-progress-bar { top: 3rem; left: 2rem; width: 8px; height: calc(100% - 6rem); }
+    .nm-progress-fill { width: 100%; height: 0%; transition: height 0.4s; }
+    #nm-step1:checked ~ .nm-progress-bar .nm-progress-fill { height: 0%; }
+    #nm-step2:checked ~ .nm-progress-bar .nm-progress-fill { height: 50%; }
+    #nm-step3:checked ~ .nm-progress-bar .nm-progress-fill { height: 100%; }
+    .nm-step-item { flex-direction: row; width: 100%; }
+}


### PR DESCRIPTION
**Title:** feat: create Responsive Stepper with Neumorphism styling (#79218) #81363

**Description:**
This PR introduces a soft-UI progress stepper. The inactive nodes and container utilize soft outer shadows, while the active node presses into the page using inset shadows. On mobile, the flex layout dynamically pivots to a vertical stepper track.

Fixes #81363

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-stepper-responsive-neumorphism/`
- Designed the stepper nodes utilizing dynamic Neumorphic shadows, where the active `:checked` state flips from `box-shadow` to `inset` shadow to visually press the button
- Implemented a `@media (max-width: 480px)` breakpoint that shifts `.nm-steps-container` to `flex-direction: column` and alters the progress bar to fill vertically
