### PR TITLE
feat: create Morphing Pagination with Material Design styling (#76441…

### DIFF
--- a/submissions/examples/css-pagination-morphing-material-design/README.md
+++ b/submissions/examples/css-pagination-morphing-material-design/README.md
@@ -1,0 +1,2 @@
+# Morphing Pagination (Material Design)
+A clean, shadow-elevated Material Design pagination block. The active state indicator is an absolute positioned circular background that morphs its `left` position smoothly across the parent container using a `cubic-bezier(0.4, 0, 0.2, 1)` curve when a new radio button is checked.

--- a/submissions/examples/css-pagination-morphing-material-design/demo.html
+++ b/submissions/examples/css-pagination-morphing-material-design/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Morphing Pagination</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="mp-pagination">
+        <input type="radio" name="mp-page" id="mp-1" checked>
+        <input type="radio" name="mp-page" id="mp-2">
+        <input type="radio" name="mp-page" id="mp-3">
+        
+        <div class="mp-active-bg"></div>
+        
+        <div class="mp-pages">
+            <label for="mp-1" class="mp-btn">1</label>
+            <label for="mp-2" class="mp-btn">2</label>
+            <label for="mp-3" class="mp-btn">3</label>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pagination-morphing-material-design/style.css
+++ b/submissions/examples/css-pagination-morphing-material-design/style.css
@@ -1,0 +1,15 @@
+:root { --bg: #f5f5f5; --surface: #ffffff; --primary: #6200ea; --text: #212121; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; }
+.mp-pagination { display: inline-flex; position: relative; background: var(--surface); border-radius: 24px; padding: 0.5rem; box-shadow: 0 3px 5px -1px rgba(0,0,0,0.1), 0 6px 10px 0 rgba(0,0,0,0.06); }
+input[type="radio"] { display: none; }
+.mp-active-bg { position: absolute; top: 0.5rem; bottom: 0.5rem; width: 40px; background: var(--primary); border-radius: 50%; transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 4px 5px 0 rgba(98, 0, 234, 0.2); z-index: 1; }
+.mp-pages { display: flex; gap: 0.5rem; position: relative; z-index: 2; }
+.mp-btn { width: 40px; height: 40px; display: flex; justify-content: center; align-items: center; border-radius: 50%; color: var(--text); font-weight: 500; cursor: pointer; transition: 0.3s; position: relative; overflow: hidden; }
+.mp-btn::after { content: ''; position: absolute; inset: 0; background: currentColor; border-radius: 50%; transform: scale(0); opacity: 0; transition: 0.3s; pointer-events: none; }
+.mp-btn:hover::after { transform: scale(1); opacity: 0.08; }
+#mp-1:checked ~ .mp-active-bg { left: 0.5rem; transform: scale(1); }
+#mp-2:checked ~ .mp-active-bg { left: calc(0.5rem + 40px + 0.5rem); transform: scale(1); }
+#mp-3:checked ~ .mp-active-bg { left: calc(0.5rem + 80px + 1rem); transform: scale(1); }
+#mp-1:checked ~ .mp-pages label:nth-child(1),
+#mp-2:checked ~ .mp-pages label:nth-child(2),
+#mp-3:checked ~ .mp-pages label:nth-child(3) { color: #fff; }


### PR DESCRIPTION
**Title:** feat: create Morphing Pagination with Material Design styling (#76441) #79793

**Description:**
This PR introduces a clean, shadow-elevated Material Design pagination block. The active state indicator is an absolute positioned circular background that morphs its `left` position smoothly across the parent container using a `cubic-bezier(0.4, 0, 0.2, 1)` curve when a new radio button is checked.

Fixes #79793

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-pagination-morphing-material-design/`
- Tied the `.mp-active-bg` pill to a hidden radio button group, animating its translation to specific calculated positions (`left: calc(...)`) based on the checked sibling
- Implemented standard Material ripple hover interactions on inactive buttons using a `scale(0)` to `scale(1)` transform on an overlaid `::after` element
