### PR TITLE
feat(core): add Zoom Elastic Stretch SCSS animation mixin

### DIFF
--- a/submissions/scss/zoom-elastic-stretch-scss-sb/README.md
+++ b/submissions/scss/zoom-elastic-stretch-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Zoom Elastic Stretch — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-zoom-elastic-stretch` keyframes and a `.ease-anim-zoom-elastic-stretch` utility class.
+
+## What it does
+An elastic zoom with a stretch overshoot. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-zoom-elastic-stretch.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-zoom-elastic-stretch" as *;
+
+.my-element {
+  @include ease-anim-zoom-elastic-stretch;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-zoom-elastic-stretch($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81881

--- a/submissions/scss/zoom-elastic-stretch-scss-sb/_ease-zoom-elastic-stretch.scss
+++ b/submissions/scss/zoom-elastic-stretch-scss-sb/_ease-zoom-elastic-stretch.scss
@@ -1,0 +1,35 @@
+// ============================================================
+// EaseMotion CSS — Zoom Elastic Stretch SCSS animation mixin
+// Submission for #81881
+// ============================================================
+
+/// Zoom Elastic Stretch animation mixin.
+///
+/// Emits the `@keyframes ease-zoom-elastic-stretch` rule and a `.ease-anim-zoom-elastic-stretch`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-zoom-elastic-stretch;
+///   @include ease-anim-zoom-elastic-stretch($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-zoom-elastic-stretch($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-zoom-elastic-stretch {
+  0%   { transform: scale(0); opacity: 0; }
+  60%  { transform: scale(1.1, 0.9); opacity: 1; }
+  80%  { transform: scale(0.95, 1.05); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+  .ease-anim-zoom-elastic-stretch {
+    animation: ease-zoom-elastic-stretch #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Zoom Elastic Stretch SCSS animation mixin** feature request (closes #81881). Placed entirely under `submissions/scss/zoom-elastic-stretch-scss-sb/` per the contribution guide.

`submissions/scss/zoom-elastic-stretch-scss-sb/`:
- **`_ease-zoom-elastic-stretch.scss`** — `@mixin ease-anim-zoom-elastic-stretch` that emits the `@keyframes ease-zoom-elastic-stretch` rule and a `.ease-anim-zoom-elastic-stretch` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-zoom-elastic-stretch` defined inside the mixin.
- `.ease-anim-zoom-elastic-stretch` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
an elastic zoom with a stretch overshoot (asymmetric scale + opacity).

### Usage
```scss
@use "./ease-zoom-elastic-stretch" as *;

.my-element {
  @include ease-anim-zoom-elastic-stretch;
}
```

Closes #81881

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._