### PR TITLE
feat: create 3D Tooltip with Neon styling (#65452) #79812

### DIFF
--- a/submissions/examples/css-tooltip-3d-neon/README.md
+++ b/submissions/examples/css-tooltip-3d-neon/README.md
@@ -1,0 +1,2 @@
+# 3D Tooltip (Neon)
+A bright, glowing high-tech tooltip. It utilizes CSS 3D transforms (`preserve-3d`, `rotateX`) to construct a physical cube. When hovered, the cube swings down into view along the X-axis, revealing its glowing neon front face.

--- a/submissions/examples/css-tooltip-3d-neon/demo.html
+++ b/submissions/examples/css-tooltip-3d-neon/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neon 3D Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="nt-container">
+        <button class="nt-target">Hover For Status</button>
+        <div class="nt-tooltip">
+            <div class="nt-face nt-front">SYSTEM ONLINE</div>
+            <div class="nt-face nt-bottom">ALL CORES NOMINAL</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-3d-neon/style.css
+++ b/submissions/examples/css-tooltip-3d-neon/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #09090b; --neon: #39ff14; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; perspective: 1000px; }
+.nt-container { position: relative; }
+.nt-target { background: transparent; border: 2px solid var(--neon); color: var(--neon); padding: 1rem 2rem; font-size: 1rem; font-weight: bold; cursor: pointer; text-transform: uppercase; box-shadow: 0 0 10px rgba(57, 255, 20, 0.2), inset 0 0 10px rgba(57, 255, 20, 0.2); transition: 0.3s; outline: none; }
+.nt-target:hover { background: rgba(57, 255, 20, 0.1); box-shadow: 0 0 20px rgba(57, 255, 20, 0.4), inset 0 0 20px rgba(57, 255, 20, 0.4); }
+.nt-tooltip { position: absolute; bottom: calc(100% + 20px); left: 50%; width: 200px; height: 40px; margin-left: -100px; transform-style: preserve-3d; transform: rotateX(-90deg); transform-origin: bottom; transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.4s; opacity: 0; pointer-events: none; }
+.nt-face { position: absolute; inset: 0; display: flex; justify-content: center; align-items: center; background: #000; border: 2px solid var(--neon); color: var(--neon); font-size: 0.8rem; font-weight: bold; text-align: center; box-shadow: 0 0 15px rgba(57, 255, 20, 0.5); }
+.nt-front { transform: translateZ(20px); }
+.nt-bottom { transform: rotateX(-90deg) translateZ(20px); background: var(--neon); color: #000; }
+.nt-container:hover .nt-tooltip { transform: rotateX(0deg); opacity: 1; }


### PR DESCRIPTION
**Title:** feat: create 3D Tooltip with Neon styling (#65452) #79812

**Description:**
This PR introduces a bright, glowing high-tech tooltip. It utilizes CSS 3D transforms (`preserve-3d`, `rotateX`) to construct a physical cube. When hovered, the cube swings down into view along the X-axis, revealing its glowing neon front face.

Fixes #79812

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-3d-neon/`
- Bound the `.nt-tooltip` container to a `perspective: 1000px` root and enabled `transform-style: preserve-3d` to map child elements onto Z-axis planes
- Animated the `.nt-tooltip` from `transform: rotateX(-90deg)` to `rotateX(0deg)` during a parent `:hover` event
