### PR TITLE
feat: add screen reader only utility example (#81324)

### DIFF
--- a/submissions/examples/81324-sr-only/README.md
+++ b/submissions/examples/81324-sr-only/README.md
@@ -1,0 +1,18 @@
+# Screen Reader Only Utility
+
+A reusable CSS example for visually hiding content while keeping it accessible to screen readers.
+
+## SCSS helper concept
+
+```scss
+@mixin sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/submissions/examples/81324-sr-only/demo.html
+++ b/submissions/examples/81324-sr-only/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Screen Reader Only</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main>
+  <h1>Screen Reader Only Utility</h1>
+  <p class="sr-only">This text is visually hidden but remains available to screen readers.</p>
+  <button aria-label="Open menu">☰</button>
+  <span class="hint">The hidden text is accessible to assistive technology.</span>
+</main>
+</body>
+</html>

--- a/submissions/examples/81324-sr-only/style.css
+++ b/submissions/examples/81324-sr-only/style.css
@@ -1,0 +1,45 @@
+*{box-sizing:border-box}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  padding:1rem;
+  background:#f3f4f6;
+  color:#111827;
+  font-family:system-ui,sans-serif
+}
+
+main{
+  width:min(100%,600px);
+  text-align:center
+}
+
+button{
+  padding:.8rem 1rem;
+  border:0;
+  border-radius:10px;
+  background:#4f46e5;
+  color:#fff;
+  font-size:1.2rem;
+  cursor:pointer
+}
+
+.hint{
+  display:block;
+  margin-top:1rem;
+  color:#6b7280
+}
+
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0
+}


### PR DESCRIPTION
## Description

This PR adds a reusable Screen Reader Only utility example for accessible visually hidden content.

It is a critical issue for improving accessibility while preserving content for assistive technologies.

## Changes

- Added screen-reader-only utility
- Added accessible hidden text example
- Added responsive styling
- Kept all changes inside `submissions/`

## Testing

Tested locally using `demo.html`.

## Issue

Closes #81324