### PR TITLE
feat: create Parallax Badge with Material Design styling (#47619) #79767

### DIFF
--- a/submissions/examples/css-badge-parallax-material-design/README.md
+++ b/submissions/examples/css-badge-parallax-material-design/README.md
@@ -1,0 +1,2 @@
+# Parallax Badge (Material Design)
+A 3D-elevated Material badge. Leveraging `preserve-3d`, the badge sits inside a perspective container. Hovering tilts the badge along the X and Y axes while deepening the standard Material shadow map. The internal icon and text independently pop outward along the Z-axis.

--- a/submissions/examples/css-badge-parallax-material-design/demo.html
+++ b/submissions/examples/css-badge-parallax-material-design/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Parallax Badge</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div class="pm-container">
+        <div class="pm-badge">
+            <i class="ph-fill ph-star"></i>
+            <span>Pro Member</span>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-badge-parallax-material-design/style.css
+++ b/submissions/examples/css-badge-parallax-material-design/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #f5f5f5; --surface: #6200ea; --text: #ffffff; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: Roboto, system-ui, sans-serif; perspective: 800px; }
+.pm-container { padding: 2rem; }
+.pm-badge { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.6rem 1.2rem; background: var(--surface); color: var(--text); border-radius: 8px; font-weight: 500; letter-spacing: 0.5px; box-shadow: 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12), 0 2px 4px -1px rgba(0,0,0,0.2); transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.4s; transform-style: preserve-3d; cursor: default; }
+.pm-badge i { font-size: 1.2rem; color: #ffd600; transform: translateZ(15px); transition: 0.4s; }
+.pm-badge span { transform: translateZ(10px); transition: 0.4s; }
+.pm-container:hover .pm-badge { transform: rotateX(15deg) rotateY(-15deg) scale(1.05); box-shadow: 0 16px 24px 2px rgba(0,0,0,0.14), 0 6px 30px 5px rgba(0,0,0,0.12), 0 8px 10px -5px rgba(0,0,0,0.2); }
+.pm-container:hover i { transform: translateZ(30px) scale(1.2); }
+.pm-container:hover span { transform: translateZ(20px); }


### PR DESCRIPTION
**Title:** feat: create Parallax Badge with Material Design styling (#47619) #79767

**Description:**
This PR introduces a 3D-elevated Material badge. Leveraging `preserve-3d`, the badge sits inside a perspective container. Hovering tilts the badge along the X and Y axes while deepening the standard Material shadow map. The internal icon and text independently pop outward along the Z-axis.

Fixes #79767

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-badge-parallax-material-design/`
- Constructed the `.pm-badge` using standard Google Material Design multi-layered shadow formulas (`box-shadow: 0 4px 5px...`)
- Applied `transform: rotateX(15deg) rotateY(-15deg) scale(1.05)` on parent hover, while pushing the internal icon and text elements forward using `translateZ` to generate the physical parallax separation
