### PR TITLE
docs: add quickstart guide for neumorphic flyout popover

### DIFF
--- a/submissions/docs/neumorphic-flyout-popover/README.md
+++ b/submissions/docs/neumorphic-flyout-popover/README.md
@@ -1,0 +1,74 @@
+# Neumorphic Flyout Popover (Quickstart Guide)
+
+This guide documents how to implement a smooth, accessible Neumorphic Flyout Popover component. Neumorphism uses subtle highlights and shadows to create elements that look extruded from or pressed into the background.
+
+## HTML Markup Example
+
+Here is the base accessible markup required for the popover:
+
+```html
+<div class="popover-container">
+    <!-- Trigger Button -->
+    <button class="neumorphic-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="popover-content">
+        Options
+    </button>
+    
+    <!-- Flyout Popover Content -->
+    <div id="popover-content" class="neumorphic-flyout" role="menu" aria-hidden="true">
+        <ul class="flyout-list">
+            <li role="none"><a href="#" role="menuitem">Profile</a></li>
+            <li role="none"><a href="#" role="menuitem">Settings</a></li>
+            <li role="none"><a href="#" role="menuitem">Log Out</a></li>
+        </ul>
+    </div>
+</div>
+```
+
+## CSS Custom Properties & Modifiers
+
+The neumorphic effect relies entirely on manipulating `box-shadow` values. 
+
+### Default Light Theme Variables
+
+```css
+:root {
+    --bg-color: #e0e5ec;
+    --text-color: #333;
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    --transition-speed: 0.3s;
+}
+```
+
+### Modifier Classes
+
+Append the `--dark` modifier class to BOTH the trigger and the flyout to switch to a sleek dark mode neumorphic theme.
+
+**Dark Mode** (`.neumorphic-flyout--dark`, `.neumorphic-trigger--dark`)
+```css
+.neumorphic-flyout--dark,
+.neumorphic-trigger--dark {
+    --bg-color: #2b2b2b;
+    --text-color: #e0e0e0;
+    --shadow-light: #3a3a3a;
+    --shadow-dark: #1c1c1c;
+}
+```
+
+## Accessibility Requirements
+
+Interactive popovers must follow the WAI-ARIA Menu or Disclosure patterns to be accessible.
+
+### ARIA Attributes
+- **Trigger**: Must have `aria-haspopup="true"`, `aria-controls="[ID_OF_POPOVER]"`, and `aria-expanded` (toggled between `"true"` and `"false"` via JS).
+- **Popover container**: Must have `role="menu"` and `aria-hidden` (toggled inverse to the trigger's `aria-expanded`).
+- **List items**: Use `role="none"` on the `<li>` and `role="menuitem"` on the inner `<a>` or `<button>`.
+
+### Keyboard Navigation Setup
+You must implement JavaScript to handle the following:
+- `Enter` / `Space` on the trigger toggles the menu.
+- Focus should immediately shift to the first `menuitem` when the popover opens.
+- Pressing `Escape` while focus is anywhere within the popover must close it and return focus to the trigger button.
+- Ensure the trigger and all links have visible focus states (e.g., using `outline` or switching to inset shadows on `:focus-visible`).
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/neumorphic-flyout-popover/demo.html
+++ b/submissions/docs/neumorphic-flyout-popover/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Flyout Popover Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <div class="popover-container">
+            <!-- Trigger Button -->
+            <button class="neumorphic-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="popover-content">
+                Options
+            </button>
+            
+            <!-- Flyout Popover -->
+            <div id="popover-content" class="neumorphic-flyout neumorphic-flyout--dark" role="menu" aria-hidden="true">
+                <ul class="flyout-list">
+                    <li role="none"><a href="#" role="menuitem">Profile</a></li>
+                    <li role="none"><a href="#" role="menuitem">Settings</a></li>
+                    <li role="none"><a href="#" role="menuitem">Log Out</a></li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        const trigger = document.querySelector('.neumorphic-trigger');
+        const popover = document.getElementById('popover-content');
+
+        // Toggle popover visibility and update ARIA attributes
+        trigger.addEventListener('click', () => {
+            const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+            trigger.setAttribute('aria-expanded', !isExpanded);
+            popover.setAttribute('aria-hidden', isExpanded);
+            
+            if (!isExpanded) {
+                // Focus the first item when opened
+                setTimeout(() => popover.querySelector('a').focus(), 100);
+            }
+        });
+
+        // Close on escape key
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && trigger.getAttribute('aria-expanded') === 'true') {
+                trigger.setAttribute('aria-expanded', 'false');
+                popover.setAttribute('aria-hidden', 'true');
+                trigger.focus();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/docs/neumorphic-flyout-popover/style.css
+++ b/submissions/docs/neumorphic-flyout-popover/style.css
@@ -1,0 +1,119 @@
+:root {
+    /* Base Neumorphic Light Theme */
+    --bg-color: #e0e5ec;
+    --text-color: #333;
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    --flyout-width: 220px;
+    --transition-speed: 0.3s;
+}
+
+/* Dark Theme Modifier */
+.neumorphic-flyout--dark,
+.neumorphic-trigger--dark {
+    --bg-color: #2b2b2b;
+    --text-color: #e0e0e0;
+    --shadow-light: #3a3a3a;
+    --shadow-dark: #1c1c1c;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background-color: var(--bg-color);
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.popover-container {
+    position: relative;
+    display: inline-block;
+}
+
+/* Trigger Button */
+.neumorphic-trigger {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: none;
+    padding: 1rem 2rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    border-radius: 12px;
+    cursor: pointer;
+    box-shadow: 
+        8px 8px 16px var(--shadow-dark), 
+        -8px -8px 16px var(--shadow-light);
+    transition: all var(--transition-speed) ease;
+}
+
+.neumorphic-trigger:active,
+.neumorphic-trigger[aria-expanded="true"] {
+    box-shadow: 
+        inset 6px 6px 10px var(--shadow-dark), 
+        inset -6px -6px 10px var(--shadow-light);
+}
+
+.neumorphic-trigger:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 4px;
+}
+
+/* Flyout Content */
+.neumorphic-flyout {
+    position: absolute;
+    top: calc(100% + 20px);
+    left: 50%;
+    transform: translateX(-50%) translateY(-10px);
+    width: var(--flyout-width);
+    background-color: var(--bg-color);
+    border-radius: 16px;
+    padding: 1rem 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    box-shadow: 
+        10px 10px 20px var(--shadow-dark), 
+        -10px -10px 20px var(--shadow-light);
+    transition: all var(--transition-speed) cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    z-index: 10;
+}
+
+/* Open State */
+.neumorphic-trigger[aria-expanded="true"] + .neumorphic-flyout {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* List Styling */
+.flyout-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.flyout-list li {
+    margin: 0.5rem 1rem;
+}
+
+.flyout-list a {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 500;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.flyout-list a:hover,
+.flyout-list a:focus-visible {
+    background-color: transparent;
+    box-shadow: 
+        inset 4px 4px 8px var(--shadow-dark), 
+        inset -4px -4px 8px var(--shadow-light);
+    outline: none;
+}


### PR DESCRIPTION
fixes #85740 

## Pull Request Description

This PR introduces the quickstart documentation guide for the Neumorphic Flyout Popover. It outlines the HTML structure, the CSS variables needed to control the soft light/dark shadows essential for the neumorphic aesthetic, and the necessary ARIA attributes and JavaScript keyboard handling logic required to ensure the popover acts as an accessible disclosure/menu component.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a complete quickstart guide detailing the implementation of a neumorphic (soft UI) popover menu, including dark mode modifiers and strict accessibility requirements.

**How does a developer use it?**

```html
<div class="popover-container">
    <button class="neumorphic-trigger neumorphic-trigger--dark" aria-haspopup="true" aria-expanded="false" aria-controls="popover-content">
        Options
    </button>
    <div id="popover-content" class="neumorphic-flyout neumorphic-flyout--dark" role="menu" aria-hidden="true">
        <!-- Interactive menu items -->
    </div>
</div>
