### PR TITLE
docs(components): add quickstart guide and documentation for brutalism segmented switch #85835

### DIFF
--- a/submissions/docs/ease-brutalist-switch-ss/README.md
+++ b/submissions/docs/ease-brutalist-switch-ss/README.md
@@ -1,0 +1,86 @@
+# Brutalism Segmented Switch Control - Quickstart Guide
+
+## Overview
+
+The **Brutalism Segmented Switch Control** is a high-impact, tactile segment toggle component designed for EaseMotion CSS. Built following Neo-Brutalist design principles, it features stark 3px solid borders, zero-blur hard drop shadows, high-contrast typography, and vibrant accent colors. It comes fully equipped with interactive WAI-ARIA roving tabindex keyboard navigation and complete Windows High Contrast Mode (`forced-colors`) support.
+
+---
+
+## Quickstart & HTML Snippets
+
+### 1. Standard Segmented Switch (Default Canary Yellow)
+
+```html
+<div class="ease-switch-brutal" role="radiogroup" aria-label="Billing Cycle">
+  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Monthly</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Quarterly</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Annual (Save 20%)</button>
+</div>
+```
+
+### 2. Large Variant with Cyan Accent
+
+```html
+<div class="ease-switch-brutal ease-switch-brutal-lg ease-accent-cyan" role="radiogroup" aria-label="View Mode">
+  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Editor</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Split</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Preview</button>
+</div>
+```
+
+### 3. Small Variant with Pink Accent
+
+```html
+<div class="ease-switch-brutal ease-switch-brutal-sm ease-accent-pink" role="radiogroup" aria-label="Resolution">
+  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">1X</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">2X</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">4X MAX</button>
+</div>
+```
+
+---
+
+## CSS Class Naming Conventions & Modifiers
+
+| CSS Selector | Description |
+| :--- | :--- |
+| `.ease-switch-brutal` | Main segmented switch container with hard 3px border and drop shadow. |
+| `.ease-switch-btn` | Individual segment button with crisp hover and active states. |
+| `.ease-switch-btn.is-active` | Selected segment state filled with `--brutal-accent` and 2px border. |
+| `.ease-switch-brutal-sm` | Compact padding and typography variant for dense toolbars. |
+| `.ease-switch-brutal-lg` | Large hero-sized segment control for pricing and checkout flows. |
+| `.ease-switch-vertical` | Stacks switch segments vertically. |
+
+---
+
+## Custom CSS Property Overrides
+
+The component uses CSS Custom Properties to allow instant theme customization:
+
+- `--brutal-accent`: Selected active background color (default: `#facc15`)
+- `--brutal-border`: Border outline color (default: `#000000`)
+- `--brutal-shadow`: Hard drop shadow color (default: `#000000`)
+- `--brutal-border-width`: Border thickness (default: `3px`)
+- `--brutal-shadow-offset`: Hard shadow distance (default: `4px`)
+
+### Custom Accent Example
+
+```css
+.my-custom-switch {
+  --brutal-accent: #a855f7; /* Purple accent override */
+}
+```
+
+---
+
+## Keyboard Navigation & Accessibility (WAI-ARIA)
+
+The segmented switch implements the WAI-ARIA Radio Group pattern:
+
+- **Parent Container**: Uses `role="radiogroup"` with a mandatory descriptive `aria-label`.
+- **Segment Buttons**: Use `role="radio"` with dynamic `aria-checked="true|false"`.
+- **Roving Tabindex**: Only the currently active segment button has `tabindex="0"`. All inactive segments have `tabindex="-1"`.
+- **Arrow Key Navigation**:
+  - `ArrowRight` / `ArrowDown`: Selects and moves focus to the next segment (wraps around).
+  - `ArrowLeft` / `ArrowUp`: Selects and moves focus to the previous segment (wraps around).
+- **High-Contrast Support**: Native `forced-colors: active` media query guarantees high visibility using system theme keywords like `CanvasText` and `Highlight`.

--- a/submissions/docs/ease-brutalist-switch-ss/demo.html
+++ b/submissions/docs/ease-brutalist-switch-ss/demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neo-Brutalism Segmented Switch - Quickstart Guide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="ease-brutal-card" aria-labelledby="guide-title">
+    <header>
+      <span style="background: #000; color: #fff; padding: 4px 8px; font-size: 0.75rem; font-weight: 900; text-transform: uppercase; letter-spacing: 1px;">Quickstart Guide</span>
+      <h1 id="guide-title" style="font-size: 2rem; font-weight: 900; margin: 0.75rem 0 0.25rem 0; text-transform: uppercase;">Brutalism Segmented Switch</h1>
+      <p style="color: #4b5563; font-size: 0.875rem; margin: 0; line-height: 1.5;">
+        High-impact tactile switch control featuring stark 3px borders, zero-blur hard drop shadows, and full WAI-ARIA keyboard navigation.
+      </p>
+    </header>
+
+    <section class="ease-switch-stack">
+      <!-- Standard Yellow Accent -->
+      <div>
+        <h2 style="font-size: 0.875rem; font-weight: 800; text-transform: uppercase; margin: 0 0 0.5rem 0;">1. Default Variant (Canary Yellow)</h2>
+        <div class="ease-switch-brutal" role="radiogroup" aria-label="Billing Cycle">
+          <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Monthly</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Quarterly</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Annual (Save 20%)</button>
+        </div>
+      </div>
+
+      <!-- Cyan Large Accent -->
+      <div>
+        <h2 style="font-size: 0.875rem; font-weight: 800; text-transform: uppercase; margin: 0 0 0.5rem 0;">2. Large + Cyan Accent (.ease-switch-brutal-lg .ease-accent-cyan)</h2>
+        <div class="ease-switch-brutal ease-switch-brutal-lg ease-accent-cyan" role="radiogroup" aria-label="View Mode">
+          <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Editor</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Split</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Preview</button>
+        </div>
+      </div>
+
+      <!-- Pink Small Accent -->
+      <div>
+        <h2 style="font-size: 0.875rem; font-weight: 800; text-transform: uppercase; margin: 0 0 0.5rem 0;">3. Small + Pink Accent (.ease-switch-brutal-sm .ease-accent-pink)</h2>
+        <div class="ease-switch-brutal ease-switch-brutal-sm ease-accent-pink" role="radiogroup" aria-label="Resolution">
+          <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">1X</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">2X</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">4X MAX</button>
+        </div>
+      </div>
+    </section>
+
+    <footer style="border-top: 2px dashed #000; padding-top: 1.25rem; font-size: 0.8125rem; color: #4b5563;">
+      Navigate using <strong>Tab</strong> to focus and <strong>Left / Right Arrow Keys</strong> or <strong>Click</strong> to switch segments.
+    </footer>
+  </main>
+
+  <script>
+    // Interactive WAI-ARIA Roving Tabindex & Arrow Key Engine
+    const switchGroups = document.querySelectorAll('.ease-switch-brutal');
+
+    switchGroups.forEach(group => {
+      const buttons = Array.from(group.querySelectorAll('.ease-switch-btn'));
+
+      function selectButton(btn) {
+        buttons.forEach(b => {
+          b.classList.remove('is-active');
+          b.setAttribute('aria-checked', 'false');
+          b.setAttribute('tabindex', '-1');
+        });
+        btn.classList.add('is-active');
+        btn.setAttribute('aria-checked', 'true');
+        btn.setAttribute('tabindex', '0');
+        btn.focus();
+      }
+
+      buttons.forEach((btn, index) => {
+        btn.addEventListener('click', () => selectButton(btn));
+
+        btn.addEventListener('keydown', (e) => {
+          let targetIndex = null;
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            targetIndex = (index + 1) % buttons.length;
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            targetIndex = (index - 1 + buttons.length) % buttons.length;
+          }
+
+          if (targetIndex !== null) {
+            e.preventDefault();
+            selectButton(buttons[targetIndex]);
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-brutalist-switch-ss/style.css
+++ b/submissions/docs/ease-brutalist-switch-ss/style.css
@@ -1,0 +1,130 @@
+/* Neo-Brutalist CSS Custom Properties Tokens */
+:root {
+  --brutal-bg: #fffbeb;
+  --brutal-surface: #ffffff;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-accent: #facc15;
+  --brutal-text: #000000;
+  --brutal-border-width: 3px;
+  --brutal-shadow-offset: 4px;
+  --brutal-radius: 6px;
+  --brutal-font-mono: 'JetBrains Mono', 'Courier New', monospace;
+}
+
+/* Layout & Background Grid */
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background-color: var(--brutal-bg);
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--brutal-text);
+  padding: 2rem;
+  box-sizing: border-box;
+  background-image: radial-gradient(#000000 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+/* Showcase Container */
+.ease-brutal-card {
+  background: var(--brutal-surface);
+  border: var(--brutal-border-width) solid var(--brutal-border);
+  border-radius: var(--brutal-radius);
+  padding: 2.5rem;
+  max-width: 780px;
+  width: 100%;
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+  box-sizing: border-box;
+}
+
+.ease-switch-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: flex-start;
+  margin: 2rem 0;
+}
+
+/* Segmented Switch Component */
+.ease-switch-brutal {
+  display: inline-flex;
+  background: #ffffff;
+  border: var(--brutal-border-width) solid var(--brutal-border);
+  border-radius: var(--brutal-radius);
+  box-shadow: var(--brutal-shadow-offset) var(--brutal-shadow-offset) 0 var(--brutal-shadow);
+  padding: 4px;
+  gap: 4px;
+  position: relative;
+  user-select: none;
+}
+
+.ease-switch-btn {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--brutal-text);
+  cursor: pointer;
+  transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  outline: none;
+}
+
+.ease-switch-btn:hover:not(.is-active) {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.ease-switch-btn.is-active {
+  background: var(--brutal-accent);
+  border: 2px solid var(--brutal-border);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+  font-weight: 900;
+}
+
+.ease-switch-btn:focus-visible {
+  outline: 3px solid #000000;
+  outline-offset: 2px;
+}
+
+/* Modifier Classes */
+.ease-switch-brutal-sm .ease-switch-btn {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.ease-switch-brutal-lg .ease-switch-btn {
+  padding: 0.875rem 1.75rem;
+  font-size: 1rem;
+}
+
+.ease-accent-cyan {
+  --brutal-accent: #38bdf8;
+}
+
+.ease-accent-pink {
+  --brutal-accent: #f472b6;
+}
+
+.ease-switch-vertical {
+  flex-direction: column;
+  width: 100%;
+  max-width: 220px;
+}
+
+/* Accessibility & High-Contrast Fallbacks */
+@media (forced-colors: active) {
+  .ease-brutal-card,
+  .ease-switch-brutal {
+    border: 3px solid CanvasText;
+  }
+  .ease-switch-btn.is-active {
+    border: 2px solid Highlight;
+    background: Highlight;
+    color: HighlightText;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds a comprehensive documentation package and quickstart guide for the **Brutalism Segmented Switch Control** under `submissions/docs/ease-brutalist-switch-ss/`. It resolves Issue #85835 by providing interactive HTML, modular raw CSS, and an extensive local quickstart guide detailing usage, CSS variables, sizing/color modifiers, and complete WAI-ARIA keyboard navigation matrix.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a complete quickstart guide and interactive reference implementation for the Neo-Brutalist Segmented Switch Control with 3px solid borders, zero-blur hard drop shadows, custom CSS variable tokens, and WAI-ARIA keyboard support.

**How does a developer use it?**

```html
<div class="ease-switch-brutal" role="radiogroup" aria-label="Billing Cycle">
  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Monthly</button>
  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Quarterly</button>
  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Annual (Save 20%)</button>
</div>

```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer
Fixes #85835
<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
oes a developer use it?**

```html
<!-- Show the class usage in HTML -->
```

**Why does it fit EaseMotion CSS?**

<!-- Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [ ] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

<!-- Anything the maintainer should know when reviewing or integrating.
     e.g. "I wasn't sure about the timing — feel free to adjust."
     e.g. "Inspired by Material UI's shimmer effect." -->

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
