### PR TITLE
feat: create Responsive Carousel with Claymorphism styling (#69372) #…

### DIFF
--- a/submissions/examples/css-carousel-responsive-claymorphism/README.md
+++ b/submissions/examples/css-carousel-responsive-claymorphism/README.md
@@ -1,0 +1,2 @@
+# Responsive Carousel (Claymorphism)
+A pillowy, highly rounded 3D slider. It utilizes bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` transitions for both the track movement and the card scaling. The active pagination dots press physically into the surface.

--- a/submissions/examples/css-carousel-responsive-claymorphism/demo.html
+++ b/submissions/examples/css-carousel-responsive-claymorphism/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claymorphism Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="clay-carousel">
+        <input type="radio" name="clay-slide" id="cs1" checked>
+        <input type="radio" name="clay-slide" id="cs2">
+        <input type="radio" name="clay-slide" id="cs3">
+        
+        <div class="clay-viewport">
+            <div class="clay-track">
+                <div class="clay-card">
+                    <div class="clay-badge">NEW</div>
+                    <h3>Analytics Dashboard</h3>
+                </div>
+                <div class="clay-card">
+                    <div class="clay-badge">PRO</div>
+                    <h3>Team Management</h3>
+                </div>
+                <div class="clay-card">
+                    <div class="clay-badge">BETA</div>
+                    <h3>AI Integration</h3>
+                </div>
+            </div>
+        </div>
+        
+        <div class="clay-nav">
+            <label for="cs1"></label>
+            <label for="cs2"></label>
+            <label for="cs3"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-responsive-claymorphism/style.css
+++ b/submissions/examples/css-carousel-responsive-claymorphism/style.css
@@ -1,0 +1,20 @@
+:root { --bg: #f2f2f2; --clay: #ffffff; --inner-shadow: rgba(0, 0, 0, 0.08); --outer-shadow: rgba(0, 0, 0, 0.12); --highlight: rgba(255, 255, 255, 1); --text: #555; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.clay-carousel { width: 90%; max-width: 500px; display: flex; flex-direction: column; align-items: center; gap: 2rem; }
+input[type="radio"] { display: none; }
+.clay-viewport { width: 100%; overflow: hidden; padding: 2rem 1rem; box-sizing: border-box; }
+.clay-track { display: flex; width: 300%; transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.clay-card { width: 33.333%; padding: 3rem 2rem; box-sizing: border-box; background: var(--clay); border-radius: 30px; text-align: center; box-shadow: 12px 12px 24px var(--outer-shadow), -12px -12px 24px var(--highlight), inset -6px -6px 12px var(--inner-shadow), inset 6px 6px 12px var(--highlight); transform: scale(0.9); opacity: 0.5; transition: all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1); margin: 0 1rem; }
+.clay-badge { display: inline-block; padding: 0.5rem 1rem; background: var(--clay); border-radius: 20px; font-weight: bold; font-size: 0.8rem; color: #ff7b93; margin-bottom: 1rem; box-shadow: 4px 4px 8px var(--outer-shadow), -4px -4px 8px var(--highlight), inset -2px -2px 4px var(--inner-shadow), inset 2px 2px 4px var(--highlight); }
+.clay-card h3 { margin: 0; color: var(--text); font-size: 1.3rem; }
+#cs1:checked ~ .clay-viewport .clay-track { transform: translateX(0); }
+#cs2:checked ~ .clay-viewport .clay-track { transform: translateX(-33.333%); }
+#cs3:checked ~ .clay-viewport .clay-track { transform: translateX(-66.666%); }
+#cs1:checked ~ .clay-viewport .clay-card:nth-child(1),
+#cs2:checked ~ .clay-viewport .clay-card:nth-child(2),
+#cs3:checked ~ .clay-viewport .clay-card:nth-child(3) { transform: scale(1); opacity: 1; }
+.clay-nav { display: flex; gap: 1rem; }
+.clay-nav label { width: 16px; height: 16px; border-radius: 50%; background: var(--clay); box-shadow: 4px 4px 8px var(--outer-shadow), -4px -4px 8px var(--highlight); cursor: pointer; transition: 0.3s; }
+#cs1:checked ~ .clay-nav label:nth-child(1),
+#cs2:checked ~ .clay-nav label:nth-child(2),
+#cs3:checked ~ .clay-nav label:nth-child(3) { box-shadow: inset 4px 4px 8px var(--inner-shadow), inset -4px -4px 8px var(--highlight); background: #f9f9f9; transform: scale(1.2); }


### PR DESCRIPTION
**Title:** feat: create Responsive Carousel with Claymorphism styling (#69372) #81399

**Description:**
This PR introduces a pillowy, highly rounded 3D slider. It utilizes bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` transitions for both the track movement and the card scaling. The active pagination dots press physically into the surface.

Fixes #81399

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-responsive-claymorphism/`
- Structured the cards with extreme `border-radius: 30px` and dual inset/outset shadows (`inset -6px -6px 12px var(--inner-shadow), inset 6px 6px 12px var(--highlight)`)
- Mapped the `.clay-nav` radio indicators to invert their shadows to `inset` while simultaneously scaling up on `:checked`
