### PR TITLE
feat(scss): Add SCSS CSS Counter Reset & Increment helper mixins (#81…

### DIFF
--- a/submissions/examples/counter-reset-increment-scss/README.md
+++ b/submissions/examples/counter-reset-increment-scss/README.md
@@ -1,0 +1,17 @@
+# SCSS CSS Counter Reset & Increment Helper Mixins
+
+An SCSS helper mixin suite for managing native CSS counters (`counter-reset` and `counter-increment`) to build custom numbered lists, steppers, and ordered workflows.
+
+## Overview & Features
+- `counter-reset($name, $value)`: Initializes or resets CSS counters on container elements.
+- `counter-increment($name, $value)`: Increments counter values on child elements.
+- `counter-stepper($name)`: Shorthand helper for automated list item counter incrementation.
+- `counter-theme($variant)`: Preset theme selectors supporting default, primary, and step variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.custom-stepper {
+  @include counter-theme('default');
+}

--- a/submissions/examples/counter-reset-increment-scss/_mixins.scss
+++ b/submissions/examples/counter-reset-increment-scss/_mixins.scss
@@ -1,0 +1,48 @@
+// ==========================================================================
+// CSS Counter Reset & Increment Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Initializes or resets a CSS counter on parent containers.
+/// @param {String} $name [ease-counter] - Counter identifier name.
+/// @param {Number} $value [0] - Initial reset integer value.
+@mixin counter-reset(
+  $name: ease-counter,
+  $value: 0
+) {
+  counter-reset: $name $value;
+}
+
+/// Increments a CSS counter on list items or step elements.
+/// @param {String} $name [ease-counter] - Counter identifier name.
+/// @param {Number} $value [1] - Increment step value.
+@mixin counter-increment(
+  $name: ease-counter,
+  $value: 1
+) {
+  counter-increment: $name $value;
+}
+
+/// Combines counter reset and item counter increment rules for custom numbered lists and steppers.
+/// @param {String} $name [ease-counter] - Counter identifier name.
+@mixin counter-stepper(
+  $name: ease-counter
+) {
+  @include counter-reset($name, 0);
+  
+  > li,
+  > .ease-step-item {
+    @include counter-increment($name, 1);
+  }
+}
+
+/// Applies preset counter theme variations.
+/// @param {String} $variant [default] - Preset variant (default, primary, steps).
+@mixin counter-theme($variant: 'default') {
+  @if $variant == 'default' {
+    @include counter-stepper(ease-counter);
+  } @else if $variant == 'primary' {
+    @include counter-stepper(primary-counter);
+  } @else if $variant == 'steps' {
+    @include counter-stepper(wizard-steps);
+  }
+}

--- a/submissions/examples/counter-reset-increment-scss/demo.html
+++ b/submissions/examples/counter-reset-increment-scss/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS CSS Counter Reset & Increment — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <ul class="ease-custom-list">
+        <li>Initialize build configurations and dependency trees.</li>
+        <li>Configure Zabbix and Grafana network monitoring containers.</li>
+        <li>Deploy production-ready SCSS helper mixin packages.</li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/counter-reset-increment-scss/style.css
+++ b/submissions/examples/counter-reset-increment-scss/style.css
@@ -1,0 +1,69 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+.ease-custom-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  counter-reset: ease-counter 0;
+}
+.ease-custom-list > li,
+.ease-custom-list > .ease-step-item {
+  counter-increment: ease-counter 1;
+}
+.ease-custom-list li {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+.ease-custom-list li::before {
+  content: counter(ease-counter);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: rgba(6, 182, 212, 0.15);
+  color: var(--ease-cyan);
+  border: 1px solid var(--ease-cyan);
+  border-radius: 50%;
+  font-size: 0.85rem;
+  font-weight: 700;
+}

--- a/submissions/examples/counter-reset-increment-scss/style.scss
+++ b/submissions/examples/counter-reset-increment-scss/style.scss
@@ -1,0 +1,68 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+.ease-custom-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  @include counter-theme('default');
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: #030712;
+    border: 1px solid var(--ease-border);
+    border-radius: 10px;
+    font-size: 0.95rem;
+
+    &::before {
+      content: counter(ease-counter);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      background: rgba(6, 182, 212, 0.15);
+      color: var(--ease-cyan);
+      border: 1px solid var(--ease-cyan);
+      border-radius: 50%;
+      font-size: 0.85rem;
+      font-weight: 700;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81301

Adds custom SCSS CSS counter reset and increment helper mixins (`counter-reset()`, `counter-increment()`, `counter-stepper()`, and `counter-theme()`) under `submissions/examples/counter-reset-increment-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/counter-reset-increment-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for native CSS counter management (`counter-reset` and `counter-increment`) tailored for custom numbered lists, steppers, and multi-step wizards.
**Why does it fit?** Expands developer counter and list styling utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari