### PR TITLE
feat: add grid template area example (#81330)

### DIFF
--- a/submissions/examples/81330-grid-template-area/README.md
+++ b/submissions/examples/81330-grid-template-area/README.md
@@ -1,0 +1,10 @@
+# Grid Template Area
+
+Responsive example demonstrating named CSS Grid layout areas.
+
+## SCSS helper concept
+
+```scss
+@mixin grid-template-areas($areas) {
+  grid-template-areas: $areas;
+}

--- a/submissions/examples/81330-grid-template-area/demo.html
+++ b/submissions/examples/81330-grid-template-area/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Grid Template Areas</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="layout">
+  <header>Header</header>
+  <nav>Navigation</nav>
+  <main>Main Content</main>
+  <aside>Sidebar</aside>
+  <footer>Footer</footer>
+</div>
+</body>
+</html>

--- a/submissions/examples/81330-grid-template-area/style.css
+++ b/submissions/examples/81330-grid-template-area/style.css
@@ -1,0 +1,53 @@
+*{box-sizing:border-box}
+
+body{
+  margin:0;
+  min-height:100vh;
+  padding:1rem;
+  font-family:system-ui,sans-serif;
+  background:#eef2f7
+}
+
+.layout{
+  width:min(100%,900px);
+  min-height:90vh;
+  margin:auto;
+  display:grid;
+  gap:1rem;
+  grid-template-areas:
+    "header header"
+    "nav main"
+    "aside main"
+    "footer footer";
+  grid-template-columns:180px 1fr;
+  grid-template-rows:auto 1fr 1fr auto
+}
+
+.layout>*{
+  padding:1.2rem;
+  border-radius:12px;
+  background:#4f46e5;
+  color:#fff;
+  display:grid;
+  place-items:center;
+  font-weight:700
+}
+
+header{grid-area:header}
+nav{grid-area:nav}
+main{grid-area:main;background:#059669}
+aside{grid-area:aside}
+footer{grid-area:footer}
+
+@media(max-width:600px){
+  .layout{
+    grid-template-areas:
+      "header"
+      "nav"
+      "main"
+      "aside"
+      "footer";
+    grid-template-columns:1fr;
+    grid-template-rows:auto
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a responsive Grid Template Area example using named CSS Grid sections.

It is a critical issue for extending the EaseMotion examples with reusable declarative layout utilities.

## Changes

- Added named grid areas
- Added responsive mobile layout
- Added SCSS helper concept
- Kept all changes inside `submissions/`

## Testing

Tested locally using `demo.html`.

## Issue

Closes #81330