### PR TITLE
feat: add basic workspace switcher row demo

### DIFF
--- a/submissions/examples/basic-workspace-switcher-row-kk/README.md
+++ b/submissions/examples/basic-workspace-switcher-row-kk/README.md
@@ -1,0 +1,52 @@
+# Basic Workspace Switcher Row
+
+## What it does
+
+This submission adds a CSS-only workspace switcher row for dashboards, team
+settings, organization menus, and multi-workspace SaaS products.
+
+It shows a workspace shortcut, workspace name, helper text, environment badge,
+member count, and current or switch state in one compact reusable row.
+
+## How to use it
+
+Add the base row class with optional `is-selected` state:
+
+```html
+<article class="basic-workspace-switcher-row is-selected">
+  <span class="workspace-icon" aria-hidden="true">AP</span>
+  <div class="workspace-copy">
+    <strong>Acme Product</strong>
+    <p>Primary team workspace</p>
+  </div>
+  <span class="workspace-env">Production</span>
+  <span class="workspace-members">18 members</span>
+  <span class="workspace-state">Current</span>
+</article>
+```
+
+## Why it fits EaseMotion CSS
+
+It fits EaseMotion CSS because it is readable, composable, and useful in common
+team and settings interfaces. Developers can reuse the same row in organization
+menus, project switchers, account sidebars, and admin dashboards while keeping
+the implementation lightweight and CSS-only.
+
+## Included features
+
+- Workspace shortcut icon block
+- Workspace name and helper text
+- Environment badge
+- Member count badge
+- Current and switch state styling
+- Subtle hover slide interaction
+- Selected side accent
+- Long text truncation for compact layouts
+- Responsive wrapping on smaller screens
+- Pure HTML and CSS implementation
+
+## Files
+
+- `demo.html` - self-contained browser demo
+- `style.css` - raw CSS for the workspace switcher row
+- `README.md` - usage and contribution context

--- a/submissions/examples/basic-workspace-switcher-row-kk/demo.html
+++ b/submissions/examples/basic-workspace-switcher-row-kk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic Workspace Switcher Row</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card">
+        <header class="hero">
+          <p class="eyebrow">Basic Workspace Switcher Row</p>
+          <h1>Simple workspace choices for multi-team products.</h1>
+          <p class="intro">
+            A CSS-only row component for switching between workspaces with team
+            name, environment, member count, and selected state.
+          </p>
+        </header>
+
+        <section class="workspace-list" aria-label="Workspace switcher row examples">
+          <article class="basic-workspace-switcher-row is-selected">
+            <span class="workspace-icon" aria-hidden="true">AP</span>
+            <div class="workspace-copy">
+              <strong>Acme Product</strong>
+              <p>Primary team workspace</p>
+            </div>
+            <span class="workspace-env">Production</span>
+            <span class="workspace-members">18 members</span>
+            <span class="workspace-state">Current</span>
+          </article>
+
+          <article class="basic-workspace-switcher-row">
+            <span class="workspace-icon" aria-hidden="true">DS</span>
+            <div class="workspace-copy">
+              <strong>Design Systems</strong>
+              <p>Shared UI documentation space</p>
+            </div>
+            <span class="workspace-env">Staging</span>
+            <span class="workspace-members">9 members</span>
+            <span class="workspace-state">Switch</span>
+          </article>
+
+          <article class="basic-workspace-switcher-row">
+            <span class="workspace-icon" aria-hidden="true">CL</span>
+            <div class="workspace-copy">
+              <strong>Client Ops</strong>
+              <p>Customer-facing operations workspace</p>
+            </div>
+            <span class="workspace-env">Sandbox</span>
+            <span class="workspace-members">6 members</span>
+            <span class="workspace-state">Switch</span>
+          </article>
+        </section>
+
+        <section class="usage-card">
+          <p class="snippet-label">HTML Usage</p>
+          <pre><code>&lt;article class="basic-workspace-switcher-row is-selected"&gt;
+  &lt;span class="workspace-icon" aria-hidden="true"&gt;AP&lt;/span&gt;
+  &lt;div class="workspace-copy"&gt;
+    &lt;strong&gt;Acme Product&lt;/strong&gt;
+    &lt;p&gt;Primary team workspace&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;span class="workspace-env"&gt;Production&lt;/span&gt;
+  &lt;span class="workspace-members"&gt;18 members&lt;/span&gt;
+  &lt;span class="workspace-state"&gt;Current&lt;/span&gt;
+&lt;/article&gt;</code></pre>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/basic-workspace-switcher-row-kk/style.css
+++ b/submissions/examples/basic-workspace-switcher-row-kk/style.css
@@ -1,0 +1,195 @@
+:root {
+  color-scheme: dark;
+  --page: #09111f;
+  --card: rgba(13, 20, 34, 0.96);
+  --panel: rgba(255, 255, 255, 0.055);
+  --line: rgba(255, 255, 255, 0.11);
+  --text: #f8fbff;
+  --muted: #aab6c8;
+  --accent: #34d399;
+  --accent-soft: #d1fae5;
+  --tag: #93c5fd;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 16% 22%, rgba(52, 211, 153, 0.15), transparent 30%),
+    radial-gradient(circle at 84% 78%, rgba(147, 197, 253, 0.13), transparent 32%),
+    linear-gradient(145deg, #050814, var(--page));
+}
+
+.demo-shell {
+  width: min(100%, 980px);
+}
+
+.demo-card {
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--card);
+  box-shadow: 0 32px 78px rgba(0, 0, 0, 0.42);
+}
+
+.eyebrow,
+.snippet-label {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 18ch;
+  margin: 0.55rem 0 0.85rem;
+  font-size: clamp(2rem, 4vw, 3.05rem);
+  line-height: 1.05;
+}
+
+.intro {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.workspace-list,
+.usage-card {
+  margin-top: 1.25rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--panel);
+}
+
+.basic-workspace-switcher-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 18px;
+  transition:
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.basic-workspace-switcher-row + .basic-workspace-switcher-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.basic-workspace-switcher-row:hover,
+.basic-workspace-switcher-row.is-selected {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateX(4px);
+}
+
+.basic-workspace-switcher-row.is-selected {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.workspace-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border-radius: 16px;
+  color: #08111b;
+  font-size: 0.8rem;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+}
+
+.workspace-copy {
+  min-width: 0;
+}
+
+.workspace-copy strong {
+  display: block;
+  overflow: hidden;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-copy p {
+  margin: 0.28rem 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-env,
+.workspace-members,
+.workspace-state {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 6.2rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.workspace-env,
+.workspace-members {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.workspace-env {
+  color: var(--tag);
+}
+
+.workspace-state {
+  color: var(--accent);
+  background: rgba(52, 211, 153, 0.12);
+}
+
+.basic-workspace-switcher-row:not(.is-selected) .workspace-state {
+  color: #f8fbff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+pre {
+  margin: 0.8rem 0 0;
+  white-space: pre-wrap;
+  color: #dbeafe;
+}
+
+code {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+@media (max-width: 810px) {
+  .demo-card {
+    padding: 1.35rem;
+  }
+
+  .basic-workspace-switcher-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .workspace-env,
+  .workspace-members,
+  .workspace-state {
+    margin-left: 3.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained Basic Workspace Switcher Row demo inside `submissions/examples/basic-workspace-switcher-row-kk/`. This submission introduces a simple CSS-only row for dashboards, team settings, organization menus, and multi-workspace SaaS products.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR

---

## Feature Description

**What does this add?**

A CSS-only workspace switcher row that displays a workspace shortcut, workspace name, helper text, environment badge, member count, and current or switch state.

**How does a developer use it?**

```html
<article class="basic-workspace-switcher-row is-selected">
  <span class="workspace-icon" aria-hidden="true">AP</span>
  <div class="workspace-copy">
    <strong>Acme Product</strong>
    <p>Primary team workspace</p>
  </div>
  <span class="workspace-env">Production</span>
  <span class="workspace-members">18 members</span>
  <span class="workspace-state">Current</span>
</article>