### PR TITLE
docs: add responsive breakpoints layout guide for brutalism cookie ba…

### DIFF
--- a/submissions/docs/brutalism-cookie-banner-responsive/README.md
+++ b/submissions/docs/brutalism-cookie-banner-responsive/README.md
@@ -1,0 +1,81 @@
+# Brutalism Cookie Consent Banner (Responsive Breakpoints Guide)
+
+This guide explains how to properly scale the Brutalism Cookie Consent Banner across different screen sizes. Brutalist design features—such as massive fonts and thick, hard block shadows—pose unique responsive challenges. If a `12px` solid black box-shadow is rendered on a small mobile device, it can easily cause horizontal overflow and break the viewport.
+
+## Responsive Architecture via CSS Variables
+
+To prevent layout breakage while maintaining the brutalist aesthetic, we scale the padding, font sizes, button widths, and the shadow offsets using root-level CSS custom properties mapped to media queries.
+
+```css
+:root {
+    /* Mobile First: Smaller shadows, full-width buttons */
+    --brutal-padding: 1.5rem;
+    --brutal-shadow-offset: 4px;
+    --title-size: 1.25rem;
+    --btn-padding: 0.75rem 1rem;
+    --btn-width: 100%;
+}
+
+/* Tablet Breakpoint */
+@media (min-width: 768px) {
+    :root {
+        --brutal-padding: 2rem;
+        --brutal-shadow-offset: 8px; /* Shadow grows */
+        --title-size: 1.5rem;
+        --btn-padding: 1rem 1.5rem;
+        --btn-width: auto; /* Buttons return to inline flow */
+    }
+}
+
+/* Desktop Breakpoint */
+@media (min-width: 1024px) {
+    :root {
+        --brutal-shadow-offset: 12px; /* Maximum brutalist impact */
+        --title-size: 1.75rem;
+        --btn-padding: 1rem 2rem;
+    }
+}
+```
+
+## HTML Layout Strategy (Flexbox)
+
+The HTML is structured with Flexbox, allowing the text content and the action buttons to stack gracefully on mobile and sit side-by-side on desktop.
+
+```html
+<div class="brutal-cookie-banner">
+    <!-- flex: 1 1 300px; Allows text to wrap or take full width -->
+    <div class="brutal-content">
+        <h2>WE USE COOKIES</h2>
+        <p>...</p>
+    </div>
+    
+    <!-- flex-wrap: wrap; Combined with --btn-width: 100% on mobile -->
+    <div class="brutal-actions">
+        <button class="brutal-btn">ACCEPT ALL</button>
+        <button class="brutal-btn">REJECT</button>
+    </div>
+</div>
+```
+
+### Implementing the Variables
+
+By applying the variables directly to the core classes, the component automatically adjusts its proportions at every breakpoint without needing to rewrite complex CSS rules.
+
+```css
+.brutal-cookie-banner {
+    padding: var(--brutal-padding);
+    /* The shadow X and Y offsets scale dynamically */
+    box-shadow: var(--brutal-shadow-offset) var(--brutal-shadow-offset) 0px var(--brutal-border);
+}
+
+.brutal-heading {
+    font-size: var(--title-size);
+}
+
+.brutal-btn {
+    padding: var(--btn-padding);
+    width: var(--btn-width); /* Forces block stacking on mobile, inline on desktop */
+}
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/brutalism-cookie-banner-responsive/demo.html
+++ b/submissions/docs/brutalism-cookie-banner-responsive/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brutalism Cookie Banner (Responsive) Demo</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <div class="brutal-cookie-banner" role="dialog" aria-labelledby="cookie-title" aria-describedby="cookie-desc">
+            <div class="brutal-content">
+                <h2 id="cookie-title" class="brutal-heading">WE USE COOKIES</h2>
+                <p id="cookie-desc">Accept them to continue. We track everything. It is what it is. No negotiations.</p>
+            </div>
+            
+            <div class="brutal-actions">
+                <button class="brutal-btn brutal-btn-accept">ACCEPT ALL</button>
+                <button class="brutal-btn brutal-btn-reject">REJECT</button>
+            </div>
+        </div>
+
+    </main>
+</body>
+</html>

--- a/submissions/docs/brutalism-cookie-banner-responsive/style.css
+++ b/submissions/docs/brutalism-cookie-banner-responsive/style.css
@@ -1,0 +1,130 @@
+:root {
+    --brutal-bg: #facc15;
+    --brutal-text: #000000;
+    --brutal-border: #000000;
+    
+    --focus-ring: #2563eb;
+    
+    /* 
+     * Default (Mobile First) Layout Variables 
+     * Brutalist shadows take up physical space. We must shrink them on mobile
+     * to prevent horizontal scrolling/overflow.
+     */
+    --brutal-padding: 1.5rem;
+    --brutal-shadow-offset: 4px;
+    --title-size: 1.25rem;
+    --btn-padding: 0.75rem 1rem;
+    --btn-width: 100%;
+}
+
+/* Tablet Breakpoint */
+@media (min-width: 768px) {
+    :root {
+        --brutal-padding: 2rem;
+        --brutal-shadow-offset: 8px;
+        --title-size: 1.5rem;
+        --btn-padding: 1rem 1.5rem;
+        --btn-width: auto;
+    }
+}
+
+/* Desktop Breakpoint */
+@media (min-width: 1024px) {
+    :root {
+        --brutal-shadow-offset: 12px;
+        --title-size: 1.75rem;
+        --btn-padding: 1rem 2rem;
+    }
+}
+
+body {
+    margin: 0;
+    background-color: #f1f5f9;
+    font-family: 'Space Mono', monospace;
+    /* Add padding so the hard shadow doesn't get clipped by the viewport */
+    padding: 2rem; 
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-container {
+    width: 100%;
+    max-width: 900px;
+}
+
+.brutal-cookie-banner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+    
+    padding: var(--brutal-padding);
+    background-color: var(--brutal-bg);
+    color: var(--brutal-text);
+    border: 4px solid var(--brutal-border);
+    
+    /* The shadow scales with the viewport */
+    box-shadow: var(--brutal-shadow-offset) var(--brutal-shadow-offset) 0px var(--brutal-border);
+}
+
+.brutal-content {
+    /* Allows the text to take up full width on mobile, and split space on desktop */
+    flex: 1 1 300px; 
+}
+
+.brutal-heading {
+    margin: 0 0 0.5rem 0;
+    font-size: var(--title-size);
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.brutal-content p {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.brutal-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    /* Take full width on mobile to force buttons to stack if --btn-width is 100% */
+    width: var(--btn-width);
+}
+
+.brutal-btn {
+    font-family: 'Space Mono', monospace;
+    font-size: 1rem;
+    font-weight: 700;
+    
+    padding: var(--btn-padding);
+    width: var(--btn-width);
+    
+    cursor: pointer;
+    text-transform: uppercase;
+    border: 3px solid var(--brutal-border);
+    transition: transform 0.1s ease;
+}
+
+.brutal-btn:active {
+    transform: translate(2px, 2px);
+}
+
+.brutal-btn-accept {
+    background-color: #000000;
+    color: #ffffff;
+}
+
+.brutal-btn-reject {
+    background-color: #ffffff;
+    color: #000000;
+}
+
+.brutal-btn:focus-visible {
+    outline: 4px solid var(--focus-ring);
+    outline-offset: 4px;
+}


### PR DESCRIPTION
fixes #85772 

## Pull Request Description

This PR introduces the Responsive Breakpoints Layout guide for the Brutalism Cookie Consent Banner. Brutalist designs are notoriously prone to breaking mobile layouts because of their reliance on massive fonts and physical, hard-edged `box-shadow` properties that don't naturally wrap. This guide solves this by implementing a CSS Variable architecture that explicitly scales padding, typography, button widths (`100%` on mobile vs `auto` on desktop), and importantly, the `--brutal-shadow-offset` across standard breakpoints. 

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a comprehensive responsive strategy for brutalist components. It maps out how to dynamically shift a Flexbox layout from a stacked, full-width mobile view to an inline, side-by-side desktop view. Crucially, it demonstrates how to bind the `box-shadow` x/y offsets to a scaling variable to prevent horizontal scrollbar overflow on narrow viewports.

**How does a developer use it?**

```css
:root {
    /* Mobile First */
    --brutal-shadow-offset: 4px;
    --btn-width: 100%;
}

@media (min-width: 768px) {
    :root {
        /* Tablet & Desktop */
        --brutal-shadow-offset: 8px; /* Safe to increase shadow footprint */
        --btn-width: auto; /* Buttons return to inline flow */
    }
}
