### PR TITLE
feat: create Glowing Stat Card with Dark Mode styling (#54161) #81457

### DIFF
--- a/submissions/examples/css-stat-card-glowing-dark/README.md
+++ b/submissions/examples/css-stat-card-glowing-dark/README.md
@@ -1,0 +1,2 @@
+# Glowing Stat Card (Dark Mode)
+A premium data visualization card for dark dashboards. The card features a subtle green radial glow originating from the top edge, which intensifies significantly when hovered while simultaneously shifting the card upward.

--- a/submissions/examples/css-stat-card-glowing-dark/demo.html
+++ b/submissions/examples/css-stat-card-glowing-dark/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Dark Stat Card</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="gd-card">
+        <div class="gd-glow"></div>
+        <div class="gd-content">
+            <div class="gd-header">
+                <span class="gd-title">Total Revenue</span>
+                <i class="ph ph-trend-up gd-icon"></i>
+            </div>
+            <div class="gd-value">$124,563.00</div>
+            <div class="gd-trend">
+                <span class="gd-positive">+14.5%</span> from last month
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-stat-card-glowing-dark/style.css
+++ b/submissions/examples/css-stat-card-glowing-dark/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #050505; --surface: #111111; --text: #ffffff; --muted: #888888; --accent: #10b981; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.gd-card { position: relative; width: 320px; border-radius: 16px; background: var(--surface); padding: 2px; transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1); cursor: default; }
+.gd-glow { position: absolute; inset: -1px; background: radial-gradient(circle at 50% -20%, rgba(16, 185, 129, 0.4), transparent 70%); border-radius: 17px; opacity: 0.5; z-index: 0; transition: opacity 0.3s; }
+.gd-content { position: relative; background: var(--surface); padding: 1.5rem; border-radius: 14px; z-index: 1; border: 1px solid #222; }
+.gd-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+.gd-title { color: var(--muted); font-size: 0.95rem; font-weight: 500; }
+.gd-icon { color: var(--accent); font-size: 1.25rem; padding: 0.5rem; background: rgba(16, 185, 129, 0.1); border-radius: 8px; }
+.gd-value { font-size: 2.25rem; font-weight: 700; color: var(--text); margin-bottom: 0.5rem; letter-spacing: -1px; }
+.gd-trend { font-size: 0.85rem; color: var(--muted); }
+.gd-positive { color: var(--accent); font-weight: 600; display: inline-flex; align-items: center; }
+.gd-card:hover { transform: translateY(-5px); }
+.gd-card:hover .gd-glow { opacity: 1; background: radial-gradient(circle at 50% -20%, rgba(16, 185, 129, 0.7), transparent 70%); }
+.gd-card:hover .gd-content { border-color: rgba(16, 185, 129, 0.3); }


### PR DESCRIPTION
**Title:** feat: create Glowing Stat Card with Dark Mode styling (#54161) #81457

**Description:**
This PR introduces a premium data visualization card for dark dashboards. The card features a subtle green radial glow originating from the top edge, which intensifies significantly when hovered while simultaneously shifting the card upward.

Fixes #81457

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-stat-card-glowing-dark/`
- Generated a scalable top-edge glow utilizing an absolutely positioned `radial-gradient(circle at 50% -20%, ...)` placed behind the main card content
- Attached a combined `transform: translateY(-5px)` and an opacity boost on the `.gd-glow` layer to the parent card's `:hover` state
