### PR TITLE
test: validate CSS loader rapid state transitions #85922

### DIFF
--- a/submissions/docs/css-loader-state-transition-validation/README.md
+++ b/submissions/docs/css-loader-state-transition-validation/README.md
@@ -1,0 +1,43 @@
+# CSS Loader State Transition Validation
+
+A self-contained test demo for validating CSS loader behavior during normal and
+rapid state transitions.
+
+## Purpose
+
+This submission validates the following transition sequence:
+
+idle → loading → cancel → loading → complete → reset
+
+The test focuses on detecting inconsistent loader behavior when multiple state
+changes happen in a short period.
+
+## What Is Validated
+
+The demo checks:
+
+- Correct loader state after every transition
+- Only one state class is active at a time
+- Previous state classes are removed correctly
+- Each state transition produces exactly one event
+- Loading animation starts and stops correctly
+- Cancelled states do not leave stale animations
+- Reset returns the loader to its initial state
+- Rapid transitions end in the expected final state
+
+## Supported States
+
+| State | Expected Behavior |
+| --- | --- |
+| `idle` | Loader is inactive |
+| `loading` | Loader animation is active |
+| `cancelled` | Animation is stopped and loader is marked cancelled |
+| `complete` | Animation is stopped and completion state is shown |
+| `reset` | Loader returns to its initial state |
+
+## Test Scenarios
+
+### 1. Normal Transition
+
+```text
+idle → loading → complete → reset

--- a/submissions/docs/css-loader-state-transition-validation/demo.html
+++ b/submissions/docs/css-loader-state-transition-validation/demo.html
@@ -1,0 +1,389 @@
+
+---
+
+# `demo.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0"
+  >
+  <title>CSS Loader State Transition Validation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+  <main class="page">
+    <section class="panel">
+      <header class="header">
+        <p class="eyebrow">EaseMotion CSS Test</p>
+        <h1>CSS Loader State Transition Validation</h1>
+        <p class="description">
+          Validate loader behavior during rapid state changes and detect
+          duplicate classes, duplicate events, stale animations, and incorrect
+          final states.
+        </p>
+      </header>
+
+      <section class="loader-section" aria-label="Loader preview">
+        <div
+          id="loader"
+          class="loader is-idle"
+          aria-label="CSS loader"
+        ></div>
+
+        <div class="state-display">
+          <span>Current State</span>
+          <strong id="currentState">idle</strong>
+        </div>
+      </section>
+
+      <section class="controls" aria-label="Loader controls">
+        <button type="button" data-action="idle">Idle</button>
+        <button type="button" data-action="loading">Start Loading</button>
+        <button type="button" data-action="cancelled">Cancel</button>
+        <button type="button" data-action="complete">Complete</button>
+        <button type="button" data-action="reset">Reset</button>
+        <button
+          type="button"
+          id="rapidSequence"
+          class="primary-button"
+        >
+          Run Rapid Sequence
+        </button>
+      </section>
+
+      <section class="sequence" aria-label="Expected sequence">
+        <h2>Rapid Sequence</h2>
+
+        <div class="sequence-list">
+          <span>idle</span>
+          <span>→</span>
+          <span>loading</span>
+          <span>→</span>
+          <span>cancelled</span>
+          <span>→</span>
+          <span>loading</span>
+          <span>→</span>
+          <span>complete</span>
+          <span>→</span>
+          <span>reset</span>
+        </div>
+      </section>
+
+      <section class="validation" aria-label="Validation results">
+        <h2>Validation</h2>
+
+        <div class="validation-grid">
+          <div class="metric">
+            <span>Transition Count</span>
+            <strong id="transitionCount">0</strong>
+          </div>
+
+          <div class="metric">
+            <span>Active State Classes</span>
+            <strong id="activeClassCount">1</strong>
+          </div>
+
+          <div class="metric">
+            <span>Duplicate Classes</span>
+            <strong id="duplicateClasses">PASS</strong>
+          </div>
+
+          <div class="metric">
+            <span>Duplicate Events</span>
+            <strong id="duplicateEvents">PASS</strong>
+          </div>
+
+          <div class="metric">
+            <span>Stale Animation</span>
+            <strong id="staleAnimation">PASS</strong>
+          </div>
+
+          <div class="metric">
+            <span>Final State</span>
+            <strong id="finalState">idle</strong>
+          </div>
+        </div>
+      </section>
+
+      <section class="event-log" aria-label="Transition event log">
+        <div class="log-header">
+          <h2>Transition Log</h2>
+          <button type="button" id="clearLog">Clear</button>
+        </div>
+
+        <ol id="eventLog" class="log-list">
+          <li class="empty-log">No transitions recorded yet.</li>
+        </ol>
+      </section>
+
+      <section id="result" class="result result-neutral">
+        Ready for testing.
+      </section>
+    </section>
+  </main>
+
+  <script>
+    const loader = document.getElementById("loader");
+    const currentState = document.getElementById("currentState");
+    const transitionCount = document.getElementById("transitionCount");
+    const activeClassCount = document.getElementById("activeClassCount");
+    const duplicateClasses = document.getElementById("duplicateClasses");
+    const duplicateEvents = document.getElementById("duplicateEvents");
+    const staleAnimation = document.getElementById("staleAnimation");
+    const finalState = document.getElementById("finalState");
+    const eventLog = document.getElementById("eventLog");
+    const result = document.getElementById("result");
+
+    const stateClasses = [
+      "is-idle",
+      "is-loading",
+      "is-cancelled",
+      "is-complete",
+      "is-reset"
+    ];
+
+    const validStates = [
+      "idle",
+      "loading",
+      "cancelled",
+      "complete",
+      "reset"
+    ];
+
+    let state = "idle";
+    let transitionTotal = 0;
+    let eventHistory = [];
+    let rapidRunId = 0;
+
+    function getActiveStateClasses() {
+      return stateClasses.filter((className) =>
+        loader.classList.contains(className)
+      );
+    }
+
+    function updateValidation() {
+      const activeClasses = getActiveStateClasses();
+      const classCount = activeClasses.length;
+
+      activeClassCount.textContent = classCount;
+
+      const hasDuplicateClasses = classCount !== 1;
+      duplicateClasses.textContent = hasDuplicateClasses
+        ? "FAIL"
+        : "PASS";
+
+      const duplicateEventDetected = eventHistory.some(
+        (entry, index) => {
+          if (index === 0) {
+            return false;
+          }
+
+          return (
+            entry.from === eventHistory[index - 1].from &&
+            entry.to === eventHistory[index - 1].to &&
+            entry.timestamp -
+              eventHistory[index - 1].timestamp <
+              20
+          );
+        }
+      );
+
+      duplicateEvents.textContent = duplicateEventDetected
+        ? "FAIL"
+        : "PASS";
+
+      const animationRunning =
+        loader.classList.contains("is-loading");
+
+      const staleAnimationDetected =
+        animationRunning && state !== "loading";
+
+      staleAnimation.textContent = staleAnimationDetected
+        ? "FAIL"
+        : "PASS";
+
+      finalState.textContent = state;
+    }
+
+    function updateResult(message, type = "neutral") {
+      result.textContent = message;
+      result.className = "result result-" + type;
+    }
+
+    function addLog(from, to) {
+      const emptyLog = eventLog.querySelector(".empty-log");
+
+      if (emptyLog) {
+        emptyLog.remove();
+      }
+
+      const item = document.createElement("li");
+
+      item.innerHTML = `
+        <span>${from}</span>
+        <strong>→</strong>
+        <span>${to}</span>
+      `;
+
+      eventLog.appendChild(item);
+    }
+
+    function setState(nextState) {
+      if (!validStates.includes(nextState)) {
+        return;
+      }
+
+      const previousState = state;
+
+      state = nextState;
+      transitionTotal += 1;
+
+      stateClasses.forEach((className) => {
+        loader.classList.remove(className);
+      });
+
+      loader.classList.add("is-" + nextState);
+
+      currentState.textContent = nextState;
+      transitionCount.textContent = transitionTotal;
+
+      eventHistory.push({
+        from: previousState,
+        to: nextState,
+        timestamp: performance.now()
+      });
+
+      addLog(previousState, nextState);
+      updateValidation();
+
+      if (getActiveStateClasses().length !== 1) {
+        updateResult(
+          "Validation failed: multiple state classes are active.",
+          "fail"
+        );
+        return;
+      }
+
+      if (
+        loader.classList.contains("is-loading") &&
+        state !== "loading"
+      ) {
+        updateResult(
+          "Validation failed: stale loading animation detected.",
+          "fail"
+        );
+        return;
+      }
+
+      updateResult(
+        `Transition validated: ${previousState} → ${nextState}`,
+        "pass"
+      );
+    }
+
+    function resetValidation() {
+      state = "idle";
+      transitionTotal = 0;
+      eventHistory = [];
+
+      stateClasses.forEach((className) => {
+        loader.classList.remove(className);
+      });
+
+      loader.classList.add("is-idle");
+
+      currentState.textContent = "idle";
+      transitionCount.textContent = "0";
+
+      eventLog.innerHTML =
+        '<li class="empty-log">No transitions recorded yet.</li>';
+
+      updateValidation();
+
+      updateResult("Ready for testing.", "neutral");
+    }
+
+    async function runRapidSequence() {
+      rapidRunId += 1;
+      const currentRun = rapidRunId;
+
+      resetValidation();
+
+      const sequence = [
+        "idle",
+        "loading",
+        "cancelled",
+        "loading",
+        "complete",
+        "reset"
+      ];
+
+      for (let index = 0; index < sequence.length; index += 1) {
+        if (currentRun !== rapidRunId) {
+          return;
+        }
+
+        setState(sequence[index]);
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 120);
+        });
+      }
+
+      const finalClasses = getActiveStateClasses();
+
+      const passed =
+        state === "reset" &&
+        finalClasses.length === 1 &&
+        finalClasses[0] === "is-reset" &&
+        duplicateClasses.textContent === "PASS" &&
+        duplicateEvents.textContent === "PASS" &&
+        staleAnimation.textContent === "PASS";
+
+      if (passed) {
+        updateResult(
+          "Rapid sequence passed: final state is reset with no stale animation or duplicate state classes.",
+          "pass"
+        );
+      } else {
+        updateResult(
+          "Rapid sequence failed. Inspect the validation metrics and transition log.",
+          "fail"
+        );
+      }
+    }
+
+    document
+      .querySelectorAll("[data-action]")
+      .forEach((button) => {
+        button.addEventListener("click", () => {
+          setState(button.dataset.action);
+        });
+      });
+
+    document
+      .getElementById("rapidSequence")
+      .addEventListener("click", runRapidSequence);
+
+    document
+      .getElementById("clearLog")
+      .addEventListener("click", () => {
+        eventHistory = [];
+
+        eventLog.innerHTML =
+          '<li class="empty-log">No transitions recorded yet.</li>';
+
+        updateValidation();
+        updateResult("Transition log cleared.", "neutral");
+      });
+
+    updateValidation();
+  </script>
+</body>
+</html>

--- a/submissions/docs/css-loader-state-transition-validation/style.css
+++ b/submissions/docs/css-loader-state-transition-validation/style.css
@@ -1,0 +1,315 @@
+:root {
+  --bg: #0f1117;
+  --panel: #181c25;
+  --panel-soft: #202531;
+  --border: #303746;
+  --text: #f4f6fa;
+  --muted: #9da6b7;
+  --accent: #7c9cff;
+  --success: #61d095;
+  --danger: #ff7272;
+  --warning: #f2c96d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+button {
+  font: inherit;
+}
+
+.page {
+  width: min(1050px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 20px 60px rgb(0 0 0 / 25%);
+}
+
+.header {
+  max-width: 780px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.05;
+}
+
+h2 {
+  margin-bottom: 16px;
+  font-size: 1rem;
+}
+
+.description {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.loader-section {
+  display: grid;
+  place-items: center;
+  gap: 22px;
+  margin: 40px 0;
+  padding: 42px;
+  background: var(--panel-soft);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+}
+
+.loader {
+  width: 72px;
+  height: 72px;
+  border: 6px solid #343b4a;
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.loader.is-idle {
+  opacity: 0.45;
+  animation: none;
+}
+
+.loader.is-loading {
+  opacity: 1;
+  animation: loader-spin 700ms linear infinite;
+}
+
+.loader.is-cancelled {
+  opacity: 0.55;
+  animation: none;
+  transform: scale(0.92);
+}
+
+.loader.is-complete {
+  opacity: 1;
+  animation: none;
+  transform: scale(1);
+}
+
+.loader.is-reset {
+  opacity: 0.35;
+  animation: none;
+  transform: scale(0.9);
+}
+
+@keyframes loader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.state-display {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.state-display strong {
+  color: var(--text);
+  text-transform: uppercase;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 32px;
+}
+
+.controls button,
+.log-header button {
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 10px 14px;
+  background: var(--panel-soft);
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease;
+}
+
+.controls button:hover,
+.log-header button:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+}
+
+.controls .primary-button {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #10131a;
+  font-weight: 700;
+}
+
+.sequence,
+.validation,
+.event-log {
+  margin-top: 24px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel-soft);
+}
+
+.sequence-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.sequence-list span:nth-child(odd) {
+  padding: 6px 9px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text);
+}
+
+.validation-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.metric {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.metric span {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.metric strong {
+  font-size: 1.05rem;
+}
+
+#duplicateClasses,
+#duplicateEvents,
+#staleAnimation {
+  color: var(--success);
+}
+
+.event-log {
+  max-height: 320px;
+  overflow: auto;
+}
+
+.log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.log-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 24px;
+}
+
+.log-list li {
+  color: var(--muted);
+}
+
+.log-list li span {
+  color: var(--text);
+}
+
+.log-list li strong {
+  margin: 0 8px;
+  color: var(--accent);
+}
+
+.empty-log {
+  color: var(--muted);
+}
+
+.result {
+  margin-top: 24px;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  line-height: 1.5;
+}
+
+.result-neutral {
+  color: var(--muted);
+}
+
+.result-pass {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.result-fail {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+@media (max-width: 760px) {
+  .panel {
+    padding: 22px;
+  }
+
+  .validation-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page {
+    width: min(100% - 20px, 1050px);
+    padding: 20px 0;
+  }
+
+  .loader-section {
+    padding: 30px 16px;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a self-contained CSS loader state-transition validation demo for issue #85922.

The demo validates loader behavior during rapid state changes such as:

`idle → loading → cancel → loading → complete → reset`

It checks for incorrect final states, duplicate classes/events, stale animations, and inconsistent state transitions.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other (Testing / validation demo)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — describes the test scenario and validation approach
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A self-contained CSS loader state-transition validation demo that tests rapid successive state changes and verifies that the loader reaches the correct final state without stale animations, duplicate classes, or inconsistent transitions.

**How does a developer use it?**

Open `demo.html` directly in a browser and use the provided controls to trigger rapid loader state transitions.

Example state sequence:

```text
idle → loading → cancel → loading → complete → reset
Closes #85922