### PR TITLE
feat(core): add Swing Pendulum Wobble SCSS animation mixin

### DIFF
--- a/submissions/scss/swing-pendulum-wobble-scss-sb/README.md
+++ b/submissions/scss/swing-pendulum-wobble-scss-sb/README.md
@@ -1,0 +1,36 @@
+# Swing Pendulum Wobble — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-swing-pendulum-wobble` keyframes and a `.ease-anim-swing-pendulum-wobble` utility class.
+
+## What it does
+A pendulum swing wobble using rotate + opacity. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ease-swing-pendulum-wobble.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ease-swing-pendulum-wobble" as *;
+
+.my-element {
+  @include ease-anim-swing-pendulum-wobble;
+}
+```
+
+### Configurable parameters
+```scss
+@include ease-anim-swing-pendulum-wobble($duration: 1.2s, $timing: ease-in-out, $fill: both);
+```
+
+Timing is also configurable at runtime via CSS custom properties:
+```css
+:root {
+  --ease-duration: 1.2s;
+  --ease-timing: ease-in-out;
+}
+```
+
+## Accessibility
+Includes a `@media (prefers-reduced-motion: reduce)` override that disables the animation.
+
+Closes #81710

--- a/submissions/scss/swing-pendulum-wobble-scss-sb/_ease-swing-pendulum-wobble.scss
+++ b/submissions/scss/swing-pendulum-wobble-scss-sb/_ease-swing-pendulum-wobble.scss
@@ -1,0 +1,36 @@
+// ============================================================
+// EaseMotion CSS — Swing Pendulum Wobble SCSS animation mixin
+// Submission for #81710
+// ============================================================
+
+/// Swing Pendulum Wobble animation mixin.
+///
+/// Emits the `@keyframes ease-swing-pendulum-wobble` rule and a `.ease-anim-swing-pendulum-wobble`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-swing-pendulum-wobble;
+///   @include ease-anim-swing-pendulum-wobble($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-swing-pendulum-wobble($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-swing-pendulum-wobble {
+  0%, 100% { transform: rotate(0deg); opacity: 1; }
+  20%      { transform: rotate(15deg); }
+  40%      { transform: rotate(-12deg); }
+  60%      { transform: rotate(8deg); }
+  80%      { transform: rotate(-5deg); }
+}
+
+  .ease-anim-swing-pendulum-wobble {
+    animation: ease-swing-pendulum-wobble #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained submission for the **Swing Pendulum Wobble SCSS animation mixin** feature request (closes #81710). Placed entirely under `submissions/scss/swing-pendulum-wobble-scss-sb/` per the contribution guide.

`submissions/scss/swing-pendulum-wobble-scss-sb/`:
- **`_ease-swing-pendulum-wobble.scss`** — `@mixin ease-anim-swing-pendulum-wobble` that emits the `@keyframes ease-swing-pendulum-wobble` rule and a `.ease-anim-swing-pendulum-wobble` utility class.
- **`README.md`** — usage docs.

### Implementation
- `@keyframes ease-swing-pendulum-wobble` defined inside the mixin.
- `.ease-anim-swing-pendulum-wobble` utility class generated.
- Configurable parameters: `\$duration`, `\$timing`, `\$fill` (plus `--ease-duration` / `--ease-timing` CSS custom props).
- `@media (prefers-reduced-motion: reduce)` override included.
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.

### Effect
a pendulum swing wobble using rotate + opacity.

### Usage
```scss
@use "./ease-swing-pendulum-wobble" as *;

.my-element {
  @include ease-anim-swing-pendulum-wobble;
}
```

Closes #81710

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._