### PR TITLE
feat(core): add Magnet Snap Pull SCSS animation mixin

### DIFF
--- a/submissions/scss/magnet-snap-pull-scss-sb/README.md
+++ b/submissions/scss/magnet-snap-pull-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Magnet Snap Pull — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-magnet-snap-pull` keyframes and a `.ease-anim-magnet-snap-pull` utility class.
+
+## What it does
+An element snapping in like pulled by a magnet (translate3d + scale + opacity). Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-magnet-snap-pull.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-magnet-snap-pull" as *;
+
+.my-element {
+  @include ease-anim-magnet-snap-pull;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-magnet-snap-pull($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81697

--- a/submissions/scss/magnet-snap-pull-scss-sb/_ease-magnet-snap-pull.scss
+++ b/submissions/scss/magnet-snap-pull-scss-sb/_ease-magnet-snap-pull.scss
@@ -1,0 +1,34 @@
+// ============================================================
+// EaseMotion CSS — Magnet Snap Pull SCSS animation mixin
+// Submission for #81697
+// ============================================================
+
+/// Magnet Snap Pull animation mixin.
+///
+/// Emits the `@keyframes ease-magnet-snap-pull` rule and a `.ease-anim-magnet-snap-pull`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-magnet-snap-pull;
+///   @include ease-anim-magnet-snap-pull($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-magnet-snap-pull($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-magnet-snap-pull {
+  0%   { transform: translate3d(24px, 0, 0) scale(0.9); opacity: 0; }
+  60%  { transform: translate3d(-6px, 0, 0) scale(1.05); opacity: 1; }
+  100% { transform: translate3d(0, 0, 0) scale(1); opacity: 1; }
+}
+
+  .ease-anim-magnet-snap-pull {
+    animation: ease-magnet-snap-pull #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Magnet Snap Pull SCSS animation mixin** feature request (closes #81697). Placed entirely under `submissions/scss/magnet-snap-pull-scss-sb/` per the contribution guide.

`submissions/scss/magnet-snap-pull-scss-sb/`:
- **`_ease-magnet-snap-pull.scss`** — `@mixin ease-anim-magnet-snap-pull` that emits the `@keyframes ease-magnet-snap-pull` rule and a `.ease-anim-magnet-snap-pull` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-magnet-snap-pull` defined inside the mixin.
- `.ease-anim-magnet-snap-pull` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
an element snapping in like pulled by a magnet (translate3d + scale + opacity).

### Usage
```scss
@use "./ease-magnet-snap-pull" as *;

.my-element {
  @include ease-anim-magnet-snap-pull;
}
```

Closes #81697

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._