### PR TITLE
Add Stepper Progress example (stepper-progress-advk)

### DIFF
--- a/submissions/examples/stepper-progress-advk/README.md
+++ b/submissions/examples/stepper-progress-advk/README.md
@@ -1,0 +1,31 @@
+# Stepper Progress example
+
+A multi-step progress bar where each connecting line is coloured from the step's **own** done state, so no sibling inspection is needed (a step is only marked done once every step before it is too). Includes forced-colors and dark-mode support.
+
+## What it does
+Each step's outgoing connector uses `var(--ease-step-done)` only when that step carries `.is-done`. Because done-ness is monotonic, colouring the connector from the step itself is correct and simpler than inspecting siblings.
+
+## Files
+- `demo.html` — copy-paste markup
+- `style.css` — pure CSS, forced-colors + dark-mode support
+- `README.md` — this guide
+
+## Usage
+```html
+<link rel="stylesheet" href="./style.css" />
+<div class="stepper-progress-advk" role="progressbar" aria-valuenow="2" aria-valuemin="1" aria-valuemax="3" aria-label="Checkout progress">
+  <ol class="stepper-progress-advk__steps">
+    <li class="stepper-progress-advk__step is-done" aria-current="step"><span class="stepper-progress-advk__dot" aria-hidden="true">1</span><span class="stepper-progress-advk__label">Cart</span></li>
+    <li class="stepper-progress-advk__step is-done" aria-current="step"><span class="stepper-progress-advk__dot" aria-hidden="true">2</span><span class="stepper-progress-advk__label">Address</span></li>
+    <li class="stepper-progress-advk__step"><span class="stepper-progress-advk__dot" aria-hidden="true">3</span><span class="stepper-progress-advk__label">Pay</span></li>
+  </ol>
+</div>
+```
+
+## Accessibility
+- `role="progressbar"` with `aria-valuenow/min/max` on the container.
+- `aria-current="step"` on each completed/active step.
+- `@media (forced-colors: active)` swaps to system colours.
+- `@media (prefers-color-scheme: light)` for dark-mode support.
+
+Closes #75548

--- a/submissions/examples/stepper-progress-advk/demo.html
+++ b/submissions/examples/stepper-progress-advk/demo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>Stepper Progress</title><link rel="stylesheet" href="style.css"/></head><body><main>
+<div class="stepper-progress-advk" role="progressbar" aria-valuenow="2" aria-valuemin="1" aria-valuemax="3" aria-label="Checkout progress">
+  <ol class="stepper-progress-advk__steps">
+    <li class="stepper-progress-advk__step is-done" aria-current="step"><span class="stepper-progress-advk__dot" aria-hidden="true">1</span><span class="stepper-progress-advk__label">Cart</span></li>
+    <li class="stepper-progress-advk__step is-done" aria-current="step"><span class="stepper-progress-advk__dot" aria-hidden="true">2</span><span class="stepper-progress-advk__label">Address</span></li>
+    <li class="stepper-progress-advk__step"><span class="stepper-progress-advk__dot" aria-hidden="true">3</span><span class="stepper-progress-advk__label">Pay</span></li>
+  </ol>
+</div>
+</main></body></html>

--- a/submissions/examples/stepper-progress-advk/style.css
+++ b/submissions/examples/stepper-progress-advk/style.css
@@ -1,0 +1,22 @@
+/* Stepper Progress — submission for #75548 */
+:root { --ease-step-done: #22c55e; --ease-step-todo: #334155; --ease-step-fg: #f1f5f9; }
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; font-family: system-ui, sans-serif; }
+.stepper-progress-advk__steps { display: flex; gap: 0; list-style: none; padding: 0; margin: 0; counter-reset: step; }
+.stepper-progress-advk__step { position: relative; display: grid; grid-template-columns: auto; gap: 0.4rem; place-items: center; flex: 1; counter-increment: step; }
+.stepper-progress-advk__step:not(:last-child)::after {
+  content: ""; position: absolute; top: 1rem; left: 50%; right: -50%; height: 3px;
+  background: var(--ease-step-todo);
+}
+/* A step's connector is coloured only when THIS step is done (done implies all prior are done) */
+.stepper-progress-advk__step.is-done:not(:last-child)::after { background: var(--ease-step-done); }
+.stepper-progress-advk__dot { width: 2rem; height: 2rem; border-radius: 50%; display: grid; place-items: center; background: var(--ease-step-todo); color: var(--ease-step-fg); font-weight: 700; z-index: 1; }
+.stepper-progress-advk__step.is-done .stepper-progress-advk__dot { background: var(--ease-step-done); }
+.stepper-progress-advk__label { color: var(--ease-step-fg); }
+@media (forced-colors: active) {
+  .stepper-progress-advk__dot, .stepper-progress-advk__step::after { border: 1px solid ButtonText; }
+  .stepper-progress-advk__step.is-done .stepper-progress-advk__dot, .stepper-progress-advk__step.is-done::after { background: Highlight; }
+}
+@media (prefers-color-scheme: light) {
+  :root { --ease-step-todo: #e2e8f0; --ease-step-fg: #0f172a; }
+  body { background: #f8fafc; }
+}


### PR DESCRIPTION
## What changed

Self-contained example submission for **Stepper Progress** (closes #75548). Placed entirely under `submissions/examples/stepper-progress-advk/` per the contribution guide.

`submissions/examples/stepper-progress-advk/`:
- **`demo.html`** — copy-paste markup.
- **`style.css`** — pure CSS with forced-colors + dark-mode support.
- **`README.md`** — overview, usage, and accessibility notes.

### Requirement
Each connecting line is coloured from the step's **own** done state rather than needing to inspect a sibling, since a step is only marked done once every step before it is too. Includes forced-colors and dark-mode support.

Closes #75548

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._