### PR TITLE
feat(scss): Add SCSS Custom Selection Highlight helper mixins (#81305)

### DIFF
--- a/submissions/examples/selection-highlight-scss/README.md
+++ b/submissions/examples/selection-highlight-scss/README.md
@@ -1,0 +1,21 @@
+# SCSS Custom Selection Highlight Mixins
+
+A lightweight SCSS helper mixin suite for brand-themed text selection highlights (`::selection` and `::-moz-selection`) with EaseMotion CSS token fallbacks.
+
+## Mixins Overview
+
+- `selection-highlight($bg, $color, $global)`: Scopes selection styling to local selectors or the global document.
+- `selection-theme($variant)`: Presets theme variants (`'cyan'`, `'magenta'`, `'emerald'`, `'amber'`).
+
+## Usage Example
+
+```scss
+@import 'mixins';
+
+// Apply global selection
+@include selection-highlight($global: true);
+
+// Apply component brand theme
+.card-magenta {
+  @include selection-theme('magenta');
+}

--- a/submissions/examples/selection-highlight-scss/_mixins.scss
+++ b/submissions/examples/selection-highlight-scss/_mixins.scss
@@ -1,0 +1,59 @@
+// ==========================================================================
+// Selection Highlight Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies custom ::selection pseudo-element styles with vendor prefix fallback.
+@mixin selection-highlight(
+  $bg: var(--ease-selection-bg, #06b6d4),
+  $color: var(--ease-selection-color, #030712),
+  $global: false
+) {
+  @if $global {
+    ::selection {
+      background-color: $bg;
+      color: $color;
+      text-shadow: none;
+    }
+    ::-moz-selection {
+      background-color: $bg;
+      color: $color;
+      text-shadow: none;
+    }
+  } @else {
+    &::selection {
+      background-color: $bg;
+      color: $color;
+      text-shadow: none;
+    }
+    &::-moz-selection {
+      background-color: $bg;
+      color: $color;
+      text-shadow: none;
+    }
+  }
+}
+
+/// Applies brand variant selection themes using EaseMotion design tokens.
+@mixin selection-theme($variant: 'cyan') {
+  @if $variant == 'cyan' {
+    @include selection-highlight(
+      $bg: var(--ease-selection-cyan-bg, rgba(6, 182, 212, 0.35)),
+      $color: var(--ease-selection-cyan-color, #f3f4f6)
+    );
+  } @else if $variant == 'magenta' {
+    @include selection-highlight(
+      $bg: var(--ease-selection-magenta-bg, rgba(236, 72, 153, 0.35)),
+      $color: var(--ease-selection-magenta-color, #f3f4f6)
+    );
+  } @else if $variant == 'emerald' {
+    @include selection-highlight(
+      $bg: var(--ease-selection-emerald-bg, rgba(16, 185, 129, 0.35)),
+      $color: var(--ease-selection-emerald-color, #f3f4f6)
+    );
+  } @else if $variant == 'amber' {
+    @include selection-highlight(
+      $bg: var(--ease-selection-amber-bg, rgba(245, 158, 11, 0.35)),
+      $color: var(--ease-selection-amber-color, #f3f4f6)
+    );
+  }
+}

--- a/submissions/examples/selection-highlight-scss/demo.html
+++ b/submissions/examples/selection-highlight-scss/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Selection Highlight — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">SCSS Helper Suite</p>
+    <h1 class="ease-heading">Custom Selection Highlights</h1>
+    <p class="ease-subtitle">Highlight or drag text across any card below to test the brand-themed SCSS selection mixins.</p>
+
+    <div class="ease-card-grid">
+      <!-- Cyan Card -->
+      <article class="ease-card ease-theme-cyan" tabindex="0">
+        <span class="ease-badge ease-badge-cyan">Cyan Theme</span>
+        <h2 class="ease-card-title">Brand Selection</h2>
+        <p class="ease-card-desc">Highlight this text to see the default cyan theme applied via SCSS mixin.</p>
+      </article>
+
+      <!-- Magenta Card -->
+      <article class="ease-card ease-theme-magenta" tabindex="0">
+        <span class="ease-badge ease-badge-magenta">Magenta Theme</span>
+        <h2 class="ease-card-title">Cyberpunk Glow</h2>
+        <p class="ease-card-desc">Highlighting text here activates translucent magenta selection styling.</p>
+      </article>
+
+      <!-- Emerald Card -->
+      <article class="ease-card ease-theme-emerald" tabindex="0">
+        <span class="ease-badge ease-badge-emerald">Emerald Theme</span>
+        <h2 class="ease-card-title">Status Accent</h2>
+        <p class="ease-card-desc">Contextual green selection states for terminal blocks and alerts.</p>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/selection-highlight-scss/style.css
+++ b/submissions/examples/selection-highlight-scss/style.css
@@ -1,0 +1,160 @@
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-muted: #9ca3af;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+  --ease-selection-cyan-bg: rgba(6, 182, 212, 0.35);
+  --ease-selection-cyan-color: #f3f4f6;
+  --ease-selection-magenta-bg: rgba(236, 72, 153, 0.35);
+  --ease-selection-magenta-color: #f3f4f6;
+  --ease-selection-emerald-bg: rgba(16, 185, 129, 0.35);
+  --ease-selection-emerald-color: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-cyan);
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.ease-heading {
+  font-size: 1.8rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-muted);
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.ease-card {
+  padding: 1.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease;
+  outline: none;
+}
+.ease-card:hover, .ease-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--ease-cyan);
+}
+
+.ease-badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  margin-bottom: 0.75rem;
+}
+
+.ease-badge-cyan {
+  color: var(--ease-cyan);
+  background: rgba(6, 182, 212, 0.12);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+.ease-badge-magenta {
+  color: var(--ease-magenta);
+  background: rgba(236, 72, 153, 0.12);
+  border: 1px solid rgba(236, 72, 153, 0.3);
+}
+
+.ease-badge-emerald {
+  color: var(--ease-emerald);
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.ease-card-title {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.ease-card-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-muted);
+  line-height: 1.6;
+}
+
+/* Applying SCSS Mixins */
+.ease-theme-cyan::selection {
+  background-color: var(--ease-selection-cyan-bg, rgba(6, 182, 212, 0.35));
+  color: var(--ease-selection-cyan-color, #f3f4f6);
+  text-shadow: none;
+}
+.ease-theme-cyan::-moz-selection {
+  background-color: var(--ease-selection-cyan-bg, rgba(6, 182, 212, 0.35));
+  color: var(--ease-selection-cyan-color, #f3f4f6);
+  text-shadow: none;
+}
+
+.ease-theme-magenta::selection {
+  background-color: var(--ease-selection-magenta-bg, rgba(236, 72, 153, 0.35));
+  color: var(--ease-selection-magenta-color, #f3f4f6);
+  text-shadow: none;
+}
+.ease-theme-magenta::-moz-selection {
+  background-color: var(--ease-selection-magenta-bg, rgba(236, 72, 153, 0.35));
+  color: var(--ease-selection-magenta-color, #f3f4f6);
+  text-shadow: none;
+}
+
+.ease-theme-emerald::selection {
+  background-color: var(--ease-selection-emerald-bg, rgba(16, 185, 129, 0.35));
+  color: var(--ease-selection-emerald-color, #f3f4f6);
+  text-shadow: none;
+}
+.ease-theme-emerald::-moz-selection {
+  background-color: var(--ease-selection-emerald-bg, rgba(16, 185, 129, 0.35));
+  color: var(--ease-selection-emerald-color, #f3f4f6);
+  text-shadow: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
+/*# sourceMappingURL=style.css.map */

--- a/submissions/examples/selection-highlight-scss/style.scss
+++ b/submissions/examples/selection-highlight-scss/style.scss
@@ -1,0 +1,142 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-muted: #9ca3af;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+
+  --ease-selection-cyan-bg: rgba(6, 182, 212, 0.35);
+  --ease-selection-cyan-color: #f3f4f6;
+  --ease-selection-magenta-bg: rgba(236, 72, 153, 0.35);
+  --ease-selection-magenta-color: #f3f4f6;
+  --ease-selection-emerald-bg: rgba(16, 185, 129, 0.35);
+  --ease-selection-emerald-color: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-cyan);
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.ease-heading {
+  font-size: 1.8rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-muted);
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.ease-card {
+  padding: 1.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease;
+  outline: none;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-4px);
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  margin-bottom: 0.75rem;
+}
+
+.ease-badge-cyan {
+  color: var(--ease-cyan);
+  background: rgba(6, 182, 212, 0.12);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+.ease-badge-magenta {
+  color: var(--ease-magenta);
+  background: rgba(236, 72, 153, 0.12);
+  border: 1px solid rgba(236, 72, 153, 0.3);
+}
+
+.ease-badge-emerald {
+  color: var(--ease-emerald);
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.ease-card-title {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.ease-card-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ease-muted);
+  line-height: 1.6;
+}
+
+/* Applying SCSS Mixins */
+.ease-theme-cyan {
+  @include selection-theme('cyan');
+}
+
+.ease-theme-magenta {
+  @include selection-theme('magenta');
+}
+
+.ease-theme-emerald {
+  @include selection-theme('emerald');
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card {
+    transition: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81305

Adds custom SCSS selection highlight helper mixins (`selection-highlight()` and `selection-theme()`) under `submissions/examples/selection-highlight-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/selection-highlight-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with EaseMotion CSS tokens

## Feature Description
**What does this add?** A complete SCSS helper suite for custom text selection highlights (`::selection` and `::-moz-selection`) featuring brand theme presets (`cyan`, `magenta`, `emerald`, `amber`).
**Why does it fit?** Extends developer utilities for customizable text highlight styling inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge