### PR TITLE
Add Color Mode Toggle example (color-mode-toggle-advk)

### DIFF
--- a/submissions/examples/color-mode-toggle-advk/README.md
+++ b/submissions/examples/color-mode-toggle-advk/README.md
@@ -1,0 +1,34 @@
+# Color Mode Toggle example
+
+A three-way light/dark/system colour mode switch. **'System' clears the stored override entirely** (`removeAttribute` + `localStorage.removeItem`) rather than resolving and storing a fixed value, so `prefers-color-scheme` keeps tracking OS changes live afterward.
+
+## What it does
+- Light/Dark set `data-color-mode` on `<html>` and persist it in `localStorage`.
+- System removes the override so the OS preference governs live.
+
+## Files
+- `demo.html` — copy-paste markup
+- `style.css` — styles + `prefers-color-scheme: light` support
+- `toggle.js` — small enhancement script (progressive; degrades gracefully without JS)
+- `README.md` — this guide
+
+## Usage
+```html
+<link rel="stylesheet" href="./style.css" />
+<div class="color-mode-toggle-advk" role="group" aria-label="Color mode">
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="light" aria-pressed="false">Light</button>
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="dark" aria-pressed="false">Dark</button>
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="system" aria-pressed="true">System</button>
+</div>
+<script src="./toggle.js" defer></script>
+```
+
+## Accessibility
+- `role="group"` + `aria-label` on the container.
+- `aria-pressed` on each button reflecting the active mode.
+- `:focus-visible` outlines for keyboard users.
+
+## No-JS degradation
+Without `toggle.js`, the toggle is inert but the page still renders using `prefers-color-scheme`.
+
+Closes #75549

--- a/submissions/examples/color-mode-toggle-advk/demo.html
+++ b/submissions/examples/color-mode-toggle-advk/demo.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>Color Mode Toggle</title><link rel="stylesheet" href="style.css"/></head><body><main>
+<div class="color-mode-toggle-advk" role="group" aria-label="Color mode">
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="light" aria-pressed="false">Light</button>
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="dark" aria-pressed="false">Dark</button>
+  <button type="button" class="color-mode-toggle-advk__btn" data-mode="system" aria-pressed="true">System</button>
+</div>
+</main><script src="./toggle.js" defer></script></body></html>

--- a/submissions/examples/color-mode-toggle-advk/style.css
+++ b/submissions/examples/color-mode-toggle-advk/style.css
@@ -1,0 +1,7 @@
+/* Color Mode Toggle — submission for #75549 */
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f1f5f9; font-family: system-ui, sans-serif; }
+.color-mode-toggle-advk { display: inline-flex; padding: 0.25rem; background: #1e293b; border-radius: 999px; }
+.color-mode-toggle-advk__btn { padding: 0.4rem 0.9rem; border: 0; background: transparent; color: #94a3b8; border-radius: 999px; cursor: pointer; }
+.color-mode-toggle-advk__btn[aria-pressed="true"] { background: #6366f1; color: #fff; }
+.color-mode-toggle-advk__btn:focus-visible { outline: 3px solid Highlight; outline-offset: 2px; }
+@media (prefers-color-scheme: light) { body { background: #f8fafc; color: #0f172a; } .color-mode-toggle-advk { background: #e2e8f0; } .color-mode-toggle-advk__btn { color: #475569; } }

--- a/submissions/examples/color-mode-toggle-advk/toggle.js
+++ b/submissions/examples/color-mode-toggle-advk/toggle.js
@@ -1,0 +1,38 @@
+/* Color Mode Toggle behaviour — submission for #75549
+ *
+ * 'System' clears the stored override entirely (removeAttribute on <html> +
+ * localStorage.removeItem) rather than resolving and storing a fixed value,
+ * so prefers-color-scheme keeps tracking OS changes live afterward.
+ */
+(function () {
+  var root = document.documentElement;
+  var KEY = "color-mode-advk";
+
+  function apply(mode) {
+    if (mode === "light" || mode === "dark") {
+      root.setAttribute("data-color-mode", mode);
+      localStorage.setItem(KEY, mode);
+    } else {
+      // System: clear the override so prefers-color-scheme stays authoritative.
+      root.removeAttribute("data-color-mode");
+      localStorage.removeItem(KEY);
+    }
+    document.querySelectorAll(".color-mode-toggle-advk__btn").forEach(function (btn) {
+      btn.setAttribute("aria-pressed", String(btn.getAttribute("data-mode") === mode));
+    });
+  }
+
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest && e.target.closest(".color-mode-toggle-advk__btn");
+    if (!btn) return;
+    apply(btn.getAttribute("data-mode"));
+  });
+
+  // Seed from stored override only; if none, leave 'system' live.
+  var stored = localStorage.getItem(KEY);
+  if (stored === "light" || stored === "dark") {
+    apply(stored);
+  } else {
+    apply("system");
+  }
+})();


### PR DESCRIPTION
## What changed

Self-contained example submission for **Color Mode Toggle** (closes #75549). Placed entirely under `submissions/examples/color-mode-toggle-advk/` per the contribution guide.

`submissions/examples/color-mode-toggle-advk/`:
- **`demo.html`** — copy-paste markup.
- **`style.css`** — styles with `prefers-color-scheme: light` support.
- **`toggle.js`** — small enhancement script (progressive; degrades gracefully without JS).
- **`README.md`** — overview, usage, and accessibility notes.

### Requirement
'System' clears the stored override entirely (`removeAttribute` + `localStorage.removeItem`) rather than resolving and storing a fixed value, so `prefers-color-scheme` keeps tracking OS changes live afterward.

Closes #75549

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._