### PR TITLE
feat(component): Add CSS-only animated tabs with sliding underline in…

### DIFF
--- a/submissions/examples/ease-tabs/README.md
+++ b/submissions/examples/ease-tabs/README.md
@@ -1,0 +1,22 @@
+# CSS-Only Animated Tabs Component
+
+A pure CSS tabbed navigation component featuring a smooth sliding underline indicator and content fade-in transitions without JavaScript.
+
+## Overview & Features
+- **Zero JavaScript**: Powered entirely by radio inputs and `:checked` state selectors.
+- **Sliding Underline**: Hardware-accelerated `transform: translateX()` and width transitions.
+- **Responsive Scroll**: Horizontally scrollable tab header container for mobile screens.
+- **Customization Tokens**: Uses `--ease-tabs-accent` and `--ease-tabs-speed`.
+
+## Usage Example
+```html
+<div class="ease-tabs">
+  <input type="radio" id="t1" name="group" checked />
+  <div class="ease-tab-list">
+    <label class="ease-tab" for="t1">Tab One</label>
+    <div class="ease-tabs-indicator"></div>
+  </div>
+  <div class="ease-panels">
+    <div class="ease-tab-panel" id="p1">Content Here</div>
+  </div>
+</div>

--- a/submissions/examples/ease-tabs/demo.html
+++ b/submissions/examples/ease-tabs/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CSS-Only Animated Tabs — EaseMotion Suite Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-tabs">
+        <input type="radio" id="tab-1" name="ease-tab-group" checked />
+        <input type="radio" id="tab-2" name="ease-tab-group" />
+        <input type="radio" id="tab-3" name="ease-tab-group" />
+
+        <div class="ease-tab-list">
+          <label class="ease-tab" for="tab-1">Overview</label>
+          <label class="ease-tab" for="tab-2">Architecture</label>
+          <label class="ease-tab" for="tab-3">Performance</label>
+          <div class="ease-tabs-indicator"></div>
+        </div>
+
+        <div class="ease-panels">
+          <div class="ease-tab-panel" id="panel-1">
+            <h3>Overview & Features</h3>
+            <p>Classic tabbed navigation built entirely with pure CSS radio inputs and the :checked pseudo-class. Features a fluid sliding underline indicator with zero JavaScript overhead.</p>
+          </div>
+          <div class="ease-tab-panel" id="panel-2">
+            <h3>Architecture & Design</h3>
+            <p>Uses modern CSS transforms and smooth cubic-bezier transitions for hardware-accelerated animations across all modern web browsers and devices.</p>
+          </div>
+          <div class="ease-tab-panel" id="panel-3">
+            <h3>Performance & Responsiveness</h3>
+            <p>Includes a horizontally scrollable tab list wrapper tailored for seamless touch navigation on mobile viewports and smaller screen sizes.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/ease-tabs/style.css
+++ b/submissions/examples/ease-tabs/style.css
@@ -1,0 +1,136 @@
+@charset "UTF-8";
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-muted: #9ca3af;
+  --ease-tabs-accent: #06b6d4;
+  --ease-tabs-speed: 300ms;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+.ease-tabs {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.ease-tabs input[type="radio"] {
+  display: none;
+}
+
+.ease-tabs .ease-tab-list {
+  display: flex;
+  position: relative;
+  border-bottom: 1px solid var(--ease-border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.ease-tabs .ease-tab-list::-webkit-scrollbar {
+  display: none;
+}
+
+.ease-tabs .ease-tab {
+  padding: 0.85rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ease-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--ease-tabs-speed) ease;
+  user-select: none;
+}
+
+.ease-tabs .ease-tab:hover {
+  color: var(--ease-text);
+}
+
+.ease-tabs .ease-tabs-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: var(--ease-tabs-accent);
+  transition: transform var(--ease-tabs-speed) cubic-bezier(0.16, 1, 0.3, 1), width var(--ease-tabs-speed) ease;
+}
+
+.ease-tabs .ease-panels {
+  position: relative;
+  padding-top: 1.5rem;
+}
+
+.ease-tabs .ease-tab-panel {
+  display: none;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity var(--ease-tabs-speed) ease, transform var(--ease-tabs-speed) ease;
+}
+
+.ease-tabs .ease-tab-panel h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ease-tabs-accent);
+  font-size: 1.15rem;
+}
+
+.ease-tabs .ease-tab-panel p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.95rem;
+}
+
+.ease-tabs #tab-1:checked ~ .ease-tab-list .ease-tabs-indicator {
+  width: 110px;
+  transform: translateX(0px);
+}
+.ease-tabs #tab-1:checked ~ .ease-tab-list .ease-tab[for="tab-1"] {
+  color: var(--ease-text);
+}
+
+.ease-tabs #tab-2:checked ~ .ease-tab-list .ease-tabs-indicator {
+  width: 105px;
+  transform: translateX(110px);
+}
+.ease-tabs #tab-2:checked ~ .ease-tab-list .ease-tab[for="tab-2"] {
+  color: var(--ease-text);
+}
+
+.ease-tabs #tab-3:checked ~ .ease-tab-list .ease-tabs-indicator {
+  width: 115px;
+  transform: translateX(215px);
+}
+.ease-tabs #tab-3:checked ~ .ease-tab-list .ease-tab[for="tab-3"] {
+  color: var(--ease-text);
+}
+
+.ease-tabs #tab-1:checked ~ .ease-panels #panel-1,
+.ease-tabs #tab-2:checked ~ .ease-panels #panel-2,
+.ease-tabs #tab-3:checked ~ .ease-panels #panel-3 {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Pull Request Description
Closes #79550

Adds the pure CSS animated tabs component with a smooth sliding underline indicator and fade-in content panels under `submissions/examples/ease-tabs/`.

## Type of Change
- [x] ✨ New component example
- [x] 🎨 CSS helper / enhancement

## Submission Checklist
- [x] All submission files placed inside `submissions/examples/ease-tabs/`
- [x] Includes `style.css`, `demo.html`, and `README.md`
- [x] Zero JavaScript usage (pure CSS radio + `:checked` architecture)
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** A classic tabbed interface with zero JS, featuring a sliding underline indicator (`transform: translateX()`), smooth tab content fade-ins, and a responsive mobile scroll container.
**Why does it fit?** Fills the standalone tab navigation component requirement in EaseMotion CSS.

## Demo
- [x] Interactive demo page added (`demo.html`)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari