### PR TITLE
feat: create Animated Navbar with Gradient styling (#19293) #79652

### DIFF
--- a/submissions/examples/css-navbar-animated-gradient/README.md
+++ b/submissions/examples/css-navbar-animated-gradient/README.md
@@ -1,0 +1,2 @@
+# Animated Navbar (Gradient)
+A clean pill-shaped navigation bar. When hovered, the entire background crossfades into a vibrant, continuously panning linear gradient while the text dynamically inverts to white for contrast.

--- a/submissions/examples/css-navbar-animated-gradient/demo.html
+++ b/submissions/examples/css-navbar-animated-gradient/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Animated Gradient Navbar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="ag-nav">
+        <div class="ag-brand">Logo</div>
+        <div class="ag-links">
+            <a href="#" class="ag-link">Home</a>
+            <a href="#" class="ag-link">Features</a>
+            <a href="#" class="ag-link">Pricing</a>
+            <a href="#" class="ag-link">Contact</a>
+        </div>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/css-navbar-animated-gradient/style.css
+++ b/submissions/examples/css-navbar-animated-gradient/style.css
@@ -1,0 +1,14 @@
+:root { --text: #333; }
+body { background: #f0f0f0; display: flex; justify-content: center; padding-top: 2rem; min-height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.ag-nav { background: #fff; width: 90%; max-width: 800px; height: 70px; border-radius: 35px; display: flex; align-items: center; justify-content: space-between; padding: 0 2rem; box-shadow: 0 10px 30px rgba(0,0,0,0.1); position: relative; overflow: hidden; }
+.ag-nav::before { content: ''; position: absolute; inset: 0; background: linear-gradient(90deg, #ff9a9e, #fecfef, #a18cd1, #fbc2eb); background-size: 300% 100%; opacity: 0; transition: 0.5s; z-index: 0; animation: ag-gradient-pan 5s infinite alternate; }
+.ag-nav:hover::before { opacity: 1; }
+.ag-brand { position: relative; z-index: 1; font-weight: 800; font-size: 1.2rem; color: var(--text); }
+.ag-links { position: relative; z-index: 1; display: flex; gap: 2rem; }
+.ag-link { text-decoration: none; color: var(--text); font-weight: 500; transition: 0.3s; position: relative; padding: 0.5rem 0; }
+.ag-link::after { content: ''; position: absolute; left: 0; bottom: 0; width: 100%; height: 2px; background: var(--text); transform: scaleX(0); transform-origin: right; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.ag-link:hover::after { transform: scaleX(1); transform-origin: left; }
+.ag-nav:hover .ag-brand, .ag-nav:hover .ag-link, .ag-nav:hover .ag-link::after { color: #fff; background-color: transparent; }
+.ag-nav:hover .ag-link::after { background: #fff; }
+@keyframes ag-gradient-pan { 0% { background-position: 0% 50%; } 100% { background-position: 100% 50%; } }
+@media (max-width: 600px) { .ag-links { display: none; } }


### PR DESCRIPTION
**Title:** feat: create Animated Navbar with Gradient styling (#19293) #79652

**Description:**
This PR introduces a clean pill-shaped navigation bar. When hovered, the entire background crossfades into a vibrant, continuously panning linear gradient while the text dynamically inverts to white for contrast.

Fixes #79652

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-navbar-animated-gradient/`
- Bound an absolutely positioned `::before` pseudo-element to the `.ag-nav` containing a 300% width `linear-gradient` that pans using an `@keyframes` loop
- Inverted all internal link and brand text colors to `#fff` simultaneously upon parent hover, overriding the base `#333` via descendant combinators
