### PR TITLE
feat(core): add skew slide reveal angle engine DSL motion preset

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1459,5 +1459,28 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: var(--ease-radius-lg, 12px);
   }
-}
 
+  /* ── Issue #86167: Skew Slide Reveal Angle ── */
+  @keyframes ease-skew-slide-reveal-angle {
+    0% {
+      opacity: 0;
+      transform: translateY(100%) skewY(10deg);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) skewY(0deg);
+    }
+  }
+
+  .ease-anim-skew-slide-reveal-angle {
+    animation: ease-skew-slide-reveal-angle var(--ease-duration, 0.6s) var(--ease-timing, cubic-bezier(0.16, 1, 0.3, 1)) forwards;
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .ease-anim-skew-slide-reveal-angle {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #86167.

This PR adds the "Skew Slide Reveal Angle" engine DSL motion preset to the EaseMotion core animation engine (`core/animations.css`). 

---

## Type of Change

- [x] ✨ New core animation / feature
- [ ] 🧩 New component submission
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Feature Description

**What does this add?**

It introduces a new keyframe animation (`@keyframes ease-skew-slide-reveal-angle`) and a utility class (`.ease-anim-skew-slide-reveal-angle`) into the core utilities layer. The animation provides a highly dynamic entrance effect that translates the element upwards from `100%` while simultaneously correcting a `10deg` skew angle, creating a premium "unveiling" reveal often seen in high-end typography and imagery entrances.

**Implementation Details:**
- **Customizable**: Configured to inherit from `--ease-duration` (default `0.6s`) and `--ease-timing` (default `cubic-bezier(0.16, 1, 0.3, 1)`).
- **Accessibility**: Explicitly includes a `@media (prefers-reduced-motion: reduce)` override to strip the animation and simply display the element statically for users who prefer reduced motion, complying with accessibility guidelines.

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*
