### PR TITLE
feat: add z-index elevation stack example (#81359)

### DIFF
--- a/submissions/examples/81359-z-index-elevation/README.md
+++ b/submissions/examples/81359-z-index-elevation/README.md
@@ -1,0 +1,17 @@
+# Z-Index Elevation Stack
+
+A responsive CSS example demonstrating a reusable z-index elevation stack for common UI layers.
+
+## Stack
+
+- Dropdown: 10
+- Modal: 20
+- Toast: 30
+- Tooltip: 40
+
+## SCSS helper concept
+
+```scss
+@mixin z-index-elevation($level) {
+  z-index: $level;
+}

--- a/submissions/examples/81359-z-index-elevation/demo.html
+++ b/submissions/examples/81359-z-index-elevation/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Z-Index Elevation Stack</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main>
+  <h1>Z-Index Elevation Stack</h1>
+
+  <div class="stack">
+    <div class="layer dropdown">Dropdown</div>
+    <div class="layer modal">Modal</div>
+    <div class="layer toast">Toast</div>
+    <div class="layer tooltip">Tooltip</div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/81359-z-index-elevation/style.css
+++ b/submissions/examples/81359-z-index-elevation/style.css
@@ -1,0 +1,40 @@
+*{box-sizing:border-box}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  padding:1rem;
+  background:#f5f7fa;
+  font-family:system-ui,sans-serif
+}
+
+main{width:min(100%,600px);text-align:center}
+
+.stack{
+  position:relative;
+  height:260px;
+  margin-top:2rem
+}
+
+.layer{
+  position:absolute;
+  left:50%;
+  width:220px;
+  padding:1.2rem;
+  border-radius:12px;
+  color:#fff;
+  font-weight:700;
+  transform:translateX(-50%);
+  box-shadow:0 10px 25px rgba(0,0,0,.15)
+}
+
+.dropdown{top:0;background:#667eea;z-index:10}
+.modal{top:35px;background:#764ba2;z-index:20}
+.toast{top:70px;background:#e67e22;z-index:30}
+.tooltip{top:105px;background:#16a085;z-index:40}
+
+@media(max-width:500px){
+  .layer{width:min(80%,220px)}
+}


### PR DESCRIPTION
## Description

This PR adds a reusable Z-Index Elevation Stack example for common UI layers.

It is a critical issue for demonstrating consistent stacking order for dropdowns, modals, toasts, and tooltips.

## Changes

- Added z-index elevation stack example
- Added responsive styling
- Documented elevation levels
- Kept all changes inside `submissions/`

## Testing

Tested locally using `demo.html`.

## Issue

Closes #81359