### PR TITLE
feat: create Animated Pagination with Retro styling (#99560) #79879

### DIFF
--- a/submissions/examples/css-pagination-animated-retro/README.md
+++ b/submissions/examples/css-pagination-animated-retro/README.md
@@ -1,0 +1,2 @@
+# Animated Pagination (Retro)
+A tactile, chunky pagination block. Modeled after old mechanical keyboards, the buttons utilize hard borders and solid drop shadows. Selecting a page physically depresses the button (`transform: translate(3px, 3px)` and removing the shadow) to indicate active state.

--- a/submissions/examples/css-pagination-animated-retro/demo.html
+++ b/submissions/examples/css-pagination-animated-retro/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Animated Pagination</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="rp-pagination">
+        <input type="radio" name="rp-page" id="rp-prev">
+        <input type="radio" name="rp-page" id="rp-1" checked>
+        <input type="radio" name="rp-page" id="rp-2">
+        <input type="radio" name="rp-page" id="rp-3">
+        <input type="radio" name="rp-page" id="rp-next">
+        
+        <div class="rp-controls">
+            <label for="rp-prev" class="rp-btn rp-nav">&lt;</label>
+            <label for="rp-1" class="rp-btn">1</label>
+            <label for="rp-2" class="rp-btn">2</label>
+            <label for="rp-3" class="rp-btn">3</label>
+            <label for="rp-next" class="rp-btn rp-nav">&gt;</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pagination-animated-retro/style.css
+++ b/submissions/examples/css-pagination-animated-retro/style.css
@@ -1,0 +1,11 @@
+:root { --bg: #e3d5ca; --btn-bg: #d5bdaf; --btn-active: #9a8c98; --border: #4a4e69; --text: #22223b; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; }
+.rp-pagination { display: inline-block; padding: 1rem; border: 4px solid var(--border); background: #f2e9e4; box-shadow: 8px 8px 0 var(--border); }
+input[type="radio"] { display: none; }
+.rp-controls { display: flex; gap: 0.5rem; }
+.rp-btn { width: 40px; height: 40px; display: flex; justify-content: center; align-items: center; background: var(--btn-bg); border: 2px solid var(--border); color: var(--text); font-weight: bold; cursor: pointer; transition: 0.1s; box-shadow: 3px 3px 0 var(--border); font-size: 1.1rem; }
+.rp-btn:active { transform: translate(3px, 3px); box-shadow: none; }
+.rp-nav { font-weight: 900; }
+#rp-1:checked ~ .rp-controls label:nth-child(2),
+#rp-2:checked ~ .rp-controls label:nth-child(3),
+#rp-3:checked ~ .rp-controls label:nth-child(4) { background: var(--btn-active); color: #fff; transform: translate(3px, 3px); box-shadow: none; border-color: var(--text); }


### PR DESCRIPTION
**Title:** feat: create Animated Pagination with Retro styling (#99560) #79879

**Description:**
This PR introduces a tactile, chunky pagination block. Modeled after old mechanical keyboards, the buttons utilize hard borders and solid drop shadows. Selecting a page physically depresses the button (`transform: translate(3px, 3px)` and removing the shadow) to indicate active state.

Fixes #79879

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-pagination-animated-retro/`
- Rendered the `.rp-btn` blocks using thick borders and unblurred `box-shadow` to simulate 90s computer hardware
- Linked the button states to a hidden radio button group, shifting the checked label downward while changing its background color to emulate a locked-down key
