### PR TITLE
docs: add accessibility setup guide for neumorphic flyout popover

### DIFF
--- a/submissions/docs/neumorphic-flyout-accessibility/README.md
+++ b/submissions/docs/neumorphic-flyout-accessibility/README.md
@@ -1,0 +1,70 @@
+# Neumorphic Flyout Popover (Accessibility Setup Guide)
+
+This guide documents the critical accessibility requirements for building a Neumorphic Flyout Popover. Neumorphism relies on subtle, low-contrast shadows to create depth, making it inherently challenging for visually impaired users. Furthermore, flyout menus require strict ARIA attributes to function correctly for screen reader users.
+
+## 1. ARIA Flyout Semantics
+
+To ensure screen readers understand that a button opens a menu, and to track whether that menu is currently open or closed, you must implement the following ARIA pattern:
+
+### The Trigger Button
+
+```html
+<button 
+    class="flyout-trigger" 
+    aria-haspopup="true" 
+    aria-expanded="false" 
+    aria-controls="options-menu"
+    id="options-menu-btn"
+>
+    Options
+</button>
+```
+- `aria-haspopup="true"`: Announces that this button triggers an interactive popup menu.
+- `aria-expanded="false"`: This state **must be toggled to true via JavaScript** when the menu opens.
+- `aria-controls="options-menu"`: Connects the button to the DOM element it controls.
+
+### The Popover Menu
+
+```html
+<ul 
+    id="options-menu" 
+    role="menu" 
+    aria-labelledby="options-menu-btn"
+>
+    <li role="presentation">
+        <a href="#" role="menuitem">Profile Settings</a>
+    </li>
+</ul>
+```
+- `role="menu"` and `role="menuitem"`: Establishes the standard menu hierarchy.
+- `aria-labelledby`: Points back to the trigger button, giving the menu an accessible name.
+
+## 2. Neumorphic Focus States (CSS)
+
+The hallmark of neumorphism is the lack of hard borders—elements appear extruded from the background using light and dark shadows. 
+
+Because of this, the default browser focus ring is often invisible or illegible. **You must define a high-contrast focus ring.**
+
+```css
+:root {
+    --focus-ring: #3182ce; /* Ensure this contrasts sharply with the background */
+}
+
+/* 1. The Trigger Button */
+.neumorphic-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px; /* Push the ring outside the drop shadow */
+}
+
+/* 2. The Menu Items */
+.neumorphic-item:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    /* Inset the ring so it doesn't break the popover's internal padding */
+    outline-offset: -2px; 
+    background-color: rgba(163, 177, 198, 0.2);
+}
+```
+
+By enforcing a high-contrast `:focus-visible` state, you maintain the premium, soft aesthetic of neumorphism for mouse users while ensuring keyboard users can safely navigate the interface.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/neumorphic-flyout-accessibility/demo.html
+++ b/submissions/docs/neumorphic-flyout-accessibility/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Flyout Popover (Accessibility) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <div class="flyout-container">
+            <!-- 
+                CRITICAL ACCESSIBILITY: ARIA Trigger Attributes 
+                aria-haspopup indicates this button opens a menu.
+                aria-expanded tells screen readers if the menu is currently visible.
+                aria-controls links the button to the popover's ID.
+            -->
+            <button 
+                type="button" 
+                class="neumorphic-btn flyout-trigger" 
+                aria-haspopup="true" 
+                aria-expanded="false" 
+                aria-controls="options-menu"
+                id="options-menu-btn"
+            >
+                Options
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+            </button>
+
+            <!-- 
+                CRITICAL ACCESSIBILITY: Menu Semantics
+                role="menu" defines the container as a list of choices.
+                aria-labelledby points back to the trigger button.
+            -->
+            <ul 
+                id="options-menu" 
+                class="neumorphic-popover" 
+                role="menu" 
+                aria-labelledby="options-menu-btn"
+                hidden
+            >
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item">Profile Settings</a>
+                </li>
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item">Notification Preferences</a>
+                </li>
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item text-danger">Sign Out</a>
+                </li>
+            </ul>
+        </div>
+
+    </main>
+
+    <script>
+        // Minimal script to demonstrate aria-expanded toggling
+        const trigger = document.querySelector('.flyout-trigger');
+        const popover = document.querySelector('.neumorphic-popover');
+
+        trigger.addEventListener('click', () => {
+            const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+            trigger.setAttribute('aria-expanded', !isExpanded);
+            
+            if (isExpanded) {
+                popover.setAttribute('hidden', '');
+            } else {
+                popover.removeAttribute('hidden');
+                // In a real app, move focus to the first menu item here
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/docs/neumorphic-flyout-accessibility/style.css
+++ b/submissions/docs/neumorphic-flyout-accessibility/style.css
@@ -1,0 +1,121 @@
+:root {
+    --bg-color: #e0e5ec;
+    --text-color: #4a5568;
+    
+    /* Neumorphic Shadows */
+    --light-shadow: #ffffff;
+    --dark-shadow: #a3b1c6;
+    
+    /* Accessibility Variables */
+    --focus-ring: #3182ce; /* High contrast blue */
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    padding-top: 10vh;
+    min-height: 100vh;
+}
+
+.demo-container {
+    padding: 2rem;
+}
+
+.flyout-container {
+    position: relative;
+    display: inline-block;
+}
+
+/* Base Neumorphic Button */
+.neumorphic-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    
+    /* Soft protruding shadow */
+    box-shadow: 
+        8px 8px 16px var(--dark-shadow), 
+        -8px -8px 16px var(--light-shadow);
+        
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.neumorphic-btn:active,
+.neumorphic-btn[aria-expanded="true"] {
+    /* Indented shadow for active/expanded state */
+    box-shadow: 
+        inset 4px 4px 8px var(--dark-shadow), 
+        inset -4px -4px 8px var(--light-shadow);
+    transform: translateY(2px);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus Visibility 
+ * Neumorphism inherently lacks hard borders. A standard browser focus ring 
+ * might be too subtle or blend into the drop shadows.
+ * We MUST provide a stark, high-contrast outline for keyboard navigation.
+ */
+.neumorphic-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px;
+}
+
+/* Neumorphic Popover Menu */
+.neumorphic-popover {
+    position: absolute;
+    top: calc(100% + 1rem);
+    left: 0;
+    min-width: 240px;
+    margin: 0;
+    padding: 1rem 0;
+    list-style: none;
+    
+    background-color: var(--bg-color);
+    border-radius: 16px;
+    
+    /* Elevated shadow */
+    box-shadow: 
+        10px 10px 20px var(--dark-shadow), 
+        -10px -10px 20px var(--light-shadow);
+        
+    z-index: 10;
+}
+
+/* Menu Items */
+.neumorphic-item {
+    display: block;
+    padding: 0.75rem 1.5rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+}
+
+.neumorphic-item:hover,
+.neumorphic-item:focus {
+    background-color: rgba(163, 177, 198, 0.15);
+}
+
+.neumorphic-item.text-danger {
+    color: #e53e3e;
+}
+
+/* Menu Item Focus */
+.neumorphic-item:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: -2px; /* Inset outline so it doesn't break the popover layout */
+    background-color: rgba(163, 177, 198, 0.2);
+}


### PR DESCRIPTION
fixes #85742 

## Pull Request Description

This PR introduces the Accessibility Setup guide for the Neumorphic Flyout Popover component. Neumorphic UI design heavily utilizes low-contrast drop shadows and entirely eschews hard borders, which natively creates severe accessibility issues for keyboard users. This documentation addresses these challenges head-on by establishing a high-contrast `:focus-visible` CSS strategy for both the trigger button and the nested menu items. Additionally, it details the strict ARIA attribute mapping (`aria-haspopup`, `aria-expanded`, `aria-controls`, `role="menu"`) required to ensure screen readers accurately announce the flyout's state and hierarchical structure.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a comprehensive guide on architecting accessible neumorphic flyout menus. It provides the exact HTML markup necessary to construct an ARIA-compliant popup menu, and documents the specialized CSS `outline-offset` techniques required to inject high-contrast focus rings into a low-contrast design language.

**How does a developer use it?**

```css
/* Crucial for neumorphic designs: define a high contrast ring */
:root {
    --focus-ring: #3182ce; 
}

/* Offset the ring to avoid clipping the soft drop shadow */
.neumorphic-btn:focus-visible {
    outline: 3px solid var(--focus-ring);
    outline-offset: 4px; 
}
