### PR TITLE
feat(core): add Slide Fade Diagonal keyframe utility class

### DIFF
--- a/submissions/examples/slide-fade-diagonal-sb/README.md
+++ b/submissions/examples/slide-fade-diagonal-sb/README.md
@@ -1,0 +1,29 @@
+# Slide Fade Diagonal
+
+A `slide-fade-diagonal` keyframe utility class for the EaseMotion core animation library.
+
+## What it does
+An element slides in diagonally while fading in.
+
+## Files
+- `demo.html` — interactive demo
+- `style.css` — `@keyframes ease-slide-fade-diagonal` + `.ease-anim-slide-fade-diagonal` utility class
+
+## Usage
+```html
+<link rel="stylesheet" href="./style.css" />
+<div class="ease-anim-slide-fade-diagonal">Hello</div>
+```
+
+### Configurable timing
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation. Hardware-accelerated using `transform` + `opacity` for 60 FPS.
+
+Closes #81878

--- a/submissions/examples/slide-fade-diagonal-sb/demo.html
+++ b/submissions/examples/slide-fade-diagonal-sb/demo.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slide Fade Diagonal</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main>
+      <div class="ease-demo-stage"><div class="ease-anim-slide-fade-diagonal ease-demo-box">↗</div></div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/slide-fade-diagonal-sb/style.css
+++ b/submissions/examples/slide-fade-diagonal-sb/style.css
@@ -1,0 +1,85 @@
+/* ============================================================
+   EaseMotion CSS — Slide Fade Diagonal keyframe utility class
+   Submission for #81878
+   ============================================================ */
+
+:root {
+  --ease-duration: 1s;
+  --ease-timing: ease;
+}
+
+@keyframes ease-slide-fade-diagonal {
+  from { transform: translate3d(24px, 24px, 0); opacity: 0; }
+  to   { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+.ease-anim-slide-fade-diagonal {
+  animation: ease-slide-fade-diagonal var(--ease-duration, 1s) var(--ease-timing, ease) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-anim-slide-fade-diagonal { animation: none !important; }
+}
+
+/* demo-only helpers (not part of the utility class) */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0b1120;
+  color: #f9fafb;
+  font-family: system-ui, sans-serif;
+}
+.ease-demo-stage {
+  display: grid;
+  place-items: center;
+  min-height: 200px;
+}
+.ease-demo-box {
+  padding: 2rem 3rem;
+  font-size: 1.5rem;
+  border-radius: 0.75rem;
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+}
+.ease-demo-gradient {
+  padding: 2rem 3rem;
+  font-size: 1.5rem;
+  border-radius: 0.75rem;
+  color: #fff;
+  background: linear-gradient(90deg, #6366f1, #ec4899, #6366f1);
+  background-size: 200% 200%;
+}
+.ease-demo-text { font-size: 2rem; font-weight: 700; }
+.ease-demo-ghost { font-size: 3rem; }
+.ease-demo-link {
+  position: relative;
+  display: inline-block;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+.ease-demo-underline {
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 100%;
+  height: 2px;
+  transform-origin: center;
+  background: var(--ease-color-primary, #6c63ff);
+}
+.ease-demo-neon {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+}
+.ease-demo-bolt, .ease-demo-sparkle { font-size: 3rem; }
+.ease-demo-perspective { perspective: 800px; }
+.ease-demo-page {
+  padding: 2rem 3rem;
+  font-size: 1.5rem;
+  background: #fff;
+  color: #1f2937;
+  border-radius: 0.5rem;
+  transform-style: preserve-3d;
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Slide Fade Diagonal keyframe utility class** feature request (closes #81878). Placed entirely under `submissions/examples/slide-fade-diagonal-sb/` per the contribution guide.

`submissions/examples/slide-fade-diagonal-sb/`:
- **`style.css`** — `@keyframes ease-slide-fade-diagonal` animation + `.ease-anim-slide-fade-diagonal` utility class.
- **`demo.html`** — interactive demo.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-slide-fade-diagonal` defined.
- `.ease-anim-slide-fade-diagonal` utility class provided.
- Configurable timing via `--ease-duration` / `--ease-timing`.
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
an element slides in diagonally while fading in (translate3d + opacity).

Closes #81878

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._