### PR TITLE
feat(scss): Add SCSS Filter Drop Shadow helper mixins

### DIFF
--- a/submissions/scss/filter-drop-shadow-ag/README.md
+++ b/submissions/scss/filter-drop-shadow-ag/README.md
@@ -1,0 +1,35 @@
+# Filter Drop Shadow Mixin (ag)
+
+## Description
+This SCSS mixin applies a customizable `filter: drop-shadow` effect for elements, which is ideal for transparent PNGs and SVGs. It natively supports hover state animations, comprehensive browser fallbacks, and CSS variable integration for runtime configuration while adhering to the core EaseMotion CSS tokens for easing and transitions.
+
+## Usage
+Import the mixin into your SCSS file and include it on your target element.
+
+```scss
+@use 'path/to/filter-drop-shadow-ag' as *;
+
+.my-transparent-image {
+  @include filter-drop-shadow(
+    $x-offset: 0px,
+    $y-offset: 6px,
+    $blur-radius: 12px,
+    $color: rgba(0, 0, 0, 0.15)
+  );
+}
+```
+
+### Parameters
+* `$x-offset`: The horizontal offset of the shadow (default: `0`)
+* `$y-offset`: The vertical offset of the shadow (default: `4px`)
+* `$blur-radius`: The blur radius of the shadow (default: `8px`)
+* `$color`: The shadow color (default: `rgba(0, 0, 0, 0.2)`)
+* `$hover-x-offset`: Hover horizontal offset (default: `0`)
+* `$hover-y-offset`: Hover vertical offset (default: `8px`)
+* `$hover-blur-radius`: Hover blur radius (default: `16px`)
+* `$hover-color`: Hover shadow color (default: `rgba(0, 0, 0, 0.3)`)
+* `$transition-duration`: The duration of the hover transition (default: `$duration-normal`)
+* `$transition-easing`: The easing curve of the transition (default: `$ease-out-cubic`)
+
+## Why is it useful?
+Using `box-shadow` on a transparent PNG or SVG applies a rectangular shadow around the element's bounding box, which ignores the actual visual outline. `filter: drop-shadow` beautifully conforms to the alpha channel of your images. This mixin solves the pain point of missing cross-browser support by implementing intelligent fallbacks using standard `box-shadow` where `filter` is unsupported, ensuring your UI degrades gracefully on older browsers.

--- a/submissions/scss/filter-drop-shadow-ag/_filter-drop-shadow-ag.scss
+++ b/submissions/scss/filter-drop-shadow-ag/_filter-drop-shadow-ag.scss
@@ -1,0 +1,47 @@
+@use '../../../../scss/variables' as *;
+
+@mixin filter-drop-shadow(
+  $x-offset: 0,
+  $y-offset: 4px,
+  $blur-radius: 8px,
+  $color: rgba(0, 0, 0, 0.2),
+  $hover-x-offset: 0,
+  $hover-y-offset: 8px,
+  $hover-blur-radius: 16px,
+  $hover-color: rgba(0, 0, 0, 0.3),
+  $transition-duration: $duration-normal,
+  $transition-easing: $ease-out-cubic
+) {
+  // CSS Variable integration
+  --drop-shadow-x: #{$x-offset};
+  --drop-shadow-y: #{$y-offset};
+  --drop-shadow-blur: #{$blur-radius};
+  --drop-shadow-color: #{$color};
+
+  --hover-drop-shadow-x: #{$hover-x-offset};
+  --hover-drop-shadow-y: #{$hover-y-offset};
+  --hover-drop-shadow-blur: #{$hover-blur-radius};
+  --hover-drop-shadow-color: #{$hover-color};
+
+  // Browser fallback using standard box-shadow
+  box-shadow: var(--drop-shadow-x) var(--drop-shadow-y) var(--drop-shadow-blur) var(--drop-shadow-color);
+  
+  // Filter drop-shadow for transparent PNGs and SVGs
+  @supports (filter: drop-shadow(0 0 0 transparent)) or (-webkit-filter: drop-shadow(0 0 0 transparent)) {
+    box-shadow: none;
+    -webkit-filter: drop-shadow(var(--drop-shadow-x) var(--drop-shadow-y) var(--drop-shadow-blur) var(--drop-shadow-color));
+    filter: drop-shadow(var(--drop-shadow-x) var(--drop-shadow-y) var(--drop-shadow-blur) var(--drop-shadow-color));
+  }
+
+  transition: filter $transition-duration $transition-easing, box-shadow $transition-duration $transition-easing, -webkit-filter $transition-duration $transition-easing;
+
+  &:hover {
+    box-shadow: var(--hover-drop-shadow-x) var(--hover-drop-shadow-y) var(--hover-drop-shadow-blur) var(--hover-drop-shadow-color);
+    
+    @supports (filter: drop-shadow(0 0 0 transparent)) or (-webkit-filter: drop-shadow(0 0 0 transparent)) {
+      box-shadow: none;
+      -webkit-filter: drop-shadow(var(--hover-drop-shadow-x) var(--hover-drop-shadow-y) var(--hover-drop-shadow-blur) var(--hover-drop-shadow-color));
+      filter: drop-shadow(var(--hover-drop-shadow-x) var(--hover-drop-shadow-y) var(--hover-drop-shadow-blur) var(--hover-drop-shadow-color));
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #81300 by adding an SCSS Filter Drop Shadow helper mixin to provide customizable, transparent shadow effects for PNGs and SVGs with built-in fallbacks.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A - SCSS Track)*
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A - SCSS Track)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a new highly customizable SCSS mixin (`filter-drop-shadow`) that applies a `filter: drop-shadow` effect. Unlike standard `box-shadow` which wraps around the bounding box, this perfectly conforms to the alpha channel of transparent images (PNGs, SVGs). It integrates CSS variables for runtime configuration, seamlessly handles fallback properties for unsupported browsers, and respects core EaseMotion duration and easing tokens during hover transitions.

**How does a developer use it?**

```scss
@use 'path/to/filter-drop-shadow-ag' as *;

// Apply to any element, specifically transparent images
.my-transparent-image {
  @include filter-drop-shadow(
    $x-offset: 0px,
    $y-offset: 6px,
    $blur-radius: 12px,
    $color: rgba(0, 0, 0, 0.15)
  );
}
