### PR TITLE
feat(core): Add Ripple Wave Click SCSS animation mixin

### DIFF
--- a/submissions/scss/ripple-wave-click-scss-sb/README.md
+++ b/submissions/scss/ripple-wave-click-scss-sb/README.md
@@ -1,0 +1,32 @@
+# Ripple Wave Click — SCSS animation mixin
+
+A reusable SCSS mixin for the EaseMotion core animation library that emits the `ease-ripple-wave-click` keyframes and a `.ease-anim-ripple-wave-click` utility class.
+
+## What it does
+A ripple expanding outward on click via scale and opacity. Hardware-accelerated using `transform` and `opacity` for 60 FPS, with a `prefers-reduced-motion` override.
+
+## Files
+- `_ripple-wave-click.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./ripple-wave-click" as *;
+
+.my-element {
+  @include ease-anim-ripple-wave-click;
+}
+```
+
+### Configurable parameters
+- `$duration` — animation duration (default: `var(--ease-duration, 1s)`)
+- `$timing` — timing function (default: `var(--ease-timing, ease)`)
+- `$fill` — fill mode (default: `both`)
+
+### CSS variables
+- `--ease-duration` — global default duration
+- `--ease-timing` — global default timing function
+
+## Accessibility
+- `@media (prefers-reduced-motion: reduce)` disables the animation.
+
+Closes #81681

--- a/submissions/scss/ripple-wave-click-scss-sb/_ripple-wave-click.scss
+++ b/submissions/scss/ripple-wave-click-scss-sb/_ripple-wave-click.scss
@@ -1,0 +1,33 @@
+// ============================================================
+// EaseMotion CSS — Ripple Wave Click SCSS animation mixin
+// Submission for #81681
+// ============================================================
+
+/// Ripple Wave Click animation mixin.
+///
+/// Emits the `@keyframes ease-ripple-wave-click` rule and a `.ease-anim-ripple-wave-click`
+/// utility class that applies it. Timing is configurable via the
+/// `--ease-duration` and `--ease-timing` CSS custom properties.
+///
+/// @param {String} $duration [var(--ease-duration, 1s)] Animation duration
+/// @param {String} $timing [var(--ease-timing, ease)] Animation timing function
+/// @param {String} $fill [both] Animation fill mode
+///
+/// @example scss
+///   @include ease-anim-ripple-wave-click;
+///   @include ease-anim-ripple-wave-click($duration: 1.2s, $timing: ease-in-out);
+///
+@mixin ease-anim-ripple-wave-click($duration: var(--ease-duration, 1s), $timing: var(--ease-timing, ease), $fill: both) {
+  @keyframes ease-ripple-wave-click {
+  0%   { transform: scale(0); opacity: 0.6; }
+  100% { transform: scale(2.5); opacity: 0; }
+  }
+
+  .ease-anim-ripple-wave-click {
+    animation: ease-ripple-wave-click #{$duration} #{$timing} #{$fill};
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained SCSS animation mixin submission for **Ripple Wave Click** (closes #81681). Placed entirely under `submissions/scss/ripple-wave-click-scss-sb/` per the contribution guide.

`submissions/scss/ripple-wave-click-scss-sb/`:
- **`_ripple-wave-click.scss`** — emits the `@keyframes ease-ripple-wave-click` rule and a `.ease-anim-ripple-wave-click` utility class, with SassDoc usage examples.
- **`README.md`** — overview, usage, configurable parameters, CSS variables, and accessibility notes.

### Implementation requirements
- Defines `@keyframes ease-ripple-wave-click`.
- Provides `ease-anim-ripple-wave-click` utility class.
- Supports configurable timing variables (`--ease-duration`, `--ease-timing`).
- Includes `@media (prefers-reduced-motion: reduce)` override.

### Acceptance criteria
- Hardware accelerated using `transform` and `opacity` for 60 FPS.
- Clean SCSS compilation without warnings (verified with `sass`).
- Compatible with core EaseMotion CSS tokens.

Closes #81681

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._