### PR TITLE
feat(scss): add aspect ratio utility mixins

### DIFF
--- a/submissions/scss/aspect-ratio-mixins-vk/README.md
+++ b/submissions/scss/aspect-ratio-mixins-vk/README.md
@@ -1,0 +1,163 @@
+# SCSS Aspect Ratio Utility Mixins
+
+A collection of responsive SCSS helper mixins for maintaining consistent aspect ratios across images, media containers, videos, and embedded content.
+
+## Features
+
+- Custom aspect ratios such as `16/9`, `4/3`, and `1/1`
+- Responsive width-based layouts
+- Native CSS `aspect-ratio` support
+- Fallback support for browsers without `aspect-ratio`
+- CSS custom property integration
+- Video and iframe embed support
+- Supports `video`, `iframe`, `embed`, and `object`
+- No JavaScript required
+
+## Mixins
+
+### `ease-aspect-ratio`
+
+Applies a responsive aspect ratio to an element.
+
+```scss
+@use "mixins";
+
+.video {
+  @include mixins.ease-aspect-ratio(16/9);
+}
+```
+
+### `ease-aspect-ratio-variable`
+
+Uses a CSS custom property to define the aspect ratio.
+
+```scss
+@use "mixins";
+
+.media {
+  @include mixins.ease-aspect-ratio-variable(4/3);
+}
+```
+
+### `ease-aspect-ratio-embed`
+
+Designed for responsive video and embedded content.
+
+```scss
+@use "mixins";
+
+.video-frame {
+  @include mixins.ease-aspect-ratio-embed(16/9);
+}
+```
+
+## Usage
+
+The mixins can be included in any SCSS component that needs a predictable responsive ratio.
+
+```scss
+@use "mixins";
+
+.video {
+  @include mixins.ease-aspect-ratio(16/9);
+}
+
+.card-image {
+  @include mixins.ease-aspect-ratio(4/3);
+}
+
+.square-media {
+  @include mixins.ease-aspect-ratio-variable(1/1);
+}
+
+.embed {
+  @include mixins.ease-aspect-ratio-embed(16/9);
+}
+```
+
+## Browser Fallback
+
+The mixins use the native CSS `aspect-ratio` property where supported and provide a fallback using traditional sizing techniques when it is unavailable.
+
+This allows the same SCSS utilities to remain usable across different browser capabilities without requiring JavaScript.
+
+## Responsive Design
+
+The mixins use responsive sizing and native aspect-ratio behavior, allowing media containers to resize naturally with their parent element.
+
+They can be used inside responsive grids, cards, content sections, and media layouts.
+
+## Video and Embedded Content
+
+The embed mixin is intended for responsive media such as videos and iframes.
+
+```html
+<div class="video">
+  <iframe
+    src="https://example.com"
+    title="Embedded content">
+  </iframe>
+</div>
+```
+
+```scss
+.video {
+  @include ease-aspect-ratio-embed(16/9);
+}
+```
+
+## Example Ratios
+
+Common ratios can be used directly with the mixins:
+
+```scss
+.landscape {
+  @include ease-aspect-ratio(16/9);
+}
+
+.standard {
+  @include ease-aspect-ratio(4/3);
+}
+
+.square {
+  @include ease-aspect-ratio(1/1);
+}
+
+.portrait {
+  @include ease-aspect-ratio(3/4);
+}
+```
+
+## Demo
+
+Open `demo.html` directly in a browser to see examples of:
+
+- 16:9 media
+- 4:3 media
+- 1:1 square media
+- Responsive video/embed containers
+
+## Why It Fits EaseMotion CSS
+
+These mixins provide reusable, human-readable SCSS utilities for a common responsive layout problem.
+
+They keep aspect-ratio behavior lightweight, composable, and independent of JavaScript while providing sensible browser fallbacks.
+
+## Accessibility
+
+The mixins do not introduce interactive elements or JavaScript behavior.
+
+Embedded content should still provide appropriate accessible attributes such as meaningful `title` values for iframes.
+
+## Files
+
+```text
+_mixins.scss   SCSS utility mixins
+demo.html      Standalone usage examples
+style.css      Styling for the demo page
+README.md      Documentation and usage examples
+```
+
+## License
+
+This contribution follows the licensing terms of the EaseMotion CSS repository.

--- a/submissions/scss/aspect-ratio-mixins-vk/_mixins.scss
+++ b/submissions/scss/aspect-ratio-mixins-vk/_mixins.scss
@@ -1,0 +1,81 @@
+/// Applies a responsive aspect ratio to an element.
+///
+/// @param {Number} $ratio - Width-to-height ratio, e.g. 16/9 or 4/3.
+/// @param {Number} $fallback-height - Fallback height for browsers without
+/// aspect-ratio support.
+///
+/// @example
+///   .video {
+///     @include ease-aspect-ratio(16/9);
+///   }
+@mixin ease-aspect-ratio($ratio, $fallback-height: auto) {
+  position: relative;
+  width: 100%;
+  height: $fallback-height;
+  overflow: hidden;
+
+  @supports (aspect-ratio: 1) {
+    height: auto;
+    aspect-ratio: $ratio;
+  }
+
+  > * {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+/// Applies a responsive aspect ratio using a CSS custom property.
+///
+/// @param {Number} $ratio - Width-to-height ratio.
+///
+/// @example
+///   .media {
+///     @include ease-aspect-ratio-variable(16/9);
+///   }
+@mixin ease-aspect-ratio-variable($ratio) {
+  --ease-aspect-ratio: #{$ratio};
+
+  width: 100%;
+  aspect-ratio: var(--ease-aspect-ratio);
+
+  @supports not (aspect-ratio: 1) {
+    position: relative;
+    height: 0;
+    padding-bottom: calc(100% / (#{$ratio}));
+
+    > * {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
+/// Applies a video/embed-friendly aspect ratio.
+///
+/// @param {Number} $ratio - Width-to-height ratio, e.g. 16/9.
+@mixin ease-aspect-ratio-embed($ratio: 16/9) {
+  position: relative;
+  width: 100%;
+  aspect-ratio: $ratio;
+  overflow: hidden;
+
+  @supports not (aspect-ratio: 1) {
+    height: 0;
+    padding-bottom: calc(100% / (#{$ratio}));
+  }
+
+  > iframe,
+  > video,
+  > embed,
+  > object {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+}

--- a/submissions/scss/aspect-ratio-mixins-vk/demo.html
+++ b/submissions/scss/aspect-ratio-mixins-vk/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aspect Ratio Mixins</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="demo">
+    <header class="hero">
+      <p class="eyebrow">EASEMOTION SCSS</p>
+      <h1>Aspect Ratio Mixins</h1>
+      <p class="intro">
+        Responsive SCSS helpers for maintaining consistent aspect ratios
+        across images, media, and embedded content.
+      </p>
+    </header>
+
+    <section class="demo-card">
+      <h2>16:9 Media</h2>
+      <p>Commonly used for videos, presentations, and wide media.</p>
+
+      <div class="ratio-box ratio-16-9">
+        <div class="placeholder">
+          <span>16 : 9</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>4:3 Media</h2>
+      <p>Useful for traditional displays, images, and content previews.</p>
+
+      <div class="ratio-box ratio-4-3">
+        <div class="placeholder">
+          <span>4 : 3</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>1:1 Square</h2>
+      <p>A square ratio works well for profile images and cards.</p>
+
+      <div class="ratio-box ratio-1-1">
+        <div class="placeholder">
+          <span>1 : 1</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>Video Embed</h2>
+      <p>
+        The embed mixin can be used with videos, iframes, and other
+        embedded media.
+      </p>
+
+      <div class="ratio-box ratio-embed">
+        <div class="placeholder">
+          <span>Video Embed · 16 : 9</span>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <p>Pure SCSS · Responsive · No JavaScript</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/scss/aspect-ratio-mixins-vk/style.css
+++ b/submissions/scss/aspect-ratio-mixins-vk/style.css
@@ -1,0 +1,161 @@
+:root {
+  --bg: #0d0d0f;
+  --surface: #151518;
+  --surface-soft: #1b1b1f;
+  --border: #2a2a2f;
+  --text: #f5f5f7;
+  --muted: #a7a7ae;
+  --accent: #8b7cff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.6;
+}
+
+.demo {
+  width: min(100% - 32px, 960px);
+  margin: 0 auto;
+  padding: 72px 0 48px;
+}
+
+.hero {
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.intro {
+  max-width: 680px;
+  margin: 24px 0 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.15rem);
+}
+
+.demo-card {
+  margin-bottom: 24px;
+  padding: 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+}
+
+.demo-card h2 {
+  margin: 0 0 6px;
+  font-size: 1.25rem;
+}
+
+.demo-card > p {
+  margin: 0 0 24px;
+  color: var(--muted);
+}
+
+.ratio-box {
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-soft);
+}
+
+.ratio-16-9 {
+  aspect-ratio: 16 / 9;
+}
+
+.ratio-4-3 {
+  aspect-ratio: 4 / 3;
+}
+
+.ratio-1-1 {
+  aspect-ratio: 1 / 1;
+  max-width: 520px;
+}
+
+.ratio-embed {
+  aspect-ratio: 16 / 9;
+}
+
+.placeholder {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(139, 124, 255, 0.16),
+      rgba(139, 124, 255, 0.03)
+    );
+  color: var(--accent);
+  font-size: clamp(1rem, 3vw, 1.5rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.placeholder span {
+  padding: 10px 16px;
+  border: 1px solid rgba(139, 124, 255, 0.3);
+  border-radius: 999px;
+  background: rgba(13, 13, 15, 0.45);
+}
+
+footer {
+  padding-top: 24px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .demo {
+    width: min(100% - 24px, 960px);
+    padding-top: 48px;
+  }
+
+  .demo-card {
+    padding: 20px;
+  }
+
+  .ratio-1-1 {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds responsive SCSS aspect-ratio utility mixins for common media layouts, including custom ratios, CSS variable integration, and responsive video/embed fallbacks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds reusable SCSS mixins for responsive aspect-ratio layouts, supporting custom ratios, CSS custom properties, and embedded media.

**How does a developer use it?**

```scss
@use "mixins";

.video {
  @include mixins.ease-aspect-ratio(16/9);
}

.card-image {
  @include mixins.ease-aspect-ratio(4/3);
}

.square-media {
  @include mixins.ease-aspect-ratio-variable(1/1);
}

.embed {
  @include mixins.ease-aspect-ratio-embed(16/9);
}
```

**Why does it fit EaseMotion CSS?**

The mixins provide lightweight, reusable, and human-readable SCSS utilities for a common responsive layout requirement. They use native CSS aspect-ratio support with fallbacks for broader browser compatibility and require no JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

The demo demonstrates:

- 16:9 aspect ratio
- 4:3 aspect ratio
- 1:1 square ratio
- Responsive video/embed ratio

---

## Browser Testing

- [x] Edge

---

## Notes for Maintainer

The contribution is contained entirely within `submissions/scss/aspect-ratio-mixins-vk/`.

The SCSS mixins support custom aspect ratios and provide fallback behavior when the native `aspect-ratio` property is unavailable.

Closes #81261