### PR TITLE
feat: create Floating Treeview with Gradient Glow styling (#25334) #8…

### DIFF
--- a/submissions/examples/css-treeview-floating-gradient-glow/README.md
+++ b/submissions/examples/css-treeview-floating-gradient-glow/README.md
@@ -1,0 +1,2 @@
+# Floating Treeview (Gradient Glow)
+A dark mode hierarchy navigator encased in a floating panel with a vibrant glowing gradient border. Node expansion is completely CSS-driven utilizing hidden checkboxes to toggle max-height and opacity on nested sub-lists.

--- a/submissions/examples/css-treeview-floating-gradient-glow/demo.html
+++ b/submissions/examples/css-treeview-floating-gradient-glow/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gradient Glow Treeview</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fg-tree-container">
+        <ul class="fg-tree">
+            <li class="fg-node">
+                <input type="checkbox" id="fg-n1" class="fg-toggle">
+                <label for="fg-n1" class="fg-label">Documents</label>
+                <ul class="fg-subtree">
+                    <li class="fg-node">
+                        <input type="checkbox" id="fg-n1-1" class="fg-toggle">
+                        <label for="fg-n1-1" class="fg-label">Work</label>
+                        <ul class="fg-subtree">
+                            <li class="fg-leaf">Report_Q1.pdf</li>
+                            <li class="fg-leaf">Strategy.docx</li>
+                        </ul>
+                    </li>
+                    <li class="fg-leaf">Resume.pdf</li>
+                </ul>
+            </li>
+            <li class="fg-node">
+                <input type="checkbox" id="fg-n2" class="fg-toggle">
+                <label for="fg-n2" class="fg-label">Images</label>
+                <ul class="fg-subtree">
+                    <li class="fg-leaf">Avatar.png</li>
+                    <li class="fg-leaf">Background.jpg</li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-treeview-floating-gradient-glow/style.css
+++ b/submissions/examples/css-treeview-floating-gradient-glow/style.css
@@ -1,0 +1,15 @@
+:root { --bg: #1e1b4b; --surface: #312e81; --text: #e0e7ff; --glow-start: #f43f5e; --glow-end: #8b5cf6; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.fg-tree-container { background: var(--surface); padding: 2rem; border-radius: 16px; box-shadow: 0 20px 40px rgba(0,0,0,0.4); width: 300px; color: var(--text); position: relative; }
+.fg-tree-container::before { content: ''; position: absolute; inset: -2px; border-radius: 18px; background: linear-gradient(135deg, var(--glow-start), var(--glow-end)); z-index: -1; filter: blur(4px); opacity: 0.5; transition: 0.3s; }
+.fg-tree-container:hover::before { opacity: 0.8; filter: blur(8px); }
+.fg-tree, .fg-subtree { list-style: none; padding: 0; margin: 0; }
+.fg-subtree { padding-left: 1.5rem; max-height: 0; overflow: hidden; transition: max-height 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s; opacity: 0; border-left: 1px solid rgba(255,255,255,0.1); margin-left: 0.75rem; }
+.fg-node, .fg-leaf { margin: 0.25rem 0; }
+.fg-toggle { display: none; }
+.fg-label, .fg-leaf { display: flex; align-items: center; padding: 0.5rem; border-radius: 6px; cursor: pointer; transition: 0.2s; position: relative; font-size: 0.95rem; }
+.fg-label::before { content: '▶'; font-size: 0.7rem; margin-right: 0.5rem; transition: transform 0.3s; color: #a5b4fc; }
+.fg-leaf::before { content: '•'; color: #a5b4fc; margin-right: 0.75rem; font-size: 1.2rem; }
+.fg-label:hover, .fg-leaf:hover { background: rgba(255, 255, 255, 0.05); color: #fff; }
+.fg-toggle:checked + .fg-label::before { transform: rotate(90deg); }
+.fg-toggle:checked ~ .fg-subtree { max-height: 300px; opacity: 1; margin-top: 0.25rem; }


### PR DESCRIPTION
**Title:** feat: create Floating Treeview with Gradient Glow styling (#25334) #81435

**Description:**
This PR introduces a dark mode hierarchy navigator encased in a floating panel with a vibrant glowing gradient border. Node expansion is completely CSS-driven utilizing hidden checkboxes to toggle max-height and opacity on nested sub-lists.

Fixes #81435

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-treeview-floating-gradient-glow/`
- Built a nested `<input type="checkbox">` architecture where `.fg-toggle:checked ~ .fg-subtree` transitions the max-height from 0 to 300px
- Encased the entire container in an animated gradient glow using a blurred `::before` pseudo-element that intensifies upon hover
