### PR TITLE
docs: add theming configuration guide for neumorphic flyout popover

### DIFF
--- a/submissions/docs/neumorphic-flyout-popover-theming/README.md
+++ b/submissions/docs/neumorphic-flyout-popover-theming/README.md
@@ -1,0 +1,71 @@
+# Neumorphic Flyout Popover (Theming Configuration Guide)
+
+This guide explains how to theme and customize the Neumorphic Flyout Popover using CSS Custom Properties. Because neumorphism heavily relies on lighting and shadows matching the background color, creating new themes requires carefully calibrating four specific CSS variables.
+
+## Theming Configuration via CSS Variables
+
+To create a new theme, you must redefine the core variables under a new CSS modifier class.
+
+### Required Variables
+- `--bg-color`: The base color for the background, button, and popover.
+- `--text-color`: The color for the text and icons.
+- `--shadow-light`: The highlight color (usually a lighter tint of the base color, or pure white).
+- `--shadow-dark`: The shadow color (usually a darker shade of the base color).
+
+### CSS Implementation (Ocean Theme Example)
+
+```css
+/* Base variables apply to the default state */
+:root {
+    --bg-color: #e0e5ec;
+    --text-color: #333;
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+}
+
+/* Ocean Theme Modifier */
+.neumorphic-flyout--ocean,
+.neumorphic-trigger--ocean {
+    --bg-color: #e0f2fe;
+    --text-color: #0369a1;
+    --shadow-light: #ffffff;
+    --shadow-dark: #b9dcf2;
+}
+```
+
+## HTML Markup Example
+
+To apply your custom theme, add the modifier classes to both the trigger button and the flyout popover container:
+
+```html
+<div class="popover-container">
+    <!-- Trigger Button with Ocean Theme -->
+    <button class="neumorphic-trigger neumorphic-trigger--ocean" aria-haspopup="true" aria-expanded="false" aria-controls="popover-ocean">
+        Ocean Theme
+    </button>
+    
+    <!-- Flyout Popover with Ocean Theme -->
+    <div id="popover-ocean" class="neumorphic-flyout neumorphic-flyout--ocean" role="menu" aria-hidden="true">
+        <ul class="flyout-list">
+            <li role="none"><a href="#" role="menuitem">Option 1</a></li>
+            <li role="none"><a href="#" role="menuitem">Option 2</a></li>
+        </ul>
+    </div>
+</div>
+```
+
+## Accessibility Requirements for Theming
+
+When creating custom themes for neumorphic UI, contrast is often a major issue. Ensure you follow these guidelines:
+
+1. **Text Contrast**: The `--text-color` must have at least a 4.5:1 contrast ratio against the `--bg-color` to meet WCAG AA requirements.
+2. **Focus Visibility**: Soft inset shadows are often not distinct enough to serve as a clear focus indicator. Ensure you retain the `outline` on `:focus-visible` for keyboard users:
+   ```css
+   .neumorphic-trigger:focus-visible {
+       outline: 2px solid var(--text-color);
+       outline-offset: 4px;
+   }
+   ```
+3. **Keyboard Navigation**: As always with this component, ensure `Escape` closes the popover and focus returns to the trigger button.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/neumorphic-flyout-popover-theming/demo.html
+++ b/submissions/docs/neumorphic-flyout-popover-theming/demo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Flyout Popover (Theming) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <!-- Light Theme -->
+        <div class="popover-container">
+            <button class="neumorphic-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="popover-light">
+                Light Theme
+            </button>
+            <div id="popover-light" class="neumorphic-flyout" role="menu" aria-hidden="true">
+                <ul class="flyout-list">
+                    <li role="none"><a href="#" role="menuitem">Option 1</a></li>
+                    <li role="none"><a href="#" role="menuitem">Option 2</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Colored Theme (Ocean) -->
+        <div class="popover-container">
+            <button class="neumorphic-trigger neumorphic-trigger--ocean" aria-haspopup="true" aria-expanded="false" aria-controls="popover-ocean">
+                Ocean Theme
+            </button>
+            <div id="popover-ocean" class="neumorphic-flyout neumorphic-flyout--ocean" role="menu" aria-hidden="true">
+                <ul class="flyout-list">
+                    <li role="none"><a href="#" role="menuitem">Option 1</a></li>
+                    <li role="none"><a href="#" role="menuitem">Option 2</a></li>
+                </ul>
+            </div>
+        </div>
+
+    </main>
+
+    <script>
+        const triggers = document.querySelectorAll('.neumorphic-trigger');
+        
+        triggers.forEach(trigger => {
+            const popoverId = trigger.getAttribute('aria-controls');
+            const popover = document.getElementById(popoverId);
+
+            trigger.addEventListener('click', () => {
+                const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+                
+                // Close all others first
+                triggers.forEach(t => {
+                    if (t !== trigger) {
+                        t.setAttribute('aria-expanded', 'false');
+                        document.getElementById(t.getAttribute('aria-controls')).setAttribute('aria-hidden', 'true');
+                    }
+                });
+
+                // Toggle current
+                trigger.setAttribute('aria-expanded', !isExpanded);
+                popover.setAttribute('aria-hidden', isExpanded);
+                
+                if (!isExpanded) {
+                    setTimeout(() => popover.querySelector('a').focus(), 100);
+                }
+            });
+        });
+
+        // Close on escape
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                const openTrigger = document.querySelector('.neumorphic-trigger[aria-expanded="true"]');
+                if (openTrigger) {
+                    openTrigger.setAttribute('aria-expanded', 'false');
+                    document.getElementById(openTrigger.getAttribute('aria-controls')).setAttribute('aria-hidden', 'true');
+                    openTrigger.focus();
+                }
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/docs/neumorphic-flyout-popover-theming/style.css
+++ b/submissions/docs/neumorphic-flyout-popover-theming/style.css
@@ -1,0 +1,129 @@
+:root {
+    /* Base Neumorphic Light Theme */
+    --bg-color: #e0e5ec;
+    --text-color: #333;
+    --shadow-light: #ffffff;
+    --shadow-dark: #a3b1c6;
+    --flyout-width: 220px;
+    --transition-speed: 0.3s;
+}
+
+/* 
+ * THEMING CONFIGURATION 
+ * Redefine the core variables under modifier classes
+ */
+.neumorphic-flyout--ocean,
+.neumorphic-trigger--ocean {
+    --bg-color: #e0f2fe;
+    --text-color: #0369a1;
+    --shadow-light: #ffffff;
+    --shadow-dark: #b9dcf2;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background-color: var(--bg-color); /* Dynamically changes if JS changes body class, otherwise static for demo */
+    margin: 0;
+    min-height: 100vh;
+}
+
+.demo-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4rem;
+    padding: 4rem;
+    min-height: 100vh;
+    background-color: #e0e5ec; /* Fixed background for light demo */
+}
+
+.popover-container {
+    position: relative;
+    display: inline-block;
+}
+
+/* Trigger Button */
+.neumorphic-trigger {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: none;
+    padding: 1rem 2rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    border-radius: 12px;
+    cursor: pointer;
+    box-shadow: 
+        8px 8px 16px var(--shadow-dark), 
+        -8px -8px 16px var(--shadow-light);
+    transition: all var(--transition-speed) ease;
+}
+
+.neumorphic-trigger:active,
+.neumorphic-trigger[aria-expanded="true"] {
+    box-shadow: 
+        inset 6px 6px 10px var(--shadow-dark), 
+        inset -6px -6px 10px var(--shadow-light);
+}
+
+.neumorphic-trigger:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 4px;
+}
+
+/* Flyout Content */
+.neumorphic-flyout {
+    position: absolute;
+    top: calc(100% + 20px);
+    left: 50%;
+    transform: translateX(-50%) translateY(-10px);
+    width: var(--flyout-width);
+    background-color: var(--bg-color);
+    border-radius: 16px;
+    padding: 1rem 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    box-shadow: 
+        10px 10px 20px var(--shadow-dark), 
+        -10px -10px 20px var(--shadow-light);
+    transition: all var(--transition-speed) cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    z-index: 10;
+}
+
+/* Open State */
+.neumorphic-trigger[aria-expanded="true"] + .neumorphic-flyout {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* List Styling */
+.flyout-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.flyout-list li {
+    margin: 0.5rem 1rem;
+}
+
+.flyout-list a {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 500;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.flyout-list a:hover,
+.flyout-list a:focus-visible {
+    background-color: transparent;
+    box-shadow: 
+        inset 4px 4px 8px var(--shadow-dark), 
+        inset -4px -4px 8px var(--shadow-light);
+    outline: none;
+}


### PR DESCRIPTION
fixes #85741 

## Pull Request Description

This PR adds a comprehensive documentation guide covering how to theme the Neumorphic Flyout Popover. Creating custom neumorphic designs requires carefully balancing four key CSS variables (`--bg-color`, `--text-color`, `--shadow-light`, and `--shadow-dark`) to maintain the extruded/pressed look. This guide explains how to construct custom modifiers (like an Ocean theme) and outlines critical contrast accessibility guidelines.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on creating and applying custom CSS variable configurations to theme the neumorphic popover, along with accessibility warnings regarding contrast ratios when customizing "soft UI".

**How does a developer use it?**

```css
/* Ocean Theme Modifier */
.neumorphic-flyout--ocean,
.neumorphic-trigger--ocean {
    --bg-color: #e0f2fe;
    --text-color: #0369a1;
    --shadow-light: #ffffff;
    --shadow-dark: #b9dcf2;
}
