### PR TITLE
feat: create Floating Stepper with Material Design styling (#71705) #…

### DIFF
--- a/submissions/examples/css-stepper-floating-material-design/README.md
+++ b/submissions/examples/css-stepper-floating-material-design/README.md
@@ -1,0 +1,2 @@
+# Floating Stepper (Material Design)
+A Google Material Design stepper that utilizes Floating Action Buttons (FABs) for its nodes. The active node elevates higher off the page by increasing its drop shadow and physically translating upward.

--- a/submissions/examples/css-stepper-floating-material-design/demo.html
+++ b/submissions/examples/css-stepper-floating-material-design/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Floating Stepper</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="md-stepper">
+        <input type="radio" name="md-step" id="md1" checked>
+        <input type="radio" name="md-step" id="md2">
+        <input type="radio" name="md-step" id="md3">
+
+        <div class="md-track"></div>
+        <div class="md-bar"></div>
+
+        <div class="md-nodes">
+            <label for="md1" class="md-node">
+                <div class="md-fab"><i class="ph ph-shopping-cart"></i></div>
+                <span>Cart</span>
+            </label>
+            <label for="md2" class="md-node">
+                <div class="md-fab"><i class="ph ph-map-pin"></i></div>
+                <span>Delivery</span>
+            </label>
+            <label for="md3" class="md-node">
+                <div class="md-fab"><i class="ph ph-check-circle"></i></div>
+                <span>Confirm</span>
+            </label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-stepper-floating-material-design/style.css
+++ b/submissions/examples/css-stepper-floating-material-design/style.css
@@ -1,0 +1,19 @@
+:root { --bg: #f5f5f5; --primary: #6200ea; --surface: #ffffff; --text: #333; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; }
+.md-stepper { width: 100%; max-width: 600px; padding: 2rem; position: relative; }
+input[type="radio"] { display: none; }
+.md-track { position: absolute; top: 46px; left: 15%; width: 70%; height: 4px; background: #e0e0e0; z-index: 1; }
+.md-bar { position: absolute; top: 46px; left: 15%; width: 0%; height: 4px; background: var(--primary); z-index: 2; transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.md-nodes { display: flex; justify-content: space-between; position: relative; z-index: 3; }
+.md-node { display: flex; flex-direction: column; align-items: center; gap: 1rem; cursor: pointer; width: 33.333%; }
+.md-fab { width: 56px; height: 56px; border-radius: 50%; background: var(--surface); color: #9e9e9e; display: flex; justify-content: center; align-items: center; font-size: 1.5rem; box-shadow: 0 3px 5px -1px rgba(0,0,0,0.2), 0 6px 10px 0 rgba(0,0,0,0.14), 0 1px 18px 0 rgba(0,0,0,0.12); transition: all 0.3s; }
+.md-node span { font-weight: 500; color: #757575; transition: 0.3s; }
+#md1:checked ~ .md-bar { width: 0%; }
+#md2:checked ~ .md-bar { width: 50%; }
+#md3:checked ~ .md-bar { width: 100%; }
+#md1:checked ~ .md-nodes label:nth-child(1) .md-fab,
+#md2:checked ~ .md-nodes label:nth-child(2) .md-fab,
+#md3:checked ~ .md-nodes label:nth-child(3) .md-fab { background: var(--primary); color: #fff; transform: translateY(-4px); box-shadow: 0 5px 5px -3px rgba(0,0,0,0.2), 0 8px 10px 1px rgba(0,0,0,0.14), 0 3px 14px 2px rgba(0,0,0,0.12); }
+#md1:checked ~ .md-nodes label:nth-child(1) span,
+#md2:checked ~ .md-nodes label:nth-child(2) span,
+#md3:checked ~ .md-nodes label:nth-child(3) span { color: var(--primary); }


### PR DESCRIPTION
**Title:** feat: create Floating Stepper with Material Design styling (#71705) #81366

**Description:**
This PR introduces a Google Material Design stepper that utilizes Floating Action Buttons (FABs) for its nodes. The active node elevates higher off the page by increasing its drop shadow and physically translating upward.

Fixes #81366

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-stepper-floating-material-design/`
- Rendered the `.md-fab` nodes utilizing standard Google Material `box-shadow` elevation metrics
- Triggered a `transform: translateY(-4px)` alongside an intensified shadow on the active node to simulate physical Z-axis elevation
