### PR TITLE
Add useOnlineStatus hook (use-online-status-advk)

### DIFF
--- a/submissions/react/use-online-status-advk/README.md
+++ b/submissions/react/use-online-status-advk/README.md
@@ -1,0 +1,27 @@
+# useOnlineStatus hook
+
+A React hook that tracks `navigator.onLine` and the `online`/`offline` events.
+
+## What it does
+- Returns a boolean reflecting current connectivity.
+- Seeded **synchronously** from `navigator.onLine` in the `useState` initializer to avoid a false "online" flash on first render for a page loaded from cache while disconnected.
+- Subscribes to `online`/`offline` events and cleans up on unmount.
+
+## Files
+- `useOnlineStatus.js` — the hook
+- `README.md` — this guide
+
+## Usage
+```jsx
+import { useOnlineStatus } from "./useOnlineStatus";
+
+function App() {
+  const online = useOnlineStatus();
+  return <div>{online ? "Online" : "Offline"}</div>;
+}
+```
+
+## Why synchronous seeding
+A lazy `useState(() => navigator.onLine)` initialiser prevents the first paint from rendering `true` (online) when the page was actually loaded from cache while offline, then flipping to `false` after mount.
+
+Closes #75553

--- a/submissions/react/use-online-status-advk/useOnlineStatus.js
+++ b/submissions/react/use-online-status-advk/useOnlineStatus.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+/**
+ * useOnlineStatus — tracks navigator.onLine and the online/offline events.
+ *
+ * Seeded synchronously from navigator.onLine to avoid a false "online" flash
+ * on first render for a page loaded from cache while disconnected.
+ *
+ * @returns {boolean} Whether the browser is currently online.
+ *
+ * @example
+ *   const online = useOnlineStatus();
+ *   if (!online) return <OfflineBanner />;
+ */
+export function useOnlineStatus() {
+  const [online, setOnline] = useState(() =>
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    // Re-sync in case state changed between initial render and effect.
+    setOnline(navigator.onLine);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return online;
+}
+
+export default useOnlineStatus;


### PR DESCRIPTION
## What changed

Self-contained React hook submission for **useOnlineStatus** (closes #75553). Placed entirely under `submissions/react/use-online-status-advk/` per the contribution guide.

`submissions/react/use-online-status-advk/`:
- **`useOnlineStatus.js`** — the hook.
- **`README.md`** — overview, usage, and rationale.

### Requirement
Tracks `navigator.onLine` and the `online`/`offline` events, seeded **synchronously** from `navigator.onLine` to avoid a false 'online' flash on first render for a page loaded from cache while disconnected.

Closes #75553

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._