### PR TITLE
feat(scss): Add SCSS Focus Visible Ring helper mixins (#81317)

### DIFF
--- a/submissions/examples/focus-visible-ring-scss/README.md
+++ b/submissions/examples/focus-visible-ring-scss/README.md
@@ -1,0 +1,15 @@
+# SCSS Focus Visible Ring Helper Mixins
+
+An SCSS helper mixin suite for managing accessible keyboard focus states (`:focus-visible`) while suppressing unwanted mouse click outlines.
+
+## Overview & Features
+- `focus-visible-ring($color, $width, $offset, $style)`: Configures custom accessible outline rings.
+- `focus-ring-theme($variant)`: Preset brand theme color variations for focus rings (cyan, magenta, emerald).
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.accessible-button {
+  @include focus-ring-theme('cyan');
+}

--- a/submissions/examples/focus-visible-ring-scss/_mixins.scss
+++ b/submissions/examples/focus-visible-ring-scss/_mixins.scss
@@ -1,0 +1,35 @@
+// ==========================================================================
+// Focus Visible Ring Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies accessible outline rings on keyboard focus while suppressing mouse click outlines.
+/// @param {Color | String} $color [var(--ease-focus-ring-color, #06b6d4)] - Outline ring color.
+/// @param {Length} $width [2px] - Outline border width.
+/// @param {Length} $offset [2px] - Outline offset distance.
+/// @param {String} $style [solid] - Outline border style.
+@mixin focus-visible-ring(
+  $color: var(--ease-focus-ring-color, #06b6d4),
+  $width: 2px,
+  $offset: 2px,
+  $style: solid
+) {
+  &:focus {
+    outline: none;
+  }
+  &:focus-visible {
+    outline: $width $style $color;
+    outline-offset: $offset;
+  }
+}
+
+/// Applies preset focus ring theme color variations.
+/// @param {String} $variant [cyan] - Preset variant (cyan, magenta, emerald).
+@mixin focus-ring-theme($variant: 'cyan') {
+  @if $variant == 'cyan' {
+    @include focus-visible-ring($color: var(--ease-focus-cyan, #06b6d4));
+  } @else if $variant == 'magenta' {
+    @include focus-visible-ring($color: var(--ease-focus-magenta, #ec4899));
+  } @else if $variant == 'emerald' {
+    @include focus-visible-ring($color: var(--ease-focus-emerald, #10b981));
+  }
+}

--- a/submissions/examples/focus-visible-ring-scss/demo.html
+++ b/submissions/examples/focus-visible-ring-scss/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Focus Visible Ring — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <button class="ease-button ease-btn-cyan">Tab Me (Cyan Focus Ring)</button>
+      <button class="ease-button ease-btn-magenta">Tab Me (Magenta Focus Ring)</button>
+      <button class="ease-button ease-btn-emerald">Tab Me (Emerald Focus Ring)</button>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/focus-visible-ring-scss/style.css
+++ b/submissions/examples/focus-visible-ring-scss/style.css
@@ -1,0 +1,71 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-button {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ease-btn-cyan:focus {
+  outline: none;
+}
+.ease-btn-cyan:focus-visible {
+  outline: 2px solid var(--ease-focus-cyan, #06b6d4);
+  outline-offset: 2px;
+}
+
+.ease-btn-magenta:focus {
+  outline: none;
+}
+.ease-btn-magenta:focus-visible {
+  outline: 2px solid var(--ease-focus-magenta, #ec4899);
+  outline-offset: 2px;
+}
+
+.ease-btn-emerald:focus {
+  outline: none;
+}
+.ease-btn-emerald:focus-visible {
+  outline: 2px solid var(--ease-focus-emerald, #10b981);
+  outline-offset: 2px;
+}

--- a/submissions/examples/focus-visible-ring-scss/style.scss
+++ b/submissions/examples/focus-visible-ring-scss/style.scss
@@ -1,0 +1,60 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-button {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ease-btn-cyan {
+  @include focus-ring-theme('cyan');
+}
+
+.ease-btn-magenta {
+  @include focus-ring-theme('magenta');
+}
+
+.ease-btn-emerald {
+  @include focus-ring-theme('emerald');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81317

Adds custom SCSS focus visible ring helper mixins (`focus-visible-ring()` and `focus-ring-theme()`) under `submissions/examples/focus-visible-ring-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/focus-visible-ring-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for keyboard-only focus rings (`:focus-visible`) that suppress visual outlines on mouse clicks, featuring CSS variable integration and preset color themes.
**Why does it fit?** Expands developer accessibility utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari