### PR TITLE
docs: add accessibility setup guide for glowing search bar

### DIFF
--- a/submissions/docs/glowing-search-bar-accessibility/README.md
+++ b/submissions/docs/glowing-search-bar-accessibility/README.md
@@ -1,0 +1,77 @@
+# Glowing Search Bar (Accessibility Setup Guide)
+
+This guide details the strict accessibility guidelines required when implementing the Glowing Search Bar. Search inputs are among the most frequently used components on a website, so their markup and focus states must be flawless.
+
+## 1. Semantic HTML Form Structure
+
+A search input should never exist in isolation. It must be wrapped in a `<form>` to allow native submit behavior (e.g., pressing `Enter`), and the form must be marked with the `search` ARIA role.
+
+Furthermore, **placeholders are not labels**. Every input must have a `<label>`. If the design dictates that no visual label should exist, you must use a visually hidden `sr-only` class.
+
+### Correct Markup Example
+
+```html
+<!-- Wrapper form with role="search" -->
+<form action="/search" role="search" class="search-form">
+    
+    <!-- Visually hidden, but screen-reader accessible label -->
+    <label for="global-search" class="sr-only">Search the site</label>
+    
+    <div class="search-wrapper">
+        <!-- Must use type="search" to trigger search-specific mobile keyboards -->
+        <input 
+            type="search" 
+            id="global-search" 
+            class="glowing-search" 
+            placeholder="Search..."
+        >
+        
+        <!-- Submit button must have an accessible name if it relies on an icon -->
+        <button type="submit" class="search-btn" aria-label="Submit search">
+            <svg>...</svg>
+        </button>
+    </div>
+</form>
+```
+
+### The `sr-only` Utility Class
+
+Never use `display: none` to hide labels, as this hides them from screen readers too.
+
+```css
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+```
+
+## 2. Keyboard Focus Visibility
+
+The defining feature of this component is the glowing `box-shadow` applied on `:focus`.
+
+**The Accessibility Problem**: Soft glowing shadows often fail WCAG contrast ratio requirements, making it difficult for keyboard users (especially those with visual impairments) to determine if the input is actively focused.
+
+**The Solution**: While mouse users clicking into the input can trigger the soft glow (`:focus`), keyboard navigators pressing `Tab` must receive a sharp, high-contrast outline (`:focus-visible`).
+
+```css
+/* Mouse/Touch interaction: Provide the aesthetic soft glow */
+.glowing-search:focus {
+    border-color: #38bdf8;
+    box-shadow: 0 0 15px rgba(56, 189, 248, 0.5);
+}
+
+/* Keyboard interaction: Ensure a high-contrast hard outline */
+.glowing-search:focus-visible {
+    outline: 3px solid #ffffff; /* White against dark bg guarantees contrast */
+    outline-offset: 2px;
+}
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/glowing-search-bar-accessibility/demo.html
+++ b/submissions/docs/glowing-search-bar-accessibility/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glowing Search Bar (Accessibility) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        <!-- 
+            CRITICAL ACCESSIBILITY: 
+            Always wrap a search input in a <form> with role="search" 
+        -->
+        <form action="#" role="search" class="search-form">
+            <!-- 
+                CRITICAL ACCESSIBILITY:
+                If visually hiding the label, use the 'sr-only' class. 
+                Do not use display: none or placeholder-only labeling.
+            -->
+            <label for="global-search" class="sr-only">Search the universe</label>
+            
+            <div class="search-wrapper">
+                <input 
+                    type="search" 
+                    id="global-search" 
+                    class="glowing-search" 
+                    placeholder="Search the universe..." 
+                    autocomplete="off"
+                >
+                <button type="submit" class="search-btn" aria-label="Submit search">
+                    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
+                </button>
+            </div>
+        </form>
+    </main>
+</body>
+</html>

--- a/submissions/docs/glowing-search-bar-accessibility/style.css
+++ b/submissions/docs/glowing-search-bar-accessibility/style.css
@@ -1,0 +1,113 @@
+:root {
+    --bg-color: #0f172a;
+    --text-color: #f8fafc;
+    
+    /* Glow Variables */
+    --glow-color: #38bdf8;
+    --glow-spread: 15px;
+    
+    /* High contrast focus ring for a11y */
+    --focus-ring: #ffffff;
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-container {
+    width: 100%;
+    max-width: 500px;
+    padding: 2rem;
+}
+
+/* Visually hidden class for labels */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.search-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.glowing-search {
+    width: 100%;
+    padding: 1rem 3rem 1rem 1.5rem;
+    font-size: 1rem;
+    color: var(--text-color);
+    background: rgba(255, 255, 255, 0.05);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    border-radius: 9999px;
+    outline: none;
+    transition: all 0.3s ease;
+}
+
+/* Remove default webkit search styling */
+.glowing-search::-webkit-search-decoration,
+.glowing-search::-webkit-search-cancel-button,
+.glowing-search::-webkit-search-results-button,
+.glowing-search::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+}
+
+.search-btn {
+    position: absolute;
+    right: 15px;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+    padding: 5px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.3s ease;
+}
+
+.search-btn:hover {
+    color: var(--text-color);
+}
+
+/* 
+ * AESTHETICS: The Glow Effect
+ * Applied on :focus, but wait! We must handle :focus-visible separately for a11y.
+ */
+.glowing-search:focus {
+    border-color: var(--glow-color);
+    box-shadow: 0 0 var(--glow-spread) rgba(56, 189, 248, 0.5);
+    background: rgba(255, 255, 255, 0.1);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus-Visible
+ * The soft box-shadow glow above might fail contrast checks against the dark background.
+ * For keyboard users navigating via Tab, we must provide a sharp, high-contrast outline.
+ */
+.glowing-search:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+/* Ensure the button also has a clear focus state */
+.search-btn:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 4px;
+    color: var(--text-color);
+}


### PR DESCRIPTION
fixes #85796 

## Pull Request Description

This PR introduces the Accessibility Setup guide for the Glowing Search Bar. Search inputs are critical UI elements that often fail basic accessibility audits due to missing labels and poor focus contrast. This guide solves these issues by documenting the exact semantic HTML needed (a `<form>` wrapper with `role="search"`, a visually hidden `<label>`, and `type="search"`) and detailing how to separate the aesthetic soft-glow (`:focus`) from the high-contrast accessibility outline (`:focus-visible`).

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on properly architecting search inputs for all users. It provides the `sr-only` utility class for visually hiding labels without removing them from screen readers, and outlines the CSS strategy to provide beautiful glowing aesthetics to mouse users while guaranteeing sharp, high-contrast focus rings for keyboard navigators.

**How does a developer use it?**

```css
/* Mouse users get the aesthetic soft glow */
.glowing-search:focus {
    box-shadow: 0 0 15px rgba(56, 189, 248, 0.5);
}

/* Keyboard navigators get a sharp, high-contrast outline */
.glowing-search:focus-visible {
    outline: 3px solid #ffffff;
    outline-offset: 2px;
}
