### PR TITLE
feat: create Dynamic Drawer with Neumorphism styling (#87024) #81414

### DIFF
--- a/submissions/examples/css-drawer-dynamic-neumorphism/README.md
+++ b/submissions/examples/css-drawer-dynamic-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Dynamic Drawer (Neumorphism)
+A soft-UI extruded side navigation drawer. The drawer panel itself, the close button, and the hovered navigation links all utilize combinations of inner and outer Neumorphic shadows to simulate physical depth.

--- a/submissions/examples/css-drawer-dynamic-neumorphism/demo.html
+++ b/submissions/examples/css-drawer-dynamic-neumorphism/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Dynamic Drawer</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <input type="checkbox" id="nm-drawer-toggle" class="nm-toggle">
+    <div class="nm-layout">
+        <label for="nm-drawer-toggle" class="nm-btn"><i class="ph ph-list"></i> Menu</label>
+        <p>Soft UI environment.</p>
+    </div>
+    
+    <div class="nm-drawer">
+        <div class="nm-header">
+            <h3>Navigation</h3>
+            <label for="nm-drawer-toggle" class="nm-close-btn"><i class="ph ph-x"></i></label>
+        </div>
+        <div class="nm-content">
+            <a href="#"><i class="ph ph-house"></i> Home</a>
+            <a href="#"><i class="ph ph-magnifying-glass"></i> Search</a>
+            <a href="#"><i class="ph ph-bell"></i> Notifications</a>
+            <a href="#"><i class="ph ph-gear"></i> Settings</a>
+        </div>
+    </div>
+    <label for="nm-drawer-toggle" class="nm-overlay"></label>
+</body>
+</html>

--- a/submissions/examples/css-drawer-dynamic-neumorphism/style.css
+++ b/submissions/examples/css-drawer-dynamic-neumorphism/style.css
@@ -1,0 +1,18 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); margin: 0; font-family: system-ui, sans-serif; color: var(--text); overflow-x: hidden; }
+.nm-toggle { display: none; }
+.nm-layout { padding: 2rem; }
+.nm-btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 1.5rem; background: var(--bg); color: var(--text); font-weight: 600; border-radius: 12px; cursor: pointer; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: 0.3s; }
+.nm-btn:active { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); }
+.nm-overlay { position: fixed; inset: 0; background: rgba(224, 229, 236, 0.7); opacity: 0; pointer-events: none; transition: opacity 0.4s; z-index: 10; backdrop-filter: blur(4px); }
+.nm-drawer { position: fixed; top: 0; left: -320px; width: 300px; height: 100vh; background: var(--bg); z-index: 20; transition: left 0.4s cubic-bezier(0.16, 1, 0.3, 1); padding: 2rem; box-sizing: border-box; box-shadow: 15px 0 30px rgba(163, 177, 198, 0.4); border-top-right-radius: 30px; border-bottom-right-radius: 30px; }
+.nm-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 3rem; }
+.nm-header h3 { margin: 0; color: var(--text); }
+.nm-close-btn { width: 40px; height: 40px; border-radius: 50%; display: flex; justify-content: center; align-items: center; background: var(--bg); box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); cursor: pointer; transition: 0.3s; }
+.nm-close-btn:active { box-shadow: inset 2px 2px 4px var(--shadow-dark), inset -2px -2px 4px var(--shadow-light); }
+.nm-content { display: flex; flex-direction: column; gap: 1.5rem; }
+.nm-content a { display: flex; align-items: center; gap: 1rem; padding: 1rem; text-decoration: none; color: #718096; font-weight: 500; border-radius: 16px; transition: 0.3s; }
+.nm-content a:hover { background: var(--bg); box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); color: var(--accent); }
+.nm-content a i { font-size: 1.25rem; }
+.nm-toggle:checked ~ .nm-drawer { left: 0; }
+.nm-toggle:checked ~ .nm-overlay { opacity: 1; pointer-events: auto; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Drawer with Neumorphism styling (#87024) #81414

**Description:**
This PR introduces a soft-UI extruded side navigation drawer. The drawer panel itself, the close button, and the hovered navigation links all utilize combinations of inner and outer Neumorphic shadows to simulate physical depth.

Fixes #81414

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-drawer-dynamic-neumorphism/`
- Designed the drawer surface incorporating a massive `15px` box shadow to separate it from the soft background, coupled with large rounded right-side corners
- Wired the navigation links and the close button to physically press into the surface on `:hover` and `:active` utilizing inverted `inset` shadows
