### PR TITLE
feat: add CSS-only pastel footer (#79850)

### DIFF
--- a/submissions/examples/79850-css-only-footer-pastel/README.md
+++ b/submissions/examples/79850-css-only-footer-pastel/README.md
@@ -1,0 +1,26 @@
+# CSS-only Footer — Pastel
+
+A responsive CSS-only footer with a soft pastel visual style
+created for EaseMotion CSS issue #79850.
+
+## Features
+
+- Pastel color palette
+- Responsive footer layout
+- Product, company and resource navigation
+- Newsletter area
+- Soft shadows and layered surfaces
+- Decorative pastel glow effects
+- Smooth hover interactions
+- Responsive desktop, tablet and mobile behavior
+- Reduced-motion support
+- Pure HTML and CSS
+- No JavaScript dependencies
+
+## Structure
+
+```text
+79850-css-only-footer-pastel/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/79850-css-only-footer-pastel/demo.html
+++ b/submissions/examples/79850-css-only-footer-pastel/demo.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="CSS-only footer with pastel styling"
+  >
+
+  <title>Pastel Footer</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+    <section class="hero">
+      <span class="hero__eyebrow">EASEMOTION CSS</span>
+
+      <h1>Build something people remember.</h1>
+
+      <p>
+        A soft pastel footer component designed for modern
+        responsive websites.
+      </p>
+    </section>
+  </main>
+
+  <footer class="footer">
+
+    <div class="footer__glow footer__glow--one"></div>
+    <div class="footer__glow footer__glow--two"></div>
+
+    <div class="footer__inner">
+
+      <div class="footer__brand">
+
+        <a href="#" class="brand" aria-label="Pastel Studio home">
+          <span class="brand__mark">P</span>
+
+          <span class="brand__text">
+            Pastel Studio
+          </span>
+        </a>
+
+        <p>
+          Thoughtful interfaces with smooth motion,
+          playful color and clean experiences.
+        </p>
+
+        <span class="footer__tag">
+          DESIGNED WITH CARE
+        </span>
+
+      </div>
+
+      <nav class="footer__nav" aria-label="Footer navigation">
+
+        <div class="footer__column">
+          <h2>Product</h2>
+
+          <a href="#">Features</a>
+          <a href="#">Solutions</a>
+          <a href="#">Pricing</a>
+          <a href="#">Changelog</a>
+        </div>
+
+        <div class="footer__column">
+          <h2>Company</h2>
+
+          <a href="#">About</a>
+          <a href="#">Careers</a>
+          <a href="#">Contact</a>
+          <a href="#">Blog</a>
+        </div>
+
+        <div class="footer__column">
+          <h2>Resources</h2>
+
+          <a href="#">Documentation</a>
+          <a href="#">Community</a>
+          <a href="#">Support</a>
+          <a href="#">Guides</a>
+        </div>
+
+      </nav>
+
+      <div class="footer__newsletter">
+
+        <span class="newsletter__eyebrow">
+          STAY IN THE LOOP
+        </span>
+
+        <h2>
+          Fresh ideas.
+          Straight to your inbox.
+        </h2>
+
+        <form class="newsletter__form">
+
+          <label
+            class="sr-only"
+            for="email"
+          >
+            Email address
+          </label>
+
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@example.com"
+            autocomplete="email"
+          >
+
+          <button type="submit">
+            →
+          </button>
+
+        </form>
+
+      </div>
+
+    </div>
+
+    <div class="footer__bottom">
+
+      <p>
+        © 2026 Pastel Studio. All rights reserved.
+      </p>
+
+      <div class="footer__legal">
+        <a href="#">Privacy</a>
+        <a href="#">Terms</a>
+        <a href="#">Cookies</a>
+      </div>
+
+    </div>
+
+  </footer>
+
+</body>
+</html>

--- a/submissions/examples/79850-css-only-footer-pastel/style.css
+++ b/submissions/examples/79850-css-only-footer-pastel/style.css
@@ -1,0 +1,685 @@
+:root {
+  --bg: #f8f6fb;
+
+  --surface: #fff9fc;
+  --surface-soft: #fff4f8;
+
+  --text: #30263b;
+  --muted: #776c83;
+  --subtle: #a49aaa;
+
+  --pink: #ef9fba;
+  --pink-light: #ffdce8;
+
+  --lavender: #b9a6eb;
+  --lavender-light: #eee7ff;
+
+  --mint: #8fd5c1;
+  --mint-light: #def5ee;
+
+  --peach: #f5c49c;
+  --peach-light: #fff0df;
+
+  --border: rgba(89, 67, 104, 0.1);
+
+  --shadow:
+    0 18px 45px
+    rgba(83, 62, 99, 0.08);
+
+  --shadow-hover:
+    0 22px 50px
+    rgba(83, 62, 99, 0.13);
+
+  --transition:
+    280ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 12% 10%,
+      rgba(239, 159, 186, 0.16),
+      transparent 25%
+    ),
+    radial-gradient(
+      circle at 88% 18%,
+      rgba(185, 166, 235, 0.14),
+      transparent 25%
+    ),
+    var(--bg);
+
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+/* =========================================================
+   Demo page
+   ========================================================= */
+
+.page {
+  min-height: 72vh;
+
+  display: grid;
+  place-items: center;
+
+  padding:
+    4rem 1rem;
+}
+
+.hero {
+  width: min(100%, 760px);
+
+  text-align: center;
+}
+
+.hero__eyebrow {
+  display: inline-block;
+
+  margin-bottom: 1rem;
+
+  color: #8d7695;
+
+  font-size: 0.65rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.15em;
+}
+
+.hero h1 {
+  margin: 0;
+
+  font-size:
+    clamp(2rem, 6vw, 4rem);
+
+  line-height: 1.05;
+
+  letter-spacing: -0.045em;
+}
+
+.hero p {
+  max-width: 580px;
+
+  margin:
+    1rem auto 0;
+
+  color: var(--muted);
+
+  font-size: 0.9rem;
+
+  line-height: 1.8;
+}
+
+/* =========================================================
+   Footer
+   ========================================================= */
+
+.footer {
+  position: relative;
+
+  overflow: hidden;
+
+  margin:
+    0 1rem 1rem;
+
+  background:
+    linear-gradient(
+      145deg,
+      #fffaff,
+      #fff3f8
+    );
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius:
+    1.6rem;
+
+  box-shadow:
+    var(--shadow);
+}
+
+.footer__glow {
+  position: absolute;
+
+  width: 260px;
+  height: 260px;
+
+  border-radius: 50%;
+
+  filter: blur(10px);
+
+  pointer-events: none;
+
+  opacity: 0.38;
+}
+
+.footer__glow--one {
+  top: -170px;
+  left: -100px;
+
+  background:
+    var(--pink-light);
+}
+
+.footer__glow--two {
+  right: -110px;
+  bottom: -170px;
+
+  background:
+    var(--lavender-light);
+}
+
+.footer__inner {
+  position: relative;
+
+  z-index: 1;
+
+  width: min(100%, 1180px);
+
+  margin: 0 auto;
+
+  display: grid;
+
+  grid-template-columns:
+    1.35fr 1.5fr 1fr;
+
+  gap: 3rem;
+
+  padding:
+    3.2rem 2rem;
+}
+
+/* =========================================================
+   Brand
+   ========================================================= */
+
+.footer__brand {
+  max-width: 290px;
+}
+
+.brand {
+  display: inline-flex;
+
+  align-items: center;
+
+  gap: 0.75rem;
+
+  color: var(--text);
+
+  text-decoration: none;
+}
+
+.brand__mark {
+  width: 2.6rem;
+  height: 2.6rem;
+
+  display: grid;
+  place-items: center;
+
+  color: #513d4d;
+
+  background:
+    linear-gradient(
+      145deg,
+      var(--pink-light),
+      var(--peach-light)
+    );
+
+  border:
+    1px solid
+    rgba(155, 94, 119, 0.1);
+
+  border-radius:
+    0.9rem;
+
+  font-size: 1rem;
+
+  font-weight: 900;
+
+  box-shadow:
+    4px 4px 0
+    rgba(239, 159, 186, 0.2);
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.brand__text {
+  font-size: 1rem;
+
+  font-weight: 800;
+
+  letter-spacing: -0.02em;
+}
+
+.brand:hover .brand__mark {
+  transform:
+    rotate(-5deg)
+    translateY(-2px);
+
+  box-shadow:
+    6px 6px 0
+    rgba(239, 159, 186, 0.24);
+}
+
+.footer__brand p {
+  margin:
+    1.15rem 0 1rem;
+
+  color: var(--muted);
+
+  font-size: 0.78rem;
+
+  line-height: 1.8;
+}
+
+.footer__tag {
+  display: inline-block;
+
+  padding:
+    0.45rem 0.7rem;
+
+  color: #7f6a77;
+
+  background:
+    rgba(255, 255, 255, 0.7);
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius:
+    999px;
+
+  font-size: 0.52rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.1em;
+}
+
+/* =========================================================
+   Navigation
+   ========================================================= */
+
+.footer__nav {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 1.5rem;
+}
+
+.footer__column {
+  display: grid;
+
+  align-content: start;
+
+  gap: 0.65rem;
+}
+
+.footer__column h2 {
+  margin: 0 0 0.45rem;
+
+  color: var(--text);
+
+  font-size: 0.78rem;
+
+  font-weight: 800;
+}
+
+.footer__column a,
+.footer__legal a {
+  width: fit-content;
+
+  color: var(--muted);
+
+  font-size: 0.7rem;
+
+  text-decoration: none;
+
+  transition:
+    color var(--transition),
+    transform var(--transition);
+}
+
+.footer__column a:hover,
+.footer__legal a:hover {
+  color: var(--text);
+
+  transform:
+    translateX(3px);
+}
+
+/* =========================================================
+   Newsletter
+   ========================================================= */
+
+.footer__newsletter {
+  padding:
+    1.2rem;
+
+  background:
+    rgba(255, 255, 255, 0.55);
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius:
+    1.1rem;
+
+  box-shadow:
+    0 8px 22px
+    rgba(83, 62, 99, 0.045);
+}
+
+.newsletter__eyebrow {
+  color: #9e8390;
+
+  font-size: 0.55rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.13em;
+}
+
+.footer__newsletter h2 {
+  margin:
+    0.55rem 0 1rem;
+
+  font-size: 1.15rem;
+
+  line-height: 1.25;
+
+  letter-spacing: -0.025em;
+}
+
+.newsletter__form {
+  display: flex;
+
+  align-items: center;
+
+  gap: 0.5rem;
+
+  padding:
+    0.35rem;
+
+  background:
+    #ffffff;
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius:
+    0.85rem;
+
+  box-shadow:
+    0 5px 15px
+    rgba(83, 62, 99, 0.05);
+}
+
+.newsletter__form input {
+  min-width: 0;
+
+  width: 100%;
+
+  padding:
+    0.65rem 0.7rem;
+
+  color: var(--text);
+
+  background: transparent;
+
+  border: 0;
+
+  outline: 0;
+
+  font: inherit;
+
+  font-size: 0.68rem;
+}
+
+.newsletter__form input::placeholder {
+  color: var(--subtle);
+}
+
+.newsletter__form button {
+  flex: 0 0 2.25rem;
+
+  width: 2.25rem;
+  height: 2.25rem;
+
+  display: grid;
+  place-items: center;
+
+  color: #513d4d;
+
+  background:
+    linear-gradient(
+      145deg,
+      var(--pink-light),
+      var(--lavender-light)
+    );
+
+  border:
+    0;
+
+  border-radius:
+    0.65rem;
+
+  cursor: pointer;
+
+  font-size: 1.1rem;
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.newsletter__form button:hover {
+  transform:
+    translateX(2px)
+    scale(1.04);
+
+  box-shadow:
+    0 5px 12px
+    rgba(185, 166, 235, 0.22);
+}
+
+/* =========================================================
+   Bottom
+   ========================================================= */
+
+.footer__bottom {
+  position: relative;
+
+  z-index: 1;
+
+  width: min(100%, 1180px);
+
+  margin: 0 auto;
+
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  gap: 1rem;
+
+  padding:
+    1.15rem 2rem
+    1.35rem;
+
+  border-top:
+    1px solid
+    var(--border);
+}
+
+.footer__bottom p {
+  margin: 0;
+
+  color: var(--subtle);
+
+  font-size: 0.62rem;
+}
+
+.footer__legal {
+  display: flex;
+
+  flex-wrap: wrap;
+
+  gap: 1.1rem;
+}
+
+/* =========================================================
+   Accessibility
+   ========================================================= */
+
+.sr-only {
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+
+  padding: 0;
+  margin: -1px;
+
+  overflow: hidden;
+
+  clip: rect(0, 0, 0, 0);
+
+  white-space: nowrap;
+
+  border: 0;
+}
+
+/* =========================================================
+   Responsive
+   ========================================================= */
+
+@media (max-width: 900px) {
+  .footer__inner {
+    grid-template-columns:
+      1fr 1fr;
+
+    gap: 2.2rem;
+  }
+
+  .footer__brand {
+    max-width: none;
+  }
+
+  .footer__newsletter {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 680px) {
+  .page {
+    min-height: 64vh;
+
+    padding:
+      2.5rem 1rem;
+  }
+
+  .footer {
+    margin:
+      0 0.6rem
+      0.6rem;
+
+    border-radius:
+      1.25rem;
+  }
+
+  .footer__inner {
+    grid-template-columns: 1fr;
+
+    gap: 2rem;
+
+    padding:
+      2rem 1.1rem;
+  }
+
+  .footer__nav {
+    grid-template-columns:
+      repeat(2, 1fr);
+  }
+
+  .footer__newsletter {
+    grid-column: auto;
+  }
+
+  .footer__bottom {
+    align-items: flex-start;
+
+    flex-direction: column;
+
+    padding:
+      1rem 1.1rem 1.2rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .footer__nav {
+    grid-template-columns: 1fr 1fr;
+
+    gap: 1.3rem;
+  }
+
+  .footer__newsletter h2 {
+    font-size: 1rem;
+  }
+
+  .footer__bottom p {
+    line-height: 1.6;
+  }
+
+  .footer__legal {
+    gap: 0.8rem;
+  }
+}
+
+/* =========================================================
+   Reduced Motion
+   ========================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+
+    animation-iteration-count: 1 !important;
+
+    transition-duration: 0.01ms !important;
+
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a responsive **CSS-only Footer with Pastel styling**
to EaseMotion CSS.

It is a critical issue for providing a reusable footer component
with a soft pastel visual system, responsive navigation and subtle
interactive states.

## Changes

- Added CSS-only pastel footer
- Added responsive navigation sections
- Added newsletter subscription UI
- Added pastel decorative glow elements
- Added smooth hover interactions
- Added responsive desktop, tablet and mobile layouts
- Added reduced-motion support
- Added standalone documentation

## Technical Details

- Pure HTML and CSS
- No JavaScript
- No external dependencies
- CSS gradients and shadows
- Responsive media queries

## Accessibility

- Semantic footer and navigation markup
- Accessible newsletter label
- Responsive layout
- Reduced-motion support

## Testing

Tested locally using the standalone `demo.html`
on desktop and mobile viewport sizes.

## Issue

Closes #79850