### PR TITLE
feat: create Dynamic Accordion with Cyberpunk styling (#68937) #79880

### DIFF
--- a/submissions/examples/css-accordion-dynamic-cyberpunk/README.md
+++ b/submissions/examples/css-accordion-dynamic-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Dynamic Accordion (Cyberpunk)
+A terminal-style expanding accordion. Toggling an item triggers a jagged `steps()` animation curve, revealing neon yellow content, appending a cyan status border, and briefly triggering a CSS text glitch keyframe on the expanding content.

--- a/submissions/examples/css-accordion-dynamic-cyberpunk/demo.html
+++ b/submissions/examples/css-accordion-dynamic-cyberpunk/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Dynamic Accordion</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cp-accordion">
+        <div class="cp-item">
+            <input type="checkbox" id="cp1" class="cp-toggle">
+            <label for="cp1" class="cp-header">
+                <span class="cp-idx">[01]</span> DATA_UPLINK
+            </label>
+            <div class="cp-content">
+                <p>Connection established. Transferring payload fragments to central server. Warning: Packet loss detected in sector 7G.</p>
+            </div>
+        </div>
+        <div class="cp-item">
+            <input type="checkbox" id="cp2" class="cp-toggle">
+            <label for="cp2" class="cp-header">
+                <span class="cp-idx">[02]</span> NEURAL_SYNC
+            </label>
+            <div class="cp-content">
+                <p>Calibration required. Please remain stationary while the system synchronizes with your prefrontal cortex implant.</p>
+            </div>
+        </div>
+        <div class="cp-item">
+            <input type="checkbox" id="cp3" class="cp-toggle">
+            <label for="cp3" class="cp-header">
+                <span class="cp-idx">[03]</span> OVERRIDE_AUTH
+            </label>
+            <div class="cp-content">
+                <p>ACCESS DENIED. Level 4 clearance required. Unauthorized attempts will be logged and reported to corporate security.</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-accordion-dynamic-cyberpunk/style.css
+++ b/submissions/examples/css-accordion-dynamic-cyberpunk/style.css
@@ -1,0 +1,16 @@
+:root { --bg: #09090b; --cyan: #00f0ff; --yellow: #fcee0a; --pink: #ff003c; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; color: #fff; }
+.cp-accordion { width: 100%; max-width: 600px; padding: 2rem; display: flex; flex-direction: column; gap: 1rem; }
+.cp-item { border: 2px solid #333; background: rgba(255,255,255,0.02); transition: 0.2s steps(4, end); position: relative; overflow: hidden; }
+.cp-item::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 4px; background: var(--cyan); transform: scaleY(0); transform-origin: top; transition: 0.2s steps(4, end); }
+.cp-toggle { display: none; }
+.cp-header { display: flex; align-items: center; padding: 1.25rem 1.5rem; cursor: pointer; font-weight: bold; font-size: 1.1rem; letter-spacing: 2px; color: #aaa; transition: 0.1s; }
+.cp-idx { color: var(--pink); margin-right: 1rem; font-size: 0.9rem; }
+.cp-header:hover { background: rgba(0, 240, 255, 0.05); color: #fff; }
+.cp-content { max-height: 0; padding: 0 1.5rem; opacity: 0; transition: all 0.2s steps(5, end); color: var(--yellow); font-size: 0.9rem; line-height: 1.6; }
+.cp-toggle:checked ~ .cp-header { color: var(--cyan); text-shadow: 2px 0 var(--pink); border-bottom: 1px dashed #444; }
+.cp-toggle:checked ~ .cp-content { max-height: 200px; padding: 1.5rem; opacity: 1; }
+.cp-toggle:checked ~ .cp-header ~ .cp-content { animation: cp-glitch-text 0.3s steps(3, end); }
+.cp-toggle:checked ~ .cp-item { border-color: var(--cyan); }
+.cp-item:has(.cp-toggle:checked)::before { transform: scaleY(1); }
+@keyframes cp-glitch-text { 0% { transform: translate(2px, 2px); } 50% { transform: translate(-2px, -2px); } 100% { transform: translate(0, 0); } }


### PR DESCRIPTION
**Title:** feat: create Dynamic Accordion with Cyberpunk styling (#68937) #79880

**Description:**
This PR introduces a terminal-style expanding accordion. Toggling an item triggers a jagged `steps()` animation curve, revealing neon yellow content, appending a cyan status border, and briefly triggering a CSS text glitch keyframe on the expanding content.

Fixes #79880

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-accordion-dynamic-cyberpunk/`
- Bound hidden `<input type="checkbox">` elements to trigger `.cp-content` expansion utilizing `max-height` transitions
- Chained a rapid `@keyframes cp-glitch-text` animation upon expansion to simulate temporary data corruption as the payload opens
