### PR TITLE
feat: create Interactive Timeline with Neumorphism styling (#53621) #…

### DIFF
--- a/submissions/examples/css-timeline-interactive-neumorphism/README.md
+++ b/submissions/examples/css-timeline-interactive-neumorphism/README.md
@@ -1,0 +1,2 @@
+# Interactive Timeline (Neumorphism)
+A soft-UI vertical stepper. Hovering over active nodes physically presses the content card and timeline marker into the page by inverting their `box-shadow` properties to `inset`, simultaneously lighting up the marker core with the primary accent color.

--- a/submissions/examples/css-timeline-interactive-neumorphism/demo.html
+++ b/submissions/examples/css-timeline-interactive-neumorphism/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Interactive Timeline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="nt-timeline">
+        <div class="nt-node">
+            <div class="nt-marker"></div>
+            <div class="nt-content">
+                <h3>Drafting</h3>
+                <p>Initial design phase.</p>
+            </div>
+        </div>
+        <div class="nt-node">
+            <div class="nt-marker"></div>
+            <div class="nt-content">
+                <h3>Review</h3>
+                <p>Pending stakeholder approval.</p>
+            </div>
+        </div>
+        <div class="nt-node nt-disabled">
+            <div class="nt-marker"></div>
+            <div class="nt-content">
+                <h3>Publish</h3>
+                <p>Deploy to production.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-timeline-interactive-neumorphism/style.css
+++ b/submissions/examples/css-timeline-interactive-neumorphism/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #e0e5ec; --shadow-dark: #a3b1c6; --shadow-light: #ffffff; --text: #4a5568; --accent: #4299e1; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.nt-timeline { position: relative; padding: 2rem 0; width: 90%; max-width: 400px; display: flex; flex-direction: column; gap: 3rem; }
+.nt-timeline::before { content: ''; position: absolute; left: 23px; top: 0; bottom: 0; width: 4px; background: var(--bg); border-radius: 2px; box-shadow: inset 2px 2px 4px var(--shadow-dark), inset -2px -2px 4px var(--shadow-light); }
+.nt-node { display: flex; gap: 2rem; position: relative; z-index: 1; align-items: flex-start; cursor: pointer; }
+.nt-marker { width: 50px; height: 50px; border-radius: 50%; background: var(--bg); flex-shrink: 0; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: 0.3s; position: relative; }
+.nt-marker::after { content: ''; position: absolute; inset: 12px; border-radius: 50%; background: var(--bg); transition: 0.3s; }
+.nt-content { background: var(--bg); padding: 1.5rem; border-radius: 16px; box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); transition: 0.3s; width: 100%; box-sizing: border-box; }
+.nt-content h3 { margin: 0 0 0.5rem 0; color: var(--text); }
+.nt-content p { margin: 0; color: #718096; font-size: 0.9rem; }
+.nt-node:hover:not(.nt-disabled) .nt-marker { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); }
+.nt-node:hover:not(.nt-disabled) .nt-marker::after { background: var(--accent); }
+.nt-node:hover:not(.nt-disabled) .nt-content { box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light); transform: scale(0.98); }
+.nt-disabled { opacity: 0.5; cursor: not-allowed; }


### PR DESCRIPTION
**Title:** feat: create Interactive Timeline with Neumorphism styling (#53621) #81374

**Description:**
This PR introduces a soft-UI vertical stepper. Hovering over active nodes physically presses the content card and timeline marker into the page by inverting their `box-shadow` properties to `inset`, simultaneously lighting up the marker core with the primary accent color.

Fixes #81374

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-timeline-interactive-neumorphism/`
- Rendered the primary timeline track and `.nt-marker` nodes utilizing matched soft outer Neumorphic shadows
- Attached an inversion on `:hover:not(.nt-disabled)` that drops the card and marker flush into the surface while triggering a slight `scale(0.98)` contraction
