### PR TITLE
Feat/scss overscroll behavior control ps

### DIFF
--- a/submissions/scss/overscroll-behavior-control-ps/README.md
+++ b/submissions/scss/overscroll-behavior-control-ps/README.md
@@ -1,0 +1,95 @@
+# Overscroll Behavior Control Mixins — `overscroll-behavior-control-ps`
+
+## What does this do?
+
+Provides a comprehensive set of SCSS mixins that control `overscroll-behavior` on modals, drawers, sidebars, and any scrollable overlay — preventing unwanted scroll chaining from propagating to the parent document.
+
+## How is it used?
+
+### 1. Forward the partial in your SCSS
+
+```scss
+@use 'path/to/overscroll-behavior-control-ps' as *;
+```
+
+### 2. Apply mixins with `@include`
+
+```scss
+// Modal — contain scroll on both axes
+.modal {
+  @include overscroll-contain;
+}
+
+// Drawer — suppress all overscroll effects
+.drawer {
+  @include overscroll-none;
+}
+
+// Full page — restore browser default
+.page-wrapper {
+  @include overscroll-auto;
+}
+
+// Sidebar — lock vertical scroll, allow horizontal gestures
+.sidebar {
+  @include overscroll-y-contain;
+}
+
+// Carousel — lock horizontal scroll, allow vertical chaining
+.carousel {
+  @include overscroll-x-contain;
+}
+
+// Custom per-axis control
+.custom-panel {
+  @include overscroll-behavior(contain, auto);
+}
+
+// Apply only at a specific breakpoint (responsive)
+.drawer-mobile {
+  @include overscroll-responsive(768px, contain, contain);
+}
+
+// Apply inside prefers-reduced-motion query
+.overlay {
+  @include overscroll-reduced-motion(contain, contain);
+}
+```
+
+### Mixin Reference
+
+| Mixin | Parameters | Description |
+|---|---|---|
+| `overscroll-behavior($x, $y)` | `$x`, `$y`: `auto \| contain \| none` | Core mixin — full per-axis control with browser fallbacks |
+| `overscroll-contain` | — | Contain scroll on both axes (modal/drawer default) |
+| `overscroll-none` | — | Disable all overscroll effects (bounce/pull-to-refresh) |
+| `overscroll-auto` | — | Restore browser default overscroll behaviour |
+| `overscroll-y-contain` | — | Lock vertical scroll; allow horizontal gesture chaining |
+| `overscroll-x-contain` | — | Lock horizontal scroll; allow vertical chaining |
+| `overscroll-responsive($bp, $x, $y)` | `$bp`: min-width breakpoint | Apply overscroll rule inside a `@media (min-width)` block |
+| `overscroll-reduced-motion($x, $y)` | `$x`, `$y` | Apply overscroll rule inside `prefers-reduced-motion: reduce` |
+
+### CSS Variable Integration
+
+The mixins read from EaseMotion CSS tokens when available:
+
+```css
+:root {
+  --ease-overscroll-x: contain;
+  --ease-overscroll-y: contain;
+}
+```
+
+If these custom properties are not set, the mixins default to `contain`.
+
+### Browser Fallback Chain
+
+1. `overscroll-behavior` shorthand — all modern browsers
+2. `overscroll-behavior-x` / `overscroll-behavior-y` — granular axis control
+3. `-ms-scroll-chaining` — IE 11 and legacy Edge
+
+## Why is it useful?
+
+EaseMotion CSS powers animated UI elements such as modals, drawers, and overlays where scroll containment is critical for a polished user experience. Without `overscroll-behavior: contain`, a user scrolling a modal to its boundary causes the entire page to scroll — breaking immersion and animation continuity.
+
+This mixin suite gives EaseMotion users a single, zero-friction API to apply correct scroll containment across all overlay patterns, with built-in browser compatibility, CSS variable integration, responsive breakpoint helpers, and a `prefers-reduced-motion` guard — all aligned to EaseMotion's token-first philosophy.

--- a/submissions/scss/overscroll-behavior-control-ps/_overscroll-behavior-control-ps.scss
+++ b/submissions/scss/overscroll-behavior-control-ps/_overscroll-behavior-control-ps.scss
@@ -1,0 +1,134 @@
+// ============================================================
+// EaseMotion CSS — Overscroll Behavior Control Mixins
+// Issue #81291 | feat(scss): Add SCSS Overscroll Behavior Control
+// ============================================================
+//
+// Provides overscroll-behavior control helpers to prevent
+// unwanted scroll chaining on modals, drawers, and overlays.
+// Integrates with EaseMotion CSS variable tokens and includes
+// browser fallbacks for maximum compatibility.
+//
+// Usage:
+//   @use 'overscroll-behavior-control-ps' as *;
+//
+//   .modal   { @include overscroll-contain; }
+//   .drawer  { @include overscroll-none; }
+//   .page    { @include overscroll-auto; }
+//   .sidebar { @include overscroll-behavior(contain, auto); }
+// ============================================================
+
+// --- Token defaults (mirror EaseMotion CSS variable surface) ---
+$overscroll-default-x: var(--ease-overscroll-x, contain) !default;
+$overscroll-default-y: var(--ease-overscroll-y, contain) !default;
+
+// ============================================================
+// Core mixin — full axis control with browser fallbacks
+// ============================================================
+// @param $x   {String} overscroll-behavior-x value
+//             Accepts: auto | contain | none
+//             Default: $overscroll-default-x (contain)
+// @param $y   {String} overscroll-behavior-y value
+//             Accepts: auto | contain | none
+//             Default: $overscroll-default-y (contain)
+//
+// Browser fallback chain:
+//   1. overscroll-behavior shorthand        (modern browsers)
+//   2. overscroll-behavior-x / -y longhand (granular control)
+//   3. -ms-scroll-chaining                 (IE 11 / legacy Edge)
+// ============================================================
+@mixin overscroll-behavior($x: $overscroll-default-x, $y: $overscroll-default-y) {
+  // Resolve shorthand value — use $x when both axes are equal,
+  // otherwise fall back to explicit longhand declarations.
+  $shorthand: if($x == $y, $x, null);
+
+  @if $shorthand {
+    overscroll-behavior: $shorthand;
+  } @else {
+    overscroll-behavior: $x $y;
+  }
+
+  // Per-axis longhand for granular browser support
+  overscroll-behavior-x: $x;
+  overscroll-behavior-y: $y;
+
+  // Legacy IE 11 / old Edge — map contain → chained (closest equivalent)
+  // none → none; auto → chained
+  @if $x == none and $y == none {
+    -ms-scroll-chaining: none;
+  } @else {
+    -ms-scroll-chaining: chained;
+  }
+}
+
+// ============================================================
+// Named convenience mixins
+// ============================================================
+
+// Contain scroll within element — recommended for modals & drawers.
+// Prevents scroll from propagating to the parent document.
+@mixin overscroll-contain {
+  @include overscroll-behavior(contain, contain);
+}
+
+// Fully disable overscroll effects (bounce / pull-to-refresh).
+// Use on full-screen overlays that must suppress all scroll events.
+@mixin overscroll-none {
+  @include overscroll-behavior(none, none);
+}
+
+// Restore browser default overscroll behaviour.
+// Useful to opt out of a parent overscroll rule.
+@mixin overscroll-auto {
+  @include overscroll-behavior(auto, auto);
+}
+
+// Contain on the Y-axis only (vertical scroll lock).
+// Allows horizontal swipe gestures to propagate normally.
+@mixin overscroll-y-contain {
+  @include overscroll-behavior(auto, contain);
+}
+
+// Contain on the X-axis only (horizontal scroll lock).
+// Allows vertical scroll chaining; useful in carousels.
+@mixin overscroll-x-contain {
+  @include overscroll-behavior(contain, auto);
+}
+
+// ============================================================
+// Responsive helper — apply overscroll rule at a breakpoint
+// ============================================================
+// @param $breakpoint  {String}  CSS min-width value (e.g. 768px)
+// @param $x           {String}  overscroll-behavior-x (default: contain)
+// @param $y           {String}  overscroll-behavior-y (default: contain)
+//
+// Example:
+//   .sidebar { @include overscroll-responsive(768px, contain, auto); }
+// ============================================================
+@mixin overscroll-responsive(
+  $breakpoint,
+  $x: $overscroll-default-x,
+  $y: $overscroll-default-y
+) {
+  @media screen and (min-width: $breakpoint) {
+    @include overscroll-behavior($x, $y);
+  }
+}
+
+// ============================================================
+// Motion-safe guard — honours prefers-reduced-motion
+// ============================================================
+// Wraps overscroll-behavior in a reduced-motion media query
+// so users who prefer reduced motion still benefit from scroll
+// containment without triggering bounce / rubber-band effects.
+//
+// @param $x  {String} overscroll-behavior-x (default: contain)
+// @param $y  {String} overscroll-behavior-y (default: contain)
+// ============================================================
+@mixin overscroll-reduced-motion(
+  $x: $overscroll-default-x,
+  $y: $overscroll-default-y
+) {
+  @media (prefers-reduced-motion: reduce) {
+    @include overscroll-behavior($x, $y);
+  }
+}

--- a/submissions/scss/overscroll-behavior-ctl/README.md
+++ b/submissions/scss/overscroll-behavior-ctl/README.md
@@ -1,0 +1,28 @@
+# Overscroll Behavior Control Mixin
+
+### What does this do?
+Provides SCSS mixins to control overscroll behavior, preventing unwanted scroll chaining (rubber-banding) on scrollable components like modals and drawers, with built-in legacy browser fallbacks and CSS variable integration.
+
+### How is it used?
+
+```scss
+@use 'submissions/scss/overscroll-behavior-ctl/overscroll-behavior-ctl' as *;
+
+// Prevent scroll chaining on both axes (perfect for modals)
+.ease-modal-content {
+  @include ease-prevent-scroll-chaining();
+}
+
+// Control overscroll behavior on a specific axis
+.ease-drawer {
+  @include ease-overscroll-behavior(contain, y);
+}
+
+// Disable overscroll bounce entirely
+.ease-no-bounce {
+  @include ease-overscroll-behavior(none);
+}
+```
+
+### Why is it useful?
+When users reach the end of a scrollable area inside a modal or drawer, the browser may start scrolling the underlying page (scroll chaining). This mixin easily prevents this behavior across modern and legacy browsers, ensuring a robust, app-like scroll experience. It also utilizes CSS variables (`--ease-overscroll-behavior`) for dynamic overrides within the EaseMotion design system.

--- a/submissions/scss/overscroll-behavior-ctl/_overscroll-behavior-ctl.scss
+++ b/submissions/scss/overscroll-behavior-ctl/_overscroll-behavior-ctl.scss
@@ -1,0 +1,33 @@
+// ============================================
+// EaseMotion CSS — Overscroll Behavior Mixins
+// ============================================
+@use '../../scss/variables' as *;
+
+/// Mixin to control overscroll behavior with fallbacks
+/// @param {String} $behavior [contain] - The overscroll behavior (auto, contain, none)
+/// @param {String} $axis [both] - The axis to apply the behavior (both, x, y)
+@mixin ease-overscroll-behavior($behavior: contain, $axis: both) {
+  // CSS Variable integration for dynamic overrides
+  $var-name: --ease-overscroll-behavior;
+  
+  // IE10+ fallback for preventing scroll chaining
+  @if $behavior == contain or $behavior == none {
+    -ms-scroll-chaining: none;
+  } @else {
+    -ms-scroll-chaining: chained;
+  }
+
+  @if $axis == x {
+    overscroll-behavior-x: var(#{$var-name}-x, #{$behavior});
+  } @else if $axis == y {
+    overscroll-behavior-y: var(#{$var-name}-y, #{$behavior});
+  } @else {
+    overscroll-behavior: var(#{$var-name}, #{$behavior});
+  }
+}
+
+/// Helper mixin to prevent unwanted scroll chaining on modals and drawers
+/// @param {String} $axis [both] - The axis to apply the behavior
+@mixin ease-prevent-scroll-chaining($axis: both) {
+  @include ease-overscroll-behavior(contain, $axis);
+}


### PR DESCRIPTION
## Pull Request Description

Adds a comprehensive SCSS mixin suite for `overscroll-behavior` control, preventing unwanted scroll chaining on modals, drawers, and overlays. Resolves issue #81291.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other — SCSS mixin submission (overscroll behavior control helpers)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` — files placed under `submissions/scss/overscroll-behavior-control-ps/`
- [ ] Includes `demo.html` — N/A for SCSS track
- [ ] Includes `style.css` — N/A for SCSS track
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A set of SCSS mixins (`overscroll-contain`, `overscroll-none`, `overscroll-auto`, `overscroll-y-contain`, `overscroll-x-contain`, `overscroll-behavior`, `overscroll-responsive`, `overscroll-reduced-motion`) that control `overscroll-behavior` on scrollable overlays to prevent scroll chaining from propagating to the parent document.

**How does a developer use it?**

```scss
@use 'path/to/overscroll-behavior-control-ps' as *;

// Modal — contain scroll on both axes
.modal {
  @include overscroll-contain;
}

// Drawer — suppress bounce/pull-to-refresh
.drawer {
  @include overscroll-none;
}

// Sidebar — lock vertical scroll, allow horizontal gestures
.sidebar {
  @include overscroll-y-contain;
}

// Custom per-axis control
.custom-panel {
  @include overscroll-behavior(contain, auto);
}

// Responsive — apply only at 768px and above
.drawer-mobile {
  @include overscroll-responsive(768px, contain, contain);
}
```

