### PR TITLE
test: add rapid CSS loader state transition tests #79559

### DIFF
--- a/submissions/docs/css-loader-rapid-state-transitions/README.md
+++ b/submissions/docs/css-loader-rapid-state-transitions/README.md
@@ -1,0 +1,79 @@
+# CSS Loader Rapid State Transition Tests
+
+## Overview
+
+This submission documents test scenarios for validating CSS loader behavior
+during rapid state transitions.
+
+## Problem
+
+Rapid start, stop, restart, and reset operations may cause:
+
+- stale animation classes
+- duplicate states
+- incorrect final loader state
+- inconsistent animation behavior
+
+## Test Scenarios
+
+### 1. Start → Stop
+
+Expected:
+- Loader starts correctly.
+- Loader stops correctly.
+- No stale animation state remains.
+
+### 2. Start → Restart
+
+Expected:
+- Previous animation state is cleared.
+- Loader restarts from the expected state.
+
+### 3. Start → Stop → Start
+
+Expected:
+- Loader returns to the active state.
+- No duplicate classes are introduced.
+
+### 4. Rapid Start/Stop
+
+Expected:
+- Repeated transitions do not corrupt the loader state.
+
+### 5. Rapid Restart
+
+Expected:
+- Only the intended active animation state remains.
+
+### 6. Reset
+
+Expected:
+- Loader returns to its initial state.
+
+## Expected Behavior
+
+After any sequence of rapid state transitions:
+
+1. Only the expected state should remain active.
+2. No stale animation classes should remain.
+3. No duplicate state classes should be created.
+4. The final visual state should match the final requested action.
+
+## Manual Testing
+
+Open `demo.html` in a browser and execute each control repeatedly.
+
+## Test Matrix
+
+| Sequence | Expected Result |
+|---|---|
+| Start → Stop | Loader stops cleanly |
+| Start → Restart | Loader restarts cleanly |
+| Start → Stop → Start | Loader becomes active |
+| Rapid Start/Stop | No stale state |
+| Rapid Restart | No duplicate state |
+| Reset | Initial state restored |
+
+## Related Issue
+
+Fixes #79559

--- a/submissions/docs/css-loader-rapid-state-transitions/demo.html
+++ b/submissions/docs/css-loader-rapid-state-transitions/demo.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <title>CSS Loader Rapid State Transition Tests</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="test-page">
+    <header class="page-header">
+      <p class="eyebrow">EaseMotion CSS · Issue #79559</p>
+
+      <h1>Rapid Loader State Transition Tests</h1>
+
+      <p class="intro">
+        Test CSS loader behavior during rapid start, stop, restart,
+        and reset operations.
+      </p>
+    </header>
+
+    <section class="test-panel">
+      <div class="loader-area">
+        <div
+          id="loader"
+          class="loader"
+          aria-label="CSS loader"
+          role="status"
+        >
+          <span class="loader-ring"></span>
+          <span class="loader-core"></span>
+        </div>
+
+        <div class="state-display">
+          <span>Current state</span>
+          <strong id="stateValue">idle</strong>
+        </div>
+      </div>
+
+      <div class="controls">
+        <button type="button" data-action="start">
+          Start
+        </button>
+
+        <button type="button" data-action="stop">
+          Stop
+        </button>
+
+        <button type="button" data-action="restart">
+          Restart
+        </button>
+
+        <button type="button" data-action="reset">
+          Reset
+        </button>
+      </div>
+
+      <div class="stress-controls">
+        <h2>Rapid transition tests</h2>
+
+        <div class="button-grid">
+          <button type="button" data-stress="start-stop">
+            Start → Stop × 5
+          </button>
+
+          <button type="button" data-stress="restart">
+            Restart × 5
+          </button>
+
+          <button type="button" data-stress="start-stop-start">
+            Start → Stop → Start
+          </button>
+
+          <button type="button" data-stress="reset-start">
+            Reset → Start
+          </button>
+
+          <button type="button" data-stress="reset">
+            Start → Reset
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="status-panel">
+      <div class="status-heading">
+        <h2>Transition log</h2>
+
+        <button
+          type="button"
+          id="clearLog"
+          class="secondary-button"
+        >
+          Clear
+        </button>
+      </div>
+
+      <ol id="eventLog" class="event-log" aria-live="polite">
+        <li class="empty-log">
+          No transitions recorded yet.
+        </li>
+      </ol>
+    </section>
+
+    <section class="validation-panel">
+      <h2>Validation checklist</h2>
+
+      <ul>
+        <li>No stale animation state after stopping.</li>
+        <li>No duplicate logical state classes.</li>
+        <li>Restart produces a fresh animation cycle.</li>
+        <li>Reset returns the loader to its initial state.</li>
+        <li>Final state matches the latest requested action.</li>
+      </ul>
+    </section>
+  </main>
+
+  <script>
+    const loader = document.getElementById("loader");
+    const stateValue = document.getElementById("stateValue");
+    const eventLog = document.getElementById("eventLog");
+    const clearLogButton = document.getElementById("clearLog");
+
+    const STATES = {
+      IDLE: "idle",
+      LOADING: "loading",
+      PAUSED: "paused"
+    };
+
+    let currentState = STATES.IDLE;
+    let transitionNumber = 0;
+
+    function sleep(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function renderState() {
+      loader.classList.remove(
+        "is-idle",
+        "is-loading",
+        "is-paused"
+      );
+
+      if (currentState === STATES.LOADING) {
+        loader.classList.add("is-loading");
+      } else if (currentState === STATES.PAUSED) {
+        loader.classList.add("is-paused");
+      } else {
+        loader.classList.add("is-idle");
+      }
+
+      stateValue.textContent = currentState;
+    }
+
+    function addLog(action, previousState, nextState) {
+      const emptyItem = eventLog.querySelector(".empty-log");
+
+      if (emptyItem) {
+        emptyItem.remove();
+      }
+
+      transitionNumber += 1;
+
+      const item = document.createElement("li");
+
+      item.innerHTML = `
+        <span class="log-number">#${transitionNumber}</span>
+        <span class="log-action">${action}</span>
+        <span class="log-state">
+          ${previousState} → ${nextState}
+        </span>
+      `;
+
+      eventLog.prepend(item);
+    }
+
+    function setState(nextState, action) {
+      const previousState = currentState;
+
+      currentState = nextState;
+      renderState();
+      addLog(action, previousState, nextState);
+    }
+
+    function start() {
+      setState(STATES.LOADING, "START");
+    }
+
+    function stop() {
+      setState(STATES.PAUSED, "STOP");
+    }
+
+    function restart() {
+      /*
+       * Force removal of the animation class before adding it again.
+       * This simulates a fresh animation cycle.
+       */
+      loader.classList.remove("is-loading");
+
+      void loader.offsetWidth;
+
+      setState(STATES.LOADING, "RESTART");
+    }
+
+    function reset() {
+      loader.classList.remove(
+        "is-loading",
+        "is-paused"
+      );
+
+      setState(STATES.IDLE, "RESET");
+    }
+
+    async function runStartStopStress() {
+      for (let i = 0; i < 5; i += 1) {
+        start();
+        await sleep(80);
+
+        stop();
+        await sleep(80);
+      }
+    }
+
+    async function runRestartStress() {
+      start();
+
+      await sleep(100);
+
+      for (let i = 0; i < 5; i += 1) {
+        restart();
+        await sleep(80);
+      }
+    }
+
+    async function runStartStopStart() {
+      start();
+
+      await sleep(60);
+
+      stop();
+
+      await sleep(60);
+
+      start();
+    }
+
+    async function runResetStart() {
+      start();
+
+      await sleep(100);
+
+      reset();
+
+      await sleep(60);
+
+      start();
+    }
+
+    async function runStartReset() {
+      start();
+
+      await sleep(100);
+
+      reset();
+    }
+
+    document.querySelectorAll("[data-action]").forEach(button => {
+      button.addEventListener("click", () => {
+        const action = button.dataset.action;
+
+        if (action === "start") {
+          start();
+        }
+
+        if (action === "stop") {
+          stop();
+        }
+
+        if (action === "restart") {
+          restart();
+        }
+
+        if (action === "reset") {
+          reset();
+        }
+      });
+    });
+
+    document.querySelectorAll("[data-stress]").forEach(button => {
+      button.addEventListener("click", async () => {
+        const stressType = button.dataset.stress;
+
+        button.disabled = true;
+
+        try {
+          if (stressType === "start-stop") {
+            await runStartStopStress();
+          }
+
+          if (stressType === "restart") {
+            await runRestartStress();
+          }
+
+          if (stressType === "start-stop-start") {
+            await runStartStopStart();
+          }
+
+          if (stressType === "reset-start") {
+            await runResetStart();
+          }
+
+          if (stressType === "reset") {
+            await runStartReset();
+          }
+        } finally {
+          button.disabled = false;
+        }
+      });
+    });
+
+    clearLogButton.addEventListener("click", () => {
+      transitionNumber = 0;
+
+      eventLog.innerHTML = `
+        <li class="empty-log">
+          No transitions recorded yet.
+        </li>
+      `;
+    });
+
+    renderState();
+  </script>
+</body>
+</html>

--- a/submissions/docs/css-loader-rapid-state-transitions/style.css
+++ b/submissions/docs/css-loader-rapid-state-transitions/style.css
@@ -1,0 +1,374 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at top,
+      #172033 0,
+      #0c1018 42%,
+      #070a0f 100%
+    );
+  color: #e8edf7;
+}
+
+button {
+  font: inherit;
+}
+
+.test-page {
+  width: min(100% - 32px, 980px);
+  margin: 0 auto;
+  padding: 56px 0 72px;
+}
+
+.page-header {
+  max-width: 760px;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #7dd3fc;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.05;
+}
+
+h2 {
+  margin-bottom: 18px;
+  font-size: 1.05rem;
+}
+
+.intro {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: #aab4c5;
+  line-height: 1.7;
+}
+
+.test-panel,
+.status-panel,
+.validation-panel {
+  border: 1px solid #283244;
+  border-radius: 20px;
+  background: rgba(13, 18, 28, 0.86);
+  box-shadow:
+    0 24px 70px rgba(0, 0, 0, 0.28),
+    inset 0 1px rgba(255, 255, 255, 0.035);
+}
+
+.test-panel {
+  padding: 28px;
+}
+
+.loader-area {
+  min-height: 310px;
+  display: grid;
+  place-items: center;
+  gap: 24px;
+}
+
+.loader {
+  position: relative;
+  width: 112px;
+  height: 112px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  transition:
+    transform 180ms ease,
+    opacity 180ms ease;
+}
+
+.loader-ring {
+  position: absolute;
+  inset: 4px;
+  border: 5px solid #263246;
+  border-top-color: #67e8f9;
+  border-right-color: #60a5fa;
+  border-radius: 50%;
+}
+
+.loader-core {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #67e8f9;
+  box-shadow:
+    0 0 18px rgba(103, 232, 249, 0.7),
+    0 0 44px rgba(96, 165, 250, 0.35);
+}
+
+.loader.is-idle {
+  opacity: 0.5;
+}
+
+.loader.is-idle .loader-ring {
+  animation: none;
+}
+
+.loader.is-idle .loader-core {
+  animation: none;
+  transform: scale(0.82);
+}
+
+.loader.is-loading {
+  opacity: 1;
+}
+
+.loader.is-loading .loader-ring {
+  animation: spin 760ms linear infinite;
+}
+
+.loader.is-loading .loader-core {
+  animation: pulse 620ms ease-in-out infinite alternate;
+}
+
+.loader.is-paused {
+  opacity: 0.72;
+}
+
+.loader.is-paused .loader-ring {
+  animation-play-state: paused;
+}
+
+.loader.is-paused .loader-core {
+  animation: none;
+  transform: scale(0.92);
+}
+
+.state-display {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #9ca9bc;
+  font-size: 0.9rem;
+}
+
+.state-display strong {
+  min-width: 86px;
+  padding: 5px 10px;
+  border: 1px solid #334155;
+  border-radius: 999px;
+  color: #e0f2fe;
+  font-size: 0.78rem;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.controls,
+.button-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.controls {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.controls button,
+.button-grid button,
+.secondary-button {
+  min-height: 44px;
+  padding: 10px 16px;
+  border: 1px solid #344156;
+  border-radius: 10px;
+  background: #151d2b;
+  color: #e6edf7;
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    border-color 150ms ease,
+    background 150ms ease;
+}
+
+.controls button:hover,
+.button-grid button:hover,
+.secondary-button:hover {
+  transform: translateY(-1px);
+  border-color: #5d718e;
+  background: #1b2637;
+}
+
+.controls button:active,
+.button-grid button:active,
+.secondary-button:active {
+  transform: translateY(0);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.stress-controls {
+  margin-top: 28px;
+  padding-top: 26px;
+  border-top: 1px solid #283244;
+}
+
+.button-grid {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.status-panel,
+.validation-panel {
+  margin-top: 18px;
+  padding: 24px;
+}
+
+.status-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.secondary-button {
+  min-height: 36px;
+  padding: 7px 12px;
+}
+
+.event-log {
+  display: grid;
+  gap: 8px;
+  max-height: 310px;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  list-style: none;
+}
+
+.event-log li {
+  display: grid;
+  grid-template-columns: 55px 110px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 11px 13px;
+  border: 1px solid #242e3e;
+  border-radius: 9px;
+  background: #101722;
+  color: #aeb9c9;
+  font-size: 0.85rem;
+}
+
+.log-number {
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+.log-action {
+  color: #67e8f9;
+  font-weight: 700;
+}
+
+.log-state {
+  color: #cbd5e1;
+}
+
+.empty-log {
+  display: block !important;
+  color: #64748b !important;
+  text-align: center;
+}
+
+.validation-panel ul {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 20px;
+  color: #aab4c5;
+  line-height: 1.55;
+}
+
+.validation-panel li::marker {
+  color: #67e8f9;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(0.78);
+    opacity: 0.65;
+  }
+
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 700px) {
+  .test-page {
+    width: min(100% - 20px, 980px);
+    padding-top: 32px;
+  }
+
+  .test-panel,
+  .status-panel,
+  .validation-panel {
+    border-radius: 15px;
+  }
+
+  .test-panel {
+    padding: 18px;
+  }
+
+  .controls,
+  .button-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .event-log li {
+    grid-template-columns: 45px 1fr;
+  }
+
+  .log-state {
+    grid-column: 2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loader-ring,
+  .loader-core,
+  .loader,
+  button {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly describe what you're submitting and the problem it solves. -->

Adds documentation and a self-contained demo for testing CSS loader behavior during rapid state transitions such as start, stop, restart, and reset operations.

This helps verify that rapid loader state changes do not result in stale animation states or inconsistent final behavior.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a self-contained CSS loader rapid state transition test/demo covering repeated start, stop, restart, and reset operations.

**How does a developer use it?**

```html
<!-- Open demo.html directly in a browser -->
<!-- The demo allows rapid CSS loader state transitions to be tested. -->
Closes #79559