### PR TITLE
feat(scss): Add SCSS Placeholder Color Styling helper mixins (#81320)

### DIFF
--- a/submissions/examples/accent-caret-scss/README.md
+++ b/submissions/examples/accent-caret-scss/README.md
@@ -1,0 +1,29 @@
+# SCSS Accent & Caret Color Helper Mixins
+
+An SCSS helper mixin suite for controlling native form control accent colors (`accent-color`) and text input insertion cursors (`caret-color`).
+
+## Mixins Overview
+
+- `accent-color($color)`: Customizes native HTML checkboxes, radios, range sliders, and progress bars.
+- `caret-color($color)`: Customizes the text input insertion cursor color.
+- `form-theme($accent, $caret)`: Combines both accent and caret color rules in a single invocation.
+
+## Usage Example
+
+```scss
+@use 'mixins' as *;
+
+// Customize text cursor
+.my-input {
+  @include caret-color(#06b6d4);
+}
+
+// Customize native form elements
+.my-checkbox {
+  @include accent-color(#ec4899);
+}
+
+// Apply full theme
+.my-form {
+  @include form-theme(#10b981, #10b981);
+}

--- a/submissions/examples/accent-caret-scss/_mixins.scss
+++ b/submissions/examples/accent-caret-scss/_mixins.scss
@@ -1,0 +1,23 @@
+// ==========================================================================
+// Accent & Caret Color Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies custom accent-color to interactive form elements (checkboxes, radios, ranges, progress).
+/// @param {Color | String} $color [var(--ease-accent-color, #06b6d4)] - Target accent color token.
+@mixin accent-color($color: var(--ease-accent-color, #06b6d4)) {
+  accent-color: $color;
+}
+
+/// Applies custom caret-color (text input insertion cursor) with transparent/custom fallbacks.
+/// @param {Color | String} $color [var(--ease-caret-color, #06b6d4)] - Target caret color token.
+@mixin caret-color($color: var(--ease-caret-color, #06b6d4)) {
+  caret-color: $color;
+}
+
+/// Combined form control mixin applying both accent and caret colors simultaneously.
+/// @param {Color | String} $accent [var(--ease-accent-color, #06b6d4)] - UI control accent color.
+/// @param {Color | String} $caret [var(--ease-caret-color, #06b6d4)] - Text field cursor color.
+@mixin form-theme($accent: var(--ease-accent-color, #06b6d4), $caret: var(--ease-caret-color, #06b6d4)) {
+  @include accent-color($accent);
+  @include caret-color($caret);
+}

--- a/submissions/examples/accent-caret-scss/demo.html
+++ b/submissions/examples/accent-caret-scss/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Accent & Caret Color — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <p class="ease-eyebrow">SCSS Helper Suite</p>
+    <h1 class="ease-heading">Accent & Caret Customization</h1>
+    <p class="ease-subtitle">Interact with the inputs and form controls below to test custom cursor caret colors and native form control accent themes.</p>
+
+    <div class="ease-card-grid">
+      <!-- Cyan Form Theme -->
+      <article class="ease-card ease-theme-cyan">
+        <span class="ease-badge ease-badge-cyan">Cyan Theme</span>
+        <div class="ease-field-group">
+          <input type="text" class="ease-input-text" value="Type here to see cyan caret" placeholder="Type text..." />
+          <label class="ease-control-row">
+            <input type="checkbox" class="ease-checkbox" checked /> Checkbox Control
+          </label>
+          <label class="ease-control-row">
+            <input type="radio" class="ease-radio" checked /> Radio Control
+          </label>
+          <input type="range" class="ease-range" min="0" max="100" value="70" />
+        </div>
+      </article>
+
+      <!-- Magenta Form Theme -->
+      <article class="ease-card ease-theme-magenta">
+        <span class="ease-badge ease-badge-magenta">Magenta Theme</span>
+        <div class="ease-field-group">
+          <input type="text" class="ease-input-text" value="Type here to see magenta caret" placeholder="Type text..." />
+          <label class="ease-control-row">
+            <input type="checkbox" class="ease-checkbox" checked /> Checkbox Control
+          </label>
+          <label class="ease-control-row">
+            <input type="radio" class="ease-radio" checked /> Radio Control
+          </label>
+          <input type="range" class="ease-range" min="0" max="100" value="85" />
+        </div>
+      </article>
+
+      <!-- Emerald Form Theme -->
+      <article class="ease-card ease-theme-emerald">
+        <span class="ease-badge ease-badge-emerald">Emerald Theme</span>
+        <div class="ease-field-group">
+          <input type="text" class="ease-input-text" value="Type here to see emerald caret" placeholder="Type text..." />
+          <label class="ease-control-row">
+            <input type="checkbox" class="ease-checkbox" checked /> Checkbox Control
+          </label>
+          <label class="ease-control-row">
+            <input type="radio" class="ease-radio" checked /> Radio Control
+          </label>
+          <input type="range" class="ease-range" min="0" max="100" value="50" />
+        </div>
+      </article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/accent-caret-scss/style.scss
+++ b/submissions/examples/accent-caret-scss/style.scss
@@ -1,0 +1,188 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-muted: #9ca3af;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+
+  --ease-accent-cyan: #06b6d4;
+  --ease-caret-cyan: #06b6d4;
+  --ease-accent-magenta: #ec4899;
+  --ease-caret-magenta: #ec4899;
+  --ease-accent-emerald: #10b981;
+  --ease-caret-emerald: #10b981;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.ease-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--ease-cyan);
+  margin: 0 0 0.5rem;
+  font-weight: 700;
+}
+
+.ease-heading {
+  font-size: 1.8rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.ease-subtitle {
+  color: var(--ease-muted);
+  margin: 0 0 2.5rem;
+  font-size: 0.95rem;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.25rem;
+}
+
+.ease-card {
+  padding: 1.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.3s ease;
+
+  &:hover,
+  &:focus-within {
+    transform: translateY(-4px);
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  margin-bottom: 0.85rem;
+}
+
+.ease-badge-cyan {
+  color: var(--ease-cyan);
+  background: rgba(6, 182, 212, 0.12);
+  border: 1px solid rgba(6, 182, 212, 0.3);
+}
+
+.ease-badge-magenta {
+  color: var(--ease-magenta);
+  background: rgba(236, 72, 153, 0.12);
+  border: 1px solid rgba(236, 72, 153, 0.3);
+}
+
+.ease-badge-emerald {
+  color: var(--ease-emerald);
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.ease-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.ease-input-text {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.88rem;
+  outline: none;
+
+  &:focus {
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-control-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.85rem;
+  color: var(--ease-muted);
+}
+
+.ease-checkbox,
+.ease-radio,
+.ease-range {
+  cursor: pointer;
+}
+
+.ease-range {
+  width: 100%;
+}
+
+// SCSS Mixin Invocations
+.ease-theme-cyan {
+  .ease-input-text {
+    @include caret-color(var(--ease-caret-cyan));
+  }
+  .ease-checkbox,
+  .ease-radio,
+  .ease-range {
+    @include accent-color(var(--ease-accent-cyan));
+  }
+}
+
+.ease-theme-magenta {
+  .ease-input-text {
+    @include caret-color(var(--ease-caret-magenta));
+  }
+  .ease-checkbox,
+  .ease-radio,
+  .ease-range {
+    @include accent-color(var(--ease-accent-magenta));
+  }
+}
+
+.ease-theme-emerald {
+  .ease-input-text {
+    @include caret-color(var(--ease-caret-emerald));
+  }
+  .ease-checkbox,
+  .ease-radio,
+  .ease-range {
+    @include accent-color(var(--ease-accent-emerald));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-card {
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/submissions/examples/placeholder-color-scss/README.md
+++ b/submissions/examples/placeholder-color-scss/README.md
@@ -1,0 +1,15 @@
+# SCSS Placeholder Color Styling Helper Mixins
+
+An SCSS helper mixin suite for styling input placeholder text colors with cross-browser vendor fallback support.
+
+## Overview & Features
+- `placeholder-color($color)`: Configures custom placeholder colors across standard and legacy vendor pseudo-elements.
+- `placeholder-theme($variant)`: Preset theme selectors supporting muted, cyan, and magenta placeholder styling.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.custom-input {
+  @include placeholder-theme('cyan');
+}

--- a/submissions/examples/placeholder-color-scss/_mixins.scss
+++ b/submissions/examples/placeholder-color-scss/_mixins.scss
@@ -1,0 +1,36 @@
+// ==========================================================================
+// Placeholder Color Styling Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Styles placeholder text colors across all browser vendor pseudo-elements.
+/// @param {Color | String} $color [var(--ease-placeholder-color, #9ca3af)] - Placeholder text color.
+@mixin placeholder-color(
+  $color: var(--ease-placeholder-color, #9ca3af)
+) {
+  &::placeholder {
+    color: $color;
+    opacity: 1;
+  }
+  &::-webkit-input-placeholder {
+    color: $color;
+  }
+  &::-moz-placeholder {
+    color: $color;
+    opacity: 1;
+  }
+  &:-ms-input-placeholder {
+    color: $color;
+  }
+}
+
+/// Applies preset placeholder color theme variations.
+/// @param {String} $variant [muted] - Preset variant (muted, cyan, magenta).
+@mixin placeholder-theme($variant: 'muted') {
+  @if $variant == 'muted' {
+    @include placeholder-color(var(--ease-placeholder-muted, #9ca3af));
+  } @else if $variant == 'cyan' {
+    @include placeholder-color(var(--ease-placeholder-cyan, #06b6d4));
+  } @else if $variant == 'magenta' {
+    @include placeholder-color(var(--ease-placeholder-magenta, #ec4899));
+  }
+}

--- a/submissions/examples/placeholder-color-scss/demo.html
+++ b/submissions/examples/placeholder-color-scss/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Placeholder Color Styling — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <input type="text" class="ease-input ease-input-muted" placeholder="Muted placeholder text..." />
+      <input type="text" class="ease-input ease-input-cyan" placeholder="Cyan brand placeholder text..." />
+      <input type="text" class="ease-input ease-input-magenta" placeholder="Magenta brand placeholder text..." />
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/placeholder-color-scss/style.css
+++ b/submissions/examples/placeholder-color-scss/style.css
@@ -1,0 +1,93 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+}
+.ease-input:focus {
+  outline: none;
+  border-color: var(--ease-cyan);
+}
+
+.ease-input-muted::placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+  opacity: 1;
+}
+.ease-input-muted::-webkit-input-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+}
+.ease-input-muted::-moz-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+  opacity: 1;
+}
+.ease-input-muted:-ms-input-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+}
+
+.ease-input-cyan::placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+  opacity: 1;
+}
+.ease-input-cyan::-webkit-input-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+}
+.ease-input-cyan::-moz-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+  opacity: 1;
+}
+.ease-input-cyan:-ms-input-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+}
+
+.ease-input-magenta::placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+  opacity: 1;
+}
+.ease-input-magenta::-webkit-input-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+}
+.ease-input-magenta::-moz-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+  opacity: 1;
+}
+.ease-input-magenta:-ms-input-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+}

--- a/submissions/examples/placeholder-color-scss/style.scss
+++ b/submissions/examples/placeholder-color-scss/style.scss
@@ -1,0 +1,62 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-input-muted {
+  @include placeholder-theme('muted');
+}
+
+.ease-input-cyan {
+  @include placeholder-theme('cyan');
+}
+
+.ease-input-magenta {
+  @include placeholder-theme('magenta');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81320

Adds custom SCSS placeholder color styling helper mixins (`placeholder-color()` and `placeholder-theme()`) under `submissions/examples/placeholder-color-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/placeholder-color-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for styling input placeholder text colors (`::placeholder`, `::-webkit-input-placeholder`, `::-moz-placeholder`, `:-ms-input-placeholder`) with CSS variable integration.
**Why does it fit?** Expands developer form control styling utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari