### PR TITLE
feat: create Glowing File Dropzone with Retro Pixel styling (#63626) …

### DIFF
--- a/submissions/examples/css-file-dropzone-glowing-retro-pixel/README.md
+++ b/submissions/examples/css-file-dropzone-glowing-retro-pixel/README.md
@@ -1,0 +1,2 @@
+# Glowing File Dropzone (Retro Pixel)
+A nostalgic 8-bit file upload target. Hovering over the invisible `<input type="file">` overrides the dashed white border with a solid neon green glow, activating an inset text shadow and a choppy `steps()` blinking animation on the upload icon.

--- a/submissions/examples/css-file-dropzone-glowing-retro-pixel/demo.html
+++ b/submissions/examples/css-file-dropzone-glowing-retro-pixel/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Pixel Glowing Dropzone</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="rp-dropzone">
+        <input type="file" id="rp-file" class="rp-input" multiple>
+        <label for="rp-file" class="rp-label">
+            <div class="rp-icon">[+]</div>
+            <div class="rp-text">INSERT DISC</div>
+            <div class="rp-subtext">OR DROP DATA HERE</div>
+        </label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-file-dropzone-glowing-retro-pixel/style.css
+++ b/submissions/examples/css-file-dropzone-glowing-retro-pixel/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #111; --pixel: #fff; --neon: #0f0; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Press Start 2P', monospace; }
+.rp-dropzone { position: relative; width: 100%; max-width: 400px; padding: 2rem; }
+.rp-input { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer; z-index: 2; }
+.rp-label { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 200px; border: 4px dashed var(--pixel); background: rgba(255, 255, 255, 0.05); color: var(--pixel); text-align: center; transition: 0.1s; position: relative; z-index: 1; box-shadow: 8px 8px 0 rgba(0,0,0,0.5); }
+.rp-icon { font-size: 2rem; margin-bottom: 1.5rem; text-shadow: 2px 2px 0 #000; }
+.rp-text { font-size: 1.2rem; margin-bottom: 1rem; line-height: 1.4; }
+.rp-subtext { font-size: 0.7rem; color: #aaa; }
+.rp-input:hover ~ .rp-label { border-color: var(--neon); color: var(--neon); background: rgba(0, 255, 0, 0.05); box-shadow: 0 0 20px rgba(0, 255, 0, 0.3), inset 0 0 20px rgba(0, 255, 0, 0.3); border-style: solid; }
+.rp-input:hover ~ .rp-label .rp-icon { text-shadow: 0 0 10px var(--neon); animation: rp-blink 1s steps(2, start) infinite; }
+@keyframes rp-blink { 50% { opacity: 0; } }


### PR DESCRIPTION
**Title:** feat: create Glowing File Dropzone with Retro Pixel styling (#63626) #81503

**Description:**
This PR introduces a nostalgic 8-bit file upload target. Hovering over the invisible `<input type="file">` overrides the dashed white border with a solid neon green glow, activating an inset text shadow and a choppy `steps()` blinking animation on the upload icon.

Fixes #81503

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-file-dropzone-glowing-retro-pixel/`
- Rendered the primary container using thick 8-bit typography and harsh block shadows (`8px 8px 0 rgba(0,0,0,0.5)`)
- Built a `:hover` state utilizing the general sibling combinator (`~`) that swaps the container to `border-color: var(--neon)` and triggers a low-framerate `@keyframes rp-blink`
