### PR TITLE
feat: create Floating Carousel with Pastel styling (#75861) #81397

### DIFF
--- a/submissions/examples/css-carousel-floating-pastel/README.md
+++ b/submissions/examples/css-carousel-floating-pastel/README.md
@@ -1,0 +1,2 @@
+# Floating Carousel (Pastel)
+A vibrant, floating pastel card slider. The active slide physically floats upward on the Y-axis using `transform: translateY(0)` while casting a larger drop shadow, pushing the inactive siblings down and out of focus.

--- a/submissions/examples/css-carousel-floating-pastel/demo.html
+++ b/submissions/examples/css-carousel-floating-pastel/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Pastel Carousel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fp-carousel">
+        <input type="radio" name="fp-slide" id="fp1" checked>
+        <input type="radio" name="fp-slide" id="fp2">
+        <input type="radio" name="fp-slide" id="fp3">
+        
+        <div class="fp-viewport">
+            <div class="fp-track">
+                <div class="fp-card fp-pink">
+                    <h3>Strawberry</h3>
+                    <p>Sweet and refreshing.</p>
+                </div>
+                <div class="fp-card fp-purple">
+                    <h3>Blueberry</h3>
+                    <p>Rich and tart.</p>
+                </div>
+                <div class="fp-card fp-green">
+                    <h3>Matcha</h3>
+                    <p>Earthy and calm.</p>
+                </div>
+            </div>
+        </div>
+        
+        <div class="fp-nav">
+            <label for="fp1"></label>
+            <label for="fp2"></label>
+            <label for="fp3"></label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-carousel-floating-pastel/style.css
+++ b/submissions/examples/css-carousel-floating-pastel/style.css
@@ -1,0 +1,23 @@
+:root { --bg: #fdfbf7; --pink: #ffb7b2; --purple: #cbb2fe; --green: #e2f0cb; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.fp-carousel { width: 90%; max-width: 450px; display: flex; flex-direction: column; align-items: center; gap: 2.5rem; }
+input[type="radio"] { display: none; }
+.fp-viewport { width: 100%; overflow: hidden; padding: 2rem 0; perspective: 1000px; }
+.fp-track { display: flex; width: 300%; transition: transform 0.7s cubic-bezier(0.2, 0.8, 0.2, 1); }
+.fp-card { width: 33.333%; padding: 4rem 2rem; box-sizing: border-box; text-align: center; border-radius: 24px; border: 4px solid #fff; box-shadow: 0 10px 30px rgba(0,0,0,0.05); transform: translateY(20px) scale(0.9); opacity: 0.5; transition: all 0.7s cubic-bezier(0.2, 0.8, 0.2, 1); margin: 0 1rem; color: #555; }
+.fp-card h3 { margin: 0 0 0.5rem 0; font-size: 1.5rem; }
+.fp-card p { margin: 0; font-size: 1rem; opacity: 0.8; }
+.fp-pink { background: var(--pink); }
+.fp-purple { background: var(--purple); }
+.fp-green { background: var(--green); }
+#fp1:checked ~ .fp-viewport .fp-track { transform: translateX(0); }
+#fp2:checked ~ .fp-viewport .fp-track { transform: translateX(-33.333%); }
+#fp3:checked ~ .fp-viewport .fp-track { transform: translateX(-66.666%); }
+#fp1:checked ~ .fp-viewport .fp-card:nth-child(1),
+#fp2:checked ~ .fp-viewport .fp-card:nth-child(2),
+#fp3:checked ~ .fp-viewport .fp-card:nth-child(3) { transform: translateY(0) scale(1); opacity: 1; box-shadow: 0 20px 40px rgba(0,0,0,0.1); }
+.fp-nav { display: flex; gap: 1rem; }
+.fp-nav label { width: 12px; height: 12px; border-radius: 50%; background: #e0e0e0; cursor: pointer; transition: 0.4s; }
+#fp1:checked ~ .fp-nav label:nth-child(1) { background: var(--pink); transform: scale(1.5); }
+#fp2:checked ~ .fp-nav label:nth-child(2) { background: var(--purple); transform: scale(1.5); }
+#fp3:checked ~ .fp-nav label:nth-child(3) { background: var(--green); transform: scale(1.5); }


### PR DESCRIPTION
**Title:** feat: create Floating Carousel with Pastel styling (#75861) #81397

**Description:**
This PR introduces a vibrant, floating pastel card slider. The active slide physically floats upward on the Y-axis using `transform: translateY(0)` while casting a larger drop shadow, pushing the inactive siblings down and out of focus.

Fixes #81397

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-carousel-floating-pastel/`
- Designed individual cards with distinct soft palettes (`--pink`, `--purple`, `--green`)
- Animated the `.fp-card` elements to rest at `translateY(20px) scale(0.9)` with reduced opacity, transitioning the `:checked` sibling up into focus at full opacity
