### PR TITLE
feat(core): add Radar Sweep Ping SCSS animation mixin

### DIFF
--- a/submissions/scss/radar-sweep-ping-scss-sb/README.md
+++ b/submissions/scss/radar-sweep-ping-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Radar Sweep Ping — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-radar-sweep-ping` keyframes and a `.ease-anim-radar-sweep-ping` utility class.
+
+## What it does
+A radar ping expanding and fading. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-radar-sweep-ping.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-radar-sweep-ping" as *;
+
+.my-element {
+  @include ease-anim-radar-sweep-ping;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-radar-sweep-ping($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81685

--- a/submissions/scss/radar-sweep-ping-scss-sb/_ease-radar-sweep-ping.scss
+++ b/submissions/scss/radar-sweep-ping-scss-sb/_ease-radar-sweep-ping.scss
@@ -1,0 +1,33 @@
+// ============================================================
+// EaseMotion CSS — Radar Sweep Ping SCSS animation mixin
+// Submission for #81685
+// ============================================================
+
+/// Radar Sweep Ping animation mixin.
+///
+/// Emits the `@keyframes ease-radar-sweep-ping` rule and a `.ease-anim-radar-sweep-ping`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-radar-sweep-ping;
+///   @include ease-anim-radar-sweep-ping($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-radar-sweep-ping($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-radar-sweep-ping {
+  0%   { transform: scale(0); opacity: 0.8; }
+  100% { transform: scale(1); opacity: 0; }
+}
+
+  .ease-anim-radar-sweep-ping {
+    animation: ease-radar-sweep-ping #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Radar Sweep Ping SCSS animation mixin** feature request (closes #81685). Placed entirely under `submissions/scss/radar-sweep-ping-scss-sb/` per the contribution guide.

`submissions/scss/radar-sweep-ping-scss-sb/`:
- **`_ease-radar-sweep-ping.scss`** — `@mixin ease-anim-radar-sweep-ping` that emits the `@keyframes ease-radar-sweep-ping` rule and a `.ease-anim-radar-sweep-ping` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-radar-sweep-ping` defined inside the mixin.
- `.ease-anim-radar-sweep-ping` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
a radar ping expanding and fading (scale + opacity).

### Usage
```scss
@use "./ease-radar-sweep-ping" as *;

.my-element {
  @include ease-anim-radar-sweep-ping;
}
```

Closes #81685

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._