### PR TITLE
feat: create Neumorphic Footer with Retro styling (#59665) #79844

### DIFF
--- a/submissions/examples/css-footer-neumorphic-retro/README.md
+++ b/submissions/examples/css-footer-neumorphic-retro/README.md
@@ -1,0 +1,2 @@
+# Neumorphic Footer (Retro)
+A unique blend of soft-UI elevation applied to a 90s-beige computer hardware color palette. The footer track is recessed using deep inset shadows, while the branding elements and links sit physically on top as clickable, compressible 3D plastic buttons.

--- a/submissions/examples/css-footer-neumorphic-retro/demo.html
+++ b/submissions/examples/css-footer-neumorphic-retro/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retro Neumorphic Footer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <footer class="nr-footer">
+        <div class="nr-brand">
+            <div class="nr-logo">V</div>
+            <span>VaporSystems</span>
+        </div>
+        <div class="nr-links">
+            <a href="#" class="nr-btn">About</a>
+            <a href="#" class="nr-btn">Products</a>
+            <a href="#" class="nr-btn">Contact</a>
+        </div>
+    </footer>
+</body>
+</html>

--- a/submissions/examples/css-footer-neumorphic-retro/style.css
+++ b/submissions/examples/css-footer-neumorphic-retro/style.css
@@ -1,0 +1,10 @@
+:root { --bg: #dfd8d1; --shadow-dark: #b8b1aa; --shadow-light: #ffffff; --accent: #ff6b6b; --text: #555; }
+body { background: var(--bg); display: flex; align-items: flex-end; min-height: 100vh; margin: 0; font-family: 'Courier New', Courier, monospace; font-weight: bold; }
+.nr-footer { width: 100%; padding: 2rem 3rem; display: flex; justify-content: space-between; align-items: center; box-shadow: inset 5px 5px 15px var(--shadow-dark), inset -5px -5px 15px var(--shadow-light); border-top: 4px solid var(--bg); box-sizing: border-box; flex-wrap: wrap; gap: 2rem; }
+.nr-brand { display: flex; align-items: center; gap: 1rem; color: var(--text); font-size: 1.2rem; text-transform: uppercase; letter-spacing: 2px; }
+.nr-logo { width: 45px; height: 45px; display: flex; justify-content: center; align-items: center; border-radius: 12px; background: var(--bg); box-shadow: 5px 5px 10px var(--shadow-dark), -5px -5px 10px var(--shadow-light); color: var(--accent); font-size: 1.5rem; }
+.nr-links { display: flex; gap: 1.5rem; }
+.nr-btn { padding: 0.75rem 1.5rem; background: var(--bg); color: var(--text); text-decoration: none; border-radius: 8px; box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light); transition: 0.2s; display: inline-block; text-transform: uppercase; font-size: 0.9rem; }
+.nr-btn:hover { color: var(--accent); box-shadow: 2px 2px 4px var(--shadow-dark), -2px -2px 4px var(--shadow-light); transform: translateY(2px); }
+.nr-btn:active { box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light); transform: translateY(4px); }
+@media (max-width: 600px) { .nr-footer { flex-direction: column; align-items: stretch; text-align: center; } .nr-brand { justify-content: center; } .nr-links { flex-direction: column; } }


### PR DESCRIPTION
**Title:** feat: create Neumorphic Footer with Retro styling (#59665) #79844

**Description:**
This PR introduces a unique blend of soft-UI elevation applied to a 90s-beige computer hardware color palette. The footer track is recessed using deep inset shadows, while the branding elements and links sit physically on top as clickable, compressible 3D plastic buttons.

Fixes #79844

**Changes:**
- Added `demo.html`, `style.css`, and `README.md` under `submissions/examples/css-footer-neumorphic-retro/`
- Rendered the `.nr-footer` baseline track utilizing deep `inset` shadows to construct an indented physical trench within the background material
- Styled the `.nr-btn` navigation links utilizing standard outset shadows, wiring a `:active` state that inverts the shadow to simulate mechanical button depression
