### PR TITLE
a11y(tab): arrow-key navigation audit submission (validation)

### DIFF
--- a/submissions/examples/tab-arrow-key-nav-vt-sb/README.md
+++ b/submissions/examples/tab-arrow-key-nav-vt-sb/README.md
@@ -1,0 +1,29 @@
+# Tab Arrow-Key Navigation Audit (validation)
+
+## What does it do?
+Wraps a real tablist and validates the arrow-key navigation invariants: `role=tablist` with `role=tab` children, `aria-controls`/`aria-selected`, roving tabindex (only the active tab is `tabindex=0`), ArrowLeft/Right (or Up/Down when vertical) move focus, Home/End jump to first/last tab. Exposes `report()` + `isCompliant()`.
+
+## How is it used?
+```javascript
+import { TabAudit } from './script.js';
+const a = new TabAudit(document.getElementById('tabs'), { vertical: false });
+a.select(0); a.next(); a.prev(); a.report(); a.isCompliant(); a.destroy();
+```
+
+## Why is it useful?
+A tablist that's mouse-only is unusable from the keyboard. The audit report makes the ARIA tablist + roving-tabindex invariants programmatically verifiable (axe-core-style).
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/tab-arrow-key-nav-vt-sb/tab.test.js
+```
+- **Happy path**: role=tablist + role=tab children; first tab active; ArrowRight moves; ArrowLeft wraps; Home/End jump; click selects; vertical uses Up/Down; report compliant; report flags broken roving tabindex; panel gets role=tabpanel + aria-hidden syncs.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (tab styling + focus ring), JavaScript (arrow nav + roving tabindex + audit report), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus a tab, use arrow keys.
+
+Closes #81891

--- a/submissions/examples/tab-arrow-key-nav-vt-sb/demo.html
+++ b/submissions/examples/tab-arrow-key-nav-vt-sb/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tab Arrow-Key Navigation Audit</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="tabs">
+      <button role="tab" id="tab0" aria-controls="p0">Alpha</button>
+      <button role="tab" id="tab1" aria-controls="p1">Beta</button>
+      <button role="tab" id="tab2" aria-controls="p2">Gamma</button>
+    </div>
+    <div id="p0">Panel A</div>
+    <div id="p1" hidden>Panel B</div>
+    <div id="p2" hidden>Panel C</div>
+    <pre id="report"></pre>
+    <script type="module">
+      import { TabAudit } from './script.js';
+      const a = new TabAudit(document.getElementById('tabs'));
+      const render = () => { document.getElementById('report').textContent = JSON.stringify(a.report(), null, 2); };
+      a.select(0); render();
+      window.__tabAudit = a;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/tab-arrow-key-nav-vt-sb/script.js
+++ b/submissions/examples/tab-arrow-key-nav-vt-sb/script.js
@@ -1,0 +1,115 @@
+/**
+ * EaseMotion CSS — Tab Arrow-Key Navigation Audit (validation)
+ * ============================================================
+ * Wraps a real tablist and validates the arrow-key navigation invariants:
+ *   - role=tablist with role=tab children and aria-controls/aria-selected
+ *   - roving tabindex (only the active tab is tabindex=0)
+ *   - ArrowLeft/Right (or Up/Down when vertical) move focus
+ *   - Home/End jump to first/last tab
+ * Exposes report() + isCompliant().
+ *
+ * API:
+ *   const a = new TabAudit(rootEl, { vertical });
+ *   a.select(i); a.next(); a.prev(); a.report(); a.isCompliant(); a.destroy();
+ * ============================================================ */
+
+export class TabAudit {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('TabAudit requires a root element');
+    }
+    this.root = root;
+    this.vertical = !!options.vertical;
+    this.tabs = Array.from(root.querySelectorAll('[role="tab"]'));
+
+    this.root.setAttribute('role', 'tablist');
+    this.root.classList.add('ease-tablist-audit');
+    this.tabs.forEach((tab) => {
+      tab.setAttribute('role', 'tab');
+      tab.classList.add('ease-tab-audit');
+      const id = tab.getAttribute('aria-controls');
+      const panel = id ? document.getElementById(id) : null;
+      if (panel) panel.setAttribute('role', 'tabpanel');
+    });
+
+    this._active = this.tabs.findIndex((t) => t.getAttribute('aria-selected') === 'true');
+    if (this._active < 0) this._active = 0;
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onClick = this._onClick.bind(this);
+    this.root.addEventListener('keydown', this._onKeydown);
+    this.root.addEventListener('click', this._onClick);
+    this._render();
+    this.select(this._active);
+  }
+
+  _render() {
+    this.tabs.forEach((tab, i) => {
+      tab.setAttribute('tabindex', i === this._active ? '0' : '-1');
+      tab.setAttribute('aria-selected', i === this._active ? 'true' : 'false');
+    });
+  }
+
+  select(index) {
+    if (index < 0 || index >= this.tabs.length) return false;
+    this._active = index;
+    this._render();
+    const t = this.tabs[index];
+    if (t && typeof t.focus === 'function') t.focus();
+    this.tabs.forEach((tab) => {
+      const panel = document.getElementById(tab.getAttribute('aria-controls'));
+      if (panel) panel.setAttribute('aria-hidden', tab.getAttribute('aria-selected') === 'true' ? 'false' : 'true');
+    });
+    return true;
+  }
+
+  next() {
+    return this.select((this._active + 1) % this.tabs.length);
+  }
+
+  prev() {
+    return this.select((this._active - 1 + this.tabs.length) % this.tabs.length);
+  }
+
+  getActive() {
+    return this._active;
+  }
+
+  _onKeydown(event) {
+    const k = event.key;
+    const horiz = !this.vertical;
+    if (k === (horiz ? 'ArrowRight' : 'ArrowDown')) { event.preventDefault(); this.next(); }
+    else if (k === (horiz ? 'ArrowLeft' : 'ArrowUp')) { event.preventDefault(); this.prev(); }
+    else if (k === 'Home') { event.preventDefault(); this.select(0); }
+    else if (k === 'End') { event.preventDefault(); this.select(this.tabs.length - 1); }
+  }
+
+  _onClick(event) {
+    const i = this.tabs.indexOf(event.target.closest('[role="tab"]'));
+    if (i >= 0) this.select(i);
+  }
+
+  report() {
+    const role = this.root.getAttribute('role');
+    const tabsOk = this.tabs.length > 0;
+    const roving = this.tabs.every((t, i) => t.getAttribute('tabindex') === (i === this._active ? '0' : '-1'));
+    const selected = this.tabs.filter((t) => t.getAttribute('aria-selected') === 'true').length;
+    const violations = [];
+    if (role !== 'tablist') violations.push({ id: 'aria-tablist', impact: 'critical' });
+    if (!tabsOk) violations.push({ id: 'no-tabs', impact: 'critical' });
+    if (!roving) violations.push({ id: 'roving-tabindex', impact: 'serious' });
+    if (selected !== 1) violations.push({ id: 'single-selected', impact: 'serious' });
+    return { role, tabCount: this.tabs.length, roving, selectedCount: selected, violations, pass: violations.length === 0 };
+  }
+
+  isCompliant() {
+    return this.report().pass;
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this.root.removeEventListener('click', this._onClick);
+  }
+}
+
+export default TabAudit;

--- a/submissions/examples/tab-arrow-key-nav-vt-sb/style.css
+++ b/submissions/examples/tab-arrow-key-nav-vt-sb/style.css
@@ -1,0 +1,28 @@
+/* ============================================================
+   EaseMotion CSS — Tab Arrow-Key Navigation Audit (validation)
+   ============================================================ */
+
+.ease-tablist-audit {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 2px solid var(--ease-color-primary, #6c63ff);
+}
+
+.ease-tab-audit {
+  padding: 0.5rem 1rem;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: #6b7280;
+}
+
+.ease-tab-audit[aria-selected='true'] {
+  color: var(--ease-color-primary, #6c63ff);
+  font-weight: 600;
+}
+
+.ease-tab-audit:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: -3px;
+}

--- a/submissions/examples/tab-arrow-key-nav-vt-sb/tab.test.js
+++ b/submissions/examples/tab-arrow-key-nav-vt-sb/tab.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TabAudit } from './script.js';
+
+describe('Tab Arrow-Key Navigation Audit (validation)', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.innerHTML = `
+      <button role="tab" id="tab0" aria-controls="p0">A</button>
+      <button role="tab" id="tab1" aria-controls="p1">B</button>
+      <button role="tab" id="tab2" aria-controls="p2">C</button>
+      <div id="p0"></div><div id="p1"></div><div id="p2"></div>`;
+    document.body.appendChild(root);
+  });
+
+  function keydown(target, key) {
+    target.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('sets role=tablist and assigns role=tab children', () => {
+    const a = new TabAudit(root);
+    expect(root.getAttribute('role')).toBe('tablist');
+    expect(root.querySelectorAll('[role="tab"]').length).toBe(3);
+    a.destroy();
+  });
+
+  it('first tab is active (aria-selected=true, tabindex=0)', () => {
+    const a = new TabAudit(root);
+    const t0 = document.getElementById('tab0');
+    expect(t0.getAttribute('aria-selected')).toBe('true');
+    expect(t0.getAttribute('tabindex')).toBe('0');
+    a.destroy();
+  });
+
+  it('ArrowRight moves focus to the next tab', () => {
+    const a = new TabAudit(root);
+    const spy = vi.spyOn(document.getElementById('tab1'), 'focus');
+    keydown(document.getElementById('tab0'), 'ArrowRight');
+    expect(a.getActive()).toBe(1);
+    expect(spy).toHaveBeenCalled();
+    a.destroy();
+  });
+
+  it('ArrowLeft wraps from first to last', () => {
+    const a = new TabAudit(root);
+    keydown(document.getElementById('tab0'), 'ArrowLeft');
+    expect(a.getActive()).toBe(2);
+    a.destroy();
+  });
+
+  it('Home/End jump to first/last', () => {
+    const a = new TabAudit(root);
+    keydown(document.getElementById('tab0'), 'End');
+    expect(a.getActive()).toBe(2);
+    keydown(document.getElementById('tab2'), 'Home');
+    expect(a.getActive()).toBe(0);
+    a.destroy();
+  });
+
+  it('click selects the clicked tab', () => {
+    const a = new TabAudit(root);
+    document.getElementById('tab2').click();
+    expect(a.getActive()).toBe(2);
+    a.destroy();
+  });
+
+  it('vertical orientation uses Up/Down', () => {
+    const a = new TabAudit(root, { vertical: true });
+    keydown(document.getElementById('tab0'), 'ArrowDown');
+    expect(a.getActive()).toBe(1);
+    a.destroy();
+  });
+
+  it('report() is compliant for a well-formed tablist', () => {
+    const a = new TabAudit(root);
+    expect(a.isCompliant()).toBe(true);
+    a.destroy();
+  });
+
+  it('report flags broken roving tabindex', () => {
+    const a = new TabAudit(root);
+    document.getElementById('tab0').setAttribute('tabindex', '-1');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('panel gets role=tabpanel and aria-hidden syncs', () => {
+    const a = new TabAudit(root);
+    const p0 = document.getElementById('p0');
+    expect(p0.getAttribute('role')).toBe('tabpanel');
+    expect(p0.getAttribute('aria-hidden')).toBe('false');
+    a.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const a = new TabAudit(root);
+    expect(() => a.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new TabAudit(null)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Tab Component Arrow Key Navigation Audit (validation test)** accessibility audit (closes #81891). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/tab-arrow-key-nav-vt-sb/`:
- **`script.js`** — `TabAudit`: validates tablist arrow-key navigation invariants: `role=tablist`, roving tabindex, `aria-selected`, Arrow/Home/End navigation, panel `role=tabpanel` + `aria-hidden` sync. Exposes an axe-core-style `report()` + `isCompliant()`.
- **`tab.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/tab-arrow-key-nav-vt-sb/tab.test.js
 ✓ tab.test.js (12 tests)
```
- **Happy path**: role=tablist + role=tab children; first tab active; ArrowRight moves; ArrowLeft wraps; Home/End jump; click selects; vertical uses Up/Down; report compliant; report flags broken roving tabindex; panel gets role=tabpanel + aria-hidden syncs.
- **Invalid inputs**: throws without root element.

Closes #81891

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._