### PR TITLE
Add link-underline Sass mixins (link-underline-advk)

### DIFF
--- a/submissions/scss/link-underline-advk/README.md
+++ b/submissions/scss/link-underline-advk/README.md
@@ -1,0 +1,27 @@
+# Link underline (background-gradient) Sass mixins
+
+Sass mixins that draw link underlines as a background gradient instead of `text-decoration`, avoiding descender clipping and enabling a smooth hover animation via `background-size` that `text-decoration-thickness` cannot provide.
+
+## What it does
+- `link-underline($color, $thickness, $gap, $hover)` — underline that grows in width on hover/focus.
+- `link-underline-always($color, $thickness, $gap)` — persistent underline for non-interactive links.
+
+## Files
+- `_link-underline.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./link-underline" as *;
+
+a {
+  @include link-underline(currentColor, 2px, 0.15em, grow);
+}
+```
+
+## Why background-gradient
+`text-decoration` underlines can clip descenders and `text-decoration-thickness` cannot animate width. A `linear-gradient` background with an animated `background-size` gives a clean, smooth grow effect that never clips glyphs.
+
+## Accessibility
+- `:focus-visible` keeps the underline visible for keyboard focus.
+
+Closes #75556

--- a/submissions/scss/link-underline-advk/_link-underline.scss
+++ b/submissions/scss/link-underline-advk/_link-underline.scss
@@ -1,0 +1,47 @@
+// ============================================================
+// EaseMotion CSS — Link underline (background-gradient) Sass mixins
+// Submission for #75556
+// ============================================================
+
+/// Draws a link underline as a background gradient instead of using
+/// text-decoration. This avoids descender clipping and enables a smooth
+/// hover animation via background-size that text-decoration-thickness
+/// cannot provide.
+///
+/// @param {Color}  $color [currentColor] Underline colour
+/// @param {Number} $thickness [2px] Underline thickness
+/// @param {Number} $gap [0.15em] Gap between baseline and underline
+/// @param {String} $hover [grow] grow | none — animate width on hover
+///
+/// @example scss
+///   a { @include link-underline(currentColor, 2px, 0.15em, grow); }
+///
+@mixin link-underline($color: currentColor, $thickness: 2px, $gap: 0.15em, $hover: grow) {
+  text-decoration: none;
+  background-image: linear-gradient($color, $color);
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% #{$thickness};
+  padding-bottom: $gap;
+  @if $hover == grow {
+    background-size: 0 #{$thickness};
+    transition: background-size 0.25s ease;
+    &:hover, &:focus-visible {
+      background-size: 100% #{$thickness};
+    }
+  }
+}
+
+/// A persistent (always-on) variant for non-interactive links.
+///
+/// @example scss
+///   .ref { @include link-underline-always(currentColor, 1px, 0.1em); }
+///
+@mixin link-underline-always($color: currentColor, $thickness: 1px, $gap: 0.1em) {
+  text-decoration: none;
+  background-image: linear-gradient($color, $color);
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% #{$thickness};
+  padding-bottom: $gap;
+}


### PR DESCRIPTION
## What changed

Self-contained Sass mixin submission for **link-underline** (closes #75556). Placed entirely under `submissions/scss/link-underline-advk/` per the contribution guide.

`submissions/scss/link-underline-advk/`:
- **`_link-underline.scss`** — the mixin partial (SassDoc + usage).
- **`README.md`** — overview, usage, and rationale.

### Requirement
Link underlines drawn as a background gradient instead of `text-decoration`, avoiding descender clipping and enabling a smooth hover animation via `background-size` that `text-decoration-thickness` cannot provide. Clean SCSS compilation verified with `sass`.

Closes #75556

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._