### PR TITLE
feat: create Glowing Toggle with Material Design styling (#72783) #79719

### DIFF
--- a/submissions/examples/css-toggle-glowing-material-design/README.md
+++ b/submissions/examples/css-toggle-glowing-material-design/README.md
@@ -1,0 +1,2 @@
+# Glowing Toggle (Material Design)
+A satisfying, tactile switch component. Uses standard Material shadow elevations for the thumb component (`::before`), which glides across the track with a `cubic-bezier` bounce when toggled. In the 'on' state, the thumb emits a soft, color-matched ambient glow via an expanded `box-shadow` layer.

--- a/submissions/examples/css-toggle-glowing-material-design/demo.html
+++ b/submissions/examples/css-toggle-glowing-material-design/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Material Toggle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <label class="gt-switch">
+        <input type="checkbox" class="gt-input">
+        <span class="gt-slider"></span>
+    </label>
+</body>
+</html>

--- a/submissions/examples/css-toggle-glowing-material-design/style.css
+++ b/submissions/examples/css-toggle-glowing-material-design/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #f0f0f0; --track-off: #b0bec5; --track-on: #80cbc4; --thumb-off: #ffffff; --thumb-on: #009688; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; }
+.gt-switch { position: relative; display: inline-block; width: 52px; height: 28px; }
+.gt-input { opacity: 0; width: 0; height: 0; }
+.gt-slider { position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0; background-color: var(--track-off); transition: 0.4s; border-radius: 34px; box-shadow: inset 0 2px 4px rgba(0,0,0,0.1); }
+.gt-slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 4px; bottom: 4px; background-color: var(--thumb-off); transition: 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275); border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.14); }
+.gt-input:checked + .gt-slider { background-color: var(--track-on); }
+.gt-input:checked + .gt-slider:before { transform: translateX(24px); background-color: var(--thumb-on); box-shadow: 0 0 12px rgba(0, 150, 136, 0.6), 0 2px 4px rgba(0,0,0,0.2); }
+.gt-input:focus-visible + .gt-slider { outline: 2px solid var(--thumb-on); outline-offset: 2px; }


### PR DESCRIPTION
**Title:** feat: create Glowing Toggle with Material Design styling (#72783) #79719

**Description:**
This PR introduces a satisfying, tactile switch component. Uses standard Material shadow elevations for the thumb component (`::before`), which glides across the track with a `cubic-bezier` bounce when toggled. In the 'on' state, the thumb emits a soft, color-matched ambient glow via an expanded `box-shadow` layer.

Fixes #79719

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-toggle-glowing-material-design/`
- Designed the thumb `.gt-slider:before` using absolute positioning and standard Material Design multi-layered shadow formulas
- Bound a hidden checkbox state (`:checked`) to animate the thumb's `translateX` while dynamically injecting a colored `box-shadow` glow
