### PR TITLE
docs: document usage for Glassmorphism Pagination

### DIFF
--- a/submissions/docs/glassmorphism-pagination-docs-sb/README.md
+++ b/submissions/docs/glassmorphism-pagination-docs-sb/README.md
@@ -1,0 +1,47 @@
+# Glassmorphism Pagination
+
+Documentation demonstrating how to use the **Glassmorphism Pagination** component.
+
+## Overview
+A frosted-glass pagination bar with prev/next arrows and numbered page buttons.
+
+## Files
+- `demo.html` — copy-paste HTML markup example
+- `style.css` — CSS with class naming conventions and modifier classes
+- `README.md` — this guide
+
+## HTML example
+```html
+<nav class="ease-pagination" aria-label="Pagination">
+  <button class="ease-pagination__btn" aria-label="Previous page">‹</button>
+  <button class="ease-pagination__page is-active" aria-current="page">1</button>
+  <button class="ease-pagination__page">2</button>
+  <button class="ease-pagination__page">3</button>
+  <button class="ease-pagination__btn" aria-label="Next page">›</button>
+</nav>
+```
+
+## CSS class naming conventions
+- `.ease-glassmorphism-pagination` — root container
+- `.ease-glassmorphism-pagination__<element>` — BEM-style child elements
+- `.is-active` — state modifier class
+
+## Custom CSS variable overrides
+```css
+:root {
+  --ease-page-accent: #6366f1;
+  --ease-page-bg: #6366f1;
+}
+```
+
+## Accessibility
+- Interactive controls use native elements (`<button>`, `<a>`) where possible.
+- `:focus-visible` outlines are provided for keyboard users.
+- `aria-label`, `aria-current`, `role`, and `aria-expanded` are used where appropriate.
+- `prefers-reduced-motion` disables transitions/animations.
+
+## Keyboard interaction
+- Tab to move focus between controls.
+- Enter/Space to activate buttons.
+
+Closes #79762

--- a/submissions/docs/glassmorphism-pagination-docs-sb/demo.html
+++ b/submissions/docs/glassmorphism-pagination-docs-sb/demo.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glassmorphism Pagination</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main>
+<nav class="ease-pagination" aria-label="Pagination">
+  <button class="ease-pagination__btn" aria-label="Previous page">‹</button>
+  <button class="ease-pagination__page is-active" aria-current="page">1</button>
+  <button class="ease-pagination__page">2</button>
+  <button class="ease-pagination__page">3</button>
+  <button class="ease-pagination__btn" aria-label="Next page">›</button>
+</nav>
+    </main>
+  </body>
+</html>

--- a/submissions/docs/glassmorphism-pagination-docs-sb/style.css
+++ b/submissions/docs/glassmorphism-pagination-docs-sb/style.css
@@ -1,0 +1,32 @@
+/* ============================================================
+   EaseMotion CSS — Glassmorphism Pagination documentation
+   Submission for #79762
+   ============================================================ */
+
+:root {
+  --ease-page-accent: #6366f1;
+  --ease-page-bg: #6366f1;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #0f172a;
+  color: #f1f5f9;
+  font-family: system-ui, sans-serif;
+}
+
+.ease-pagination { display: flex; gap: 0.5rem; padding: 0.75rem; background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 0.75rem; }
+.ease-pagination__btn, .ease-pagination__page { min-width: 2.5rem; height: 2.5rem; border: 0; border-radius: 0.5rem; background: rgba(255,255,255,0.06); color: #cbd5e1; cursor: pointer; }
+.ease-pagination__page.is-active { background: #6366f1; color: #fff; }
+.ease-pagination__btn:focus-visible, .ease-pagination__page:focus-visible { outline: 3px solid Highlight; outline-offset: 2px; }
+
+@media (forced-colors: active) {
+  .ease-glassmorphism-pagination, .ease-glassmorphism-pagination * { border: 1px solid ButtonText; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
+}


### PR DESCRIPTION
## What changed

Documentation demonstrating how to use the **Glassmorphism Pagination** component (closes #79762). Placed entirely under `submissions/docs/glassmorphism-pagination-docs-sb/` per the contribution guide.

`submissions/docs/glassmorphism-pagination-docs-sb/`:
- **`demo.html`** — copy-paste HTML markup example.
- **`style.css`** — CSS with class naming conventions and modifier classes.
- **`README.md`** — overview, usage, custom CSS variable overrides, accessibility notes, and keyboard interaction guidance.

### Highlights
- Copy-paste HTML markup examples included.
- CSS class naming conventions (BEM) and modifier classes documented.
- Custom CSS variable overrides documented.
- Accessibility notes and keyboard interaction guidance included.
- Valid Markdown with highlighted code blocks.

Closes #79762

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._