### PR TITLE
docs: add responsive breakpoints layout guide for neumorphic flyout p…

### DIFF
--- a/submissions/docs/neumorphic-flyout-responsive/README.md
+++ b/submissions/docs/neumorphic-flyout-responsive/README.md
@@ -1,0 +1,76 @@
+# Neumorphic Flyout Popover (Responsive Breakpoints Guide)
+
+This guide details how to handle responsive scaling for absolute-positioned elements, specifically the Neumorphic Flyout Popover. 
+
+When a user clicks a button to open a menu, the menu must appear anchored to the button. However, on narrow mobile screens, anchoring a fixed-width popover to a button often causes the popover to bleed off the edge of the screen, creating horizontal scrollbars and breaking the layout.
+
+## Responsive Architecture via CSS Variables
+
+To prevent viewport overflow, we change how the popover anchors and scales based on the screen size.
+
+```css
+:root {
+    /* 
+     * Mobile First
+     * Instead of anchoring to the button's left edge, pull the popover left 
+     * and stretch it to fill almost the entire viewport width.
+     */
+    --popover-width: calc(100vw - 4rem);
+    --popover-left: -2rem; 
+    
+    /* Larger tap targets for mobile fingers */
+    --item-padding: 1rem 1.5rem;
+}
+
+/* Tablet & Desktop Breakpoints */
+@media (min-width: 768px) {
+    :root {
+        /* 
+         * Return to standard flyout behavior.
+         * The popover anchors to the left edge of the trigger button 
+         * and takes a fixed width.
+         */
+        --popover-width: 260px;
+        --popover-left: 0;
+        
+        /* Tighter padding for mouse users */
+        --item-padding: 0.75rem 1.5rem;
+    }
+}
+```
+
+## CSS Implementation
+
+Apply the variables to the absolute-positioned `.neumorphic-popover` element. 
+
+```css
+.flyout-container {
+    position: relative;
+    /* Keeps the container tightly wrapped around the trigger button */
+    display: inline-block; 
+}
+
+.neumorphic-popover {
+    position: absolute;
+    
+    /* Anchors below the button */
+    top: calc(100% + 1.5rem); 
+    
+    /* Responsive variables applied here */
+    left: var(--popover-left);
+    width: var(--popover-width);
+    
+    /* Neumorphic styling */
+    border-radius: 16px;
+    box-shadow: 10px 10px 20px #a3b1c6, -10px -10px 20px #ffffff;
+}
+
+.neumorphic-item {
+    /* Responsive tap targets applied here */
+    padding: var(--item-padding);
+}
+```
+
+By binding the `left` and `width` coordinates to breakpoints, the component behaves like a full-width bottom sheet on mobile devices and a sleek contextual flyout on desktop devices, all without requiring JavaScript resize listeners.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/neumorphic-flyout-responsive/demo.html
+++ b/submissions/docs/neumorphic-flyout-responsive/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Neumorphic Flyout Popover (Responsive) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <div class="flyout-container">
+            <button 
+                type="button" 
+                class="neumorphic-btn flyout-trigger" 
+                aria-haspopup="true" 
+                aria-expanded="false" 
+                aria-controls="options-menu"
+                id="options-menu-btn"
+            >
+                Options
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+            </button>
+
+            <ul 
+                id="options-menu" 
+                class="neumorphic-popover" 
+                role="menu" 
+                aria-labelledby="options-menu-btn"
+                hidden
+            >
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item">Profile Settings</a>
+                </li>
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item">Notification Preferences</a>
+                </li>
+                <li role="presentation">
+                    <a href="#" role="menuitem" class="neumorphic-item text-danger">Sign Out</a>
+                </li>
+            </ul>
+        </div>
+
+    </main>
+
+    <script>
+        const trigger = document.querySelector('.flyout-trigger');
+        const popover = document.querySelector('.neumorphic-popover');
+
+        trigger.addEventListener('click', () => {
+            const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+            trigger.setAttribute('aria-expanded', !isExpanded);
+            
+            if (isExpanded) {
+                popover.setAttribute('hidden', '');
+            } else {
+                popover.removeAttribute('hidden');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/submissions/docs/neumorphic-flyout-responsive/style.css
+++ b/submissions/docs/neumorphic-flyout-responsive/style.css
@@ -1,0 +1,131 @@
+:root {
+    --bg-color: #e0e5ec;
+    --text-color: #4a5568;
+    --light-shadow: #ffffff;
+    --dark-shadow: #a3b1c6;
+    
+    /* Mobile First: Popover spans nearly the full viewport width */
+    --popover-width: calc(100vw - 4rem);
+    --popover-left: -2rem; /* Pull back to align with viewport edge */
+    --item-padding: 1rem 1.5rem;
+}
+
+/* Tablet Breakpoint */
+@media (min-width: 768px) {
+    :root {
+        /* Popover anchors to the button, normal width */
+        --popover-width: 260px;
+        --popover-left: 0;
+        --item-padding: 0.75rem 1.5rem;
+    }
+}
+
+/* Desktop Breakpoint */
+@media (min-width: 1024px) {
+    :root {
+        --popover-width: 300px;
+    }
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    padding-top: 10vh;
+    min-height: 100vh;
+}
+
+.demo-container {
+    padding: 2rem;
+    position: relative;
+}
+
+/* Important: The container anchors the absolute positioned popover */
+.flyout-container {
+    position: relative;
+    display: inline-block;
+}
+
+.neumorphic-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    
+    box-shadow: 
+        8px 8px 16px var(--dark-shadow), 
+        -8px -8px 16px var(--light-shadow);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.neumorphic-btn:active,
+.neumorphic-btn[aria-expanded="true"] {
+    box-shadow: 
+        inset 4px 4px 8px var(--dark-shadow), 
+        inset -4px -4px 8px var(--light-shadow);
+    transform: translateY(2px);
+}
+
+.neumorphic-popover {
+    position: absolute;
+    top: calc(100% + 1.5rem);
+    
+    /* Dynamically adjusted by CSS Variables based on breakpoint */
+    left: var(--popover-left);
+    width: var(--popover-width);
+    
+    margin: 0;
+    padding: 1rem 0;
+    list-style: none;
+    
+    background-color: var(--bg-color);
+    border-radius: 16px;
+    
+    box-shadow: 
+        10px 10px 20px var(--dark-shadow), 
+        -10px -10px 20px var(--light-shadow);
+    z-index: 10;
+}
+
+.neumorphic-item {
+    display: block;
+    
+    /* Padding scales based on breakpoint */
+    padding: var(--item-padding);
+    
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 0.95rem;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+}
+
+.neumorphic-item:hover,
+.neumorphic-item:focus {
+    background-color: rgba(163, 177, 198, 0.15);
+}
+
+.neumorphic-item.text-danger {
+    color: #e53e3e;
+}
+
+/* Accessibility */
+.neumorphic-btn:focus-visible {
+    outline: 3px solid #3182ce;
+    outline-offset: 4px;
+}
+.neumorphic-item:focus-visible {
+    outline: 2px solid #3182ce;
+    outline-offset: -2px;
+    background-color: rgba(163, 177, 198, 0.2);
+}


### PR DESCRIPTION
fixes #85743 

## Pull Request Description

This PR introduces the Responsive Breakpoints Layout guide for the Neumorphic Flyout Popover. A common issue with absolute-positioned dropdowns is that they frequently overflow narrow mobile viewports, causing horizontal scrollbars and breaking the layout. This guide documents a CSS Custom Property architecture (`--popover-width`, `--popover-left`) that seamlessly transforms the popover from a sleek, contextual dropdown on desktop to a full-width, touch-friendly menu on mobile screens without requiring JavaScript resize event listeners.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on managing absolute positioning coordinates across viewports. By extracting the `left` and `width` coordinates of the `.neumorphic-popover` into CSS variables, developers can effortlessly switch the popover's anchoring strategy. On mobile, it pulls left and expands to `calc(100vw - 4rem)`. On desktop, it anchors strictly to the trigger button with a fixed width of `260px`.

**How does a developer use it?**

```css
:root {
    /* Mobile: expand width, pull left to align with screen */
    --popover-width: calc(100vw - 4rem);
    --popover-left: -2rem; 
}

@media (min-width: 768px) {
    :root {
        /* Desktop: fixed width, anchor to button */
        --popover-width: 260px;
        --popover-left: 0;
    }
}
