### PR TITLE
docs: add quickstart guide for dark mode star rating

### DIFF
--- a/submissions/docs/dark-mode-star-rating/README.md
+++ b/submissions/docs/dark-mode-star-rating/README.md
@@ -1,0 +1,94 @@
+# Dark Mode Star Rating (Quickstart Guide)
+
+This guide explains how to implement a purely CSS-driven Star Rating component optimized for dark mode interfaces. By utilizing CSS `clip-path` and the flex-direction reverse trick, we can create an interactive rating system without a single line of JavaScript.
+
+## HTML Markup Example
+
+The Star Rating relies on a `<fieldset>` containing a group of radio buttons. This is the most accessible way to construct a rating form. 
+
+Because we use `flex-direction: row-reverse` in the CSS to make the sibling selector (`~`) work, the DOM order of the inputs must go from highest (5) to lowest (1).
+
+```html
+<form action="#" class="rating-form">
+    <fieldset class="star-rating">
+        <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+        
+        <div class="star-rating__group">
+            <!-- 5 Star -->
+            <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+            <label for="star5" aria-label="5 stars" class="star-label"></label>
+            
+            <!-- 4 Star -->
+            <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+            <label for="star4" aria-label="4 stars" class="star-label"></label>
+            
+            <!-- 3 Star -->
+            <input type="radio" id="star3" name="rating" value="3" class="sr-only">
+            <label for="star3" aria-label="3 stars" class="star-label"></label>
+            
+            <!-- 2 Star -->
+            <input type="radio" id="star2" name="rating" value="2" class="sr-only">
+            <label for="star2" aria-label="2 stars" class="star-label"></label>
+            
+            <!-- 1 Star -->
+            <input type="radio" id="star1" name="rating" value="1" class="sr-only">
+            <label for="star1" aria-label="1 star" class="star-label"></label>
+        </div>
+    </fieldset>
+</form>
+```
+
+## CSS Architecture & Variables
+
+The component uses a CSS `clip-path` polygon to draw the stars, which makes it incredibly easy to resize and recolor them.
+
+### Variables
+
+```css
+:root {
+    --star-size: 3rem;
+    --star-gap: 0.5rem;
+    
+    --star-color-inactive: #333333;
+    --star-color-hover: #ffb400;
+    --star-color-active: #ff9900;
+}
+```
+
+### The CSS Trick
+
+To color all stars to the "left" of the hovered or checked star, we use `flex-direction: row-reverse` to flip the visual order of the elements. Then, we use the general sibling combinator `~` to target all siblings that come *after* the hovered element in the DOM (which appear *before* it visually).
+
+```css
+.star-rating__group {
+    display: inline-flex;
+    flex-direction: row-reverse;
+}
+
+/* Color hovered star and all stars visually before it */
+.star-label:hover,
+.star-label:hover ~ .star-label {
+    background-color: var(--star-color-hover);
+}
+
+/* Color checked star and all stars visually before it */
+.star-rating__group input:checked ~ .star-label {
+    background-color: var(--star-color-active);
+}
+```
+
+## Accessibility Setup
+
+Because we are hiding the native radio inputs to show our custom `clip-path` stars, we must hide them carefully:
+
+1. **Visually Hidden (`sr-only`)**: Never use `display: none`. Use a visually hidden class so the inputs remain focusable by the keyboard and readable by screen readers.
+2. **Focus Rings**: Ensure that when the hidden input receives focus via the `Tab` key, its sibling `<label>` displays a clear outline.
+
+```css
+.star-rating__group input:focus-visible + .star-label {
+    outline: 2px solid #ffffff;
+    outline-offset: 4px;
+}
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/dark-mode-star-rating/demo.html
+++ b/submissions/docs/dark-mode-star-rating/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Mode Star Rating Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <form action="#" class="rating-form">
+            <fieldset class="star-rating">
+                <legend class="sr-only">Rate this product from 1 to 5 stars</legend>
+                
+                <div class="star-rating__group">
+                    <input type="radio" id="star5" name="rating" value="5" class="sr-only">
+                    <label for="star5" aria-label="5 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star4" name="rating" value="4" class="sr-only">
+                    <label for="star4" aria-label="4 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star3" name="rating" value="3" class="sr-only">
+                    <label for="star3" aria-label="3 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star2" name="rating" value="2" class="sr-only">
+                    <label for="star2" aria-label="2 stars" class="star-label"></label>
+                    
+                    <input type="radio" id="star1" name="rating" value="1" class="sr-only">
+                    <label for="star1" aria-label="1 star" class="star-label"></label>
+                </div>
+            </fieldset>
+            
+            <p class="rating-note">Hover to select, click to rate.</p>
+        </form>
+    </main>
+</body>
+</html>

--- a/submissions/docs/dark-mode-star-rating/style.css
+++ b/submissions/docs/dark-mode-star-rating/style.css
@@ -1,0 +1,84 @@
+:root {
+    --star-size: 3rem;
+    --star-gap: 0.5rem;
+    
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    
+    --star-color-inactive: #333333;
+    --star-color-hover: #ffb400;
+    --star-color-active: #ff9900;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.rating-form {
+    text-align: center;
+}
+
+.rating-note {
+    margin-top: 2rem;
+    color: #888;
+    font-size: 0.9rem;
+}
+
+.star-rating {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.star-rating__group {
+    display: inline-flex;
+    flex-direction: row-reverse;
+    gap: var(--star-gap);
+    justify-content: center;
+}
+
+.star-label {
+    cursor: pointer;
+    width: var(--star-size);
+    height: var(--star-size);
+    background-color: var(--star-color-inactive);
+    clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.star-label:hover,
+.star-label:hover ~ .star-label {
+    background-color: var(--star-color-hover);
+}
+
+.star-label:hover {
+    transform: scale(1.1);
+}
+
+.star-rating__group input:checked ~ .star-label {
+    background-color: var(--star-color-active);
+}
+
+.star-rating__group input:focus-visible + .star-label {
+    outline: 2px solid #ffffff;
+    outline-offset: 4px;
+}


### PR DESCRIPTION
fixes #85752 

## Pull Request Description

This PR adds the Quickstart Documentation guide for the Dark Mode Star Rating. It breaks down the core `flex-direction: row-reverse` CSS trick that allows the component to function without JavaScript, explains the `clip-path` polygon used to draw the stars, and emphasizes the necessary accessibility markup required when hiding native form inputs.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds the primary usage guide for implementing the CSS-only Star Rating. It provides developers with the HTML `<fieldset>` structure, the core CSS variables for sizing/spacing, and the underlying logic (`row-reverse` + general sibling combinator) that drives the hover and active states.

**How does a developer use it?**

```css
/* Color the hovered star and all stars visually before it */
.star-label:hover,
.star-label:hover ~ .star-label {
    background-color: var(--star-color-hover);
}
