### PR TITLE
feat: Add CSS Hyper Speed Warp Drive

### DIFF
--- a/submissions/examples/css-hyper-speed-warp-drive/README.md
+++ b/submissions/examples/css-hyper-speed-warp-drive/README.md
@@ -1,16 +1,31 @@
 # CSS Hyper Speed Warp Drive
 
-A dynamic particle starfield effect utilizing massive algorithmic `box-shadow` generations scaled infinitely through a central 3D perspective point to simulate warp speed.
+A dynamic particle starfield effect simulating warp speed, generated entirely with CSS `box-shadow`/transform stars scaled through a central 3D perspective point.
 
-## Features
-- Infinite 3D scaling utilizing `translateZ`
-- Massive `box-shadow` for performant particle generation
-- Pure CSS with `perspective` and `radial-gradient` masking
+## What it does
+48 stars positioned around a circle each streak outward along the Z-axis via `translateZ`, creating an infinite warp-drive tunnel. No JavaScript.
 
-## Structure
+## Files
+- `demo.html` — interactive demo
+- `style.css` — pure CSS animation
+- `README.md` — this guide
+
+## Usage
+```html
+<link rel="stylesheet" href="./style.css" />
+<div class="warp">
+  <span class="warp__star" style="--x:120px;--y:0px"></span>
+  ...
+</div>
 ```
-css-hyper-speed-warp-drive/
-├── demo.html
-├── style.css
-└── README.md
-```
+
+## Techniques
+- `perspective` + `translateZ` for depth.
+- Staggered `animation-delay` for a continuous starfield.
+- Hardware-accelerated `transform`/`opacity` for 60 FPS.
+
+## Accessibility
+- `role="img"` + `aria-label` for screen readers.
+- `prefers-reduced-motion` disables the streaks.
+
+Closes #75227

--- a/submissions/examples/css-hyper-speed-warp-drive/demo.html
+++ b/submissions/examples/css-hyper-speed-warp-drive/demo.html
@@ -1,17 +1,63 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hyper Speed Warp Drive</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS Hyper Speed Warp Drive</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <div class="warp-drive">
-        <div class="starfield sf-1"></div>
-        <div class="starfield sf-2"></div>
-        <div class="starfield sf-3"></div>
-        <div class="warp-core"></div>
+  <main>
+    <div class="warp" role="img" aria-label="Warp speed starfield">
+  <span class="warp__star warp__star--fast" style="--x:160px;--y:0px; animation-delay:0.0s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:159px;--y:21px; animation-delay:0.15s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:155px;--y:41px; animation-delay:0.3s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:148px;--y:61px; animation-delay:0.44999999999999996s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:139px;--y:80px; animation-delay:0.6s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:127px;--y:97px; animation-delay:0.75s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:113px;--y:113px; animation-delay:0.8999999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:97px;--y:127px; animation-delay:1.05s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:80px;--y:139px; animation-delay:1.2s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:61px;--y:148px; animation-delay:1.3499999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:41px;--y:155px; animation-delay:1.5s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:21px;--y:159px; animation-delay:1.65s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:0px;--y:160px; animation-delay:0.0s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-21px;--y:159px; animation-delay:0.15s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-41px;--y:155px; animation-delay:0.3s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-61px;--y:148px; animation-delay:0.44999999999999996s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-80px;--y:139px; animation-delay:0.6s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-97px;--y:127px; animation-delay:0.75s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-113px;--y:113px; animation-delay:0.8999999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-127px;--y:97px; animation-delay:1.05s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-139px;--y:80px; animation-delay:1.2s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-148px;--y:61px; animation-delay:1.3499999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-155px;--y:41px; animation-delay:1.5s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-159px;--y:21px; animation-delay:1.65s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-160px;--y:0px; animation-delay:0.0s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-159px;--y:-21px; animation-delay:0.15s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-155px;--y:-41px; animation-delay:0.3s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-148px;--y:-61px; animation-delay:0.44999999999999996s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-139px;--y:-80px; animation-delay:0.6s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-127px;--y:-97px; animation-delay:0.75s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-113px;--y:-113px; animation-delay:0.8999999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-97px;--y:-127px; animation-delay:1.05s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-80px;--y:-139px; animation-delay:1.2s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:-61px;--y:-148px; animation-delay:1.3499999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:-41px;--y:-155px; animation-delay:1.5s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:-21px;--y:-159px; animation-delay:1.65s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:0px;--y:-160px; animation-delay:0.0s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:21px;--y:-159px; animation-delay:0.15s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:41px;--y:-155px; animation-delay:0.3s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:61px;--y:-148px; animation-delay:0.44999999999999996s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:80px;--y:-139px; animation-delay:0.6s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:97px;--y:-127px; animation-delay:0.75s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:113px;--y:-113px; animation-delay:0.8999999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:127px;--y:-97px; animation-delay:1.05s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:139px;--y:-80px; animation-delay:1.2s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--fast" style="--x:148px;--y:-61px; animation-delay:1.3499999999999999s" aria-hidden="true"></span>
+  <span class="warp__star warp__star--slow" style="--x:155px;--y:-41px; animation-delay:1.5s" aria-hidden="true"></span>
+  <span class="warp__star " style="--x:159px;--y:-21px; animation-delay:1.65s" aria-hidden="true"></span>
     </div>
+  </main>
 </body>
 </html>

--- a/submissions/examples/css-hyper-speed-warp-drive/style.css
+++ b/submissions/examples/css-hyper-speed-warp-drive/style.css
@@ -1,74 +1,52 @@
+/* CSS Hyper Speed Warp Drive — pure CSS animation
+   Submission for #75227 */
 body {
   margin: 0;
-  padding: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
   background: #000;
+  font-family: system-ui, sans-serif;
   overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  perspective: 800px;
 }
 
-.warp-drive {
+.warp {
   position: relative;
-  width: 100vw;
-  height: 100vh;
-  transform-style: preserve-3d;
+  width: 400px;
+  height: 400px;
+  perspective: 600px;
 }
 
-.warp-core {
+.warp__star {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 20px;
-  height: 20px;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
   background: #fff;
-  border-radius: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 0 100px 50px rgba(0, 150, 255, 0.5);
-  animation: pulse 2s infinite alternate;
+  transform: translateZ(0) translateX(-50%) translateY(-50%);
+  animation: warp-streak 2s linear infinite;
+  opacity: 0;
 }
 
-.starfield {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 1px;
-  height: 10px;
-  background: transparent;
-  transform-style: preserve-3d;
-  /* Algorithmic massive box-shadow for warp speed trails */
-  box-shadow: 
-    120px 200px 0 0 #fff, -120px -200px 0 0 #fff, 300px -100px 0 0 #0ff, -300px 100px 0 0 #0ff,
-    150px -250px 0 0 #fff, -150px 250px 0 0 #fff, 350px 200px 0 0 #0ff, -350px -200px 0 0 #0ff,
-    200px 300px 0 0 #fff, -200px -300px 0 0 #fff, 400px -200px 0 0 #0ff, -400px 200px 0 0 #0ff,
-    50px 100px 0 0 #fff, -50px -100px 0 0 #fff, 250px -300px 0 0 #0ff, -250px 300px 0 0 #0ff,
-    100px -150px 0 0 #fff, -100px 150px 0 0 #fff, 150px 100px 0 0 #0ff, -150px -100px 0 0 #0ff,
-    450px 350px 0 0 #fff, -450px -350px 0 0 #fff, 500px -250px 0 0 #0ff, -500px 250px 0 0 #0ff,
-    550px -400px 0 0 #fff, -550px 400px 0 0 #fff, 600px 300px 0 0 #0ff, -600px -300px 0 0 #0ff;
-  border-radius: 50%;
+.warp__star--slow { animation-duration: 4s; }
+.warp__star--fast { animation-duration: 1.2s; }
+
+@keyframes warp-streak {
+  0% {
+    transform: translateZ(-300px) translateX(var(--x, 0)) translateY(var(--y, 0)) scale(0.2);
+    opacity: 0;
+    box-shadow: 0 0 0 0 #fff;
+  }
+  20% { opacity: 1; }
+  100% {
+    transform: translateZ(300px) translateX(var(--x, 0)) translateY(var(--y, 0)) scale(1);
+    opacity: 0;
+    box-shadow: 0 0 8px 2px #fff;
+  }
 }
 
-.sf-1 { animation: warp 1.5s linear infinite; }
-.sf-2 { animation: warp 1.5s linear infinite 0.5s; }
-.sf-3 { animation: warp 1.5s linear infinite 1s; }
-
-@keyframes warp {
-  0% { transform: translateZ(-2000px) scale(1); opacity: 0; }
-  10% { opacity: 1; }
-  80% { opacity: 1; }
-  100% { transform: translateZ(1000px) scale(15); opacity: 0; }
-}
-
-@keyframes pulse {
-  0% { transform: translate(-50%, -50%) scale(1); opacity: 0.8; }
-  100% { transform: translate(-50%, -50%) scale(1.5); opacity: 1; box-shadow: 0 0 150px 80px rgba(0, 255, 255, 0.8); }
-}
-
-.warp-drive::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at center, transparent 10%, #000 90%);
+@media (prefers-reduced-motion: reduce) {
+  .warp__star { animation: none !important; opacity: 0.5; }
 }


### PR DESCRIPTION
## What changed

Self-contained pure-CSS submission for **css-hyper-speed-warp-drive** (closes #75227). Placed entirely under `submissions/examples/css-hyper-speed-warp-drive/` per the contribution guide.

`submissions/examples/css-hyper-speed-warp-drive/`:
- **`demo.html`** — fully self-contained working animation/pattern.
- **`style.css`** — pure CSS (no external JS), hardware-accelerated.
- **`README.md`** — usage docs + accessibility notes.

### Implementation
- Pure HTML & Vanilla CSS (no external JavaScript).
- Hardware-accelerated using `transform` and `opacity` for 60 FPS.
- `@media (prefers-reduced-motion: reduce)` override disables animations.
- Dark mode compatible.

Closes #75227

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._