### PR TITLE
feat(scss): Add SCSS Backface Visibility helper mixins (#81311)

### DIFF
--- a/submissions/examples/backface-visibility-scss/README.md
+++ b/submissions/examples/backface-visibility-scss/README.md
@@ -1,0 +1,16 @@
+# SCSS Backface Visibility Helper Mixins
+
+An SCSS helper mixin suite for managing `backface-visibility` properties during 3D card flips and rotation animations with cross-browser vendor prefix support.
+
+## Overview & Features
+- `backface-hidden()`: Applies `backface-visibility: hidden` and `-webkit-backface-visibility: hidden`.
+- `backface-visibility($visibility)`: Sets custom visibility states.
+- `backface-theme($variant)`: Preset theme selectors supporting hidden and visible states.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.card-front {
+  @include backface-theme('hidden');
+}

--- a/submissions/examples/backface-visibility-scss/_mixins.scss
+++ b/submissions/examples/backface-visibility-scss/_mixins.scss
@@ -1,0 +1,28 @@
+// ==========================================================================
+// Backface Visibility Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Hides element backface during 3D transform animations with vendor prefix support.
+@mixin backface-hidden {
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+/// Sets element backface visibility state.
+/// @param {String} $visibility [visible] - Visibility state (visible or hidden).
+@mixin backface-visibility(
+  $visibility: visible
+) {
+  backface-visibility: $visibility;
+  -webkit-backface-visibility: $visibility;
+}
+
+/// Applies preset backface visibility theme variations for 3D card flips.
+/// @param {String} $variant [hidden] - Preset variant (hidden, visible).
+@mixin backface-theme($variant: 'hidden') {
+  @if $variant == 'hidden' {
+    @include backface-hidden;
+  } @else if $variant == 'visible' {
+    @include backface-visibility(visible);
+  }
+}

--- a/submissions/examples/backface-visibility-scss/demo.html
+++ b/submissions/examples/backface-visibility-scss/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Backface Visibility — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-flip-card-face">
+        <h3>3D Card Face (Backface Hidden)</h3>
+        <p>Demonstrates backface visibility hiding rules for smooth 3D transform rotation and card flipping animations.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/backface-visibility-scss/style.css
+++ b/submissions/examples/backface-visibility-scss/style.css
@@ -1,0 +1,54 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-flip-card-face {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+.ease-flip-card-face h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ease-cyan);
+  font-size: 1.1rem;
+}
+.ease-flip-card-face p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.9rem;
+}

--- a/submissions/examples/backface-visibility-scss/style.scss
+++ b/submissions/examples/backface-visibility-scss/style.scss
@@ -1,0 +1,56 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-flip-card-face {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  @include backface-theme('hidden');
+
+  h3 {
+    margin: 0 0 0.5rem;
+    color: var(--ease-cyan);
+    font-size: 1.1rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81311

Adds custom SCSS backface visibility helper mixins (`backface-hidden()`, `backface-visibility()`, and `backface-theme()`) under `submissions/examples/backface-visibility-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/backface-visibility-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for 3D transform backface visibility (`backface-visibility: hidden` with WebKit prefixes) designed for card flipping animations.
**Why does it fit?** Expands developer 3D animation utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari