### PR TITLE
feat: create Animated Tooltip with Dark Mode styling (#29135) #79865

### DIFF
--- a/submissions/examples/css-tooltip-animated-dark-mode/README.md
+++ b/submissions/examples/css-tooltip-animated-dark-mode/README.md
@@ -1,0 +1,2 @@
+# Animated Tooltip (Dark Mode)
+A deeply styled, high-contrast dark tooltip. It utilizes a bouncy `cubic-bezier` transform (scaling up and sliding into position) on hover. Complete with a meticulously layered CSS triangle caret mimicking a tiny arrow.

--- a/submissions/examples/css-tooltip-animated-dark-mode/demo.html
+++ b/submissions/examples/css-tooltip-animated-dark-mode/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Animated Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="dt-container">
+        <button class="dt-target">
+            <i class="ph ph-info"></i> Hover Me
+            <div class="dt-tooltip">
+                <strong>Information</strong>
+                <p>This is a highly responsive, animated dark mode tooltip providing additional context.</p>
+            </div>
+        </button>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-animated-dark-mode/style.css
+++ b/submissions/examples/css-tooltip-animated-dark-mode/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #0f172a; --surface: #1e293b; --text: #f8fafc; --accent: #3b82f6; --border: #334155; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.dt-container { position: relative; }
+.dt-target { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 1rem; cursor: pointer; transition: 0.3s; position: relative; outline: none; }
+.dt-target:hover { background: #27354f; border-color: #475569; }
+.dt-target i { color: var(--accent); font-size: 1.2rem; }
+.dt-tooltip { position: absolute; bottom: calc(100% + 15px); left: 50%; width: 220px; background: #000; border: 1px solid var(--border); border-radius: 12px; padding: 1rem; color: #cbd5e1; text-align: left; font-size: 0.85rem; box-shadow: 0 10px 25px rgba(0,0,0,0.5); opacity: 0; visibility: hidden; transform: translateX(-50%) translateY(10px) scale(0.95); transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); pointer-events: none; z-index: 10; }
+.dt-tooltip::after { content: ''; position: absolute; top: 100%; left: 50%; margin-left: -6px; border-width: 6px; border-style: solid; border-color: #000 transparent transparent transparent; }
+.dt-tooltip::before { content: ''; position: absolute; top: 100%; left: 50%; margin-left: -7px; border-width: 7px; border-style: solid; border-color: var(--border) transparent transparent transparent; z-index: -1; }
+.dt-tooltip strong { display: block; color: #fff; margin-bottom: 0.25rem; font-size: 0.95rem; }
+.dt-tooltip p { margin: 0; line-height: 1.4; }
+.dt-target:hover .dt-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0) scale(1); }


### PR DESCRIPTION
**Title:** feat: create Animated Tooltip with Dark Mode styling (#29135) #79865

**Description:**
This PR introduces a deeply styled, high-contrast dark tooltip. It utilizes a bouncy `cubic-bezier` transform (scaling up and sliding into position) on hover. Complete with a meticulously layered CSS triangle caret mimicking a tiny arrow.

Fixes #79865

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-animated-dark-mode/`
- Built the tooltip arrow utilizing stacked `::before` and `::after` pseudo-elements utilizing transparent border hacks
- Animated the entrance of the `.dt-tooltip` using `transform: translateX(-50%) translateY(0) scale(1)` tied to a parent `:hover` trigger
