### PR TITLE
fix(ci): resolve stylelint formatting violations in docs and examples

### DIFF
--- a/docs/docs-improvement-chhavi/style.css
+++ b/docs/docs-improvement-chhavi/style.css
@@ -14,7 +14,6 @@ body{
 .hero{
     text-align:center;
     padding:80px 20px;
-
     background:linear-gradient(
         135deg,
         #6c63ff,
@@ -42,7 +41,6 @@ body{
     top:0;
     height:100vh;
     padding:30px;
-
     display:flex;
     flex-direction:column;
     gap:15px;
@@ -69,9 +67,7 @@ body{
     background:#1c1b29;
     transition: all 0.3s ease;
     padding:25px;
-
     border-radius:12px;
-
     margin-bottom:20px;
 }
 

--- a/submission/examples/aspect-ratio-fix/style.css
+++ b/submission/examples/aspect-ratio-fix/style.css
@@ -64,7 +64,6 @@
      Excess fractional pixel edges crop away symmetrically instead of squishing. */
   object-fit: cover;
   object-position: center; /* Locks focus precisely to center composition tracks */
-  
   will-change: transform;
 }
 

--- a/submission/examples/css-accordion/style.css
+++ b/submission/examples/css-accordion/style.css
@@ -77,6 +77,7 @@
 }
 
 /* ── Active Disclosure State Target Layout Chains ────────── */
+
 /* When the structural input checkbox transitions into a checked position, update adjacent sibling components fluidly */
 .alm-accordion-toggle:checked ~ .alm-accordion-content {
   /* SUCCESS: Expand container target bounds to a safe, comfortable maximum ceiling threshold.

--- a/submission/examples/flex-wrap-fix/style.css
+++ b/submission/examples/flex-wrap-fix/style.css
@@ -36,6 +36,7 @@
 }
 
 /* ── Legacy WebKit/Safari Fallback Layer Mitigation ──────── */
+
 /* If the browser does not natively understand the modern row-gap implementation mechanics inside a flex element, calculate layout overrides dynamically */
 @supports not (row-gap: 1px) {
   .alm-flex-wrap-container {
@@ -62,7 +63,6 @@
   font-weight: 500;
   text-decoration: none;
   white-space: nowrap;
-  
   transition: 
     background var(--ease-speed-fast, 150ms) ease,
     border-color var(--ease-speed-fast, 150ms) ease,

--- a/submission/examples/glass-interactions-sh/style.css
+++ b/submission/examples/glass-interactions-sh/style.css
@@ -28,6 +28,7 @@
   filter: blur(80px);
   z-index: 1;
 }
+
 .ease-bg-orb-1-sh {
   width: 300px;
   height: 300px;
@@ -35,6 +36,7 @@
   top: 20%;
   left: 25%;
 }
+
 .ease-bg-orb-2-sh {
   width: 350px;
   height: 350px;
@@ -109,11 +111,13 @@
   position: relative;
   z-index: 3;
 }
+
 .ease-glass-content-sh h3 {
   margin: 0 0 12px 0;
   font-size: 1.4rem;
   letter-spacing: 0.5px;
 }
+
 .ease-glass-content-sh p {
   color: var(--text-muted);
   line-height: 1.6;

--- a/submission/examples/infinite-marquee/style.css
+++ b/submission/examples/infinite-marquee/style.css
@@ -11,6 +11,7 @@
   0% {
     transform: translateX(0);
   }
+
   100% {
     /* SUCCESS: Translating exactly negative 100% shifts the track length perfectly.
        The duplicate clone snaps right into position, hiding the layout loop reset point. */

--- a/submission/examples/progress-bar-sh/style.css
+++ b/submission/examples/progress-bar-sh/style.css
@@ -30,6 +30,7 @@
     #60a5fa 75%, 
     #60a5fa
   );
+
   /* Making stripes slightly larger so the pattern reads perfectly */
   background-size: 2rem 2rem; 
   

--- a/submission/examples/radial-progress/style.css
+++ b/submission/examples/radial-progress/style.css
@@ -11,6 +11,7 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }
@@ -31,6 +32,7 @@
 .alm-radial-svg {
   width: 100%;
   height: 100%;
+
   /* Shift orientation so progress starts strictly from the top (12 o'clock position) */
   transform: rotate(-90deg);
   transform-origin: center;

--- a/submission/examples/scroll to top/style.css
+++ b/submission/examples/scroll to top/style.css
@@ -22,11 +22,9 @@ body {
     font-size: 24px;
     cursor: pointer;
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-
     opacity: 0;
     visibility: hidden;
     transform: translateY(15px);
-
     transition:
         opacity 0.3s ease,
         transform 0.3s ease,

--- a/submission/examples/star-rating/style.css
+++ b/submission/examples/star-rating/style.css
@@ -31,6 +31,7 @@
 /* ── Reverse Flex Row Track (The Core Fix) ───────────────── */
 .alm-rating-stars-track {
   display: inline-flex;
+
   /* SUCCESS: Flips the visual rendering direction. Items written first in the 
      HTML markup render on the far right, allowing the '~' selector to cascade leftward. */
   flex-direction: row-reverse;
@@ -95,6 +96,7 @@
 .alm-rating-stars-track:hover .alm-rating-input:checked ~ .alm-rating-label {
   color: #334155; /* temporarily dim checked elements outside cursor limits */
 }
+
 .alm-rating-stars-track .alm-rating-label:hover,
 .alm-rating-stars-track .alm-rating-label:hover ~ .alm-rating-label {
   color: var(--ease-color-warning, #f59e0b);


### PR DESCRIPTION
## Pull Request Description

This PR fixes 20 stylelint formatting errors across `docs/` and `submission/examples/` stylesheets. 
Previously, running `npm run release:check` (and CI release pipeline) failed during the `npm run lint` step. 

All stylelint errors are now fixed and `npm run release:check` passes completely (lint, build, duplicates check, and 61/61 vitest unit tests).

---

## Type of Change

- [x] 🐛 Bug fix in existing submission / repo tooling
- [x] Other: CI Pipeline Fix

---

## Verification

Run the release check suite:
\`\`\`bash
npm run release:check
\`\`\`
Output:
- `validate:manifest`: Passed
- `validate:bundle`: Passed
- `build`: Passed
- `lint`: Passed (0 errors)
- `lint:duplicates`: Passed
- `test`: 61 passed
- `validate:pack`: Passed
