### PR TITLE
feat(scss): Add SCSS Target Highlighted Element helper mixins (#81303)

### DIFF
--- a/submissions/examples/target-highlight-scss/README.md
+++ b/submissions/examples/target-highlight-scss/README.md
@@ -1,0 +1,15 @@
+# SCSS Target Highlighted Element Helper Mixins
+
+An SCSS helper mixin suite for styling elements targeted via URL fragment identifiers (`:target`) with smooth visual transitions and highlight pulses.
+
+## Overview & Features
+- `target-highlight($bg, $border, $duration)`: Configures custom background, border, and glow effects for targeted elements.
+- `target-theme($variant)`: Preset theme selectors supporting cyan, magenta, and emerald color variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.anchor-section {
+  @include target-theme('cyan');
+}

--- a/submissions/examples/target-highlight-scss/_mixins.scss
+++ b/submissions/examples/target-highlight-scss/_mixins.scss
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Target Highlighted Element Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Styles elements targeted via URL fragment links (`:target`) with animated highlight pulses and smooth transitions.
+/// @param {Color | String} $bg [var(--ease-target-bg, rgba(6, 182, 212, 0.15))] - Highlight background color.
+/// @param {Color | String} $border [var(--ease-target-border, #06b6d4)] - Highlight border color.
+/// @param {String} $duration [1s] - Animation transition duration.
+@mixin target-highlight(
+  $bg: var(--ease-target-bg, rgba(6, 182, 212, 0.15)),
+  $border: var(--ease-target-border, #06b6d4),
+  $duration: 1s
+) {
+  transition: background-color $duration ease, border-color $duration ease, box-shadow $duration ease;
+
+  &:target {
+    background-color: $bg;
+    border-color: $border;
+    box-shadow: 0 0 20px rgba(6, 182, 212, 0.3);
+  }
+}
+
+/// Applies preset target highlight theme variations.
+/// @param {String} $variant [cyan] - Preset variant (cyan, magenta, emerald).
+@mixin target-theme($variant: 'cyan') {
+  @if $variant == 'cyan' {
+    @include target-highlight(rgba(6, 182, 212, 0.15), #06b6d4, 1s);
+  } @else if $variant == 'magenta' {
+    @include target-highlight(rgba(236, 72, 153, 0.15), #ec4899, 1s);
+  } @else if $variant == 'emerald' {
+    @include target-highlight(rgba(16, 185, 129, 0.15), #10b981, 1s);
+  }
+}

--- a/submissions/examples/target-highlight-scss/demo.html
+++ b/submissions/examples/target-highlight-scss/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Target Highlighted Element — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div id="section-highlight" class="ease-section-target">
+        <h3>Target Highlight Section</h3>
+        <p>Demonstrates `:target` pseudo-class styling for smooth scrolling fragment highlights and visual anchor feedback.</p>
+      </div>
+      <a href="#section-highlight" style="color: var(--ease-cyan); font-size: 0.9rem; text-decoration: none;">Jump to Target Section (#section-highlight)</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/target-highlight-scss/style.css
+++ b/submissions/examples/target-highlight-scss/style.css
@@ -1,0 +1,58 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-section-target {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  transition: background-color 1s ease, border-color 1s ease, box-shadow 1s ease;
+}
+.ease-section-target:target {
+  background-color: rgba(6, 182, 212, 0.15);
+  border-color: #06b6d4;
+  box-shadow: 0 0 20px rgba(6, 182, 212, 0.3);
+}
+.ease-section-target h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ease-cyan);
+  font-size: 1.1rem;
+}
+.ease-section-target p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.9rem;
+}

--- a/submissions/examples/target-highlight-scss/style.scss
+++ b/submissions/examples/target-highlight-scss/style.scss
@@ -1,0 +1,56 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-section-target {
+  padding: 1.5rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  color: var(--ease-text);
+  @include target-theme('cyan');
+
+  h3 {
+    margin: 0 0 0.5rem;
+    color: var(--ease-cyan);
+    font-size: 1.1rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81303

Adds custom SCSS target highlighted element helper mixins (`target-highlight()` and `target-theme()`) under `submissions/examples/target-highlight-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/target-highlight-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for URL fragment target states (`:target`) featuring smooth transition highlighting and glow effects.
**Why does it fit?** Expands developer anchor navigation feedback utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari