### PR TITLE
feat: add basic display density row demo

### DIFF
--- a/submissions/examples/basic-display-density-row-kk/README.md
+++ b/submissions/examples/basic-display-density-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Display Density Row
+
+## What it does
+
+This submission adds a CSS-only display density row for dashboards, admin
+settings, tables, and account preference screens.
+
+It shows a density shortcut, density name, helper text, row size, usage context,
+and selected or available state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with optional `is-selected` state:
+
+```html
+<article class="basic-display-density-row is-selected">
+  <span class="density-icon" aria-hidden="true">CF</span>
+  <div class="density-copy">
+    <strong>Comfortable</strong>
+    <p>Balanced spacing for everyday dashboard workflows.</p>
+  </div>
+  <span class="density-size">44 px rows</span>
+  <span class="density-use">Default</span>
+  <span class="density-state">Selected</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+dashboard settings. Developers can reuse the same row in table preferences,
+admin panels, account settings, and product configuration screens while keeping
+the implementation lightweight and CSS-only.
+
+## Included features
+
+- Compact, comfortable, and spacious examples
+- Density shortcut icon block
+- Row size metadata pill
+- Usage context pill
+- Selected and available state styling
+- Subtle hover slide interaction
+- Selected side accent
+- Long text truncation for compact layouts
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the display density row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-display-density-row-kk/demo.html
+++ b/submissions/examples/basic-display-density-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Display Density Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Display Density Row</p>
+          <h1>Simple layout density choices for dashboards.</h1>
+          <p class="intro">
+            A CSS-only settings row for choosing compact, comfortable, or
+            spacious interface density in admin and dashboard screens.
+          </p>
+        </header>
+
+        <section class="density-list" aria-label="Display density row examples">
+          <article class="basic-display-density-row">
+            <span class="density-icon" aria-hidden="true">CP</span>
+            <div class="density-copy">
+              <strong>Compact</strong>
+              <p>Shows more rows with tighter spacing for power users.</p>
+            </div>
+            <span class="density-size">32 px rows</span>
+            <span class="density-use">Data heavy</span>
+            <span class="density-state">Available</span>
+          </article>
+
+          <article class="basic-display-density-row is-selected">
+            <span class="density-icon" aria-hidden="true">CF</span>
+            <div class="density-copy">
+              <strong>Comfortable</strong>
+              <p>Balanced spacing for everyday dashboard workflows.</p>
+            </div>
+            <span class="density-size">44 px rows</span>
+            <span class="density-use">Default</span>
+            <span class="density-state">Selected</span>
+          </article>
+
+          <article class="basic-display-density-row">
+            <span class="density-icon" aria-hidden="true">SP</span>
+            <div class="density-copy">
+              <strong>Spacious</strong>
+              <p>Adds more breathing room for touch-friendly interfaces.</p>
+            </div>
+            <span class="density-size">56 px rows</span>
+            <span class="density-use">Touch UI</span>
+            <span class="density-state">Available</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-display-density-row is-selected"&gt;
+  &lt;span class="density-icon" aria-hidden="true"&gt;CF&lt;/span&gt;
+  &lt;div class="density-copy"&gt;
+    &lt;strong&gt;Comfortable&lt;/strong&gt;
+    &lt;p&gt;Balanced spacing for everyday dashboard workflows.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="density-size"&gt;44 px rows&lt;/span&gt;
+  &lt;span class="density-use"&gt;Default&lt;/span&gt;
+  &lt;span class="density-state"&gt;Selected&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-display-density-row-kk/style.css
+++ b/submissions/examples/basic-display-density-row-kk/style.css
@@ -1,0 +1,195 @@
+:root {
+  color-scheme: dark;
+  --page: #11131a;
+  --card: rgba(20, 23, 32, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.12);
+  --text: #f8fbff;
+  --muted: #aeb8c7;
+  --accent: #38bdf8;
+  --accent-soft: #dbeafe;
+  --warm: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 16% 20%, rgba(56, 189, 248, 0.14), transparent 30%),
+    radial-gradient(circle at 84% 78%, rgba(251, 191, 36, 0.12), transparent 32%),
+    linear-gradient(145deg, #07080d, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.05rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.density-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-display-density-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-display-density-row + .basic-display-density-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-display-density-row:hover,
+.basic-display-density-row.is-selected {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateX(4px);
+}
+
+.basic-display-density-row.is-selected {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.density-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  color: #07111f;
+  font-size: 0.8rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+}
+
+.density-copy {
+  min-width: 0;
+}
+
+.density-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.density-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.density-size,
+.density-use,
+.density-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6.1rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.density-size,
+.density-use {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.density-use {
+  color: var(--warm);
+}
+
+.density-state {
+  color: var(--accent);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.basic-display-density-row:not(.is-selected) .density-state {
+  color: #f8fbff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 810px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-display-density-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .density-size,
+  .density-use,
+  .density-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Display Density Row demo inside `submissions/examples/basic-display-density-row-kk/`. This submission introduces a simple CSS-only row for dashboard settings, table preferences, admin panels, and account preference screens.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only display density row that displays compact, comfortable, and spacious layout choices with row size, usage context, and selected or available state.

**How does a developer use it?**

```html
<article class="basic-display-density-row is-selected">
  <span class="density-icon" aria-hidden="true">CF</span>
  <div class="density-copy">
    <strong>Comfortable</strong>
    <p>Balanced spacing for everyday dashboard workflows.</p>
  </div>
  <span class="density-size">44 px rows</span>
  <span class="density-use">Default</span>
  <span class="density-state">Selected</span>
</article>