### PR TITLE
feat(core): add Flip Turn Page SCSS animation mixin

### DIFF
--- a/submissions/scss/flip-turn-page-scss-sb/README.md
+++ b/submissions/scss/flip-turn-page-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Flip Turn Page — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-flip-turn-page` keyframes and a `.ease-anim-flip-turn-page` utility class.
+
+## What it does
+A page-turn flip using rotateY. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-flip-turn-page.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-flip-turn-page" as *;
+
+.my-element {
+  @include ease-anim-flip-turn-page;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-flip-turn-page($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81883

--- a/submissions/scss/flip-turn-page-scss-sb/_ease-flip-turn-page.scss
+++ b/submissions/scss/flip-turn-page-scss-sb/_ease-flip-turn-page.scss
@@ -1,0 +1,34 @@
+// ============================================================
+// EaseMotion CSS — Flip Turn Page SCSS animation mixin
+// Submission for #81883
+// ============================================================
+
+/// Flip Turn Page animation mixin.
+///
+/// Emits the `@keyframes ease-flip-turn-page` rule and a `.ease-anim-flip-turn-page`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-flip-turn-page;
+///   @include ease-anim-flip-turn-page($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-flip-turn-page($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-flip-turn-page {
+  0%   { transform: rotateY(0deg); opacity: 1; }
+  50%  { transform: rotateY(90deg); opacity: 0.2; }
+  100% { transform: rotateY(0deg); opacity: 1; }
+}
+
+  .ease-anim-flip-turn-page {
+    animation: ease-flip-turn-page #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Flip Turn Page SCSS animation mixin** feature request (closes #81883). Placed entirely under `submissions/scss/flip-turn-page-scss-sb/` per the contribution guide.

`submissions/scss/flip-turn-page-scss-sb/`:
- **`_ease-flip-turn-page.scss`** — `@mixin ease-anim-flip-turn-page` that emits the `@keyframes ease-flip-turn-page` rule and a `.ease-anim-flip-turn-page` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-flip-turn-page` defined inside the mixin.
- `.ease-anim-flip-turn-page` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
a page-turn flip using rotateY (3D transform + opacity).

### Usage
```scss
@use "./ease-flip-turn-page" as *;

.my-element {
  @include ease-anim-flip-turn-page;
}
```

Closes #81883

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._