### PR TITLE
feat(scss): Add SCSS Break Inside Avoid helper mixins (#81309)

### DIFF
--- a/submissions/examples/break-inside-avoid-scss/README.md
+++ b/submissions/examples/break-inside-avoid-scss/README.md
@@ -1,0 +1,16 @@
+# SCSS Break Inside Avoid Helper Mixins
+
+An SCSS helper mixin suite for preventing awkward page and column breaks inside structured elements during document printing.
+
+## Overview & Features
+- `break-inside-avoid()`: Applies `break-inside: avoid` and legacy `page-break-inside: avoid`.
+- `break-inside($value)`: Sets custom break-inside parameters with fallback support.
+- `break-inside-theme($variant)`: Preset theme selectors supporting avoid, page, and column variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.invoice-item {
+  @include break-inside-theme('avoid');
+}

--- a/submissions/examples/break-inside-avoid-scss/_mixins.scss
+++ b/submissions/examples/break-inside-avoid-scss/_mixins.scss
@@ -1,0 +1,34 @@
+// ==========================================================================
+// Break Inside Avoid Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Prevents awkward mid-element page and column splits during document printing and multi-column layouts.
+@mixin break-inside-avoid {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+/// Sets custom break-inside behavior values.
+/// @param {String} $value [avoid] - Break-inside value (avoid, auto, avoid-page, avoid-column).
+@mixin break-inside(
+  $value: avoid
+) {
+  break-inside: $value;
+  @if $value == avoid or $value == avoid-page or $value == avoid-column {
+    page-break-inside: avoid;
+  } @else {
+    page-break-inside: auto;
+  }
+}
+
+/// Applies preset break-inside theme variations.
+/// @param {String} $variant [avoid] - Preset variant (avoid, page, column).
+@mixin break-inside-theme($variant: 'avoid') {
+  @if $variant == 'avoid' {
+    @include break-inside-avoid;
+  } @else if $variant == 'page' {
+    @include break-inside(avoid-page);
+  } @else if $variant == 'column' {
+    @include break-inside(avoid-column);
+  }
+}

--- a/submissions/examples/break-inside-avoid-scss/demo.html
+++ b/submissions/examples/break-inside-avoid-scss/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Break Inside Avoid — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-print-block">
+        <h3>Unbroken Print Block Content</h3>
+        <p>Demonstrates break-inside rules preventing awkward mid-element page and column splits when printing reports and multi-column documents.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/break-inside-avoid-scss/style.css
+++ b/submissions/examples/break-inside-avoid-scss/style.css
@@ -1,0 +1,54 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-print-block {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.ease-print-block h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ease-cyan);
+  font-size: 1.1rem;
+}
+.ease-print-block p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.9rem;
+}

--- a/submissions/examples/break-inside-avoid-scss/style.scss
+++ b/submissions/examples/break-inside-avoid-scss/style.scss
@@ -1,0 +1,56 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-print-block {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  @include break-inside-theme('avoid');
+
+  h3 {
+    margin: 0 0 0.5rem;
+    color: var(--ease-cyan);
+    font-size: 1.1rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81309

Adds custom SCSS break inside avoid helper mixins (`break-inside-avoid()`, `break-inside()`, and `break-inside-theme()`) under `submissions/examples/break-inside-avoid-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/break-inside-avoid-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for preventing awkward page and column breaks (`break-inside: avoid` and `page-break-inside: avoid`) during document printing.
**Why does it fit?** Expands developer print layout utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari