### PR TITLE
feat: create Floating Stepper with Claymorphism styling (#73339) #81372

### DIFF
--- a/submissions/examples/css-stepper-floating-claymorphism/README.md
+++ b/submissions/examples/css-stepper-floating-claymorphism/README.md
@@ -1,0 +1,2 @@
+# Floating Stepper (Claymorphism)
+A soft, pillowy 3D stepper component. The background track is recessed into the page using inset shadows, while the active step node physically detaches and floats upward via a bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` hover transform.

--- a/submissions/examples/css-stepper-floating-claymorphism/demo.html
+++ b/submissions/examples/css-stepper-floating-claymorphism/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Floating Claymorphism Stepper</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="fc-stepper">
+        <input type="radio" name="fc-step" id="fc1" checked>
+        <input type="radio" name="fc-step" id="fc2">
+        <input type="radio" name="fc-step" id="fc3">
+        
+        <div class="fc-track">
+            <div class="fc-fill"></div>
+        </div>
+        
+        <div class="fc-nodes">
+            <label for="fc1" class="fc-node">1</label>
+            <label for="fc2" class="fc-node">2</label>
+            <label for="fc3" class="fc-node">3</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-stepper-floating-claymorphism/style.css
+++ b/submissions/examples/css-stepper-floating-claymorphism/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #eef2f5; --clay: #ffffff; --inner-shadow: rgba(0, 0, 0, 0.08); --outer-shadow: rgba(0, 0, 0, 0.12); --highlight: rgba(255, 255, 255, 1); --accent: #ff7b93; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.fc-stepper { width: 100%; max-width: 400px; padding: 2rem; position: relative; }
+input[type="radio"] { display: none; }
+.fc-track { position: absolute; top: 50%; left: 15%; width: 70%; height: 16px; transform: translateY(-50%); background: var(--clay); border-radius: 8px; box-shadow: inset 4px 4px 8px var(--inner-shadow), inset -4px -4px 8px var(--highlight); z-index: 1; }
+.fc-fill { height: 100%; width: 0%; background: var(--accent); border-radius: 8px; transition: width 0.5s cubic-bezier(0.34, 1.56, 0.64, 1); box-shadow: inset 2px 2px 4px rgba(255,255,255,0.4), inset -2px -2px 4px rgba(0,0,0,0.1); }
+.fc-nodes { display: flex; justify-content: space-between; position: relative; z-index: 2; }
+.fc-node { width: 50px; height: 50px; border-radius: 50%; background: var(--clay); display: flex; justify-content: center; align-items: center; font-weight: bold; color: #aaa; cursor: pointer; transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); box-shadow: 8px 8px 16px var(--outer-shadow), -8px -8px 16px var(--highlight), inset -4px -4px 8px var(--inner-shadow), inset 4px 4px 8px var(--highlight); }
+#fc1:checked ~ .fc-track .fc-fill { width: 0%; }
+#fc2:checked ~ .fc-track .fc-fill { width: 50%; }
+#fc3:checked ~ .fc-track .fc-fill { width: 100%; }
+#fc1:checked ~ .fc-nodes label:nth-child(1),
+#fc2:checked ~ .fc-nodes label:nth-child(2),
+#fc3:checked ~ .fc-nodes label:nth-child(3) { transform: translateY(-10px) scale(1.1); color: var(--accent); box-shadow: 12px 12px 24px var(--outer-shadow), -12px -12px 24px var(--highlight), inset -4px -4px 8px var(--inner-shadow), inset 4px 4px 8px var(--highlight); }


### PR DESCRIPTION
**Title:** feat: create Floating Stepper with Claymorphism styling (#73339) #81372

**Description:**
This PR introduces a soft, pillowy 3D stepper component. The background track is recessed into the page using inset shadows, while the active step node physically detaches and floats upward via a bouncy `cubic-bezier(0.34, 1.56, 0.64, 1)` hover transform.

Fixes #81372

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-stepper-floating-claymorphism/`
- Styled the `.fc-track` using deep `inset` shadows to emulate an indented physical trench within the background material
- Targeted the active `.fc-node` utilizing sibling combinators (`~`), triggering an intense `transform: translateY(-10px) scale(1.1)` and thickening its outer shadow
