### PR TITLE
feat: add CSS masking and clip-path example (#81265)

### DIFF
--- a/submissions/examples/81265-css-masking-clip-path/README.md
+++ b/submissions/examples/81265-css-masking-clip-path/README.md
@@ -1,0 +1,38 @@
+# CSS Masking & Clip-Path
+
+A simple example demonstrating the concept of CSS Masking and Clip-Path helper mixins using standard CSS.
+
+## Features
+
+- Polygon clip-path shapes
+- Hexagon, diamond and star examples
+- Responsive flex layout
+- Pure HTML & CSS
+- No JavaScript
+
+## SCSS Equivalent
+
+```scss
+@mixin clip-shape($polygon) {
+  clip-path: $polygon;
+}
+
+@mixin mask-image($mask) {
+  -webkit-mask-image: $mask;
+  mask-image: $mask;
+}
+```
+
+## Preview
+
+Open `demo.html` in any modern browser.
+
+## Files
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+All files are contained within:
+
+`submissions/examples/81265-css-masking-clip-path/`

--- a/submissions/examples/81265-css-masking-clip-path/demo.html
+++ b/submissions/examples/81265-css-masking-clip-path/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Masking & Clip-Path Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main class="container">
+  <h1>CSS Masking & Clip-Path</h1>
+
+  <div class="shapes">
+    <div class="shape hexagon"></div>
+    <div class="shape diamond"></div>
+    <div class="shape star"></div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/81265-css-masking-clip-path/style.css
+++ b/submissions/examples/81265-css-masking-clip-path/style.css
@@ -1,0 +1,53 @@
+*{
+  box-sizing:border-box;
+}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  background:#eef2ff;
+  font-family:system-ui,sans-serif;
+}
+
+.container{
+  text-align:center;
+}
+
+.shapes{
+  display:flex;
+  gap:2rem;
+  flex-wrap:wrap;
+  justify-content:center;
+  margin-top:2rem;
+}
+
+.shape{
+  width:140px;
+  height:140px;
+  background:linear-gradient(135deg,#2563eb,#7c3aed);
+}
+
+.hexagon{
+  clip-path:polygon(25% 6%,75% 6%,100% 50%,75% 94%,25% 94%,0 50%);
+}
+
+.diamond{
+  clip-path:polygon(50% 0,100% 50%,50% 100%,0 50%);
+}
+
+.star{
+  clip-path:polygon(
+    50% 0%,
+    61% 35%,
+    98% 35%,
+    68% 57%,
+    79% 91%,
+    50% 70%,
+    21% 91%,
+    32% 57%,
+    2% 35%,
+    39% 35%
+  );
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a submission example demonstrating the **CSS Masking & Clip-Path** helper mixin concept using pure HTML and CSS.

The example showcases multiple geometric shapes created with `clip-path` and includes SCSS mixin examples for clip-path and masking.

---

## Type of Change

- [x] ✨ New example
- [ ] 🧪 Test improvement
- [ ] 🎨 UI enhancement
- [x] 📝 Documentation
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `scss/`
- [x] One feature per PR

---

## Features

- Polygon clip-path examples
- Multiple geometric shapes
- Responsive layout
- Pure HTML & CSS
- No JavaScript

---

## Demo

- [x] Demo included
- [x] Opens directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainers

This submission is fully self-contained inside the `submissions/examples/81265-css-masking-clip-path/` directory and follows the repository's submission-only contribution guidelines.

Closes #81265