### PR TITLE
feat: create Dynamic Input Field with Pastel styling (#11364) #79727

### DIFF
--- a/submissions/examples/css-input-dynamic-pastel/README.md
+++ b/submissions/examples/css-input-dynamic-pastel/README.md
@@ -1,0 +1,2 @@
+# Dynamic Input Field (Pastel)
+A soft, playful floating-label text input. It utilizes the `:placeholder-shown` hack to detect when the field is populated, animating the label upwards and shrinking it. When focused, an absolute-positioned multi-color pastel gradient border scales outward (`scaleX(1)`) from the center.

--- a/submissions/examples/css-input-dynamic-pastel/demo.html
+++ b/submissions/examples/css-input-dynamic-pastel/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pastel Dynamic Input</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="pi-wrapper">
+        <input type="text" class="pi-input" id="pi-name" placeholder=" " required>
+        <label for="pi-name" class="pi-label">First Name</label>
+        <div class="pi-border"></div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-input-dynamic-pastel/style.css
+++ b/submissions/examples/css-input-dynamic-pastel/style.css
@@ -1,0 +1,9 @@
+:root { --bg: #fff5f5; --text: #4a5568; --placeholder: #a0aec0; --pink: #fbb6ce; --purple: #d6bcfa; --blue: #bee3f8; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.pi-wrapper { position: relative; width: 260px; margin-top: 20px; }
+.pi-input { width: 100%; padding: 0.75rem 0.5rem; font-size: 1rem; color: var(--text); background: transparent; border: none; border-bottom: 2px solid #e2e8f0; outline: none; transition: 0.3s; box-sizing: border-box; }
+.pi-label { position: absolute; left: 0.5rem; top: 0.75rem; color: var(--placeholder); font-size: 1rem; transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1); pointer-events: none; }
+.pi-border { position: absolute; bottom: 0; left: 0; height: 3px; width: 100%; background: linear-gradient(90deg, var(--pink), var(--purple), var(--blue)); transform: scaleX(0); transform-origin: center; transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1); border-radius: 2px; }
+.pi-input:focus ~ .pi-border, .pi-input:not(:placeholder-shown) ~ .pi-border { transform: scaleX(1); }
+.pi-input:focus ~ .pi-label, .pi-input:not(:placeholder-shown) ~ .pi-label { top: -20px; left: 0; font-size: 0.85rem; color: #805ad5; font-weight: 600; }
+.pi-input:hover { background: rgba(255,255,255,0.5); border-radius: 4px 4px 0 0; }


### PR DESCRIPTION
**Title:** feat: create Dynamic Input Field with Pastel styling (#11364) #79727

**Description:**
This PR introduces a soft, playful floating-label text input. It utilizes the `:placeholder-shown` hack to detect when the field is populated, animating the label upwards and shrinking it. When focused, an absolute-positioned multi-color pastel gradient border scales outward (`scaleX(1)`) from the center.

Fixes #79727

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-input-dynamic-pastel/`
- Leveraged the `input:not(:placeholder-shown)` CSS state to shift the `.pi-label` upwards via `top: -20px`, ensuring the label stays elevated when text is present
- Animated an absolute-positioned `.pi-border` under-bar using `transform: scaleX(0)` to `scaleX(1)` with a multi-stop pastel `linear-gradient`
