### PR TITLE
feat(core): Add Ripple Wave Click SCSS animation mixin

### DIFF
--- a/submissions/scss/ripple-wave-click-ps/README.md
+++ b/submissions/scss/ripple-wave-click-ps/README.md
@@ -1,0 +1,37 @@
+# Ripple Wave Click SCSS Mixin
+
+Adds a ripple wave effect when clicking (active state) an element. This mixin supports configurable timing variables and automatically handles `prefers-reduced-motion`.
+
+## Implementation
+- Defines `@keyframes ease-ripple-wave-click` animation.
+- Provides `ease-anim-ripple-wave-click` utility class.
+- Supports configurable timing variables (`--ease-duration`, `--ease-timing`).
+- Includes `@media (prefers-reduced-motion: reduce)` override.
+- Hardware accelerated using `transform` and `opacity`.
+
+## Parameters / Variables
+| Variable | Default | Description |
+|---|---|---|
+| `--ease-duration` | `0.6s` | Duration of the ripple animation |
+| `--ease-timing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Timing function for the ripple |
+
+## Usage Example
+
+### SCSS Mixin Usage
+```scss
+@import 'ripple-wave-click-ps';
+
+.my-button {
+  @include ease-ripple-wave-click-mixin;
+  
+  // Optional: override timing
+  --ease-duration: 0.8s;
+}
+```
+
+### Utility Class Usage
+```html
+<button class="ease-anim-ripple-wave-click">
+  Click Me
+</button>
+```

--- a/submissions/scss/ripple-wave-click-ps/_ripple-wave-click-ps.scss
+++ b/submissions/scss/ripple-wave-click-ps/_ripple-wave-click-ps.scss
@@ -1,0 +1,50 @@
+// submissions/scss/ripple-wave-click-ps/_ripple-wave-click-ps.scss
+
+@keyframes ease-ripple-wave-click {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.5);
+    opacity: 0;
+  }
+}
+
+@mixin ease-ripple-wave-click-mixin {
+  --ease-duration: 0.6s;
+  --ease-timing: cubic-bezier(0.4, 0, 0.2, 1);
+  
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    background-color: currentColor;
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+    will-change: transform, opacity;
+  }
+
+  &:active::after {
+    animation: ease-ripple-wave-click var(--ease-duration) var(--ease-timing);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+}
+
+.ease-anim-ripple-wave-click {
+  @include ease-ripple-wave-click-mixin;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Ripple Wave Click** SCSS mixin (`ease-ripple-wave-click-mixin`) to provide a customizable, hardware-accelerated ripple effect on click (active state). This solves the need for an easy-to-implement material-like ripple animation that can be dropped onto any interactive element.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server *(Not applicable for SCSS mixin track, but README is included)*
- [x] Includes `style.css` — raw CSS for the proposed feature *(SCSS partial included)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a configurable SCSS mixin (`ease-ripple-wave-click-mixin`) and utility class (`ease-anim-ripple-wave-click`) that generates a smooth, outward-expanding ripple effect when an element is clicked.

**How does a developer use it?**

```html
<!-- SCSS Mixin Usage -->
<style>
  .my-button {
    @include ease-ripple-wave-click-mixin;
    --ease-duration: 0.8s; /* Optional timing override */
  }
</style>

<!-- Utility Class Usage -->
<button class="ease-anim-ripple-wave-click">
  Click Me
</button>
