### PR TITLE
feat(scss): Add SCSS Column & Row Gap helper mixins (#81314)

### DIFF
--- a/submissions/examples/gap-helpers-scss/README.md
+++ b/submissions/examples/gap-helpers-scss/README.md
@@ -1,0 +1,17 @@
+# SCSS Column & Row Gap Helper Mixins
+
+An SCSS helper mixin suite for managing layout grid and flexbox gutter spacing with precise control over row and column gaps.
+
+## Overview & Features
+- `gap($value)`: Quickly applies spacing gaps to containers.
+- `row-gap($value)`: Configures vertical row spacing between grid/flex items.
+- `column-gap($value)`: Configures horizontal column spacing between grid/flex items.
+- `flex-grid-gap($row, $column)`: Shorthand helper for setting distinct row and column gutters.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.card-container {
+  @include flex-grid-gap(2rem, 1.5rem);
+}

--- a/submissions/examples/gap-helpers-scss/_mixins.scss
+++ b/submissions/examples/gap-helpers-scss/_mixins.scss
@@ -1,0 +1,38 @@
+// ==========================================================================
+// Column & Row Gap Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies both row and column spacing gaps on grid or flexbox containers.
+/// @param {Length | String} $value [var(--ease-gap, 1rem)] - Gap spacing value.
+@mixin gap(
+  $value: var(--ease-gap, 1rem)
+) {
+  gap: $value;
+}
+
+/// Applies vertical row spacing gaps between grid or flexbox items.
+/// @param {Length | String} $value [var(--ease-row-gap, 1rem)] - Row gap spacing value.
+@mixin row-gap(
+  $value: var(--ease-row-gap, 1rem)
+) {
+  row-gap: $value;
+}
+
+/// Applies horizontal column spacing gaps between grid or flexbox items.
+/// @param {Length | String} $value [var(--ease-column-gap, 1rem)] - Column gap spacing value.
+@mixin column-gap(
+  $value: var(--ease-column-gap, 1rem)
+) {
+  column-gap: $value;
+}
+
+/// Comprehensive spacing mixin for specifying independent row and column gutters.
+/// @param {Length | String} $row [1rem] - Row gap value.
+/// @param {Length | String} $column [1rem] - Column gap value.
+@mixin flex-grid-gap(
+  $row: 1rem,
+  $column: 1rem
+) {
+  @include row-gap($row);
+  @include column-gap($column);
+}

--- a/submissions/examples/gap-helpers-scss/demo.html
+++ b/submissions/examples/gap-helpers-scss/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Column & Row Gap — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-grid-layout">
+        <div>Grid Card Item 01</div>
+        <div>Grid Card Item 02</div>
+        <div>Grid Card Item 03</div>
+        <div>Grid Card Item 04</div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gap-helpers-scss/style.css
+++ b/submissions/examples/gap-helpers-scss/style.css
@@ -1,0 +1,45 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 650px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+.ease-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  row-gap: 1.5rem;
+  column-gap: 1rem;
+}
+.ease-grid-layout > div {
+  padding: 1.25rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  font-size: 0.9rem;
+  color: var(--ease-text);
+}

--- a/submissions/examples/gap-helpers-scss/style.scss
+++ b/submissions/examples/gap-helpers-scss/style.scss
@@ -1,0 +1,46 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 650px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+.ease-grid-layout {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  @include flex-grid-gap(1.5rem, 1rem);
+
+  > div {
+    padding: 1.25rem;
+    background: #030712;
+    border: 1px solid var(--ease-border);
+    border-radius: 10px;
+    font-size: 0.9rem;
+    color: var(--ease-text);
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81314

Adds custom SCSS column and row gap helper mixins (`gap()`, `row-gap()`, `column-gap()`, and `flex-grid-gap()`) under `submissions/examples/gap-helpers-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/gap-helpers-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for grid and flexbox gutter management (`gap`, `row-gap`, `column-gap`) with CSS variable integration.
**Why does it fit?** Expands developer layout spacing utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari