### PR TITLE
feat: create Floating Popover with Minimalist styling (#57300) #81403

### DIFF
--- a/submissions/examples/css-popover-floating-minimalist/README.md
+++ b/submissions/examples/css-popover-floating-minimalist/README.md
@@ -1,0 +1,2 @@
+# Floating Popover (Minimalist)
+A stark, ultra-clean popover. It drops heavy styling in favor of thin 1px borders, subtle soft shadows, and clean monochromatic typography. Uses `:focus-within` for seamless pure CSS toggling.

--- a/submissions/examples/css-popover-floating-minimalist/demo.html
+++ b/submissions/examples/css-popover-floating-minimalist/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Floating Popover</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="mf-popover-container">
+        <button class="mf-btn">More Options</button>
+        <div class="mf-popover">
+            <a href="#">Edit Profile</a>
+            <a href="#">Privacy Settings</a>
+            <div class="mf-divider"></div>
+            <a href="#" class="mf-danger">Delete Account</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-floating-minimalist/style.css
+++ b/submissions/examples/css-popover-floating-minimalist/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #ffffff; --text: #111111; --gray: #f5f5f5; --border: #eaeaea; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+.mf-popover-container { position: relative; }
+.mf-btn { padding: 0.5rem 1rem; background: transparent; border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.9rem; font-weight: 500; cursor: pointer; transition: 0.2s; }
+.mf-btn:hover { background: var(--gray); }
+.mf-popover { position: absolute; top: calc(100% + 12px); left: 50%; transform: translateX(-50%) translateY(8px); background: #fff; border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 12px 24px -6px rgba(0,0,0,0.08); width: 200px; padding: 0.5rem; opacity: 0; visibility: hidden; transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1); z-index: 10; }
+.mf-popover a { display: block; padding: 0.6rem 0.75rem; color: #444; text-decoration: none; font-size: 0.9rem; border-radius: 6px; transition: 0.2s; }
+.mf-popover a:hover { background: var(--gray); color: var(--text); }
+.mf-popover a.mf-danger { color: #dc2626; }
+.mf-popover a.mf-danger:hover { background: #fef2f2; }
+.mf-divider { height: 1px; background: var(--border); margin: 0.4rem 0; }
+.mf-popover-container:focus-within .mf-popover { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
**Title:** feat: create Floating Popover with Minimalist styling (#57300) #81403

**Description:**
This PR introduces a stark, ultra-clean popover. It drops heavy styling in favor of thin 1px borders, subtle soft shadows, and clean monochromatic typography. Uses `:focus-within` for seamless pure CSS toggling.

Fixes #81403

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-floating-minimalist/`
- Stripped away unnecessary borders in favor of a faint `1px solid #eaeaea` line bounding the popover, relying entirely on a deeply blurred shadow for elevation mapping
- Designed a distinct semantic `mf-danger` link state that highlights red upon hover for destructive actions
