### PR TITLE
docs: add accessibility setup guide for dark mode star rating

### DIFF
--- a/submissions/docs/dark-mode-star-rating-accessibility/README.md
+++ b/submissions/docs/dark-mode-star-rating-accessibility/README.md
@@ -1,0 +1,66 @@
+# Dark Mode Star Rating (Accessibility Setup Guide)
+
+This guide documents the strict accessibility requirements necessary for implementing a purely CSS-driven Star Rating component. Since we rely on a CSS trick (`flex-direction: row-reverse` and the `~` sibling selector) to color the stars, the underlying markup must be perfectly semantic to compensate.
+
+## Accessibility Requirements & Keyboard Navigation
+
+### 1. Semantic Form Elements
+A star rating is fundamentally a form input where a user selects one value from a set. The most accessible way to represent this is using a group of radio buttons.
+
+- **Fieldset & Legend**: Wrap the radio group in a `<fieldset>` and provide a `<legend>`. If you don't want the legend visible, hide it using a visually hidden (`sr-only`) utility class. This ensures screen readers announce the purpose of the group when a user focuses on any of the radio inputs.
+- **Labels**: Every radio `<input>` must have an associated `<label>`. Use `aria-label` on the label if the visual content is purely decorative (like our CSS clip-path stars).
+
+### 2. Visually Hiding Inputs (The `sr-only` class)
+**NEVER use `display: none` or `visibility: hidden` on the radio inputs.** 
+Doing so removes them from the accessibility tree, making keyboard navigation impossible. Instead, use an `sr-only` class to clip them out of view while keeping them focusable.
+
+```css
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+```
+
+### 3. Focus States
+Keyboard users navigating via the `Tab` key will focus on the hidden radio inputs. You must use the `:focus-visible` pseudo-class on the hidden input to apply a visible outline to its adjacent sibling `<label>`.
+
+```css
+.star-rating__group input:focus-visible + .star-label {
+    outline: 3px solid #ffffff;
+    outline-offset: 4px;
+}
+```
+
+## HTML Markup Example
+
+Here is the complete, accessible markup pattern:
+
+```html
+<form action="#" class="rating-form">
+    <fieldset class="star-rating">
+        <!-- The legend provides context for the radio group -->
+        <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+        
+        <div class="star-rating__group">
+            <!-- Inputs are visually hidden but remain in the tab order -->
+            <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+            <!-- Labels provide the visible star shape and accessible name -->
+            <label for="star5" aria-label="5 stars" class="star-label"></label>
+            
+            <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+            <label for="star4" aria-label="4 stars" class="star-label"></label>
+            
+            <!-- ... remaining stars ... -->
+        </div>
+    </fieldset>
+</form>
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/dark-mode-star-rating-accessibility/demo.html
+++ b/submissions/docs/dark-mode-star-rating-accessibility/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Star Rating (Accessibility Setup) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <form action="#" class="rating-form">
+            <!-- 
+                CRITICAL ACCESSIBILITY: 
+                Use fieldset and legend to group the radio buttons semantically. 
+            -->
+            <fieldset class="star-rating">
+                <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+                
+                <div class="star-rating__group">
+                    <!-- 
+                        CRITICAL ACCESSIBILITY:
+                        Never use display: none on the inputs. Use a visually hidden (sr-only) class
+                        so they remain focusable and readable by screen readers.
+                    -->
+                    <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+                    <label for="star5" aria-label="5 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+                    <label for="star4" aria-label="4 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star3" name="rating" value="3" class="sr-only">
+                    <label for="star3" aria-label="3 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star2" name="rating" value="2" class="sr-only">
+                    <label for="star2" aria-label="2 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star1" name="rating" value="1" class="sr-only">
+                    <label for="star1" aria-label="1 star" class="star-label"></label>
+                </div>
+            </fieldset>
+            
+            <p class="a11y-note">Try navigating the stars using your keyboard (Tab, then Arrow Keys).</p>
+        </form>
+    </main>
+</body>
+</html>

--- a/submissions/docs/dark-mode-star-rating-accessibility/style.css
+++ b/submissions/docs/dark-mode-star-rating-accessibility/style.css
@@ -1,0 +1,95 @@
+:root {
+    --star-size: 3rem;
+    --star-gap: 0.5rem;
+    
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    
+    --star-color-inactive: #333333;
+    --star-color-hover: #ffb400;
+    --star-color-active: #ff9900;
+    
+    /* High contrast focus ring for accessibility */
+    --focus-ring-color: #ffffff;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Visually Hidden Class
+ * Hides the radio inputs visually without removing them from the accessibility tree 
+ * or breaking keyboard navigation.
+ */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.rating-form {
+    text-align: center;
+}
+
+.a11y-note {
+    margin-top: 2rem;
+    color: #888;
+    font-size: 0.9rem;
+}
+
+.star-rating {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.star-rating__group {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    gap: var(--star-gap);
+    justify-content: center;
+}
+
+.star-label {
+    cursor: pointer;
+    width: var(--star-size);
+    height: var(--star-size);
+    background-color: var(--star-color-inactive);
+    clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.star-label:hover,
+.star-label:hover ~ .star-label {
+    background-color: var(--star-color-hover);
+}
+
+.star-rating__group input:checked ~ .star-label {
+    background-color: var(--star-color-active);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus States
+ * When the visually hidden radio button receives keyboard focus, 
+ * apply a highly visible outline to its adjacent sibling label.
+ */
+.star-rating__group input:focus-visible + .star-label {
+    outline: 3px solid var(--focus-ring-color);
+    outline-offset: 4px;
+    /* In high contrast mode, outline colors can be stripped. Adding a background tweak helps */
+    background-color: var(--star-color-hover);
+}


### PR DESCRIPTION
fixes #85754 

## Pull Request Description

This PR introduces the critical accessibility documentation guide for the purely CSS-driven Dark Mode Star Rating component. Because this component relies on CSS tricks (`flex-direction: row-reverse` and the general sibling combinator `~`), it requires a perfectly semantic HTML foundation. This guide documents the necessity of the `<fieldset>` / radio input pattern, how to visually hide inputs without removing them from the accessibility tree (`sr-only`), and how to properly manage keyboard focus states.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on implementing the accessible `<fieldset>` pattern for star ratings. It details the `sr-only` utility class to ensure screen reader compatibility without breaking visual aesthetics, and provides CSS to ensure keyboard navigators receive clear `:focus-visible` outlines.

**How does a developer use it?**

```css
/* Apply outline to the sibling label when the hidden radio is focused */
.star-rating__group input:focus-visible + .star-label {
    outline: 3px solid #ffffff;
    outline-offset: 4px;
}
