### PR TITLE
feat(scss): add grid auto rows mixins (#81356)

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -50,3 +50,13 @@
 @mixin zoom-out($duration: $duration-normal, $easing: $ease-in-cubic, $delay: $delay-none, $fill: $fill-both) {
   @include animate(ease-kf-zoom-out, $duration, $easing, $delay, $fill);
 }
+
+// --- Grid Helpers ---
+
+@mixin grid-auto-rows($value: auto) {
+  grid-auto-rows: $value;
+}
+
+@mixin grid-auto-flow($value: row) {
+  grid-auto-flow: $value;
+}


### PR DESCRIPTION
## Description

This PR adds reusable SCSS helper mixins for CSS Grid implicit row sizing and auto-flow behavior.

It is a critical issue for extending the EaseMotion SCSS mixin suite with reusable grid helpers.

## Changes

- Added `grid-auto-rows` mixin
- Added `grid-auto-flow` mixin
- Preserved existing SCSS mixins

## Testing

Verified the SCSS syntax and generated declarations.

## Issue

Closes #81356
