### PR TITLE
feat: Add Ripple Wave Click SCSS animation mixin (#81681)

### DIFF
--- a/submissions/scss/ripple-wave-click-ps/README.md
+++ b/submissions/scss/ripple-wave-click-ps/README.md
@@ -1,0 +1,38 @@
+# Ripple Wave Click — SCSS Mixin
+
+## What does this do?
+
+Adds a smooth, outward-expanding ripple wave animation on any element when it is clicked (`:active` state), using only CSS — no JavaScript required.
+
+## How is it used?
+
+### Utility class (drop-in)
+
+```html
+<button class="ease-anim-ripple-wave-click">Click Me</button>
+```
+
+### SCSS mixin (configurable)
+
+```scss
+@import 'ripple-wave-click-ps';
+
+.my-button {
+  @include ease-ripple-wave-click-mixin;
+
+  /* Optional overrides */
+  --ease-duration: 0.8s;
+  --ease-timing: ease-out;
+}
+```
+
+## Parameters
+
+| Variable | Default | Description |
+|---|---|---|
+| `--ease-duration` | `0.6s` | Duration of the ripple animation |
+| `--ease-timing` | `cubic-bezier(0.4, 0, 0.2, 1)` | Easing function for the ripple |
+
+## Why is it useful?
+
+This mixin fits EaseMotion's animation-first philosophy by providing a tactile, material-style click feedback using only CSS custom properties and hardware-accelerated `transform` and `opacity`. It is accessible by default via a `prefers-reduced-motion` media query override.

--- a/submissions/scss/ripple-wave-click-ps/_ripple-wave-click-ps.scss
+++ b/submissions/scss/ripple-wave-click-ps/_ripple-wave-click-ps.scss
@@ -1,0 +1,48 @@
+@keyframes ease-ripple-wave-click {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(2.5);
+    opacity: 0;
+  }
+}
+
+@mixin ease-ripple-wave-click-mixin {
+  --ease-duration: 0.6s;
+  --ease-timing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    background-color: currentColor;
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+    pointer-events: none;
+    will-change: transform, opacity;
+  }
+
+  &:active::after {
+    animation: ease-ripple-wave-click var(--ease-duration) var(--ease-timing);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
+}
+
+.ease-anim-ripple-wave-click {
+  @include ease-ripple-wave-click-mixin;
+}


### PR DESCRIPTION
## Pull Request Description

Adds a new **Ripple Wave Click** SCSS animation mixin (`ease-ripple-wave-click-mixin`) that produces a smooth, outward-expanding ripple effect on click using only CSS — no JavaScript required. Closes #81681.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/scss/ripple-wave-click-ps/`)
- [ ] Includes `demo.html` — self-contained, opens in browser with no server *(N/A — SCSS track)*
- [ ] Includes `style.css` — raw CSS for the proposed feature *(N/A — SCSS track uses `_ripple-wave-click-ps.scss`)*
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A configurable SCSS mixin and utility class that renders a hardware-accelerated ripple wave animation on any element when clicked.

**How does a developer use it?**

```html
<!-- Utility class (zero config) -->
<button class="ease-anim-ripple-wave-click">Click Me</button>
/* Or via mixin with custom timing */
.my-button {
  @include ease-ripple-wave-click-mixin;
  --ease-duration: 0.8s;
  --ease-timing: ease-out;
}
