### PR TITLE
feat(scss): Add SCSS Object-Fit & Position helper mixins (#81302)

### DIFF
--- a/submissions/examples/object-fit-position-scss/README.md
+++ b/submissions/examples/object-fit-position-scss/README.md
@@ -1,0 +1,16 @@
+# SCSS Object-Fit & Position Helper Mixins
+
+An SCSS helper mixin suite for controlling image and video scaling behavior (`object-fit` and `object-position`) inside responsive media containers.
+
+## Overview & Features
+- `object-fit-position($fit, $position)`: Configures custom object-fit and positioning rules.
+- `object-cover()`: Shorthand helper for centered `object-fit: cover`.
+- `object-fit-theme($variant)`: Preset theme selectors supporting cover, contain, and fill variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.hero-image {
+  @include object-cover;
+}

--- a/submissions/examples/object-fit-position-scss/_mixins.scss
+++ b/submissions/examples/object-fit-position-scss/_mixins.scss
@@ -1,0 +1,31 @@
+// ==========================================================================
+// Object-Fit & Position Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Applies object-fit and object-position scaling rules for responsive media elements (images and videos).
+/// @param {String} $fit [cover] - Object fit property value (cover, contain, fill, none, scale-down).
+/// @param {String} $position [center] - Object position property value (e.g., center, top, bottom, 50% 50%).
+@mixin object-fit-position(
+  $fit: cover,
+  $position: center
+) {
+  object-fit: $fit;
+  object-position: $position;
+}
+
+/// Shorthand helper for centered object-fit cover media scaling.
+@mixin object-cover {
+  @include object-fit-position(cover, center);
+}
+
+/// Applies preset object-fit theme variations.
+/// @param {String} $variant [cover] - Preset variant (cover, contain, fill).
+@mixin object-fit-theme($variant: 'cover') {
+  @if $variant == 'cover' {
+    @include object-fit-position(cover, center);
+  } @else if $variant == 'contain' {
+    @include object-fit-position(contain, center);
+  } @else if $variant == 'fill' {
+    @include object-fit-position(fill, center);
+  }
+}

--- a/submissions/examples/object-fit-position-scss/demo.html
+++ b/submissions/examples/object-fit-position-scss/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Object-Fit & Position — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-media-frame">
+        <img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='600' height='220' viewBox='0 0 600 220'><rect width='600' height='220' fill='%230b0f19'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%2306b6d4' font-family='sans-serif' font-size='18'>Responsive Media Asset (Object-Fit Cover)</text></svg>" alt="Cover Media Asset" />
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/object-fit-position-scss/style.css
+++ b/submissions/examples/object-fit-position-scss/style.css
@@ -1,0 +1,52 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-media-frame {
+  width: 100%;
+  height: 220px;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ease-media-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}

--- a/submissions/examples/object-fit-position-scss/style.scss
+++ b/submissions/examples/object-fit-position-scss/style.scss
@@ -1,0 +1,53 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ease-media-frame {
+  width: 100%;
+  height: 220px;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    @include object-fit-theme('cover');
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81302

Adds custom SCSS object-fit and position helper mixins (`object-fit-position()`, `object-cover()`, and `object-fit-theme()`) under `submissions/examples/object-fit-position-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/object-fit-position-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for media scaling (`object-fit` and `object-position`) ensuring robust responsive layout handling for images and videos.
**Why does it fit?** Expands developer media styling utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari