### PR TITLE
feat: create Dynamic Loader with Gradient styling (#56107) #79811

### DIFF
--- a/submissions/examples/css-loader-dynamic-gradient/README.md
+++ b/submissions/examples/css-loader-dynamic-gradient/README.md
@@ -1,0 +1,2 @@
+# Dynamic Loader (Gradient)
+A vibrant, continuous loading ring. It utilizes a `conic-gradient` spun via an `@keyframes` rotation, relying on advanced CSS `mask-composite` techniques to hollow out the center. A blurred `::before` pseudo-element sits beneath it to project an ambient, rotating glow.

--- a/submissions/examples/css-loader-dynamic-gradient/demo.html
+++ b/submissions/examples/css-loader-dynamic-gradient/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Gradient Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="dg-loader"></div>
+</body>
+</html>

--- a/submissions/examples/css-loader-dynamic-gradient/style.css
+++ b/submissions/examples/css-loader-dynamic-gradient/style.css
@@ -1,0 +1,5 @@
+:root { --bg: #111827; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.dg-loader { width: 60px; height: 60px; border-radius: 50%; padding: 4px; background: conic-gradient(from 0deg, #3b82f6, #ec4899, #f59e0b, #3b82f6); -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: xor; mask-composite: exclude; animation: dg-spin 1.5s linear infinite; position: relative; }
+.dg-loader::before { content: ''; position: absolute; inset: -4px; border-radius: 50%; background: inherit; filter: blur(10px); opacity: 0.7; animation: inherit; z-index: -1; }
+@keyframes dg-spin { 100% { transform: rotate(360deg); } }


### PR DESCRIPTION
**Title:** feat: create Dynamic Loader with Gradient styling (#56107) #79811

**Description:**
This PR introduces a vibrant, continuous loading ring. It utilizes a `conic-gradient` spun via an `@keyframes` rotation, relying on advanced CSS `mask-composite` techniques to hollow out the center. A blurred `::before` pseudo-element sits beneath it to project an ambient, rotating glow.

Fixes #79811

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-loader-dynamic-gradient/`
- Designed the ring utilizing a multi-stop `conic-gradient` combined with `-webkit-mask: linear-gradient(#fff 0 0) content-box...` to cut out the transparent center
- Extruded an ambient glow by layering a heavily blurred `filter: blur(10px)` `::before` element beneath the spinner, inheriting both the parent's gradient and animation
