### PR TITLE
feat: add container query breakpoints example (#81260)

### DIFF
--- a/submissions/examples/81260-container-query-breakpoints/README.md
+++ b/submissions/examples/81260-container-query-breakpoints/README.md
@@ -1,0 +1,35 @@
+# Container Query Breakpoints
+
+A simple example demonstrating the concept of **Container Query Breakpoints** using modern CSS container queries.
+
+## Features
+
+- CSS Container Queries
+- Inline-size container support
+- Responsive component layout
+- Pure HTML & CSS
+- No JavaScript
+
+## SCSS Equivalent
+
+```scss
+@mixin container-breakpoint($size) {
+  @container (min-width: $size) {
+    @content;
+  }
+}
+```
+
+## Preview
+
+Open `demo.html` in a modern browser and drag the right edge of the container to see the layout change.
+
+## Files
+
+- `demo.html`
+- `style.css`
+- `README.md`
+
+All files are contained within:
+
+`submissions/examples/81260-container-query-breakpoints/`

--- a/submissions/examples/81260-container-query-breakpoints/demo.html
+++ b/submissions/examples/81260-container-query-breakpoints/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Container Query Breakpoints Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="wrapper">
+  <div class="card-container">
+    <article class="card">
+      <h2>Container Query</h2>
+      <p>
+        Resize the container to see the layout adapt using
+        CSS container queries instead of viewport media queries.
+      </p>
+      <button>Learn More</button>
+    </article>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/81260-container-query-breakpoints/style.css
+++ b/submissions/examples/81260-container-query-breakpoints/style.css
@@ -1,0 +1,65 @@
+*{
+  box-sizing:border-box;
+}
+
+body{
+  margin:0;
+  min-height:100vh;
+  display:grid;
+  place-items:center;
+  padding:2rem;
+  background:#f3f4f6;
+  font-family:system-ui,sans-serif;
+}
+
+.wrapper{
+  width:min(90%,900px);
+}
+
+.card-container{
+  container-type:inline-size;
+  resize:horizontal;
+  overflow:auto;
+  min-width:260px;
+  max-width:800px;
+  margin:auto;
+  border:2px dashed #cbd5e1;
+  padding:1rem;
+}
+
+.card{
+  display:grid;
+  gap:1rem;
+  padding:1.5rem;
+  border-radius:14px;
+  background:#ffffff;
+  box-shadow:0 10px 24px rgba(0,0,0,.08);
+}
+
+button{
+  padding:.8rem 1.2rem;
+  border:none;
+  border-radius:8px;
+  background:#2563eb;
+  color:#fff;
+  cursor:pointer;
+}
+
+@container (min-width:500px){
+  .card{
+    grid-template-columns:2fr 1fr;
+    align-items:center;
+  }
+
+  h2,
+  p{
+    grid-column:1;
+  }
+
+  button{
+    grid-column:2;
+    grid-row:1 / span 2;
+    align-self:center;
+    justify-self:end;
+  }
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a submission example demonstrating the **Container Query Breakpoints** helper mixin concept using pure HTML and CSS.

The example showcases a responsive card that adapts to its container size using CSS Container Queries rather than viewport media queries.

---

## Type of Change

- [x] ✨ New example
- [ ] 🧪 Test improvement
- [ ] 🎨 UI enhancement
- [x] 📝 Documentation
- [ ] 🐛 Bug fix

---

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `scss/`
- [x] One feature per PR

---

## Features

- CSS Container Queries
- Inline-size responsive behavior
- Resizable demo container
- Pure HTML & CSS
- No JavaScript

---

## Demo

- [x] Demo included
- [x] Opens directly in a browser

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainers

This submission is fully self-contained inside the `submissions/examples/81260-container-query-breakpoints/` directory and follows the repository's submission-only contribution guidelines.

Closes #81260