### PR TITLE
a11y(progress): ARIA valuenow compliance submission (enhancement)

### DIFF
--- a/submissions/examples/progress-bar-aria-valuenow-enh-sb/README.md
+++ b/submissions/examples/progress-bar-aria-valuenow-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Progress Bar ARIA Valuenow Compliance
+
+## What does it do?
+A determinate progress bar exposing `role=progressbar` + `aria-valuenow` (current value), `aria-valuemin` (0), `aria-valuemax` (100), and `aria-valuetext` (human-readable "40%"). Keeps the value, label, and bar width in sync.
+
+## How is it used?
+```javascript
+import { ProgressBar } from './script.js';
+const p = new ProgressBar(document.getElementById('pb'), { label: 'Upload progress' });
+p.setValue(40); p.getValue(); p.setLabel('Download'); p.destroy();
+```
+
+## Why is it useful?
+A determinate progress bar must expose `aria-valuenow` so screen readers can announce the current percentage. Many implementations forget `aria-valuetext` (the human-readable form) or let the visual width drift from the ARIA value. This keeps them in sync.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/progress-bar-aria-valuenow-enh-sb/progress.test.js
+```
+- **Happy path**: role=progressbar + aria-valuemin/max/now; starts at 0%; setValue(40) updates valuenow + valuetext + width.
+- **Edge cases**: clamps to [0,100]; coerces non-numbers to 0; getValue; setLabel sets aria-label.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (bar + reduced motion + forced-colors), JavaScript (ARIA value sync), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, watch the bar fill.
+
+Closes #81902

--- a/submissions/examples/progress-bar-aria-valuenow-enh-sb/demo.html
+++ b/submissions/examples/progress-bar-aria-valuenow-enh-sb/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Progress Bar ARIA Valuenow</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="pb" aria-label="Upload progress"></div>
+    <script type="module">
+      import { ProgressBar } from './script.js';
+      const p = new ProgressBar(document.getElementById('pb'), { label: 'Upload progress' });
+      let v = 0;
+      const id = setInterval(() => { v = Math.min(100, v + 10); p.setValue(v); if (v >= 100) clearInterval(id); }, 250);
+    </script>
+  </body>
+</html>

--- a/submissions/examples/progress-bar-aria-valuenow-enh-sb/progress.test.js
+++ b/submissions/examples/progress-bar-aria-valuenow-enh-sb/progress.test.js
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProgressBar } from './script.js';
+
+describe('Progress Bar ARIA Valuenow Compliance', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  it('sets role=progressbar + aria-valuemin/max/now', () => {
+    const p = new ProgressBar(root);
+    expect(root.getAttribute('role')).toBe('progressbar');
+    expect(root.getAttribute('aria-valuemin')).toBe('0');
+    expect(root.getAttribute('aria-valuemax')).toBe('100');
+    expect(root.getAttribute('aria-valuenow')).toBe('0');
+    p.destroy();
+  });
+
+  it('starts at 0% width', () => {
+    const p = new ProgressBar(root);
+    expect(root.querySelector('.ease-progress__bar').style.width).toBe('0%');
+    p.destroy();
+  });
+
+  it('setValue(40) updates aria-valuenow + aria-valuetext + width', () => {
+    const p = new ProgressBar(root);
+    p.setValue(40);
+    expect(root.getAttribute('aria-valuenow')).toBe('40');
+    expect(root.getAttribute('aria-valuetext')).toBe('40%');
+    expect(root.querySelector('.ease-progress__bar').style.width).toBe('40%');
+    p.destroy();
+  });
+
+  it('setValue clamps to [0,100]', () => {
+    const p = new ProgressBar(root);
+    expect(p.setValue(-20)).toBe(0);
+    expect(p.setValue(999)).toBe(100);
+    expect(root.getAttribute('aria-valuenow')).toBe('100');
+    p.destroy();
+  });
+
+  it('setValue coerces non-numbers to 0', () => {
+    const p = new ProgressBar(root);
+    p.setValue('abc');
+    expect(root.getAttribute('aria-valuenow')).toBe('0');
+    p.destroy();
+  });
+
+  it('getValue returns the current value', () => {
+    const p = new ProgressBar(root);
+    p.setValue(73);
+    expect(p.getValue()).toBe(73);
+    p.destroy();
+  });
+
+  it('setLabel sets aria-label', () => {
+    const p = new ProgressBar(root);
+    p.setLabel('Upload progress');
+    expect(root.getAttribute('aria-label')).toBe('Upload progress');
+    p.destroy();
+  });
+
+  it('destroy() removes ARIA attributes and bar node', () => {
+    const p = new ProgressBar(root);
+    p.destroy();
+    expect(root.hasAttribute('role')).toBe(false);
+    expect(root.querySelector('.ease-progress__bar')).toBeNull();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new ProgressBar(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/progress-bar-aria-valuenow-enh-sb/script.js
+++ b/submissions/examples/progress-bar-aria-valuenow-enh-sb/script.js
@@ -1,0 +1,74 @@
+/**
+ * EaseMotion CSS — Progress Bar ARIA Valuenow Compliance (enhancement)
+ * ============================================================
+ * A determinate progress bar exposing role=progressbar + aria-valuenow
+ * (current value), aria-valuemin (0), aria-valuemax (100), and
+ * aria-valuetext (human-readable). Keeps the value, label, and text
+ * node in sync.
+ *
+ * API:
+ *   const p = new ProgressBar(rootEl, { label });
+ *   p.setValue(40); p.getValue(); p.getLabel(); p.destroy();
+ * ============================================================ */
+
+export class ProgressBar {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('ProgressBar requires a root element');
+    }
+    this.root = root;
+    this._value = 0;
+    this._label = options.label || '';
+
+    this.root.setAttribute('role', 'progressbar');
+    this.root.setAttribute('aria-valuemin', '0');
+    this.root.setAttribute('aria-valuemax', '100');
+    this.root.setAttribute('aria-valuenow', '0');
+    this.root.classList.add('ease-progress');
+
+    if (this._label) {
+      const labelId = this.root.id || ('ease-progress-' + Math.random().toString(36).slice(2, 8));
+      this.root.id = labelId;
+      this.root.setAttribute('aria-labelledby', labelId);
+    }
+
+    this._bar = document.createElement('div');
+    this._bar.className = 'ease-progress__bar';
+    this._bar.style.width = '0%';
+    this.root.appendChild(this._bar);
+  }
+
+  setValue(value) {
+    const v = Math.max(0, Math.min(100, Number(value) || 0));
+    this._value = v;
+    this.root.setAttribute('aria-valuenow', String(v));
+    this.root.setAttribute('aria-valuetext', v + '%');
+    this._bar.style.width = v + '%';
+    return v;
+  }
+
+  getValue() {
+    return this._value;
+  }
+
+  getLabel() {
+    return this._label;
+  }
+
+  setLabel(label) {
+    this._label = label;
+    if (label) this.root.setAttribute('aria-label', label);
+    return this._label;
+  }
+
+  destroy() {
+    if (this._bar.parentNode) this._bar.parentNode.removeChild(this._bar);
+    this.root.removeAttribute('role');
+    this.root.removeAttribute('aria-valuemin');
+    this.root.removeAttribute('aria-valuemax');
+    this.root.removeAttribute('aria-valuenow');
+    this.root.removeAttribute('aria-valuetext');
+  }
+}
+
+export default ProgressBar;

--- a/submissions/examples/progress-bar-aria-valuenow-enh-sb/style.css
+++ b/submissions/examples/progress-bar-aria-valuenow-enh-sb/style.css
@@ -1,0 +1,27 @@
+/* ============================================================
+   EaseMotion CSS — Progress Bar ARIA Valuenow Compliance
+   ============================================================ */
+
+.ease-progress {
+  width: 100%;
+  height: 0.75rem;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.ease-progress__bar {
+  height: 100%;
+  background: var(--ease-color-primary, #6c63ff);
+  border-radius: inherit;
+  transition: width 0.25s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress__bar { transition: none !important; }
+}
+
+@media (forced-colors: active) {
+  .ease-progress { border: 1px solid ButtonText; }
+  .ease-progress__bar { background: ButtonText; }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Progress Bar ARIA Valuenow Compliance (enhancement)** accessibility audit (closes #81902). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/progress-bar-aria-valuenow-enh-sb/`:
- **`script.js`** — `ProgressBar`: determinate progress bar exposing `role=progressbar` + `aria-valuenow` + `aria-valuemin` + `aria-valuemax` + `aria-valuetext`, keeping the value, label, and bar width in sync.
- **`progress.test.js`** — 9 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/progress-bar-aria-valuenow-enh-sb/progress.test.js
 ✓ progress.test.js (9 tests)
```
- **Happy path**: role=progressbar + aria-valuemin/max/now; starts at 0%; setValue(40) updates valuenow + valuetext + width.
- **Edge cases**: clamps to [0,100]; coerces non-numbers to 0; getValue; setLabel sets aria-label.
- **Invalid inputs**: throws without root element.

Closes #81902

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._