### PR TITLE
feat: create Glowing Pagination with Neon styling (#37261) #79768

### DIFF
--- a/submissions/examples/css-pagination-glowing-neon/README.md
+++ b/submissions/examples/css-pagination-glowing-neon/README.md
@@ -1,0 +1,2 @@
+# Glowing Pagination (Neon)
+A high-contrast, cyberpunk-inspired navigation block. Unselected items remain dark and inactive. The selected page dynamically floods with a bright cyan background, triggering an intense outer drop-shadow glow and a subtle physical elevation (`translateY`).

--- a/submissions/examples/css-pagination-glowing-neon/demo.html
+++ b/submissions/examples/css-pagination-glowing-neon/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neon Glowing Pagination</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="np-container">
+        <input type="radio" name="np-page" id="np-1">
+        <input type="radio" name="np-page" id="np-2" checked>
+        <input type="radio" name="np-page" id="np-3">
+
+        <label for="np-1" class="np-btn">1</label>
+        <label for="np-2" class="np-btn">2</label>
+        <label for="np-3" class="np-btn">3</label>
+    </div>
+</body>
+</html>

--- a/submissions/examples/css-pagination-glowing-neon/style.css
+++ b/submissions/examples/css-pagination-glowing-neon/style.css
@@ -1,0 +1,12 @@
+:root { --bg: #050505; --neon: #00ffcc; --neon-dim: rgba(0, 255, 204, 0.2); }
+body { background: var(--bg); display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; font-family: system-ui, sans-serif; }
+.np-container { display: flex; gap: 1rem; padding: 1.5rem; background: #0a0a0a; border-radius: 12px; border: 1px solid #1a1a1a; }
+input[type="radio"] { display: none; }
+.np-btn { display: flex; justify-content: center; align-items: center; width: 45px; height: 45px; border-radius: 8px; background: transparent; color: #666; border: 2px solid #333; cursor: pointer; font-weight: bold; font-size: 1.1rem; transition: all 0.3s ease; position: relative; overflow: hidden; }
+.np-btn:hover { color: #fff; border-color: #666; }
+#np-1:checked ~ label[for="np-1"],
+#np-2:checked ~ label[for="np-2"],
+#np-3:checked ~ label[for="np-3"] { color: var(--bg); border-color: var(--neon); background: var(--neon); box-shadow: 0 0 15px var(--neon), inset 0 0 10px rgba(255,255,255,0.5); text-shadow: 0 0 5px rgba(0,0,0,0.5); transform: translateY(-3px); }
+#np-1:checked ~ label[for="np-1"]::before,
+#np-2:checked ~ label[for="np-2"]::before,
+#np-3:checked ~ label[for="np-3"]::before { content: ''; position: absolute; inset: 0; border: 2px solid #fff; border-radius: 6px; filter: blur(2px); opacity: 0.5; }


### PR DESCRIPTION
**Title:** feat: create Glowing Pagination with Neon styling (#37261) #79768

**Description:**
This PR introduces a high-contrast, cyberpunk-inspired navigation block. Unselected items remain dark and inactive. The selected page dynamically floods with a bright cyan background, triggering an intense outer drop-shadow glow and a subtle physical elevation (`translateY`).

Fixes #79768

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-pagination-glowing-neon/`
- Implemented the active state via the Checkbox/Radio Hack (`#np-1:checked ~ label...`), allowing fully CSS-driven selection tracking
- Augmented the checked labels with intense `0 0 15px var(--neon)` glowing drop shadows paired with a blurred white `::before` pseudo-element for added bloom
