### PR TITLE
docs: add quickstart guide for pastel stat metric card

### DIFF
--- a/submissions/docs/pastel-stat-metric-card/README.md
+++ b/submissions/docs/pastel-stat-metric-card/README.md
@@ -1,0 +1,81 @@
+# Pastel Stat Metric Card (Quickstart Guide)
+
+This guide documents how to implement a clean, accessible Pastel Stat Metric Card with subtle hover animations. This component is perfect for dashboard overviews and data visualizations.
+
+## HTML Markup Example
+
+Here is the base accessible markup for the metric card. Notice the use of `<article>` and the `sr-only` class to ensure screen readers interpret the trend data correctly.
+
+```html
+<article class="stat-card" tabindex="0">
+    <!-- Icon container marked as hidden so screen readers ignore the raw SVG -->
+    <div class="stat-card__icon" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+        </svg>
+    </div>
+    
+    <div class="stat-card__content">
+        <h2 class="stat-card__title">Total Users</h2>
+        <div class="stat-card__value">14,230</div>
+        
+        <!-- Accessible Trend Indicator -->
+        <div class="stat-card__trend stat-card__trend--up">
+            <span class="sr-only">Increased by</span>
+            <span aria-hidden="true">↑</span> 12.5%
+        </div>
+    </div>
+</article>
+```
+
+## CSS Custom Properties & Modifiers
+
+The aesthetic relies on soft pastel backgrounds for the icons, contrasting against a crisp white card. You can theme the icon and background using CSS variables.
+
+### Default Variables (Purple Theme)
+
+```css
+:root {
+    --card-bg: #fff;
+    --card-shadow: rgba(149, 157, 165, 0.1);
+    
+    --icon-bg: #f3f0ff; /* Pastel Purple */
+    --icon-color: #7c3aed; /* Deep Purple */
+}
+```
+
+### Modifier Classes
+
+Append these modifier classes to the `.stat-card` element to instantly change the icon's pastel color scheme:
+
+**Mint Theme** (`.stat-card--mint`)
+```css
+.stat-card--mint {
+    --icon-bg: #d1fae5;
+    --icon-color: #059669;
+}
+```
+
+**Peach Theme** (`.stat-card--peach`)
+```css
+.stat-card--peach {
+    --icon-bg: #ffedd5;
+    --icon-color: #ea580c;
+}
+```
+
+## Accessibility Requirements
+
+Dashboard metrics often convey dense information. Follow these guidelines to ensure inclusivity:
+
+### Screen Reader Context
+- Avoid letting screen readers read out raw symbols like `↑` or `↓`. Wrap the symbol in `<span aria-hidden="true">` and provide a visually hidden text alternative (e.g., `<span class="sr-only">Increased by</span>`) right next to it.
+- Hide purely decorative SVG icons using `aria-hidden="true"` on the parent `.stat-card__icon` wrapper.
+
+### Keyboard Navigation
+- If the card acts as a link or interactive element, use `<a class="stat-card" href="...">` or `<button class="stat-card">`.
+- If it is purely informational but you still want hover effects to be discoverable by keyboard users, add `tabindex="0"`.
+- Ensure the `:focus-visible` state is clearly defined (e.g., using `outline: 2px solid var(--icon-color)`).
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/pastel-stat-metric-card/demo.html
+++ b/submissions/docs/pastel-stat-metric-card/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pastel Stat Metric Card Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="dashboard">
+        
+        <!-- Default Pastel Metric Card -->
+        <article class="stat-card" tabindex="0">
+            <div class="stat-card__icon" aria-hidden="true">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                    <circle cx="9" cy="7" r="4"></circle>
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                </svg>
+            </div>
+            <div class="stat-card__content">
+                <h2 class="stat-card__title">Total Users</h2>
+                <div class="stat-card__value">14,230</div>
+                <div class="stat-card__trend stat-card__trend--up">
+                    <span class="sr-only">Increased by</span>
+                    <span aria-hidden="true">↑</span> 12.5%
+                </div>
+            </div>
+        </article>
+
+        <!-- Mint Modifier -->
+        <article class="stat-card stat-card--mint" tabindex="0">
+            <div class="stat-card__icon" aria-hidden="true">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="12" y1="1" x2="12" y2="23"></line>
+                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                </svg>
+            </div>
+            <div class="stat-card__content">
+                <h2 class="stat-card__title">Monthly Revenue</h2>
+                <div class="stat-card__value">$42,500</div>
+                <div class="stat-card__trend stat-card__trend--up">
+                    <span class="sr-only">Increased by</span>
+                    <span aria-hidden="true">↑</span> 8.2%
+                </div>
+            </div>
+        </article>
+
+    </main>
+</body>
+</html>

--- a/submissions/docs/pastel-stat-metric-card/style.css
+++ b/submissions/docs/pastel-stat-metric-card/style.css
@@ -1,0 +1,135 @@
+:root {
+    /* Base Pastel Theme Variables */
+    --card-bg: #fff;
+    --card-border: #f0f0f5;
+    --card-shadow: rgba(149, 157, 165, 0.1);
+    
+    --icon-bg: #f3f0ff; /* Pastel Purple */
+    --icon-color: #7c3aed;
+    
+    --text-main: #1f2937;
+    --text-muted: #6b7280;
+    
+    --trend-up: #10b981;
+    --trend-down: #ef4444;
+    
+    --transition-speed: 0.3s;
+}
+
+/* Modifier: Pastel Mint Theme */
+.stat-card--mint {
+    --icon-bg: #d1fae5;
+    --icon-color: #059669;
+}
+
+/* Modifier: Pastel Peach Theme */
+.stat-card--peach {
+    --icon-bg: #ffedd5;
+    --icon-color: #ea580c;
+}
+
+body {
+    font-family: -apple-system, system-ui, sans-serif;
+    background-color: #f9fafb;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.dashboard {
+    display: flex;
+    gap: 2rem;
+    padding: 2rem;
+    flex-wrap: wrap;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.stat-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 1.5rem;
+    min-width: 240px;
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    box-shadow: 0 4px 12px var(--card-shadow);
+    transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+    cursor: default;
+}
+
+.stat-card:hover,
+.stat-card:focus-visible {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 24px rgba(149, 157, 165, 0.15);
+}
+
+.stat-card:focus-visible {
+    outline: 2px solid var(--icon-color);
+    outline-offset: 4px;
+}
+
+.stat-card__icon {
+    background-color: var(--icon-bg);
+    color: var(--icon-color);
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: transform var(--transition-speed) ease;
+}
+
+.stat-card:hover .stat-card__icon,
+.stat-card:focus-visible .stat-card__icon {
+    transform: scale(1.1) rotate(5deg);
+}
+
+.stat-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.stat-card__title {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.stat-card__value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-main);
+}
+
+.stat-card__trend {
+    font-size: 0.875rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.stat-card__trend--up {
+    color: var(--trend-up);
+}
+
+.stat-card__trend--down {
+    color: var(--trend-down);
+}


### PR DESCRIPTION
fixes #85756 

## Pull Request Description

This PR introduces the quickstart documentation guide for the Pastel Stat Metric Card. It details the semantic HTML structure, the CSS variables required for the pastel theming modifiers, and critical accessibility guidance for handling screen reader announcements of data trends (e.g., hiding raw SVG/arrow symbols and providing visually hidden text alternatives).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a thorough guide on implementing an aesthetically pleasing, hover-animated pastel stat card commonly used in dashboards, focusing specifically on data accessibility.

**How does a developer use it?**

```html
<article class="stat-card stat-card--mint" tabindex="0">
    <!-- Icon with aria-hidden -->
    <div class="stat-card__content">
        <h2 class="stat-card__title">Monthly Revenue</h2>
        <div class="stat-card__value">$42,500</div>
        <!-- Accessible Trend -->
        <div class="stat-card__trend stat-card__trend--up">
            <span class="sr-only">Increased by</span>
            <span aria-hidden="true">↑</span> 8.2%
        </div>
    </div>
</article>
