### PR TITLE
feat(scss): Add SCSS Contain Layout & Paint helper mixins (#81313)

### DIFF
--- a/submissions/examples/contain-helpers-scss/README.md
+++ b/submissions/examples/contain-helpers-scss/README.md
@@ -1,0 +1,17 @@
+# SCSS Contain Layout & Paint Helper Mixins
+
+An SCSS helper mixin suite for browser rendering optimization using CSS containment (`contain`).
+
+## Overview & Features
+- `contain($value)`: Isolates component subtrees with custom containment parameters.
+- `contain-strict()`: Applies strict containment rules.
+- `contain-content()`: Applies content containment rules.
+- `contain-theme($variant)`: Preset theme selectors supporting standard, strict, and content isolation.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.widget-box {
+  @include contain-theme('standard');
+}

--- a/submissions/examples/contain-helpers-scss/_mixins.scss
+++ b/submissions/examples/contain-helpers-scss/_mixins.scss
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Contain Layout & Paint Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies CSS containment optimization for isolated component layout and paint subtrees.
+/// @param {String} $value [layout paint] - Containment property values (e.g., layout paint, size, strict, content).
+@mixin contain(
+  $value: layout paint
+) {
+  contain: $value;
+}
+
+/// Applies strict CSS containment restricting all layout, style, paint, and size propagation.
+@mixin contain-strict {
+  contain: strict;
+}
+
+/// Applies content CSS containment isolating layout, paint, and size.
+@mixin contain-content {
+  contain: content;
+}
+
+/// Applies preset containment theme variations.
+/// @param {String} $variant [standard] - Preset variant (standard, strict, content).
+@mixin contain-theme($variant: 'standard') {
+  @if $variant == 'standard' {
+    @include contain(layout paint);
+  } @else if $variant == 'strict' {
+    @include contain-strict;
+  } @else if $variant == 'content' {
+    @include contain-content;
+  }
+}

--- a/submissions/examples/contain-helpers-scss/demo.html
+++ b/submissions/examples/contain-helpers-scss/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Contain Layout & Paint — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-contained-widget">
+        <h3>Contained Component Subtree</h3>
+        <p>This widget uses CSS containment to isolate layout and paint calculations, preventing reflow bleeding and enhancing rendering performance.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/contain-helpers-scss/style.css
+++ b/submissions/examples/contain-helpers-scss/style.css
@@ -1,0 +1,52 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-contained-widget {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  contain: layout paint;
+}
+.ease-contained-widget h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ease-cyan);
+  font-size: 1.1rem;
+}
+.ease-contained-widget p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.9rem;
+}

--- a/submissions/examples/contain-helpers-scss/style.scss
+++ b/submissions/examples/contain-helpers-scss/style.scss
@@ -1,0 +1,55 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-contained-widget {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  @include contain-theme('standard');
+
+  h3 {
+    margin: 0 0 0.5rem;
+    color: var(--ease-cyan);
+    font-size: 1.1rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81313

Adds custom SCSS contain layout and paint helper mixins (`contain()`, `contain-strict()`, `contain-content()`, and `contain-theme()`) under `submissions/examples/contain-helpers-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/contain-helpers-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for browser rendering optimization (`contain: layout paint`, `strict`, `content`), enabling isolated component subtrees and enhanced reflow performance.
**Why does it fit?** Expands developer performance optimization utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari