### PR TITLE
a11y(drawer): escape-key audit submission (validation)

### DIFF
--- a/submissions/examples/drawer-escape-key-vt-sb/README.md
+++ b/submissions/examples/drawer-escape-key-vt-sb/README.md
@@ -1,0 +1,30 @@
+# Drawer Escape Key Audit (validation)
+
+## What does it do?
+Wraps a real slide-in drawer and validates the escape-key invariants: `role=dialog` + `aria-modal=true` while open, `aria-hidden` sync, Escape closes only when open, and focus returns to the trigger on close. Exposes `report()` + `isCompliant()`.
+
+## How is it used?
+```javascript
+import { DrawerAudit } from './script.js';
+const a = new DrawerAudit(document.getElementById('drawer'), { trigger: document.getElementById('open') });
+a.open(); a.close(); a.toggle(); a.report(); a.isCompliant(); a.destroy();
+```
+
+## Why is it useful?
+Drawers are dialogs, so they need the ARIA dialog semantics and an Escape handler. The audit report makes the invariants programmatically verifiable (axe-core-style).
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/drawer-escape-key-vt-sb/drawer.test.js
+```
+- **Happy path**: starts hidden; role=dialog + aria-modal; open/close toggle aria-hidden.
+- **Edge cases**: Escape closes only when open; close restores focus; trigger opens; toggle; report compliant; report flags missing role.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (drawer overlay), JavaScript (escape key + audit report), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click Open, press Escape.
+
+Closes #81889

--- a/submissions/examples/drawer-escape-key-vt-sb/demo.html
+++ b/submissions/examples/drawer-escape-key-vt-sb/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Drawer Escape Key Audit</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="open">Open drawer</button>
+    <aside id="drawer" tabindex="-1">
+      <p>Press Escape to close.</p>
+      <button id="close-btn">Close</button>
+    </aside>
+    <pre id="report"></pre>
+    <script type="module">
+      import { DrawerAudit } from './script.js';
+      const a = new DrawerAudit(document.getElementById('drawer'), { trigger: document.getElementById('open') });
+      document.getElementById('close-btn').addEventListener('click', () => a.close());
+      const render = () => { document.getElementById('report').textContent = JSON.stringify(a.report(), null, 2); };
+      render();
+      window.__drawerAudit = a;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/drawer-escape-key-vt-sb/drawer.test.js
+++ b/submissions/examples/drawer-escape-key-vt-sb/drawer.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DrawerAudit } from './script.js';
+
+describe('Drawer Escape Key Audit (validation)', () => {
+  let root, trigger;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('aside');
+    root.innerHTML = '<button>Close</button>';
+    trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    document.body.appendChild(root);
+  });
+
+  function keydown(key) {
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('starts hidden with role=dialog + aria-modal=true + aria-hidden=true', () => {
+    const a = new DrawerAudit(root);
+    expect(root.getAttribute('role')).toBe('dialog');
+    expect(root.getAttribute('aria-modal')).toBe('true');
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(a.isOpen()).toBe(false);
+    a.destroy();
+  });
+
+  it('open() toggles aria-hidden to false', () => {
+    const a = new DrawerAudit(root);
+    a.open();
+    expect(a.isOpen()).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    a.destroy();
+  });
+
+  it('close() toggles aria-hidden back to true', () => {
+    const a = new DrawerAudit(root);
+    a.open();
+    a.close();
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    a.destroy();
+  });
+
+  it('Escape closes only when open', () => {
+    const a = new DrawerAudit(root);
+    keydown('Escape');
+    expect(a.isOpen()).toBe(false);
+    a.open();
+    keydown('Escape');
+    expect(a.isOpen()).toBe(false);
+    a.destroy();
+  });
+
+  it('close() returns focus to the trigger', () => {
+    const a = new DrawerAudit(root, { trigger });
+    const spy = vi.spyOn(trigger, 'focus');
+    a.open();
+    a.close();
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('trigger click opens the drawer', () => {
+    const a = new DrawerAudit(root, { trigger });
+    trigger.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(a.isOpen()).toBe(true);
+    a.destroy();
+  });
+
+  it('toggle() flips state', () => {
+    const a = new DrawerAudit(root);
+    a.toggle();
+    expect(a.isOpen()).toBe(true);
+    a.toggle();
+    expect(a.isOpen()).toBe(false);
+    a.destroy();
+  });
+
+  it('report() is compliant when closed and open', () => {
+    const a = new DrawerAudit(root);
+    expect(a.isCompliant()).toBe(true);
+    a.open();
+    expect(a.isCompliant()).toBe(true);
+    a.destroy();
+  });
+
+  it('report() flags missing role', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const a = new DrawerAudit(div);
+    div.removeAttribute('role');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const a = new DrawerAudit(root);
+    expect(() => a.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new DrawerAudit(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/drawer-escape-key-vt-sb/script.js
+++ b/submissions/examples/drawer-escape-key-vt-sb/script.js
@@ -1,0 +1,96 @@
+/**
+ * EaseMotion CSS — Drawer Escape Key Audit (validation)
+ * ============================================================
+ * Wraps a real slide-in drawer and validates the escape-key invariants:
+ *   - role=dialog + aria-modal=true while open
+ *   - Escape closes the drawer
+ *   - focus returns to the trigger on close
+ * Exposes report() + isCompliant().
+ *
+ * API:
+ *   const a = new DrawerAudit(rootEl, { trigger });
+ *   a.open(); a.close(); a.toggle(); a.isOpen(); a.report(); a.destroy();
+ * ============================================================ */
+
+export class DrawerAudit {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('DrawerAudit requires a root element');
+    }
+    this.root = root;
+    this.trigger = options.trigger || null;
+    this._open = false;
+
+    this.root.setAttribute('role', 'dialog');
+    this.root.setAttribute('aria-modal', 'true');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.root.setAttribute('hidden', '');
+    this.root.classList.add('ease-drawer-audit');
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onTrigger = this._onTrigger.bind(this);
+    document.addEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.addEventListener('click', this._onTrigger);
+  }
+
+  open() {
+    if (this._open) return false;
+    this._open = true;
+    this.root.removeAttribute('hidden');
+    this.root.setAttribute('aria-hidden', 'false');
+    const focusable = this.root.querySelector('[autofocus],button,input,a,[tabindex]');
+    if (focusable && typeof focusable.focus === 'function') focusable.focus();
+    return true;
+  }
+
+  close() {
+    if (!this._open) return false;
+    this._open = false;
+    this.root.setAttribute('hidden', '');
+    this.root.setAttribute('aria-hidden', 'true');
+    if (this.trigger && typeof this.trigger.focus === 'function') this.trigger.focus();
+    return true;
+  }
+
+  toggle() {
+    return this._open ? this.close() : this.open();
+  }
+
+  isOpen() {
+    return this._open;
+  }
+
+  _onKeydown(event) {
+    if (this._open && event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+    }
+  }
+
+  _onTrigger() {
+    this.open();
+  }
+
+  report() {
+    const role = this.root.getAttribute('role');
+    const ariaModal = this.root.getAttribute('aria-modal');
+    const ariaHidden = this.root.getAttribute('aria-hidden');
+    const violations = [];
+    if (role !== 'dialog') violations.push({ id: 'aria-role', impact: 'critical' });
+    if (ariaModal !== 'true') violations.push({ id: 'aria-modal', impact: 'critical' });
+    if (this._open && ariaHidden !== 'false') violations.push({ id: 'aria-hidden-open', impact: 'serious' });
+    if (!this._open && ariaHidden !== 'true') violations.push({ id: 'aria-hidden-closed', impact: 'serious' });
+    return { role, ariaModal, ariaHidden, open: this._open, violations, pass: violations.length === 0 };
+  }
+
+  isCompliant() {
+    return this.report().pass;
+  }
+
+  destroy() {
+    document.removeEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.removeEventListener('click', this._onTrigger);
+  }
+}
+
+export default DrawerAudit;

--- a/submissions/examples/drawer-escape-key-vt-sb/style.css
+++ b/submissions/examples/drawer-escape-key-vt-sb/style.css
@@ -1,0 +1,22 @@
+/* ============================================================
+   EaseMotion CSS — Drawer Escape Key Audit (validation)
+   ============================================================ */
+
+.ease-drawer-audit[hidden] { display: none !important; }
+
+.ease-drawer-audit {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(80vw, 24rem);
+  background: #fff;
+  box-shadow: -0.5rem 0 2rem rgba(0, 0, 0, 0.2);
+  z-index: 110;
+  padding: 1.5rem;
+}
+
+.ease-drawer-audit:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: -3px;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Drawer Component Escape Key Audit (validation test)** accessibility audit (closes #81889). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/drawer-escape-key-vt-sb/`:
- **`script.js`** — `DrawerAudit`: validates drawer escape-key invariants: `role=dialog` + `aria-modal=true`, `aria-hidden` sync, Escape closes only when open, focus returns to the trigger on close. Exposes an axe-core-style `report()` + `isCompliant()`.
- **`drawer.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/drawer-escape-key-vt-sb/drawer.test.js
 ✓ drawer.test.js (11 tests)
```
- **Happy path**: starts hidden; role=dialog + aria-modal; open/close toggle aria-hidden.
- **Edge cases**: Escape closes only when open; close restores focus; trigger opens; toggle; report compliant; report flags missing role.
- **Invalid inputs**: throws without root element.

Closes #81889

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._