### PR TITLE
feat(scss): Add SCSS Disabled Input Opacity helper mixins (#81319)

### DIFF
--- a/submissions/examples/disabled-input-opacity-scss/README.md
+++ b/submissions/examples/disabled-input-opacity-scss/README.md
@@ -1,0 +1,15 @@
+# SCSS Disabled Input Opacity Helper Mixins
+
+An SCSS helper mixin suite for styling disabled form elements with reduced opacity, restricted cursor interaction, and pointer event blocking.
+
+## Overview & Features
+- `disabled-input-opacity($opacity, $cursor)`: Configures custom opacity levels and non-interactive states for disabled elements.
+- `disabled-theme($variant)`: Preset theme selectors supporting standard, muted, and faint disabled opacities.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.form-input {
+  @include disabled-theme('standard');
+}

--- a/submissions/examples/disabled-input-opacity-scss/_mixins.scss
+++ b/submissions/examples/disabled-input-opacity-scss/_mixins.scss
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Disabled Input Opacity Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Styles disabled form inputs and buttons with reduced opacity, restricted cursor, and disabled pointer events.
+/// @param {Number} $opacity [var(--ease-disabled-opacity, 0.5)] - Opacity level for disabled state.
+/// @param {String} $cursor [not-allowed] - Cursor style.
+@mixin disabled-input-opacity(
+  $opacity: var(--ease-disabled-opacity, 0.5),
+  $cursor: not-allowed
+) {
+  &:disabled,
+  &.is-disabled,
+  &[aria-disabled="true"] {
+    opacity: $opacity;
+    cursor: $cursor;
+    pointer-events: none;
+    user-select: none;
+    filter: grayscale(20%);
+  }
+}
+
+/// Applies preset disabled state variations.
+/// @param {String} $variant [standard] - Preset variant (standard, muted, faint).
+@mixin disabled-theme($variant: 'standard') {
+  @if $variant == 'standard' {
+    @include disabled-input-opacity($opacity: var(--ease-disabled-standard, 0.6));
+  } @else if $variant == 'muted' {
+    @include disabled-input-opacity($opacity: var(--ease-disabled-muted, 0.4));
+  } @else if $variant == 'faint' {
+    @include disabled-input-opacity($opacity: var(--ease-disabled-faint, 0.25));
+  }
+}

--- a/submissions/examples/disabled-input-opacity-scss/demo.html
+++ b/submissions/examples/disabled-input-opacity-scss/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Disabled Input Opacity — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <input type="text" class="ease-input ease-input-standard" disabled value="Standard disabled input state" />
+      <input type="text" class="ease-input ease-input-muted" disabled value="Muted disabled input state" />
+      <input type="text" class="ease-input ease-input-faint" disabled value="Faint disabled input state" />
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/disabled-input-opacity-scss/style.css
+++ b/submissions/examples/disabled-input-opacity-scss/style.css
@@ -1,0 +1,72 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+}
+.ease-input:focus {
+  outline: none;
+  border-color: var(--ease-cyan);
+}
+
+.ease-input-standard:disabled, .ease-input-standard.is-disabled, .ease-input-standard[aria-disabled=true] {
+  opacity: var(--ease-disabled-standard, 0.6);
+  cursor: not-allowed;
+  pointer-events: none;
+  user-select: none;
+  filter: grayscale(20%);
+}
+
+.ease-input-muted:disabled, .ease-input-muted.is-disabled, .ease-input-muted[aria-disabled=true] {
+  opacity: var(--ease-disabled-muted, 0.4);
+  cursor: not-allowed;
+  pointer-events: none;
+  user-select: none;
+  filter: grayscale(20%);
+}
+
+.ease-input-faint:disabled, .ease-input-faint.is-disabled, .ease-input-faint[aria-disabled=true] {
+  opacity: var(--ease-disabled-faint, 0.25);
+  cursor: not-allowed;
+  pointer-events: none;
+  user-select: none;
+  filter: grayscale(20%);
+}

--- a/submissions/examples/disabled-input-opacity-scss/style.scss
+++ b/submissions/examples/disabled-input-opacity-scss/style.scss
@@ -1,0 +1,62 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-input-standard {
+  @include disabled-theme('standard');
+}
+
+.ease-input-muted {
+  @include disabled-theme('muted');
+}
+
+.ease-input-faint {
+  @include disabled-theme('faint');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81319

Adds custom SCSS disabled input opacity helper mixins (`disabled-input-opacity()` and `disabled-theme()`) under `submissions/examples/disabled-input-opacity-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/disabled-input-opacity-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for disabled form states (`:disabled`, `.is-disabled`, `[aria-disabled="true"]`) featuring configurable reduced opacity, restricted cursor (`not-allowed`), and disabled pointer events.
**Why does it fit?** Expands developer form control state utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari