### PR TITLE
feat: create Glowing Button with Minimalist styling (#41622) #79771

### DIFF
--- a/submissions/examples/css-button-glowing-minimalist/README.md
+++ b/submissions/examples/css-button-glowing-minimalist/README.md
@@ -1,0 +1,2 @@
+# Glowing Button (Minimalist)
+A highly restrained, monochrome glowing button. It rests as a simple outlined pill, but transitions sharply to a solid black fill on hover while simultaneously projecting a soft, diffused white/gray gradient glow from behind.

--- a/submissions/examples/css-button-glowing-minimalist/demo.html
+++ b/submissions/examples/css-button-glowing-minimalist/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minimalist Glowing Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <button class="mb-btn">
+        <div class="mb-glow"></div>
+        <span class="mb-text">Get Started</span>
+    </button>
+</body>
+</html>

--- a/submissions/examples/css-button-glowing-minimalist/style.css
+++ b/submissions/examples/css-button-glowing-minimalist/style.css
@@ -1,0 +1,8 @@
+:root { --bg: #fafafa; --text: #111111; --accent: #000000; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+.mb-btn { position: relative; padding: 1rem 2.5rem; background: var(--bg); border: 1px solid #ddd; border-radius: 30px; font-size: 1rem; font-weight: 500; color: var(--text); cursor: pointer; outline: none; transition: 0.3s; z-index: 1; }
+.mb-glow { position: absolute; inset: -4px; background: linear-gradient(90deg, #e5e5e5, #ffffff, #e5e5e5); border-radius: 34px; filter: blur(8px); opacity: 0; transition: 0.4s; z-index: -1; }
+.mb-text { position: relative; z-index: 2; transition: 0.3s; }
+.mb-btn:hover { border-color: var(--text); background: var(--text); color: #fff; transform: translateY(-2px); box-shadow: 0 10px 20px -10px rgba(0,0,0,0.2); }
+.mb-btn:hover .mb-glow { opacity: 1; }
+.mb-btn:active { transform: translateY(0); box-shadow: none; }


### PR DESCRIPTION
**Title:** feat: create Glowing Button with Minimalist styling (#41622) #79771

**Description:**
This PR introduces a highly restrained, monochrome glowing button. It rests as a simple outlined pill, but transitions sharply to a solid black fill on hover while simultaneously projecting a soft, diffused white/gray gradient glow from behind.

Fixes #79771

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-button-glowing-minimalist/`
- Designed the `.mb-glow` layer using a heavily blurred grayscale `linear-gradient` tucked behind the button using `z-index: -1`
- Activated the glow by shifting its opacity from 0 to 1 during hover, tied alongside a crisp inversion of the main button colors
