### PR TITLE
feat: create Animated File Dropzone with Material Design styling (#71…

### DIFF
--- a/submissions/examples/css-file-dropzone-animated-material-design/README.md
+++ b/submissions/examples/css-file-dropzone-animated-material-design/README.md
@@ -1,0 +1,2 @@
+# Animated File Dropzone (Material Design)
+A Google Material Design inspired upload target. Interacting with the hit area triggers an expansive, slow-moving radial ripple effect originating from the center, serving as a background state indicator while the primary icon elevates.

--- a/submissions/examples/css-file-dropzone-animated-material-design/demo.html
+++ b/submissions/examples/css-file-dropzone-animated-material-design/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Animated Dropzone</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="md-dz-container">
+        <input type="file" id="md-dz-file" class="md-dz-input" multiple>
+        <label for="md-dz-file" class="md-dz-label">
+            <div class="md-dz-ripple"></div>
+            <i class="ph ph-cloud-arrow-up md-dz-icon"></i>
+            <h3>Upload Files</h3>
+            <p>Drag and drop files here</p>
+        </label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-file-dropzone-animated-material-design/style.css
+++ b/submissions/examples/css-file-dropzone-animated-material-design/style.css
@@ -1,0 +1,13 @@
+:root { --bg: #eeeeee; --surface: #ffffff; --primary: #6200ea; --text: #212121; --secondary: #757575; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; }
+.md-dz-container { position: relative; width: 100%; max-width: 400px; padding: 1rem; }
+.md-dz-input { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer; z-index: 10; }
+.md-dz-label { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 220px; background: var(--surface); border-radius: 12px; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); position: relative; overflow: hidden; transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1); z-index: 1; }
+.md-dz-ripple { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(0); width: 300px; height: 300px; border-radius: 50%; background: rgba(98, 0, 234, 0.05); z-index: 0; transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.6s; opacity: 0; }
+.md-dz-icon { font-size: 3rem; color: var(--secondary); margin-bottom: 1rem; position: relative; z-index: 2; transition: 0.3s; }
+.md-dz-label h3 { margin: 0 0 0.5rem 0; color: var(--text); font-weight: 500; font-size: 1.25rem; position: relative; z-index: 2; transition: 0.3s; }
+.md-dz-label p { margin: 0; color: var(--secondary); font-size: 0.9rem; position: relative; z-index: 2; }
+.md-dz-input:hover ~ .md-dz-label { box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); }
+.md-dz-input:hover ~ .md-dz-label .md-dz-ripple { transform: translate(-50%, -50%) scale(2); opacity: 1; }
+.md-dz-input:hover ~ .md-dz-label .md-dz-icon { color: var(--primary); transform: translateY(-5px); }
+.md-dz-input:hover ~ .md-dz-label h3 { color: var(--primary); }


### PR DESCRIPTION
**Description:**
This PR introduces a Google Material Design inspired upload target. Interacting with the hit area triggers an expansive, slow-moving radial ripple effect originating from the center, serving as a background state indicator while the primary icon elevates.

Fixes #81500

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-file-dropzone-animated-material-design/`
- Designed a scalable `.md-dz-ripple` pseudo-layer mapped to expand from `scale(0)` to `scale(2)` upon hovering the drop target
- Increased the primary box shadow (`box-shadow`) dynamically during interaction to emulate physical Z-axis elevation off the page surface
