### PR TITLE
feat(scss): add modern viewport units helper mixins

### DIFF
--- a/submissions/scss/modern-viewport-units-vk/README.md
+++ b/submissions/scss/modern-viewport-units-vk/README.md
@@ -1,0 +1,172 @@
+# SCSS Modern Viewport Units Helper Mixins
+
+A collection of responsive SCSS helper mixins for working with modern viewport units such as `svh`, `lvh`, `dvh`, and `svw`, with practical fallbacks for browsers that do not support them.
+
+## Features
+
+- Small viewport height (`svh`) helper
+- Large viewport height (`lvh`) helper
+- Dynamic viewport height (`dvh`) helper
+- Small viewport width (`svw`) helper
+- Combined viewport size helper
+- Dynamic viewport size helper
+- Browser fallbacks using `vh` and `vw`
+- Responsive layout support
+- CSS custom-property-friendly architecture
+- No JavaScript required
+- Lightweight and reusable
+
+## Available Mixins
+
+### `ease-viewport-height-small`
+
+Applies a height based on the small viewport height unit.
+
+    @use "mixins";
+
+    .hero {
+      @include mixins.ease-viewport-height-small(100);
+    }
+
+This generates a height using `svh` with a `vh` fallback when `svh` is unavailable.
+
+### `ease-viewport-height-large`
+
+Applies a height based on the large viewport height unit.
+
+    @use "mixins";
+
+    .hero {
+      @include mixins.ease-viewport-height-large(100);
+    }
+
+This is useful when the layout should account for the largest available viewport.
+
+### `ease-viewport-height-dynamic`
+
+Applies a height based on the dynamic viewport height unit.
+
+    @use "mixins";
+
+    .hero {
+      @include mixins.ease-viewport-height-dynamic(100);
+    }
+
+The `dvh` unit adapts as the browser viewport changes dynamically.
+
+### `ease-viewport-width-small`
+
+Applies a width based on the small viewport width unit.
+
+    @use "mixins";
+
+    .section {
+      @include mixins.ease-viewport-width-small(100);
+    }
+
+A `vw` fallback is provided when `svw` is unavailable.
+
+### `ease-viewport-size`
+
+Sets both width and height using small viewport units.
+
+    @use "mixins";
+
+    .panel {
+      @include mixins.ease-viewport-size(100, 100);
+    }
+
+The mixin uses `svw` and `svh` and provides `vw` and `vh` fallbacks.
+
+### `ease-viewport-dynamic`
+
+Sets width and height using dynamic viewport units.
+
+    @use "mixins";
+
+    .app {
+      @include mixins.ease-viewport-dynamic(100, 100);
+    }
+
+This is useful for layouts that need to adapt to changes in the visible browser viewport.
+
+## Custom Values
+
+The mixins accept numeric values so they can be adapted to different layouts.
+
+    @use "mixins";
+
+    .hero {
+      @include mixins.ease-viewport-height-small(80);
+    }
+
+    .content {
+      @include mixins.ease-viewport-height-dynamic(90);
+    }
+
+    .panel {
+      @include mixins.ease-viewport-size(90, 80);
+    }
+
+## Browser Fallbacks
+
+Modern viewport units are used when supported.
+
+The mixins provide traditional `vh` and `vw` fallbacks through CSS `@supports` rules.
+
+For example:
+
+    @supports not (height: 1svh) {
+      .hero {
+        height: 100vh;
+      }
+    }
+
+This allows the same utility to remain usable in browsers without modern viewport unit support.
+
+## Responsive Design
+
+Modern viewport units are particularly useful for responsive layouts where browser interface changes can affect the visible viewport.
+
+The dynamic viewport helper can be used for full-height application layouts:
+
+    @use "mixins";
+
+    .application {
+      @include mixins.ease-viewport-dynamic(100, 100);
+    }
+
+## Demo
+
+Open `demo.html` directly in a browser to view examples of:
+
+- `svh` small viewport height
+- `lvh` large viewport height
+- `dvh` dynamic viewport height
+- `svw` small viewport width
+- Dynamic viewport width and height
+
+No server or JavaScript is required.
+
+## Why It Fits EaseMotion CSS
+
+These helpers provide a lightweight and human-readable SCSS abstraction for modern responsive viewport units.
+
+They keep viewport sizing reusable and composable while providing practical fallbacks for environments where newer viewport units are unavailable.
+
+## Accessibility
+
+The mixins only control layout dimensions and do not introduce interactive behavior.
+
+When using viewport-based layouts, content should remain accessible and should not be clipped or hidden when the viewport changes.
+
+## Files
+
+    _mixins.scss   SCSS viewport utility mixins
+    demo.html      Standalone usage examples
+    style.css      Demo page styling
+    README.md      Documentation and usage examples
+
+## License
+
+This contribution is part of EaseMotion CSS and follows the repository's existing license and contribution guidelines.

--- a/submissions/scss/modern-viewport-units-vk/_mixins.scss
+++ b/submissions/scss/modern-viewport-units-vk/_mixins.scss
@@ -1,0 +1,66 @@
+// EaseMotion SCSS - Modern Viewport Unit Helper Mixins
+// Provides helpers for small, large, dynamic, and small viewport units.
+
+// Small viewport height
+@mixin ease-viewport-height-small($value: 100) {
+  height: #{$value}svh;
+
+  @supports not (height: 1svh) {
+    height: #{$value}vh;
+  }
+}
+
+// Large viewport height
+@mixin ease-viewport-height-large($value: 100) {
+  height: #{$value}lvh;
+
+  @supports not (height: 1lvh) {
+    height: #{$value}vh;
+  }
+}
+
+// Dynamic viewport height
+@mixin ease-viewport-height-dynamic($value: 100) {
+  height: #{$value}dvh;
+
+  @supports not (height: 1dvh) {
+    height: #{$value}vh;
+  }
+}
+
+// Small viewport width
+@mixin ease-viewport-width-small($value: 100) {
+  width: #{$value}svw;
+
+  @supports not (width: 1svw) {
+    width: #{$value}vw;
+  }
+}
+
+// Generic modern viewport size
+@mixin ease-viewport-size($width: 100, $height: 100) {
+  width: #{$width}svw;
+  height: #{$height}svh;
+
+  @supports not (width: 1svw) {
+    width: #{$width}vw;
+  }
+
+  @supports not (height: 1svh) {
+    height: #{$height}vh;
+  }
+}
+
+// Dynamic viewport size for responsive layouts
+@mixin ease-viewport-dynamic($width: 100, $height: 100) {
+  width: #{$width}dvw;
+  height: #{$height}dvh;
+
+  @supports not (width: 1dvw) {
+    width: #{$width}vw;
+  }
+
+  @supports not (height: 1dvh) {
+    height: #{$height}vh;
+  }
+}

--- a/submissions/scss/modern-viewport-units-vk/demo.html
+++ b/submissions/scss/modern-viewport-units-vk/demo.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modern Viewport Unit Mixins</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">EASEMOTION SCSS</p>
+
+      <h1>Modern Viewport Units</h1>
+
+      <p class="intro">
+        Responsive SCSS helpers for small, large, dynamic, and small
+        viewport units with practical browser fallbacks.
+      </p>
+    </header>
+
+    <section class="demo-card">
+      <div class="card-content">
+        <span class="unit-label">SVH</span>
+        <h2>Small Viewport Height</h2>
+        <p>
+          Uses <strong>svh</strong> to provide a stable height based on
+          the small viewport.
+        </p>
+      </div>
+
+      <div class="viewport-preview preview-svh">
+        <span>100svh</span>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <div class="card-content">
+        <span class="unit-label">LVH</span>
+        <h2>Large Viewport Height</h2>
+        <p>
+          Uses <strong>lvh</strong> for layouts that should fill the
+          largest available viewport.
+        </p>
+      </div>
+
+      <div class="viewport-preview preview-lvh">
+        <span>100lvh</span>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <div class="card-content">
+        <span class="unit-label">DVH</span>
+        <h2>Dynamic Viewport Height</h2>
+        <p>
+          Uses <strong>dvh</strong> to adapt as the browser viewport
+          dynamically changes.
+        </p>
+      </div>
+
+      <div class="viewport-preview preview-dvh">
+        <span>100dvh</span>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <div class="card-content">
+        <span class="unit-label">SVW</span>
+        <h2>Small Viewport Width</h2>
+        <p>
+          Uses <strong>svw</strong> for width calculations based on the
+          small viewport.
+        </p>
+      </div>
+
+      <div class="viewport-preview preview-svw">
+        <span>100svw</span>
+      </div>
+    </section>
+
+    <section class="demo-card">
+      <div class="card-content">
+        <span class="unit-label">DYNAMIC</span>
+        <h2>Dynamic Viewport Size</h2>
+        <p>
+          Combines dynamic viewport width and height for adaptive layouts.
+        </p>
+      </div>
+
+      <div class="viewport-preview preview-dynamic">
+        <span>100dvw × 100dvh</span>
+      </div>
+    </section>
+
+    <footer>
+      <p>Pure SCSS · Responsive · No JavaScript</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/scss/modern-viewport-units-vk/style.css
+++ b/submissions/scss/modern-viewport-units-vk/style.css
@@ -1,0 +1,251 @@
+:root {
+  --bg: #0d0d0f;
+  --surface: #151519;
+  --surface-soft: #1b1b20;
+  --border: #2b2b32;
+  --text: #f5f5f7;
+  --muted: #a6a6b0;
+  --accent: #8b7cff;
+  --accent-soft: rgba(139, 124, 255, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.page {
+  width: min(100% - 32px, 1000px);
+  margin: 0 auto;
+  padding: 72px 0;
+}
+
+.hero {
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.8rem, 7vw, 5.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+
+.intro {
+  max-width: 720px;
+  margin: 24px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.8fr);
+  align-items: center;
+  gap: 28px;
+
+  margin-bottom: 24px;
+  padding: 28px;
+
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+}
+
+.card-content {
+  min-width: 0;
+}
+
+.unit-label {
+  display: inline-block;
+  margin-bottom: 12px;
+  padding: 6px 10px;
+
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid rgba(139, 124, 255, 0.25);
+  border-radius: 999px;
+
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.demo-card h2 {
+  margin: 0 0 10px;
+  font-size: 1.35rem;
+}
+
+.demo-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.demo-card strong {
+  color: var(--text);
+}
+
+.viewport-preview {
+  min-height: 180px;
+
+  display: grid;
+  place-items: center;
+
+  padding: 24px;
+
+  background:
+    linear-gradient(
+      135deg,
+      rgba(139, 124, 255, 0.18),
+      rgba(139, 124, 255, 0.04)
+    );
+
+  border: 1px solid rgba(139, 124, 255, 0.28);
+  border-radius: 16px;
+
+  color: var(--accent);
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+/*
+ * The demo previews use viewport units directly.
+ * These correspond to the SCSS helpers documented in _mixins.scss.
+ */
+
+.preview-svh {
+  height: min(32svh, 280px);
+}
+
+.preview-lvh {
+  height: min(32lvh, 280px);
+}
+
+.preview-dvh {
+  height: min(32dvh, 280px);
+}
+
+.preview-svw {
+  width: min(100svw, 420px);
+  justify-self: end;
+}
+
+.preview-dynamic {
+  width: min(42dvw, 420px);
+  height: min(32dvh, 280px);
+  justify-self: end;
+}
+
+footer {
+  padding-top: 24px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 760px) {
+  .page {
+    width: min(100% - 24px, 700px);
+    padding: 52px 0;
+  }
+
+  .demo-card {
+    grid-template-columns: 1fr;
+    padding: 22px;
+  }
+
+  .viewport-preview {
+    width: 100%;
+    justify-self: stretch;
+  }
+
+  .preview-svw,
+  .preview-dynamic {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero h1 {
+    font-size: clamp(2.5rem, 14vw, 4rem);
+  }
+
+  .demo-card {
+    border-radius: 16px;
+  }
+
+  .viewport-preview {
+    min-height: 150px;
+  }
+}
+
+@supports not (height: 1svh) {
+  .preview-svh {
+    height: min(32vh, 280px);
+  }
+}
+
+@supports not (height: 1lvh) {
+  .preview-lvh {
+    height: min(32vh, 280px);
+  }
+}
+
+@supports not (height: 1dvh) {
+  .preview-dvh {
+    height: min(32vh, 280px);
+  }
+}
+
+@supports not (width: 1svw) {
+  .preview-svw {
+    width: min(100vw, 420px);
+  }
+}
+
+@supports not (width: 1dvw) {
+  .preview-dynamic {
+    width: min(42vw, 420px);
+  }
+}
+
+@supports not (height: 1dvh) {
+  .preview-dynamic {
+    height: min(32vh, 280px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds SCSS helper mixins for modern viewport units including `svh`, `lvh`, `dvh`, and `svw`, with browser fallbacks and responsive usage examples.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: SCSS utility/helper mixins

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds reusable SCSS helper mixins for modern viewport units such as `svh`, `lvh`, `dvh`, and `svw`, with fallbacks for browsers that do not support these newer units.

**How does a developer use it?**

    @use "mixins";

    .hero {
      @include mixins.ease-viewport-height-small(100);
    }

    .app {
      @include mixins.ease-viewport-height-dynamic(100);
    }

    .panel {
      @include mixins.ease-viewport-size(100, 100);
    }

**Why does it fit EaseMotion CSS?**

The mixins provide a lightweight, reusable, and human-readable way to work with modern responsive viewport units while maintaining practical browser fallbacks. They simplify responsive sizing without requiring JavaScript.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Edge

---

## Notes for Maintainer

The demo was tested by opening `demo.html` directly in Chrome. The implementation includes fallback handling for browsers that do not support modern viewport units.

Closes #81262