### PR TITLE
feat(core): add Lightning Flash Burst SCSS animation mixin

### DIFF
--- a/submissions/scss/lightning-flash-burst-scss-sb/README.md
+++ b/submissions/scss/lightning-flash-burst-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Lightning Flash Burst — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-lightning-flash-burst` keyframes and a `.ease-anim-lightning-flash-burst` utility class.
+
+## What it does
+A lightning bolt that flashes in bursts. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-lightning-flash-burst.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-lightning-flash-burst" as *;
+
+.my-element {
+  @include ease-anim-lightning-flash-burst;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-lightning-flash-burst($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81869

--- a/submissions/scss/lightning-flash-burst-scss-sb/_ease-lightning-flash-burst.scss
+++ b/submissions/scss/lightning-flash-burst-scss-sb/_ease-lightning-flash-burst.scss
@@ -1,0 +1,36 @@
+// ============================================================
+// EaseMotion CSS — Lightning Flash Burst SCSS animation mixin
+// Submission for #81869
+// ============================================================
+
+/// Lightning Flash Burst animation mixin.
+///
+/// Emits the `@keyframes ease-lightning-flash-burst` rule and a `.ease-anim-lightning-flash-burst`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-lightning-flash-burst;
+///   @include ease-anim-lightning-flash-burst($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-lightning-flash-burst($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-lightning-flash-burst {
+  0%   { transform: scale(0.8); opacity: 0; }
+  10%  { transform: scale(1.2); opacity: 1; }
+  20%  { transform: scale(1); opacity: 0.2; }
+  30%  { transform: scale(1.1); opacity: 1; }
+  100% { transform: scale(1); opacity: 0; }
+}
+
+  .ease-anim-lightning-flash-burst {
+    animation: ease-lightning-flash-burst #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Lightning Flash Burst SCSS animation mixin** feature request (closes #81869). Placed entirely under `submissions/scss/lightning-flash-burst-scss-sb/` per the contribution guide.

`submissions/scss/lightning-flash-burst-scss-sb/`:
- **`_ease-lightning-flash-burst.scss`** — `@mixin ease-anim-lightning-flash-burst` that emits the `@keyframes ease-lightning-flash-burst` rule and a `.ease-anim-lightning-flash-burst` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-lightning-flash-burst` defined inside the mixin.
- `.ease-anim-lightning-flash-burst` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
a lightning bolt that flashes in bursts (scale + opacity).

### Usage
```scss
@use "./ease-lightning-flash-burst" as *;

.my-element {
  @include ease-anim-lightning-flash-burst;
}
```

Closes #81869

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._