### PR TITLE
fix: ease-zoom-in scrollbar flicker in Chrome on page load

### DIFF
--- a/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/README.md
+++ b/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/README.md
@@ -1,0 +1,35 @@
+# Bug Fix #79354: ease-zoom-in scrollbar flicker in Chrome on page load
+
+## What does this do?
+Fixes a brief vertical/horizontal scrollbar flicker in Chrome when `.ease-zoom-in` is applied to a full-width (`100vw`) hero section: the `scale()` transform momentarily pushes content outside the viewport before settling.
+
+## Root cause
+`ease-kf-zoom-in` animates `transform: scale(0.85) -> scale(1)`. A scaled full-bleed box extends beyond the viewport during the animation, so Chrome shows a transient scrollbar in the first ~200ms before the transform settles.
+
+## Fix
+- `contain: layout paint` on `.ease-zoom-in` so the scaled box cannot trigger layout/scroll changes in the viewport.
+- `will-change: transform` to promote the element to its own compositor layer (scaling no longer reflows the page).
+- `overflow: clip` + a `contain-intrinsic-size` hint on the animated element/host to keep layout stable before first paint and prevent the scaled content reaching the viewport edge.
+- A hero-specific guard (`.ease-zoom-in.is-hero`) ensures full-bleed heroes cannot push scrollbars during zoom.
+
+## How is it used?
+No HTML changes required. Apply the CSS patch from `core-patch/zoom.css` to `easemotion/zoom.css` (or include it after the EaseMotion bundle).
+
+```html
+<link rel="stylesheet" href="easemotion.min.css" />
+<link rel="stylesheet" href="./core-patch/zoom.css" />
+<section class="hero ease-zoom-in is-hero">...</section>
+```
+
+## Expected behavior
+No scrollbar appears during the zoom-in animation on a full-width hero in Chrome.
+
+## Accessibility
+- `prefers-reduced-motion: reduce` reverts `contain`/`will-change` so the reduced-motion path has no residual layout constraints.
+
+## Files
+- `core-patch/zoom.css` — the patch
+- `demo.html` — verification (full-bleed hero with zoom-in)
+- `README.md` — this guide
+
+Closes #79354

--- a/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/core-patch/zoom.css
+++ b/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/core-patch/zoom.css
@@ -1,0 +1,39 @@
+/* Patch for #79354: ease-zoom-in causes brief scrollbar flicker in Chrome
+ *
+ * When .ease-zoom-in animates scale() from 0.85 -> 1 on a width:100vw hero,
+ * the scaled content momentarily extends beyond the viewport, triggering a
+ * transient scrollbar in Chrome during the first ~200ms.
+ *
+ * Fix: contain the transform paint region with contain: layout paint, add
+ * will-change: transform for a compositor layer, and set overflow: clip on the
+ * animated element's nearest scroll container so the scaling never reaches the
+ * viewport edge. A @starting-style-free approach is used for broad support.
+ */
+.ease-zoom-in {
+  contain: layout paint;          /* prevent the scaled box from causing layout/scroll in the viewport */
+  will-change: transform;         /* promote to a compositor layer so scaling does not reflow the page */
+  transform-origin: center center;
+}
+
+/* The flicker source is the scaled box exceeding the viewport edge. Clipping
+ * the element's own overflow ensures the scaled content is painted within its
+ * box, and contain-intrinsic-size keeps layout stable before first paint. */
+.ease-zoom-in,
+.ease-zoom-in-host {
+  overflow: clip;
+  contain-intrinsic-size: 1px;   /* minimal hint; avoids layout shift jumps */
+}
+
+/* Hero-specific guard: ensure full-bleed heroes cannot push scrollbars during zoom. */
+@media (prefers-reduced-motion: no-preference) {
+  .ease-zoom-in.is-hero,
+  .is-hero .ease-zoom-in {
+    width: 100%;
+    max-width: 100%;
+    overflow: clip;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-zoom-in { will-change: auto; contain: none; }
+}

--- a/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/demo.html
+++ b/submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/demo.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><title>ease-zoom-in flicker fix</title>
+<style>body { margin: 0; } .hero { width: 100vw; height: 60vh; display: grid; place-items: center; color: #fff; background: linear-gradient(135deg, #6366f1, #ec4899); font-family: system-ui, sans-serif; }</style>
+<link rel="stylesheet" href="./core-patch/zoom.css" />
+<style>.hero { animation: ease-kf-zoom-in 600ms var(--ease-ease, ease) both; } @keyframes ease-kf-zoom-in { from { opacity: 0; transform: scale(0.85); } to { opacity: 1; transform: scale(1); } }</style>
+</head><body><section class="hero ease-zoom-in is-hero">No scrollbar flicker</section></body></html>


### PR DESCRIPTION
## What changed

Self-contained bug-fix submission for **#79354**. Placed under `submissions/examples/bug-79354-zoom-in-scrollbar-flicker-sb/` per the contribution guide.

Fixes a brief vertical/horizontal scrollbar flicker in Chrome when `.ease-zoom-in` is applied to a full-width (`100vw`) hero section: the `scale()` transform momentarily pushes content outside the viewport before settling.

### Root cause
`ease-kf-zoom-in` animates `transform: scale(0.85) -> scale(1)`; a scaled full-bleed box extends beyond the viewport during the animation, so Chrome shows a transient scrollbar in the first ~200ms.

### Fix
- `contain: layout paint` on `.ease-zoom-in` so the scaled box cannot trigger layout/scroll changes in the viewport.
- `will-change: transform` to promote to a compositor layer (scaling no longer reflows the page).
- `overflow: clip` + `contain-intrinsic-size` hint to keep layout stable before first paint.
- A hero-specific guard (`.ease-zoom-in.is-hero`) ensures full-bleed heroes cannot push scrollbars during zoom.

### Files
- **`core-patch/zoom.css`** — the patch (apply to `easemotion/zoom.css`).
- **`demo.html`** — verification (full-bleed hero with zoom-in).
- **`README.md`** — root cause, fix, and expected behaviour.

### Expected behavior
No scrollbar appears during the zoom-in animation on a full-width hero in Chrome. `prefers-reduced-motion: reduce` reverts the layout constraints.

Closes #79354

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._