### PR TITLE
feat(scss): Add SCSS Grayscale Filter Transition helper mixins

### DIFF
--- a/submissions/scss/grayscale-filter-transition-ag/README.md
+++ b/submissions/scss/grayscale-filter-transition-ag/README.md
@@ -1,0 +1,35 @@
+# Grayscale Filter Transition SCSS Mixins
+
+## What does this do?
+Adds comprehensive SCSS mixins to create smooth, responsive CSS filter transitions (grayscale, sepia, and hue-rotate) with CSS variables, vendor prefixes, and accessibility (reduced motion) fallbacks.
+
+## How is it used?
+
+Include the mixin in your SCSS file:
+
+```scss
+@import 'grayscale-filter-transition';
+
+// Standard grayscale transition on hover
+.image-gallery img {
+  @include grayscale-transition(100%, 0.4s, ease-out);
+}
+
+// Vintage sepia effect
+.card-vintage {
+  @include sepia-transition(80%, 0.3s, ease-in-out);
+}
+
+// Color cycling effect
+.dynamic-logo {
+  @include hue-rotate-transition(180deg, 0.5s);
+}
+
+// Custom filter base mixin
+.custom-element {
+  @include filter-transition(invert, 100%, 0.2s, linear);
+}
+```
+
+## Why is it useful?
+It seamlessly integrates complex CSS filter transitions with minimal SCSS boilerplate, while adhering to EaseMotion's standards for accessibility (honoring `prefers-reduced-motion`) and CSS variables integration, ensuring the effects degrade gracefully and can be easily customized dynamically.

--- a/submissions/scss/grayscale-filter-transition-ag/_grayscale-filter-transition.scss
+++ b/submissions/scss/grayscale-filter-transition-ag/_grayscale-filter-transition.scss
@@ -1,0 +1,54 @@
+// _grayscale-filter-transition.scss
+
+/// Grayscale Filter Transition Mixin
+///
+/// Applies a smooth transition to grayscale, sepia, or hue-rotate filters.
+/// Provides fallback for older browsers and uses CSS variables where available.
+///
+/// @param {String} $type [grayscale] - The type of filter ('grayscale', 'sepia', 'hue-rotate')
+/// @param {Number|String} $amount [100%] - The amount of filter to apply
+/// @param {Time} $duration [0.3s] - The transition duration
+/// @param {String} $easing [ease-in-out] - The transition easing
+@mixin filter-transition($type: grayscale, $amount: 100%, $duration: 0.3s, $easing: ease-in-out) {
+  // CSS Variables configuration
+  --ease-filter-amount: #{$amount};
+  --ease-filter-duration: #{$duration};
+  --ease-filter-easing: #{$easing};
+
+  // Base state
+  filter: #{$type}(0%);
+  -webkit-filter: #{$type}(0%);
+
+  // Base transition
+  transition: filter var(--ease-filter-duration, #{$duration}) var(--ease-filter-easing, #{$easing});
+  -webkit-transition: -webkit-filter var(--ease-filter-duration, #{$duration}) var(--ease-filter-easing, #{$easing});
+
+  // Active state on interaction
+  &:hover,
+  &:focus-within,
+  &.is-active {
+    filter: #{$type}(var(--ease-filter-amount, #{$amount}));
+    -webkit-filter: #{$type}(var(--ease-filter-amount, #{$amount}));
+  }
+  
+  // Accessibility: respect reduced motion preference
+  @media (prefers-reduced-motion: reduce) {
+    transition: none !important;
+    -webkit-transition: none !important;
+  }
+}
+
+/// Convenience Mixin: Grayscale
+@mixin grayscale-transition($amount: 100%, $duration: 0.3s, $easing: ease-in-out) {
+  @include filter-transition(grayscale, $amount, $duration, $easing);
+}
+
+/// Convenience Mixin: Sepia
+@mixin sepia-transition($amount: 100%, $duration: 0.3s, $easing: ease-in-out) {
+  @include filter-transition(sepia, $amount, $duration, $easing);
+}
+
+/// Convenience Mixin: Hue-Rotate
+@mixin hue-rotate-transition($amount: 90deg, $duration: 0.3s, $easing: ease-in-out) {
+  @include filter-transition(hue-rotate, $amount, $duration, $easing);
+}


### PR DESCRIPTION
## Pull Request Description

Adds comprehensive SCSS helper mixins for CSS filter transitions, specifically `grayscale`, `sepia`, and `hue-rotate`. It provides a seamless way to incorporate these effects with CSS variable integration and reduced-motion accessibility fallbacks.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: New SCSS helper mixin

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/scss/grayscale-filter-transition-ag/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A: SCSS Track)*
- [x] Includes `_grayscale-filter-transition.scss` — raw SCSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds SCSS mixins to easily create smooth, responsive CSS filter transitions (grayscale, sepia, hue-rotate) with support for CSS variables, vendor prefixes, and `prefers-reduced-motion` accessibility fallbacks.

**How does a developer use it?**

*Note: As this is an SCSS mixin submission, usage is within an SCSS file rather than raw HTML class usage.*

```scss
@import 'grayscale-filter-transition';

// Standard grayscale transition on hover
.image-gallery img {
  @include grayscale-transition(100%, 0.4s, ease-out);
}

// Vintage sepia effect
.card-vintage {
  @include sepia-transition(80%, 0.3s, ease-in-out);
}

// Color cycling effect
.dynamic-logo {
  @include hue-rotate-transition(180deg, 0.5s);
}
