### PR TITLE
feat: create Glowing Tab Bar with Pastel styling (#33353) #79846

### DIFF
--- a/submissions/examples/css-tab-bar-glowing-pastel/README.md
+++ b/submissions/examples/css-tab-bar-glowing-pastel/README.md
@@ -1,0 +1,2 @@
+# Glowing Tab Bar (Pastel)
+A bouncy mobile-app style navigation bar. The active `.pt-highlight` pill glides between tabs tracking the checked state. Selecting a tab pushes its icon upwards while revealing the label beneath, casting a soft, color-coordinated pastel glow onto the surface below.

--- a/submissions/examples/css-tab-bar-glowing-pastel/demo.html
+++ b/submissions/examples/css-tab-bar-glowing-pastel/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pastel Glowing Tab Bar</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="pt-bar">
+        <input type="radio" name="pt-tab" id="pt1" checked>
+        <input type="radio" name="pt-tab" id="pt2">
+        <input type="radio" name="pt-tab" id="pt3">
+        <input type="radio" name="pt-tab" id="pt4">
+
+        <div class="pt-highlight"></div>
+
+        <label for="pt1" class="pt-tab pt-pink">
+            <i class="ph ph-house"></i><span>Home</span>
+        </label>
+        <label for="pt2" class="pt-tab pt-purple">
+            <i class="ph ph-magnifying-glass"></i><span>Explore</span>
+        </label>
+        <label for="pt3" class="pt-tab pt-green">
+            <i class="ph ph-bell"></i><span>Alerts</span>
+        </label>
+        <label for="pt4" class="pt-tab pt-yellow">
+            <i class="ph ph-user"></i><span>Profile</span>
+        </label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tab-bar-glowing-pastel/style.css
+++ b/submissions/examples/css-tab-bar-glowing-pastel/style.css
@@ -1,0 +1,20 @@
+:root { --bg: #faf9f6; --pink: #ffb7b2; --purple: #cbb2fe; --green: #e2f0cb; --yellow: #ffe6a7; --text: #888; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: flex-end; padding-bottom: 2rem; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; box-sizing: border-box; }
+.pt-bar { display: flex; position: relative; background: #fff; padding: 0.5rem 1rem; border-radius: 30px; box-shadow: 0 10px 30px rgba(0,0,0,0.05); width: 100%; max-width: 400px; justify-content: space-between; }
+input[type="radio"] { display: none; }
+.pt-highlight { position: absolute; top: 0.5rem; bottom: 0.5rem; width: calc((100% - 2rem) / 4); background: #f0f0f0; border-radius: 20px; transition: 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); z-index: 1; }
+.pt-tab { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0.25rem; cursor: pointer; position: relative; z-index: 2; padding: 0.5rem 0; color: var(--text); transition: 0.3s; }
+.pt-tab i { font-size: 1.5rem; transition: 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); }
+.pt-tab span { font-size: 0.75rem; font-weight: 600; opacity: 0; transform: translateY(10px); transition: 0.3s; position: absolute; bottom: 4px; pointer-events: none; }
+#pt1:checked ~ .pt-highlight { left: 1rem; background: var(--pink); box-shadow: 0 4px 15px rgba(255, 183, 178, 0.6); }
+#pt2:checked ~ .pt-highlight { left: calc(1rem + ((100% - 2rem) / 4)); background: var(--purple); box-shadow: 0 4px 15px rgba(203, 178, 254, 0.6); }
+#pt3:checked ~ .pt-highlight { left: calc(1rem + ((100% - 2rem) / 4) * 2); background: var(--green); box-shadow: 0 4px 15px rgba(226, 240, 203, 0.6); }
+#pt4:checked ~ .pt-highlight { left: calc(1rem + ((100% - 2rem) / 4) * 3); background: var(--yellow); box-shadow: 0 4px 15px rgba(255, 230, 167, 0.6); }
+#pt1:checked ~ .pt-tab:nth-of-type(1) i,
+#pt2:checked ~ .pt-tab:nth-of-type(2) i,
+#pt3:checked ~ .pt-tab:nth-of-type(3) i,
+#pt4:checked ~ .pt-tab:nth-of-type(4) i { transform: translateY(-12px); color: #555; }
+#pt1:checked ~ .pt-tab:nth-of-type(1) span,
+#pt2:checked ~ .pt-tab:nth-of-type(2) span,
+#pt3:checked ~ .pt-tab:nth-of-type(3) span,
+#pt4:checked ~ .pt-tab:nth-of-type(4) span { opacity: 1; transform: translateY(0); color: #555; }


### PR DESCRIPTION
**Title:** feat: create Glowing Tab Bar with Pastel styling (#33353) #79846

**Description:**
This PR introduces a bouncy mobile-app style navigation bar. The active `.pt-highlight` pill glides between tabs tracking the checked state. Selecting a tab pushes its icon upwards while revealing the label beneath, casting a soft, color-coordinated pastel glow onto the surface below.

Fixes #79846

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tab-bar-glowing-pastel/`
- Tied an absolutely positioned `.pt-highlight` background pill to the radio button states, animating its `left` property and background color as selection changes
- Pushed the icon `.pt-tab i` upward on selection while fading in the previously hidden text span below it
