### PR TITLE
a11y(command-palette): ARIA combobox submission (enhancement)

### DIFF
--- a/submissions/examples/command-palette-aria-combobox-enh-sb/README.md
+++ b/submissions/examples/command-palette-aria-combobox-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Command Palette ARIA Combobox
+
+## What does it do?
+Implements the ARIA 1.2 combobox + listbox pattern: input has `role=combobox` + `aria-expanded` + `aria-autocomplete=list` + `aria-controls` + `aria-activedescendant`, the list has `role=listbox`, each option has `role=option` + `aria-selected`. Up/Down move the active option, Enter selects, Escape closes.
+
+## How is it used?
+```javascript
+import { CommandPalette } from './script.js';
+const c = new CommandPalette(root, { options: ['Save', 'Open', 'Search'] });
+c.open(); c.query('sa'); c.selectActive(); c.destroy();
+```
+
+## Why is it useful?
+A command palette is a combobox of commands. Screen-reader users need the combobox/listbox semantics + `aria-activedescendant` to track which option is active as they arrow through. Without it the palette is unusable from assistive tech.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/command-palette-aria-combobox-enh-sb/command.test.js
+```
+- **Happy path**: role=combobox + aria-expanded + aria-autocomplete; role=option items with aria-selected; query filters; ArrowDown opens + moves; Enter selects; Escape closes; click selects; aria-activedescendant tracks active.
+- **Edge cases**: ArrowUp wraps; selectActive returns null when no matches; destroy.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (listbox styling), JavaScript (ARIA combobox + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, type, arrow, Enter.
+
+Closes #81896

--- a/submissions/examples/command-palette-aria-combobox-enh-sb/command.test.js
+++ b/submissions/examples/command-palette-aria-combobox-enh-sb/command.test.js
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CommandPalette } from './script.js';
+
+describe('Command Palette ARIA Combobox', () => {
+  let root, input, list;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    input = document.createElement('input');
+    input.setAttribute('data-cp-input', '');
+    list = document.createElement('ul');
+    list.setAttribute('data-cp-list', '');
+    root.appendChild(input);
+    root.appendChild(list);
+    document.body.appendChild(root);
+  });
+
+  function keydown(key) {
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('sets role=combobox + aria-expanded=false + aria-autocomplete=list on the input', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    expect(input.getAttribute('role')).toBe('combobox');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(input.getAttribute('aria-autocomplete')).toBe('list');
+    c.destroy();
+  });
+
+  it('renders role=option items with aria-selected reflecting the active index', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    const opts = list.querySelectorAll('[role="option"]');
+    expect(opts.length).toBe(2);
+    expect(opts[0].getAttribute('aria-selected')).toBe('true');
+    expect(opts[1].getAttribute('aria-selected')).toBe('false');
+    c.destroy();
+  });
+
+  it('query() filters options', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open', 'Search'] });
+    const res = c.query('sa');
+    expect(res.length).toBe(1);
+    expect(res[0]).toBe('Save');
+    c.destroy();
+  });
+
+  it('ArrowDown opens and moves active to next option', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    keydown('ArrowDown');
+    expect(c.isOpen()).toBe(true);
+    expect(list.querySelectorAll('[role="option"]')[1].getAttribute('aria-selected')).toBe('true');
+    c.destroy();
+  });
+
+  it('ArrowUp wraps to the last option', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    keydown('ArrowUp');
+    expect(list.querySelectorAll('[role="option"]')[1].getAttribute('aria-selected')).toBe('true');
+    c.destroy();
+  });
+
+  it('Enter selects the active option and closes', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    c.open();
+    const val = c.selectActive();
+    expect(val).toBe('Save');
+    expect(c.isOpen()).toBe(false);
+    c.destroy();
+  });
+
+  it('Escape closes the palette', () => {
+    const c = new CommandPalette(root, { options: ['Save'] });
+    c.open();
+    keydown('Escape');
+    expect(c.isOpen()).toBe(false);
+    c.destroy();
+  });
+
+  it('clicking an option selects it', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    list.querySelectorAll('[role="option"]')[1].click();
+    expect(input.value).toBe('Open');
+    expect(c.isOpen()).toBe(false);
+    c.destroy();
+  });
+
+  it('aria-activedescendant points to the active option', () => {
+    const c = new CommandPalette(root, { options: ['Save', 'Open'] });
+    expect(input.getAttribute('aria-activedescendant')).toBe('cp-option-0');
+    c.move(1);
+    expect(input.getAttribute('aria-activedescendant')).toBe('cp-option-1');
+    c.destroy();
+  });
+
+  it('selectActive() returns null when no options match', () => {
+    const c = new CommandPalette(root, { options: ['Save'] });
+    c.query('zzz');
+    expect(c.selectActive()).toBeNull();
+    c.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const c = new CommandPalette(root, { options: ['Save'] });
+    expect(() => c.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new CommandPalette(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/command-palette-aria-combobox-enh-sb/demo.html
+++ b/submissions/examples/command-palette-aria-combobox-enh-sb/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Command Palette ARIA Combobox</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div>
+      <input data-cp-input placeholder="Type a command" />
+      <ul data-cp-list></ul>
+    </div>
+    <script type="module">
+      import { CommandPalette } from './script.js';
+      window.__cp = new CommandPalette(document.querySelector('div'), {
+        options: ['Save', 'Open', 'Close', 'Search', 'Settings', 'Help'],
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/command-palette-aria-combobox-enh-sb/script.js
+++ b/submissions/examples/command-palette-aria-combobox-enh-sb/script.js
@@ -1,0 +1,122 @@
+/**
+ * EaseMotion CSS — Command Palette ARIA Combobox (enhancement)
+ * ============================================================
+ * An ARIA 1.2 combobox + listbox pattern:
+ *   - the input has role=combobox + aria-controls + aria-expanded
+ *   - the list has role=listbox
+ *   - each option has role=option + aria-selected
+ *   - Up/Down move the active option, Enter selects, Escape clears
+ *
+ * API:
+ *   const c = new CommandPalette(rootEl, { options });
+ *   c.open(); c.close(); c.query('save'); c.selectActive(); c.destroy();
+ * ============================================================ */
+
+export class CommandPalette {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('CommandPalette requires a root element');
+    }
+    this.root = root;
+    this.options = Array.isArray(options.options) ? options.options.slice() : [];
+    this._open = false;
+    this._active = 0;
+    this._filtered = this.options.slice();
+
+    this.input = root.querySelector('[data-cp-input]') || document.createElement('input');
+    this.list = root.querySelector('[data-cp-list]') || document.createElement('ul');
+
+    this.input.setAttribute('role', 'combobox');
+    this.input.setAttribute('aria-expanded', 'false');
+    this.input.setAttribute('aria-autocomplete', 'list');
+    this.input.setAttribute('aria-controls', 'cp-list');
+    this.list.id = 'cp-list';
+    this.list.setAttribute('role', 'listbox');
+
+    this._onInput = this._onInput.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+    this.input.addEventListener('input', this._onInput);
+    this.input.addEventListener('keydown', this._onKeydown);
+    this.list.addEventListener('click', this._onListClick.bind(this));
+
+    this._render();
+  }
+
+  _render() {
+    this.list.innerHTML = '';
+    this._filtered.forEach((opt, i) => {
+      const li = document.createElement('li');
+      li.setAttribute('role', 'option');
+      li.setAttribute('id', 'cp-option-' + i);
+      li.setAttribute('aria-selected', i === this._active ? 'true' : 'false');
+      li.textContent = opt;
+      this.list.appendChild(li);
+    });
+    this.input.setAttribute('aria-activedescendant', this._filtered.length ? 'cp-option-' + this._active : '');
+  }
+
+  open() {
+    this._open = true;
+    this.input.setAttribute('aria-expanded', 'true');
+  }
+
+  close() {
+    this._open = false;
+    this.input.setAttribute('aria-expanded', 'false');
+  }
+
+  isOpen() {
+    return this._open;
+  }
+
+  query(term) {
+    const t = String(term || '').toLowerCase();
+    this._filtered = this.options.filter((o) => String(o).toLowerCase().includes(t));
+    this._active = 0;
+    this._render();
+    return this._filtered.slice();
+  }
+
+  move(delta) {
+    if (!this._filtered.length) return false;
+    this._active = (this._active + delta + this._filtered.length) % this._filtered.length;
+    this._render();
+    return true;
+  }
+
+  selectActive() {
+    if (!this._filtered.length) return null;
+    const val = this._filtered[this._active];
+    this.input.value = val;
+    this.close();
+    return val;
+  }
+
+  _onInput() {
+    if (!this._open) this.open();
+    this.query(this.input.value);
+  }
+
+  _onKeydown(event) {
+    switch (event.key) {
+      case 'ArrowDown': event.preventDefault(); this.open(); this.move(1); break;
+      case 'ArrowUp': event.preventDefault(); this.move(-1); break;
+      case 'Enter': event.preventDefault(); this.selectActive(); break;
+      case 'Escape': event.preventDefault(); this.close(); break;
+    }
+  }
+
+  _onListClick(event) {
+    const li = event.target.closest('[role="option"]');
+    if (!li) return;
+    const i = Array.from(this.list.children).indexOf(li);
+    if (i >= 0) { this._active = i; this.selectActive(); }
+  }
+
+  destroy() {
+    this.input.removeEventListener('input', this._onInput);
+    this.input.removeEventListener('keydown', this._onKeydown);
+  }
+}
+
+export default CommandPalette;

--- a/submissions/examples/command-palette-aria-combobox-enh-sb/style.css
+++ b/submissions/examples/command-palette-aria-combobox-enh-sb/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   EaseMotion CSS — Command Palette ARIA Combobox
+   ============================================================ */
+
+[data-cp-list] {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+[data-cp-list] [role='option'] {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+[data-cp-list] [role='option'][aria-selected='true'] {
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+
+[data-cp-input] {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  font: inherit;
+  width: 100%;
+}
+
+[data-cp-input]:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 1px;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Command Palette ARIA Combobox Role (enhancement)** accessibility audit (closes #81896). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/command-palette-aria-combobox-enh-sb/`:
- **`script.js`** — `CommandPalette`: implements the ARIA 1.2 combobox + listbox pattern — `role=combobox` + `aria-expanded` + `aria-autocomplete=list` + `aria-controls` + `aria-activedescendant` on the input, `role=option` + `aria-selected` on items, Arrow/Enter/Escape keyboard support.
- **`command.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/command-palette-aria-combobox-enh-sb/command.test.js
 ✓ command.test.js (12 tests)
```
- **Happy path**: role=combobox + aria-expanded + aria-autocomplete; role=option items with aria-selected; query filters; ArrowDown opens + moves; Enter selects; Escape closes; click selects; aria-activedescendant tracks active.
- **Edge cases**: ArrowUp wraps; selectActive returns null when no matches; destroy.
- **Invalid inputs**: throws without root element.

Closes #81896

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._