### PR TITLE
feat(scss): add SCSS Filter Drop Shadow helper mixins

### DIFF
--- a/submissions/scss/ease-filter-drop-shadow-ag/README.md
+++ b/submissions/scss/ease-filter-drop-shadow-ag/README.md
@@ -1,0 +1,21 @@
+# ease-filter-drop-shadow-ag
+
+Adds comprehensive functionality to the EaseMotion SCSS mixin suite for filter drop-shadow mixin providing transparent PNG and SVG shadow effects.
+
+## Usage
+
+```scss
+@use "ease-filter-drop-shadow-ag" as *;
+
+.my-element {
+  @include ease-filter-drop-shadow-ag(0, 8px, 12px, rgba(0,0,0,0.15));
+}
+
+.my-png-icon {
+  @include ease-png-svg-shadow-ag(rgba(0,0,0,0.2));
+}
+```
+
+## Why is it useful?
+
+It provides an easy way to add drop shadows to transparent images like PNGs and SVGs with browser fallbacks and CSS variable integration, maintaining full compatibility with core EaseMotion CSS tokens.

--- a/submissions/scss/ease-filter-drop-shadow-ag/_ease-filter-drop-shadow-ag.scss
+++ b/submissions/scss/ease-filter-drop-shadow-ag/_ease-filter-drop-shadow-ag.scss
@@ -1,0 +1,30 @@
+// _ease-filter-drop-shadow-ag.scss
+@use '../../../scss/variables' as *;
+
+/// Adds a customizable filter drop-shadow with browser fallbacks and CSS variable integration.
+/// @param {Length} $x [0] - Horizontal offset
+/// @param {Length} $y [4px] - Vertical offset
+/// @param {Length} $blur [6px] - Blur radius
+/// @param {Color} $color [rgba(0,0,0,0.1)] - Shadow color
+/// @param {String} $var-name ['--ease-drop-shadow'] - CSS variable name for the shadow
+/// @example scss
+///   .my-element {
+///     @include ease-filter-drop-shadow-ag(0, 8px, 12px, rgba(0,0,0,0.15));
+///   }
+@mixin ease-filter-drop-shadow-ag($x: 0, $y: 4px, $blur: 6px, $color: rgba(0,0,0,0.1), $var-name: '--ease-drop-shadow') {
+  #{$var-name}: drop-shadow(#{$x} #{$y} #{$blur} #{$color});
+  
+  -webkit-filter: drop-shadow(#{$x} #{$y} #{$blur} #{$color});
+  filter: drop-shadow(#{$x} #{$y} #{$blur} #{$color});
+  filter: var(#{$var-name});
+}
+
+/// Utility for transparent PNG and SVG shadow effects.
+/// @param {Color} $color [rgba(0,0,0,0.15)] - Shadow color
+/// @example scss
+///   .my-png-icon {
+///     @include ease-png-svg-shadow-ag(rgba(0,0,0,0.2));
+///   }
+@mixin ease-png-svg-shadow-ag($color: rgba(0,0,0,0.15)) {
+  @include ease-filter-drop-shadow-ag(0, 8px, 12px, $color, '--ease-png-svg-shadow');
+}


### PR DESCRIPTION
## Pull Request Description

Adds comprehensive functionality to the EaseMotion SCSS mixin suite for a filter drop-shadow mixin, providing support for transparent PNG and SVG shadow effects with browser fallbacks and CSS variable integration.

Resolves #81300

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A for SCSS track)*
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A for SCSS track - `_ease-filter-drop-shadow-ag.scss` provided)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Provides customizable `filter: drop-shadow()` mixins designed specifically to cast accurate shadows behind transparent elements like PNGs and SVGs.

**How does a developer use it?**

```scss
@use "ease-filter-drop-shadow-ag" as *;

.my-element {
  @include ease-filter-drop-shadow-ag(0, 8px, 12px, rgba(0,0,0,0.15));
}

.my-png-icon {
  @include ease-png-svg-shadow-ag(rgba(0,0,0,0.2));
}
