### PR TITLE
feat: add animated floating bulk-action toolbar component 

### DIFF
--- a/submissions/examples/bulk-action-toolbar-nk/README.md
+++ b/submissions/examples/bulk-action-toolbar-nk/README.md
@@ -1,0 +1,112 @@
+# Floating Bulk-Action Toolbar — `bulk-action-toolbar-nk`
+
+## 1. What does this do?
+
+An animated floating bulk-action toolbar that slides up from the bottom when items are selected, shows a scale-pop count badge that animates on every change, staggers action buttons in left-to-right, and slides back down when selection is cleared — all transitions driven by pure CSS keyframes off state classes toggled by a minimal JS bridge.
+
+---
+
+## 2. How is it used?
+
+### HTML structure
+
+```html
+<!-- Selectable list item -->
+<li class="bat-item" data-id="1">
+  <label class="bat-check-wrap">
+    <input type="checkbox" class="bat-chk-input bat-item-chk" />
+    <span class="bat-chk-box">
+      <svg class="bat-chk-icon">...</svg>
+    </span>
+  </label>
+  <span class="bat-item__name">design-system.fig</span>
+</li>
+
+<!-- Floating toolbar -->
+<div class="bat-toolbar" role="toolbar" hidden>
+  <span class="bat-count-badge">3</span>
+  <span>selected</span>
+  <div class="bat-toolbar__actions">
+    <button class="bat-action" data-action="move">Move</button>
+    <button class="bat-action" data-action="delete">Delete</button>
+  </div>
+  <button class="bat-deselect">✕</button>
+</div>
+```
+
+### State classes
+
+| Class | Applied to | Effect |
+|---|---|---|
+| `bat-item--selected` | `.bat-item` | Indigo background on selected row |
+| `bat-chk-input:checked + .bat-chk-box` | `.bat-chk-box` | Scale-up + checkmark draws in |
+| `bat-toolbar--in` | `.bat-toolbar` | Slide-up bounce entrance from bottom |
+| `bat-toolbar--out` | `.bat-toolbar` | Slide-down fade exit |
+| `bat-action--in` | `.bat-action` | Staggered fade-up per button |
+| `bat-count-pop` | `.bat-count-badge` | Scale bounce pop on count change |
+| `.bat-deselect:hover svg` | deselect icon | 90° rotation |
+
+### JS bridge (minimal — only toggles classes and hidden state)
+
+```js
+// Show toolbar on first selection
+toolbar.hidden = false;
+toolbar.classList.add('bat-toolbar--in');
+
+// Stagger buttons
+actions.forEach((btn, i) => {
+  btn.style.animationDelay = (0.08 + i * 0.055) + 's';
+  btn.classList.add('bat-action--in');
+});
+
+// Pop badge on count change
+countBadge.textContent = n;
+countBadge.classList.add('bat-count-pop');
+
+// Hide toolbar
+toolbar.classList.add('bat-toolbar--out');
+// on animationend: toolbar.hidden = true
+```
+
+All visual transitions are pure CSS. The JS manages hidden state, count updates, and focus only.
+
+---
+
+## 3. Why is it useful?
+
+Bulk selection is a high-frequency action in every SaaS file manager, inbox, table view, and list UI — Gmail, Notion, Linear, Dropbox all have it. Yet it had essentially zero coverage in the EaseMotion repo.
+
+This component fits EaseMotion's philosophy because:
+
+- **Every state change has a motion signal.** The toolbar sliding up says "you have power over these items." The count badge popping says "one more added." The stagger entrance gives the action buttons spatial weight. The slide-down says "done."
+- **CSS does the heavy lifting.** All 5 keyframes (fade-up, toolbar-in, toolbar-out, action-in, count-pop) are pure CSS. The JS is ~60 lines managing state and counts only — swap for React `useState`, Alpine `x-bind`, or plain HTMX without touching the stylesheet.
+- **Accessible by default.** The toolbar uses `role="toolbar"` + `aria-label`. Each action button has an `aria-label`. A `role="status"` live region announces every state change. Checkboxes support indeterminate state for partial selection. `prefers-reduced-motion` collapses all durations.
+- **Mobile-friendly.** At `< 480px`, button labels hide and only icons show — the toolbar stays usable on small screens.
+- **Zero dependencies.** Open `demo.html` directly in any modern browser — no server, no CDN, no build step.
+
+---
+
+## Animations used
+
+| Animation | Trigger | Effect |
+|---|---|---|
+| `bat-fade-up` | Page header / list on load | Fade + slide up entrance |
+| `bat-toolbar-in` | `.bat-toolbar--in` | Slide-up bounce from bottom, scale from 0.94→1 |
+| `bat-toolbar-out` | `.bat-toolbar--out` | Slide-down fade exit |
+| `bat-action-in` | `.bat-action--in` (staggered 55ms) | Fade + slide up per button |
+| `bat-count-pop` | `.bat-count-pop` on count change | Scale bounce 1→1.35→0.9→1 |
+| Checkmark draw | `bat-chk-input:checked` | Stroke-dashoffset draw |
+| Checkbox scale | `bat-chk-input:checked` | Scale-up 1.1× bounce |
+| Deselect spin | `.bat-deselect:hover svg` | `rotate(90deg)` transition |
+| Row select | `.bat-item--selected` | Indigo bg fade on selection |
+
+---
+
+## Files
+
+```
+submissions/examples/bulk-action-toolbar-nk/
+├── demo.html   — self-contained demo, works by opening directly in a browser
+├── style.css   — all styles, keyframes, and state transitions
+└── README.md   — this file
+```

--- a/submissions/examples/bulk-action-toolbar-nk/demo.html
+++ b/submissions/examples/bulk-action-toolbar-nk/demo.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bulk Action Toolbar — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="demo-wrapper">
+
+      <!-- ── Page header ── -->
+      <div class="bat-page-header">
+        <div class="bat-page-header__left">
+          <!-- Select-all checkbox -->
+          <label class="bat-check-wrap" aria-label="Select all items">
+            <input type="checkbox" id="chk-all" class="bat-chk-input" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round"
+                      stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <h1 class="bat-page-title">All Files</h1>
+          <span class="bat-page-count" id="total-count">8 items</span>
+        </div>
+        <button class="bat-upload-btn" type="button">+ Upload</button>
+      </div>
+
+      <!-- ── File list ── -->
+      <ul class="bat-list" id="bat-list" role="list" aria-label="File list">
+
+        <li class="bat-item" data-id="1" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select design-system.fig">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--fig" aria-hidden="true">◈</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">design-system.fig</span>
+            <span class="bat-item__meta">Figma · 4.2 MB · 2h ago</span>
+          </span>
+          <span class="bat-item__badge">Shared</span>
+        </li>
+
+        <li class="bat-item" data-id="2" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select brand-guidelines.pdf">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--pdf" aria-hidden="true">⬛</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">brand-guidelines.pdf</span>
+            <span class="bat-item__meta">PDF · 8.7 MB · yesterday</span>
+          </span>
+          <span class="bat-item__badge bat-item__badge--green">Approved</span>
+        </li>
+
+        <li class="bat-item" data-id="3" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select hero-illustration.svg">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--svg" aria-hidden="true">⬡</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">hero-illustration.svg</span>
+            <span class="bat-item__meta">SVG · 120 KB · 3d ago</span>
+          </span>
+        </li>
+
+        <li class="bat-item" data-id="4" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select onboarding-flow.mp4">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--mp4" aria-hidden="true">▶</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">onboarding-flow.mp4</span>
+            <span class="bat-item__meta">MP4 · 54 MB · 5d ago</span>
+          </span>
+          <span class="bat-item__badge bat-item__badge--amber">Review</span>
+        </li>
+
+        <li class="bat-item" data-id="5" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select component-audit.xlsx">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--xls" aria-hidden="true">▦</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">component-audit.xlsx</span>
+            <span class="bat-item__meta">Excel · 340 KB · 1w ago</span>
+          </span>
+        </li>
+
+        <li class="bat-item" data-id="6" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select motion-spec.md">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--md" aria-hidden="true">◻</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">motion-spec.md</span>
+            <span class="bat-item__meta">Markdown · 18 KB · 1w ago</span>
+          </span>
+          <span class="bat-item__badge">Shared</span>
+        </li>
+
+        <li class="bat-item" data-id="7" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select cover-photo.png">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--img" aria-hidden="true">⬜</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">cover-photo.png</span>
+            <span class="bat-item__meta">PNG · 2.1 MB · 2w ago</span>
+          </span>
+          <span class="bat-item__badge bat-item__badge--green">Approved</span>
+        </li>
+
+        <li class="bat-item" data-id="8" role="listitem">
+          <label class="bat-check-wrap" aria-label="Select prototype-v3.fig">
+            <input type="checkbox" class="bat-chk-input bat-item-chk" />
+            <span class="bat-chk-box" aria-hidden="true">
+              <svg class="bat-chk-icon" viewBox="0 0 12 10" fill="none">
+                <path d="M1 5l3.5 3.5L11 1" stroke="currentColor"
+                      stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+          </label>
+          <span class="bat-item__icon bat-item__icon--fig" aria-hidden="true">◈</span>
+          <span class="bat-item__info">
+            <span class="bat-item__name">prototype-v3.fig</span>
+            <span class="bat-item__meta">Figma · 6.8 MB · 3w ago</span>
+          </span>
+        </li>
+
+      </ul><!-- /list -->
+
+      <!-- ── Floating bulk-action toolbar ── -->
+      <div
+        class="bat-toolbar"
+        id="bat-toolbar"
+        role="toolbar"
+        aria-label="Bulk actions"
+        aria-live="polite"
+        hidden
+      >
+        <!-- Count badge -->
+        <div class="bat-toolbar__count" aria-live="polite" aria-atomic="true">
+          <span class="bat-count-badge" id="bat-count-badge">0</span>
+          <span class="bat-toolbar__count-label">selected</span>
+        </div>
+
+        <div class="bat-toolbar__divider" aria-hidden="true"></div>
+
+        <!-- Action buttons -->
+        <div class="bat-toolbar__actions" role="group" aria-label="Bulk actions">
+          <button class="bat-action" data-action="move" type="button"
+                  aria-label="Move selected">
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M2 8h12M10 5l3 3-3 3" stroke="currentColor"
+                    stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span>Move</span>
+          </button>
+
+          <button class="bat-action" data-action="label" type="button"
+                  aria-label="Label selected">
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M3 3h5l5 5-5 5-5-5V3z" stroke="currentColor"
+                    stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span>Label</span>
+          </button>
+
+          <button class="bat-action" data-action="export" type="button"
+                  aria-label="Export selected">
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M8 2v8M5 7l3 3 3-3M3 13h10"
+                    stroke="currentColor" stroke-width="1.5"
+                    stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span>Export</span>
+          </button>
+
+          <button class="bat-action bat-action--danger" data-action="delete"
+                  type="button" aria-label="Delete selected">
+            <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M3 4h10M6 4V2h4v2M5 4v9h6V4"
+                    stroke="currentColor" stroke-width="1.5"
+                    stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span>Delete</span>
+          </button>
+        </div>
+
+        <div class="bat-toolbar__divider" aria-hidden="true"></div>
+
+        <!-- Deselect all -->
+        <button class="bat-deselect" id="bat-deselect" type="button"
+                aria-label="Deselect all">
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
+      </div><!-- /toolbar -->
+
+    </div><!-- /wrapper -->
+
+    <!-- SR live region -->
+    <div style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)"
+         role="status" aria-live="polite" id="bat-sr"></div>
+
+    <script>
+    (function () {
+      const toolbar    = document.getElementById('bat-toolbar');
+      const countBadge = document.getElementById('bat-count-badge');
+      const deselectBtn= document.getElementById('bat-deselect');
+      const chkAll     = document.getElementById('chk-all');
+      const itemChks   = Array.from(document.querySelectorAll('.bat-item-chk'));
+      const items      = Array.from(document.querySelectorAll('.bat-item'));
+      const srEl       = document.getElementById('bat-sr');
+
+      function announce(msg) {
+        srEl.textContent = '';
+        requestAnimationFrame(() => { srEl.textContent = msg; });
+      }
+
+      function selectedCount() {
+        return itemChks.filter(c => c.checked).length;
+      }
+
+      /* ── update badge with pop animation ── */
+      function updateBadge(n) {
+        const prev = parseInt(countBadge.textContent, 10);
+        if (prev === n) return;
+        countBadge.classList.remove('bat-count-pop');
+        void countBadge.offsetWidth;
+        countBadge.textContent = n;
+        countBadge.classList.add('bat-count-pop');
+        countBadge.addEventListener('animationend', () => {
+          countBadge.classList.remove('bat-count-pop');
+        }, { once: true });
+      }
+
+      /* ── show / hide toolbar ── */
+      function showToolbar(n) {
+        if (toolbar.hidden) {
+          toolbar.hidden = false;
+          toolbar.classList.remove('bat-toolbar--out');
+          toolbar.classList.add('bat-toolbar--in');
+
+          /* stagger action buttons */
+          const actions = toolbar.querySelectorAll('.bat-action, .bat-deselect');
+          actions.forEach((btn, i) => {
+            btn.style.animationDelay = (0.08 + i * 0.055) + 's';
+            btn.classList.remove('bat-action--in');
+            void btn.offsetWidth;
+            btn.classList.add('bat-action--in');
+          });
+        }
+        updateBadge(n);
+        announce(n + ' item' + (n === 1 ? '' : 's') + ' selected.');
+      }
+
+      function hideToolbar() {
+        toolbar.classList.remove('bat-toolbar--in');
+        toolbar.classList.add('bat-toolbar--out');
+        toolbar.addEventListener('animationend', () => {
+          toolbar.hidden = true;
+          toolbar.classList.remove('bat-toolbar--out');
+        }, { once: true });
+        announce('Selection cleared.');
+      }
+
+      /* ── sync select-all checkbox ── */
+      function syncSelectAll() {
+        const n     = selectedCount();
+        const total = itemChks.length;
+        chkAll.checked       = n === total;
+        chkAll.indeterminate = n > 0 && n < total;
+      }
+
+      /* ── item selection ── */
+      function onItemChange() {
+        syncSelectAll();
+        const n = selectedCount();
+
+        items.forEach((item, i) => {
+          item.classList.toggle('bat-item--selected', itemChks[i].checked);
+        });
+
+        if (n > 0) showToolbar(n);
+        else       hideToolbar();
+      }
+
+      itemChks.forEach(chk => {
+        chk.addEventListener('change', onItemChange);
+      });
+
+      /* click on row also toggles */
+      items.forEach((item, i) => {
+        item.addEventListener('click', e => {
+          if (e.target.closest('label')) return;
+          itemChks[i].checked = !itemChks[i].checked;
+          onItemChange();
+        });
+      });
+
+      /* ── select all ── */
+      chkAll.addEventListener('change', () => {
+        itemChks.forEach(c => { c.checked = chkAll.checked; });
+        onItemChange();
+      });
+
+      /* ── deselect all ── */
+      deselectBtn.addEventListener('click', () => {
+        itemChks.forEach(c => { c.checked = false; });
+        chkAll.checked       = false;
+        chkAll.indeterminate = false;
+        items.forEach(item => item.classList.remove('bat-item--selected'));
+        hideToolbar();
+      });
+
+      /* ── action buttons ── */
+      toolbar.querySelectorAll('.bat-action').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const action = btn.dataset.action;
+          const n      = selectedCount();
+          announce(action + ' applied to ' + n + ' item' + (n === 1 ? '' : 's') + '.');
+          /* simulate action — just deselect for demo */
+          if (action === 'delete') {
+            itemChks.forEach(c => { c.checked = false; });
+            chkAll.checked = false;
+            chkAll.indeterminate = false;
+            items.forEach(item => item.classList.remove('bat-item--selected'));
+            hideToolbar();
+          }
+        });
+      });
+
+    })();
+    </script>
+  </body>
+</html>

--- a/submissions/examples/bulk-action-toolbar-nk/style.css
+++ b/submissions/examples/bulk-action-toolbar-nk/style.css
@@ -1,0 +1,534 @@
+/* ============================================================
+   Floating Bulk-Action Toolbar — EaseMotion CSS Submission
+   Track: Standard (HTML/CSS)
+   Component ID: bulk-action-toolbar-nk
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   0. Design tokens
+   ------------------------------------------------------------ */
+:root {
+  --bat-color-bg:          #ffffff;
+  --bat-color-surface:     #f8fafc;
+  --bat-color-border:      #e2e8f0;
+  --bat-color-text:        #1e293b;
+  --bat-color-muted:       #94a3b8;
+  --bat-color-label:       #475569;
+
+  --bat-color-primary:     #6366f1;
+  --bat-color-primary-lt:  #eef2ff;
+  --bat-color-success:     #10b981;
+  --bat-color-warning:     #f59e0b;
+  --bat-color-danger:      #ef4444;
+  --bat-color-danger-lt:   #fef2f2;
+
+  --bat-toolbar-bg:        #1e293b;
+  --bat-toolbar-border:    rgba(255,255,255,0.1);
+  --bat-toolbar-text:      #f1f5f9;
+
+  --bat-glow-primary: 0 0 0 3px rgba(99,102,241,0.18);
+  --bat-glow-danger:  0 0 0 3px rgba(239,68,68,0.18);
+
+  --bat-radius-sm:    6px;
+  --bat-radius-md:    10px;
+  --bat-radius-lg:    14px;
+  --bat-radius-card:  16px;
+  --bat-radius-pill:  9999px;
+
+  --bat-speed-fast:   0.14s;
+  --bat-speed-mid:    0.26s;
+  --bat-speed-slow:   0.4s;
+  --bat-ease:         cubic-bezier(0.4, 0, 0.2, 1);
+  --bat-ease-out:     cubic-bezier(0, 0, 0.2, 1);
+  --bat-ease-bounce:  cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ------------------------------------------------------------
+   1. Base reset
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+  min-height: 100vh;
+  padding: 2rem 1rem 8rem;
+  color: var(--bat-color-text);
+}
+
+/* ------------------------------------------------------------
+   2. Layout wrapper
+   ------------------------------------------------------------ */
+.demo-wrapper {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ------------------------------------------------------------
+   3. Page header
+   ------------------------------------------------------------ */
+.bat-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0 1rem;
+  animation: bat-fade-up var(--bat-speed-slow) var(--bat-ease-out) both;
+}
+
+.bat-page-header__left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bat-page-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--bat-color-text);
+}
+
+.bat-page-count {
+  font-size: 0.8125rem;
+  color: var(--bat-color-muted);
+  font-weight: 500;
+}
+
+.bat-upload-btn {
+  padding: 0.45rem 1rem;
+  background: var(--bat-color-primary);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--bat-radius-md);
+  cursor: pointer;
+  transition:
+    transform    var(--bat-speed-fast) var(--bat-ease),
+    box-shadow   var(--bat-speed-fast) var(--bat-ease);
+}
+
+.bat-upload-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(99,102,241,0.3);
+}
+
+/* ------------------------------------------------------------
+   4. Animated checkbox
+   ------------------------------------------------------------ */
+.bat-check-wrap {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.bat-chk-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.bat-chk-box {
+  width: 18px;
+  height: 18px;
+  border: 1.5px solid var(--bat-color-border);
+  border-radius: 5px;
+  background: var(--bat-color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background    var(--bat-speed-fast) var(--bat-ease),
+    border-color  var(--bat-speed-fast) var(--bat-ease),
+    transform     var(--bat-speed-mid)  var(--bat-ease-bounce);
+  position: relative;
+}
+
+.bat-chk-input:checked + .bat-chk-box,
+.bat-chk-input:indeterminate + .bat-chk-box {
+  background: var(--bat-color-primary);
+  border-color: var(--bat-color-primary);
+  transform: scale(1.1);
+}
+
+.bat-chk-icon {
+  width: 9px;
+  height: 9px;
+  stroke: white;
+  stroke-dasharray: 20;
+  stroke-dashoffset: 20;
+  transition: stroke-dashoffset var(--bat-speed-mid) var(--bat-ease-out);
+}
+
+.bat-chk-input:checked + .bat-chk-box .bat-chk-icon {
+  stroke-dashoffset: 0;
+}
+
+/* Indeterminate shows a line */
+.bat-chk-input:indeterminate + .bat-chk-box .bat-chk-icon {
+  stroke-dashoffset: 0;
+}
+
+.bat-chk-input:focus-visible + .bat-chk-box {
+  box-shadow: var(--bat-glow-primary);
+}
+
+/* ------------------------------------------------------------
+   5. File list
+   ------------------------------------------------------------ */
+.bat-list {
+  list-style: none;
+  background: var(--bat-color-bg);
+  border: 1px solid var(--bat-color-border);
+  border-radius: var(--bat-radius-card);
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,.05), 0 4px 12px rgba(0,0,0,.06);
+  animation: bat-fade-up var(--bat-speed-slow) var(--bat-ease-out) 0.05s both;
+}
+
+/* ------------------------------------------------------------
+   6. List item
+   ------------------------------------------------------------ */
+.bat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  border-bottom: 1px solid var(--bat-color-border);
+  cursor: pointer;
+  transition:
+    background  var(--bat-speed-fast) var(--bat-ease),
+    transform   var(--bat-speed-mid)  var(--bat-ease);
+  position: relative;
+}
+
+.bat-item:last-child { border-bottom: none; }
+
+.bat-item:hover { background: var(--bat-color-surface); }
+
+/* Selected state */
+.bat-item--selected {
+  background: var(--bat-color-primary-lt) !important;
+}
+
+.bat-item--selected .bat-item__name {
+  color: var(--bat-color-primary);
+}
+
+/* File type icon */
+.bat-item__icon {
+  font-size: 1.125rem;
+  width: 28px;
+  text-align: center;
+  flex-shrink: 0;
+  transition: transform var(--bat-speed-mid) var(--bat-ease-bounce);
+}
+
+.bat-item:hover .bat-item__icon { transform: scale(1.15); }
+
+.bat-item__icon--fig  { color: #a259ff; }
+.bat-item__icon--pdf  { color: #ef4444; }
+.bat-item__icon--svg  { color: #f59e0b; }
+.bat-item__icon--mp4  { color: #3b82f6; }
+.bat-item__icon--xls  { color: #10b981; }
+.bat-item__icon--md   { color: #94a3b8; }
+.bat-item__icon--img  { color: #06b6d4; }
+
+/* File info */
+.bat-item__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bat-item__name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--bat-color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color var(--bat-speed-fast) var(--bat-ease);
+}
+
+.bat-item__meta {
+  font-size: 0.75rem;
+  color: var(--bat-color-muted);
+}
+
+/* Status badge */
+.bat-item__badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.2em 0.6em;
+  border-radius: var(--bat-radius-pill);
+  background: var(--bat-color-surface);
+  color: var(--bat-color-muted);
+  border: 1px solid var(--bat-color-border);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.bat-item__badge--green {
+  background: #f0fdf4;
+  color: var(--bat-color-success);
+  border-color: #bbf7d0;
+}
+
+.bat-item__badge--amber {
+  background: #fffbeb;
+  color: var(--bat-color-warning);
+  border-color: #fde68a;
+}
+
+/* ------------------------------------------------------------
+   7. Floating toolbar
+   ------------------------------------------------------------ */
+.bat-toolbar {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  background: var(--bat-toolbar-bg);
+  border: 1px solid var(--bat-toolbar-border);
+  border-radius: var(--bat-radius-pill);
+  box-shadow:
+    0 8px 24px rgba(0,0,0,.25),
+    0 2px 6px rgba(0,0,0,.15);
+  z-index: 100;
+  white-space: nowrap;
+}
+
+/* Toolbar slide-up entrance */
+.bat-toolbar--in {
+  animation: bat-toolbar-in var(--bat-speed-mid) var(--bat-ease-bounce) both;
+}
+
+/* Toolbar slide-down exit */
+.bat-toolbar--out {
+  animation: bat-toolbar-out var(--bat-speed-fast) var(--bat-ease) forwards;
+}
+
+/* ------------------------------------------------------------
+   8. Toolbar: count badge
+   ------------------------------------------------------------ */
+.bat-toolbar__count {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.bat-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 0.35em;
+  background: var(--bat-color-primary);
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  border-radius: var(--bat-radius-pill);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Count pop animation on change */
+.bat-count-pop {
+  animation: bat-count-pop var(--bat-speed-mid) var(--bat-ease-bounce) both;
+}
+
+.bat-toolbar__count-label {
+  font-size: 0.8125rem;
+  color: var(--bat-toolbar-text);
+  font-weight: 500;
+  opacity: 0.75;
+}
+
+/* ------------------------------------------------------------
+   9. Toolbar: divider
+   ------------------------------------------------------------ */
+.bat-toolbar__divider {
+  width: 1px;
+  height: 20px;
+  background: var(--bat-toolbar-border);
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* ------------------------------------------------------------
+   10. Toolbar: action buttons
+   ------------------------------------------------------------ */
+.bat-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+.bat-action {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border: none;
+  border-radius: var(--bat-radius-md);
+  background: transparent;
+  color: var(--bat-toolbar-text);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    background  var(--bat-speed-fast) var(--bat-ease),
+    color       var(--bat-speed-fast) var(--bat-ease),
+    transform   var(--bat-speed-mid)  var(--bat-ease-bounce);
+}
+
+.bat-action svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.bat-action:hover {
+  background: rgba(255,255,255,0.12);
+}
+
+.bat-action:focus-visible {
+  outline: 2px solid rgba(99,102,241,0.7);
+  outline-offset: 2px;
+}
+
+/* Danger action */
+.bat-action--danger {
+  color: #fca5a5;
+}
+
+.bat-action--danger:hover {
+  background: rgba(239,68,68,0.2);
+  color: #fecaca;
+}
+
+/* Stagger entrance */
+.bat-action--in {
+  animation: bat-action-in var(--bat-speed-mid) var(--bat-ease-out) both;
+}
+
+/* ------------------------------------------------------------
+   11. Toolbar: deselect button
+   ------------------------------------------------------------ */
+.bat-deselect {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.1);
+  color: var(--bat-toolbar-text);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    background  var(--bat-speed-fast) var(--bat-ease),
+    transform   var(--bat-speed-mid)  var(--bat-ease-bounce);
+}
+
+.bat-deselect svg {
+  width: 13px;
+  height: 13px;
+  transition: transform var(--bat-speed-mid) var(--bat-ease-bounce);
+}
+
+.bat-deselect:hover {
+  background: rgba(255,255,255,0.2);
+}
+
+.bat-deselect:hover svg {
+  transform: rotate(90deg);
+}
+
+.bat-deselect:focus-visible {
+  outline: 2px solid rgba(99,102,241,0.7);
+  outline-offset: 2px;
+}
+
+.bat-deselect--in {
+  animation: bat-action-in var(--bat-speed-mid) var(--bat-ease-out) both;
+}
+
+/* ------------------------------------------------------------
+   12. Keyframes
+   ------------------------------------------------------------ */
+
+/* Page entrance */
+@keyframes bat-fade-up {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Toolbar slide-up with bounce */
+@keyframes bat-toolbar-in {
+  0%   { opacity: 0; transform: translateX(-50%) translateY(28px) scale(0.94); }
+  60%  { transform: translateX(-50%) translateY(-4px) scale(1.01); }
+  100% { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+}
+
+/* Toolbar slide-down exit */
+@keyframes bat-toolbar-out {
+  from { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateX(-50%) translateY(20px) scale(0.95); }
+}
+
+/* Action button stagger in */
+@keyframes bat-action-in {
+  from { opacity: 0; transform: translateY(5px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Count badge pop */
+@keyframes bat-count-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.35); }
+  70%  { transform: scale(0.9); }
+  100% { transform: scale(1); }
+}
+
+/* Checkbox draw */
+@keyframes bat-chk-draw {
+  from { stroke-dashoffset: 20; }
+  to   { stroke-dashoffset: 0; }
+}
+
+/* ------------------------------------------------------------
+   13. Reduced motion
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+  }
+}
+
+/* ------------------------------------------------------------
+   14. Responsive
+   ------------------------------------------------------------ */
+@media (max-width: 480px) {
+  .bat-action span { display: none; }
+  .bat-action      { padding: 0.375rem 0.5rem; }
+  .bat-toolbar     { padding: 0.5rem 0.75rem; gap: 0.375rem; }
+}


### PR DESCRIPTION
fix #85781

## Pull Request Description

Adds a fully animated floating bulk-action toolbar (`bulk-action-toolbar-nk`) that slides up with a bounce entrance when items are selected, shows a scale-pop count badge on every change, staggers 4 action buttons left-to-right, and slides back down when selection is cleared. Closes issue #85781.

### Type of Change

- [x] 🧩 New component

### Submission Checklist

- [x] All changes are inside `submissions/examples/bulk-action-toolbar-nk/`
- [x] Includes `demo.html` - self-contained, opens in browser with no server
- [x] Includes `style.css` - raw CSS for the proposed feature
- [x] Includes `README.md` - what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

### Feature Description

**What does this add?**

A floating bulk-action toolbar for file/list UIs - slide-up bounce entrance, count-pop badge on selection change, 4 staggered action buttons (Move, Label, Export, Delete), animated checkbox draw, select-all with indeterminate state, deselect-all `×` that spins on hover, and slide-down exit.

**How does a developer use it?**

```html
<div class="bat-toolbar" role="toolbar" hidden>
  <span class="bat-count-badge">3</span>
  <div class="bat-toolbar__actions">
    <button class="bat-action bat-action--in">Move</button>
    <button class="bat-action bat-action--in bat-action--danger">Delete</button>
  </div>
  <button class="bat-deselect">✕</button>
</div>
```

JS adds `bat-toolbar--in` to show, `bat-toolbar--out` to hide, `bat-count-pop` on badge, `bat-action--in` (staggered) on buttons. All animation is CSS.

**Why does it fit EaseMotion CSS?**

The floating toolbar sliding up from nothing is one of the most satisfying interactions in SaaS. Stagger, count pop, and slide-down each deliver spatial feedback through motion - completely absent from the repo before this PR.

### Demo

- `demo.html` works by opening directly in a browser
- Check any item → toolbar slides up, buttons stagger in
- Check more items → count badge pops on every change
- Check all via select-all → indeterminate → fully checked state
- Click ✕ → toolbar slides down and hides
- Click Delete → deselects all + toolbar hides

### Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge

### Notes for Maintainer

All 5 keyframes use `--bat-*` CSS custom property tokens. `prefers-reduced-motion` collapses all durations. On `< 480px`, button labels hide and only icons show. The toolbar uses `position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%)` - ready to drop into any layout. JS is ~60 lines, framework-agnostic.