### PR TITLE
feat(scss): add scroll margin and padding helpers (#81307)

### DIFF
--- a/submissions/scss/81307-scroll-margin-padding-helpers-ks/README.md
+++ b/submissions/scss/81307-scroll-margin-padding-helpers-ks/README.md
@@ -1,0 +1,105 @@
+# SCSS Scroll Margin & Padding Helper Mixins
+Reusable SCSS helpers for fixed and sticky header scroll offsets.
+## Issue
+#81307 — Add SCSS Scroll Margin & Padding Helper Mixins
+## Overview
+Provides reusable mixins for `scroll-margin-top` and `scroll-padding-top`.
+They prevent anchored content from being hidden behind persistent headers.
+## Features
+- Scroll margin helper
+- Scroll padding helper
+- Combined offset helper
+- CSS custom-property support
+- Fallback values
+- Responsive offsets
+- Anchor-target support
+- Scroll-container support
+- Configurable defaults
+- No JavaScript
+## File Structure
+```text
+81307-feat-scss-add-scss-scroll-margin-padding-helper-mixins-ks/
+├── _scroll-margin-padding-helper-mixins.scss
+└── README.md
+```
+## Installation
+Import the partial:
+```scss
+@use "scroll-margin-padding-helper-mixins" as scroll;
+```
+Then include the required mixin.
+## Scroll Margin
+Use `ease-scroll-margin-top` for anchor targets:
+```scss
+.section {
+  @include scroll.ease-scroll-margin-top(5rem);
+}
+```
+This keeps the target visible below a fixed header.
+## Scroll Padding
+Use `ease-scroll-padding-top` on the scrolling container:
+```scss
+html {
+  @include scroll.ease-scroll-padding-top(5rem);
+}
+```
+## Combined Offset
+Use `ease-scroll-offset` when both properties need the same value:
+```scss
+.section {
+  @include scroll.ease-scroll-offset(4rem);
+}
+```
+## CSS Variables
+The helpers support custom properties:
+```scss
+:root {
+  --ease-scroll-offset: 4rem;
+}
+```
+```scss
+.section {
+  @include scroll.ease-scroll-margin-top(var(--ease-scroll-offset, 4rem));
+}
+```
+## Configuration
+Default values can be overridden:
+```scss
+$ease-scroll-offset: 4rem !default;
+$ease-scroll-offset-mobile: 3rem !default;
+```
+## Fallback Support
+A concrete fallback is provided before the CSS variable:
+```css
+.section {
+  scroll-margin-top: 4rem;
+  scroll-margin-top: var(--ease-scroll-offset, 4rem);
+}
+```
+## Parameters
+### `ease-scroll-margin-top`
+| Parameter | Default | Description |
+|---|---|---|
+| `$offset` | CSS variable | Scroll margin |
+| `$fallback` | `4rem` | Fallback |
+### `ease-scroll-padding-top`
+| Parameter | Default | Description |
+|---|---|---|
+| `$offset` | CSS variable | Scroll padding |
+| `$fallback` | `4rem` | Fallback |
+## Why Use These Helpers?
+Fixed and sticky headers can overlap anchored content.
+`scroll-margin-top` offsets the target; `scroll-padding-top` offsets the container.
+## Testing
+Compile with Sass and verify the generated properties and responsive rules.
+## Checklist
+- [x] SCSS partial
+- [x] Scroll margin and padding helpers
+- [x] CSS variable and fallback support
+- [x] Responsive helpers
+- [x] Usage documentation
+- [x] No JavaScript or external dependencies
+## Related Issue
+Closes #81307
+## Summary
+Compact SCSS utilities for reliable scroll offsets around persistent headers.

--- a/submissions/scss/81307-scroll-margin-padding-helpers-ks/_scroll-margin-padding-helpers.scss
+++ b/submissions/scss/81307-scroll-margin-padding-helpers-ks/_scroll-margin-padding-helpers.scss
@@ -1,0 +1,279 @@
+// ============================================================
+// EaseMotion CSS
+// Scroll Margin & Padding Helper Mixins
+// Issue: #81307
+// ============================================================
+
+
+// ============================================================
+// Default Configuration
+// ============================================================
+
+// Default scroll offset used when no custom value is supplied.
+$ease-scroll-offset: 4rem !default;
+
+// Default mobile scroll offset.
+$ease-scroll-offset-mobile: 3rem !default;
+
+
+// ============================================================
+// Scroll Margin Top
+// ============================================================
+
+/// Adds a scroll-margin-top offset to an element.
+///
+/// Useful for headings and anchor targets that need to remain
+/// visible below a fixed or sticky header.
+///
+/// @param {Length} $offset
+///   Scroll offset applied to the top margin.
+///
+/// @param {Length} $fallback
+///   Fallback value used before the CSS custom property.
+///
+/// @example
+///   .section {
+///     @include ease-scroll-margin-top(5rem);
+///   }
+///
+/// @example
+///   .section {
+///     @include ease-scroll-margin-top(
+///       var(--ease-scroll-offset, 4rem)
+///     );
+///   }
+
+@mixin ease-scroll-margin-top(
+  $offset: var(--ease-scroll-offset, #{$ease-scroll-offset}),
+  $fallback: $ease-scroll-offset
+) {
+  // Browser fallback.
+  scroll-margin-top: $fallback;
+
+  // CSS variable-aware value.
+  scroll-margin-top: $offset;
+}
+
+
+// ============================================================
+// Scroll Padding Top
+// ============================================================
+
+/// Adds a scroll-padding-top offset to a scroll container.
+///
+/// Useful when the scrolling container has a fixed or sticky
+/// header occupying space at the top of the viewport.
+///
+/// @param {Length} $offset
+///   Scroll padding applied to the top.
+///
+/// @param {Length} $fallback
+///   Fallback value used before the CSS custom property.
+///
+/// @example
+///   html {
+///     @include ease-scroll-padding-top(5rem);
+///   }
+///
+/// @example
+///   html {
+///     @include ease-scroll-padding-top(
+///       var(--ease-scroll-offset, 4rem)
+///     );
+///   }
+
+@mixin ease-scroll-padding-top(
+  $offset: var(--ease-scroll-offset, #{$ease-scroll-offset}),
+  $fallback: $ease-scroll-offset
+) {
+  // Browser fallback.
+  scroll-padding-top: $fallback;
+
+  // CSS variable-aware value.
+  scroll-padding-top: $offset;
+}
+
+
+// ============================================================
+// Combined Scroll Offset
+// ============================================================
+
+/// Applies both scroll-margin-top and scroll-padding-top.
+///
+/// This helper is useful when a project needs a consistent
+/// scroll offset for both anchor targets and scroll containers.
+///
+/// @param {Length} $offset
+///   Shared scroll offset.
+///
+/// @param {Length} $fallback
+///   Fallback value.
+///
+/// @example
+///   .section {
+///     @include ease-scroll-offset(4rem);
+///   }
+
+@mixin ease-scroll-offset(
+  $offset: var(--ease-scroll-offset, #{$ease-scroll-offset}),
+  $fallback: $ease-scroll-offset
+) {
+  @include ease-scroll-margin-top($offset, $fallback);
+  @include ease-scroll-padding-top($offset, $fallback);
+}
+
+
+// ============================================================
+// Responsive Scroll Margin
+// ============================================================
+
+/// Creates a responsive scroll-margin-top value.
+///
+/// The desktop offset is used by default and a smaller mobile
+/// offset is applied through a media query.
+///
+/// @param {Length} $desktop
+///   Desktop scroll offset.
+///
+/// @param {Length} $mobile
+///   Mobile scroll offset.
+///
+/// @param {Length} $breakpoint
+///   Responsive breakpoint.
+///
+/// @example
+///   .section {
+///     @include ease-responsive-scroll-margin(
+///       5rem,
+///       3rem,
+///       768px
+///     );
+///   }
+
+@mixin ease-responsive-scroll-margin(
+  $desktop: $ease-scroll-offset,
+  $mobile: $ease-scroll-offset-mobile,
+  $breakpoint: 768px
+) {
+  scroll-margin-top: $desktop;
+
+  @media (max-width: $breakpoint) {
+    scroll-margin-top: $mobile;
+  }
+}
+
+
+// ============================================================
+// Responsive Scroll Padding
+// ============================================================
+
+/// Creates a responsive scroll-padding-top value.
+///
+/// @param {Length} $desktop
+///   Desktop scroll padding.
+///
+/// @param {Length} $mobile
+///   Mobile scroll padding.
+///
+/// @param {Length} $breakpoint
+///   Responsive breakpoint.
+///
+/// @example
+///   html {
+///     @include ease-responsive-scroll-padding(
+///       5rem,
+///       3rem,
+///       768px
+///     );
+///   }
+
+@mixin ease-responsive-scroll-padding(
+  $desktop: $ease-scroll-offset,
+  $mobile: $ease-scroll-offset-mobile,
+  $breakpoint: 768px
+) {
+  scroll-padding-top: $desktop;
+
+  @media (max-width: $breakpoint) {
+    scroll-padding-top: $mobile;
+  }
+}
+
+
+// ============================================================
+// CSS Variable Integration
+// ============================================================
+
+/// Defines the shared EaseMotion scroll offset custom property.
+///
+/// This allows the scroll offset to be changed at runtime
+/// without recompiling the SCSS.
+///
+/// @param {Length} $offset
+///   Initial scroll offset.
+///
+/// @example
+///   :root {
+///     @include ease-scroll-token(4rem);
+///   }
+
+@mixin ease-scroll-token(
+  $offset: $ease-scroll-offset
+) {
+  --ease-scroll-offset: #{$offset};
+}
+
+
+// ============================================================
+// Header-Aware Anchor Target
+// ============================================================
+
+/// Creates a reusable header-aware anchor offset.
+///
+/// This is useful for sections that are targeted through
+/// fragment links such as #about or #contact.
+///
+/// @param {Length} $offset
+///   Header offset.
+///
+/// @example
+///   section[id] {
+///     @include ease-anchor-offset(4rem);
+///   }
+
+@mixin ease-anchor-offset(
+  $offset: var(--ease-scroll-offset, #{$ease-scroll-offset}),
+  $fallback: $ease-scroll-offset
+) {
+  scroll-margin-top: $fallback;
+  scroll-margin-top: $offset;
+}
+
+
+// ============================================================
+// Header-Aware Scroll Container
+// ============================================================
+
+/// Creates a scroll container offset that accounts for a
+/// fixed or sticky header.
+///
+/// @param {Length} $offset
+///   Header offset.
+///
+/// @example
+///   html {
+///     @include ease-scroll-container(4rem);
+///   }
+
+@mixin ease-scroll-container(
+  $offset: var(--ease-scroll-offset, #{$ease-scroll-offset}),
+  $fallback: $ease-scroll-offset
+) {
+  scroll-padding-top: $fallback;
+  scroll-padding-top: $offset;
+}
+
+
+// ============================================================
+// End of Scroll Margin & Padding Helpers
+// ============================================================


### PR DESCRIPTION
## Description

- Added reusable SCSS helpers for `scroll-margin-top` and `scroll-padding-top`
- Added configurable scroll offsets and CSS custom-property support
- Added fallback values for scroll positioning
- Added responsive scroll margin and padding utilities
- Added anchor-target and scroll-container helpers
- Added documentation and usage examples

Closes #81307