### PR TITLE
docs: add accessibility setup guide for cyberpunk vertical timeline

### DIFF
--- a/submissions/docs/cyberpunk-vertical-timeline-accessibility/README.md
+++ b/submissions/docs/cyberpunk-vertical-timeline-accessibility/README.md
@@ -1,0 +1,77 @@
+# Cyberpunk Vertical Timeline (Accessibility Setup Guide)
+
+This guide details the strict accessibility standards required when implementing the Cyberpunk Vertical Timeline. Highly stylized "Neon/Cyberpunk" aesthetics often sacrifice accessibility for visual flair, specifically failing contrast ratio checks and ignoring users with motion sensitivities.
+
+## 1. Semantic HTML Structure
+
+A timeline is essentially an ordered list of events. We must use semantic HTML so screen readers can properly parse and announce the sequence.
+
+- **Use `<ol>`**: Wrap the entire timeline in an ordered list so assistive tech announces the total number of items and their order.
+- **Use `<time>`**: Wrap dates/times in a `<time>` element with a valid `datetime` attribute.
+- **Use Headings**: Wrap the title of each event in an `<h3>` (or appropriate heading level) to create a document outline that users can jump through.
+
+### Example Markup
+
+```html
+<!-- Use aria-label to give context to the list -->
+<ol class="cyber-timeline" aria-label="System event timeline">
+    
+    <li class="timeline-item">
+        <!-- Machine-readable datetime -->
+        <time datetime="2077-10-12T04:00" class="timeline-date">2077.10.12 // 04:00</time>
+        
+        <div class="timeline-content">
+            <h3 class="timeline-title">SYSTEM_INIT</h3>
+            <p class="timeline-desc">Core systems online.</p>
+            <a href="#" class="cyber-link">VIEW_LOGS</a>
+        </div>
+    </li>
+    
+</ol>
+```
+
+## 2. Keyboard Focus Visibility
+
+Cyberpunk aesthetics rely heavily on CSS `box-shadow` to create glowing effects. However, a subtle glow is often insufficient as a focus indicator for keyboard users. 
+
+You must define a distinct, solid outline using `:focus-visible` to ensure WCAG compliance.
+
+```css
+.cyber-link:focus-visible {
+    /* Solid, high-contrast outline */
+    outline: 2px solid var(--neon-yellow);
+    /* Offset it so it doesn't get lost in the component's internal glow */
+    outline-offset: 4px;
+    /* Optional: shift the background slightly for extra visibility */
+    background-color: rgba(252, 238, 10, 0.1);
+}
+```
+
+## 3. Reduced Motion (`prefers-reduced-motion`)
+
+Neon aesthetics often feature pulsing glows, typing animations, or rapid hover transitions. These can trigger motion sickness or vestibular disorders in some users. 
+
+You must respect the user's OS-level motion preferences by disabling or speeding up transitions using the `@media (prefers-reduced-motion: reduce)` query.
+
+```css
+/* Define transition speed as a variable */
+:root {
+    --animation-speed: 0.3s;
+}
+
+.cyber-link {
+    transition: all var(--animation-speed) ease;
+}
+
+/* 
+ * If the user prefers reduced motion, set the transition speed to 0s
+ * to make changes instantaneous instead of animated.
+ */
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --animation-speed: 0s;
+    }
+}
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/cyberpunk-vertical-timeline-accessibility/demo.html
+++ b/submissions/docs/cyberpunk-vertical-timeline-accessibility/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Vertical Timeline (Accessibility) Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+</head>
+<body>
+    <main>
+        <div class="cyber-container">
+            <h2 class="cyber-heading">SYSTEM LOG</h2>
+            
+            <!-- 
+                CRITICAL ACCESSIBILITY:
+                Use an ordered list for timelines so screen readers announce 
+                the number of items and their sequence.
+            -->
+            <ol class="cyber-timeline" aria-label="System event timeline">
+                
+                <li class="timeline-item">
+                    <!-- Semantic time tag with datetime attribute -->
+                    <time datetime="2077-10-12T04:00" class="timeline-date">2077.10.12 // 04:00</time>
+                    <div class="timeline-content">
+                        <!-- Heading provides structure for screen reader jumping -->
+                        <h3 class="timeline-title">SYSTEM_INIT</h3>
+                        <p class="timeline-desc">Core systems online. Neural net establishing connection.</p>
+                        <!-- Focusable elements need high contrast outlines -->
+                        <a href="#" class="cyber-link">VIEW_LOGS</a>
+                    </div>
+                </li>
+
+                <li class="timeline-item">
+                    <time datetime="2077-10-12T04:15" class="timeline-date">2077.10.12 // 04:15</time>
+                    <div class="timeline-content">
+                        <h3 class="timeline-title">BREACH_DETECTED</h3>
+                        <p class="timeline-desc">Unauthorized access in sector 7G. Countermeasures deployed.</p>
+                        <a href="#" class="cyber-link">TRACE_IP</a>
+                    </div>
+                </li>
+
+            </ol>
+        </div>
+        
+        <p class="a11y-note">Press Tab to navigate through the timeline links. Note the high-contrast focus rings and reduced-motion support.</p>
+    </main>
+</body>
+</html>

--- a/submissions/docs/cyberpunk-vertical-timeline-accessibility/style.css
+++ b/submissions/docs/cyberpunk-vertical-timeline-accessibility/style.css
@@ -1,0 +1,171 @@
+:root {
+    --bg-color: #0d0d12;
+    --text-color: #e0e0e0;
+    --neon-blue: #00f3ff;
+    --neon-pink: #ff00ea;
+    --neon-yellow: #fcee0a;
+    
+    /* Accessibility Variables */
+    --focus-ring-color: #fcee0a;
+    --animation-speed: 0.3s;
+}
+
+body {
+    font-family: 'Share Tech Mono', monospace;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+}
+
+.cyber-container {
+    width: 100%;
+    max-width: 600px;
+    border: 2px solid var(--neon-blue);
+    padding: 2rem;
+    box-shadow: 0 0 10px rgba(0, 243, 255, 0.2), inset 0 0 10px rgba(0, 243, 255, 0.1);
+    position: relative;
+}
+
+/* Decorative grid background */
+.cyber-container::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(rgba(0, 243, 255, 0.05) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0, 243, 255, 0.05) 1px, transparent 1px);
+    background-size: 20px 20px;
+    z-index: 0;
+    pointer-events: none;
+}
+
+.cyber-heading {
+    color: var(--neon-pink);
+    text-shadow: 0 0 5px var(--neon-pink);
+    margin-top: 0;
+    margin-bottom: 2rem;
+    position: relative;
+    z-index: 1;
+}
+
+.cyber-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    position: relative;
+    z-index: 1;
+}
+
+/* Timeline Vertical Line */
+.cyber-timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 120px;
+    width: 2px;
+    background-color: var(--neon-blue);
+    box-shadow: 0 0 8px var(--neon-blue);
+}
+
+.timeline-item {
+    display: flex;
+    margin-bottom: 3rem;
+    position: relative;
+}
+
+.timeline-date {
+    width: 100px;
+    padding-right: 20px;
+    text-align: right;
+    color: var(--neon-blue);
+    font-size: 0.85rem;
+    padding-top: 0.25rem;
+}
+
+/* Timeline Node */
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: 115px;
+    top: 0.25rem;
+    width: 12px;
+    height: 12px;
+    background-color: var(--bg-color);
+    border: 2px solid var(--neon-pink);
+    box-shadow: 0 0 8px var(--neon-pink);
+    transform: rotate(45deg); /* Diamond shape */
+}
+
+.timeline-content {
+    padding-left: 40px;
+    flex: 1;
+}
+
+.timeline-title {
+    margin: 0 0 0.5rem 0;
+    color: #fff;
+    font-size: 1.1rem;
+    letter-spacing: 1px;
+}
+
+.timeline-desc {
+    margin: 0 0 1rem 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: #aaa;
+}
+
+.cyber-link {
+    display: inline-block;
+    color: var(--neon-yellow);
+    text-decoration: none;
+    border: 1px solid var(--neon-yellow);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+    transition: all var(--animation-speed) ease;
+}
+
+.cyber-link:hover {
+    background-color: var(--neon-yellow);
+    color: #000;
+    box-shadow: 0 0 10px var(--neon-yellow);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus States
+ * Ensure focus rings are highly visible and don't rely solely on glow (which can be hard to see).
+ * Using a solid outline offset from the element.
+ */
+.cyber-link:focus-visible {
+    outline: 2px solid var(--focus-ring-color);
+    outline-offset: 4px;
+    background-color: rgba(252, 238, 10, 0.1); /* Subtle background shift */
+}
+
+.a11y-note {
+    margin-top: 2rem;
+    color: #888;
+    max-width: 600px;
+    text-align: center;
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Reduced Motion
+ * Disable or tone down glowing pulses/transitions for users who prefer reduced motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --animation-speed: 0s;
+    }
+    
+    /* Remove text shadows/box-shadows if they animate */
+    .cyber-link {
+        transition: none;
+    }
+}


### PR DESCRIPTION
fixes #85734 

## Pull Request Description

This PR introduces the Accessibility Setup guide for the Cyberpunk Vertical Timeline. Highly stylized UI elements like neon glows and pulsing animations often introduce severe accessibility barriers. This guide documents three critical solutions: mapping the timeline to a semantic HTML `<ol>` structure with `<time>` tags, enforcing solid `:focus-visible` rings (because subtle box-shadow glows fail contrast checks for keyboard users), and implementing `@media (prefers-reduced-motion)` to disable jarring animations for users with vestibular sensitivities.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on building accessible timelines that don't compromise on aggressive cyberpunk aesthetics. It details the semantic DOM structure needed for screen readers and explains how to hook CSS custom properties into OS-level reduced motion preferences.

**How does a developer use it?**

```css
/* Disable transition animations for users with motion sensitivities */
@media (prefers-reduced-motion: reduce) {
    :root {
        --animation-speed: 0s;
    }
}
