### PR TITLE
feat(scss): Add SCSS Accent & Caret Color helper mixins (#81292)

### DIFF
--- a/submissions/examples/accent-caret-color-scss/README.md
+++ b/submissions/examples/accent-caret-color-scss/README.md
@@ -1,0 +1,17 @@
+# SCSS Accent & Caret Color Helper Mixins
+
+An SCSS helper mixin suite for customizing native form input accent colors (checkboxes, radios, ranges) and text caret cursor colors.
+
+## Overview & Features
+- `accent-color($color)`: Configures native UI accent color properties.
+- `caret-color($color)`: Configures text input typing cursor color properties.
+- `accent-caret($accent, $caret)`: Combines both properties into a single utility mixin.
+- `accent-caret-theme($variant)`: Preset theme color variations (cyan, magenta, emerald).
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.custom-form-control {
+  @include accent-caret-theme('cyan');
+}

--- a/submissions/examples/accent-caret-color-scss/_mixins.scss
+++ b/submissions/examples/accent-caret-color-scss/_mixins.scss
@@ -1,0 +1,42 @@
+// ==========================================================================
+// Accent & Caret Color Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies native UI accent-color styling for checkboxes, radio buttons, range sliders, and progress elements.
+/// @param {Color | String} $color [var(--ease-accent-color, #06b6d4)] - Accent color value.
+@mixin accent-color(
+  $color: var(--ease-accent-color, #06b6d4)
+) {
+  accent-color: $color;
+}
+
+/// Applies custom caret (text cursor) color styling for text inputs and textareas.
+/// @param {Color | String} $color [var(--ease-caret-color, #06b6d4)] - Caret color value.
+@mixin caret-color(
+  $color: var(--ease-caret-color, #06b6d4)
+) {
+  caret-color: $color;
+}
+
+/// Combines accent-color and caret-color properties with CSS variable theme integration.
+/// @param {Color | String} $accent [var(--ease-accent-color, #06b6d4)] - Accent color.
+/// @param {Color | String} $caret [var(--ease-caret-color, #06b6d4)] - Caret color.
+@mixin accent-caret(
+  $accent: var(--ease-accent-color, #06b6d4),
+  $caret: var(--ease-caret-color, #06b6d4)
+) {
+  @include accent-color($accent);
+  @include caret-color($caret);
+}
+
+/// Applies preset accent and caret color theme variations.
+/// @param {String} $variant [cyan] - Preset variant (cyan, magenta, emerald).
+@mixin accent-caret-theme($variant: 'cyan') {
+  @if $variant == 'cyan' {
+    @include accent-caret(var(--ease-accent-cyan, #06b6d4), var(--ease-caret-cyan, #06b6d4));
+  } @else if $variant == 'magenta' {
+    @include accent-caret(var(--ease-accent-magenta, #ec4899), var(--ease-caret-magenta, #ec4899));
+  } @else if $variant == 'emerald' {
+    @include accent-caret(var(--ease-accent-emerald, #10b981), var(--ease-caret-emerald, #10b981));
+  }
+}

--- a/submissions/examples/accent-caret-color-scss/demo.html
+++ b/submissions/examples/accent-caret-color-scss/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Accent & Caret Color — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <!-- Cyan Theme Group -->
+      <div class="ease-input-group ease-theme-cyan">
+        <input type="text" class="ease-text-input" value="Cyan caret & accent inputs" />
+        <div class="ease-control-row">
+          <label><input type="checkbox" checked /> Cyan Checkbox</label>
+          <label><input type="radio" checked /> Cyan Radio</label>
+        </div>
+      </div>
+
+      <!-- Magenta Theme Group -->
+      <div class="ease-input-group ease-theme-magenta">
+        <input type="text" class="ease-text-input" value="Magenta caret & accent inputs" />
+        <div class="ease-control-row">
+          <label><input type="checkbox" checked /> Magenta Checkbox</label>
+          <label><input type="radio" checked /> Magenta Radio</label>
+        </div>
+      </div>
+
+      <!-- Emerald Theme Group -->
+      <div class="ease-input-group ease-theme-emerald">
+        <input type="text" class="ease-text-input" value="Emerald caret & accent inputs" />
+        <div class="ease-control-row">
+          <label><input type="checkbox" checked /> Emerald Checkbox</label>
+          <label><input type="radio" checked /> Emerald Radio</label>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/accent-caret-color-scss/style.css
+++ b/submissions/examples/accent-caret-color-scss/style.css
@@ -1,0 +1,77 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ease-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ease-text-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+}
+.ease-text-input:focus {
+  outline: none;
+}
+
+.ease-control-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ease-text);
+  font-size: 0.9rem;
+}
+
+.ease-theme-cyan {
+  accent-color: var(--ease-accent-cyan, #06b6d4);
+  caret-color: var(--ease-caret-cyan, #06b6d4);
+}
+
+.ease-theme-magenta {
+  accent-color: var(--ease-accent-magenta, #ec4899);
+  caret-color: var(--ease-caret-magenta, #ec4899);
+}
+
+.ease-theme-emerald {
+  accent-color: var(--ease-accent-emerald, #10b981);
+  caret-color: var(--ease-caret-emerald, #10b981);
+}

--- a/submissions/examples/accent-caret-color-scss/style.scss
+++ b/submissions/examples/accent-caret-color-scss/style.scss
@@ -1,0 +1,76 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+  --ease-emerald: #10b981;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.ease-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ease-text-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.ease-control-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--ease-text);
+  font-size: 0.9rem;
+}
+
+.ease-theme-cyan {
+  @include accent-caret-theme('cyan');
+}
+
+.ease-theme-magenta {
+  @include accent-caret-theme('magenta');
+}
+
+.ease-theme-emerald {
+  @include accent-caret-theme('emerald');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81292

Adds custom SCSS accent and caret color helper mixins (`accent-color()`, `caret-color()`, `accent-caret()`, and `accent-caret-theme()`) under `submissions/examples/accent-caret-color-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/accent-caret-color-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for native form input customization (`accent-color` and `caret-color`) featuring CSS variable integration and preset color theme variants.
**Why does it fit?** Expands developer form control styling utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari