### PR TITLE
docs: add quickstart guide for glassmorphism stepper nav

### DIFF
--- a/submissions/docs/glassmorphism-stepper-nav/README.md
+++ b/submissions/docs/glassmorphism-stepper-nav/README.md
@@ -1,0 +1,78 @@
+# Glassmorphism Stepper Nav (Quickstart Guide)
+
+This guide documents how to build a beautiful, accessible Stepper Navigation component using modern Glassmorphism (frosted glass) aesthetics.
+
+## Glassmorphism CSS Architecture
+
+The core of the glass effect relies on `backdrop-filter: blur()` combined with a semi-transparent background and a subtle light border to simulate the edge of the glass.
+
+```css
+:root {
+    --glass-bg: rgba(255, 255, 255, 0.15);
+    --glass-border: rgba(255, 255, 255, 0.3);
+    --glass-blur: 12px;
+}
+
+.glass-stepper {
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur)); /* Safari support */
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+}
+```
+
+## HTML Markup Example
+
+A Stepper is fundamentally a list of steps. We use an `<ol>` (ordered list) wrapped in a `<nav>`.
+
+```html
+<nav aria-label="Checkout Progress" class="glass-stepper">
+    <ol class="stepper-list">
+        
+        <!-- COMPLETED STEP -->
+        <li class="stepper-item is-complete">
+            <a href="#cart" class="stepper-link">
+                <!-- Hide decorative icons/numbers from screen readers -->
+                <span class="stepper-circle" aria-hidden="true">✓</span>
+                <span class="stepper-label">Cart</span>
+            </a>
+        </li>
+        
+        <!-- ACTIVE STEP -->
+        <li class="stepper-item is-active">
+            <!-- aria-current indicates the current step -->
+            <a href="#shipping" class="stepper-link" aria-current="step">
+                <span class="stepper-circle" aria-hidden="true">2</span>
+                <span class="stepper-label">Shipping</span>
+            </a>
+        </li>
+        
+        <!-- UPCOMING/DISABLED STEP -->
+        <li class="stepper-item is-upcoming">
+            <!-- Use a span (or disabled button) instead of an anchor if it's not clickable -->
+            <span class="stepper-link" aria-disabled="true">
+                <span class="stepper-circle" aria-hidden="true">3</span>
+                <span class="stepper-label">Payment</span>
+            </span>
+        </li>
+        
+    </ol>
+</nav>
+```
+
+## Accessibility Requirements
+
+Glassmorphism can be tricky for accessibility because it inherently relies on low-opacity backgrounds, which can cause contrast issues.
+
+1. **Aria-Current**: The active step *must* be marked with `aria-current="step"`. This tells screen readers exactly where the user is in the flow.
+2. **Focus Rings**: Glass UIs often lack harsh borders. You must manually define a high-contrast `:focus-visible` ring so keyboard users (navigating via `Tab`) know which step is focused.
+   ```css
+   .stepper-link:focus-visible .stepper-circle {
+       outline: 3px solid #fbbf24; /* High contrast yellow/gold */
+       outline-offset: 4px;
+   }
+   ```
+3. **Disabled States**: If an upcoming step cannot be clicked yet, do not use an `<a href="#">`. Use a `<span>` or a `<button disabled>` and add `aria-disabled="true"`.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/glassmorphism-stepper-nav/demo.html
+++ b/submissions/docs/glassmorphism-stepper-nav/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glassmorphism Stepper Nav Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="background-wrapper">
+        <nav aria-label="Checkout Progress" class="glass-stepper">
+            <ol class="stepper-list">
+                
+                <!-- Completed Step -->
+                <li class="stepper-item is-complete">
+                    <a href="#cart" class="stepper-link">
+                        <span class="stepper-circle" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="20 6 9 17 4 12"></polyline>
+                            </svg>
+                        </span>
+                        <span class="stepper-label">Cart</span>
+                    </a>
+                </li>
+                
+                <!-- Active/Current Step -->
+                <li class="stepper-item is-active">
+                    <a href="#shipping" class="stepper-link" aria-current="step">
+                        <span class="stepper-circle" aria-hidden="true">2</span>
+                        <span class="stepper-label">Shipping</span>
+                    </a>
+                </li>
+                
+                <!-- Upcoming/Disabled Step -->
+                <li class="stepper-item is-upcoming">
+                    <span class="stepper-link" aria-disabled="true">
+                        <span class="stepper-circle" aria-hidden="true">3</span>
+                        <span class="stepper-label">Payment</span>
+                    </span>
+                </li>
+                
+            </ol>
+        </nav>
+    </main>
+</body>
+</html>

--- a/submissions/docs/glassmorphism-stepper-nav/style.css
+++ b/submissions/docs/glassmorphism-stepper-nav/style.css
@@ -1,0 +1,144 @@
+:root {
+    /* Base Glassmorphism Variables */
+    --glass-bg: rgba(255, 255, 255, 0.15);
+    --glass-border: rgba(255, 255, 255, 0.3);
+    --glass-blur: 12px;
+    --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
+    
+    /* Stepper Variables */
+    --step-complete: #10b981;
+    --step-active: #3b82f6;
+    --step-upcoming: rgba(255, 255, 255, 0.4);
+    --text-color: #ffffff;
+    
+    /* Accessibility Focus Ring */
+    --focus-ring: #fbbf24;
+}
+
+/* Modifiers for theming */
+.glass-stepper--dark {
+    --glass-bg: rgba(0, 0, 0, 0.3);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --step-active: #8b5cf6;
+}
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    color: var(--text-color);
+}
+
+.background-wrapper {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    /* Beautiful gradient background to show off the glass effect */
+    background: linear-gradient(45deg, #4158D0 0%, #C850C0 46%, #FFCC70 100%);
+    padding: 2rem;
+}
+
+/* Glassmorphism Container */
+.glass-stepper {
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--glass-border);
+    border-radius: 24px;
+    padding: 2rem 3rem;
+    box-shadow: var(--glass-shadow);
+    width: 100%;
+    max-width: 600px;
+}
+
+.stepper-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+}
+
+/* Connecting Line */
+.stepper-list::before {
+    content: '';
+    position: absolute;
+    top: 20px;
+    left: 40px;
+    right: 40px;
+    height: 2px;
+    background: var(--glass-border);
+    z-index: 1;
+}
+
+.stepper-item {
+    position: relative;
+    z-index: 2;
+    text-align: center;
+    flex: 1;
+}
+
+.stepper-link {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+    color: var(--text-color);
+    outline: none;
+}
+
+.stepper-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: var(--glass-bg);
+    border: 2px solid var(--glass-border);
+    backdrop-filter: blur(4px);
+    font-weight: bold;
+    transition: all 0.3s ease;
+}
+
+.stepper-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+/* State: Complete */
+.is-complete .stepper-circle {
+    background: var(--step-complete);
+    border-color: var(--step-complete);
+}
+
+/* State: Active */
+.is-active .stepper-circle {
+    background: var(--step-active);
+    border-color: var(--step-active);
+    box-shadow: 0 0 15px rgba(59, 130, 246, 0.5);
+    transform: scale(1.1);
+}
+.is-active .stepper-label {
+    opacity: 1;
+    font-weight: 700;
+}
+
+/* State: Upcoming/Disabled */
+.is-upcoming .stepper-circle {
+    border-color: var(--step-upcoming);
+    color: var(--step-upcoming);
+}
+.is-upcoming .stepper-label {
+    opacity: 0.5;
+}
+
+/* Focus States for Accessibility */
+.stepper-link:focus-visible .stepper-circle {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px;
+}


### PR DESCRIPTION
fixes #85728 

## Pull Request Description

This PR introduces the Quickstart Documentation guide for the Glassmorphism Stepper Nav component. It outlines the core CSS properties required to achieve the frosted glass effect (`backdrop-filter: blur`, semi-transparent backgrounds, subtle borders) and thoroughly details the accessibility requirements for stepper components (using an ordered list `<ol>`, `aria-current="step"`, and proper focus states).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds the primary usage guide for implementing the Glassmorphism Stepper component. It provides the base HTML structure utilizing semantic tags (`<nav>`, `<ol>`) and the core CSS variables needed to construct the glass aesthetic and the active/completed states.

**How does a developer use it?**

```css
/* Core Glassmorphism Engine */
.glass-stepper {
    background: rgba(255, 255, 255, 0.15);
    backdrop-filter: blur(12px);
    -webkit-backdrop-filter: blur(12px); /* Safari support */
    border: 1px solid rgba(255, 255, 255, 0.3);
}
