### PR TITLE
feat: create Dynamic Drawer with Cyberpunk styling (#75332) #81415

### DIFF
--- a/submissions/examples/css-drawer-dynamic-cyberpunk/README.md
+++ b/submissions/examples/css-drawer-dynamic-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Dynamic Drawer (Cyberpunk)
+A gritty, high-tech side drawer. It utilizes sharp geometry, jarring `steps()` entrance animations, and high-contrast neon colors to emulate a retro-futuristic terminal interface.

--- a/submissions/examples/css-drawer-dynamic-cyberpunk/demo.html
+++ b/submissions/examples/css-drawer-dynamic-cyberpunk/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Drawer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <input type="checkbox" id="cp-drawer-toggle" class="cp-toggle">
+    <div class="cp-layout">
+        <label for="cp-drawer-toggle" class="cp-btn">ACCESS SYS_DRAWER</label>
+        <p class="cp-text">Awaiting input...</p>
+    </div>
+    
+    <div class="cp-drawer">
+        <div class="cp-header">
+            <h2>SYS_MENU_v3.4</h2>
+            <label for="cp-drawer-toggle" class="cp-close">TERMINATE</label>
+        </div>
+        <div class="cp-content">
+            <a href="#">[01] DATABASE</a>
+            <a href="#">[02] UPLINK</a>
+            <a href="#">[03] OVERRIDE</a>
+            <a href="#">[04] EXIT</a>
+        </div>
+    </div>
+    <label for="cp-drawer-toggle" class="cp-overlay"></label>
+</body>
+</html>

--- a/submissions/examples/css-drawer-dynamic-cyberpunk/style.css
+++ b/submissions/examples/css-drawer-dynamic-cyberpunk/style.css
@@ -1,0 +1,17 @@
+:root { --bg: #09090b; --yellow: #fcee0a; --cyan: #00f0ff; --pink: #ff003c; }
+body { background: var(--bg); margin: 0; font-family: 'Courier New', monospace; color: #fff; overflow-x: hidden; }
+.cp-toggle { display: none; }
+.cp-layout { padding: 2rem; }
+.cp-btn { display: inline-block; padding: 1rem 2rem; background: var(--yellow); color: #000; font-weight: bold; font-size: 1.1rem; cursor: pointer; border: none; position: relative; letter-spacing: 2px; }
+.cp-btn::after { content: ''; position: absolute; top: 0; right: -20px; border-width: 20px 0 20px 20px; border-style: solid; border-color: transparent transparent transparent var(--yellow); }
+.cp-text { margin-top: 2rem; color: var(--cyan); letter-spacing: 1px; }
+.cp-overlay { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.8); opacity: 0; pointer-events: none; transition: 0s; z-index: 10; backdrop-filter: blur(2px); }
+.cp-drawer { position: fixed; top: 0; left: -400px; width: 350px; height: 100vh; background: #000; border-right: 4px solid var(--cyan); z-index: 20; transition: left 0.2s steps(8, end); padding: 2rem; box-sizing: border-box; box-shadow: 10px 0 30px rgba(0, 240, 255, 0.2); }
+.cp-header { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 2px solid var(--pink); padding-bottom: 1rem; margin-bottom: 2rem; }
+.cp-header h2 { margin: 0; color: var(--yellow); font-size: 1.2rem; letter-spacing: 2px; }
+.cp-close { color: var(--pink); cursor: pointer; font-size: 0.9rem; font-weight: bold; background: rgba(255, 0, 60, 0.1); padding: 0.25rem 0.5rem; border: 1px solid var(--pink); }
+.cp-close:hover { background: var(--pink); color: #000; }
+.cp-content a { display: block; color: var(--cyan); text-decoration: none; padding: 1rem; margin-bottom: 0.5rem; border-left: 2px solid transparent; transition: 0s; font-weight: bold; font-size: 1.1rem; }
+.cp-content a:hover { background: rgba(0, 240, 255, 0.1); border-left-color: var(--yellow); color: #fff; padding-left: 1.5rem; }
+.cp-toggle:checked ~ .cp-drawer { left: 0; }
+.cp-toggle:checked ~ .cp-overlay { opacity: 1; pointer-events: auto; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Drawer with Cyberpunk styling (#75332) #81415

**Description:**
This PR introduces a gritty, high-tech side drawer. It utilizes sharp geometry, jarring `steps()` entrance animations, and high-contrast neon colors to emulate a retro-futuristic terminal interface.

Fixes #81415

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-drawer-dynamic-cyberpunk/`
- Rendered the primary trigger button utilizing a clipped corner effect generated via a transparent `::after` border hack
- Attached a jarring `transition: left 0.2s steps(8, end)` to the drawer panel to simulate a low-framerate mechanical opening sequence
