### PR TITLE
feat(core): add Text Kinetic Wave SCSS animation mixin

### DIFF
--- a/submissions/scss/text-kinetic-wave-scss-sb/README.md
+++ b/submissions/scss/text-kinetic-wave-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Text Kinetic Wave — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-text-kinetic-wave` keyframes and a `.ease-anim-text-kinetic-wave` utility class.
+
+## What it does
+Text rises and falls in a gentle kinetic wave. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-text-kinetic-wave.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-text-kinetic-wave" as *;
+
+.my-element {
+  @include ease-anim-text-kinetic-wave;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-text-kinetic-wave($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81846

--- a/submissions/scss/text-kinetic-wave-scss-sb/_ease-text-kinetic-wave.scss
+++ b/submissions/scss/text-kinetic-wave-scss-sb/_ease-text-kinetic-wave.scss
@@ -1,0 +1,35 @@
+// ============================================================
+// EaseMotion CSS — Text Kinetic Wave SCSS animation mixin
+// Submission for #81846
+// ============================================================
+
+/// Text Kinetic Wave animation mixin.
+///
+/// Emits the `@keyframes ease-text-kinetic-wave` rule and a `.ease-anim-text-kinetic-wave`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-text-kinetic-wave;
+///   @include ease-anim-text-kinetic-wave($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-text-kinetic-wave($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-text-kinetic-wave {
+  0%, 100% { transform: translateY(0) scale(1); opacity: 0.8; }
+  25%      { transform: translateY(-6px) scale(1.04); opacity: 1; }
+  50%      { transform: translateY(0) scale(1); opacity: 0.8; }
+  75%      { transform: translateY(6px) scale(0.96); opacity: 1; }
+}
+
+  .ease-anim-text-kinetic-wave {
+    animation: ease-text-kinetic-wave #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Text Kinetic Wave SCSS animation mixin** feature request (closes #81846). Placed entirely under `submissions/scss/text-kinetic-wave-scss-sb/` per the contribution guide.

`submissions/scss/text-kinetic-wave-scss-sb/`:
- **`_ease-text-kinetic-wave.scss`** — `@mixin ease-anim-text-kinetic-wave` that emits the `@keyframes ease-text-kinetic-wave` rule and a `.ease-anim-text-kinetic-wave` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-text-kinetic-wave` defined inside the mixin.
- `.ease-anim-text-kinetic-wave` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
text rises and falls in a gentle kinetic wave (translateY + scale + opacity).

### Usage
```scss
@use "./ease-text-kinetic-wave" as *;

.my-element {
  @include ease-anim-text-kinetic-wave;
}
```

Closes #81846

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._