### PR TITLE
feat: create Morphing Breadcrumb with Glassmorphism styling (#38942) …

### DIFF
--- a/submissions/examples/css-breadcrumb-morphing-glassmorphism/README.md
+++ b/submissions/examples/css-breadcrumb-morphing-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Morphing Breadcrumb (Glassmorphism)
+A stunning frosted-glass navigation trail. Set against a blurred, animated gradient background orb, the breadcrumb items morph on hover by smoothly scaling a soft white overlay (`transform: scaleX(1)`) beneath the text from left to right.

--- a/submissions/examples/css-breadcrumb-morphing-glassmorphism/demo.html
+++ b/submissions/examples/css-breadcrumb-morphing-glassmorphism/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Breadcrumb</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="gb-scene">
+        <div class="gb-orb"></div>
+        <nav class="gb-breadcrumb">
+            <a href="#" class="gb-item">
+                <span class="gb-text">Home</span>
+            </a>
+            <span class="gb-sep">/</span>
+            <a href="#" class="gb-item">
+                <span class="gb-text">Products</span>
+            </a>
+            <span class="gb-sep">/</span>
+            <a href="#" class="gb-item gb-active">
+                <span class="gb-text">Accessories</span>
+            </a>
+        </nav>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-breadcrumb-morphing-glassmorphism/style.css
+++ b/submissions/examples/css-breadcrumb-morphing-glassmorphism/style.css
@@ -1,0 +1,13 @@
+:root { --glass: rgba(255, 255, 255, 0.1); --border: rgba(255, 255, 255, 0.2); --text: #ffffff; }
+body { background: #1e1b4b; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; overflow: hidden; }
+.gb-scene { position: relative; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; }
+.gb-orb { position: absolute; width: 400px; height: 400px; background: radial-gradient(circle, #8b5cf6, #ec4899); border-radius: 50%; filter: blur(60px); opacity: 0.5; animation: gb-pulse 8s infinite alternate; z-index: 0; }
+.gb-breadcrumb { position: relative; z-index: 1; display: flex; align-items: center; background: var(--glass); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); padding: 0.5rem 1rem; border-radius: 30px; border: 1px solid var(--border); box-shadow: 0 10px 30px rgba(0,0,0,0.2); gap: 0.5rem; }
+.gb-item { text-decoration: none; color: rgba(255, 255, 255, 0.6); padding: 0.5rem 1rem; border-radius: 20px; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); position: relative; font-size: 0.95rem; font-weight: 500; overflow: hidden; }
+.gb-item::before { content: ''; position: absolute; inset: 0; background: rgba(255, 255, 255, 0.15); transform: scaleX(0); transform-origin: left; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); border-radius: 20px; }
+.gb-text { position: relative; z-index: 2; transition: 0.3s; }
+.gb-item:hover { color: var(--text); }
+.gb-item:hover::before { transform: scaleX(1); }
+.gb-sep { color: rgba(255, 255, 255, 0.3); font-weight: 300; }
+.gb-active { color: var(--text); background: rgba(255, 255, 255, 0.1); }
+@keyframes gb-pulse { 100% { transform: scale(1.2) translate(20px, -20px); } }


### PR DESCRIPTION
**Title:** feat: create Morphing Breadcrumb with Glassmorphism styling (#38942) #79795

**Description:**
This PR introduces a stunning frosted-glass navigation trail. Set against a blurred, animated gradient background orb, the breadcrumb items morph on hover by smoothly scaling a soft white overlay (`transform: scaleX(1)`) beneath the text from left to right.

Fixes #79795

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-breadcrumb-morphing-glassmorphism/`
- Styled the `.gb-breadcrumb` parent using intense `backdrop-filter: blur(16px)` layered over the animated `.gb-orb` mesh
- Applied a smooth `transform: scaleX(1)` anchored at `transform-origin: left` to the `::before` pseudo-element of hovered navigation items
