### PR TITLE
feat: create Responsive Stepper with Minimalist styling (#80732) #81365

### DIFF
--- a/submissions/examples/css-stepper-responsive-minimalist/README.md
+++ b/submissions/examples/css-stepper-responsive-minimalist/README.md
@@ -1,0 +1,2 @@
+# Responsive Stepper (Minimalist)
+A stark, monochrome process tracker. It utilizes hairline borders and absolute contrast between completed and pending states. On mobile viewports, the connecting lines are stripped away entirely in favor of a clean vertical stack.

--- a/submissions/examples/css-stepper-responsive-minimalist/demo.html
+++ b/submissions/examples/css-stepper-responsive-minimalist/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Stepper</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ms-stepper">
+        <input type="radio" name="ms-step" id="ms1" checked>
+        <input type="radio" name="ms-step" id="ms2">
+        <input type="radio" name="ms-step" id="ms3">
+        
+        <div class="ms-nodes">
+            <label for="ms1" class="ms-node">
+                <div class="ms-dot"></div>
+                <span>Details</span>
+            </label>
+            <div class="ms-line"></div>
+            <label for="ms2" class="ms-node">
+                <div class="ms-dot"></div>
+                <span>Shipping</span>
+            </label>
+            <div class="ms-line"></div>
+            <label for="ms3" class="ms-node">
+                <div class="ms-dot"></div>
+                <span>Review</span>
+            </label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-stepper-responsive-minimalist/style.css
+++ b/submissions/examples/css-stepper-responsive-minimalist/style.css
@@ -1,0 +1,22 @@
+:root { --bg: #ffffff; --text: #000000; --gray-light: #e5e5e5; --gray-dark: #666666; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+.ms-stepper { width: 100%; max-width: 500px; padding: 2rem; }
+input[type="radio"] { display: none; }
+.ms-nodes { display: flex; align-items: center; justify-content: space-between; position: relative; }
+.ms-node { display: flex; flex-direction: column; align-items: center; gap: 0.75rem; cursor: pointer; z-index: 2; flex: 1; }
+.ms-dot { width: 12px; height: 12px; border-radius: 50%; background: var(--gray-light); transition: 0.3s; border: 2px solid var(--bg); box-shadow: 0 0 0 1px var(--gray-light); }
+.ms-node span { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 1px; color: var(--gray-dark); transition: 0.3s; }
+.ms-line { flex: 2; height: 1px; background: var(--gray-light); position: relative; top: -14px; z-index: 1; transition: 0.3s; }
+#ms1:checked ~ .ms-nodes label:nth-child(1) .ms-dot,
+#ms2:checked ~ .ms-nodes label:nth-child(3) .ms-dot,
+#ms3:checked ~ .ms-nodes label:nth-child(5) .ms-dot { background: var(--text); box-shadow: 0 0 0 1px var(--text); }
+#ms1:checked ~ .ms-nodes label:nth-child(1) span,
+#ms2:checked ~ .ms-nodes label:nth-child(3) span,
+#ms3:checked ~ .ms-nodes label:nth-child(5) span { color: var(--text); font-weight: bold; }
+#ms2:checked ~ .ms-nodes .ms-line:nth-child(2),
+#ms3:checked ~ .ms-nodes .ms-line { background: var(--text); }
+@media (max-width: 480px) {
+    .ms-nodes { flex-direction: column; align-items: flex-start; gap: 2rem; }
+    .ms-node { flex-direction: row; width: 100%; }
+    .ms-line { display: none; }
+}


### PR DESCRIPTION
**Title:** feat: create Responsive Stepper with Minimalist styling (#80732) #81365

**Description:**
This PR introduces a stark, monochrome process tracker. It utilizes hairline borders and absolute contrast between completed and pending states. On mobile viewports, the connecting lines are stripped away entirely in favor of a clean vertical stack.

Fixes #81365

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-stepper-responsive-minimalist/`
- Bound the active node styles to the `<input type="radio">` state to flip the hairline dot borders from `#e5e5e5` to stark `#000000`
- Utilized CSS sibling combinators (`~`) to conditionally fill the intermediate `.ms-line` tracking bars based on the user's current step
