### PR TITLE
feat: add retro CSS input field (#78723)

### DIFF
--- a/submissions/examples/78723-css-input-retro/README.md
+++ b/submissions/examples/78723-css-input-retro/README.md
@@ -1,0 +1,29 @@
+# CSS-only Input Field — Retro
+
+A responsive CSS-only input field component inspired by
+retro arcade and pixel-era interfaces.
+
+Implemented for issue #78723.
+
+## Features
+
+- Retro visual styling
+- Pixel-inspired borders and shadows
+- CSS-only implementation
+- Responsive layout
+- Multiple input types
+- Animated focus state
+- Hover feedback
+- Retro gradient action button
+- Keyboard accessible
+- Native semantic form controls
+- Reduced-motion support
+- No external dependencies
+
+## Structure
+
+```text
+78723-css-input-retro/
+├── demo.html
+├── style.css
+└── README.md

--- a/submissions/examples/78723-css-input-retro/demo.html
+++ b/submissions/examples/78723-css-input-retro/demo.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+
+  <meta
+    name="description"
+    content="CSS-only Input Field with Retro styling."
+  >
+
+  <title>CSS Input Field — Retro</title>
+
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <main class="page">
+
+    <section class="demo">
+
+      <span class="eyebrow">EASEMOTION CSS</span>
+
+      <h1>Retro Input Field</h1>
+
+      <p class="intro">
+        A responsive CSS-only input component inspired by
+        classic arcade interfaces and pixel-era visuals.
+      </p>
+
+      <div class="retro-card">
+
+        <div class="retro-card__header">
+
+          <div>
+            <span class="header__label">
+              USER CONSOLE
+            </span>
+
+            <h2>PLAYER PROFILE</h2>
+          </div>
+
+          <span class="header__badge">
+            READY
+          </span>
+
+        </div>
+
+        <form class="retro-form">
+
+          <div class="field">
+
+            <label for="player-name">
+              PLAYER NAME
+            </label>
+
+            <div class="field__wrapper">
+
+              <span
+                class="field__prefix"
+                aria-hidden="true"
+              >
+                &gt;_
+              </span>
+
+              <input
+                id="player-name"
+                name="player-name"
+                type="text"
+                placeholder="ENTER YOUR NAME"
+                autocomplete="name"
+              >
+
+            </div>
+
+            <small>
+              Maximum 20 characters
+            </small>
+
+          </div>
+
+          <div class="field">
+
+            <label for="player-email">
+              EMAIL ADDRESS
+            </label>
+
+            <div class="field__wrapper">
+
+              <span
+                class="field__prefix"
+                aria-hidden="true"
+              >
+                @
+              </span>
+
+              <input
+                id="player-email"
+                name="player-email"
+                type="email"
+                placeholder="PLAYER@EXAMPLE.COM"
+                autocomplete="email"
+              >
+
+            </div>
+
+            <small>
+              Used for account notifications
+            </small>
+
+          </div>
+
+          <div class="field">
+
+            <label for="player-code">
+              ACCESS CODE
+            </label>
+
+            <div class="field__wrapper">
+
+              <span
+                class="field__prefix"
+                aria-hidden="true"
+              >
+                #
+              </span>
+
+              <input
+                id="player-code"
+                name="player-code"
+                type="password"
+                placeholder="ENTER ACCESS CODE"
+                autocomplete="current-password"
+              >
+
+            </div>
+
+            <small>
+              Keep your access code secure
+            </small>
+
+          </div>
+
+          <button
+            class="retro-button"
+            type="submit"
+          >
+            <span>&gt;</span>
+            START SESSION
+          </button>
+
+        </form>
+
+        <div class="retro-card__footer">
+
+          <span>
+            SYSTEM STATUS: ONLINE
+          </span>
+
+          <span class="footer__code">
+            INPUT_78723
+          </span>
+
+        </div>
+
+      </div>
+
+      <p class="demo__note">
+        Built with semantic HTML and pure CSS.
+      </p>
+
+    </section>
+
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/78723-css-input-retro/style.css
+++ b/submissions/examples/78723-css-input-retro/style.css
@@ -1,0 +1,626 @@
+/* =========================================================
+   CSS-only Input Field — Retro
+   EaseMotion CSS — Issue #78723
+   ========================================================= */
+
+:root {
+  --bg: #120f18;
+
+  --surface: #1a1522;
+  --surface-soft: #211b2a;
+
+  --text: #f9f0d4;
+  --muted: #b5a88d;
+  --subtle: #786f5d;
+
+  --border: #493d4d;
+
+  --yellow: #ffd84d;
+  --pink: #ff5d9e;
+  --cyan: #4de8d1;
+
+  --retro-gradient:
+    linear-gradient(
+      90deg,
+      var(--yellow),
+      var(--pink)
+    );
+
+  --shadow:
+    0 16px 0
+    rgba(0, 0, 0, 0.22);
+
+  --pixel-shadow:
+    4px 4px 0
+    rgba(0, 0, 0, 0.24);
+
+  --ease:
+    180ms ease;
+}
+
+/* =========================================================
+   Reset
+   ========================================================= */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+}
+
+body {
+  margin: 0;
+
+  min-height: 100vh;
+
+  color: var(--text);
+
+  background:
+    linear-gradient(
+      rgba(255, 255, 255, 0.015) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.015) 1px,
+      transparent 1px
+    ),
+    var(--bg);
+
+  background-size:
+    14px 14px;
+
+  font-family:
+    "Courier New",
+    Courier,
+    monospace;
+}
+
+/* =========================================================
+   Page
+   ========================================================= */
+
+.page {
+  min-height: 100vh;
+
+  display: grid;
+
+  place-items: center;
+
+  padding:
+    3rem 1rem;
+}
+
+.demo {
+  width: min(100%, 54rem);
+
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-block;
+
+  margin-bottom: 0.8rem;
+
+  color: var(--yellow);
+
+  font-size: 0.65rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.15em;
+
+  text-shadow:
+    3px 3px 0
+    rgba(255, 93, 158, 0.25);
+}
+
+.demo h1 {
+  margin: 0;
+
+  color: var(--text);
+
+  font-size:
+    clamp(2rem, 6vw, 4rem);
+
+  line-height: 1.05;
+
+  letter-spacing: 0.02em;
+
+  text-transform: uppercase;
+
+  text-shadow:
+    4px 4px 0
+    rgba(255, 216, 77, 0.14);
+}
+
+.intro {
+  width: min(100%, 40rem);
+
+  margin:
+    1rem auto 2.8rem;
+
+  color: var(--muted);
+
+  font-size: 0.72rem;
+
+  line-height: 1.8;
+}
+
+/* =========================================================
+   Card
+   ========================================================= */
+
+.retro-card {
+  position: relative;
+
+  width: min(100%, 48rem);
+
+  margin: 0 auto;
+
+  padding:
+    clamp(1.2rem, 4vw, 1.8rem);
+
+  background:
+    var(--surface);
+
+  border:
+    2px solid
+    var(--border);
+
+  border-radius: 0.4rem;
+
+  box-shadow:
+    var(--shadow);
+
+  text-align: left;
+}
+
+.retro-card::before,
+.retro-card::after {
+  content: "";
+
+  position: absolute;
+
+  width: 7px;
+  height: 7px;
+
+  background:
+    var(--yellow);
+}
+
+.retro-card::before {
+  top: -3px;
+  left: -3px;
+}
+
+.retro-card::after {
+  right: -3px;
+  bottom: -3px;
+
+  background:
+    var(--pink);
+}
+
+/* =========================================================
+   Header
+   ========================================================= */
+
+.retro-card__header {
+  display: flex;
+
+  align-items: flex-start;
+
+  justify-content: space-between;
+
+  gap: 1rem;
+
+  padding-bottom: 1.25rem;
+
+  border-bottom:
+    2px dashed
+    var(--border);
+}
+
+.header__label {
+  color: var(--cyan);
+
+  font-size: 0.55rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.12em;
+}
+
+.retro-card__header h2 {
+  margin:
+    0.45rem 0 0;
+
+  color: var(--text);
+
+  font-size:
+    clamp(1rem, 3vw, 1.4rem);
+
+  line-height: 1.2;
+
+  letter-spacing: 0.05em;
+}
+
+.header__badge {
+  flex-shrink: 0;
+
+  padding:
+    0.4rem 0.6rem;
+
+  color: #171218;
+
+  background:
+    var(--yellow);
+
+  border:
+    2px solid
+    #171218;
+
+  box-shadow:
+    var(--pixel-shadow);
+
+  font-size: 0.52rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.08em;
+}
+
+/* =========================================================
+   Form
+   ========================================================= */
+
+.retro-form {
+  display: grid;
+
+  gap: 1.35rem;
+
+  padding:
+    1.7rem 0;
+}
+
+.field {
+  display: grid;
+
+  gap: 0.45rem;
+}
+
+.field label {
+  color: var(--yellow);
+
+  font-size: 0.58rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.09em;
+}
+
+.field small {
+  color: var(--subtle);
+
+  font-size: 0.5rem;
+
+  line-height: 1.5;
+}
+
+/* =========================================================
+   Input Wrapper
+   ========================================================= */
+
+.field__wrapper {
+  display: flex;
+
+  align-items: stretch;
+
+  min-width: 0;
+
+  background:
+    var(--surface-soft);
+
+  border:
+    2px solid
+    var(--border);
+
+  box-shadow:
+    4px 4px 0
+    rgba(0, 0, 0, 0.14);
+
+  transition:
+    border-color var(--ease),
+    box-shadow var(--ease),
+    transform var(--ease),
+    background var(--ease);
+}
+
+.field__wrapper:hover {
+  border-color:
+    rgba(255, 216, 77, 0.55);
+}
+
+.field__wrapper:focus-within {
+  background:
+    #261f31;
+
+  border-color:
+    var(--cyan);
+
+  box-shadow:
+    4px 4px 0
+    rgba(77, 232, 209, 0.14);
+
+  transform:
+    translate(-2px, -2px);
+}
+
+/* =========================================================
+   Prefix
+   ========================================================= */
+
+.field__prefix {
+  min-width: 3.1rem;
+
+  display: grid;
+
+  place-items: center;
+
+  color: var(--pink);
+
+  border-right:
+    2px solid
+    var(--border);
+
+  font-size: 0.72rem;
+
+  font-weight: 900;
+}
+
+/* =========================================================
+   Input
+   ========================================================= */
+
+.field input {
+  width: 100%;
+
+  min-width: 0;
+
+  padding:
+    0.85rem 0.8rem;
+
+  color: var(--text);
+
+  background:
+    transparent;
+
+  border: 0;
+
+  outline: 0;
+
+  font:
+    inherit;
+
+  font-size: 0.68rem;
+
+  letter-spacing: 0.04em;
+}
+
+.field input::placeholder {
+  color: var(--subtle);
+
+  opacity: 1;
+}
+
+.field input:focus::placeholder {
+  color:
+    rgba(77, 232, 209, 0.38);
+}
+
+/* =========================================================
+   Button
+   ========================================================= */
+
+.retro-button {
+  justify-self: start;
+
+  display: inline-flex;
+
+  align-items: center;
+
+  justify-content: center;
+
+  gap: 0.55rem;
+
+  min-height: 3rem;
+
+  padding:
+    0.7rem 1rem;
+
+  color: #171218;
+
+  background:
+    var(--retro-gradient);
+
+  border:
+    2px solid
+    #171218;
+
+  box-shadow:
+    5px 5px 0
+    rgba(0, 0, 0, 0.28);
+
+  cursor: pointer;
+
+  font:
+    inherit;
+
+  font-size: 0.6rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.08em;
+
+  transition:
+    transform var(--ease),
+    box-shadow var(--ease),
+    filter var(--ease);
+}
+
+.retro-button:hover {
+  transform:
+    translate(-2px, -2px);
+
+  box-shadow:
+    7px 7px 0
+    rgba(0, 0, 0, 0.28);
+
+  filter:
+    brightness(1.08);
+}
+
+.retro-button:active {
+  transform:
+    translate(2px, 2px);
+
+  box-shadow:
+    2px 2px 0
+    rgba(0, 0, 0, 0.28);
+}
+
+.retro-button:focus-visible {
+  outline:
+    3px solid
+    var(--cyan);
+
+  outline-offset: 4px;
+}
+
+/* =========================================================
+   Footer
+   ========================================================= */
+
+.retro-card__footer {
+  display: flex;
+
+  align-items: center;
+
+  justify-content: space-between;
+
+  gap: 1rem;
+
+  padding-top: 1rem;
+
+  border-top:
+    2px dashed
+    var(--border);
+
+  color: var(--muted);
+
+  font-size: 0.5rem;
+}
+
+.footer__code {
+  color: var(--cyan);
+
+  font-size: 0.48rem;
+
+  font-weight: 900;
+
+  letter-spacing: 0.08em;
+}
+
+/* =========================================================
+   Note
+   ========================================================= */
+
+.demo__note {
+  margin-top: 1.5rem;
+
+  color: var(--subtle);
+
+  font-size: 0.55rem;
+}
+
+/* =========================================================
+   Responsive
+   ========================================================= */
+
+@media (max-width: 620px) {
+  .page {
+    padding:
+      2rem 0.8rem;
+  }
+
+  .demo {
+    text-align: left;
+  }
+
+  .intro {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .retro-card {
+    width: 100%;
+  }
+}
+
+@media (max-width: 470px) {
+  .retro-card__header {
+    align-items: flex-start;
+
+    flex-direction: column;
+  }
+
+  .header__badge {
+    align-self: flex-end;
+  }
+
+  .field__prefix {
+    min-width: 2.65rem;
+  }
+
+  .field input {
+    padding:
+      0.8rem 0.65rem;
+
+    font-size: 0.59rem;
+  }
+
+  .retro-button {
+    width: 100%;
+  }
+
+  .retro-card__footer {
+    align-items: flex-start;
+
+    flex-direction: column;
+  }
+
+  .footer__code {
+    align-self: flex-end;
+  }
+}
+
+/* =========================================================
+   Reduced Motion
+   ========================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+
+    animation-duration: 0.01ms !important;
+
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a **CSS-only Input Field with Retro styling**
to EaseMotion CSS.

It is a critical issue for introducing a reusable retro-inspired
input component with responsive behavior, polished focus states,
and accessible native form controls.

## Changes

- Added retro CSS-only input field
- Added text, email and password examples
- Added pixel-inspired borders and shadows
- Added animated focus-within states
- Added retro gradient action button
- Added responsive mobile layout
- Added keyboard accessibility
- Added reduced-motion support
- Added standalone demo and documentation

## Technical Details

- Pure HTML and CSS
- No JavaScript
- No external dependencies
- CSS custom properties
- CSS gradients
- CSS transitions and transforms
- Responsive media queries

## Accessibility

- Semantic form structure
- Explicit labels
- Native input controls
- Keyboard navigation
- Focus-visible button state
- Reduced-motion support

## Testing

Tested locally using `demo.html` across desktop, tablet,
and mobile viewport sizes.

## Issue

Closes #78723