### PR TITLE
Add sr-live-region Sass mixins (sr-live-region-advk)

### DIFF
--- a/submissions/scss/sr-live-region-advk/README.md
+++ b/submissions/scss/sr-live-region-advk/README.md
@@ -1,0 +1,28 @@
+# aria-live region Sass mixins
+
+Sass mixins for aria-live regions: a visually-hidden clip-based variant (not `display:none`, which some screen readers skip announcing) for announce-only status text, plus a visible variant for status toasts that should also be seen.
+
+## What it does
+- `sr-only-live` — visually hides a live region while keeping it announceable (clip-based, not `display:none`).
+- `visible-live($bg, $fg, $duration)` — visible toast styling with a polite enter animation and reduced-motion guard.
+
+## Files
+- `_sr-live-region.scss` — the mixin partial
+
+## Usage
+```scss
+@use "./sr-live-region" as *;
+
+.sr-status { @include sr-only-live; }
+.toast     { @include visible-live(#1e293b, #f1f5f9); }
+```
+
+```html
+<p class="sr-status" role="status" aria-live="polite">Saved.</p>
+<div class="toast" role="status" aria-live="polite">Saved.</div>
+```
+
+## Why clip, not display:none
+Some screen readers do not announce content inside `display:none` elements. A clip-based hide keeps the text in the accessibility tree so the live region fires.
+
+Closes #75557

--- a/submissions/scss/sr-live-region-advk/_sr-live-region.scss
+++ b/submissions/scss/sr-live-region-advk/_sr-live-region.scss
@@ -1,0 +1,54 @@
+// ============================================================
+// EaseMotion CSS — aria-live region Sass mixins
+// Submission for #75557
+// ============================================================
+
+/// Visually-hidden, clip-based variant for announce-only status text.
+/// Uses clip (not display:none, which some screen readers skip announcing)
+/// so the live region's text is still read out.
+///
+/// @example scss
+///   .sr-status { @include sr-only-live; }
+///   <p class="sr-status" role="status" aria-live="polite">Saved.</p>
+///
+@mixin sr-only-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/// Visible variant for status toasts that should also be seen (not just
+/// announced). Pairs with role="status" / aria-live="polite".
+///
+/// @param {Color}  $bg [var(--ease-toast-bg, #1e293b)] Toast background
+/// @param {Color}  $fg [var(--ease-toast-fg, #f1f5f9)] Toast foreground
+/// @param {Number} $duration [0.3s] Enter animation duration
+///
+/// @example scss
+///   .toast { @include visible-live(#1e293b, #f1f5f9); }
+///   <div class="toast" role="status" aria-live="polite">Saved.</div>
+///
+@mixin visible-live($bg: var(--ease-toast-bg, #1e293b), $fg: var(--ease-toast-fg, #f1f5f9), $duration: 0.3s) {
+  padding: 0.75rem 1rem;
+  background: $bg;
+  color: $fg;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  animation: ease-toast-in #{$duration} ease both;
+
+  @keyframes ease-toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What changed

Self-contained Sass mixin submission for **sr-live-region** (closes #75557). Placed entirely under `submissions/scss/sr-live-region-advk/` per the contribution guide.

`submissions/scss/sr-live-region-advk/`:
- **`_sr-live-region.scss`** — the mixin partial (SassDoc + usage).
- **`README.md`** — overview, usage, and accessibility notes.

### Requirement
Sass mixins for aria-live regions: a visually-hidden clip-based variant (not `display:none`, which some screen readers skip announcing) for announce-only status text, plus a visible variant for status toasts that should also be seen. Clean SCSS compilation verified with `sass`.

Closes #75557

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._