### PR TITLE
a11y(rating): star keypress selection submission (enhancement)

### DIFF
--- a/submissions/examples/rating-star-keypress-enh-sb/README.md
+++ b/submissions/examples/rating-star-keypress-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Rating Star Keypress Selection
+
+## What does it do?
+A star-rating with `role=slider` (composite) semantics: the group has `role=slider` + `aria-valuemin/max/now/text`, each star is a button with `aria-label`. ArrowLeft/Right (or Up/Down) adjust the value by ±1, Home/End jump. Respects `prefers-reduced-motion`.
+
+## How is it used?
+```javascript
+import { Rating } from './script.js';
+const r = new Rating(document.getElementById('rating'), { max: 5, value: 3 });
+r.setValue(4); r.getValue(); r.destroy();
+```
+
+## Why is it useful?
+Star ratings that are mouse-only are unusable from the keyboard. The composite-slider pattern lets keyboard users set the value with arrows, and `aria-valuetext` announces the current rating ("3 of 5 stars") to screen readers.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/rating-star-keypress-enh-sb/rating.test.js
+```
+- **Happy path**: role=slider + aria-valuemin/max; max star buttons with aria-label; starts at value 0.
+- **Edge cases**: ArrowRight/Left adjust; Home/End; clamps to [0, max]; click sets value; aria-valuetext format; aria-pressed on stars.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (star styling + reduced motion + forced-colors), JavaScript (composite slider), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, focus the rating, use arrow keys.
+
+Closes #81904

--- a/submissions/examples/rating-star-keypress-enh-sb/demo.html
+++ b/submissions/examples/rating-star-keypress-enh-sb/demo.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Rating Star Keypress Selection</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="rating"></div>
+    <script type="module">
+      import { Rating } from './script.js';
+      window.__rating = new Rating(document.getElementById('rating'), { max: 5, value: 3 });
+    </script>
+  </body>
+</html>

--- a/submissions/examples/rating-star-keypress-enh-sb/rating.test.js
+++ b/submissions/examples/rating-star-keypress-enh-sb/rating.test.js
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Rating } from './script.js';
+
+describe('Rating Star Keypress Selection', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  function keydown(key) {
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('sets role=slider + tabindex=0 + aria-valuemin/max', () => {
+    const r = new Rating(root, { max: 5, value: 0 });
+    expect(root.getAttribute('role')).toBe('slider');
+    expect(root.getAttribute('tabindex')).toBe('0');
+    expect(root.getAttribute('aria-valuemin')).toBe('0');
+    expect(root.getAttribute('aria-valuemax')).toBe('5');
+    r.destroy();
+  });
+
+  it('creates max star buttons with aria-label', () => {
+    const r = new Rating(root, { max: 5, value: 0 });
+    expect(root.querySelectorAll('.ease-rating__star').length).toBe(5);
+    expect(root.querySelector('[data-index="1"]').getAttribute('aria-label')).toBe('2 stars');
+    r.destroy();
+  });
+
+  it('starts with value 0 (no stars active)', () => {
+    const r = new Rating(root, { max: 5, value: 0 });
+    expect(root.querySelectorAll('.is-active').length).toBe(0);
+    r.destroy();
+  });
+
+  it('ArrowRight increases value by 1', () => {
+    const r = new Rating(root, { max: 5, value: 2 });
+    keydown('ArrowRight');
+    expect(r.getValue()).toBe(3);
+    expect(root.getAttribute('aria-valuenow')).toBe('3');
+    r.destroy();
+  });
+
+  it('ArrowLeft decreases value by 1', () => {
+    const r = new Rating(root, { max: 5, value: 3 });
+    keydown('ArrowLeft');
+    expect(r.getValue()).toBe(2);
+    r.destroy();
+  });
+
+  it('Home sets value to 0, End sets to max', () => {
+    const r = new Rating(root, { max: 5, value: 3 });
+    keydown('Home');
+    expect(r.getValue()).toBe(0);
+    keydown('End');
+    expect(r.getValue()).toBe(5);
+    r.destroy();
+  });
+
+  it('value clamps to [0, max]', () => {
+    const r = new Rating(root, { max: 5, value: 3 });
+    r.setValue(-5); expect(r.getValue()).toBe(0);
+    r.setValue(99); expect(r.getValue()).toBe(5);
+    r.destroy();
+  });
+
+  it('clicking the 4th star sets value to 4', () => {
+    const r = new Rating(root, { max: 5, value: 0 });
+    root.querySelector('[data-index="3"]').click();
+    expect(r.getValue()).toBe(4);
+    r.destroy();
+  });
+
+  it('aria-valuetext is "N of max stars"', () => {
+    const r = new Rating(root, { max: 5, value: 3 });
+    expect(root.getAttribute('aria-valuetext')).toBe('3 of 5 stars');
+    r.destroy();
+  });
+
+  it('active stars get aria-pressed=true', () => {
+    const r = new Rating(root, { max: 5, value: 2 });
+    const stars = root.querySelectorAll('.ease-rating__star');
+    expect(stars[0].getAttribute('aria-pressed')).toBe('true');
+    expect(stars[2].getAttribute('aria-pressed')).toBe('false');
+    r.destroy();
+  });
+
+  it('destroy() removes listeners without throwing', () => {
+    const r = new Rating(root, { max: 5, value: 2 });
+    expect(() => r.destroy()).not.toThrow();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new Rating(null)).toThrow(TypeError);
+  });
+});

--- a/submissions/examples/rating-star-keypress-enh-sb/script.js
+++ b/submissions/examples/rating-star-keypress-enh-sb/script.js
@@ -1,0 +1,87 @@
+/**
+ * EaseMotion CSS — Rating Star Keypress Selection (enhancement)
+ * ============================================================
+ * A star-rating with role=slider (composite) semantics: the group has
+ * role=slider + aria-valuemin/max/now/text, each star is a button with
+ * aria-label. ArrowLeft/Right adjust the value by ±1, Home/End jump.
+ * Respects prefers-reduced-motion (no star-fill transition).
+ *
+ * API:
+ *   const r = new Rating(rootEl, { max, value });
+ *   r.setValue(3); r.getValue(); r.destroy();
+ * ============================================================ */
+
+export class Rating {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('Rating requires a root element');
+    }
+    this.root = root;
+    this.max = Math.max(1, Number(options.max) || 5);
+    this._value = Math.max(0, Math.min(this.max, Number(options.value) || 0));
+
+    this.root.setAttribute('role', 'slider');
+    this.root.setAttribute('tabindex', '0');
+    this.root.setAttribute('aria-valuemin', '0');
+    this.root.setAttribute('aria-valuemax', String(this.max));
+    this.root.classList.add('ease-rating');
+
+    this.stars = [];
+    for (let i = 0; i < this.max; i++) {
+      const star = document.createElement('button');
+      star.type = 'button';
+      star.setAttribute('aria-label', (i + 1) + ' star' + (i ? 's' : ''));
+      star.className = 'ease-rating__star';
+      star.dataset.index = String(i);
+      this.root.appendChild(star);
+      this.stars.push(star);
+    }
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onClick = this._onClick.bind(this);
+    this.root.addEventListener('keydown', this._onKeydown);
+    this.root.addEventListener('click', this._onClick);
+    this._render();
+  }
+
+  setValue(v) {
+    this._value = Math.max(0, Math.min(this.max, Number(v) || 0));
+    this._render();
+    return this._value;
+  }
+
+  getValue() {
+    return this._value;
+  }
+
+  _render() {
+    this.root.setAttribute('aria-valuenow', String(this._value));
+    this.root.setAttribute('aria-valuetext', this._value + ' of ' + this.max + ' stars');
+    this.stars.forEach((star, i) => {
+      const active = i < this._value;
+      star.setAttribute('aria-pressed', active ? 'true' : 'false');
+      star.classList.toggle('is-active', active);
+    });
+  }
+
+  _onKeydown(event) {
+    const k = event.key;
+    if (k === 'ArrowRight' || k === 'ArrowUp') { event.preventDefault(); this.setValue(this._value + 1); }
+    else if (k === 'ArrowLeft' || k === 'ArrowDown') { event.preventDefault(); this.setValue(this._value - 1); }
+    else if (k === 'Home') { event.preventDefault(); this.setValue(0); }
+    else if (k === 'End') { event.preventDefault(); this.setValue(this.max); }
+  }
+
+  _onClick(event) {
+    const star = event.target.closest('[data-index]');
+    if (!star) return;
+    this.setValue(Number(star.dataset.index) + 1);
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this.root.removeEventListener('click', this._onClick);
+  }
+}
+
+export default Rating;

--- a/submissions/examples/rating-star-keypress-enh-sb/style.css
+++ b/submissions/examples/rating-star-keypress-enh-sb/style.css
@@ -1,0 +1,41 @@
+/* ============================================================
+   EaseMotion CSS — Rating Star Keypress Selection
+   ============================================================ */
+
+.ease-rating {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.ease-rating:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 2px;
+}
+
+.ease-rating__star {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: #d1d5db;
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.ease-rating__star.is-active {
+  color: #f59e0b;
+}
+
+.ease-rating__star:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-rating__star { transition: none !important; }
+}
+
+@media (forced-colors: active) {
+  .ease-rating__star.is-active { color: Highlight; }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Rating Component Star Keypress Selection (enhancement)** accessibility audit (closes #81904). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/rating-star-keypress-enh-sb/`:
- **`script.js`** — `Rating`: star-rating with `role=slider` (composite) semantics — `aria-valuemin/max/now/text` on the group, each star is a button with `aria-label`. Arrow/Home/End keyboard support. Respects `prefers-reduced-motion`.
- **`rating.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/rating-star-keypress-enh-sb/rating.test.js
 ✓ rating.test.js (12 tests)
```
- **Happy path**: role=slider + aria-valuemin/max; max star buttons with aria-label; starts at value 0.
- **Edge cases**: ArrowRight/Left adjust; Home/End; clamps to [0, max]; click sets value; aria-valuetext format; aria-pressed on stars.
- **Invalid inputs**: throws without root element.

Closes #81904

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._