### PR TITLE
feat: create Floating Cookie Banner with Gradient Glow styling (#1205…

### DIFF
--- a/submissions/examples/css-cookie-banner-floating-gradient-glow/README.md
+++ b/submissions/examples/css-cookie-banner-floating-gradient-glow/README.md
@@ -1,0 +1,2 @@
+# Floating Cookie Banner (Gradient Glow)
+A highly visible, pure CSS dismissible cookie banner. It features a continuous animated multi-color gradient glow border behind a dark surface. The user's choice is tracked via a hidden checkbox that triggers a smooth exit animation.

--- a/submissions/examples/css-cookie-banner-floating-gradient-glow/demo.html
+++ b/submissions/examples/css-cookie-banner-floating-gradient-glow/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gradient Glow Cookie Banner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="gg-cookie-container">
+        <input type="checkbox" id="gg-dismiss" class="gg-dismiss-input">
+        <div class="gg-banner">
+            <div class="gg-glow-bg"></div>
+            <div class="gg-content">
+                <div class="gg-text">
+                    <strong>We value your privacy</strong>
+                    <p>We use cookies to enhance your browsing experience, serve personalized ads or content, and analyze our traffic.</p>
+                </div>
+                <div class="gg-actions">
+                    <label for="gg-dismiss" class="gg-btn gg-decline">Decline</label>
+                    <label for="gg-dismiss" class="gg-btn gg-accept">Accept All</label>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-cookie-banner-floating-gradient-glow/style.css
+++ b/submissions/examples/css-cookie-banner-floating-gradient-glow/style.css
@@ -1,0 +1,23 @@
+:root { --bg: #0f172a; --surface: #1e293b; --text: #f1f5f9; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: flex-end; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; padding-bottom: 2rem; overflow: hidden; }
+.gg-cookie-container { width: 100%; max-width: 700px; padding: 0 1rem; box-sizing: border-box; }
+.gg-dismiss-input { display: none; }
+.gg-banner { position: relative; border-radius: 16px; background: var(--surface); transform: translateY(0); transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1); opacity: 1; box-shadow: 0 20px 40px rgba(0,0,0,0.5); }
+.gg-glow-bg { position: absolute; inset: -2px; background: linear-gradient(90deg, #ec4899, #8b5cf6, #3b82f6); border-radius: 18px; filter: blur(8px); z-index: -1; opacity: 0.7; animation: gg-pulse 3s infinite alternate; }
+.gg-content { position: relative; background: var(--surface); border-radius: 16px; padding: 1.5rem 2rem; display: flex; justify-content: space-between; align-items: center; gap: 2rem; border: 1px solid rgba(255,255,255,0.1); }
+.gg-text { flex: 1; color: var(--text); }
+.gg-text strong { display: block; font-size: 1.1rem; margin-bottom: 0.5rem; }
+.gg-text p { margin: 0; font-size: 0.9rem; color: #94a3b8; line-height: 1.5; }
+.gg-actions { display: flex; gap: 1rem; flex-shrink: 0; }
+.gg-btn { padding: 0.6rem 1.25rem; border-radius: 8px; font-weight: 600; font-size: 0.9rem; cursor: pointer; transition: 0.2s; text-align: center; }
+.gg-decline { background: transparent; color: #94a3b8; border: 1px solid #475569; }
+.gg-decline:hover { background: #334155; color: var(--text); }
+.gg-accept { background: linear-gradient(90deg, #8b5cf6, #3b82f6); color: #fff; border: none; box-shadow: 0 4px 15px rgba(59, 130, 246, 0.4); }
+.gg-accept:hover { filter: brightness(1.1); box-shadow: 0 6px 20px rgba(59, 130, 246, 0.6); transform: translateY(-2px); }
+.gg-dismiss-input:checked ~ .gg-banner { transform: translateY(150%); opacity: 0; pointer-events: none; }
+@keyframes gg-pulse { 0% { opacity: 0.5; } 100% { opacity: 0.9; } }
+@media (max-width: 600px) {
+    .gg-content { flex-direction: column; text-align: center; padding: 1.5rem; }
+    .gg-actions { width: 100%; flex-direction: column; }
+    .gg-btn { width: 100%; box-sizing: border-box; }
+}


### PR DESCRIPTION
**Title:** feat: create Floating Cookie Banner with Gradient Glow styling (#12057) #81494

**Description:**
This PR introduces a highly visible, pure CSS dismissible cookie banner. It features a continuous animated multi-color gradient glow border behind a dark surface. The user's choice is tracked via a hidden checkbox that triggers a smooth exit animation.

Fixes #81494

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-cookie-banner-floating-gradient-glow/`
- Implemented the `.gg-glow-bg` using a heavily blurred `linear-gradient(90deg, ...)` layer tucked underneath the main surface utilizing `z-index: -1` and `inset: -2px`
- Wired the "Accept" and "Decline" buttons to target a hidden `#gg-dismiss` checkbox, which translates the banner `150%` downward off-screen when checked
