### PR TITLE
Add useToggle hook (use-toggle-advk)

### DIFF
--- a/submissions/react/use-toggle-advk/README.md
+++ b/submissions/react/use-toggle-advk/README.md
@@ -1,0 +1,31 @@
+# useToggle hook
+
+A React hook providing boolean state with a stable `toggle` function plus explicit `setTrue` / `setFalse`.
+
+## What it does
+- `toggle` flips the boolean (stable identity via `useCallback`).
+- `setTrue` / `setFalse` are unconditional, for cases that need "always set false" rather than a flip (e.g. closing a modal from an overlay click).
+
+## Files
+- `useToggle.js` — the hook
+- `README.md` — this guide
+
+## Usage
+```jsx
+import { useToggle } from "./useToggle";
+
+function Modal({ children }) {
+  const [open, { toggle, setFalse }] = useToggle(false);
+  return (
+    <div onClick={setFalse}>
+      <button onClick={toggle}>{open ? "Close" : "Open"}</button>
+      {open && <dialog onClick={(e) => e.stopPropagation()}>{children}</dialog>}
+    </div>
+  );
+}
+```
+
+## Why not just toggle
+Overlay-click-to-close must always set `false`, even if a child event already toggled state. `setFalse` guarantees that without depending on the previous value.
+
+Closes #75554

--- a/submissions/react/use-toggle-advk/useToggle.js
+++ b/submissions/react/use-toggle-advk/useToggle.js
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+/**
+ * useToggle — boolean state with a stable toggle function plus explicit
+ * setTrue / setFalse.
+ *
+ * Operations like closing a modal from an overlay click need "always set
+ * false", not a flip. The returned `toggle` flips, while `setTrue`/`setFalse`
+ * are unconditional for those cases.
+ *
+ * @param {boolean} [initial=false] Initial value
+ * @returns {[boolean, {toggle: Function, setTrue: Function, setFalse: Function, setValue: Function}]}
+ *
+ * @example
+ *   const [open, { toggle, setFalse }] = useToggle(false);
+ *   return <dialog open={open} onClick={setFalse}>{children}</dialog>;
+ */
+export function useToggle(initial = false) {
+  const [value, setValue] = useState(initial);
+
+  const toggle = useCallback(() => setValue((v) => !v), []);
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
+
+  return [value, { toggle, setTrue, setFalse, setValue }];
+}
+
+export default useToggle;


### PR DESCRIPTION
## What changed

Self-contained React hook submission for **useToggle** (closes #75554). Placed entirely under `submissions/react/use-toggle-advk/` per the contribution guide.

`submissions/react/use-toggle-advk/`:
- **`useToggle.js`** — the hook.
- **`README.md`** — overview, usage, and rationale.

### Requirement
Provides boolean state with a stable `toggle` function plus explicit `setTrue`/`setFalse`, since operations like closing a modal from an overlay click need 'always set false', not a flip.

Closes #75554

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._