### PR TITLE
feat: add basic currency selector row demo

### DIFF
--- a/submissions/examples/basic-currency-selector-row-kk/README.md
+++ b/submissions/examples/basic-currency-selector-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Currency Selector Row
+
+## What it does
+
+This submission adds a CSS-only currency selector row for billing settings,
+checkout preferences, account setup screens, and subscription dashboards.
+
+It shows a currency symbol, currency name, helper text, currency code, region,
+and selected or available state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with optional `is-selected` state:
+
+```html
+<article class="basic-currency-selector-row is-selected">
+  <span class="currency-icon" aria-hidden="true">$</span>
+  <div class="currency-copy">
+    <strong>US Dollar</strong>
+    <p>Default billing currency for United States accounts.</p>
+  </div>
+  <span class="currency-code">USD</span>
+  <span class="currency-region">United States</span>
+  <span class="currency-state">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+billing and account interfaces. Developers can reuse the same row in checkout
+settings, subscription dashboards, pricing tools, and onboarding screens while
+keeping the implementation lightweight and CSS-only.
+
+## Included features
+
+- Currency symbol icon block
+- Currency name and helper text
+- Currency code pill
+- Region pill
+- Selected and available state styling
+- Subtle hover slide interaction
+- Selected side accent
+- Long text truncation for compact layouts
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the currency selector row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-currency-selector-row-kk/demo.html
+++ b/submissions/examples/basic-currency-selector-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Currency Selector Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Currency Selector Row</p>
+          <h1>Clear currency choices for billing settings.</h1>
+          <p class="intro">
+            A CSS-only row component for choosing billing currency with symbol,
+            region, format, and selected or available state.
+          </p>
+        </header>
+
+        <section class="currency-list" aria-label="Currency selector row examples">
+          <article class="basic-currency-selector-row is-selected">
+            <span class="currency-icon" aria-hidden="true">$</span>
+            <div class="currency-copy">
+              <strong>US Dollar</strong>
+              <p>Default billing currency for United States accounts.</p>
+            </div>
+            <span class="currency-code">USD</span>
+            <span class="currency-region">United States</span>
+            <span class="currency-state">Selected</span>
+          </article>
+
+          <article class="basic-currency-selector-row">
+            <span class="currency-icon" aria-hidden="true">EU</span>
+            <div class="currency-copy">
+              <strong>Euro</strong>
+              <p>Used for European Union invoices and subscriptions.</p>
+            </div>
+            <span class="currency-code">EUR</span>
+            <span class="currency-region">Europe</span>
+            <span class="currency-state">Available</span>
+          </article>
+
+          <article class="basic-currency-selector-row">
+            <span class="currency-icon" aria-hidden="true">IN</span>
+            <div class="currency-copy">
+              <strong>Indian Rupee</strong>
+              <p>Useful for India-based billing and local pricing pages.</p>
+            </div>
+            <span class="currency-code">INR</span>
+            <span class="currency-region">India</span>
+            <span class="currency-state">Available</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-currency-selector-row is-selected"&gt;
+  &lt;span class="currency-icon" aria-hidden="true"&gt;$&lt;/span&gt;
+  &lt;div class="currency-copy"&gt;
+    &lt;strong&gt;US Dollar&lt;/strong&gt;
+    &lt;p&gt;Default billing currency for United States accounts.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="currency-code"&gt;USD&lt;/span&gt;
+  &lt;span class="currency-region"&gt;United States&lt;/span&gt;
+  &lt;span class="currency-state"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-currency-selector-row-kk/style.css
+++ b/submissions/examples/basic-currency-selector-row-kk/style.css
@@ -1,0 +1,194 @@
+:root {
+  color-scheme: dark;
+  --page: #10141d;
+  --card: rgba(19, 24, 35, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.12);
+  --text: #f8fbff;
+  --muted: #abb6c7;
+  --accent: #22c55e;
+  --accent-soft: #bbf7d0;
+  --code: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 18% 20%, rgba(34, 197, 94, 0.15), transparent 30%),
+    radial-gradient(circle at 84% 76%, rgba(251, 191, 36, 0.13), transparent 32%),
+    linear-gradient(145deg, #070a12, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.05rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.currency-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-currency-selector-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-currency-selector-row + .basic-currency-selector-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-currency-selector-row:hover,
+.basic-currency-selector-row.is-selected {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateX(4px);
+}
+
+.basic-currency-selector-row.is-selected {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.currency-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  color: #07110d;
+  font-size: 1.15rem;
+  font-weight: 950;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+}
+
+.currency-copy {
+  min-width: 0;
+}
+
+.currency-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.currency-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.currency-code,
+.currency-region,
+.currency-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6.1rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.currency-code,
+.currency-region {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.currency-code {
+  color: var(--code);
+}
+
+.currency-state {
+  color: var(--accent);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.basic-currency-selector-row:not(.is-selected) .currency-state {
+  color: #f8fbff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 810px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-currency-selector-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .currency-code,
+  .currency-region,
+  .currency-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Currency Selector Row demo inside `submissions/examples/basic-currency-selector-row-kk/`. This submission introduces a simple CSS-only row for billing settings, checkout preferences, account setup screens, and subscription dashboards.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only currency selector row that displays a currency symbol, currency name, helper text, currency code, region, and selected or available state.

**How does a developer use it?**

```html
<article class="basic-currency-selector-row is-selected">
  <span class="currency-icon" aria-hidden="true">$</span>
  <div class="currency-copy">
    <strong>US Dollar</strong>
    <p>Default billing currency for United States accounts.</p>
  </div>
  <span class="currency-code">USD</span>
  <span class="currency-region">United States</span>
  <span class="currency-state">Selected</span>
</article>