### PR TITLE
a11y(tooltip): ARIA-describedby link submission (enhancement)

### DIFF
--- a/submissions/examples/tooltip-aria-describedby-enh-sb/README.md
+++ b/submissions/examples/tooltip-aria-describedby-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Tooltip ARIA Describedby Link
+
+## What does it do?
+A tooltip that links a trigger element to a tooltip element via `aria-describedby`. The tooltip is hidden with the HTML `hidden` attribute (not `display:none`, so SRs can read it) and toggled on hover/focus. Respects `prefers-reduced-motion`.
+
+## How is it used?
+```javascript
+import { Tooltip } from './script.js';
+const t = new Tooltip(document.getElementById('btn'), { text: 'More info' });
+t.show(); t.hide(); t.toggle(); t.isVisible(); t.destroy();
+```
+
+## Why is it useful?
+Without `aria-describedby`, screen-reader users don't hear the tooltip text. The attribute programmatically links the trigger to the tooltip so AT can announce it. Using `hidden` (not `display:none`) lets the tooltip content remain in the a11y tree.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/tooltip-aria-describedby-enh-sb/tooltip.test.js
+```
+- **Happy path**: role=tooltip + aria-describedby link; starts hidden; show/hide toggle + aria-expanded.
+- **Edge cases**: hover shows; focus/blur show/hide; Escape hides; title attribute reused + removed; toggle; reduced motion adds static class.
+- **Invalid inputs**: throws without trigger element.
+
+## Tech Stack
+HTML, CSS (positioned tooltip + reduced-motion), JavaScript (aria-describedby + hover/focus), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, hover or focus the button.
+
+Closes #81900

--- a/submissions/examples/tooltip-aria-describedby-enh-sb/demo.html
+++ b/submissions/examples/tooltip-aria-describedby-enh-sb/demo.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tooltip ARIA Describedby Link</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="t" title="Click to save your work">Save</button>
+    <script type="module">
+      import { Tooltip } from './script.js';
+      window.__tip = new Tooltip(document.getElementById('t'));
+    </script>
+  </body>
+</html>

--- a/submissions/examples/tooltip-aria-describedby-enh-sb/script.js
+++ b/submissions/examples/tooltip-aria-describedby-enh-sb/script.js
@@ -1,0 +1,93 @@
+/**
+ * EaseMotion CSS — Tooltip ARIA Describedby Link (enhancement)
+ * ============================================================
+ * A tooltip that links a trigger element to a tooltip element via
+ * aria-describedby. The tooltip is hidden with the HTML hidden attribute
+ * (NOT display:none, so SRs can read it) and toggled on hover/focus.
+ * Respects prefers-reduced-motion (no fade animation).
+ *
+ * API:
+ *   const t = new Tooltip(triggerEl, options);
+ *   t.show(); t.hide(); t.toggle(); t.isVisible(); t.destroy();
+ * ============================================================ */
+
+let _idSeq = 0;
+
+export class Tooltip {
+  constructor(trigger, options = {}) {
+    if (!trigger || typeof trigger.addEventListener !== 'function') {
+      throw new TypeError('Tooltip requires a trigger element');
+    }
+    this.trigger = trigger;
+    this.text = options.text || trigger.getAttribute('title') || '';
+    this._reduced = typeof window !== 'undefined' && window.matchMedia
+      ? !!window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+
+    this.tooltip = document.createElement('span');
+    this.tooltip.id = 'ease-tooltip-' + (++_idSeq);
+    this.tooltip.setAttribute('role', 'tooltip');
+    this.tooltip.textContent = this.text;
+    this.tooltip.setAttribute('hidden', '');
+    this.tooltip.classList.add('ease-tooltip');
+    if (this._reduced) this.tooltip.classList.add('ease-tooltip--static');
+
+    this.trigger.setAttribute('aria-describedby', this.tooltip.id);
+    this.trigger.classList.add('ease-tooltip-trigger');
+    this.trigger.appendChild(this.tooltip);
+    if (this.trigger.getAttribute('title')) this.trigger.removeAttribute('title');
+
+    this._show = this._show.bind(this);
+    this._hide = this._hide.bind(this);
+    this._onKey = this._onKey.bind(this);
+    this.trigger.addEventListener('mouseenter', this._show);
+    this.trigger.addEventListener('mouseleave', this._hide);
+    this.trigger.addEventListener('focusin', this._show);
+    this.trigger.addEventListener('focusout', this._hide);
+    this.trigger.addEventListener('keydown', this._onKey);
+  }
+
+  show() {
+    this.tooltip.removeAttribute('hidden');
+    this.tooltip.classList.add('is-visible');
+    this.trigger.setAttribute('aria-expanded', 'true');
+  }
+
+  hide() {
+    this.tooltip.setAttribute('hidden', '');
+    this.tooltip.classList.remove('is-visible');
+    this.trigger.setAttribute('aria-expanded', 'false');
+  }
+
+  toggle() {
+    this.isVisible() ? this.hide() : this.show();
+  }
+
+  isVisible() {
+    return !this.tooltip.hasAttribute('hidden');
+  }
+
+  getText() {
+    return this.text;
+  }
+
+  _show() { this.show(); }
+  _hide() { this.hide(); }
+
+  _onKey(event) {
+    if (event.key === 'Escape') this.hide();
+  }
+
+  destroy() {
+    this.trigger.removeEventListener('mouseenter', this._show);
+    this.trigger.removeEventListener('mouseleave', this._hide);
+    this.trigger.removeEventListener('focusin', this._show);
+    this.trigger.removeEventListener('focusout', this._hide);
+    this.trigger.removeEventListener('keydown', this._onKey);
+    this.trigger.removeAttribute('aria-describedby');
+    this.trigger.removeAttribute('aria-expanded');
+    if (this.tooltip.parentNode) this.tooltip.parentNode.removeChild(this.tooltip);
+  }
+}
+
+export default Tooltip;

--- a/submissions/examples/tooltip-aria-describedby-enh-sb/style.css
+++ b/submissions/examples/tooltip-aria-describedby-enh-sb/style.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   EaseMotion CSS — Tooltip ARIA Describedby Link
+   ============================================================ */
+
+.ease-tooltip-trigger {
+  position: relative;
+}
+
+.ease-tooltip {
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1f2937;
+  color: #f9fafb;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.375rem;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+
+.ease-tooltip.is-visible {
+  opacity: 1;
+}
+
+.ease-tooltip--static,
+.ease-tooltip--static.is-visible {
+  transition: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip { transition: none !important; }
+}

--- a/submissions/examples/tooltip-aria-describedby-enh-sb/tooltip.test.js
+++ b/submissions/examples/tooltip-aria-describedby-enh-sb/tooltip.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Tooltip } from './script.js';
+
+describe('Tooltip ARIA Describedby Link', () => {
+  let trigger;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    trigger = document.createElement('button');
+    trigger.textContent = 'Help';
+    document.body.appendChild(trigger);
+  });
+
+  it('creates a role=tooltip element linked via aria-describedby', () => {
+    const t = new Tooltip(trigger, { text: 'More info' });
+    expect(trigger.getAttribute('aria-describedby')).toMatch(/^ease-tooltip-\d+$/);
+    const tip = document.getElementById(trigger.getAttribute('aria-describedby'));
+    expect(tip).not.toBeNull();
+    expect(tip.getAttribute('role')).toBe('tooltip');
+    expect(tip.textContent).toBe('More info');
+    t.destroy();
+  });
+
+  it('starts hidden', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    expect(t.isVisible()).toBe(false);
+    t.destroy();
+  });
+
+  it('show() removes hidden and sets aria-expanded=true', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    t.show();
+    expect(t.isVisible()).toBe(true);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    t.destroy();
+  });
+
+  it('hide() restores hidden', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    t.show();
+    t.hide();
+    expect(t.isVisible()).toBe(false);
+    t.destroy();
+  });
+
+  it('hover (mouseenter) shows the tooltip', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    trigger.dispatchEvent(new window.MouseEvent('mouseenter', { bubbles: true }));
+    expect(t.isVisible()).toBe(true);
+    t.destroy();
+  });
+
+  it('focus shows and blur hides the tooltip', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    trigger.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true }));
+    expect(t.isVisible()).toBe(true);
+    trigger.dispatchEvent(new window.FocusEvent('focusout', { bubbles: true }));
+    expect(t.isVisible()).toBe(false);
+    t.destroy();
+  });
+
+  it('Escape hides the tooltip', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    t.show();
+    trigger.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(t.isVisible()).toBe(false);
+    t.destroy();
+  });
+
+  it('uses the title attribute as the tooltip text and removes title', () => {
+    trigger.setAttribute('title', 'From title');
+    const t = new Tooltip(trigger);
+    expect(t.getText()).toBe('From title');
+    expect(trigger.hasAttribute('title')).toBe(false);
+    t.destroy();
+  });
+
+  it('toggle() flips visibility', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    t.toggle();
+    expect(t.isVisible()).toBe(true);
+    t.toggle();
+    expect(t.isVisible()).toBe(false);
+    t.destroy();
+  });
+
+  it('reduced motion adds the static class', () => {
+    window.matchMedia = () => ({ matches: true });
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    expect(t.tooltip.classList.contains('ease-tooltip--static')).toBe(true);
+    delete window.matchMedia;
+    t.destroy();
+  });
+
+  it('destroy() removes the tooltip and aria-describedby', () => {
+    const t = new Tooltip(trigger, { text: 'Hi' });
+    t.destroy();
+    expect(trigger.hasAttribute('aria-describedby')).toBe(false);
+    expect(document.querySelectorAll('[role="tooltip"]').length).toBe(0);
+  });
+
+  it('throws without a trigger element', () => {
+    expect(() => new Tooltip(null)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Tooltip ARIA Describedby Link (enhancement)** accessibility audit (closes #81900). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/tooltip-aria-describedby-enh-sb/`:
- **`script.js`** — `Tooltip`: links a trigger to a `role=tooltip` element via `aria-describedby`. The tooltip is hidden with the HTML `hidden` attribute (not `display:none`, so SRs can read it) and toggled on hover/focus. Respects `prefers-reduced-motion`.
- **`tooltip.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/tooltip-aria-describedby-enh-sb/tooltip.test.js
 ✓ tooltip.test.js (12 tests)
```
- **Happy path**: role=tooltip + aria-describedby link; starts hidden; show/hide toggle + aria-expanded.
- **Edge cases**: hover shows; focus/blur show/hide; Escape hides; title attribute reused + removed; toggle; reduced motion adds static class.
- **Invalid inputs**: throws without trigger element.

Closes #81900

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._