### PR TITLE
a11y(toast): ARIA live audit submission (validation)

### DIFF
--- a/submissions/examples/toast-aria-live-vt-sb/README.md
+++ b/submissions/examples/toast-aria-live-vt-sb/README.md
@@ -1,0 +1,30 @@
+# Toast ARIA Live Audit (validation)
+
+## What does it do?
+Wraps a real toast container and validates the `aria-live` invariants: container has `role=status` (or `alert`) + `aria-live` + `aria-atomic`, toasts are appended to the live region (so AT announces them), and announcements aren't queued when `aria-live=off`. Exposes `report()` + `isCompliant()` + `announce(text, { type })`.
+
+## How is it used?
+```javascript
+import { ToastAudit } from './script.js';
+const a = new ToastAudit(document.getElementById('toast'), { live: 'polite' });
+a.announce('Saved', { type: 'success' }); a.report(); a.isCompliant(); a.destroy();
+```
+
+## Why is it useful?
+Toasts that aren't in a live region are invisible to screen readers — the visual notification happens but AT users never hear it. The audit report makes the `role=status`/`aria-live`/`aria-atomic` invariants programmatically verifiable (axe-core-style).
+
+## Testing
+```bash
+npx vitest run --config <inline include> submissions/examples/toast-aria-live-vt-sb/toast.test.js
+```
+- **Happy path**: role=status + aria-live=polite + aria-atomic; assertive configurable; announce appends; records announcements; type class.
+- **Edge cases**: clear empties; report compliant; report flags missing aria-live; report flags live=off with announcements; report flags missing aria-atomic.
+- **Invalid inputs**: throws without root element.
+
+## Tech Stack
+HTML, CSS (toast styling + reduced motion + forced-colors), JavaScript (aria-live + audit report), EaseMotion CSS.
+
+## Preview
+Open `demo.html`, click Show toast, watch the report.
+
+Closes #81895

--- a/submissions/examples/toast-aria-live-vt-sb/demo.html
+++ b/submissions/examples/toast-aria-live-vt-sb/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Toast ARIA Live Audit</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <button id="btn">Show toast</button>
+    <div id="toast"></div>
+    <pre id="report"></pre>
+    <script type="module">
+      import { ToastAudit } from './script.js';
+      const a = new ToastAudit(document.getElementById('toast'), { live: 'polite' });
+      document.getElementById('btn').addEventListener('click', () => {
+        a.announce('Saved successfully', { type: 'success' });
+        document.getElementById('report').textContent = JSON.stringify(a.report(), null, 2);
+      });
+      window.__toast = a;
+    </script>
+  </body>
+</html>

--- a/submissions/examples/toast-aria-live-vt-sb/script.js
+++ b/submissions/examples/toast-aria-live-vt-sb/script.js
@@ -1,0 +1,74 @@
+/**
+ * EaseMotion CSS — Toast ARIA Live Audit (validation)
+ * ============================================================
+ * Wraps a real toast container and validates the aria-live invariants:
+ *   - container has role=status (or alert) + aria-live + aria-atomic
+ *   - toasts are appended to the live region (so AT announces them)
+ *   - announcement is queued (no announcement when live=off)
+ * Exposes report() + isCompliant() + announce(text, { type }).
+ *
+ * API:
+ *   const a = new ToastAudit(rootEl, { live });
+ *   a.announce('Saved'); a.report(); a.destroy();
+ * ============================================================ */
+
+export class ToastAudit {
+  constructor(root, options = {}) {
+    if (!root || typeof root.addEventListener !== 'function') {
+      throw new TypeError('ToastAudit requires a root element');
+    }
+    this.root = root;
+    this._live = options.live || 'polite'; // 'polite' | 'assertive' | 'off'
+
+    this.root.setAttribute('role', 'status');
+    this.root.setAttribute('aria-live', this._live);
+    this.root.setAttribute('aria-atomic', 'true');
+    this.root.classList.add('ease-toast-audit');
+    this._announced = [];
+  }
+
+  announce(text, options = {}) {
+    const type = options.type || 'info';
+    const el = document.createElement('div');
+    el.className = 'ease-toast-audit__item ease-toast-audit__item--' + type;
+    el.textContent = String(text);
+    this.root.appendChild(el);
+    this._announced.push({ text: String(text), type });
+    return this._announced[this._announced.length - 1];
+  }
+
+  clear() {
+    this.root.innerHTML = '';
+    this._announced = [];
+  }
+
+  getLive() {
+    return this._live;
+  }
+
+  getAnnouncements() {
+    return this._announced.slice();
+  }
+
+  report() {
+    const role = this.root.getAttribute('role');
+    const live = this.root.getAttribute('aria-live');
+    const atomic = this.root.getAttribute('aria-atomic');
+    const violations = [];
+    if (role !== 'status' && role !== 'alert') violations.push({ id: 'aria-role', impact: 'critical' });
+    if (live !== 'polite' && live !== 'assertive') violations.push({ id: 'aria-live', impact: 'critical' });
+    if (atomic !== 'true') violations.push({ id: 'aria-atomic', impact: 'serious' });
+    if (live === 'off' && this._announced.length > 0) violations.push({ id: 'live-off-announced', impact: 'serious' });
+    return { role, live, atomic, count: this._announced.length, violations, pass: violations.length === 0 };
+  }
+
+  isCompliant() {
+    return this.report().pass;
+  }
+
+  destroy() {
+    this.clear();
+  }
+}
+
+export default ToastAudit;

--- a/submissions/examples/toast-aria-live-vt-sb/style.css
+++ b/submissions/examples/toast-aria-live-vt-sb/style.css
@@ -1,0 +1,38 @@
+/* ============================================================
+   EaseMotion CSS — Toast ARIA Live Audit (validation)
+   ============================================================ */
+
+.ease-toast-audit {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 120;
+}
+
+.ease-toast-audit__item {
+  background: #1f2937;
+  color: #f9fafb;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.2);
+  animation: ease-toast-fade-in 0.25s ease;
+}
+
+.ease-toast-audit__item--error { background: #dc2626; }
+.ease-toast-audit__item--success { background: #16a34a; }
+
+@keyframes ease-toast-fade-in {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast-audit__item { animation: none !important; }
+}
+
+@media (forced-colors: active) {
+  .ease-toast-audit__item { border: 2px solid ButtonText; }
+}

--- a/submissions/examples/toast-aria-live-vt-sb/toast.test.js
+++ b/submissions/examples/toast-aria-live-vt-sb/toast.test.js
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ToastAudit } from './script.js';
+
+describe('Toast ARIA Live Audit (validation)', () => {
+  let root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  it('sets role=status + aria-live=polite + aria-atomic=true', () => {
+    const a = new ToastAudit(root);
+    expect(root.getAttribute('role')).toBe('status');
+    expect(root.getAttribute('aria-live')).toBe('polite');
+    expect(root.getAttribute('aria-atomic')).toBe('true');
+    a.destroy();
+  });
+
+  it('assertive live region is configurable', () => {
+    const a = new ToastAudit(root, { live: 'assertive' });
+    expect(root.getAttribute('aria-live')).toBe('assertive');
+    expect(a.getLive()).toBe('assertive');
+    a.destroy();
+  });
+
+  it('announce() appends an item to the live region', () => {
+    const a = new ToastAudit(root);
+    a.announce('Saved');
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].textContent).toBe('Saved');
+    a.destroy();
+  });
+
+  it('announce() records the announcement', () => {
+    const a = new ToastAudit(root);
+    a.announce('Saved');
+    a.announce('Error', { type: 'error' });
+    const list = a.getAnnouncements();
+    expect(list.length).toBe(2);
+    expect(list[1]).toEqual({ text: 'Error', type: 'error' });
+    a.destroy();
+  });
+
+  it('announce() adds a type class', () => {
+    const a = new ToastAudit(root);
+    a.announce('Oops', { type: 'error' });
+    expect(root.children[0].classList.contains('ease-toast-audit__item--error')).toBe(true);
+    a.destroy();
+  });
+
+  it('clear() empties the region and announcements', () => {
+    const a = new ToastAudit(root);
+    a.announce('Saved');
+    a.clear();
+    expect(root.children.length).toBe(0);
+    expect(a.getAnnouncements().length).toBe(0);
+    a.destroy();
+  });
+
+  it('report() is compliant for a polite region', () => {
+    const a = new ToastAudit(root);
+    a.announce('Saved');
+    expect(a.isCompliant()).toBe(true);
+    a.destroy();
+  });
+
+  it('report() flags a missing aria-live', () => {
+    const a = new ToastAudit(root);
+    root.removeAttribute('aria-live');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('report() flags live=off with announcements', () => {
+    const a = new ToastAudit(root, { live: 'off' });
+    a.announce('Saved');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('report() flags missing aria-atomic', () => {
+    const a = new ToastAudit(root);
+    root.removeAttribute('aria-atomic');
+    expect(a.report().pass).toBe(false);
+    a.destroy();
+  });
+
+  it('destroy() clears the region without throwing', () => {
+    const a = new ToastAudit(root);
+    a.announce('Saved');
+    expect(() => a.destroy()).not.toThrow();
+    expect(root.children.length).toBe(0);
+  });
+
+  it('throws without a root element', () => {
+    expect(() => new ToastAudit(null)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What changed

Self-contained submission for the **Toast Notification ARIA Live Region (validation test)** accessibility audit (closes #81895). Placed entirely under `submissions/examples/` per the contribution guide.

`submissions/examples/toast-aria-live-vt-sb/`:
- **`script.js`** — `ToastAudit`: validates toast `aria-live` invariants — container has `role=status` (or `alert`) + `aria-live` + `aria-atomic`, toasts are appended to the live region, announcements aren't queued when `aria-live=off`. Exposes an axe-core-style `report()` + `isCompliant()` + `announce(text, { type })`.
- **`toast.test.js`** — 12 Vitest tests (happy path, edge cases, invalid inputs) — all passing.
- **`demo.html`**, **`style.css`**, **`README.md`**.

### Test coverage
```
npx vitest run --config <inline include> submissions/examples/toast-aria-live-vt-sb/toast.test.js
 ✓ toast.test.js (12 tests)
```
- **Happy path**: role=status + aria-live=polite + aria-atomic; assertive configurable; announce appends; records announcements; type class.
- **Edge cases**: clear empties; report compliant; report flags missing aria-live; report flags live=off with announcements; report flags missing aria-atomic.
- **Invalid inputs**: throws without root element.

Closes #81895

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._