### PR TITLE
feat: create Dynamic Popover with Retro Pixel styling (#53238) #81406

### DIFF
--- a/submissions/examples/css-popover-dynamic-retro-pixel/README.md
+++ b/submissions/examples/css-popover-dynamic-retro-pixel/README.md
@@ -1,0 +1,2 @@
+# Dynamic Popover (Retro Pixel)
+A chunky 8-bit popover menu. The UI utilizes thick solid borders, hard drop shadows (`6px 6px 0 rgba(0,0,0,0.5)`), and a jagged `steps()` animation curve to replicate classic video game aesthetics.

--- a/submissions/examples/css-popover-dynamic-retro-pixel/demo.html
+++ b/submissions/examples/css-popover-dynamic-retro-pixel/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Pixel Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="rp-popover-container">
+        <button class="rp-btn">OPTIONS</button>
+        <div class="rp-popover">
+            <div class="rp-menu">
+                <a href="#">> SAVE GAME</a>
+                <a href="#">> LOAD GAME</a>
+                <a href="#">> SETTINGS</a>
+                <a href="#">> QUIT</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-dynamic-retro-pixel/style.css
+++ b/submissions/examples/css-popover-dynamic-retro-pixel/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #222222; --pixel-color: #f8f9fa; --border-color: #000; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Press Start 2P', monospace; }
+.rp-popover-container { position: relative; display: inline-block; }
+.rp-btn { padding: 1rem 1.5rem; background: var(--pixel-color); border: 4px solid var(--border-color); color: var(--border-color); font-family: inherit; font-size: 1rem; cursor: pointer; box-shadow: 4px 4px 0 rgba(0,0,0,0.5); transition: 0.1s; }
+.rp-btn:active { transform: translate(4px, 4px); box-shadow: none; }
+.rp-popover { position: absolute; top: calc(100% + 10px); left: 0; background: var(--pixel-color); border: 4px solid var(--border-color); width: 220px; opacity: 0; visibility: hidden; transform: translateY(-10px); transition: transform 0.2s steps(4, end), opacity 0.2s steps(4, end); z-index: 10; box-shadow: 6px 6px 0 rgba(0,0,0,0.5); }
+.rp-menu { display: flex; flex-direction: column; }
+.rp-menu a { padding: 1rem; color: var(--border-color); text-decoration: none; font-size: 0.85rem; border-bottom: 4px dashed #ccc; transition: 0s; }
+.rp-menu a:last-child { border-bottom: none; }
+.rp-menu a:hover { background: var(--border-color); color: var(--pixel-color); padding-left: 1.5rem; }
+.rp-popover-container:focus-within .rp-popover { opacity: 1; visibility: visible; transform: translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Dynamic Popover with Retro Pixel styling (#53238) #81406

**Description:**
This PR introduces a chunky 8-bit popover menu. The UI utilizes thick solid borders, hard drop shadows (`6px 6px 0 rgba(0,0,0,0.5)`), and a jagged `steps()` animation curve to replicate classic video game aesthetics.

Fixes #81406

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-dynamic-retro-pixel/`
- Styled the popover trigger utilizing a thick `4px solid #000` border paired with an un-blurred drop shadow that translates physically down and right when clicked
- Applied a low-framerate `steps(4, end)` curve to both the opacity fade and the Y-axis translation during the `:focus-within` popover reveal
