### PR TITLE
feat(core): Add Particle Float Drift SCSS animation mixin

### DIFF
--- a/submissions/scss/particle-float-drift-scss-sb/README.md
+++ b/submissions/scss/particle-float-drift-scss-sb/README.md
@@ -1,0 +1,32 @@
+# Particle Float Drift — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-particle-float-drift` keyframes and a `.ease-anim-particle-float-drift` utility class.
+
+## What it does
+A particle drifting and fading upward with translate3d. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_particle-float-drift.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./particle-float-drift" as *;
+
+.my-element {
+  @include ease-anim-particle-float-drift;
+}
+```
+
+### Configurable parameters
+- `$duration` — animation duration (default: `var(--ease-duration, 1s)`)
+- `$timing` — timing function (default: `var(--ease-timing, ease)`)
+- `$fill` — fill mode (default: `both`)
+
+### CSS variables
+- `--ease-duration` — global default duration
+- `--ease-timing` — global default timing function
+
+## Accessibility
+- `@media (prefers-reduced-motion: reduce)` disables the animation.
+
+Closes #81677

--- a/submissions/scss/particle-float-drift-scss-sb/_particle-float-drift.scss
+++ b/submissions/scss/particle-float-drift-scss-sb/_particle-float-drift.scss
@@ -1,0 +1,35 @@
+// ============================================================
+// EaseMotion CSS — Particle Float Drift SCSS animation mixin
+// Submission for #81677
+// ============================================================
+
+/// Particle Float Drift animation mixin.
+///
+/// Emits the `@keyframes ease-particle-float-drift` rule and a `.ease-anim-particle-float-drift`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-particle-float-drift;
+///   @include ease-anim-particle-float-drift($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-particle-float-drift($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-particle-float-drift {
+  0%   { transform: translate3d(0, 12px, 0) scale(0.6); opacity: 0; }
+  40%  { transform: translate3d(6px, -6px, 0) scale(1); opacity: 1; }
+  70%  { transform: translate3d(-4px, -10px, 0) scale(0.96); opacity: 0.9; }
+  100% { transform: translate3d(2px, -20px, 0) scale(0.8); opacity: 0; }
+  }
+
+  .ease-anim-particle-float-drift {
+    animation: ease-particle-float-drift #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained SCSS animation mixin submission for **Particle Float Drift** (closes #81677). Placed entirely under `submissions/scss/particle-float-drift-scss-sb/` per the contribution guide.

`submissions/scss/particle-float-drift-scss-sb/`:
- **`_particle-float-drift.scss`** — emits the `@keyframes ease-particle-float-drift` rule and a `.ease-anim-particle-float-drift` utility class, with SassDoc usage examples.
- **`README.md`** — overview, usage, configurable parameters, CSS variables, and accessibility notes.

### Implementation requirements
- Defines `@keyframes ease-particle-float-drift`.
- Provides `ease-anim-particle-float-drift` utility class.
- Supports configurable timing variables (`--ease-duration`, `--ease-timing`).
- Includes `@media (prefers-reduced-motion: reduce)` override.

### Acceptance criteria
- Hardware accelerated using `transform` and `opacity` for 60 FPS.
- Clean SCSS compilation without warnings (verified with `sass`).
- Compatible with core EaseMotion CSS tokens.

Closes #81677

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._