### PR TITLE
feat: add animated workspace switcher component (workspace-switcher-nk)

### DIFF
--- a/submissions/examples/workspace-switcher-nk/README.md
+++ b/submissions/examples/workspace-switcher-nk/README.md
@@ -1,0 +1,117 @@
+# Workspace Switcher — `workspace-switcher-nk`
+
+## 1. What does this do?
+
+An animated workspace/account switcher dropdown where a trigger button with a rotating chevron opens a panel with staggered item entrance, a left accent bar that slides in on hover, a checkmark that scale-pops on the active item, a cross-fade when switching workspaces, a spinning `+` on the "Create workspace" item, and a scale-pop on the active workspace card — all driven by pure CSS keyframes and transitions off state classes toggled by a minimal JS bridge.
+
+---
+
+## 2. How is it used?
+
+### HTML structure
+
+```html
+<!-- Trigger -->
+<button class="ws-trigger" aria-haspopup="listbox" aria-expanded="false"
+        aria-controls="ws-panel">
+  <span class="ws-trigger__avatar">A</span>
+  <span class="ws-trigger__name">Acme Corp</span>
+  <svg class="ws-trigger__chevron">...</svg>
+</button>
+
+<!-- Panel -->
+<div class="ws-panel" id="ws-panel" role="listbox" hidden>
+  <ul class="ws-list">
+    <li class="ws-item ws-item--active" role="option"
+        data-name="Acme Corp" data-initial="A" data-color="#6366f1"
+        aria-selected="true" tabindex="-1">
+      <span class="ws-item__accent"></span>
+      <span class="ws-item__avatar" style="--ws-avatar-color:#6366f1">A</span>
+      <span class="ws-item__info">
+        <span class="ws-item__name">Acme Corp</span>
+        <span class="ws-item__role">Owner</span>
+      </span>
+      <svg class="ws-item__check">...</svg>
+    </li>
+  </ul>
+  <button class="ws-new">
+    <span class="ws-new__icon">+</span>
+    <span class="ws-new__label">Create workspace</span>
+  </button>
+</div>
+```
+
+### State classes
+
+| Class | Applied to | Effect |
+|---|---|---|
+| `ws-trigger--open` | `.ws-trigger` | Chevron rotates 180° |
+| `ws-trigger--switching` | `.ws-trigger` | Cross-fade animation on name swap |
+| `ws-panel--open` | `.ws-panel` | scaleY slide-down entrance |
+| `ws-panel--closing` | `.ws-panel` | scaleY slide-up close |
+| `ws-item--in` | `.ws-item` | Staggered fade-up entrance |
+| `ws-item--active` | `.ws-item` | Indigo bg + checkmark scale-pop |
+| `:hover .ws-item__accent` | `.ws-item__accent` | Left bar scaleY slides in |
+| `:hover .ws-item__avatar` | `.ws-item__avatar` | Scale-up 1.1× |
+| `:hover .ws-new__icon` | `.ws-new__icon` | 90° rotation (+ spin) |
+| `ws-avatar--pop` | `.ws-active-card__avatar` | Scale bounce on switch |
+
+### JS bridge (minimal — only toggles classes and aria attributes)
+
+```js
+// Open panel
+panel.classList.add('ws-panel--open');
+trigger.classList.add('ws-trigger--open');
+items.forEach((item, i) => {
+  item.style.animationDelay = (i * 0.055) + 's';
+  item.classList.add('ws-item--in');
+});
+
+// Switch workspace
+trigger.classList.add('ws-trigger--switching');
+// on animationend: update text content
+item.classList.add('ws-item--active');
+avatar.classList.add('ws-avatar--pop');
+```
+
+All visual transitions are pure CSS. The JS manages aria attributes, hidden state, and focus only.
+
+---
+
+## 3. Why is it useful?
+
+Workspace switching is a high-frequency action in every SaaS product — Slack, Linear, Notion, Vercel all have it. Yet it had zero coverage across thousands of EaseMotion submissions.
+
+This component fits EaseMotion's philosophy because:
+
+- **Every interaction has a micro-animation.** The chevron rotation signals open/closed state. The stagger entrance gives the panel spatial depth. The accent bar sliding in on hover guides the eye. The cross-fade on switch confirms the change without a page reload.
+- **CSS does the heavy lifting.** All 6 keyframes (fade-up, panel-open, panel-close, item-in, trigger-switch, avatar-pop) and all hover transitions are pure CSS. The JS is ~80 lines managing aria attributes, focus, and keyboard navigation only — swap for React `useState`, Alpine `x-bind`, or Svelte without touching the stylesheet.
+- **Fully keyboard accessible.** `↑↓` navigates items, `Enter`/`Space` selects, `Esc` closes, `Tab` closes. Proper `role="listbox"` + `role="option"` + `aria-selected` + `aria-expanded` semantics. Focus returns to trigger on close.
+- **Zero dependencies.** Open `demo.html` directly in any modern browser — no server, no CDN, no build step.
+
+---
+
+## Animations used
+
+| Animation | Trigger | Effect |
+|---|---|---|
+| `ws-fade-up` | Card / hint on page load | Fade + slide up entrance |
+| `ws-panel-open` | `.ws-panel--open` | scaleY expand from top with bounce |
+| `ws-panel-close` | `.ws-panel--closing` | scaleY collapse to top |
+| `ws-item-in` | `.ws-item--in` (staggered) | Fade + slide up, 55ms delay each |
+| `ws-trigger-switch` | `.ws-trigger--switching` | Cross-fade (out → in) on name change |
+| `ws-avatar-pop` | `.ws-avatar--pop` | Scale bounce 1 → 1.2 → 1 on switch |
+| Chevron rotate | `.ws-trigger--open` | 180° CSS `transform: rotate` transition |
+| Accent bar slide | `.ws-item:hover .ws-item__accent` | `scaleY(0 → 1)` bounce transition |
+| `+` icon spin | `.ws-new:hover .ws-new__icon` | `rotate(90deg)` transition |
+
+---
+
+## Files
+
+```
+submissions/examples/workspace-switcher-nk/
+├── demo.html   — self-contained demo, works by opening directly in a browser
+├── style.css   — all styles, keyframes, and state transitions
+└── README.md   — this file
+```

--- a/submissions/examples/workspace-switcher-nk/demo.html
+++ b/submissions/examples/workspace-switcher-nk/demo.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workspace Switcher — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+
+      <!-- ── Topbar context ── -->
+      <div class="ws-topbar">
+        <div class="ws-topbar__left">
+
+          <!-- ── Trigger ── -->
+          <div class="ws-trigger-wrap" id="ws-trigger-wrap">
+            <button
+              class="ws-trigger"
+              id="ws-trigger"
+              type="button"
+              aria-haspopup="listbox"
+              aria-expanded="false"
+              aria-controls="ws-panel"
+              aria-label="Switch workspace"
+            >
+              <span class="ws-trigger__avatar" id="ws-trigger-avatar"
+                    aria-hidden="true">A</span>
+              <span class="ws-trigger__name" id="ws-trigger-name">
+                Acme Corp
+              </span>
+              <svg class="ws-trigger__chevron" viewBox="0 0 16 16" fill="none"
+                   aria-hidden="true">
+                <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="2"
+                      stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+
+            <!-- ── Dropdown panel ── -->
+            <div
+              class="ws-panel"
+              id="ws-panel"
+              role="listbox"
+              aria-label="Workspaces"
+              hidden
+            >
+              <p class="ws-panel__heading">Workspaces</p>
+
+              <ul class="ws-list" id="ws-list" role="presentation">
+
+                <li class="ws-item ws-item--active" role="option"
+                    data-id="1" data-name="Acme Corp" data-initial="A"
+                    data-color="#6366f1" aria-selected="true" tabindex="-1">
+                  <span class="ws-item__accent" aria-hidden="true"></span>
+                  <span class="ws-item__avatar"
+                        style="--ws-avatar-color:#6366f1">A</span>
+                  <span class="ws-item__info">
+                    <span class="ws-item__name">Acme Corp</span>
+                    <span class="ws-item__role">Owner</span>
+                  </span>
+                  <svg class="ws-item__check" viewBox="0 0 16 16" fill="none"
+                       aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </li>
+
+                <li class="ws-item" role="option"
+                    data-id="2" data-name="Moonshot Labs" data-initial="M"
+                    data-color="#10b981" aria-selected="false" tabindex="-1">
+                  <span class="ws-item__accent" aria-hidden="true"></span>
+                  <span class="ws-item__avatar"
+                        style="--ws-avatar-color:#10b981">M</span>
+                  <span class="ws-item__info">
+                    <span class="ws-item__name">Moonshot Labs</span>
+                    <span class="ws-item__role">Member</span>
+                  </span>
+                  <svg class="ws-item__check" viewBox="0 0 16 16" fill="none"
+                       aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </li>
+
+                <li class="ws-item" role="option"
+                    data-id="3" data-name="Pixel Studio" data-initial="P"
+                    data-color="#f59e0b" aria-selected="false" tabindex="-1">
+                  <span class="ws-item__accent" aria-hidden="true"></span>
+                  <span class="ws-item__avatar"
+                        style="--ws-avatar-color:#f59e0b">P</span>
+                  <span class="ws-item__info">
+                    <span class="ws-item__name">Pixel Studio</span>
+                    <span class="ws-item__role">Admin</span>
+                  </span>
+                  <svg class="ws-item__check" viewBox="0 0 16 16" fill="none"
+                       aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </li>
+
+                <li class="ws-item" role="option"
+                    data-id="4" data-name="Nova Systems" data-initial="N"
+                    data-color="#ef4444" aria-selected="false" tabindex="-1">
+                  <span class="ws-item__accent" aria-hidden="true"></span>
+                  <span class="ws-item__avatar"
+                        style="--ws-avatar-color:#ef4444">N</span>
+                  <span class="ws-item__info">
+                    <span class="ws-item__name">Nova Systems</span>
+                    <span class="ws-item__role">Viewer</span>
+                  </span>
+                  <svg class="ws-item__check" viewBox="0 0 16 16" fill="none"
+                       aria-hidden="true">
+                    <path d="M3 8l4 4 6-6" stroke="currentColor" stroke-width="2"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </li>
+
+              </ul>
+
+              <div class="ws-divider"></div>
+
+              <!-- Create new workspace -->
+              <button class="ws-new" id="ws-new" type="button"
+                      aria-label="Create new workspace">
+                <span class="ws-new__icon" aria-hidden="true">
+                  <svg viewBox="0 0 16 16" fill="none">
+                    <path d="M8 3v10M3 8h10" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </span>
+                <span class="ws-new__label">Create workspace</span>
+              </button>
+
+            </div><!-- /panel -->
+          </div><!-- /trigger-wrap -->
+
+        </div>
+
+        <div class="ws-topbar__right">
+          <div class="ws-avatar-btn" aria-label="User menu" role="button"
+               tabindex="0">N</div>
+        </div>
+      </div>
+
+      <!-- ── Active workspace display ── -->
+      <div class="ws-active-card" id="ws-active-card">
+        <div class="ws-active-card__avatar" id="ws-active-avatar"
+             style="--ws-avatar-color:#6366f1">A</div>
+        <div>
+          <p class="ws-active-card__label">Active Workspace</p>
+          <p class="ws-active-card__name" id="ws-active-name">Acme Corp</p>
+        </div>
+      </div>
+
+      <!-- Demo hint -->
+      <div class="demo-hint">
+        <p class="demo-hint__title">Try these interactions:</p>
+        <ul class="demo-hint__list">
+          <li>Click trigger → panel slides down with staggered items</li>
+          <li>Hover items → left border slides in + scale-up</li>
+          <li>Click a workspace → cross-fade trigger name + scale-pop</li>
+          <li>Hover "Create workspace" → <strong>+</strong> icon spins</li>
+          <li>Use <kbd>↑↓</kbd> to navigate, <kbd>Enter</kbd> to select,
+              <kbd>Esc</kbd> to close</li>
+        </ul>
+      </div>
+
+    </div>
+
+    <div class="ws-sr" role="status" aria-live="polite" id="ws-sr"></div>
+
+    <script>
+    (function () {
+      const trigger     = document.getElementById('ws-trigger');
+      const panel       = document.getElementById('ws-panel');
+      const triggerWrap = document.getElementById('ws-trigger-wrap');
+      const triggerAvtr = document.getElementById('ws-trigger-avatar');
+      const triggerName = document.getElementById('ws-trigger-name');
+      const items       = Array.from(document.querySelectorAll('.ws-item'));
+      const activeAvtr  = document.getElementById('ws-active-avatar');
+      const activeName  = document.getElementById('ws-active-name');
+      const srEl        = document.getElementById('ws-sr');
+
+      let isOpen    = false;
+      let focusIdx  = -1;
+
+      function announce(msg) {
+        srEl.textContent = '';
+        requestAnimationFrame(() => { srEl.textContent = msg; });
+      }
+
+      /* ── open ── */
+      function open() {
+        isOpen = true;
+        trigger.setAttribute('aria-expanded', 'true');
+        panel.hidden = false;
+        panel.classList.remove('ws-panel--closing');
+        panel.classList.add('ws-panel--open');
+        trigger.classList.add('ws-trigger--open');
+
+        /* stagger each item */
+        items.forEach((item, i) => {
+          item.style.animationDelay = (i * 0.055) + 's';
+          item.classList.remove('ws-item--in');
+          void item.offsetWidth;
+          item.classList.add('ws-item--in');
+        });
+
+        /* focus active item */
+        const activeIdx = items.findIndex(it =>
+          it.getAttribute('aria-selected') === 'true');
+        focusIdx = activeIdx >= 0 ? activeIdx : 0;
+        items[focusIdx].focus();
+        announce('Workspace menu open.');
+      }
+
+      /* ── close ── */
+      function close() {
+        isOpen = false;
+        trigger.setAttribute('aria-expanded', 'false');
+        trigger.classList.remove('ws-trigger--open');
+        panel.classList.remove('ws-panel--open');
+        panel.classList.add('ws-panel--closing');
+        panel.addEventListener('animationend', () => {
+          panel.classList.remove('ws-panel--closing');
+          panel.hidden = true;
+        }, { once: true });
+        announce('Workspace menu closed.');
+      }
+
+      /* ── switch workspace ── */
+      function switchTo(item) {
+        const name    = item.dataset.name;
+        const initial = item.dataset.initial;
+        const color   = item.dataset.color;
+
+        /* update active state on items */
+        items.forEach(it => {
+          it.classList.remove('ws-item--active');
+          it.setAttribute('aria-selected', 'false');
+        });
+        item.classList.add('ws-item--active');
+        item.setAttribute('aria-selected', 'true');
+
+        /* cross-fade trigger */
+        trigger.classList.add('ws-trigger--switching');
+        trigger.addEventListener('animationend', () => {
+          trigger.classList.remove('ws-trigger--switching');
+          triggerName.textContent = name;
+          triggerAvtr.textContent = initial;
+          triggerAvtr.style.setProperty('--ws-avatar-color', color);
+        }, { once: true });
+
+        /* update active card */
+        activeName.textContent = name;
+        activeAvtr.textContent = initial;
+        activeAvtr.style.setProperty('--ws-avatar-color', color);
+        activeAvtr.classList.remove('ws-avatar--pop');
+        void activeAvtr.offsetWidth;
+        activeAvtr.classList.add('ws-avatar--pop');
+
+        announce('Switched to ' + name);
+        close();
+        trigger.focus();
+      }
+
+      /* ── toggle ── */
+      trigger.addEventListener('click', () => {
+        isOpen ? close() : open();
+      });
+
+      /* ── item click ── */
+      items.forEach(item => {
+        item.addEventListener('click', () => switchTo(item));
+        item.addEventListener('mouseenter', () => {
+          focusIdx = items.indexOf(item);
+        });
+      });
+
+      /* ── keyboard ── */
+      triggerWrap.addEventListener('keydown', e => {
+        if (!isOpen) {
+          if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+            e.preventDefault(); open();
+          }
+          return;
+        }
+
+        switch (e.key) {
+          case 'ArrowDown':
+            e.preventDefault();
+            focusIdx = Math.min(focusIdx + 1, items.length - 1);
+            items[focusIdx].focus();
+            break;
+          case 'ArrowUp':
+            e.preventDefault();
+            focusIdx = Math.max(focusIdx - 1, 0);
+            items[focusIdx].focus();
+            break;
+          case 'Enter':
+          case ' ':
+            e.preventDefault();
+            if (focusIdx >= 0) switchTo(items[focusIdx]);
+            break;
+          case 'Escape':
+            e.preventDefault();
+            close();
+            trigger.focus();
+            break;
+          case 'Tab':
+            close();
+            break;
+        }
+      });
+
+      /* ── close on outside click ── */
+      document.addEventListener('click', e => {
+        if (isOpen && !triggerWrap.contains(e.target)) close();
+      });
+
+      /* ── create workspace ── */
+      document.getElementById('ws-new').addEventListener('click', () => {
+        announce('Create workspace clicked.');
+        close();
+      });
+
+    })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/workspace-switcher-nk/style.css
+++ b/submissions/examples/workspace-switcher-nk/style.css
@@ -1,0 +1,597 @@
+/* ============================================================
+   Workspace Switcher — EaseMotion CSS Submission
+   Track: Standard (HTML/CSS)
+   Component ID: workspace-switcher-nk
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   0. Design tokens
+   ------------------------------------------------------------ */
+:root {
+  --ws-color-bg:         #ffffff;
+  --ws-color-surface:    #f8fafc;
+  --ws-color-border:     #e2e8f0;
+  --ws-color-text:       #1e293b;
+  --ws-color-muted:      #94a3b8;
+  --ws-color-label:      #475569;
+
+  --ws-color-primary:    #6366f1;
+  --ws-color-primary-lt: #eef2ff;
+  --ws-color-hover-bg:   #f1f5f9;
+
+  --ws-glow-primary: 0 0 0 3px rgba(99,102,241,0.15);
+
+  --ws-radius-sm:   6px;
+  --ws-radius-md:   10px;
+  --ws-radius-lg:   14px;
+  --ws-radius-card: 18px;
+  --ws-radius-pill: 9999px;
+
+  --ws-speed-fast:  0.14s;
+  --ws-speed-mid:   0.24s;
+  --ws-speed-slow:  0.38s;
+  --ws-ease:        cubic-bezier(0.4, 0, 0.2, 1);
+  --ws-ease-out:    cubic-bezier(0, 0, 0.2, 1);
+  --ws-ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ------------------------------------------------------------
+   1. Base reset
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f0fdf4 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+  color: var(--ws-color-text);
+}
+
+.ws-sr {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* ------------------------------------------------------------
+   2. Layout
+   ------------------------------------------------------------ */
+.demo-wrapper {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ------------------------------------------------------------
+   3. Topbar
+   ------------------------------------------------------------ */
+.ws-topbar {
+  background: var(--ws-color-bg);
+  border: 1px solid var(--ws-color-border);
+  border-radius: var(--ws-radius-card);
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 1px 3px rgba(0,0,0,.06), 0 6px 16px rgba(0,0,0,.06);
+  animation: ws-fade-up var(--ws-speed-slow) var(--ws-ease-out) both;
+}
+
+.ws-topbar__left { display: flex; align-items: center; gap: 0.75rem; }
+.ws-topbar__right { display: flex; align-items: center; gap: 0.5rem; }
+
+.ws-avatar-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  color: var(--ws-color-label);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* ------------------------------------------------------------
+   4. Trigger button
+   ------------------------------------------------------------ */
+.ws-trigger-wrap {
+  position: relative;
+}
+
+.ws-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  border: 1.5px solid var(--ws-color-border);
+  border-radius: var(--ws-radius-md);
+  background: var(--ws-color-bg);
+  cursor: pointer;
+  transition:
+    background    var(--ws-speed-fast) var(--ws-ease),
+    border-color  var(--ws-speed-fast) var(--ws-ease),
+    box-shadow    var(--ws-speed-fast) var(--ws-ease);
+  outline: none;
+}
+
+.ws-trigger:hover {
+  background: var(--ws-color-surface);
+  border-color: #c7d2fe;
+}
+
+.ws-trigger:focus-visible {
+  box-shadow: var(--ws-glow-primary);
+  border-color: var(--ws-color-primary);
+}
+
+/* Trigger avatar */
+.ws-trigger__avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--ws-radius-sm);
+  background: var(--ws-avatar-color, var(--ws-color-primary));
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background var(--ws-speed-fast) var(--ws-ease);
+}
+
+/* Trigger name */
+.ws-trigger__name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ws-color-text);
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Chevron — rotates when open */
+.ws-trigger__chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--ws-color-muted);
+  flex-shrink: 0;
+  transition: transform var(--ws-speed-mid) var(--ws-ease-bounce),
+              color     var(--ws-speed-fast) var(--ws-ease);
+}
+
+.ws-trigger--open .ws-trigger__chevron {
+  transform: rotate(180deg);
+  color: var(--ws-color-primary);
+}
+
+/* Trigger switch cross-fade */
+.ws-trigger--switching {
+  animation: ws-trigger-switch var(--ws-speed-mid) var(--ws-ease) both;
+}
+
+/* ------------------------------------------------------------
+   5. Dropdown panel
+   ------------------------------------------------------------ */
+.ws-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 260px;
+  background: var(--ws-color-bg);
+  border: 1px solid var(--ws-color-border);
+  border-radius: var(--ws-radius-lg);
+  box-shadow:
+    0 4px 6px rgba(0,0,0,.05),
+    0 16px 40px rgba(0,0,0,.12);
+  z-index: 100;
+  overflow: hidden;
+  transform-origin: top left;
+}
+
+/* Panel slide down open */
+.ws-panel--open {
+  animation: ws-panel-open var(--ws-speed-mid) var(--ws-ease-bounce) both;
+}
+
+/* Panel slide up close */
+.ws-panel--closing {
+  animation: ws-panel-close var(--ws-speed-fast) var(--ws-ease) forwards;
+}
+
+.ws-panel__heading {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: var(--ws-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 0.75rem 1rem 0.4rem;
+}
+
+/* ------------------------------------------------------------
+   6. Workspace list items
+   ------------------------------------------------------------ */
+.ws-list {
+  list-style: none;
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ws-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.525rem 0.625rem;
+  border-radius: var(--ws-radius-md);
+  cursor: pointer;
+  outline: none;
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    background var(--ws-speed-fast) var(--ws-ease),
+    transform  var(--ws-speed-mid)  var(--ws-ease-bounce);
+}
+
+/* Stagger entrance */
+.ws-item--in {
+  animation: ws-item-in var(--ws-speed-mid) var(--ws-ease-out) both;
+}
+
+.ws-item:hover,
+.ws-item:focus-visible {
+  background: var(--ws-color-hover-bg);
+  transform: scale(1.015);
+}
+
+.ws-item:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ws-color-primary);
+}
+
+/* ── Left accent bar — slides in on hover ── */
+.ws-item__accent {
+  position: absolute;
+  left: 0;
+  top: 20%;
+  height: 60%;
+  width: 3px;
+  border-radius: var(--ws-radius-pill);
+  background: var(--ws-avatar-color, var(--ws-color-primary));
+  transform: scaleY(0);
+  transform-origin: center;
+  transition: transform var(--ws-speed-mid) var(--ws-ease-bounce);
+}
+
+.ws-item:hover  .ws-item__accent,
+.ws-item:focus-visible .ws-item__accent {
+  transform: scaleY(1);
+}
+
+/* Avatar */
+.ws-item__avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--ws-avatar-color, var(--ws-color-primary));
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform var(--ws-speed-mid) var(--ws-ease-bounce);
+}
+
+.ws-item:hover .ws-item__avatar {
+  transform: scale(1.1);
+}
+
+/* Info */
+.ws-item__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.ws-item__name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ws-color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-item__role {
+  font-size: 0.6875rem;
+  color: var(--ws-color-muted);
+}
+
+/* Active checkmark */
+.ws-item__check {
+  width: 14px;
+  height: 14px;
+  color: var(--ws-color-primary);
+  opacity: 0;
+  transform: scale(0.5);
+  transition:
+    opacity   var(--ws-speed-fast) var(--ws-ease),
+    transform var(--ws-speed-mid)  var(--ws-ease-bounce);
+  flex-shrink: 0;
+}
+
+.ws-item--active .ws-item__check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Active item background */
+.ws-item--active {
+  background: var(--ws-color-primary-lt);
+}
+
+.ws-item--active .ws-item__name {
+  color: var(--ws-color-primary);
+}
+
+/* ------------------------------------------------------------
+   7. Divider
+   ------------------------------------------------------------ */
+.ws-divider {
+  height: 1px;
+  background: var(--ws-color-border);
+  margin: 0.375rem 0.5rem;
+}
+
+/* ------------------------------------------------------------
+   8. Create new workspace button
+   ------------------------------------------------------------ */
+.ws-new {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: calc(100% - 1rem);
+  margin: 0.25rem 0.5rem 0.5rem;
+  padding: 0.525rem 0.625rem;
+  border: 1.5px dashed var(--ws-color-border);
+  border-radius: var(--ws-radius-md);
+  background: transparent;
+  cursor: pointer;
+  transition:
+    border-color var(--ws-speed-fast) var(--ws-ease),
+    background   var(--ws-speed-fast) var(--ws-ease);
+  outline: none;
+}
+
+.ws-new:hover {
+  border-color: var(--ws-color-primary);
+  background: var(--ws-color-primary-lt);
+}
+
+.ws-new:focus-visible {
+  box-shadow: var(--ws-glow-primary);
+  border-color: var(--ws-color-primary);
+}
+
+.ws-new__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1.5px dashed var(--ws-color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ws-color-muted);
+  flex-shrink: 0;
+  transition:
+    border-color var(--ws-speed-fast) var(--ws-ease),
+    color        var(--ws-speed-fast) var(--ws-ease),
+    transform    var(--ws-speed-mid)  var(--ws-ease);
+}
+
+.ws-new__icon svg {
+  width: 13px;
+  height: 13px;
+}
+
+/* + icon spins on hover */
+.ws-new:hover .ws-new__icon {
+  transform: rotate(90deg);
+  border-color: var(--ws-color-primary);
+  color: var(--ws-color-primary);
+}
+
+.ws-new__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ws-color-muted);
+  transition: color var(--ws-speed-fast) var(--ws-ease);
+}
+
+.ws-new:hover .ws-new__label {
+  color: var(--ws-color-primary);
+}
+
+/* ------------------------------------------------------------
+   9. Active workspace card
+   ------------------------------------------------------------ */
+.ws-active-card {
+  background: var(--ws-color-bg);
+  border: 1px solid var(--ws-color-border);
+  border-radius: var(--ws-radius-card);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,.05), 0 4px 12px rgba(0,0,0,.06);
+  animation: ws-fade-up var(--ws-speed-slow) var(--ws-ease-out) 0.05s both;
+}
+
+.ws-active-card__avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--ws-avatar-color, var(--ws-color-primary));
+  color: #fff;
+  font-size: 1.125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background var(--ws-speed-mid) var(--ws-ease);
+}
+
+.ws-avatar--pop {
+  animation: ws-avatar-pop var(--ws-speed-mid) var(--ws-ease-bounce) both;
+}
+
+.ws-active-card__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ws-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.ws-active-card__name {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--ws-color-text);
+  letter-spacing: -0.01em;
+  margin-top: 0.15rem;
+}
+
+/* ------------------------------------------------------------
+   10. Demo hint
+   ------------------------------------------------------------ */
+.demo-hint {
+  background: var(--ws-color-bg);
+  border: 1px solid var(--ws-color-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  animation: ws-fade-up var(--ws-speed-slow) var(--ws-ease-out) 0.1s both;
+}
+
+.demo-hint__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--ws-color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.demo-hint__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.demo-hint__list li {
+  font-size: 0.8125rem;
+  color: var(--ws-color-text);
+  padding-left: 1rem;
+  position: relative;
+}
+
+.demo-hint__list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--ws-color-primary);
+  font-size: 0.75rem;
+}
+
+kbd {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  background: var(--ws-color-surface);
+  border: 1px solid var(--ws-color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.75em;
+  color: var(--ws-color-label);
+}
+
+/* ------------------------------------------------------------
+   11. Keyframes
+   ------------------------------------------------------------ */
+
+/* Card entrance */
+@keyframes ws-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Panel slide open */
+@keyframes ws-panel-open {
+  from { opacity: 0; transform: scaleY(0.88) translateY(-8px); }
+  60%  { transform: scaleY(1.02) translateY(1px); }
+  to   { opacity: 1; transform: scaleY(1) translateY(0); }
+}
+
+/* Panel slide close */
+@keyframes ws-panel-close {
+  from { opacity: 1; transform: scaleY(1) translateY(0); }
+  to   { opacity: 0; transform: scaleY(0.92) translateY(-6px); }
+}
+
+/* Item stagger in */
+@keyframes ws-item-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Trigger name cross-fade on switch */
+@keyframes ws-trigger-switch {
+  0%   { opacity: 1; transform: scale(1); }
+  40%  { opacity: 0; transform: scale(0.94); }
+  70%  { opacity: 0; transform: scale(0.94); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+/* Active card avatar pop */
+@keyframes ws-avatar-pop {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
+
+/* ------------------------------------------------------------
+   12. Reduced motion
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+  }
+}
+
+/* ------------------------------------------------------------
+   13. Responsive
+   ------------------------------------------------------------ */
+@media (max-width: 400px) {
+  .ws-panel { width: 220px; }
+  .ws-trigger__name { max-width: 90px; }
+}


### PR DESCRIPTION
fix #85342 

## Pull Request Description

Adds a fully animated workspace/account switcher dropdown (`workspace-switcher-nk`) — a pattern completely absent from the repo despite being present in every major SaaS product. Features a rotating chevron trigger, staggered panel entrance, left accent bar slide-in on hover, cross-fade name swap on switch, avatar scale-pop, and a spinning `+` on the create button — all driven by pure CSS keyframes and transitions, fully keyboard accessible.

### Type of Change

- 🧩 New component

### Submission Checklist

- [x] All changes are inside `submissions/examples/workspace-switcher-nk/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

### Feature Description

**What does this add?**

An animated workspace switcher dropdown with chevron rotation on open, staggered item entrance (55ms delay each), left accent bar scaleY slide-in on hover, avatar scale(1.1) on hover, cross-fade trigger name on switch, avatar pop animation on the active card, and a rotate(90deg) `+` icon on the create button.

**How does a developer use it?**

```html
<button class="ws-trigger" aria-haspopup="listbox" aria-expanded="false">
  <span class="ws-trigger__avatar">A</span>
  <span class="ws-trigger__name">Acme Corp</span>
  <svg class="ws-trigger__chevron">...</svg>
</button>
<div class="ws-panel" role="listbox" hidden>
  <ul class="ws-list">
    <li class="ws-item ws-item--active" role="option" aria-selected="true">
      <span class="ws-item__accent"></span>
      <span class="ws-item__avatar" style="--ws-avatar-color:#6366f1">A</span>
      ...
    </li>
  </ul>
</div>
```

JS adds `ws-trigger--open`, `ws-panel--open`, `ws-item--in` (staggered), `ws-item--active`, `ws-trigger--switching`, `ws-avatar--pop`. All animation is CSS.

**Why does it fit EaseMotion CSS?**

Workspace switching is a high-frequency action in SaaS — Slack, Linear, Notion, Vercel all have it. The stagger entrance, border accent, cross-fade, and pop each deliver spatial feedback through motion, not static visual changes. Completely absent from the repo before this PR.

### Demo

- `demo.html` works by opening directly in a browser
- Click trigger → panel slides down, items stagger in
- Hover items → left border slides in, avatar scales up
- Click workspace → cross-fade trigger name + active card avatar pops
- Hover "Create workspace" → `+` rotates 90°
- ↑↓ navigates, Enter selects, Esc closes

### Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

### Notes for Maintainer

All 6 keyframes use `--ws-*` CSS custom property tokens. Each item uses `--ws-avatar-color` CSS custom property for avatar + accent bar colour, making it trivially themeable per workspace. `prefers-reduced-motion` collapses all durations to near-zero. Keyboard navigation follows ARIA listbox pattern with ↑↓, Enter, Esc. JS is ~80 lines, framework-agnostic.