### PR TITLE
docs: add responsive layout guide for dark mode star rating

### DIFF
--- a/submissions/docs/dark-mode-star-rating-responsive/README.md
+++ b/submissions/docs/dark-mode-star-rating-responsive/README.md
@@ -1,0 +1,80 @@
+# Dark Mode Star Rating (Responsive Breakpoints Layout)
+
+This guide documents how to create a fluid, responsive layout for the Dark Mode Star Rating component. Using media queries, we dynamically adjust the size and spacing of the stars to ensure an optimal touch target size on mobile and a prominent display on desktop.
+
+## Responsive Configuration via CSS Variables
+
+The most maintainable approach to responsive design in EaseMotion is updating CSS Custom Properties at different breakpoints, rather than redeclaring complex styling rules.
+
+### CSS Implementation
+
+```css
+:root {
+    /* Base Variables (Mobile First - ensures safe touch target) */
+    --star-size: 2rem;
+    --star-gap: 0.25rem;
+}
+
+/* 
+ * RESPONSIVE BREAKPOINTS MODIFIER
+ */
+.star-rating--responsive {
+    
+    /* Tablet Breakpoint */
+    @media (min-width: 768px) {
+        --star-size: 3rem;
+        --star-gap: 0.5rem;
+    }
+
+    /* Desktop Breakpoint */
+    @media (min-width: 1024px) {
+        --star-size: 4rem;
+        --star-gap: 0.75rem;
+    }
+}
+```
+
+## HTML Markup Example
+
+Apply the `.star-rating--responsive` class to the main `<fieldset>` container. Note the use of `<fieldset>` and radio inputs, which is the standard accessible pattern for star ratings.
+
+```html
+<form action="#" class="rating-form">
+    <!-- Applied responsive modifier class -->
+    <fieldset class="star-rating star-rating--responsive">
+        <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+        
+        <!-- Note: We use flex-direction: row-reverse in CSS, so the DOM order is 5 to 1 -->
+        <div class="star-rating__group">
+            <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+            <label for="star5" aria-label="5 stars" class="star-label"></label>
+            
+            <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+            <label for="star4" aria-label="4 stars" class="star-label"></label>
+            
+            <!-- ... Stars 3, 2, 1 ... -->
+        </div>
+    </fieldset>
+</form>
+```
+
+## Accessibility & Keyboard Navigation
+
+The star rating must be fully accessible via keyboard.
+
+### Keyboard Interaction
+Because the underlying markup uses native `<input type="radio">` elements:
+- Users can navigate to the rating component using `Tab`.
+- Once focused, users can cycle through the star ratings using the `Arrow Left` and `Arrow Right` keys.
+- `Space` or `Enter` is not strictly necessary for selection as native radio groups update their checked state on arrow navigation, but ensure your form submission logic handles this correctly.
+
+### Focus States
+When a user tabs to a radio input, its associated `<label>` must show a clear focus state:
+```css
+.star-rating__group input:focus-visible + .star-label {
+    outline: 2px solid #ffffff;
+    outline-offset: 4px;
+}
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/dark-mode-star-rating-responsive/demo.html
+++ b/submissions/docs/dark-mode-star-rating-responsive/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Star Rating (Responsive) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <form action="#" class="rating-form">
+            <!-- Apply responsive modifier class -->
+            <fieldset class="star-rating star-rating--responsive">
+                <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+                
+                <div class="star-rating__group">
+                    <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+                    <label for="star5" aria-label="5 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+                    <label for="star4" aria-label="4 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star3" name="rating" value="3" class="sr-only">
+                    <label for="star3" aria-label="3 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star2" name="rating" value="2" class="sr-only">
+                    <label for="star2" aria-label="2 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star1" name="rating" value="1" class="sr-only">
+                    <label for="star1" aria-label="1 star" class="star-label"></label>
+                </div>
+            </fieldset>
+            
+            <p class="resize-note">Resize the window to see the star sizes adjust!</p>
+        </form>
+    </main>
+</body>
+</html>

--- a/submissions/docs/dark-mode-star-rating-responsive/style.css
+++ b/submissions/docs/dark-mode-star-rating-responsive/style.css
@@ -1,0 +1,110 @@
+:root {
+    /* Base Variables (Mobile First) */
+    --star-size: 2rem;
+    --star-gap: 0.25rem;
+    
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    
+    --star-color-inactive: #333333;
+    --star-color-hover: #ffb400;
+    --star-color-active: #ff9900;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.rating-form {
+    text-align: center;
+}
+
+.resize-note {
+    margin-top: 2rem;
+    color: #888;
+    font-size: 0.9rem;
+}
+
+.star-rating {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+/* 
+ * CSS Flex-Reverse Trick for Rating logic 
+ * Allows subsequent sibling combinator (~) to color previous stars
+ */
+.star-rating__group {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    gap: var(--star-gap);
+    justify-content: center;
+}
+
+.star-label {
+    cursor: pointer;
+    width: var(--star-size);
+    height: var(--star-size);
+    background-color: var(--star-color-inactive);
+    /* Clip-path for star shape */
+    clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+/* Hover State */
+.star-label:hover,
+.star-label:hover ~ .star-label {
+    background-color: var(--star-color-hover);
+}
+
+.star-label:hover {
+    transform: scale(1.1);
+}
+
+/* Checked/Active State */
+.star-rating__group input:checked ~ .star-label {
+    background-color: var(--star-color-active);
+}
+
+/* Focus State for Accessibility */
+.star-rating__group input:focus-visible + .star-label {
+    outline: 2px solid #fff;
+    outline-offset: 4px;
+}
+
+/* 
+ * RESPONSIVE BREAKPOINTS MODIFIER
+ */
+.star-rating--responsive {
+    /* Tablet Breakpoint */
+    @media (min-width: 768px) {
+        --star-size: 3rem;
+        --star-gap: 0.5rem;
+    }
+
+    /* Desktop Breakpoint */
+    @media (min-width: 1024px) {
+        --star-size: 4rem;
+        --star-gap: 0.75rem;
+    }
+}


### PR DESCRIPTION
fixes #85755 

## Pull Request Description

This PR adds a comprehensive documentation guide detailing how to manage responsive breakpoints for the Dark Mode Star Rating component. It covers updating CSS custom properties to ensure safe, finger-friendly touch targets on mobile devices, while properly scaling up the interactive star visuals for desktop environments. It also documents the accessible `<fieldset>` and radio input pattern necessary for keyboard users.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on implementing the `.star-rating--responsive` modifier. This guides developers on how to use CSS media queries to dynamically adjust the `--star-size` and `--star-gap` variables across mobile, tablet, and desktop viewports.

**How does a developer use it?**

```css
.star-rating--responsive {
    /* Tablet Breakpoint */
    @media (min-width: 768px) {
        --star-size: 3rem;
        --star-gap: 0.5rem;
    }
}
