### PR TITLE
feat(core): add Rotate Perspective Spin SCSS animation mixin

### DIFF
--- a/submissions/scss/rotate-perspective-spin-scss-sb/README.md
+++ b/submissions/scss/rotate-perspective-spin-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Rotate Perspective Spin — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-rotate-perspective-spin` keyframes and a `.ease-anim-rotate-perspective-spin` utility class.
+
+## What it does
+A 3D perspective spin using rotate3d. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-rotate-perspective-spin.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-rotate-perspective-spin" as *;
+
+.my-element {
+  @include ease-anim-rotate-perspective-spin;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-rotate-perspective-spin($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81885

--- a/submissions/scss/rotate-perspective-spin-scss-sb/_ease-rotate-perspective-spin.scss
+++ b/submissions/scss/rotate-perspective-spin-scss-sb/_ease-rotate-perspective-spin.scss
@@ -1,0 +1,33 @@
+// ============================================================
+// EaseMotion CSS — Rotate Perspective Spin SCSS animation mixin
+// Submission for #81885
+// ============================================================
+
+/// Rotate Perspective Spin animation mixin.
+///
+/// Emits the `@keyframes ease-rotate-perspective-spin` rule and a `.ease-anim-rotate-perspective-spin`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-rotate-perspective-spin;
+///   @include ease-anim-rotate-perspective-spin($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-rotate-perspective-spin($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-rotate-perspective-spin {
+  0%   { transform: rotate3d(1, 1, 0, 0deg); opacity: 0.6; }
+  100% { transform: rotate3d(1, 1, 0, 360deg); opacity: 1; }
+}
+
+  .ease-anim-rotate-perspective-spin {
+    animation: ease-rotate-perspective-spin #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Rotate Perspective Spin SCSS animation mixin** feature request (closes #81885). Placed entirely under `submissions/scss/rotate-perspective-spin-scss-sb/` per the contribution guide.

`submissions/scss/rotate-perspective-spin-scss-sb/`:
- **`_ease-rotate-perspective-spin.scss`** — `@mixin ease-anim-rotate-perspective-spin` that emits the `@keyframes ease-rotate-perspective-spin` rule and a `.ease-anim-rotate-perspective-spin` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-rotate-perspective-spin` defined inside the mixin.
- `.ease-anim-rotate-perspective-spin` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
a 3D perspective spin using rotate3d (+ opacity).

### Usage
```scss
@use "./ease-rotate-perspective-spin" as *;

.my-element {
  @include ease-anim-rotate-perspective-spin;
}
```

Closes #81885

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._