### PR TITLE
feat: add text underline offset example

### DIFF
--- a/submissions/examples/81344-text-underline-offset/README.md
+++ b/submissions/examples/81344-text-underline-offset/README.md
@@ -1,0 +1,36 @@
+# Text Underline Offset
+
+A simple example demonstrating the concept of a Text Underline Offset helper mixin using standard CSS.
+
+## Features
+
+- Adjustable underline offset
+- Custom underline color
+- Smooth hover transition
+- Pure HTML & CSS
+- No JavaScript
+
+## SCSS Equivalent
+
+```scss
+@mixin text-underline-offset(
+  $offset: 4px,
+  $color: currentColor
+) {
+  text-decoration: underline;
+  text-underline-offset: $offset;
+  text-decoration-color: $color;
+}
+```
+
+## Preview
+
+Open `demo.html` in any modern browser.
+
+## Files
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+All files are contained within `submissions/examples/81344-text-underline-offset/`.

--- a/submissions/examples/81344-text-underline-offset/demo.html
+++ b/submissions/examples/81344-text-underline-offset/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Underline Offset Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="container">
+  <h1>Text Underline Offset</h1>
+
+  <p>
+    Explore the
+    <a href="#">EaseMotion Documentation</a>
+    to see how underline offsets improve readability.
+  </p>
+
+  <p>
+    Visit our
+    <a href="#">Component Library</a>
+    for more examples.
+  </p>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/81344-text-underline-offset/style.css
+++ b/submissions/examples/81344-text-underline-offset/style.css
@@ -1,0 +1,44 @@
+*{
+  box-sizing:border-box;
+}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  background:#f5f7fa;
+  font-family:system-ui,sans-serif;
+  padding:2rem;
+}
+
+.container{
+  max-width:650px;
+  background:#fff;
+  padding:2rem;
+  border-radius:16px;
+  box-shadow:0 12px 30px rgba(0,0,0,.08);
+}
+
+h1{
+  margin-top:0;
+  color:#1f2937;
+}
+
+p{
+  color:#4b5563;
+  line-height:1.8;
+}
+
+a{
+  color:#2563eb;
+  text-decoration:underline;
+  text-underline-offset:6px;
+  text-decoration-color:#60a5fa;
+  transition:.25s ease;
+}
+
+a:hover{
+  text-underline-offset:10px;
+  text-decoration-color:#1d4ed8;
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a submission example demonstrating the **Text Underline Offset** helper mixin concept using pure HTML and CSS.

The example showcases customizable underline spacing, underline color, and smooth hover transitions while keeping the implementation lightweight and easy to understand.

---

## Type of Change

- [x] ✨ New example
- [ ] 🧪 Test improvement
- [ ] 🎨 UI enhancement
- [x] 📝 Documentation
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `scss/`
- [x] One feature per PR

---

## Features

- Adjustable text underline offset
- Custom underline color
- Smooth hover transition
- Pure HTML & CSS
- Responsive layout
- No JavaScript

---

## Demo

- [x] Demo included
- [x] Opens directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainers

This submission is completely self-contained inside the `submissions/examples/81344-text-underline-offset/` directory and follows the repository's submission-only contribution guidelines.

Closes #81344