### PR TITLE
Fix issue 79711

### DIFF
--- a/submissions/examples/css-button-parallax-glassmorphism/README.md
+++ b/submissions/examples/css-button-parallax-glassmorphism/README.md
@@ -1,0 +1,2 @@
+# Parallax Button (Glassmorphism)
+A stunning 3D frosted-glass button. The element sits in a perspective container over animated glowing orbs. Hovering the button scales it up along the Z-axis, casting a deeper shadow while a linear-gradient shine sweeps across the glass surface.

--- a/submissions/examples/css-button-parallax-glassmorphism/demo.html
+++ b/submissions/examples/css-button-parallax-glassmorphism/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Parallax Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="pg-scene">
+        <div class="pg-orb pg-orb-1"></div>
+        <div class="pg-orb pg-orb-2"></div>
+        <button class="pg-btn">
+            <span class="pg-text">Discover More</span>
+            <div class="pg-shine"></div>
+        </button>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-button-parallax-glassmorphism/style.css
+++ b/submissions/examples/css-button-parallax-glassmorphism/style.css
@@ -1,0 +1,14 @@
+:root { --glass: rgba(255, 255, 255, 0.15); --border: rgba(255, 255, 255, 0.4); }
+body { background: #1a1a2e; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; overflow: hidden; }
+.pg-scene { position: relative; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; perspective: 1000px; }
+.pg-orb { position: absolute; border-radius: 50%; filter: blur(50px); opacity: 0.7; z-index: 0; }
+.pg-orb-1 { width: 300px; height: 300px; background: #ff2a5f; top: 30%; left: 35%; animation: pg-float 6s infinite alternate; }
+.pg-orb-2 { width: 250px; height: 250px; background: #00d2ff; bottom: 30%; right: 35%; animation: pg-float 8s infinite alternate-reverse; }
+.pg-btn { position: relative; padding: 1.25rem 3rem; background: var(--glass); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border: 1px solid var(--border); border-radius: 50px; color: #fff; font-size: 1.1rem; font-weight: 600; cursor: pointer; overflow: hidden; z-index: 1; box-shadow: 0 15px 35px rgba(0,0,0,0.2), inset 0 0 15px rgba(255,255,255,0.1); transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); transform-style: preserve-3d; outline: none; }
+.pg-text { position: relative; z-index: 2; display: inline-block; transition: 0.3s; transform: translateZ(20px); }
+.pg-shine { position: absolute; top: 0; left: -100%; width: 50%; height: 100%; background: linear-gradient(to right, transparent, rgba(255,255,255,0.4), transparent); transform: skewX(-20deg); transition: 0s; z-index: 1; }
+.pg-btn:hover { transform: scale(1.05) translateZ(30px); border-color: rgba(255,255,255,0.6); box-shadow: 0 20px 40px rgba(0,0,0,0.3), inset 0 0 20px rgba(255,255,255,0.2); }
+.pg-btn:hover .pg-text { text-shadow: 0 4px 10px rgba(0,0,0,0.3); }
+.pg-btn:hover .pg-shine { animation: pg-shine-sweep 0.8s; }
+@keyframes pg-float { 100% { transform: translateY(30px); } }
+@keyframes pg-shine-sweep { 100% { left: 200%; } }

--- a/submissions/examples/css-dropdown-morphing-dark-mode/README.md
+++ b/submissions/examples/css-dropdown-morphing-dark-mode/README.md
@@ -1,0 +1,2 @@
+# Morphing Dropdown (Dark Mode)
+A sleek, high-contrast settings menu. Triggering the hidden checkbox causes the caret icon to rotate 180 degrees while the dropdown menu smoothly morphs into existence using a `scaleY` transform originating from the top edge.

--- a/submissions/examples/css-dropdown-morphing-dark-mode/demo.html
+++ b/submissions/examples/css-dropdown-morphing-dark-mode/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Morphing Dropdown</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="md-container">
+        <input type="checkbox" id="md-toggle" class="md-input">
+        <label for="md-toggle" class="md-btn">
+            Settings <i class="ph ph-caret-down"></i>
+        </label>
+        <div class="md-menu">
+            <a href="#"><i class="ph ph-user"></i> Account</a>
+            <a href="#"><i class="ph ph-bell"></i> Notifications</a>
+            <a href="#"><i class="ph ph-lock"></i> Privacy</a>
+            <a href="#" class="md-danger"><i class="ph ph-sign-out"></i> Logout</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-dropdown-morphing-dark-mode/style.css
+++ b/submissions/examples/css-dropdown-morphing-dark-mode/style.css
@@ -1,0 +1,17 @@
+:root { --bg: #0f172a; --surface: #1e293b; --text: #f8fafc; --border: #334155; --accent: #3b82f6; --danger: #ef4444; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: flex-start; padding-top: 10vh; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.md-container { position: relative; width: 160px; }
+.md-input { display: none; }
+.md-btn { display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 0.75rem 1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 8px; cursor: pointer; transition: 0.3s; font-weight: 500; box-sizing: border-box; }
+.md-btn i { transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
+.md-btn:hover { background: #27354f; }
+.md-menu { position: absolute; top: calc(100% + 8px); left: 0; width: 220px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; box-shadow: 0 10px 25px rgba(0,0,0,0.5); opacity: 0; visibility: hidden; transform: translateY(-10px) scaleY(0.8); transform-origin: top; transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1); }
+.md-menu a { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; color: #cbd5e1; text-decoration: none; border-radius: 8px; transition: 0.2s; font-size: 0.95rem; }
+.md-menu a:hover { background: rgba(255,255,255,0.05); color: var(--text); transform: translateX(4px); }
+.md-menu a i { font-size: 1.1rem; color: #64748b; }
+.md-menu a:hover i { color: var(--accent); }
+.md-menu a.md-danger:hover { color: var(--danger); background: rgba(239, 68, 68, 0.1); }
+.md-menu a.md-danger:hover i { color: var(--danger); }
+.md-input:checked ~ .md-menu { opacity: 1; visibility: visible; transform: translateY(0) scaleY(1); }
+.md-input:checked ~ .md-btn i { transform: rotate(180deg); }
+.md-input:checked ~ .md-btn { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2); }


### PR DESCRIPTION
**Title:** feat: create Parallax Button with Glassmorphism styling (#24559) #79711

**Description:**
This PR introduces a stunning 3D frosted-glass button. The element sits in a perspective container over animated glowing orbs. Hovering the button scales it up along the Z-axis, casting a deeper shadow while a linear-gradient shine sweeps across the glass surface.

Fixes #79711

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-button-parallax-glassmorphism/`
- Engineered the `.pg-btn` using `transform-style: preserve-3d` and mapped the internal text to `translateZ(20px)` to simulate physical depth
- Injected a skewed `.pg-shine` overlay that rapidly sweeps from `-100%` to `200%` horizontally when the button hover state is engaged
