### PR TITLE
feat: add basic language selector row demo

### DIFF
--- a/submissions/examples/basic-language-selector-row-kk/README.md
+++ b/submissions/examples/basic-language-selector-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Language Selector Row
+
+## What it does
+
+This submission adds a CSS-only language selector row for profile settings,
+localization panels, onboarding flows, and account preference screens.
+
+It shows a language shortcut, language name, region, locale code, writing
+script, and selected or available state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with optional `is-selected` state:
+
+```html
+<article class="basic-language-selector-row is-selected">
+  <span class="language-icon" aria-hidden="true">EN</span>
+  <div class="language-copy">
+    <strong>English</strong>
+    <p>United States</p>
+  </div>
+  <span class="language-code">en-US</span>
+  <span class="language-script">Latin</span>
+  <span class="language-state">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+settings interfaces. Developers can reuse the same row in profile forms,
+localization menus, onboarding steps, and account settings while keeping the
+implementation lightweight and CSS-only.
+
+## Included features
+
+- Language shortcut icon block
+- Language name and region text
+- Locale code pill
+- Writing script pill
+- Selected and available state styling
+- Subtle hover slide interaction
+- Selected side accent
+- Long text truncation for compact layouts
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the language selector row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-language-selector-row-kk/demo.html
+++ b/submissions/examples/basic-language-selector-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Language Selector Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Language Selector Row</p>
+          <h1>Readable language choices for account settings.</h1>
+          <p class="intro">
+            A CSS-only row component for showing a language name, region,
+            locale code, writing script, and selected or available state.
+          </p>
+        </header>
+
+        <section class="language-list" aria-label="Language selector row examples">
+          <article class="basic-language-selector-row is-selected">
+            <span class="language-icon" aria-hidden="true">EN</span>
+            <div class="language-copy">
+              <strong>English</strong>
+              <p>United States</p>
+            </div>
+            <span class="language-code">en-US</span>
+            <span class="language-script">Latin</span>
+            <span class="language-state">Selected</span>
+          </article>
+
+          <article class="basic-language-selector-row">
+            <span class="language-icon" aria-hidden="true">HI</span>
+            <div class="language-copy">
+              <strong>Hindi</strong>
+              <p>India</p>
+            </div>
+            <span class="language-code">hi-IN</span>
+            <span class="language-script">Devanagari</span>
+            <span class="language-state">Available</span>
+          </article>
+
+          <article class="basic-language-selector-row">
+            <span class="language-icon" aria-hidden="true">ES</span>
+            <div class="language-copy">
+              <strong>Spanish</strong>
+              <p>Spain</p>
+            </div>
+            <span class="language-code">es-ES</span>
+            <span class="language-script">Latin</span>
+            <span class="language-state">Available</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-language-selector-row is-selected"&gt;
+  &lt;span class="language-icon" aria-hidden="true"&gt;EN&lt;/span&gt;
+  &lt;div class="language-copy"&gt;
+    &lt;strong&gt;English&lt;/strong&gt;
+    &lt;p&gt;United States&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="language-code"&gt;en-US&lt;/span&gt;
+  &lt;span class="language-script"&gt;Latin&lt;/span&gt;
+  &lt;span class="language-state"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-language-selector-row-kk/style.css
+++ b/submissions/examples/basic-language-selector-row-kk/style.css
@@ -1,0 +1,196 @@
+:root {
+  color-scheme: dark;
+  --page: #0c1320;
+  --card: rgba(13, 22, 38, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.11);
+  --text: #f8fbff;
+  --muted: #aab4c4;
+  --accent: #f59e0b;
+  --accent-soft: #fde68a;
+  --tag: #93c5fd;
+  --success: #86efac;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 14% 20%, rgba(245, 158, 11, 0.14), transparent 30%),
+    radial-gradient(circle at 82% 78%, rgba(147, 197, 253, 0.14), transparent 32%),
+    linear-gradient(145deg, #060915, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.05rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.language-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-language-selector-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-language-selector-row + .basic-language-selector-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-language-selector-row:hover,
+.basic-language-selector-row.is-selected {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateX(4px);
+}
+
+.basic-language-selector-row.is-selected {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.language-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  color: #10151d;
+  font-size: 0.8rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+}
+
+.language-copy {
+  min-width: 0;
+}
+
+.language-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-code,
+.language-script,
+.language-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.language-code,
+.language-script {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.language-code {
+  color: var(--tag);
+}
+
+.language-state {
+  color: var(--success);
+  background: rgba(134, 239, 172, 0.12);
+}
+
+.basic-language-selector-row:not(.is-selected) .language-state {
+  color: var(--accent);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 800px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-language-selector-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .language-code,
+  .language-script,
+  .language-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Language Selector Row demo inside `submissions/examples/basic-language-selector-row-kk/`. This submission introduces a simple CSS-only row for profile settings, localization panels, onboarding flows, and account preference screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only language selector row that displays a language shortcut, language name, region, locale code, writing script, and selected or available state.

**How does a developer use it?**

```html
<article class="basic-language-selector-row is-selected">
  <span class="language-icon" aria-hidden="true">EN</span>
  <div class="language-copy">
    <strong>English</strong>
    <p>United States</p>
  </div>
  <span class="language-code">en-US</span>
  <span class="language-script">Latin</span>
  <span class="language-state">Selected</span>
</article>