### PR TITLE
feat(scss): Add SCSS Active Press Scale helper mixins (#81318)

### DIFF
--- a/submissions/examples/active-press-scale-scss/README.md
+++ b/submissions/examples/active-press-scale-scss/README.md
@@ -1,0 +1,2 @@
+# SCSS Active Press Scale Helper Mixins
+Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`.

--- a/submissions/examples/active-press-scale-scss/_mixins.scss
+++ b/submissions/examples/active-press-scale-scss/_mixins.scss
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Active Press Scale Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies active press scaling transition for interactive buttons and cards.
+/// @param {Number} $scale [var(--ease-press-scale, 0.96)] - Scale transformation factor.
+/// @param {String} $duration [150ms] - Transition duration.
+/// @param {String} $timing [cubic-bezier(0.16, 1, 0.3, 1)] - Easing function.
+@mixin active-press-scale(
+  $scale: var(--ease-press-scale, 0.96),
+  $duration: 150ms,
+  $timing: cubic-bezier(0.16, 1, 0.3, 1)
+) {
+  transition: transform $duration $timing;
+  will-change: transform;
+
+  &:active,
+  &.is-active {
+    transform: scale($scale);
+  }
+}
+
+/// Applies preset scale theme variations.
+/// @param {String} $variant [subtle] - Preset variant (subtle, medium, deep).
+@mixin press-scale-theme($variant: 'subtle') {
+  @if $variant == 'subtle' {
+    @include active-press-scale($scale: var(--ease-press-scale-subtle, 0.98));
+  } @else if $variant == 'medium' {
+    @include active-press-scale($scale: var(--ease-press-scale-medium, 0.95));
+  } @else if $variant == 'deep' {
+    @include active-press-scale($scale: var(--ease-press-scale-deep, 0.92));
+  }
+}

--- a/submissions/examples/active-press-scale-scss/demo.html
+++ b/submissions/examples/active-press-scale-scss/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><link rel="stylesheet" href="style.css"></head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card-grid">
+      <article class="ease-card"><button class="ease-btn-subtle">Subtle Press</button></article>
+      <article class="ease-card"><button class="ease-btn-medium">Medium Press</button></article>
+      <article class="ease-card"><button class="ease-btn-deep">Deep Press</button></article>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/active-press-scale-scss/style.css
+++ b/submissions/examples/active-press-scale-scss/style.css
@@ -1,0 +1,84 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.25rem;
+}
+
+.ease-card {
+  padding: 1.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+}
+
+.ease-btn-subtle {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-cyan);
+  color: #030712;
+  transition: transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+.ease-btn-subtle:active, .ease-btn-subtle.is-active {
+  transform: scale(var(--ease-press-scale-subtle, 0.98));
+}
+
+.ease-btn-medium {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-magenta);
+  color: #030712;
+  transition: transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+.ease-btn-medium:active, .ease-btn-medium.is-active {
+  transform: scale(var(--ease-press-scale-medium, 0.95));
+}
+
+.ease-btn-deep {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-emerald);
+  color: #030712;
+  transition: transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+.ease-btn-deep:active, .ease-btn-deep.is-active {
+  transform: scale(var(--ease-press-scale-deep, 0.92));
+}

--- a/submissions/examples/active-press-scale-scss/style.scss
+++ b/submissions/examples/active-press-scale-scss/style.scss
@@ -1,0 +1,73 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+}
+
+.ease-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.ease-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.25rem;
+}
+
+.ease-card {
+  padding: 1.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+}
+
+.ease-btn-subtle {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-cyan);
+  color: #030712;
+  @include press-scale-theme('subtle');
+}
+
+.ease-btn-medium {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-magenta);
+  color: #030712;
+  @include press-scale-theme('medium');
+}
+
+.ease-btn-deep {
+  width: 100%;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--ease-emerald);
+  color: #030712;
+  @include press-scale-theme('deep');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81318

Adds custom SCSS active press scale helper mixins (`active-press-scale()` and `press-scale-theme()`) under `submissions/examples/active-press-scale-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/active-press-scale-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for tactile button press feedback (`transform: scale()`) with hardware acceleration and CSS variable integration.
**Why does it fit?** Expands developer interactive component utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari