### PR TITLE
docs: add quickstart guide for interactive file dropzone

### DIFF
--- a/submissions/docs/interactive-file-dropzone/README.md
+++ b/submissions/docs/interactive-file-dropzone/README.md
@@ -1,0 +1,73 @@
+# Interactive File Drag Dropzone (Quickstart Guide)
+
+This guide documents the implementation of a modern, interactive file drag-and-drop zone. The primary challenge of building a custom file upload interface is that the native browser `<input type="file">` is notoriously difficult to style.
+
+## 1. The HTML Pattern (Hidden Input + Label)
+
+The solution is to visually hide the native file input and construct a custom UI using a `<label>` element that points to it via the `for` attribute. Clicking anywhere on the label will automatically trigger the hidden input.
+
+```html
+<div class="dropzone-container">
+    
+    <!-- 1. Visually hide the native input using 'sr-only' -->
+    <input 
+        type="file" 
+        id="upload-input" 
+        class="dropzone-input sr-only" 
+        multiple
+    >
+    
+    <!-- 2. The label acts as the visual dropzone -->
+    <label for="upload-input" class="dropzone-label">
+        <div class="dropzone-content">
+            <svg>...</svg>
+            <span class="dropzone-title">Drag & drop files here</span>
+            <span class="dropzone-subtitle">or click to browse</span>
+        </div>
+    </label>
+</div>
+```
+
+## 2. Visually Hiding the Input (Accessibility)
+
+**Do not** use `display: none` or `visibility: hidden` to hide the file input. Doing so removes it from the browser's accessibility tree, making it impossible for keyboard users to focus on it.
+
+Instead, use a visually hidden utility class (e.g., `sr-only`) that shrinks the input to a 1px square while keeping it technically focusable.
+
+```css
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+```
+
+## 3. Keyboard Navigation (The Adjacent Sibling Selector)
+
+Because the physical input is invisible, when a keyboard user presses `Tab` and focuses on it, they won't know they've done so. 
+
+We solve this using CSS. When the hidden input receives `:focus-visible`, we use the adjacent sibling combinator (`+`) to apply a focus ring to the custom `<label>` that immediately follows it.
+
+```css
+/* When the hidden input receives focus... */
+.dropzone-input:focus-visible + .dropzone-label {
+    
+    /* ...draw a high-contrast outline on the label */
+    outline: 3px solid #3b82f6;
+    outline-offset: 4px;
+    
+    /* Optional: Trigger the same visual hover state */
+    border-color: #3b82f6;
+    background-color: #eff6ff;
+}
+```
+
+By connecting the hidden input's focus state to the label's visual state, the component behaves exactly like a native, accessible button.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/interactive-file-dropzone/demo.html
+++ b/submissions/docs/interactive-file-dropzone/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive File Dropzone (Quickstart) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <!-- Dropzone Component -->
+        <div class="dropzone-container">
+            
+            <!-- Visually hidden file input -->
+            <input 
+                type="file" 
+                id="file-upload" 
+                class="dropzone-input sr-only" 
+                multiple
+            >
+            
+            <!-- Label acts as the visual dropzone and trigger for the input -->
+            <label for="file-upload" class="dropzone-label">
+                
+                <div class="dropzone-content">
+                    <svg class="upload-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="17 8 12 3 7 8"></polyline>
+                        <line x1="12" y1="3" x2="12" y2="15"></line>
+                    </svg>
+                    
+                    <span class="dropzone-title">Drag & drop files here</span>
+                    <span class="dropzone-subtitle">or click to browse</span>
+                </div>
+                
+            </label>
+        </div>
+
+    </main>
+</body>
+</html>

--- a/submissions/docs/interactive-file-dropzone/style.css
+++ b/submissions/docs/interactive-file-dropzone/style.css
@@ -1,0 +1,118 @@
+:root {
+    --bg-color: #f8fafc;
+    --text-color: #334155;
+    
+    /* Core Dropzone Variables */
+    --dz-bg: #ffffff;
+    --dz-border: #cbd5e1;
+    --dz-border-hover: #3b82f6;
+    --dz-bg-hover: #eff6ff;
+    --dz-text-muted: #64748b;
+    --dz-icon-color: #94a3b8;
+    
+    --focus-ring: #3b82f6;
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-container {
+    width: 100%;
+    max-width: 600px;
+    padding: 2rem;
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Visually hide the input
+ * Do not use `display: none` or `visibility: hidden`, 
+ * otherwise it cannot receive keyboard focus.
+ */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.dropzone-container {
+    position: relative;
+    width: 100%;
+}
+
+.dropzone-label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    
+    width: 100%;
+    min-height: 200px;
+    padding: 2rem;
+    box-sizing: border-box;
+    
+    background-color: var(--dz-bg);
+    border: 2px dashed var(--dz-border);
+    border-radius: 12px;
+    
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.dropzone-label:hover {
+    border-color: var(--dz-border-hover);
+    background-color: var(--dz-bg-hover);
+}
+
+.dropzone-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: center;
+}
+
+.upload-icon {
+    width: 48px;
+    height: 48px;
+    color: var(--dz-icon-color);
+    transition: color 0.2s ease;
+}
+
+.dropzone-label:hover .upload-icon {
+    color: var(--dz-border-hover);
+}
+
+.dropzone-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.dropzone-subtitle {
+    font-size: 0.875rem;
+    color: var(--dz-text-muted);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus-Visible
+ * The physical input is hidden, so we must apply the focus ring 
+ * to the label when the hidden input receives focus.
+ */
+.dropzone-input:focus-visible + .dropzone-label {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px;
+    border-color: var(--dz-border-hover);
+    background-color: var(--dz-bg-hover);
+}


### PR DESCRIPTION
fixes #85773 

## Pull Request Description

This PR introduces the Quickstart documentation guide for the Interactive File Drag Dropzone component. Styling native `<input type="file">` elements is notoriously restrictive. This guide details the industry-standard pattern of visually hiding the native input and overlaying a custom `<label>` that serves as the dropzone/click-target. Crucially, it documents the CSS required to maintain keyboard accessibility, demonstrating how to use the adjacent sibling selector (`+`) to pass the hidden input's `:focus-visible` state onto the visual label.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on building an accessible, custom-styled file upload dropzone. It provides the necessary HTML markup (associating a label to a hidden input) and the CSS architecture required to map the native browser focus state to the custom UI, ensuring the component is fully navigable via the keyboard.

**How does a developer use it?**

```css
/* 1. Visually hide the input, but keep it focusable (do NOT use display: none) */
.dropzone-input.sr-only {
    position: absolute; width: 1px; height: 1px; clip: rect(0,0,0,0); overflow: hidden;
}

/* 2. When the hidden input is focused via keyboard, style the adjacent label */
.dropzone-input:focus-visible + .dropzone-label {
    outline: 3px solid var(--focus-ring);
    outline-offset: 4px;
}
