### PR TITLE
docs: add accessibility setup guide for brutalism cookie banner

### DIFF
--- a/submissions/docs/brutalism-cookie-banner-accessibility/README.md
+++ b/submissions/docs/brutalism-cookie-banner-accessibility/README.md
@@ -1,0 +1,63 @@
+# Brutalism Cookie Consent Banner (Accessibility Setup Guide)
+
+This guide documents the critical accessibility requirements for the Brutalism Cookie Consent Banner. While brutalism intentionally breaks many traditional design rules (using clashing colors, extreme fonts, and jarring layouts), it must **never** break accessibility rules.
+
+## 1. ARIA Dialog Implementation
+
+A cookie banner is an interruption that demands the user's attention. For screen reader users, it must be explicitly defined as a dialog.
+
+### HTML Structure
+
+```html
+<!-- 
+  role="alertdialog": Signals an urgent interruption.
+  aria-labelledby: Points to the ID of the banner's title.
+  aria-describedby: Points to the ID of the banner's main text.
+-->
+<div 
+    class="brutal-cookie-banner" 
+    role="alertdialog" 
+    aria-labelledby="cookie-title" 
+    aria-describedby="cookie-desc"
+>
+    <div class="brutal-content">
+        <h2 id="cookie-title">WE USE COOKIES</h2>
+        <p id="cookie-desc">Accept them to continue. We track everything.</p>
+    </div>
+    <!-- Buttons -->
+</div>
+```
+
+When a screen reader encounters this container, it will announce it as a dialog and read the title and description seamlessly, rather than forcing the user to manually hunt for the context of the buttons.
+
+## 2. Managing the Keyboard Focus Ring
+
+Brutalist designs frequently rely on thick, `#000000` borders and hard, `#000000` box shadows. 
+
+If you rely on the browser's default focus ring (which is often a thin dashed line or a light blue glow), it will become entirely invisible against the brutalist borders.
+
+### CSS Solution: Outline Offset
+
+To ensure keyboard users can clearly see which button they are focused on, use `outline-offset` to push a thick, high-contrast ring *outside* the button's border.
+
+```css
+:root {
+    --focus-ring-color: #2563eb; /* High contrast bright blue */
+}
+
+.brutal-btn:focus-visible {
+    /* 4px thick line */
+    outline: 4px solid var(--focus-ring-color);
+    
+    /* Push it 4px away from the black border so it doesn't blend in */
+    outline-offset: 4px;
+}
+```
+
+## 3. Focus Trapping (JavaScript Requirement)
+
+While this CSS documentation focuses on markup and styling, note that a true `alertdialog` requires JavaScript to trap focus. 
+
+When the banner appears, keyboard focus should be moved to the banner (specifically the "Accept" or "Reject" button). If the user presses `Tab`, the focus must cycle between the buttons in the banner and not escape to the background page until a choice is made.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/brutalism-cookie-banner-accessibility/demo.html
+++ b/submissions/docs/brutalism-cookie-banner-accessibility/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brutalism Cookie Banner (Accessibility) Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <!-- 
+            CRITICAL ACCESSIBILITY:
+            A cookie banner interrupts the user flow and requires a response.
+            It must be marked as a dialog and explicitly label itself.
+        -->
+        <div 
+            class="brutal-cookie-banner" 
+            role="alertdialog" 
+            aria-labelledby="cookie-title" 
+            aria-describedby="cookie-desc"
+        >
+            <div class="brutal-content">
+                <!-- 
+                    The ID here must match the aria-labelledby of the parent dialog 
+                -->
+                <h2 id="cookie-title" class="brutal-heading">WE USE COOKIES</h2>
+                
+                <!-- 
+                    The ID here must match the aria-describedby of the parent dialog 
+                -->
+                <p id="cookie-desc">Accept them to continue. We track everything. It is what it is.</p>
+            </div>
+            
+            <div class="brutal-actions">
+                <!-- 
+                    Focus management (usually handled via JS) should ideally trap 
+                    focus inside the dialog until an option is selected.
+                -->
+                <button class="brutal-btn brutal-btn-accept">ACCEPT ALL</button>
+                <button class="brutal-btn brutal-btn-reject">REJECT</button>
+            </div>
+        </div>
+
+    </main>
+</body>
+</html>

--- a/submissions/docs/brutalism-cookie-banner-accessibility/style.css
+++ b/submissions/docs/brutalism-cookie-banner-accessibility/style.css
@@ -1,0 +1,106 @@
+:root {
+    --brutal-bg: #facc15;
+    --brutal-text: #000000;
+    --brutal-border: #000000;
+    
+    --btn-accept-bg: #000000;
+    --btn-accept-text: #ffffff;
+    --btn-reject-bg: #ffffff;
+    --btn-reject-text: #000000;
+    
+    /* Accessibility Variables */
+    --focus-ring-color: #2563eb; /* High contrast blue */
+}
+
+body {
+    margin: 0;
+    background-color: #f1f5f9;
+    font-family: 'Space Mono', monospace;
+    padding: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.demo-container {
+    width: 100%;
+    max-width: 800px;
+}
+
+.brutal-cookie-banner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+    padding: 2rem;
+    
+    background-color: var(--brutal-bg);
+    color: var(--brutal-text);
+    border: 4px solid var(--brutal-border);
+    box-shadow: 8px 8px 0px var(--brutal-border);
+}
+
+.brutal-content {
+    flex: 1 1 300px;
+}
+
+.brutal-heading {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.brutal-content p {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.brutal-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.brutal-btn {
+    font-family: 'Space Mono', monospace;
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 1rem 2rem;
+    cursor: pointer;
+    text-transform: uppercase;
+    border: 3px solid var(--brutal-border);
+}
+
+.brutal-btn-accept {
+    background-color: var(--btn-accept-bg);
+    color: var(--btn-accept-text);
+}
+
+.brutal-btn-reject {
+    background-color: var(--btn-reject-bg);
+    color: var(--btn-reject-text);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus-Visible
+ * Brutalist buttons have thick, dark borders. A standard browser focus ring 
+ * often blends into these borders or the hard shadow. 
+ * We must use `outline-offset` to push the focus ring away from the border,
+ * and we must use a highly contrasting color (like bright blue or magenta).
+ */
+.brutal-btn:focus-visible {
+    outline: 4px solid var(--focus-ring-color);
+    outline-offset: 4px;
+}
+
+/* 
+ * Optional but recommended: Shift the shadow on focus so it feels interactive 
+ * for keyboard users just like it does for mouse users on hover/active.
+ */
+.brutal-btn:active,
+.brutal-btn:focus-visible {
+    transform: translate(2px, 2px);
+    box-shadow: 2px 2px 0px var(--brutal-border);
+}


### PR DESCRIPTION
fixes #85771 

## Pull Request Description

This PR introduces the Accessibility Setup guide for the Brutalism Cookie Consent Banner. Brutalist designs are notoriously hostile to default browser accessibility styles—specifically, standard focus rings become entirely invisible against thick black borders. This guide resolves this by documenting how to use `outline-offset` to push a high-contrast focus ring outside the component's geometry. Furthermore, it details the strict semantic HTML requirements (`role="alertdialog"`, `aria-labelledby`, `aria-describedby`) necessary to ensure screen readers properly announce the interruption to users.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on properly architecting brutalist components for screen readers and keyboard users. It demonstrates how to tie the visual heading and description to the container via ARIA attributes so that assistive technologies announce the banner comprehensively.

**How does a developer use it?**

```css
/* Ensure the focus ring doesn't blend into the thick brutalist borders */
.brutal-btn:focus-visible {
    outline: 4px solid var(--focus-ring-color);
    outline-offset: 4px; /* Critical for brutalist aesthetics */
}
