### PR TITLE
feat(core): Add Origami Paper Fold SCSS animation mixin

### DIFF
--- a/submissions/scss/origami-paper-fold-scss-sb/README.md
+++ b/submissions/scss/origami-paper-fold-scss-sb/README.md
@@ -1,0 +1,32 @@
+# Origami Paper Fold — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-origami-paper-fold` keyframes and a `.ease-anim-origami-paper-fold` utility class.
+
+## What it does
+An element unfolding like origami paper via 3D perspective rotation. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_origami-paper-fold.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./origami-paper-fold" as *;
+
+.my-element {
+  @include ease-anim-origami-paper-fold;
+}
+```
+
+### Configurable parameters
+- `$duration` — animation duration (default: `var(--ease-duration, 1s)`)
+- `$timing` — timing function (default: `var(--ease-timing, ease)`)
+- `$fill` — fill mode (default: `both`)
+
+### CSS variables
+- `--ease-duration` — global default duration
+- `--ease-timing` — global default timing function
+
+## Accessibility
+- `@media (prefers-reduced-motion: reduce)` disables the animation.
+
+Closes #81675

--- a/submissions/scss/origami-paper-fold-scss-sb/_origami-paper-fold.scss
+++ b/submissions/scss/origami-paper-fold-scss-sb/_origami-paper-fold.scss
@@ -1,0 +1,34 @@
+// ============================================================
+// EaseMotion CSS — Origami Paper Fold SCSS animation mixin
+// Submission for #81675
+// ============================================================
+
+/// Origami Paper Fold animation mixin.
+///
+/// Emits the `@keyframes ease-origami-paper-fold` rule and a `.ease-anim-origami-paper-fold`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-origami-paper-fold;
+///   @include ease-anim-origami-paper-fold($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-origami-paper-fold($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-origami-paper-fold {
+  0%   { transform: perspective(600px) rotateY(90deg) scaleX(0.6); opacity: 0; }
+  50%  { transform: perspective(600px) rotateY(-8deg) scaleX(1.02); opacity: 1; }
+  100% { transform: perspective(600px) rotateY(0) scaleX(1); opacity: 1; }
+  }
+
+  .ease-anim-origami-paper-fold {
+    animation: ease-origami-paper-fold #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained SCSS animation mixin submission for **Origami Paper Fold** (closes #81675). Placed entirely under `submissions/scss/origami-paper-fold-scss-sb/` per the contribution guide.

`submissions/scss/origami-paper-fold-scss-sb/`:
- **`_origami-paper-fold.scss`** — emits the `@keyframes ease-origami-paper-fold` rule and a `.ease-anim-origami-paper-fold` utility class, with SassDoc usage examples.
- **`README.md`** — overview, usage, configurable parameters, CSS variables, and accessibility notes.

### Implementation requirements
- Defines `@keyframes ease-origami-paper-fold`.
- Provides `ease-anim-origami-paper-fold` utility class.
- Supports configurable timing variables (`--ease-duration`, `--ease-timing`).
- Includes `@media (prefers-reduced-motion: reduce)` override.

### Acceptance criteria
- Hardware accelerated using `transform` and `opacity` for 60 FPS.
- Clean SCSS compilation without warnings (verified with `sass`).
- Compatible with core EaseMotion CSS tokens.

Closes #81675

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._