### PR TITLE
feat: add view transition name example (#81352)

### DIFF
--- a/submissions/examples/81352-view-transition-name/README.md
+++ b/submissions/examples/81352-view-transition-name/README.md
@@ -1,0 +1,10 @@
+# View Transition Name
+
+A small responsive example demonstrating the CSS `view-transition-name` concept for identifying elements during view transitions.
+
+## SCSS helper concept
+
+```scss
+@mixin view-transition-name($name) {
+  view-transition-name: $name;
+}

--- a/submissions/examples/81352-view-transition-name/demo.html
+++ b/submissions/examples/81352-view-transition-name/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>View Transition Name</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main>
+  <h1>View Transition Name</h1>
+  <div class="card">
+    <div class="box">Transition Element</div>
+    <p>view-transition-name: demo-card</p>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/81352-view-transition-name/style.css
+++ b/submissions/examples/81352-view-transition-name/style.css
@@ -1,0 +1,47 @@
+*{box-sizing:border-box}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  padding:1rem;
+  background:#eef2ff;
+  color:#20243a;
+  font-family:system-ui,sans-serif
+}
+
+main{
+  width:min(100%,600px);
+  text-align:center
+}
+
+.card{
+  padding:2rem;
+  background:#fff;
+  border-radius:16px;
+  box-shadow:0 12px 30px rgba(0,0,0,.08)
+}
+
+.box{
+  padding:2rem;
+  border-radius:12px;
+  background:#6366f1;
+  color:#fff;
+  font-weight:700;
+  view-transition-name:demo-card
+}
+
+p{
+  color:#697386;
+  font-size:.8rem
+}
+
+::view-transition-old(demo-card),
+::view-transition-new(demo-card){
+  animation-duration:.3s
+}
+
+@media(max-width:500px){
+  .card{padding:1rem}
+}


### PR DESCRIPTION
## Description

This PR adds a responsive example demonstrating the `view-transition-name`
CSS helper concept for reusable SPA view transition element tagging.

It is a critical issue for extending the EaseMotion examples with modern
view transition support.

## Changes

- Added named view-transition example
- Added responsive styling
- Added SCSS helper concept
- Kept all changes inside `submissions/`

## Testing

Tested locally using `demo.html`.

## Issue

Closes #81352