### PR TITLE
feat(scss): add subgrid layout helper mixins

### DIFF
--- a/submissions/scss/subgrid-layout-mixins-vk/README.md
+++ b/submissions/scss/subgrid-layout-mixins-vk/README.md
@@ -1,0 +1,148 @@
+# SCSS Subgrid Layout Helper Mixins
+
+Responsive SCSS helper mixins for creating consistent CSS Grid layouts with native `subgrid` support and graceful fallbacks.
+
+## Features
+
+- Column subgrid helper
+- Row subgrid helper
+- Combined row and column subgrid helper
+- Responsive subgrid helper
+- Customizable column and row counts
+- Customizable gaps
+- Graceful fallback for browsers without subgrid support
+- CSS `@supports` integration
+- Responsive mobile layouts
+- Lightweight and dependency-free
+- Works with standard CSS Grid
+
+## Available Mixins
+
+### `ease-subgrid-columns`
+
+Creates a configurable column grid with native subgrid support when available.
+
+    @use "mixins";
+
+    .container {
+      @include mixins.ease-subgrid-columns(12, 1rem);
+    }
+
+### `ease-subgrid-rows`
+
+Creates configurable rows with native row subgrid support when available.
+
+    @use "mixins";
+
+    .container {
+      @include mixins.ease-subgrid-rows(3, 1rem);
+    }
+
+### `ease-subgrid`
+
+Creates a layout supporting both column and row subgrid behavior.
+
+    @use "mixins";
+
+    .container {
+      @include mixins.ease-subgrid(12, 2, 1rem);
+    }
+
+### `ease-subgrid-item`
+
+Allows a child element to span a specific range of grid columns.
+
+    @use "mixins";
+
+    .item {
+      @include mixins.ease-subgrid-item(1, -1);
+    }
+
+### `ease-subgrid-responsive`
+
+Creates a responsive subgrid layout and switches to a single-column layout below the specified breakpoint.
+
+    @use "mixins";
+
+    .container {
+      @include mixins.ease-subgrid-responsive(12, 1rem, 768px);
+    }
+
+## Usage
+
+Import the mixins using the Sass module system:
+
+    @use "mixins";
+
+    .layout {
+      @include mixins.ease-subgrid-columns(12, 1rem);
+    }
+
+    .layout-item {
+      @include mixins.ease-subgrid-item(1, -1);
+    }
+
+## Customization
+
+The mixins accept configurable values for columns, rows, gaps, and breakpoints.
+
+    @use "mixins";
+
+    .gallery {
+      @include mixins.ease-subgrid-columns(4, 1.5rem);
+    }
+
+    .content {
+      @include mixins.ease-subgrid-responsive(6, 1rem, 900px);
+    }
+
+## Browser Support
+
+The mixins use CSS `@supports` to detect native subgrid support.
+
+When subgrid is unavailable, a regular CSS Grid fallback is provided so the layout remains usable.
+
+    @supports (grid-template-columns: subgrid) {
+      .layout {
+        grid-template-columns: subgrid;
+      }
+    }
+
+## Responsive Behavior
+
+The responsive helper can switch to a single-column layout at a chosen breakpoint.
+
+    @use "mixins";
+
+    .cards {
+      @include mixins.ease-subgrid-responsive(3, 1rem, 768px);
+    }
+
+On smaller screens, the layout falls back to:
+
+    grid-template-columns: 1fr;
+
+## Demo
+
+Open `demo.html` directly in a browser to view examples of:
+
+- Column subgrid
+- Row subgrid
+- Responsive subgrid
+- Full-width subgrid items
+
+No server or JavaScript is required.
+
+## Why It Fits EaseMotion CSS
+
+These helpers follow the EaseMotion philosophy of keeping styling utilities simple, readable, reusable, and easy to integrate.
+
+They provide a lightweight SCSS abstraction over CSS Grid while preserving native CSS behavior and providing practical fallbacks for browsers without `subgrid` support.
+
+## Accessibility
+
+The mixins only control layout and do not introduce additional interactive behavior. Semantic HTML and accessible content can therefore be used normally with the generated layouts.
+
+## License
+
+This contribution is part of EaseMotion CSS and follows the repository's existing license and contribution guidelines.

--- a/submissions/scss/subgrid-layout-mixins-vk/_mixins.scss
+++ b/submissions/scss/subgrid-layout-mixins-vk/_mixins.scss
@@ -1,0 +1,65 @@
+// EaseMotion SCSS - Subgrid Layout Helper Mixins
+// Provides responsive subgrid helpers with graceful fallbacks.
+
+// Subgrid for columns
+@mixin ease-subgrid-columns($columns: 12, $gap: 1rem) {
+  display: grid;
+  grid-template-columns: repeat($columns, minmax(0, 1fr));
+  gap: $gap;
+
+  @supports (grid-template-columns: subgrid) {
+    grid-template-columns: subgrid;
+  }
+}
+
+// Subgrid for rows
+@mixin ease-subgrid-rows($rows: 1, $gap: 1rem) {
+  display: grid;
+  grid-template-rows: repeat($rows, minmax(0, auto));
+  gap: $gap;
+
+  @supports (grid-template-rows: subgrid) {
+    grid-template-rows: subgrid;
+  }
+}
+
+// Subgrid for both columns and rows
+@mixin ease-subgrid($columns: 12, $rows: 1, $gap: 1rem) {
+  display: grid;
+  grid-template-columns: repeat($columns, minmax(0, 1fr));
+  grid-template-rows: repeat($rows, minmax(0, auto));
+  gap: $gap;
+
+  @supports (
+    grid-template-columns: subgrid
+  ) and (
+    grid-template-rows: subgrid
+  ) {
+    grid-template-columns: subgrid;
+    grid-template-rows: subgrid;
+  }
+}
+
+// Child helper for spanning the parent subgrid
+@mixin ease-subgrid-item($column-start: 1, $column-end: -1) {
+  grid-column: $column-start / $column-end;
+}
+
+// Responsive subgrid helper
+@mixin ease-subgrid-responsive(
+  $columns: 12,
+  $gap: 1rem,
+  $breakpoint: 768px
+) {
+  display: grid;
+  grid-template-columns: repeat($columns, minmax(0, 1fr));
+  gap: $gap;
+
+  @supports (grid-template-columns: subgrid) {
+    grid-template-columns: subgrid;
+  }
+
+  @media (max-width: $breakpoint) {
+    grid-template-columns: 1fr;
+  }
+}

--- a/submissions/scss/subgrid-layout-mixins-vk/demo.html
+++ b/submissions/scss/subgrid-layout-mixins-vk/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion SCSS - Subgrid Layout Mixins</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EASEMOTION SCSS</p>
+      <h1>Subgrid Layout Mixins</h1>
+      <p class="intro">
+        Responsive SCSS helpers for creating aligned layouts with CSS Grid
+        subgrid support and graceful fallbacks.
+      </p>
+    </header>
+
+    <section class="demo-card">
+      <h2>Column Subgrid</h2>
+      <p>
+        Child elements inherit the parent grid columns while maintaining
+        consistent spacing.
+      </p>
+
+      <div class="subgrid-demo columns-demo">
+        <article class="item">
+          <span>01</span>
+          <h3>Design</h3>
+          <p>Consistent column alignment.</p>
+        </article>
+
+        <article class="item">
+          <span>02</span>
+          <h3>Develop</h3>
+          <p>Flexible responsive structure.</p>
+        </article>
+
+        <article class="item">
+          <span>03</span>
+          <h3>Deploy</h3>
+          <p>Clean and maintainable layouts.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>Row Subgrid</h2>
+      <p>
+        Rows can share the same sizing to keep content aligned across cards.
+      </p>
+
+      <div class="subgrid-demo rows-demo">
+        <article class="item">
+          <span>01</span>
+          <h3>Reusable</h3>
+          <p>
+            Build layouts that can be reused across different sections.
+          </p>
+        </article>
+
+        <article class="item">
+          <span>02</span>
+          <h3>Responsive</h3>
+          <p>
+            Adapt the layout smoothly across different screen sizes.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>Responsive Subgrid</h2>
+      <p>
+        The responsive helper switches to a single-column layout on smaller
+        screens.
+      </p>
+
+      <div class="subgrid-demo responsive-demo">
+        <article class="item">
+          <span>01</span>
+          <h3>Desktop</h3>
+          <p>Multi-column layout with shared grid tracks.</p>
+        </article>
+
+        <article class="item">
+          <span>02</span>
+          <h3>Tablet</h3>
+          <p>Flexible spacing and consistent alignment.</p>
+        </article>
+
+        <article class="item">
+          <span>03</span>
+          <h3>Mobile</h3>
+          <p>Automatically collapses into one column.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <h2>Subgrid Item</h2>
+      <p>
+        A child can span the complete parent grid using the item helper.
+      </p>
+
+      <div class="subgrid-demo item-demo">
+        <div class="item">
+          <span>FULL WIDTH</span>
+          <h3>Shared Grid Area</h3>
+          <p>
+            This element demonstrates a child spanning across the available
+            grid columns.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/scss/subgrid-layout-mixins-vk/style.css
+++ b/submissions/scss/subgrid-layout-mixins-vk/style.css
@@ -1,0 +1,220 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #0d0d0f;
+  --surface: #151519;
+  --surface-soft: #1b1b20;
+  --border: #2b2b32;
+  --text: #f5f5f7;
+  --muted: #a6a6b0;
+  --accent: #8b7cff;
+  --accent-soft: rgba(139, 124, 255, 0.12);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(1100px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 80px 0;
+}
+
+.hero {
+  margin-bottom: 56px;
+}
+
+.eyebrow {
+  margin: 0 0 18px;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+.hero h1 {
+  margin: 0;
+  max-width: 850px;
+  font-size: clamp(3rem, 7vw, 6rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.intro {
+  max-width: 720px;
+  margin: 28px 0 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.demo-card {
+  margin-bottom: 28px;
+  padding: 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+}
+
+.demo-card h2 {
+  margin: 0 0 10px;
+  font-size: 1.5rem;
+}
+
+.demo-card > p {
+  margin: 0 0 24px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.subgrid-demo {
+  padding: 20px;
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.item {
+  min-width: 0;
+  padding: 24px;
+  background: var(--accent-soft);
+  border: 1px solid rgba(139, 124, 255, 0.28);
+  border-radius: 14px;
+}
+
+.item span {
+  display: inline-block;
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.item h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.item p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+/* Column subgrid fallback */
+.columns-demo {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@supports (grid-template-columns: subgrid) {
+  .columns-demo {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .columns-demo .item {
+    grid-column: span 1;
+  }
+}
+
+/* Row subgrid fallback */
+.rows-demo {
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, auto));
+  gap: 16px;
+}
+
+@supports (grid-template-rows: subgrid) {
+  .rows-demo {
+    grid-template-rows: subgrid;
+  }
+}
+
+/* Responsive subgrid */
+.responsive-demo {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@supports (grid-template-columns: subgrid) {
+  .responsive-demo {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* Full-width subgrid item */
+.item-demo {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.item-demo .item {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 768px) {
+  .page {
+    width: min(100% - 28px, 680px);
+    padding: 56px 0;
+  }
+
+  .hero {
+    margin-bottom: 40px;
+  }
+
+  .demo-card {
+    padding: 24px;
+  }
+
+  .columns-demo,
+  .responsive-demo,
+  .item-demo {
+    grid-template-columns: 1fr;
+  }
+
+  .item-demo .item {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    width: min(100% - 20px, 680px);
+    padding: 40px 0;
+  }
+
+  .demo-card {
+    padding: 20px;
+    border-radius: 16px;
+  }
+
+  .subgrid-demo {
+    padding: 14px;
+  }
+
+  .item {
+    padding: 20px;
+  }
+
+  .intro {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds reusable SCSS helper mixins for CSS Grid subgrid layouts, including column, row, combined, item-span, and responsive subgrid utilities with graceful fallbacks for browsers without native subgrid support.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: SCSS utility mixins

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds reusable SCSS mixins for creating responsive CSS Grid subgrid layouts with configurable columns, rows, gaps, breakpoints, and graceful fallbacks.

**How does a developer use it?**

    @use "mixins";

    .layout {
      @include mixins.ease-subgrid-columns(12, 1rem);
    }

    .item {
      @include mixins.ease-subgrid-item(1, -1);
    }

    .responsive-layout {
      @include mixins.ease-subgrid-responsive(3, 1rem, 768px);
    }

**Why does it fit EaseMotion CSS?**

The mixins provide a lightweight, readable, and reusable SCSS abstraction for modern CSS Grid layouts while preserving standard CSS Grid fallbacks for browsers without native `subgrid` support.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Edge

---

## Notes for Maintainer

The demo demonstrates column subgrid, row subgrid, responsive subgrid, and full-width subgrid item usage.

The implementation uses CSS `@supports` to provide graceful fallbacks when native subgrid support is unavailable.

Closes #81259