### PR TITLE
feat(core): add Confetti Burst Scale SCSS animation mixin

### DIFF
--- a/submissions/scss/confetti-burst-scale-scss-sb/README.md
+++ b/submissions/scss/confetti-burst-scale-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Confetti Burst Scale — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-confetti-burst-scale` keyframes and a `.ease-anim-confetti-burst-scale` utility class.
+
+## What it does
+Confetti pieces burst outward with an overshoot scale pop. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-confetti-burst-scale.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-confetti-burst-scale" as *;
+
+.my-element {
+  @include ease-anim-confetti-burst-scale;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-confetti-burst-scale($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81842

--- a/submissions/scss/confetti-burst-scale-scss-sb/_ease-confetti-burst-scale.scss
+++ b/submissions/scss/confetti-burst-scale-scss-sb/_ease-confetti-burst-scale.scss
@@ -1,0 +1,34 @@
+// ============================================================
+// EaseMotion CSS — Confetti Burst Scale SCSS animation mixin
+// Submission for #81842
+// ============================================================
+
+/// Confetti Burst Scale animation mixin.
+///
+/// Emits the `@keyframes ease-confetti-burst-scale` rule and a `.ease-anim-confetti-burst-scale`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-confetti-burst-scale;
+///   @include ease-anim-confetti-burst-scale($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-confetti-burst-scale($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-confetti-burst-scale {
+  0%   { transform: scale(0); opacity: 0; }
+  50%  { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); opacity: 0.9; }
+}
+
+  .ease-anim-confetti-burst-scale {
+    animation: ease-confetti-burst-scale #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Confetti Burst Scale SCSS animation mixin** feature request (closes #81842). Placed entirely under `submissions/scss/confetti-burst-scale-scss-sb/` per the contribution guide.

`submissions/scss/confetti-burst-scale-scss-sb/`:
- **`_ease-confetti-burst-scale.scss`** — `@mixin ease-anim-confetti-burst-scale` that emits the `@keyframes ease-confetti-burst-scale` rule and a `.ease-anim-confetti-burst-scale` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-confetti-burst-scale` defined inside the mixin.
- `.ease-anim-confetti-burst-scale` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
confetti pieces burst outward with an overshoot scale pop (scale + opacity).

### Usage
```scss
@use "./ease-confetti-burst-scale" as *;

.my-element {
  @include ease-anim-confetti-burst-scale;
}
```

Closes #81842

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._