### PR TITLE
feat: add backdrop blur filter example (#81266)

### DIFF
--- a/submissions/examples/81266-backdrop-blur-filter/README.md
+++ b/submissions/examples/81266-backdrop-blur-filter/README.md
@@ -1,0 +1,37 @@
+# Backdrop Blur Filter
+
+A simple Glassmorphism example demonstrating the concept of a **Backdrop Blur Filter** helper mixin using standard CSS.
+
+## Features
+
+- Glassmorphism UI
+- CSS `backdrop-filter` blur effect
+- WebKit browser fallback
+- Responsive card layout
+- Pure HTML & CSS
+- No JavaScript
+
+## SCSS Equivalent
+
+```scss
+@mixin backdrop-blur-filter($blur: 14px) {
+  backdrop-filter: blur($blur);
+  -webkit-backdrop-filter: blur($blur);
+}
+```
+
+## Preview
+
+Open `demo.html` in any modern browser.
+
+## Files
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+All files are contained within:
+
+```
+submissions/examples/81266-backdrop-blur-filter/
+```

--- a/submissions/examples/81266-backdrop-blur-filter/demo.html
+++ b/submissions/examples/81266-backdrop-blur-filter/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Backdrop Blur Filter Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="background"></div>
+
+<main class="glass-card">
+  <h1>Backdrop Blur Filter</h1>
+  <p>
+    This example demonstrates a glassmorphism card using
+    <code>backdrop-filter: blur()</code>.
+  </p>
+  <button>Learn More</button>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/81266-backdrop-blur-filter/style.css
+++ b/submissions/examples/81266-backdrop-blur-filter/style.css
@@ -1,0 +1,60 @@
+*{
+  box-sizing:border-box;
+}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  overflow:hidden;
+  font-family:system-ui,sans-serif;
+  background:linear-gradient(135deg,#4f46e5,#06b6d4,#22c55e);
+}
+
+.background{
+  position:fixed;
+  inset:0;
+  background:
+    radial-gradient(circle at top left,#ffffff55,transparent 35%),
+    radial-gradient(circle at bottom right,#ffffff33,transparent 30%);
+}
+
+.glass-card{
+  position:relative;
+  z-index:1;
+  width:min(90%,420px);
+  padding:2rem;
+  border-radius:20px;
+  background:rgba(255,255,255,.18);
+  border:1px solid rgba(255,255,255,.35);
+  backdrop-filter:blur(14px);
+  -webkit-backdrop-filter:blur(14px);
+  text-align:center;
+  color:#fff;
+  box-shadow:0 18px 40px rgba(0,0,0,.2);
+}
+
+h1{
+  margin-top:0;
+}
+
+p{
+  line-height:1.6;
+  margin-bottom:1.8rem;
+}
+
+button{
+  padding:.8rem 1.5rem;
+  border:none;
+  border-radius:999px;
+  background:#fff;
+  color:#111827;
+  cursor:pointer;
+  font-weight:600;
+  transition:.25s;
+}
+
+button:hover{
+  transform:translateY(-2px);
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a submission example demonstrating the **Backdrop Blur Filter** helper mixin concept using pure HTML and CSS.

The example showcases a modern glassmorphism card using `backdrop-filter` with a WebKit fallback, responsive layout, and clean styling.

---

## Type of Change

- [x] ✨ New example
- [ ] 🧪 Test improvement
- [ ] 🎨 UI enhancement
- [x] 📝 Documentation
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `scss/`
- [x] One feature per PR

---

## Features

- Glassmorphism card design
- CSS `backdrop-filter` blur effect
- WebKit fallback support
- Responsive layout
- Pure HTML & CSS
- No JavaScript

---

## Demo

- [x] Demo included
- [x] Opens directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainers

This submission is completely self-contained inside the `submissions/examples/81266-backdrop-blur-filter/` directory and follows the repository's submission-only contribution guidelines.

Closes #81266