### PR TITLE
feat(core): add Slide Fade Diagonal SCSS animation mixin

### DIFF
--- a/submissions/scss/slide-fade-diagonal-scss-sb/README.md
+++ b/submissions/scss/slide-fade-diagonal-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Slide Fade Diagonal — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-slide-fade-diagonal` keyframes and a `.ease-anim-slide-fade-diagonal` utility class.
+
+## What it does
+An element slides in diagonally while fading in. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-slide-fade-diagonal.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-slide-fade-diagonal" as *;
+
+.my-element {
+  @include ease-anim-slide-fade-diagonal;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-slide-fade-diagonal($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81879

--- a/submissions/scss/slide-fade-diagonal-scss-sb/_ease-slide-fade-diagonal.scss
+++ b/submissions/scss/slide-fade-diagonal-scss-sb/_ease-slide-fade-diagonal.scss
@@ -1,0 +1,33 @@
+// ============================================================
+// EaseMotion CSS — Slide Fade Diagonal SCSS animation mixin
+// Submission for #81879
+// ============================================================
+
+/// Slide Fade Diagonal animation mixin.
+///
+/// Emits the `@keyframes ease-slide-fade-diagonal` rule and a `.ease-anim-slide-fade-diagonal`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-slide-fade-diagonal;
+///   @include ease-anim-slide-fade-diagonal($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-slide-fade-diagonal($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-slide-fade-diagonal {
+  from { transform: translate3d(24px, 24px, 0); opacity: 0; }
+  to   { transform: translate3d(0, 0, 0); opacity: 1; }
+}
+
+  .ease-anim-slide-fade-diagonal {
+    animation: ease-slide-fade-diagonal #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Slide Fade Diagonal SCSS animation mixin** feature request (closes #81879). Placed entirely under `submissions/scss/slide-fade-diagonal-scss-sb/` per the contribution guide.

`submissions/scss/slide-fade-diagonal-scss-sb/`:
- **`_ease-slide-fade-diagonal.scss`** — `@mixin ease-anim-slide-fade-diagonal` that emits the `@keyframes ease-slide-fade-diagonal` rule and a `.ease-anim-slide-fade-diagonal` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-slide-fade-diagonal` defined inside the mixin.
- `.ease-anim-slide-fade-diagonal` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
an element slides in diagonally while fading in (translate3d + opacity).

### Usage
```scss
@use "./ease-slide-fade-diagonal" as *;

.my-element {
  @include ease-anim-slide-fade-diagonal;
}
```

Closes #81879

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._