### PR TITLE
feat: add parallax dark mode badge (#79836)

### DIFF
--- a/submissions/examples/79836-parallax-badge-dark-mode/README.md
+++ b/submissions/examples/79836-parallax-badge-dark-mode/README.md
@@ -1,0 +1,26 @@
+# Parallax Badge — Dark Mode
+
+A responsive Parallax Badge with a dark-mode visual style created
+for EaseMotion CSS issue #79836.
+
+## Features
+
+- Dark-mode badge design
+- CSS-only parallax effect
+- Layered 3D depth
+- Glowing cyan, blue and violet accents
+- Floating decorative orbs
+- Animated highlight sweep
+- Smooth hover and focus states
+- Responsive desktop, tablet and mobile layouts
+- Reduced-motion support
+- Pure HTML and CSS
+- No JavaScript dependencies
+
+## Structure
+
+```text
+79836-parallax-badge-dark-mode/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/79836-parallax-badge-dark-mode/demo.html
+++ b/submissions/examples/79836-parallax-badge-dark-mode/demo.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="Parallax Badge with Dark Mode styling"
+  >
+
+  <title>Parallax Badge - Dark Mode</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="showcase">
+
+      <span class="showcase__eyebrow">
+        EASEMOTION CSS / COMPONENT 79836
+      </span>
+
+      <h1>
+        Parallax Badge
+      </h1>
+
+      <p class="showcase__intro">
+        Move your pointer across the badge to reveal layered
+        depth, subtle parallax motion and a dark-mode glow.
+      </p>
+
+      <div class="badge-scene">
+
+        <a
+          href="#"
+          class="parallax-badge"
+          aria-label="Explore premium features"
+        >
+
+          <span
+            class="parallax-badge__glow"
+            aria-hidden="true"
+          ></span>
+
+          <span
+            class="parallax-badge__grid"
+            aria-hidden="true"
+          ></span>
+
+          <span
+            class="parallax-badge__orb parallax-badge__orb--one"
+            aria-hidden="true"
+          ></span>
+
+          <span
+            class="parallax-badge__orb parallax-badge__orb--two"
+            aria-hidden="true"
+          ></span>
+
+          <span class="parallax-badge__content">
+
+            <span class="parallax-badge__icon">
+              ✦
+            </span>
+
+            <span class="parallax-badge__copy">
+
+              <span class="parallax-badge__label">
+                FEATURED
+              </span>
+
+              <strong>
+                Premium Access
+              </strong>
+
+              <span>
+                Unlock the full experience
+              </span>
+
+            </span>
+
+            <span class="parallax-badge__arrow">
+              →
+            </span>
+
+          </span>
+
+          <span
+            class="parallax-badge__shine"
+            aria-hidden="true"
+          ></span>
+
+        </a>
+
+      </div>
+
+      <p class="showcase__hint">
+        Hover / focus the badge
+      </p>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/79836-parallax-badge-dark-mode/style.css
+++ b/submissions/examples/79836-parallax-badge-dark-mode/style.css
@@ -1,0 +1,776 @@
+:root {
+  --bg: #07090f;
+  --surface: #0e121c;
+  --surface-light: #141a27;
+
+  --text: #f4f7ff;
+  --muted: #8993a7;
+  --subtle: #596377;
+
+  --cyan: #56e6ff;
+  --blue: #687bff;
+  --violet: #a26dff;
+
+  --border: rgba(255, 255, 255, 0.09);
+
+  --shadow:
+    0 24px 60px rgba(0, 0, 0, 0.45),
+    0 7px 18px rgba(0, 0, 0, 0.28);
+
+  --shadow-hover:
+    0 34px 80px rgba(0, 0, 0, 0.58),
+    0 10px 28px rgba(0, 0, 0, 0.34);
+
+  --gradient:
+    linear-gradient(
+      135deg,
+      var(--cyan),
+      var(--blue) 48%,
+      var(--violet)
+    );
+
+  --transition:
+    320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+
+  color: var(--text);
+
+  background:
+    radial-gradient(
+      circle at 14% 18%,
+      rgba(86, 230, 255, 0.09),
+      transparent 25%
+    ),
+    radial-gradient(
+      circle at 84% 76%,
+      rgba(162, 109, 255, 0.11),
+      transparent 28%
+    ),
+    linear-gradient(
+      145deg,
+      #06080d,
+      #090c14 55%,
+      #070910
+    );
+
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+/* =========================================================
+   Showcase
+   ========================================================= */
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+  place-items: center;
+
+  padding:
+    4rem 1rem;
+}
+
+.showcase {
+  width: min(100%, 850px);
+
+  text-align: center;
+}
+
+.showcase__eyebrow {
+  display: inline-block;
+
+  margin-bottom: 0.85rem;
+
+  color: var(--cyan);
+
+  font-size: 0.61rem;
+
+  font-weight: 800;
+
+  letter-spacing: 0.15em;
+
+  text-transform: uppercase;
+
+  text-shadow:
+    0 0 18px
+    rgba(86, 230, 255, 0.28);
+}
+
+.showcase h1 {
+  margin: 0;
+
+  font-size:
+    clamp(2.2rem, 6vw, 4.3rem);
+
+  line-height: 1;
+
+  letter-spacing: -0.05em;
+}
+
+.showcase__intro {
+  width: min(100%, 620px);
+
+  margin:
+    1rem auto 0;
+
+  color: var(--muted);
+
+  font-size: 0.86rem;
+
+  line-height: 1.8;
+}
+
+/* =========================================================
+   Badge Scene
+   ========================================================= */
+
+.badge-scene {
+  width: min(100%, 620px);
+
+  margin:
+    3.2rem auto 1rem;
+
+  display: grid;
+
+  place-items: center;
+
+  perspective:
+    1200px;
+}
+
+/* =========================================================
+   Badge
+   ========================================================= */
+
+.parallax-badge {
+  --rotate-x: 0deg;
+  --rotate-y: 0deg;
+  --move-x: 0px;
+  --move-y: 0px;
+
+  position: relative;
+
+  display: block;
+
+  width: min(100%, 510px);
+
+  min-height: 190px;
+
+  padding:
+    1.2rem;
+
+  overflow: hidden;
+
+  color: var(--text);
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(20, 26, 39, 0.98),
+      rgba(10, 14, 23, 0.98)
+    );
+
+  border:
+    1px solid
+    var(--border);
+
+  border-radius:
+    1.4rem;
+
+  text-decoration: none;
+
+  box-shadow:
+    var(--shadow);
+
+  transform:
+    translate3d(
+      var(--move-x),
+      var(--move-y),
+      0
+    )
+    rotateX(var(--rotate-x))
+    rotateY(var(--rotate-y));
+
+  transform-style:
+    preserve-3d;
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition),
+    border-color var(--transition);
+
+  isolation: isolate;
+}
+
+.parallax-badge:hover,
+.parallax-badge:focus-visible {
+  --move-y: -5px;
+
+  border-color:
+    rgba(86, 230, 255, 0.2);
+
+  box-shadow:
+    var(--shadow-hover),
+    0 0 35px
+      rgba(86, 230, 255, 0.08);
+}
+
+.parallax-badge:focus-visible {
+  outline:
+    2px solid
+    var(--cyan);
+
+  outline-offset:
+    5px;
+}
+
+/* =========================================================
+   Layered Glow
+   ========================================================= */
+
+.parallax-badge__glow {
+  position: absolute;
+
+  width: 260px;
+  height: 260px;
+
+  top: -155px;
+  right: -100px;
+
+  border-radius: 50%;
+
+  background:
+    radial-gradient(
+      circle,
+      rgba(86, 230, 255, 0.22),
+      rgba(104, 123, 255, 0.08) 42%,
+      transparent 72%
+    );
+
+  filter:
+    blur(4px);
+
+  transform:
+    translate3d(
+      calc(var(--move-x) * -1),
+      calc(var(--move-y) * -1),
+      35px
+    );
+
+  pointer-events: none;
+
+  transition:
+    transform var(--transition),
+    opacity var(--transition);
+
+  opacity: 0.8;
+}
+
+.parallax-badge:hover
+  .parallax-badge__glow,
+.parallax-badge:focus-visible
+  .parallax-badge__glow {
+  opacity: 1;
+
+  transform:
+    translate3d(
+      calc(var(--move-x) * -2),
+      calc(var(--move-y) * -2),
+      55px
+    );
+}
+
+/* =========================================================
+   Grid Layer
+   ========================================================= */
+
+.parallax-badge__grid {
+  position: absolute;
+
+  inset: 0;
+
+  background:
+    linear-gradient(
+      rgba(255, 255, 255, 0.035) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.035) 1px,
+      transparent 1px
+    );
+
+  background-size:
+    26px 26px;
+
+  mask-image:
+    linear-gradient(
+      to bottom,
+      black,
+      transparent 75%
+    );
+
+  transform:
+    translateZ(15px);
+
+  pointer-events: none;
+
+  opacity: 0.5;
+}
+
+/* =========================================================
+   Orbs
+   ========================================================= */
+
+.parallax-badge__orb {
+  position: absolute;
+
+  border-radius: 50%;
+
+  pointer-events: none;
+
+  transition:
+    transform var(--transition);
+}
+
+.parallax-badge__orb--one {
+  width: 100px;
+  height: 100px;
+
+  top: 20px;
+  right: 55px;
+
+  background:
+    radial-gradient(
+      circle,
+      rgba(86, 230, 255, 0.3),
+      transparent 68%
+    );
+
+  transform:
+    translate3d(0, 0, 45px);
+}
+
+.parallax-badge__orb--two {
+  width: 140px;
+  height: 140px;
+
+  bottom: -75px;
+  left: 25px;
+
+  background:
+    radial-gradient(
+      circle,
+      rgba(162, 109, 255, 0.22),
+      transparent 68%
+    );
+
+  transform:
+    translate3d(0, 0, 25px);
+}
+
+.parallax-badge:hover
+  .parallax-badge__orb--one {
+  transform:
+    translate3d(
+      12px,
+      -8px,
+      70px
+    );
+}
+
+.parallax-badge:hover
+  .parallax-badge__orb--two {
+  transform:
+    translate3d(
+      -10px,
+      7px,
+      45px
+    );
+}
+
+/* =========================================================
+   Content
+   ========================================================= */
+
+.parallax-badge__content {
+  position: relative;
+
+  z-index: 3;
+
+  min-height: 165px;
+
+  display: grid;
+
+  grid-template-columns:
+    auto 1fr auto;
+
+  align-items: center;
+
+  gap: 1rem;
+
+  padding:
+    1.15rem;
+
+  background:
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.015)
+    );
+
+  border:
+    1px solid
+    rgba(255, 255, 255, 0.06);
+
+  border-radius:
+    1rem;
+
+  backdrop-filter:
+    blur(10px);
+
+  transform:
+    translateZ(45px);
+
+  transition:
+    transform var(--transition);
+}
+
+.parallax-badge:hover
+  .parallax-badge__content {
+  transform:
+    translate3d(
+      5px,
+      -3px,
+      65px
+    );
+}
+
+/* =========================================================
+   Icon
+   ========================================================= */
+
+.parallax-badge__icon {
+  width: 58px;
+  height: 58px;
+
+  display: grid;
+  place-items: center;
+
+  flex: none;
+
+  color: #ffffff;
+
+  background:
+    var(--gradient);
+
+  border-radius:
+    1rem;
+
+  font-size: 1.35rem;
+
+  box-shadow:
+    0 0 24px
+    rgba(104, 123, 255, 0.25);
+
+  transform:
+    translateZ(55px);
+
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.parallax-badge:hover
+  .parallax-badge__icon {
+  transform:
+    translate3d(
+      4px,
+      -4px,
+      80px
+    )
+    rotate(-4deg);
+
+  box-shadow:
+    0 0 32px
+    rgba(86, 230, 255, 0.34);
+}
+
+/* =========================================================
+   Copy
+   ========================================================= */
+
+.parallax-badge__copy {
+  display: grid;
+
+  gap: 0.35rem;
+
+  text-align: left;
+
+  transform:
+    translateZ(50px);
+}
+
+.parallax-badge__label {
+  color: var(--cyan);
+
+  font-size: 0.56rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.13em;
+}
+
+.parallax-badge__copy strong {
+  color: var(--text);
+
+  font-size:
+    clamp(1.1rem, 3vw, 1.45rem);
+
+  line-height: 1.15;
+
+  letter-spacing: -0.03em;
+}
+
+.parallax-badge__copy span:last-child {
+  color: var(--muted);
+
+  font-size: 0.68rem;
+
+  line-height: 1.5;
+}
+
+/* =========================================================
+   Arrow
+   ========================================================= */
+
+.parallax-badge__arrow {
+  width: 42px;
+  height: 42px;
+
+  display: grid;
+  place-items: center;
+
+  color: var(--text);
+
+  background:
+    rgba(255, 255, 255, 0.045);
+
+  border:
+    1px solid
+    rgba(255, 255, 255, 0.09);
+
+  border-radius: 50%;
+
+  font-size: 1.1rem;
+
+  transform:
+    translateZ(55px);
+
+  transition:
+    transform var(--transition),
+    background var(--transition),
+    color var(--transition);
+}
+
+.parallax-badge:hover
+  .parallax-badge__arrow {
+  color: #ffffff;
+
+  background:
+    rgba(86, 230, 255, 0.12);
+
+  transform:
+    translate3d(
+      6px,
+      0,
+      80px
+    );
+}
+
+/* =========================================================
+   Shine
+   ========================================================= */
+
+.parallax-badge__shine {
+  position: absolute;
+
+  width: 180px;
+  height: 500px;
+
+  top: -150px;
+  left: -230px;
+
+  background:
+    linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.14),
+      transparent
+    );
+
+  transform:
+    rotate(22deg)
+    translateZ(70px);
+
+  transition:
+    left 650ms ease;
+
+  pointer-events: none;
+
+  z-index: 4;
+}
+
+.parallax-badge:hover
+  .parallax-badge__shine,
+.parallax-badge:focus-visible
+  .parallax-badge__shine {
+  left:
+    calc(100% + 100px);
+}
+
+/* =========================================================
+   Hint
+   ========================================================= */
+
+.showcase__hint {
+  margin:
+    1.3rem 0 0;
+
+  color: var(--subtle);
+
+  font-size: 0.6rem;
+
+  letter-spacing: 0.1em;
+
+  text-transform: uppercase;
+}
+
+/* =========================================================
+   Responsive
+   ========================================================= */
+
+@media (max-width: 650px) {
+  .page {
+    padding:
+      2.5rem 0.85rem;
+  }
+
+  .badge-scene {
+    margin-top:
+      2.4rem;
+  }
+
+  .parallax-badge {
+    min-height: 175px;
+
+    padding:
+      0.8rem;
+
+    border-radius:
+      1.15rem;
+  }
+
+  .parallax-badge__content {
+    min-height: 150px;
+
+    grid-template-columns:
+      auto 1fr;
+
+    padding:
+      1rem;
+  }
+
+  .parallax-badge__arrow {
+    display: none;
+  }
+
+  .parallax-badge__icon {
+    width: 50px;
+    height: 50px;
+
+    border-radius:
+      0.8rem;
+  }
+}
+
+@media (max-width: 440px) {
+  .showcase__intro {
+    font-size: 0.76rem;
+  }
+
+  .parallax-badge__content {
+    gap: 0.75rem;
+  }
+
+  .parallax-badge__icon {
+    width: 44px;
+    height: 44px;
+
+    font-size: 1rem;
+  }
+
+  .parallax-badge__copy strong {
+    font-size: 1rem;
+  }
+
+  .parallax-badge__copy span:last-child {
+    font-size: 0.61rem;
+  }
+
+  .parallax-badge__label {
+    font-size: 0.5rem;
+  }
+}
+
+/* =========================================================
+   Reduced Motion
+   ========================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+
+    animation-iteration-count: 1 !important;
+
+    transition-duration: 0.01ms !important;
+
+    scroll-behavior: auto !important;
+  }
+
+  .parallax-badge,
+  .parallax-badge__content,
+  .parallax-badge__icon,
+  .parallax-badge__arrow,
+  .parallax-badge__orb,
+  .parallax-badge__glow {
+    transform:
+      none !important;
+  }
+
+  .parallax-badge__shine {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a responsive **Parallax Badge with Dark Mode styling**
to EaseMotion CSS.

It is a critical issue for providing a reusable badge component
with layered depth, subtle parallax motion and a polished dark-mode
visual system.

## Changes

- Added dark-mode Parallax Badge
- Added CSS-only layered parallax effect
- Added perspective-based depth
- Added cyan, blue and violet gradient accents
- Added animated decorative orbs
- Added diagonal shine animation
- Added hover and keyboard focus interactions
- Added responsive layouts
- Added reduced-motion support
- Added standalone documentation

## Technical Details

- Pure HTML and CSS
- No JavaScript
- No external dependencies
- CSS 3D transforms
- CSS gradients and shadows
- Responsive media queries

## Accessibility

- Semantic anchor element
- Accessible badge label
- Visible keyboard focus state
- Reduced-motion support

## Testing

Tested locally using the standalone `demo.html`
on desktop and mobile viewport sizes.

## Issue

Closes #79836