### PR TITLE
a11y(modal): focus-trap audit submission (validation)

### DIFF
--- a/submissions/examples/modal-focus-trap-vt-sb/README.md
+++ b/submissions/examples/modal-focus-trap-vt-sb/README.md
@@ -1,0 +1,30 @@
+# Modal Focus Trap Audit (validation)
+
+## What does it do?
+Wraps a real modal dialog and validates the focus-trap invariants: `role=dialog` + `aria-modal=true`, Tab cycles within focusables (last→first, first→last), Escape closes, focus moves into the dialog on open and back to the trigger on close. Exposes `report()` + `isCompliant()`.
+
+## How is it used?
+```javascript
+import { ModalAudit } from './script.js';
+const a = new ModalAudit(document.getElementById('modal'), { trigger: document.getElementById('open') });
+a.open(); a.close(); a.report(); a.isCompliant(); a.destroy();
+```
+
+## Why is it useful?
+A focus trap prevents keyboard users from tabbing out of the dialog into the hidden page. The audit report makes the ARIA-dialog invariants programmatically verifiable (axe-core-style).
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/modal-focus-trap-vt-sb/modal.test.js
+```
+- **Happy path**: role=dialog + aria-modal; open sets aria-hidden=false + focus; Escape closes.
+- **Edge cases**: Tab wraps last→first; Shift+Tab wraps first→last; close restores focus; trigger opens; report compliant; report flags missing role.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (overlay), JavaScript (focus trap + audit report), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, Tab around, press Escape.
+
+Closes #81887

--- a/submissions/examples/modal-focus-trap-vt-sb/demo.html
+++ b/submissions/examples/modal-focus-trap-vt-sb/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Modal Focus Trap Audit</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="open">Open modal</button>
+    <div id="modal" class="ease-modal-audit">
+      <div class="ease-modal-audit__dialog" tabindex="-1">
+        <p>Focus is trapped here.</p>
+        <button id="close">Close</button>
+        <label>Name <input id="field" /></label>
+      </div>
+    </div>
+    <pre id="report"></pre>
+    <script type="module">
+      import { ModalAudit } from './script.js';
+      const a = new ModalAudit(document.getElementById('modal'), { trigger: document.getElementById('open') });
+      document.getElementById('close').addEventListener('click', () => a.close());
+      const render = () => { document.getElementById('report').textContent = JSON.stringify(a.report(), null, 2); };
+      a.open(); render();
+      window.__modalAudit = a;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/modal-focus-trap-vt-sb/modal.test.js
+++ b/submissions/examples/modal-focus-trap-vt-sb/modal.test.js
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ModalAudit } from './script.js';
+
+describe('Modal Focus Trap Audit (validation)', () => {
+  let root, trigger;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.innerHTML = '<button id="close">Close</button><input id="field" />';
+    trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    document.body.appendChild(root);
+  });
+
+  function keydown(key, shiftKey = false) {
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key, shiftKey, bubbles: true }));
+  }
+
+  it('sets role=dialog + aria-modal=true, hidden initially', () => {
+    const a = new ModalAudit(root);
+    expect(root.getAttribute('role')).toBe('dialog');
+    expect(root.getAttribute('aria-modal')).toBe('true');
+    expect(root.hasAttribute('hidden')).toBe(true);
+    a.destroy();
+  });
+
+  it('open() sets aria-hidden=false and moves focus to first focusable', () => {
+    const a = new ModalAudit(root);
+    const spy = vi.spyOn(document.getElementById('close'), 'focus');
+    a.open();
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('Escape closes', () => {
+    const a = new ModalAudit(root);
+    a.open();
+    keydown('Escape');
+    expect(a.isOpen()).toBe(false);
+    a.destroy();
+  });
+
+  it('Tab on last focusable wraps to first', () => {
+    const a = new ModalAudit(root);
+    a.open();
+    document.getElementById('field').focus();
+    const spy = vi.spyOn(document.getElementById('close'), 'focus');
+    keydown('Tab');
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('Shift+Tab on first focusable wraps to last', () => {
+    const a = new ModalAudit(root);
+    a.open();
+    document.getElementById('close').focus();
+    const spy = vi.spyOn(document.getElementById('field'), 'focus');
+    keydown('Tab', true);
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('close() restores focus to the saved element', () => {
+    const a = new ModalAudit(root, { trigger });
+    trigger.focus();
+    a.open();
+    const spy = vi.spyOn(trigger, 'focus');
+    a.close();
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('trigger click opens', () => {
+    const a = new ModalAudit(root, { trigger });
+    trigger.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(a.isOpen()).toBe(true);
+    a.destroy();
+  });
+
+  it('report() is compliant for a well-formed open modal', () => {
+    const a = new ModalAudit(root);
+    a.open();
+    expect(a.isCompliant()).toBe(true);
+    a.destroy();
+  });
+
+  it('report flags a modal missing role=dialog', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<button>x</button>';
+    document.body.appendChild(div);
+    const a = new ModalAudit(div);
+    div.removeAttribute('role');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const a = new ModalAudit(root);
+    expect(() => a.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new ModalAudit(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/modal-focus-trap-vt-sb/script.js
+++ b/submissions/examples/modal-focus-trap-vt-sb/script.js
@@ -1,0 +1,116 @@
+/**
+ * EaseMotion CSS — Modal Focus Trap Audit (validation)
+ * ============================================================
+ * Wraps a real modal dialog and validates the focus-trap invariants:
+ *   - root has role=dialog + aria-modal=true
+ *   - while open, Tab cycles within focusables (last→first, first→last)
+ *   - Escape closes
+ *   - focus moves into the dialog on open and back to the trigger on close
+ * Exposes report() + isCompliant().
+ *
+ * API:
+ *   const a = new ModalAudit(rootEl, { trigger });
+ *   a.open(); a.close(); a.report(); a.isCompliant(); a.destroy();
+ * ============================================================ */
+
+export class ModalAudit {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('ModalAudit requires a root element');
+    }
+    this.root = root;
+    this.trigger = options.trigger || null;
+    this._open = false;
+    this._savedFocus = null;
+
+    this.root.setAttribute('role', 'dialog');
+    this.root.setAttribute('aria-modal', 'true');
+    this.root.setAttribute('hidden', '');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.root.classList.add('ease-modal-audit');
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onTrigger = this._onTrigger.bind(this);
+    document.addEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.addEventListener('click', this._onTrigger);
+  }
+
+  _focusables() {
+    return Array.from(
+      this.root.querySelectorAll(
+        'a[href],button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])',
+      ),
+    );
+  }
+
+  open() {
+    if (this._open) return false;
+    this._open = true;
+    this._savedFocus = document.activeElement;
+    this.root.removeAttribute('hidden');
+    this.root.setAttribute('aria-hidden', 'false');
+    const f = this._focusables();
+    if (f.length) f[0].focus();
+    return true;
+  }
+
+  close() {
+    if (!this._open) return false;
+    this._open = false;
+    this.root.setAttribute('hidden', '');
+    this.root.setAttribute('aria-hidden', 'true');
+    if (this._savedFocus) this._savedFocus.focus();
+    return true;
+  }
+
+  isOpen() {
+    return this._open;
+  }
+
+  _onKeydown(event) {
+    if (!this._open) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+    if (event.key === 'Tab') {
+      const f = this._focusables();
+      if (!f.length) { event.preventDefault(); return; }
+      const first = f[0];
+      const last = f[f.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) { event.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { event.preventDefault(); first.focus(); }
+      }
+    }
+  }
+
+  _onTrigger() {
+    this.open();
+  }
+
+  report() {
+    const role = this.root.getAttribute('role');
+    const ariaModal = this.root.getAttribute('aria-modal');
+    const ariaHidden = this.root.getAttribute('aria-hidden');
+    const violations = [];
+    if (role !== 'dialog') violations.push({ id: 'aria-role', impact: 'critical' });
+    if (ariaModal !== 'true') violations.push({ id: 'aria-modal', impact: 'critical' });
+    if (this._open && ariaHidden === 'true') violations.push({ id: 'aria-hidden-open', impact: 'serious' });
+    if (this._open && this._focusables().length === 0) violations.push({ id: 'no-focusables', impact: 'serious' });
+    return { role, ariaModal, ariaHidden, open: this._open, violations, pass: violations.length === 0 };
+  }
+
+  isCompliant() {
+    return this.report().pass;
+  }
+
+  destroy() {
+    document.removeEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.removeEventListener('click', this._onTrigger);
+  }
+}
+
+export default ModalAudit;

--- a/submissions/examples/modal-focus-trap-vt-sb/style.css
+++ b/submissions/examples/modal-focus-trap-vt-sb/style.css
@@ -1,0 +1,28 @@
+/* ============================================================
+   EaseMotion CSS — Modal Focus Trap Audit (validation)
+   ============================================================ */
+
+.ease-modal-audit[hidden] { display: none !important; }
+
+.ease-modal-audit {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+}
+
+.ease-modal-audit__dialog {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 32rem;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+}
+
+.ease-modal-audit__dialog:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Modal Component Focus Trap Audit (validation test)** accessibility audit (closes #81887). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/modal-focus-trap-vt-sb/`:
- **`script.js`** — `ModalAudit`: validates modal focus-trap invariants: `role=dialog` + `aria-modal=true`, Tab cycling within focusables (last→first, first→last), Escape close, focus moves in on open and back to the trigger on close. Exposes an axe-core-style `report()` + `isCompliant()`.
- **`modal.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/modal-focus-trap-vt-sb/modal.test.js
 ✓ modal.test.js (11 tests)
```
- **Happy path**: role=dialog + aria-modal; open sets aria-hidden=false + focus; Escape closes.
- **Edge cases**: Tab wraps last→first; Shift+Tab wraps first→last; close restores focus; trigger opens; report compliant; report flags missing role.
- **Invalid inputs**: throws without root element.

Closes #81887

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._