### PR TITLE
feat: add SCSS box sizing border box example (#81361)

### DIFF
--- a/submissions/examples/81361-scss-box-sizing-border-box/README.md
+++ b/submissions/examples/81361-scss-box-sizing-border-box/README.md
@@ -1,0 +1,197 @@
+# SCSS Box Sizing Border Box Helpers
+
+A standalone EaseMotion example demonstrating reusable SCSS helpers for the `border-box` box-sizing model.
+
+This submission is intentionally contained inside `submissions/examples/` and does not modify the existing EaseMotion SCSS source files.
+
+## Features
+
+- `box-sizing: border-box` helper
+- Component-tree box-sizing helper
+- Configurable SCSS helper
+- CSS custom-property integration
+- Responsive component example
+- Predictable component dimensions
+- Documentation and usage examples
+
+---
+
+## Why `border-box`?
+
+With the default `content-box` model, declared width and height describe only the content area.
+
+Padding and borders are added outside those dimensions.
+
+With:
+
+```scss
+box-sizing: border-box;
+
+the declared width and height include:
+
+Content
+Padding
+Border
+
+This makes component dimensions easier to reason about.
+
+1. Basic Helper
+
+The simplest helper applies border-box to the current element.
+
+@mixin box-border-box {
+  box-sizing: border-box;
+}
+
+Usage:
+
+.card {
+  @include box-border-box;
+}
+
+Generated CSS:
+
+.card {
+  box-sizing: border-box;
+}
+2. Component Tree Helper
+
+For reusable components containing nested elements, the inheritance pattern can be used:
+
+@mixin box-border-box-tree {
+  box-sizing: border-box;
+
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
+}
+
+Usage:
+
+.card {
+  @include box-border-box-tree;
+}
+
+This makes the box-sizing model consistent throughout the component.
+
+3. Configurable Helper
+
+A generic helper can expose the box-sizing value as a parameter:
+
+@mixin box-sizing($value: border-box) {
+  box-sizing: $value;
+}
+
+Usage:
+
+.card {
+  @include box-sizing;
+}
+
+Or:
+
+.component {
+  @include box-sizing(content-box);
+}
+
+The default remains border-box.
+
+CSS Variable Integration
+
+The example uses a CSS custom property:
+
+:root {
+  --ease-box-sizing: border-box;
+}
+
+A component can consume the token:
+
+.component {
+  box-sizing: var(--ease-box-sizing);
+}
+
+A component-specific value can be supplied without changing the helper:
+
+.component {
+  --ease-box-sizing: border-box;
+}
+
+This keeps the helper compatible with token-based design systems.
+
+Browser Fallback
+
+box-sizing has broad browser support.
+
+For older or constrained environments, the helper still compiles to a standard CSS declaration:
+
+box-sizing: border-box;
+
+No JavaScript or runtime calculation is required.
+
+Responsive Usage
+
+The helper can be combined with responsive styles:
+
+.card {
+  @include box-border-box;
+
+
+  width: 100%;
+
+
+  @media (min-width: 768px) {
+    width: 50%;
+  }
+}
+
+The box-sizing model remains consistent as the component changes size.
+
+Example
+
+A component using the tree helper:
+
+.card {
+  @include box-border-box-tree;
+
+
+  width: 100%;
+  padding: 1rem;
+  border: 1px solid var(--ease-border);
+}
+
+The declared width includes both padding and border.
+
+Accessibility
+
+The helper is purely related to layout and does not alter semantic or interactive behavior.
+
+When using it with UI components:
+
+Keep semantic HTML.
+Preserve visible focus states.
+Avoid clipping keyboard focus.
+Ensure responsive layouts remain usable.
+Do not rely on box dimensions alone to communicate information.
+Performance
+
+The helper produces a static CSS property and does not require JavaScript calculations.
+
+It therefore adds no runtime layout scripting overhead.
+
+Demo
+
+Open demo.html in a browser to view:
+
+Single-element border-box usage.
+Component-tree box-sizing.
+Responsive component sizing.
+CSS variable integration.
+SCSS helper documentation.
+Issue
+
+This example addresses:
+
+#81361 — feat(scss): Add SCSS Box Sizing Border Box helper mixins

--- a/submissions/examples/81361-scss-box-sizing-border-box/demo.html
+++ b/submissions/examples/81361-scss-box-sizing-border-box/demo.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="SCSS Box Sizing Border Box helper mixin example for EaseMotion CSS."
+  >
+  <title>SCSS Box Sizing Border Box</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+
+    <header class="hero">
+      <span class="eyebrow">EaseMotion SCSS Helper</span>
+
+      <h1>Box Sizing Border Box</h1>
+
+      <p>
+        A reusable SCSS helper that keeps component dimensions predictable
+        by applying the <code>border-box</code> box-sizing model.
+      </p>
+    </header>
+
+    <section class="demo-grid" aria-label="Box sizing examples">
+
+      <article class="demo-card">
+        <div class="card-number">01</div>
+
+        <h2>Single Element</h2>
+
+        <p>
+          Applies <code>box-sizing: border-box</code> to one component.
+        </p>
+
+        <div class="demo-area">
+          <div class="sizing-box">
+            <span>width: 100%</span>
+            <small>padding + border included</small>
+          </div>
+        </div>
+
+        <pre><code>@include box-border-box;</code></pre>
+      </article>
+
+      <article class="demo-card">
+        <div class="card-number">02</div>
+
+        <h2>Component Tree</h2>
+
+        <p>
+          The helper can be applied to a component and its descendants.
+        </p>
+
+        <div class="demo-area">
+          <div class="component-box">
+            <div class="component-child">
+              Child element
+            </div>
+
+            <div class="component-child">
+              Child element
+            </div>
+          </div>
+        </div>
+
+        <pre><code>@include box-border-box-tree;</code></pre>
+      </article>
+
+      <article class="demo-card">
+        <div class="card-number">03</div>
+
+        <h2>Responsive Component</h2>
+
+        <p>
+          The helper works with fluid widths and responsive layouts.
+        </p>
+
+        <div class="demo-area">
+          <div class="responsive-box">
+            <strong>Responsive card</strong>
+            <span>Border and padding remain inside the declared width.</span>
+          </div>
+        </div>
+
+        <pre><code>@include box-border-box;</code></pre>
+      </article>
+
+    </section>
+
+    <section class="api-section">
+      <span class="eyebrow">SCSS API</span>
+
+      <h2>Reusable Helper Mixins</h2>
+
+      <p class="section-description">
+        The following helpers demonstrate how the box-sizing reset can be
+        abstracted for individual components or complete component trees.
+      </p>
+
+      <pre><code>// Apply border-box to the current element.
+@mixin box-border-box {
+  box-sizing: border-box;
+}
+
+// Apply border-box to the current element
+// and all of its descendants.
+@mixin box-border-box-tree {
+  box-sizing: border-box;
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
+}
+
+// Optional configurable helper.
+@mixin box-sizing($value: border-box) {
+  box-sizing: $value;
+}</code></pre>
+    </section>
+
+    <section class="token-section">
+      <div>
+        <span class="eyebrow">Design Tokens</span>
+
+        <h2>CSS Variable Integration</h2>
+
+        <p>
+          The example exposes a CSS custom property for the preferred
+          box-sizing value, allowing component-level customization.
+        </p>
+      </div>
+
+      <pre><code>:root {
+  --ease-box-sizing: border-box;
+}
+
+.component {
+  box-sizing: var(--ease-box-sizing);
+}</code></pre>
+    </section>
+
+    <section class="comparison">
+      <span class="eyebrow">Why It Matters</span>
+
+      <h2>Predictable Component Dimensions</h2>
+
+      <div class="comparison-grid">
+        <div>
+          <strong>content-box</strong>
+          <p>
+            Padding and borders are added outside the declared width
+            and height.
+          </p>
+        </div>
+
+        <div>
+          <strong>border-box</strong>
+          <p>
+            Padding and borders are included inside the declared width
+            and height.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      EaseMotion CSS · Issue #81361
+    </footer>
+
+  </main>
+</body>
+</html>

--- a/submissions/examples/81361-scss-box-sizing-border-box/style.css
+++ b/submissions/examples/81361-scss-box-sizing-border-box/style.css
@@ -1,0 +1,438 @@
+:root {
+  --ease-box-sizing: border-box;
+
+  --page-bg: #f4f7fb;
+  --surface: #ffffff;
+  --surface-soft: #f8f9fc;
+
+  --text: #172033;
+  --muted: #667085;
+
+  --border: #dfe5ee;
+
+  --accent: #635bff;
+  --accent-soft: #eeedff;
+
+  --code-bg: #151922;
+  --code-text: #e8ecf5;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: var(--ease-box-sizing);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+
+  background: var(--page-bg);
+  color: var(--text);
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+code,
+pre {
+  font-family:
+    "Cascadia Code",
+    "SFMono-Regular",
+    Consolas,
+    "Liberation Mono",
+    monospace;
+}
+
+code {
+  padding: 2px 6px;
+
+  border-radius: 5px;
+
+  background: #eef1f6;
+
+  font-size: 0.88em;
+}
+
+.page {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 72px 0 44px;
+}
+
+.hero {
+  max-width: 760px;
+  margin: 0 auto 52px;
+
+  text-align: center;
+}
+
+.eyebrow {
+  display: inline-flex;
+
+  padding: 7px 12px;
+
+  border: 1px solid #d8d5ff;
+  border-radius: 999px;
+
+  background: var(--accent-soft);
+  color: var(--accent);
+
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  margin: 16px 0 0;
+
+  font-size: clamp(2.3rem, 5vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+}
+
+.hero p {
+  margin: 20px auto 0;
+
+  color: var(--muted);
+
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.demo-card {
+  overflow: hidden;
+
+  border: 1px solid var(--border);
+  border-radius: 20px;
+
+  background: var(--surface);
+
+  box-shadow: 0 14px 35px rgba(31, 41, 55, 0.07);
+}
+
+.demo-card > h2,
+.demo-card > p {
+  margin-left: 22px;
+  margin-right: 22px;
+}
+
+.card-number {
+  display: grid;
+
+  width: 36px;
+  height: 36px;
+
+  margin: 22px;
+
+  place-items: center;
+
+  border-radius: 10px;
+
+  background: var(--accent-soft);
+  color: var(--accent);
+
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.demo-card h2 {
+  margin-top: 0;
+  margin-bottom: 8px;
+
+  font-size: 1.15rem;
+}
+
+.demo-card > p {
+  min-height: 48px;
+
+  color: var(--muted);
+
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.demo-area {
+  display: grid;
+
+  min-height: 210px;
+  margin: 20px 18px;
+
+  place-items: center;
+
+  border: 1px dashed #c8d0dc;
+  border-radius: 14px;
+
+  background: var(--surface-soft);
+}
+
+.sizing-box {
+  width: 100%;
+  max-width: 220px;
+
+  padding: 28px 20px;
+
+  border: 8px solid #817cff;
+  border-radius: 14px;
+
+  background: #eeedff;
+
+  text-align: center;
+}
+
+.sizing-box span,
+.sizing-box small {
+  display: block;
+}
+
+.sizing-box span {
+  font-weight: 800;
+}
+
+.sizing-box small {
+  margin-top: 7px;
+
+  color: var(--muted);
+
+  font-size: 0.75rem;
+}
+
+.component-box {
+  display: grid;
+
+  width: min(100% - 30px, 220px);
+
+  gap: 10px;
+
+  padding: 14px;
+
+  border: 4px solid #817cff;
+  border-radius: 14px;
+
+  background: #eeedff;
+}
+
+.component-child {
+  padding: 12px;
+
+  border: 2px solid #b9b5ff;
+  border-radius: 9px;
+
+  background: #ffffff;
+
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.responsive-box {
+  width: min(100% - 30px, 240px);
+
+  padding: 24px;
+
+  border: 6px solid #817cff;
+  border-radius: 16px;
+
+  background: #eeedff;
+}
+
+.responsive-box strong,
+.responsive-box span {
+  display: block;
+}
+
+.responsive-box span {
+  margin-top: 7px;
+
+  color: var(--muted);
+
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.demo-card pre {
+  margin: 0;
+
+  padding: 16px 20px;
+
+  overflow-x: auto;
+
+  background: var(--code-bg);
+  color: var(--code-text);
+
+  font-size: 0.75rem;
+  line-height: 1.7;
+}
+
+.api-section,
+.token-section,
+.comparison {
+  margin-top: 28px;
+  padding: 30px;
+
+  border: 1px solid var(--border);
+  border-radius: 20px;
+
+  background: var(--surface);
+
+  box-shadow: 0 14px 35px rgba(31, 41, 55, 0.06);
+}
+
+.api-section h2,
+.token-section h2,
+.comparison h2 {
+  margin: 12px 0 8px;
+
+  font-size: 1.4rem;
+}
+
+.section-description,
+.token-section p {
+  margin: 0 0 22px;
+
+  color: var(--muted);
+
+  line-height: 1.65;
+}
+
+.api-section pre,
+.token-section pre {
+  margin: 0;
+
+  padding: 22px;
+
+  overflow-x: auto;
+
+  border-radius: 12px;
+
+  background: var(--code-bg);
+  color: var(--code-text);
+
+  font-size: 0.78rem;
+  line-height: 1.75;
+}
+
+.token-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  align-items: center;
+}
+
+.token-section p {
+  margin-bottom: 0;
+}
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+
+  margin-top: 22px;
+}
+
+.comparison-grid > div {
+  padding: 22px;
+
+  border: 1px solid var(--border);
+  border-radius: 14px;
+
+  background: var(--surface-soft);
+}
+
+.comparison-grid strong {
+  display: block;
+
+  color: var(--accent);
+
+  font-size: 1rem;
+}
+
+.comparison-grid p {
+  margin: 8px 0 0;
+
+  color: var(--muted);
+
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+footer {
+  padding-top: 38px;
+
+  color: var(--muted);
+
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .demo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-card {
+    width: min(620px, 100%);
+    margin: 0 auto;
+  }
+
+  .token-section {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .page {
+    width: min(100% - 20px, 520px);
+    padding-top: 44px;
+  }
+
+  .hero {
+    margin-bottom: 38px;
+  }
+
+  .hero p {
+    font-size: 0.95rem;
+  }
+
+  .api-section,
+  .token-section,
+  .comparison {
+    padding: 20px;
+  }
+
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Description

It is a critical issue to provide reusable and well-documented SCSS helpers for predictable component sizing.

This PR adds a standalone Box Sizing Border Box example for #81361.

### Changes

- Added `box-border-box` helper example.
- Added component-tree box-sizing helper.
- Added configurable box-sizing helper.
- Added CSS custom-property integration.
- Added responsive usage examples.
- Added documentation for `border-box`.
- Added browser compatibility/fallback notes.
- Added accessibility guidance.
- Added interactive visual demo.

### Repository Guidelines

All changes are contained inside:

`submissions/examples/81361-scss-box-sizing-border-box/`

No existing EaseMotion core or SCSS source files were modified.

### Testing

- Verified the demo in a browser.
- Verified responsive layout.
- Ran `git diff --check`.
- Verified only the three submission example files are changed.

Closes #81361