### PR TITLE
feat(core): add Underline Expand Center SCSS animation mixin

### DIFF
--- a/submissions/scss/underline-expand-center-scss-sb/README.md
+++ b/submissions/scss/underline-expand-center-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Underline Expand Center — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-underline-expand-center` keyframes and a `.ease-anim-underline-expand-center` utility class.
+
+## What it does
+An underline that expands outward from the center. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-underline-expand-center.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-underline-expand-center" as *;
+
+.my-element {
+  @include ease-anim-underline-expand-center;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-underline-expand-center($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81851

--- a/submissions/scss/underline-expand-center-scss-sb/_ease-underline-expand-center.scss
+++ b/submissions/scss/underline-expand-center-scss-sb/_ease-underline-expand-center.scss
@@ -1,0 +1,33 @@
+// ============================================================
+// EaseMotion CSS — Underline Expand Center SCSS animation mixin
+// Submission for #81851
+// ============================================================
+
+/// Underline Expand Center animation mixin.
+///
+/// Emits the `@keyframes ease-underline-expand-center` rule and a `.ease-anim-underline-expand-center`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-underline-expand-center;
+///   @include ease-anim-underline-expand-center($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-underline-expand-center($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-underline-expand-center {
+  0%   { transform: scaleX(0); opacity: 0; }
+  100% { transform: scaleX(1); opacity: 1; }
+}
+
+  .ease-anim-underline-expand-center {
+    animation: ease-underline-expand-center #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Underline Expand Center SCSS animation mixin** feature request (closes #81851). Placed entirely under `submissions/scss/underline-expand-center-scss-sb/` per the contribution guide.

`submissions/scss/underline-expand-center-scss-sb/`:
- **`_ease-underline-expand-center.scss`** — `@mixin ease-anim-underline-expand-center` that emits the `@keyframes ease-underline-expand-center` rule and a `.ease-anim-underline-expand-center` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-underline-expand-center` defined inside the mixin.
- `.ease-anim-underline-expand-center` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
an underline that expands outward from the center (scaleX + opacity).

### Usage
```scss
@use "./ease-underline-expand-center" as *;

.my-element {
  @include ease-anim-underline-expand-center;
}
```

Closes #81851

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._