### PR TITLE
feat: add truncate single line example (#81323)

### DIFF
--- a/submissions/examples/81323-truncate-single-line/README.md
+++ b/submissions/examples/81323-truncate-single-line/README.md
@@ -1,0 +1,12 @@
+# Truncate Single Line
+
+Responsive example for single-line text truncation.
+
+## SCSS helper concept
+
+```scss
+@mixin truncate-single-line {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/submissions/examples/81323-truncate-single-line/demo.html
+++ b/submissions/examples/81323-truncate-single-line/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Truncate Single Line</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<main>
+  <h1>Single Line Truncation</h1>
+  <p class="truncate">This is a long line of text that will be truncated with an ellipsis when it exceeds the available width.</p>
+</main>
+</body>
+</html>

--- a/submissions/examples/81323-truncate-single-line/style.css
+++ b/submissions/examples/81323-truncate-single-line/style.css
@@ -1,0 +1,21 @@
+*{box-sizing:border-box}
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  padding:1rem;
+  background:#eef2f7;
+  font-family:system-ui,sans-serif
+}
+main{width:min(100%,600px);text-align:center}
+.truncate{
+  max-width:100%;
+  margin:2rem auto;
+  padding:1rem;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  border-radius:10px;
+  background:#fff
+}


### PR DESCRIPTION
## Description

This PR adds a reusable single-line text truncation example.

It is a critical issue for handling overflowing text cleanly in responsive interfaces.

## Changes

- Added single-line truncation
- Added ellipsis overflow handling
- Added responsive styling
- Kept all changes inside `submissions/`

## Testing

Tested locally using `demo.html`.

## Issue

Closes #81323