### PR TITLE
feat(core): Add Curtain Slide Reveal SCSS animation mixin

### DIFF
--- a/submissions/scss/curtain-slide-reveal-scss-sb/README.md
+++ b/submissions/scss/curtain-slide-reveal-scss-sb/README.md
@@ -1,0 +1,32 @@
+# Curtain Slide Reveal — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-curtain-slide-reveal` keyframes and a `.ease-anim-curtain-slide-reveal` utility class.
+
+## What it does
+An element revealing like a curtain dropping (scaleY from top). Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_curtain-slide-reveal.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./curtain-slide-reveal" as *;
+
+.my-element {
+  @include ease-anim-curtain-slide-reveal;
+}
+```
+
+### Configurable parameters
+- `$duration` — animation duration (default: `var(--ease-duration, 1s)`)
+- `$timing` — timing function (default: `var(--ease-timing, ease)`)
+- `$fill` — fill mode (default: `both`)
+
+### CSS variables
+- `--ease-duration` — global default duration
+- `--ease-timing` — global default timing function
+
+## Accessibility
+- `@media (prefers-reduced-motion: reduce)` disables the animation.
+
+Closes #81673

--- a/submissions/scss/curtain-slide-reveal-scss-sb/_curtain-slide-reveal.scss
+++ b/submissions/scss/curtain-slide-reveal-scss-sb/_curtain-slide-reveal.scss
@@ -1,0 +1,34 @@
+// ============================================================
+// EaseMotion CSS — Curtain Slide Reveal SCSS animation mixin
+// Submission for #81673
+// ============================================================
+
+/// Curtain Slide Reveal animation mixin.
+///
+/// Emits the `@keyframes ease-curtain-slide-reveal` rule and a `.ease-anim-curtain-slide-reveal`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-curtain-slide-reveal;
+///   @include ease-anim-curtain-slide-reveal($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-curtain-slide-reveal($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-curtain-slide-reveal {
+  0%   { transform: scaleY(0); transform-origin: top; opacity: 0; }
+  60%  { transform: scaleY(1.02); opacity: 1; }
+  100% { transform: scaleY(1); opacity: 1; }
+  }
+
+  .ease-anim-curtain-slide-reveal {
+    animation: ease-curtain-slide-reveal #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained SCSS animation mixin submission for **Curtain Slide Reveal** (closes #81673). Placed entirely under `submissions/scss/curtain-slide-reveal-scss-sb/` per the contribution guide.

`submissions/scss/curtain-slide-reveal-scss-sb/`:
- **`_curtain-slide-reveal.scss`** — emits the `@keyframes ease-curtain-slide-reveal` rule and a `.ease-anim-curtain-slide-reveal` utility class, with SassDoc usage examples.
- **`README.md`** — overview, usage, configurable parameters, CSS variables, and accessibility notes.

### Implementation requirements
- Defines `@keyframes ease-curtain-slide-reveal`.
- Provides `ease-anim-curtain-slide-reveal` utility class.
- Supports configurable timing variables (`--ease-duration`, `--ease-timing`).
- Includes `@media (prefers-reduced-motion: reduce)` override.

### Acceptance criteria
- Hardware accelerated using `transform` and `opacity` for 60 FPS.
- Clean SCSS compilation without warnings (verified with `sass`).
- Compatible with core EaseMotion CSS tokens.

Closes #81673

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._