### PR TITLE
Add Empty State Search example (empty-state-search-advk)

### DIFF
--- a/submissions/examples/empty-state-search-advk/README.md
+++ b/submissions/examples/empty-state-search-advk/README.md
@@ -1,0 +1,39 @@
+# Empty State Search example
+
+A filtered search results list whose empty state **echoes back the exact query** ("No results for xyz") rather than being a dead end. Uses the `hidden` attribute for visibility state and degrades to the full list with JS disabled.
+
+## What it does
+- Filters the list as you type.
+- When nothing matches, shows "No results for {query}" with the exact text echoed.
+- With JS disabled, the full list is shown (the empty-state paragraph stays `hidden`).
+
+## Files
+- `demo.html` — copy-paste markup
+- `style.css` — styles
+- `filter.js` — small enhancement script (progressive)
+- `README.md` — this guide
+
+## Usage
+```html
+<link rel="stylesheet" href="./style.css" />
+<section class="empty-state-search-advk" aria-labelledby="ess-title">
+  <input type="search" class="empty-state-search-advk__input" placeholder="Search..." aria-label="Search" />
+  <ul class="empty-state-search-advk__results" aria-live="polite">
+    <li class="empty-state-search-advk__item">Apple</li>
+    <li class="empty-state-search-advk__item">Banana</li>
+    <li class="empty-state-search-advk__item">Cherry</li>
+  </ul>
+  <p class="empty-state-search-advk__empty" hidden id="ess-title">No results for <span class="empty-state-search-advk__query"></span></p>
+</section>
+<script src="./filter.js" defer></script>
+```
+
+## Accessibility
+- `aria-live="polite"` on the results container so screen readers announce updates.
+- `aria-labelledby` linking the section to the empty-state title.
+- `:focus-visible` outlines for keyboard users.
+
+## No-JS degradation
+Without `filter.js`, the full list renders and the empty state stays `hidden`.
+
+Closes #75551

--- a/submissions/examples/empty-state-search-advk/demo.html
+++ b/submissions/examples/empty-state-search-advk/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>Empty State Search</title><link rel="stylesheet" href="style.css"/></head><body><main>
+<section class="empty-state-search-advk" aria-labelledby="ess-title">
+  <input type="search" class="empty-state-search-advk__input" placeholder="Search..." aria-label="Search" />
+  <ul class="empty-state-search-advk__results" aria-live="polite">
+    <li class="empty-state-search-advk__item">Apple</li>
+    <li class="empty-state-search-advk__item">Banana</li>
+    <li class="empty-state-search-advk__item">Cherry</li>
+  </ul>
+  <p class="empty-state-search-advk__empty" hidden id="ess-title">No results for <span class="empty-state-search-advk__query"></span></p>
+</section>
+</main><script src="./filter.js" defer></script></body></html>

--- a/submissions/examples/empty-state-search-advk/filter.js
+++ b/submissions/examples/empty-state-search-advk/filter.js
@@ -1,0 +1,31 @@
+/* Empty State Search — submission for #75551
+ *
+ * Filters results and toggles the `hidden` attribute. Echoes back the exact
+ * query ("No results for xyz") so the empty state is not a dead end.
+ * Uses the `hidden` attribute for visibility state; degrades to the full
+ * list with JS disabled (the empty-state paragraph is hidden by default).
+ */
+(function () {
+  var section = document.querySelector(".empty-state-search-advk");
+  if (!section) return;
+  var input = section.querySelector(".empty-state-search-advk__input");
+  var items = Array.prototype.slice.call(section.querySelectorAll(".empty-state-search-advk__item"));
+  var empty = section.querySelector(".empty-state-search-advk__empty");
+  var queryEl = section.querySelector(".empty-state-search-advk__query");
+
+  input.addEventListener("input", function () {
+    var q = input.value.trim().toLowerCase();
+    var visible = 0;
+    items.forEach(function (item) {
+      var match = item.textContent.toLowerCase().indexOf(q) !== -1;
+      item.hidden = !match;
+      if (match) visible++;
+    });
+    if (visible === 0 && q !== "") {
+      queryEl.textContent = input.value.trim();
+      empty.hidden = false;
+    } else {
+      empty.hidden = true;
+    }
+  });
+})();

--- a/submissions/examples/empty-state-search-advk/style.css
+++ b/submissions/examples/empty-state-search-advk/style.css
@@ -1,0 +1,9 @@
+/* Empty State Search — submission for #75549 -> 75551 */
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f1f5f9; font-family: system-ui, sans-serif; }
+.empty-state-search-advk { display: grid; gap: 0.75rem; width: 18rem; }
+.empty-state-search-advk__input { padding: 0.6rem 0.9rem; border: 1px solid #334155; background: #1e293b; color: #f1f5f9; border-radius: 0.5rem; }
+.empty-state-search-advk__input:focus-visible { outline: 3px solid Highlight; outline-offset: 2px; border-color: #6366f1; }
+.empty-state-search-advk__results { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.25rem; }
+.empty-state-search-advk__item { padding: 0.5rem 0.75rem; background: #1e293b; border-radius: 0.4rem; }
+.empty-state-search-advk__empty { color: #94a3b8; text-align: center; }
+.empty-state-search-advk__query { color: #f1f5f9; font-weight: 700; }


### PR DESCRIPTION
## What changed

Self-contained example submission for **Empty State Search** (closes #75551). Placed entirely under `submissions/examples/empty-state-search-advk/` per the contribution guide.

`submissions/examples/empty-state-search-advk/`:
- **`demo.html`** — copy-paste markup.
- **`style.css`** — styles.
- **`filter.js`** — small enhancement script (progressive; degrades gracefully without JS).
- **`README.md`** — overview, usage, and accessibility notes.

### Requirement
The empty state echoes back the exact query, so 'No results' reads as 'No results for xyz' rather than a dead end. Uses the `hidden` attribute for visibility state and degrades to the full list with JS disabled.

Closes #75551

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._