### PR TITLE
feat: create Morphing Footer with Cyberpunk styling (#89366) #79855

### DIFF
--- a/submissions/examples/css-footer-morphing-cyberpunk/README.md
+++ b/submissions/examples/css-footer-morphing-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Morphing Footer (Cyberpunk)
+A dark, gritty terminal-style footer. It features a persistent scanline background, jagged `steps()` animations on hover states, and a call-to-action button that morphs its background fill across the element in a choppy, low-framerate sweep.

--- a/submissions/examples/css-footer-morphing-cyberpunk/demo.html
+++ b/submissions/examples/css-footer-morphing-cyberpunk/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Morphing Footer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="cp-footer">
+        <div class="cp-glitch-layer"></div>
+        <div class="cp-content">
+            <div class="cp-brand">
+                <span class="cp-sys">[SYS_COM]</span>
+                <h2>NEON_CORE_v9</h2>
+            </div>
+            <div class="cp-links">
+                <a href="#">// DATABASE</a>
+                <a href="#">// PROTOCOLS</a>
+                <a href="#">// UPLINK</a>
+            </div>
+        </div>
+        <div class="cp-morph-btn">
+            <span>INITIATE CONTACT</span>
+            <div class="cp-morph-bg"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-footer-morphing-cyberpunk/style.css
+++ b/submissions/examples/css-footer-morphing-cyberpunk/style.css
@@ -1,0 +1,21 @@
+:root { --bg: #0a0a0c; --cyan: #00f0ff; --pink: #ff003c; --yellow: #fcee0a; }
+body { background: #111; display: flex; align-items: flex-end; min-height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; color: #fff; overflow-x: hidden; }
+.cp-footer { width: 100%; background: var(--bg); padding: 3rem 2rem; position: relative; border-top: 2px solid var(--cyan); display: flex; justify-content: space-between; align-items: flex-end; box-sizing: border-box; }
+.cp-glitch-layer { position: absolute; inset: 0; background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 240, 255, 0.1) 2px, rgba(0, 240, 255, 0.1) 4px); pointer-events: none; }
+.cp-content { z-index: 1; }
+.cp-brand h2 { margin: 0; color: var(--yellow); letter-spacing: 2px; text-shadow: 3px 0 var(--pink); font-size: 2rem; text-transform: uppercase; }
+.cp-sys { color: var(--cyan); font-size: 0.9rem; letter-spacing: 1px; }
+.cp-links { display: flex; gap: 2rem; margin-top: 1.5rem; }
+.cp-links a { color: #aaa; text-decoration: none; font-size: 0.9rem; transition: 0.2s; position: relative; }
+.cp-links a:hover { color: #fff; text-shadow: 0 0 8px var(--cyan); }
+.cp-links a::after { content: ''; position: absolute; left: 0; bottom: -4px; width: 0; height: 2px; background: var(--pink); transition: 0.2s steps(4, end); }
+.cp-links a:hover::after { width: 100%; }
+.cp-morph-btn { position: relative; padding: 1rem 2rem; border: 1px solid var(--cyan); cursor: pointer; z-index: 1; font-weight: bold; letter-spacing: 1px; overflow: hidden; }
+.cp-morph-btn span { position: relative; z-index: 2; transition: 0.1s; }
+.cp-morph-bg { position: absolute; inset: 0; background: var(--cyan); transform: scaleX(0); transform-origin: left; transition: 0.2s steps(5, end); z-index: 1; }
+.cp-morph-btn:hover .cp-morph-bg { transform: scaleX(1); }
+.cp-morph-btn:hover span { color: #000; }
+@media (max-width: 768px) {
+    .cp-footer { flex-direction: column; align-items: flex-start; gap: 2rem; }
+    .cp-links { flex-direction: column; gap: 1rem; }
+}


### PR DESCRIPTION
**Title:** feat: create Morphing Footer with Cyberpunk styling (#89366) #79855

**Description:**
This PR introduces a dark, gritty terminal-style footer. It features a persistent scanline background, jagged `steps()` animations on hover states, and a call-to-action button that morphs its background fill across the element in a choppy, low-framerate sweep.

Fixes #79855

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-footer-morphing-cyberpunk/`
- Rendered the `.cp-glitch-layer` scanlines utilizing an overlaid `repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 240, 255, 0.1) 2px, rgba(0, 240, 255, 0.1) 4px)`
- Designed the `.cp-morph-btn` interaction using an absolutely positioned `.cp-morph-bg` that expands via `transform: scaleX(1)` tied to a 5-step animation curve
