### PR TITLE
a11y(switch): toggle ARIA checked submission (enhancement)

### DIFF
--- a/submissions/examples/switch-toggle-aria-checked-enh-sb/README.md
+++ b/submissions/examples/switch-toggle-aria-checked-enh-sb/README.md
@@ -1,0 +1,30 @@
+# Switch Toggle ARIA Checked State
+
+## What does it do?
+A switch built on a `<button>` with `role=switch` + `aria-checked`. Click and Space/Enter toggle the state; the visible knob follows. Exposes `getState()`/`setState()` and dispatches a `change` event.
+
+## How is it used?
+```javascript
+import { Switch } from './script.js';
+const s = new Switch(document.getElementById('sw'), { checked: false, label: 'Dark mode' });
+s.toggle(); s.getState(); s.setState(true); s.destroy();
+```
+
+## Why is it useful?
+A toggle switch needs `role=switch` + `aria-checked` (not `role=checkbox`/`aria-pressed`) so screen readers announce it as a switch. The keyboard support (Space/Enter) and the `change` event make it usable from the keyboard and easy to wire up.
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/switch-toggle-aria-checked-enh-sb/switch.test.js
+```
+- **Happy path**: role=switch + tabindex + aria-checked; initial checked reflects; toggle flips; Space toggles; Enter toggles; click toggles.
+- **Edge cases**: setState(true); change event fires with detail; aria-label set; non-boolean coercion.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (switch + knob + reduced motion + forced-colors), JavaScript (aria-checked + keyboard), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click or focus + Space.
+
+Closes #81914

--- a/submissions/examples/switch-toggle-aria-checked-enh-sb/demo.html
+++ b/submissions/examples/switch-toggle-aria-checked-enh-sb/demo.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Switch Toggle ARIA Checked</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="sw" type="button"></button>
+    <script type="module">
+      import { Switch } from './script.js';
+      const s = new Switch(document.getElementById('sw'), { checked: false, label: 'Dark mode' });
+      s.root.addEventListener('change', (e) => console.log('checked:', e.detail.checked));
+      window.__switch = s;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/switch-toggle-aria-checked-enh-sb/script.js
+++ b/submissions/examples/switch-toggle-aria-checked-enh-sb/script.js
@@ -1,0 +1,75 @@
+/**
+ * EaseMotion CSS — Switch Toggle ARIA Checked State (enhancement)
+ * ============================================================
+ * A switch built on a <button> with role=switch + aria-checked. Click
+ * and Space/Enter toggle the state; the visible knob follows. Exposes
+ * getState()/setState() and dispatches a 'change' event.
+ *
+ * API:
+ *   const s = new Switch(rootEl, { checked, label });
+ *   s.toggle(); s.getState(); s.setState(true); s.destroy();
+ * ============================================================ */
+
+export class Switch {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('Switch requires a root element');
+    }
+    this.root = root;
+    this._checked = !!options.checked;
+
+    this.root.setAttribute('role', 'switch');
+    this.root.setAttribute('tabindex', '0');
+    this.root.setAttribute('aria-checked', String(this._checked));
+    if (options.label) this.root.setAttribute('aria-label', options.label);
+    this.root.classList.add('ease-switch');
+
+    this._knob = document.createElement('span');
+    this._knob.className = 'ease-switch__knob';
+    this.root.appendChild(this._knob);
+    this.root.classList.toggle('is-on', this._checked);
+
+    this._onKeydown = this._onKeydown.bind(this);
+    this._onClick = this._onClick.bind(this);
+    this.root.addEventListener('keydown', this._onKeydown);
+    this.root.addEventListener('click', this._onClick);
+  }
+
+  toggle() {
+    return this.setState(!this._checked);
+  }
+
+  setState(value) {
+    this._checked = !!value;
+    this.root.setAttribute('aria-checked', String(this._checked));
+    this.root.classList.toggle('is-on', this._checked);
+    this.root.dispatchEvent(new window.CustomEvent('change', { detail: { checked: this._checked } }));
+    return this._checked;
+  }
+
+  getState() {
+    return this._checked;
+  }
+
+  _onKeydown(event) {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      this.toggle();
+    }
+  }
+
+  _onClick() {
+    this.toggle();
+  }
+
+  destroy() {
+    this.root.removeEventListener('keydown', this._onKeydown);
+    this.root.removeEventListener('click', this._onClick);
+    this.root.removeAttribute('role');
+    this.root.removeAttribute('tabindex');
+    this.root.removeAttribute('aria-checked');
+    if (this._knob.parentNode) this._knob.parentNode.removeChild(this._knob);
+  }
+}
+
+export default Switch;

--- a/submissions/examples/switch-toggle-aria-checked-enh-sb/style.css
+++ b/submissions/examples/switch-toggle-aria-checked-enh-sb/style.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   EaseMotion CSS — Switch Toggle ARIA Checked State
+   ============================================================ */
+
+.ease-switch {
+  --ease-switch-w: 2.75rem;
+  --ease-switch-h: 1.5rem;
+  position: relative;
+  display: inline-block;
+  width: var(--ease-switch-w);
+  height: var(--ease-switch-h);
+  border: 0;
+  border-radius: 999px;
+  background: #cbd5e1;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s ease;
+}
+
+.ease-switch.is-on {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-switch__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(var(--ease-switch-h) - 4px);
+  height: calc(var(--ease-switch-h) - 4px);
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.ease-switch.is-on .ease-switch__knob {
+  transform: translateX(calc(var(--ease-switch-w) - var(--ease-switch-h)));
+}
+
+.ease-switch:focus-visible {
+  outline: 3px solid Highlight;
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-switch, .ease-switch__knob { transition: none !important; }
+}
+
+@media (forced-colors: active) {
+  .ease-switch { border: 2px solid ButtonText; }
+  .ease-switch__knob { background: ButtonText; }
+}

--- a/submissions/examples/switch-toggle-aria-checked-enh-sb/switch.test.js
+++ b/submissions/examples/switch-toggle-aria-checked-enh-sb/switch.test.js
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Switch } from './script.js';
+
+describe('Switch Toggle ARIA Checked State', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('button');
+    root.type = 'button';
+    document.body.appendChild(root);
+  });
+
+  function keydown(key) {
+    root.dispatchEvent(new window.KeyboardEvent('keydown', { key, bubbles: true }));
+  }
+
+  it('sets role=switch + tabindex=0 + aria-checked', () => {
+    const s = new Switch(root, { checked: false });
+    expect(root.getAttribute('role')).toBe('switch');
+    expect(root.getAttribute('tabindex')).toBe('0');
+    expect(root.getAttribute('aria-checked')).toBe('false');
+    s.destroy();
+  });
+
+  it('initial checked state reflects in aria-checked + class', () => {
+    const s = new Switch(root, { checked: true });
+    expect(root.getAttribute('aria-checked')).toBe('true');
+    expect(root.classList.contains('is-on')).toBe(true);
+    s.destroy();
+  });
+
+  it('toggle() flips the state', () => {
+    const s = new Switch(root, { checked: false });
+    s.toggle();
+    expect(s.getState()).toBe(true);
+    expect(root.getAttribute('aria-checked')).toBe('true');
+    s.destroy();
+  });
+
+  it('Space toggles the switch', () => {
+    const s = new Switch(root, { checked: false });
+    keydown(' ');
+    expect(s.getState()).toBe(true);
+    s.destroy();
+  });
+
+  it('Enter toggles the switch', () => {
+    const s = new Switch(root, { checked: false });
+    keydown('Enter');
+    expect(s.getState()).toBe(true);
+    s.destroy();
+  });
+
+  it('click toggles the switch', () => {
+    const s = new Switch(root, { checked: true });
+    root.click();
+    expect(s.getState()).toBe(false);
+    s.destroy();
+  });
+
+  it('setState(true) sets aria-checked=true + is-on', () => {
+    const s = new Switch(root, { checked: false });
+    s.setState(true);
+    expect(root.getAttribute('aria-checked')).toBe('true');
+    expect(root.classList.contains('is-on')).toBe(true);
+    s.destroy();
+  });
+
+  it('change event fires with the new checked state', () => {
+    const s = new Switch(root, { checked: false });
+    const handler = vi.fn();
+    root.addEventListener('change', handler);
+    s.toggle();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].detail.checked).toBe(true);
+    s.destroy();
+  });
+
+  it('aria-label is set when provided', () => {
+    const s = new Switch(root, { label: 'Dark mode' });
+    expect(root.getAttribute('aria-label')).toBe('Dark mode');
+    s.destroy();
+  });
+
+  it('setState coerces non-booleans', () => {
+    const s = new Switch(root, { checked: false });
+    s.setState(1);
+    expect(s.getState()).toBe(true);
+    s.setState(0);
+    expect(s.getState()).toBe(false);
+    s.destroy();
+  });
+
+  it('destroy() removes role + aria-checked + knob', () => {
+    const s = new Switch(root, { checked: false });
+    s.destroy();
+    expect(root.hasAttribute('role')).toBe(false);
+    expect(root.hasAttribute('aria-checked')).toBe(false);
+    expect(root.querySelector('.ease-switch__knob')).toBeNull();
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new Switch(null)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Switch Toggle ARIA Checked State (enhancement)** accessibility audit (closes #81914). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/switch-toggle-aria-checked-enh-sb/`:
- **`script.js`** — `Switch`: a switch built on a `<button>` with `role=switch` + `aria-checked`. Click and Space/Enter toggle the state; the visible knob follows. Exposes `getState()`/`setState()` and dispatches a `change` event.
- **`switch.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/switch-toggle-aria-checked-enh-sb/switch.test.js
 ✓ switch.test.js (12 tests)
```
- **Happy path**: role=switch + tabindex + aria-checked; initial checked reflects; toggle flips; Space toggles; Enter toggles; click toggles.
- **Edge cases**: setState(true); change event fires with detail; aria-label set; non-boolean coercion.
- **Invalid inputs**: throws without root element.

Closes #81914

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._