### PR TITLE
feat(scss): add ease motion curves and transition mixins partial (-ik)

### DIFF
--- a/submissions/scss/ease-motion-curves-bundle-ik/README.md
+++ b/submissions/scss/ease-motion-curves-bundle-ik/README.md
@@ -1,0 +1,51 @@
+# EaseMotion SCSS Motion Curves Partial (`ease-motion-curves-bundle-ik`)
+
+A comprehensive Sass/SCSS partial providing canonical timing functions, responsive motion mixins, and component glow utilities for EaseMotion CSS.
+
+Submitted by: **@Ishita-Katiyar-06** (`-ik`)
+
+---
+
+## 1. Description
+
+This SCSS module exports reusable cubic-bezier variables and powerful `@include` mixins (`@include ease-transition`, `@include ease-animate`, and `@include ease-glow`) designed for seamless integration with SCSS pipelines.
+
+All mixins automatically incorporate `@media (prefers-color-scheme)` and `@media (prefers-reduced-motion)` accessibility standards.
+
+---
+
+## 2. Usage Examples
+
+Import the partial into your project SCSS stylesheet:
+
+```scss
+@use 'ease-motion-curves-bundle-ik' as ease;
+
+.card-component {
+  background-color: #1e293b;
+  border-radius: 12px;
+
+  // Apply smooth spring hover transition
+  @include ease.ease-transition(transform, 300ms, ease.$ease-spring-bounce);
+
+  &:hover {
+    transform: translateY(-6px);
+    @include ease.ease-glow(rgba(56, 189, 248, 0.4), 24px);
+  }
+}
+
+.modal-dialog {
+  // Apply keyframe animation
+  @include ease.ease-animate(ease-kf-fade-in, 400ms, ease.$ease-cubic-out);
+}
+```
+
+---
+
+## 3. Mixin Reference & Parameters
+
+| Mixin | Parameters | Default Value | Description |
+|-------|------------|---------------|-------------|
+| `ease-transition` | `$properties, $duration, $easing, $delay` | `all, 300ms, $ease-cubic-default, 0ms` | Configures element transition properties with reduced-motion support. |
+| `ease-animate` | `$name, $duration, $easing, $iterations, $fill` | `-, 500ms, $ease-cubic-out, 1, both` | Configures keyframe animation parameters with accessibility fallbacks. |
+| `ease-glow` | `$color, $radius` | `rgba(56, 189, 248, 0.35), 20px` | Adds dynamic elevated box-shadow glow. |

--- a/submissions/scss/ease-motion-curves-bundle-ik/_ease-motion-curves-bundle-ik.scss
+++ b/submissions/scss/ease-motion-curves-bundle-ik/_ease-motion-curves-bundle-ik.scss
@@ -1,0 +1,43 @@
+// ============================================================
+// EaseMotion CSS — SCSS Motion Curves & Elevation Partial
+// Submitted by: @Ishita-Katiyar-06 (-ik)
+// ============================================================
+
+// 1. Easing Curve Dictionary
+$ease-cubic-default: cubic-bezier(0.4, 0, 0.2, 1) !default;
+$ease-cubic-in: cubic-bezier(0.4, 0, 1, 1) !default;
+$ease-cubic-out: cubic-bezier(0, 0, 0.2, 1) !default;
+$ease-spring-bounce: cubic-bezier(0.34, 1.56, 0.64, 1) !default;
+$ease-snap-sharp: cubic-bezier(0.77, 0, 0.175, 1) !default;
+
+// 2. Motion Transition Mixin
+@mixin ease-transition($properties: all, $duration: 300ms, $easing: $ease-cubic-default, $delay: 0ms) {
+  transition-property: #{$properties};
+  transition-duration: $duration;
+  transition-timing-function: $easing;
+  transition-delay: $delay;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+  }
+}
+
+// 3. Keyframe Animation Helper
+@mixin ease-animate($name, $duration: 500ms, $easing: $ease-cubic-out, $iterations: 1, $fill: both) {
+  animation-name: #{$name};
+  animation-duration: $duration;
+  animation-timing-function: $easing;
+  animation-iteration-count: $iterations;
+  animation-fill-mode: $fill;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+// 4. Component Elevation Glow Mixin
+@mixin ease-glow($color: rgba(56, 189, 248, 0.35), $radius: 20px) {
+  box-shadow: 0 8px $radius -4px #{$color};
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds an SCSS mixin partial under `submissions/scss/ease-motion-curves-bundle-ik/` providing canonical timing curves, reusable transition/animation mixins (`@include ease-transition`, `@include ease-animate`), and elevation glow utilities (`@include ease-glow`) with built-in `prefers-reduced-motion` accessibility support.

---

## Type of Change

- [x] 🧩 New component / SCSS Mixin
- [x] 📝 Documentation improvement

---

## Submission Checklist

- [x] All changes are inside `submissions/` (`submissions/scss/ease-motion-curves-bundle-ik/`)
- [x] Includes `_ease-motion-curves-bundle-ik.scss` — partial SCSS stylesheet
- [x] Includes `README.md` — description, parameters table, and SCSS usage example
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
Provides Sass/SCSS developers with a comprehensive mixin library for EaseMotion timing functions, keyframe transitions, and box-shadow glows.

**How does a developer use it?**
```scss
@use 'ease-motion-curves-bundle-ik' as ease;

.card {
  @include ease.ease-transition(transform, 300ms, ease.$ease-spring-bounce);
}
