### PR TITLE
feat(scss): Add SCSS Placeholder Color Styling helper mixins (#81320)

### DIFF
--- a/submissions/examples/placeholder-color-scss/README.md
+++ b/submissions/examples/placeholder-color-scss/README.md
@@ -1,0 +1,15 @@
+# SCSS Placeholder Color Styling Helper Mixins
+
+An SCSS helper mixin suite for styling input placeholder text colors with cross-browser vendor fallback support.
+
+## Overview & Features
+- `placeholder-color($color)`: Configures custom placeholder colors across standard and legacy vendor pseudo-elements.
+- `placeholder-theme($variant)`: Preset theme selectors supporting muted, cyan, and magenta placeholder styling.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.custom-input {
+  @include placeholder-theme('cyan');
+}

--- a/submissions/examples/placeholder-color-scss/_mixins.scss
+++ b/submissions/examples/placeholder-color-scss/_mixins.scss
@@ -1,0 +1,36 @@
+// ==========================================================================
+// Placeholder Color Styling Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Styles placeholder text colors across all browser vendor pseudo-elements.
+/// @param {Color | String} $color [var(--ease-placeholder-color, #9ca3af)] - Placeholder text color.
+@mixin placeholder-color(
+  $color: var(--ease-placeholder-color, #9ca3af)
+) {
+  &::placeholder {
+    color: $color;
+    opacity: 1;
+  }
+  &::-webkit-input-placeholder {
+    color: $color;
+  }
+  &::-moz-placeholder {
+    color: $color;
+    opacity: 1;
+  }
+  &:-ms-input-placeholder {
+    color: $color;
+  }
+}
+
+/// Applies preset placeholder color theme variations.
+/// @param {String} $variant [muted] - Preset variant (muted, cyan, magenta).
+@mixin placeholder-theme($variant: 'muted') {
+  @if $variant == 'muted' {
+    @include placeholder-color(var(--ease-placeholder-muted, #9ca3af));
+  } @else if $variant == 'cyan' {
+    @include placeholder-color(var(--ease-placeholder-cyan, #06b6d4));
+  } @else if $variant == 'magenta' {
+    @include placeholder-color(var(--ease-placeholder-magenta, #ec4899));
+  }
+}

--- a/submissions/examples/placeholder-color-scss/demo.html
+++ b/submissions/examples/placeholder-color-scss/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Placeholder Color Styling — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <input type="text" class="ease-input ease-input-muted" placeholder="Muted placeholder text..." />
+      <input type="text" class="ease-input ease-input-cyan" placeholder="Cyan brand placeholder text..." />
+      <input type="text" class="ease-input ease-input-magenta" placeholder="Magenta brand placeholder text..." />
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/placeholder-color-scss/style.css
+++ b/submissions/examples/placeholder-color-scss/style.css
@@ -1,0 +1,93 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+}
+.ease-input:focus {
+  outline: none;
+  border-color: var(--ease-cyan);
+}
+
+.ease-input-muted::placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+  opacity: 1;
+}
+.ease-input-muted::-webkit-input-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+}
+.ease-input-muted::-moz-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+  opacity: 1;
+}
+.ease-input-muted:-ms-input-placeholder {
+  color: var(--ease-placeholder-muted, #9ca3af);
+}
+
+.ease-input-cyan::placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+  opacity: 1;
+}
+.ease-input-cyan::-webkit-input-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+}
+.ease-input-cyan::-moz-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+  opacity: 1;
+}
+.ease-input-cyan:-ms-input-placeholder {
+  color: var(--ease-placeholder-cyan, #06b6d4);
+}
+
+.ease-input-magenta::placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+  opacity: 1;
+}
+.ease-input-magenta::-webkit-input-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+}
+.ease-input-magenta::-moz-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+  opacity: 1;
+}
+.ease-input-magenta:-ms-input-placeholder {
+  color: var(--ease-placeholder-magenta, #ec4899);
+}

--- a/submissions/examples/placeholder-color-scss/style.scss
+++ b/submissions/examples/placeholder-color-scss/style.scss
@@ -1,0 +1,62 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-magenta: #ec4899;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 8px;
+  color: var(--ease-text);
+  font-size: 0.95rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--ease-cyan);
+  }
+}
+
+.ease-input-muted {
+  @include placeholder-theme('muted');
+}
+
+.ease-input-cyan {
+  @include placeholder-theme('cyan');
+}
+
+.ease-input-magenta {
+  @include placeholder-theme('magenta');
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81320

Adds custom SCSS placeholder color styling helper mixins (`placeholder-color()` and `placeholder-theme()`) under `submissions/examples/placeholder-color-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/placeholder-color-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for styling input placeholder text colors (`::placeholder`, `::-webkit-input-placeholder`, `::-moz-placeholder`, `:-ms-input-placeholder`) with CSS variable integration.
**Why does it fit?** Expands developer form control styling utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari