### PR TITLE
feat: create Dynamic Timeline with Material Design styling (#43512) #…

### DIFF
--- a/submissions/examples/css-timeline-dynamic-material-design/README.md
+++ b/submissions/examples/css-timeline-dynamic-material-design/README.md
@@ -1,0 +1,2 @@
+# Dynamic Timeline (Material Design)
+A classic Google Material Design vertical stepper. Active nodes utilize heavy drop shadows mimicking physical elevation (`box-shadow`), while hovering a completed node dynamically increases its shadow depth and scales up its corresponding Floating Action Button (FAB) icon.

--- a/submissions/examples/css-timeline-dynamic-material-design/demo.html
+++ b/submissions/examples/css-timeline-dynamic-material-design/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Dynamic Timeline</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="mdt-timeline">
+        <div class="mdt-node">
+            <div class="mdt-icon bg-primary"><i class="ph ph-check"></i></div>
+            <div class="mdt-card">
+                <h4>Order Placed</h4>
+                <p>We have received your order.</p>
+                <span class="mdt-time">09:41 AM</span>
+            </div>
+        </div>
+        <div class="mdt-node">
+            <div class="mdt-icon bg-secondary"><i class="ph ph-package"></i></div>
+            <div class="mdt-card">
+                <h4>Processing</h4>
+                <p>Your items are being packed.</p>
+                <span class="mdt-time">10:15 AM</span>
+            </div>
+        </div>
+        <div class="mdt-node mdt-pending">
+            <div class="mdt-icon bg-surface"><i class="ph ph-truck"></i></div>
+            <div class="mdt-card">
+                <h4>Out for Delivery</h4>
+                <p>Awaiting courier pickup.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-timeline-dynamic-material-design/style.css
+++ b/submissions/examples/css-timeline-dynamic-material-design/style.css
@@ -1,0 +1,18 @@
+:root { --bg: #f5f5f5; --surface: #ffffff; --primary: #6200ea; --secondary: #00b0ff; --text: #212121; --muted: #757575; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; }
+.mdt-timeline { position: relative; padding: 2rem 0; width: 90%; max-width: 500px; display: flex; flex-direction: column; gap: 2rem; }
+.mdt-timeline::before { content: ''; position: absolute; left: 20px; top: 0; bottom: 0; width: 2px; background: #e0e0e0; z-index: 1; }
+.mdt-node { position: relative; padding-left: 4rem; z-index: 2; }
+.mdt-icon { position: absolute; left: 0; top: 0; width: 42px; height: 42px; border-radius: 50%; display: flex; justify-content: center; align-items: center; color: #fff; font-size: 1.2rem; box-shadow: 0 3px 5px -1px rgba(0,0,0,0.2), 0 6px 10px 0 rgba(0,0,0,0.14), 0 1px 18px 0 rgba(0,0,0,0.12); z-index: 2; transition: 0.3s; }
+.bg-primary { background: var(--primary); }
+.bg-secondary { background: var(--secondary); }
+.bg-surface { background: var(--surface); color: var(--muted); border: 2px solid #e0e0e0; box-shadow: none; width: 38px; height: 38px; }
+.mdt-card { background: var(--surface); padding: 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1); cursor: pointer; position: relative; overflow: hidden; }
+.mdt-card::after { content: ''; position: absolute; inset: 0; background: currentColor; opacity: 0; transition: 0.3s; pointer-events: none; }
+.mdt-card h4 { margin: 0 0 0.25rem 0; color: var(--text); font-weight: 500; font-size: 1.1rem; }
+.mdt-card p { margin: 0; color: var(--muted); font-size: 0.95rem; }
+.mdt-time { position: absolute; top: 1.5rem; right: 1.5rem; font-size: 0.75rem; color: var(--muted); font-weight: 500; }
+.mdt-node:not(.mdt-pending):hover .mdt-card { box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22); transform: translateY(-2px); }
+.mdt-node:not(.mdt-pending):hover .mdt-card::after { opacity: 0.04; }
+.mdt-node:not(.mdt-pending):hover .mdt-icon { transform: scale(1.1); }
+.mdt-pending .mdt-card { opacity: 0.6; box-shadow: none; border: 1px dashed #bdbdbd; background: transparent; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Timeline with Material Design styling (#43512) #81378

**Description:**
This PR introduces a classic Google Material Design vertical stepper. Active nodes utilize heavy drop shadows mimicking physical elevation (`box-shadow`), while hovering a completed node dynamically increases its shadow depth and scales up its corresponding Floating Action Button (FAB) icon.

Fixes #81378

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-timeline-dynamic-material-design/`
- Designed the `.mdt-icon` markers to perfectly emulate standard Material FABs utilizing precise `0 3px 5px -1px rgba(0,0,0,0.2)...` shadow layers
- Wired a hover interaction for completed nodes that translates the card up (`translateY(-2px)`), deepens its shadow, and triggers a subtle background opacity overlay (`::after`)
