### PR TITLE
feat: create Interactive Popover with Neumorphism styling (#97731) #8…

### DIFF
--- a/submissions/examples/css-popover-interactive-neumorphism/README.md
+++ b/submissions/examples/css-popover-interactive-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Interactive Popover (Neumorphism)
+A fully tactile Neumorphic popover menu. The trigger button and internal action buttons physically press into the surface when interacted with, utilizing an inversion from outer `box-shadow` to `inset` shadow on hover and active states.

--- a/submissions/examples/css-popover-interactive-neumorphism/demo.html
+++ b/submissions/examples/css-popover-interactive-neumorphism/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Interactive Popover</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="ni-popover-container">
+        <button class="ni-btn"><i class="ph ph-dots-three"></i></button>
+        <div class="ni-popover">
+            <button class="ni-action"><i class="ph ph-pencil-simple"></i> Edit</button>
+            <button class="ni-action"><i class="ph ph-copy"></i> Duplicate</button>
+            <button class="ni-action ni-danger"><i class="ph ph-trash"></i> Delete</button>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-popover-interactive-neumorphism/style.css
+++ b/submissions/examples/css-popover-interactive-neumorphism/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; --danger: #e53e3e; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.ni-popover-container { position: relative; display: inline-block; }
+.ni-btn { width: 50px; height: 50px; border-radius: 50%; background: var(--bg); border: none; color: var(--text); font-size: 1.5rem; cursor: pointer; display: flex; justify-content: center; align-items: center; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: 0.2s; }
+.ni-btn:active { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); }
+.ni-popover { position: absolute; top: calc(100% + 15px); right: 0; width: 180px; background: var(--bg); border-radius: 16px; padding: 1rem; box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light); opacity: 0; visibility: hidden; transform: translateY(-10px) scale(0.95); transform-origin: top right; transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1); z-index: 10; display: flex; flex-direction: column; gap: 0.75rem; }
+.ni-action { width: 100%; text-align: left; background: var(--bg); border: none; padding: 0.75rem 1rem; border-radius: 10px; color: var(--text); font-size: 0.95rem; font-weight: 500; cursor: pointer; display: flex; align-items: center; gap: 0.75rem; transition: 0.3s; box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light); }
+.ni-action i { font-size: 1.2rem; }
+.ni-action:hover { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); color: var(--accent); }
+.ni-action.ni-danger:hover { color: var(--danger); }
+.ni-popover-container:focus-within .ni-popover { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Interactive Popover with Neumorphism styling (#97731) #81401

**Description:**
This PR introduces a fully tactile Neumorphic popover menu. The trigger button and internal action buttons physically press into the surface when interacted with, utilizing an inversion from outer `box-shadow` to `inset` shadow on hover and active states.

Fixes #81401

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-popover-interactive-neumorphism/`
- Bound the `.ni-action` internal buttons to toggle their shading dynamically on `:hover` from `box-shadow` to `box-shadow: inset`
- Utilized an animated `scale(0.95)` to `scale(1)` transform chained to a `transform-origin: top right` pivot for the popover entrance
