### PR TITLE
feat: create Animated Tooltip with Cyberpunk styling (#91099) #79847

### DIFF
--- a/submissions/examples/css-tooltip-animated-cyberpunk/README.md
+++ b/submissions/examples/css-tooltip-animated-cyberpunk/README.md
@@ -1,0 +1,2 @@
+# Animated Tooltip (Cyberpunk)
+A gritty, terminal-style overlay. The tooltip utilizes jagged `steps()` animation curves for its entrance, revealing a hard-bordered container with a high-contrast magenta layout. The text inside rapidly glitches horizontally on hover to simulate data corruption.

--- a/submissions/examples/css-tooltip-animated-cyberpunk/demo.html
+++ b/submissions/examples/css-tooltip-animated-cyberpunk/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Animated Tooltip</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="ct-container">
+        <button class="ct-target">SCAN DATA</button>
+        <div class="ct-tooltip">
+            <span class="ct-sys">[SYS_ALERT]</span>
+            <p>Unauthorized intrusion detected in Sector 4. Immediate lockdown protocol engaged.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-tooltip-animated-cyberpunk/style.css
+++ b/submissions/examples/css-tooltip-animated-cyberpunk/style.css
@@ -1,0 +1,14 @@
+:root { --bg: #09090b; --cyan: #00f0ff; --pink: #ff003c; --yellow: #fcee0a; }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; }
+.ct-container { position: relative; display: inline-block; }
+.ct-target { padding: 0.75rem 1.5rem; background: transparent; border: 2px solid var(--cyan); color: var(--cyan); font-family: inherit; font-weight: bold; cursor: pointer; text-transform: uppercase; transition: 0.2s; position: relative; overflow: hidden; outline: none; }
+.ct-target::after { content: ''; position: absolute; inset: 0; background: var(--cyan); transform: scaleX(0); transform-origin: left; transition: 0.2s steps(4, end); z-index: -1; }
+.ct-target:hover { color: #000; }
+.ct-target:hover::after { transform: scaleX(1); }
+.ct-tooltip { position: absolute; bottom: calc(100% + 15px); left: 50%; transform: translateX(-50%) translateY(20px); width: 250px; background: rgba(0,0,0,0.9); border: 2px solid var(--pink); border-left: 6px solid var(--pink); padding: 1rem; color: #fff; opacity: 0; visibility: hidden; pointer-events: none; z-index: 10; transition: 0.2s steps(5, end); box-shadow: 4px 4px 0 rgba(255, 0, 60, 0.3); }
+.ct-tooltip::before { content: ''; position: absolute; top: 100%; left: 50%; margin-left: -8px; border-width: 8px; border-style: solid; border-color: var(--pink) transparent transparent transparent; }
+.ct-sys { display: block; color: var(--yellow); font-weight: bold; font-size: 0.85rem; margin-bottom: 0.5rem; }
+.ct-tooltip p { margin: 0; font-size: 0.85rem; line-height: 1.4; color: #ccc; }
+.ct-container:hover .ct-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }
+.ct-container:hover .ct-tooltip p { animation: ct-glitch 0.4s steps(3, end); }
+@keyframes ct-glitch { 0% { transform: translate(2px, 2px); } 50% { transform: translate(-2px, -2px); } 100% { transform: translate(0, 0); } }


### PR DESCRIPTION
**Title:** feat: create Animated Tooltip with Cyberpunk styling (#91099) #79847

**Description:**
This PR introduces a gritty, terminal-style overlay. The tooltip utilizes jagged `steps()` animation curves for its entrance, revealing a hard-bordered container with a high-contrast magenta layout. The text inside rapidly glitches horizontally on hover to simulate data corruption.

Fixes #79847

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-tooltip-animated-cyberpunk/`
- Designed the tooltip `.ct-tooltip` block using heavy `#ff003c` left-borders and an offset magenta `box-shadow` to simulate CRT glow
- Triggered a `@keyframes ct-glitch` translation on internal paragraphs upon parent hover, bound with `steps(3, end)` to create the choppy visual distortion
