### PR TITLE
a11y(dropdown): ARIA menuitem focus submission (enhancement)

### DIFF
--- a/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/README.md
+++ b/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Dropdown Menu ARIA Menuitem Focus
+
+## What does it do?
+A disclosure menu using `role=menu` / `role=menuitem` with full keyboard support: Enter/Space toggle, ArrowUp/Down move between items, Home/End jump, Escape closes, roving tabindex (only the active item is focusable).
+
+## How is it used?
+```javascript
+import { DropdownMenu } from './script.js';
+const m = new DropdownMenu(document.getElementById('menu'), { trigger: document.getElementById('trigger') });
+m.open(); m.close(); m.toggle(); m.isOpen(); m.destroy();
+```
+
+## Why is it useful?
+Menus need `role=menu`/`role=menuitem` semantics and arrow-key navigation for screen-reader and keyboard users. The disclosure pattern (trigger toggles + Escape closes + focus returns) matches the ARIA Authoring Practices guide.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/dropdown-menu-aria-menuitem-enh-sb/dropdown.test.js
+```
+- **Happy path**: role=menu + aria-hidden; role=menuitem; first item tabindex=0; open toggles aria-hidden + aria-expanded.
+- **Edge cases**: ArrowDown moves + roving tabindex; ArrowUp wraps; Home/End; Escape closes + restores focus; trigger toggles.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (menu styling), JavaScript (arrow nav + roving tabindex), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click the trigger, arrow through items.
+
+Closes #81898

--- a/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/demo.html
+++ b/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dropdown Menu ARIA Menuitem Focus</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="trigger">File</button>
+    <div id="menu">
+      <button data-menu-item>Open</button>
+      <button data-menu-item>Edit</button>
+      <button data-menu-item>Save</button>
+    </div>
+    <script type="module">
+      import { DropdownMenu } from './script.js';
+      window.__menu = new DropdownMenu(document.getElementById('menu'), {
+        trigger: document.getElementById('trigger'),
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/dropdown.test.js
+++ b/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/dropdown.test.js
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DropdownMenu } from './script.js';
+
+describe('Dropdown Menu ARIA Menuitem Focus', () => {
+  let root, trigger;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    root.innerHTML = '<button data-menu-item>Open</button><button data-menu-item>Edit</button><button data-menu-item>Save</button>';
+    trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    document.body.appendChild(root);
+  });
+
+  function keydown(key) {
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('sets role=menu + aria-hidden=true; items get role=menuitem', () => {
+    const m = new DropdownMenu(root, { trigger });
+    expect(root.getAttribute('role')).toBe('menu');
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(root.querySelectorAll('[role="menuitem"]').length).toBe(3);
+    m.destroy();
+  });
+
+  it('first item has tabindex=0 (roving)', () => {
+    const m = new DropdownMenu(root, { trigger });
+    const items = root.querySelectorAll('[role="menuitem"]');
+    expect(items[0].getAttribute('tabindex')).toBe('0');
+    expect(items[1].getAttribute('tabindex')).toBe('-1');
+    m.destroy();
+  });
+
+  it('open() sets aria-hidden=false + trigger aria-expanded=true', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    expect(m.isOpen()).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('false');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    m.destroy();
+  });
+
+  it('ArrowDown moves active focus to the next item', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    const items = root.querySelectorAll('[role="menuitem"]');
+    const spy = vi.spyOn(items[1], 'focus');
+    keydown('ArrowDown');
+    expect(spy).toHaveBeenCalled();
+    expect(items[0].getAttribute('tabindex')).toBe('-1');
+    expect(items[1].getAttribute('tabindex')).toBe('0');
+    m.destroy();
+  });
+
+  it('ArrowUp wraps to the last item', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    const items = root.querySelectorAll('[role="menuitem"]');
+    const spy = vi.spyOn(items[2], 'focus');
+    keydown('ArrowUp');
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('Home/End jump to first/last item', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    const items = root.querySelectorAll('[role="menuitem"]');
+    keydown('End');
+    expect(items[2].getAttribute('tabindex')).toBe('0');
+    keydown('Home');
+    expect(items[0].getAttribute('tabindex')).toBe('0');
+    m.destroy();
+  });
+
+  it('Escape closes and restores focus to the trigger', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    const spy = vi.spyOn(trigger, 'focus');
+    keydown('Escape');
+    expect(m.isOpen()).toBe(false);
+    expect(spy).toHaveBeenCalled();
+    m.destroy();
+  });
+
+  it('trigger click toggles the menu', () => {
+    const m = new DropdownMenu(root, { trigger });
+    trigger.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(m.isOpen()).toBe(true);
+    trigger.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    expect(m.isOpen()).toBe(false);
+    m.destroy();
+  });
+
+  it('close() sets aria-hidden=true + trigger aria-expanded=false', () => {
+    const m = new DropdownMenu(root, { trigger });
+    m.open();
+    m.close();
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    m.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const m = new DropdownMenu(root, { trigger });
+    expect(() => m.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new DropdownMenu(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/script.js
+++ b/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/script.js
@@ -1,0 +1,98 @@
+/**
+ * EaseMotion CSS — Dropdown Menu ARIA Menuitem Focus (enhancement)
+ * ============================================================
+ * A disclosure menu using role=menu / role=menuitem with full keyboard
+ * support: Enter/Space toggle, ArrowUp/Down move between items, Escape
+ * closes, roving tabindex (only the active item is focusable).
+ *
+ * API:
+ *   const m = new DropdownMenu(rootEl, { trigger });
+ *   m.open(); m.close(); m.toggle(); m.isOpen(); m.destroy();
+ * ============================================================ */
+
+export class DropdownMenu {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('DropdownMenu requires a root element');
+    }
+    this.root = root;
+    this.trigger = options.trigger || null;
+    this._open = false;
+    this.items = Array.from(root.querySelectorAll('[data-menu-item]'));
+
+    this.root.setAttribute('role', 'menu');
+    this.root.setAttribute('aria-hidden', 'true');
+    this.items.forEach((item, i) => {
+      item.setAttribute('role', 'menuitem');
+      item.setAttribute('tabindex', i === 0 ? '0' : '-1');
+    });
+
+    this._active = 0;
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onTrigger = this._onTrigger.bind(this);
+    this.root.addEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.addEventListener('click', this._onTrigger);
+  }
+
+  open() {
+    if (this._open) return false;
+    this._open = true;
+    this.root.setAttribute('aria-hidden', 'false');
+    if (this.trigger) this.trigger.setAttribute('aria-expanded', 'true');
+    const first = this.items[0];
+    if (first && typeof first.focus === 'function') first.focus();
+    return true;
+  }
+
+  close() {
+    if (!this._open) return false;
+    this._open = false;
+    this.root.setAttribute('aria-hidden', 'true');
+    if (this.trigger) {
+      this.trigger.setAttribute('aria-expanded', 'false');
+      if (typeof this.trigger.focus === 'function') this.trigger.focus();
+    }
+    return true;
+  }
+
+  toggle() {
+    return this._open ? this.close() : this.open();
+  }
+
+  isOpen() {
+    return this._open;
+  }
+
+  _move(delta) {
+    if (!this.items.length) return;
+    this._active = (this._active + delta + this.items.length) % this.items.length;
+    this._applyRoving();
+  }
+
+  _applyRoving() {
+    this.items.forEach((item, i) => item.setAttribute('tabindex', i === this._active ? '0' : '-1'));
+    const t = this.items[this._active];
+    if (t && typeof t.focus === 'function') t.focus();
+  }
+
+  _onKeydown(event) {
+    switch (event.key) {
+      case 'ArrowDown': event.preventDefault(); this._move(1); break;
+      case 'ArrowUp': event.preventDefault(); this._move(-1); break;
+      case 'Home': event.preventDefault(); this._active = 0; this._applyRoving(); break;
+      case 'End': event.preventDefault(); this._active = this.items.length - 1; this._applyRoving(); break;
+      case 'Escape': event.preventDefault(); this.close(); break;
+    }
+  }
+
+  _onTrigger() {
+    this.toggle();
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    if (this.trigger) this.trigger.removeEventListener('click', this._onTrigger);
+  }
+}
+
+export default DropdownMenu;

--- a/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/style.css
+++ b/submissions/examples/dropdown-menu-aria-menuitem-enh-sb/style.css
@@ -1,0 +1,34 @@
+/* ============================================================
+   EaseMotion CSS — Dropdown Menu ARIA Menuitem Focus
+   ============================================================ */
+
+[role='menu'] {
+  display: none;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.12);
+  padding: 0.25rem;
+  min-width: 10rem;
+}
+
+[role='menu'][aria-hidden='false'] {
+  display: flex;
+}
+
+[role='menuitem'] {
+  padding: 0.5rem 0.75rem;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font: inherit;
+  color: #1f2937;
+}
+
+[role='menuitem']:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: -2px;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Dropdown Menu ARIA Menuitem Focus (enhancement)** accessibility audit (closes #81898). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/dropdown-menu-aria-menuitem-enh-sb/`:
- **`script.js`** — `DropdownMenu`: disclosure menu using `role=menu` / `role=menuitem` with ArrowUp/Down + Home/End + Escape keyboard support and roving tabindex (only the active item is focusable).
- **`dropdown.test.js`** — 11 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/dropdown-menu-aria-menuitem-enh-sb/dropdown.test.js
 ✓ dropdown.test.js (11 tests)
```
- **Happy path**: role=menu + aria-hidden; role=menuitem; first item tabindex=0; open toggles aria-hidden + aria-expanded.
- **Edge cases**: ArrowDown moves + roving tabindex; ArrowUp wraps; Home/End; Escape closes + restores focus; trigger toggles.
- **Invalid inputs**: throws without root element.

Closes #81898

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._