### PR TITLE
feat: Pure CSS 3D Coverflow Carousel (#82920)

### DIFF
--- a/submissions/examples/3d-coverflow-carousel-82920/README.md
+++ b/submissions/examples/3d-coverflow-carousel-82920/README.md
@@ -1,0 +1,59 @@
+# Pure CSS 3D Coverflow Carousel (`.ease-coverflow`)
+
+## What does this do?
+
+A dependency-free, scroll-snapped 3D Coverflow carousel where side cards angle inward and the centered card pops forward, built entirely with CSS 3D transforms — no JavaScript.
+
+## How is it used?
+
+Drop the carousel markup into your page and link `style.css`:
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<section class="ease-coverflow-viewport" tabindex="0" aria-label="Coverflow">
+  <div class="ease-coverflow-track">
+    <a class="ease-coverflow-card" id="cover-1" href="#cover-1">
+      <span class="ease-coverflow-art"></span>
+      <span class="ease-coverflow-card-label">
+        <span class="ease-coverflow-card-index">01</span>
+        <span class="ease-coverflow-card-title">Amber Pulse</span>
+      </span>
+    </a>
+    <!-- repeat for every card -->
+  </div>
+</section>
+
+<nav class="ease-coverflow-nav" aria-label="Quick navigation">
+  <a class="ease-coverflow-dot" href="#cover-1" aria-label="Go to card 1"></a>
+  <!-- one dot per card -->
+</nav>
+```
+
+Interaction works three ways, all CSS-only:
+
+- **Scroll snapping** — the viewport uses `scroll-snap-type: x mandatory` with `scroll-snap-align: center`, so dragging, trackpads, and arrow keys land each card dead-center.
+- **`:target` anchors** — clicking a card or a navigation dot jumps/smooth-scrolls that card to the center.
+- **`:hover` / `:focus-visible`** — hovering or focusing a card glows, brightens the artwork, and lifts it above its neighbors.
+
+## The 3D engine
+
+```css
+.ease-coverflow-viewport { perspective: 1000px; }
+.ease-coverflow-track     { transform-style: preserve-3d; }
+.ease-coverflow-card      { backface-visibility: hidden; }
+```
+
+1. **Perspective stage** — `perspective: 1000px` on the viewport creates the vanishing point; `transform-style: preserve-3d` on the track keeps every card inside one shared 3D space.
+2. **Position-driven transforms** — a scroll-driven animation (`animation-timeline: view(x)`) rotates each card from `rotateY(-45deg) scale(0.8)` (right side) through `rotateY(0deg) scale(1.12) translateZ(60px)` (center) to `rotateY(45deg) scale(0.8)` (left side). `backface-visibility: hidden` removes any mirrored back-edge artifacts.
+3. **Floor reflections** — each artwork gets a realistic glossy floor echo via `-webkit-box-reflect: below 0px linear-gradient(rgba(0,0,0,0.4), transparent 42%)`, which fades out with distance like a real mirrored surface.
+4. **Graceful fallbacks** — browsers without scroll-driven animations get a static coverflow via `@supports not` (`:nth-child` left/center/right placement + hover pop), and `prefers-reduced-motion` collapses everything to a still, centered layout.
+
+## Why is it useful?
+
+3D Coverflow is one of the most iconic media-browsing patterns in UI history, and this implementation proves it can ship with **zero JavaScript**. The demo leans entirely on EaseMotion's philosophy — readable, semantic classes, human-readable CSS, and buttery 3D motion driven by the browser's own rendering and scroll engine. It is a flagship showcase for CSS 3D transforms, scroll-driven animations, and `-webkit-box-reflect` working together.
+
+## Browser support
+
+- Scroll-driven animations: Chrome/Edge 115+, Firefox 130+, Safari 26+.
+- Older browsers automatically fall back to a static, still-interactive coverflow.

--- a/submissions/examples/3d-coverflow-carousel-82920/demo.html
+++ b/submissions/examples/3d-coverflow-carousel-82920/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>3D Coverflow Carousel - EaseMotion</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="ease-coverflow-page">
+    <header class="ease-coverflow-header">
+      <p class="ease-coverflow-eyebrow">EaseMotion &middot; Pure CSS</p>
+      <h1 class="ease-coverflow-title">3D Coverflow Carousel</h1>
+      <p class="ease-coverflow-subtitle">
+        Perspective, preserve-3d, rotateY and <code>-webkit-box-reflect</code> &mdash; no JavaScript.
+      </p>
+    </header>
+
+    <section
+      class="ease-coverflow-viewport"
+      tabindex="0"
+      aria-label="3D coverflow carousel. Scroll, drag, or use arrow keys to browse; click a card or dot to snap it to the center."
+    >
+      <div class="ease-coverflow-track">
+        <a class="ease-coverflow-card ease-coverflow-card--1" id="cover-1" href="#cover-1" aria-label="View Amber Pulse">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">01</span>
+            <span class="ease-coverflow-card-title">Amber Pulse</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--2" id="cover-2" href="#cover-2" aria-label="View Neon Drift">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">02</span>
+            <span class="ease-coverflow-card-title">Neon Drift</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--3" id="cover-3" href="#cover-3" aria-label="View Midnight Bloom">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">03</span>
+            <span class="ease-coverflow-card-title">Midnight Bloom</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--4" id="cover-4" href="#cover-4" aria-label="View Solar Echo">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">04</span>
+            <span class="ease-coverflow-card-title">Solar Echo</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--5" id="cover-5" href="#cover-5" aria-label="View Violet Static">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">05</span>
+            <span class="ease-coverflow-card-title">Violet Static</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--6" id="cover-6" href="#cover-6" aria-label="View Ocean Memory">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">06</span>
+            <span class="ease-coverflow-card-title">Ocean Memory</span>
+          </span>
+        </a>
+        <a class="ease-coverflow-card ease-coverflow-card--7" id="cover-7" href="#cover-7" aria-label="View Golden Hour">
+          <span class="ease-coverflow-art" aria-hidden="true"></span>
+          <span class="ease-coverflow-card-label">
+            <span class="ease-coverflow-card-index">07</span>
+            <span class="ease-coverflow-card-title">Golden Hour</span>
+          </span>
+        </a>
+      </div>
+    </section>
+
+    <nav class="ease-coverflow-nav" aria-label="Coverflow quick navigation">
+      <a class="ease-coverflow-dot" href="#cover-1" aria-label="Go to Amber Pulse"></a>
+      <a class="ease-coverflow-dot" href="#cover-2" aria-label="Go to Neon Drift"></a>
+      <a class="ease-coverflow-dot" href="#cover-3" aria-label="Go to Midnight Bloom"></a>
+      <a class="ease-coverflow-dot" href="#cover-4" aria-label="Go to Solar Echo"></a>
+      <a class="ease-coverflow-dot" href="#cover-5" aria-label="Go to Violet Static"></a>
+      <a class="ease-coverflow-dot" href="#cover-6" aria-label="Go to Ocean Memory"></a>
+      <a class="ease-coverflow-dot" href="#cover-7" aria-label="Go to Golden Hour"></a>
+    </nav>
+
+    <p class="ease-coverflow-hint">Scroll &middot; drag &middot; arrow keys &middot; or click any card / dot</p>
+  </main>
+</body>
+</html>

--- a/submissions/examples/3d-coverflow-carousel-82920/style.css
+++ b/submissions/examples/3d-coverflow-carousel-82920/style.css
@@ -1,0 +1,345 @@
+/* ============================================================
+   EaseMotion - 3D Coverflow Carousel (Pure CSS)
+   ============================================================
+   A scroll-snapped 3D coverflow built entirely with CSS:
+   - perspective + preserve-3d on the stage
+   - rotateY / scale / translateZ per card position
+   - -webkit-box-reflect floor reflections
+   - navigation via scroll-snap, :target anchors, and :hover
+   ============================================================ */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 50% 30%, #101827 0%, #05070d 70%);
+  color: #e5e7eb;
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+.ease-coverflow-page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem) 1rem;
+  text-align: center;
+}
+
+/* ---------- Header ---------- */
+
+.ease-coverflow-eyebrow {
+  margin: 0 0 0.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: #7dd3fc;
+}
+
+.ease-coverflow-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 4.5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(90deg, #e0f2fe, #93c5fd, #e0f2fe);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.ease-coverflow-subtitle {
+  margin: 0.5rem 0 2rem;
+  font-size: 0.95rem;
+  color: #94a3b8;
+}
+
+.ease-coverflow-subtitle code {
+  padding: 0.1em 0.4em;
+  border-radius: 0.3em;
+  background: #1e293b;
+  color: #a5f3fc;
+  font-size: 0.85em;
+}
+
+/* ---------- 3D stage / scroll viewport ---------- */
+
+.ease-coverflow-viewport {
+  --em-cover-card-w: clamp(170px, 24vw, 235px);
+  --em-cover-card-h: calc(var(--em-cover-card-w) * 1.32);
+  --em-cover-gap: clamp(14px, 2.5vw, 30px);
+
+  height: calc(var(--em-cover-card-h) + clamp(5rem, 9vw, 7rem));
+  margin: 0 auto;
+  padding-top: clamp(1rem, 3vw, 2rem);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  perspective: 1000px;
+  outline: none;
+}
+
+.ease-coverflow-viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-coverflow-viewport:focus-visible {
+  border-radius: 1rem;
+  box-shadow: 0 0 0 2px #38bdf8;
+}
+
+/* ---------- Track ---------- */
+
+.ease-coverflow-track {
+  display: flex;
+  align-items: center;
+  gap: var(--em-cover-gap);
+  padding-inline: calc(50% - (var(--em-cover-card-w) / 2));
+  padding-bottom: clamp(4rem, 8vw, 6.5rem);
+  width: max-content;
+  transform-style: preserve-3d;
+}
+
+/* ---------- Card ---------- */
+
+.ease-coverflow-card {
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  width: var(--em-cover-card-w);
+  height: var(--em-cover-card-h);
+  border-radius: clamp(10px, 1.2vw, 16px);
+  scroll-snap-align: center;
+  text-decoration: none;
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(148, 163, 184, 0.18),
+    0 0 40px rgba(0, 0, 0, 0.35);
+  transition: box-shadow 0.35s ease;
+}
+
+.ease-coverflow-card:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 4px;
+}
+
+/* Album art carries the gradient AND the floor reflection */
+
+.ease-coverflow-art {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  border-radius: inherit;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  -webkit-box-reflect:
+    below 0px linear-gradient(transparent, rgba(0, 0, 0, 0.4));
+}
+
+.ease-coverflow-card-label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: inherit;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  background: rgba(7, 11, 20, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  color: #f1f5f9;
+  transition: background 0.35s ease;
+}
+
+.ease-coverflow-card-index {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: #94a3b8;
+  transition: color 0.35s ease;
+}
+
+.ease-coverflow-card-title {
+  overflow: hidden;
+  font-size: clamp(0.8rem, 1vw, 0.95rem);
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* ---------- Album art palettes ---------- */
+
+.ease-coverflow-card--1 .ease-coverflow-art {
+  background: radial-gradient(circle at 30% 25%, #fcd34d 0%, #f97316 45%, #7c2d12 100%);
+}
+
+.ease-coverflow-card--2 .ease-coverflow-art {
+  background: linear-gradient(135deg, #22d3ee 0%, #6366f1 55%, #312e81 100%);
+}
+
+.ease-coverflow-card--3 .ease-coverflow-art {
+  background: radial-gradient(circle at 70% 20%, #f0abfc 0%, #a21caf 55%, #1e1b4b 100%);
+}
+
+.ease-coverflow-card--4 .ease-coverflow-art {
+  background: linear-gradient(160deg, #fde68a 0%, #fb923c 55%, #9a3412 100%);
+}
+
+.ease-coverflow-card--5 .ease-coverflow-art {
+  background: linear-gradient(200deg, #c084fc 0%, #6d28d9 60%, #2e1065 100%);
+}
+
+.ease-coverflow-card--6 .ease-coverflow-art {
+  background: linear-gradient(150deg, #5eead4 0%, #0ea5e9 55%, #0c4a6e 100%);
+}
+
+.ease-coverflow-card--7 .ease-coverflow-art {
+  background: linear-gradient(120deg, #fcd34d 0%, #f59e0b 50%, #78350f 100%);
+}
+
+/* ---------- Hover / focus interactivity ---------- */
+
+.ease-coverflow-card:hover,
+.ease-coverflow-card:focus-visible {
+  z-index: 3;
+}
+
+.ease-coverflow-card:hover {
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(186, 230, 253, 0.5),
+    0 0 50px rgba(56, 189, 248, 0.25);
+}
+
+.ease-coverflow-card:hover .ease-coverflow-art {
+  filter: brightness(1.12) saturate(1.12);
+}
+
+.ease-coverflow-card:hover .ease-coverflow-card-label {
+  background: rgba(10, 16, 28, 0.88);
+}
+
+.ease-coverflow-card:hover .ease-coverflow-card-index {
+  color: #7dd3fc;
+}
+
+/* ---------- Scroll-driven 3D coverflow animation ---------- */
+
+@keyframes ease-coverflow-rotate {
+  0% {
+    transform: rotateY(-45deg) scale(0.8);
+  }
+  50% {
+    transform: rotateY(0deg) scale(1.1) translateZ(50px);
+  }
+  100% {
+    transform: rotateY(45deg) scale(0.8);
+  }
+}
+
+@supports (animation-timeline: view()) {
+  .ease-coverflow-card {
+    animation: ease-coverflow-rotate linear both;
+    animation-timeline: view(x);
+  }
+}
+
+/* ---------- Fallback: static coverflow without scroll-driven animation ---------- */
+
+@supports not (animation-timeline: view()) {
+  .ease-coverflow-card:nth-child(-n + 3) {
+    transform: rotateY(45deg) scale(0.8);
+  }
+
+  .ease-coverflow-card:nth-child(4) {
+    transform: rotateY(0deg) scale(1.1) translateZ(50px);
+  }
+
+  .ease-coverflow-card:nth-child(n + 5) {
+    transform: rotateY(-45deg) scale(0.8);
+  }
+
+  .ease-coverflow-card:hover,
+  .ease-coverflow-card:target {
+    transform: rotateY(0deg) scale(1.1) translateZ(50px);
+  }
+}
+
+/* ---------- Navigation dots ---------- */
+
+.ease-coverflow-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.65rem;
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+.ease-coverflow-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #334155;
+  transition:
+    background 0.3s ease,
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.ease-coverflow-dot:hover {
+  background: #7dd3fc;
+  transform: scale(1.4);
+}
+
+.ease-coverflow-dot:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.ease-coverflow-card:target {
+  outline: 2px solid #38bdf8;
+  outline-offset: 4px;
+}
+
+/* ---------- Hint ---------- */
+
+.ease-coverflow-hint {
+  margin: 1.2rem 0 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+/* ---------- Reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-coverflow-viewport {
+    scroll-behavior: auto;
+  }
+
+  .ease-coverflow-card {
+    animation: none !important;
+  }
+
+  .ease-coverflow-card:nth-child(-n + 3) {
+    transform: rotateY(45deg) scale(0.8);
+  }
+
+  .ease-coverflow-card:nth-child(4) {
+    transform: rotateY(0deg) scale(1.1) translateZ(50px);
+  }
+
+  .ease-coverflow-card:nth-child(n + 5) {
+    transform: rotateY(-45deg) scale(0.8);
+  }
+}


### PR DESCRIPTION
﻿## Pull Request Description

Adds a **Pure CSS 3D Coverflow Carousel** (.ease-coverflow) to submissions/examples/3d-coverflow-carousel-82920/. It implements the GSSoC issue #82920 spec with zero JavaScript: a scroll-snapped carousel where side cards angle inward and the centered card pops forward using perspective, 	ransform-style: preserve-3d, otateY(), scale(), 	ranslateZ(), and -webkit-box-reflect.

---

## Type of Change

- [ ] New animation / hover effect
- [x] New component
- [ ] Documentation improvement
- [ ] Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside submissions/ (e.g., submissions/examples/your-feature-name/)
- [x] Includes demo.html — self-contained, opens in browser with no server
- [x] Includes style.css — raw CSS for the proposed feature
- [x] Includes README.md — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to core/
- [x] No changes to components/
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A dependency-free, scroll-snapped 3D coverflow carousel: side cards angle inward at otateY(±45deg) scale(0.8), the centered card pops forward at otateY(0deg) scale(1.1) translateZ(50px), and every card gets a glossy floor reflection via -webkit-box-reflect.

**How does a developer use it?**

`html
<link rel="stylesheet" href="style.css">

<section class="ease-coverflow-viewport" tabindex="0" aria-label="Coverflow">
  <div class="ease-coverflow-track">
    <a class="ease-coverflow-card" id="cover-1" href="#cover-1">
      <span class="ease-coverflow-art"></span>
      <span class="ease-coverflow-card-label">
        <span class="ease-coverflow-card-index">01</span>
        <span class="ease-coverflow-card-title">Amber Pulse</span>
      </span>
    </a>
    <!-- repeat for every card -->
  </div>
</section>
`

**Why does it fit EaseMotion CSS?**

It showcases the browser's native 3D transform and scroll engine as a flagship, human-readable CSS demo — no JS, semantic classes, scroll-snap, :target, :hover, and :focus-visible for interaction, with graceful fallbacks for older browsers and prefers-reduced-motion.

---

## Demo

- [x] Demo added (demo.html works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Folder name uses the -82920 suffix because submissions/examples/3d-coverflow-carousel/ already exists in main from an earlier, different coverflow submission (PR #6702) and the auto-merge validator blocks PRs that modify existing files. This new folder keeps the feature isolated as a single new submission per the CONTRIBUTING guidance. Scroll-driven animation is enhanced with a static @supports not fallback.
