### PR TITLE
docs: Add Animation Duration Reference Table

### DIFF
--- a/submissions/docs/animation-duration-reference-table-sb/README.md
+++ b/submissions/docs/animation-duration-reference-table-sb/README.md
@@ -1,0 +1,50 @@
+# Animation Duration Reference Table
+
+A quick-reference table for EaseMotion CSS animation durations, so developers can choose appropriate timings without inspecting the source code.
+
+## What it does
+Maps each duration token to its value and recommended use case, with usage examples.
+
+## Files
+- `demo.html` — rendered reference table
+- `style.css` — table styling
+- `README.md` — this guide with the table + usage examples
+
+## Reference
+
+| Class / token | Key | Duration | Use case |
+| --- | --- | --- | --- |
+| `--ease-speed-fast` | fast | 150ms | Micro-interactions, hovers, toggles |
+| `--ease-speed-medium` | medium | 300ms | Standard UI transitions, reveals |
+| `--ease-speed-slow` | slow | 600ms | Large surfaces, page transitions |
+| `var(--ease-duration, 1s)` | custom | overridable | Animation mixins & custom timing |
+
+## Usage examples
+```css
+/* Fast hover */
+.btn { transition: color var(--ease-speed-fast) var(--ease-ease); }
+
+/* Medium reveal */
+.panel { transition: opacity var(--ease-speed-medium) var(--ease-ease); }
+
+/* Slow page transition */
+.page { transition: transform var(--ease-speed-slow) var(--ease-ease); }
+
+/* Custom duration via animation mixin */
+.my-element {
+  --ease-duration: 1.2s;
+  animation: spin var(--ease-duration) linear infinite;
+}
+```
+
+## Choosing a duration
+- Use **fast (150ms)** for feedback the user should barely perceive (hovers, toggles, ripples).
+- Use **medium (300ms)** for the bulk of UI motion (panels, cards, accordions).
+- Use **slow (600ms)** for large surfaces or full-page transitions where the eye needs time to track movement.
+- Override with `--ease-duration` for animation mixins and bespoke timing.
+
+## Accessibility
+- Always pair durations with `@media (prefers-reduced-motion: reduce)` to disable or shorten motion for users who request it.
+- Keep motion under ~500ms for individual transitions to avoid vestibular discomfort.
+
+Closes #63794

--- a/submissions/docs/animation-duration-reference-table-sb/demo.html
+++ b/submissions/docs/animation-duration-reference-table-sb/demo.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>Animation Duration Reference</title><link rel="stylesheet" href="style.css"/></head><body>
+<table class="ease-dur-ref" aria-label="EaseMotion animation duration reference">
+  <caption>Animation Duration Reference</caption>
+  <thead><tr><th scope="col">Class</th><th scope="col">Token</th><th scope="col">Duration</th><th scope="col">Use case</th></tr></thead>
+  <tbody>
+    <tr><td><code>--ease-speed-fast</code></td><td>fast</td><td>150ms</td><td>Micro-interactions, hovers, toggles</td></tr>
+    <tr><td><code>--ease-speed-medium</code></td><td>medium</td><td>300ms</td><td>Standard UI transitions, reveals</td></tr>
+    <tr><td><code>--ease-speed-slow</code></td><td>slow</td><td>600ms</td><td>Large surfaces, page transitions</td></tr>
+    <tr><td><code>var(--ease-duration, 1s)</code></td><td>custom</td><td>overridable</td><td>Animation mixins & custom timing</td></tr>
+  </tbody>
+</table>
+</body></html>

--- a/submissions/docs/animation-duration-reference-table-sb/style.css
+++ b/submissions/docs/animation-duration-reference-table-sb/style.css
@@ -1,0 +1,9 @@
+/* Animation Duration Reference Table — submission for #63794 */
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f1f5f9; font-family: system-ui, sans-serif; padding: 2rem; }
+.ease-dur-ref { width: min(720px, 100%); border-collapse: collapse; font-size: 0.9rem; }
+.ease-dur-ref caption { caption-side: top; text-align: left; font-weight: 700; margin-bottom: 0.5rem; color: #6ee7b7; }
+.ease-dur-ref th, .ease-dur-ref td { padding: 0.6rem 0.75rem; border-bottom: 1px solid #334155; text-align: left; }
+.ease-dur-ref th { color: #94a3b8; font-weight: 600; }
+.ease-dur-ref tbody tr:nth-child(odd) { background: rgba(255,255,255,0.02); }
+.ease-dur-ref code { background: #1e293b; padding: 0.1em 0.4em; border-radius: 0.25rem; color: #22d3ee; }
+.ease-dur-ref td:focus-within { outline: 2px solid Highlight; outline-offset: -2px; }


### PR DESCRIPTION
## What changed

Self-contained documentation submission for the **Animation Duration Reference Table** (closes #63794). Placed under `submissions/docs/animation-duration-reference-table-sb/` per the contribution guide.

A quick-reference table for EaseMotion CSS animation durations, so developers can choose appropriate timings without inspecting the source code.

### Files
- **`demo.html`** — rendered reference table.
- **`style.css`** — table styling.
- **`README.md`** — the reference table, usage examples, and guidance on choosing a duration.

### Acceptance criteria
- Duration table included.
- Each duration explained with a use case.
- Usage examples included.

Closes #63794

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._