### PR TITLE
docs: add theming configuration guide for saas modern offcanvas drawer

### DIFF
--- a/submissions/docs/saas-offcanvas-drawer-theming/README.md
+++ b/submissions/docs/saas-offcanvas-drawer-theming/README.md
@@ -1,0 +1,68 @@
+# SaaS Modern Offcanvas Drawer (Theming Configuration Guide)
+
+This guide documents how to easily theme the SaaS Modern Offcanvas Drawer using CSS Custom Properties. Many modern SaaS applications require both Light and Dark modes. By defining structural colors as CSS variables, we can toggle themes instantly without rewriting the complex drawer layout or animation logic.
+
+## Theming Architecture
+
+The colors for the drawer background, text, borders, and footer are mapped to CSS variables at the `:root` level. 
+
+### Core Variables (Default Light Theme)
+```css
+:root {
+    --drawer-bg: #ffffff;
+    --drawer-text: #0f172a;
+    --drawer-text-muted: #64748b;
+    --drawer-border: #e2e8f0;
+    --drawer-footer-bg: #f8fafc;
+    
+    --drawer-close-hover: #f1f5f9;
+    --focus-ring: #3b82f6;
+}
+```
+
+## Creating a Dark Theme Modifier
+
+To create a dark theme, define a modifier class (e.g., `.drawer-theme-dark`) that overrides these core variables.
+
+### CSS Example
+
+```css
+/* Custom Dark Theme Modifier */
+.drawer-theme-dark {
+    --drawer-bg: #0f172a;
+    --drawer-text: #f8fafc;
+    --drawer-text-muted: #94a3b8;
+    --drawer-border: #334155;
+    --drawer-footer-bg: #1e293b;
+    
+    --drawer-close-hover: #334155;
+    
+    /* Lighter blue to maintain contrast against the dark background */
+    --focus-ring: #60a5fa; 
+}
+```
+
+### HTML Implementation
+
+Apply the modifier class directly to the root `<aside>` element of the drawer.
+
+```html
+<!-- Default (Light) Drawer -->
+<aside class="saas-drawer" role="dialog" aria-modal="true">
+    ...
+</aside>
+
+<!-- Dark Mode Drawer -->
+<aside class="saas-drawer drawer-theme-dark" role="dialog" aria-modal="true">
+    ...
+</aside>
+```
+
+## Theming & Accessibility 
+
+When creating custom themes for a drawer, pay close attention to the following accessibility requirements:
+
+1. **Focus Ring Contrast**: Notice how the `--focus-ring` variable was changed from `#3b82f6` (standard blue) to `#60a5fa` (lighter blue) in the dark theme. Focus rings must maintain a high contrast ratio against the background color they sit on.
+2. **Backdrop Separation**: The darkened backdrop (`.drawer-backdrop`) generally does not need to be themed, as it is a semi-transparent black overlay that works on both light and dark backgrounds. However, ensure it remains a separate HTML element from the drawer itself.
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/saas-offcanvas-drawer-theming/demo.html
+++ b/submissions/docs/saas-offcanvas-drawer-theming/demo.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SaaS Offcanvas Drawer (Theming) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main class="demo-container">
+        
+        <div class="demo-actions">
+            <!-- Trigger for Default Light Theme -->
+            <button type="button" class="saas-btn trigger-light" aria-expanded="false" aria-controls="drawer-light">
+                Open Light Drawer
+            </button>
+            
+            <!-- Trigger for Dark Theme Modifier -->
+            <button type="button" class="saas-btn btn-dark trigger-dark" aria-expanded="false" aria-controls="drawer-dark">
+                Open Dark Drawer
+            </button>
+        </div>
+
+        <!-- Shared Backdrop -->
+        <div class="drawer-backdrop" aria-hidden="true" id="drawer-backdrop"></div>
+
+        <!-- Default Light Drawer -->
+        <aside class="saas-drawer" id="drawer-light" role="dialog" aria-modal="true" aria-labelledby="title-light" hidden>
+            <div class="drawer-header">
+                <h2 id="title-light" class="drawer-title">Light Theme</h2>
+                <button type="button" class="drawer-close" aria-label="Close">✕</button>
+            </div>
+            <div class="drawer-body">
+                <p>Standard SaaS interface styling.</p>
+                <input type="text" class="saas-input" placeholder="Input example">
+            </div>
+            <div class="drawer-footer">
+                <button type="button" class="saas-btn drawer-close">Close</button>
+            </div>
+        </aside>
+
+        <!-- Dark Theme Drawer (.drawer-theme-dark) -->
+        <aside class="saas-drawer drawer-theme-dark" id="drawer-dark" role="dialog" aria-modal="true" aria-labelledby="title-dark" hidden>
+            <div class="drawer-header">
+                <h2 id="title-dark" class="drawer-title">Dark Theme</h2>
+                <button type="button" class="drawer-close" aria-label="Close">✕</button>
+            </div>
+            <div class="drawer-body">
+                <p>Ideal for developer tools and dark-mode dashboards.</p>
+                <input type="text" class="saas-input" placeholder="Input example">
+            </div>
+            <div class="drawer-footer">
+                <button type="button" class="saas-btn drawer-close">Close</button>
+            </div>
+        </aside>
+
+    </main>
+
+    <script>
+        const backdrop = document.getElementById('drawer-backdrop');
+        let activeDrawer = null;
+
+        function openDrawer(id) {
+            activeDrawer = document.getElementById(id);
+            activeDrawer.removeAttribute('hidden');
+            backdrop.classList.add('is-active');
+            
+            setTimeout(() => {
+                activeDrawer.classList.add('is-open');
+            }, 10);
+        }
+
+        function closeDrawer() {
+            if (!activeDrawer) return;
+            activeDrawer.classList.remove('is-open');
+            backdrop.classList.remove('is-active');
+            
+            const currentDrawer = activeDrawer;
+            setTimeout(() => {
+                currentDrawer.setAttribute('hidden', '');
+            }, 300);
+            
+            activeDrawer = null;
+        }
+
+        document.querySelector('.trigger-light').addEventListener('click', () => openDrawer('drawer-light'));
+        document.querySelector('.trigger-dark').addEventListener('click', () => openDrawer('drawer-dark'));
+        
+        backdrop.addEventListener('click', closeDrawer);
+        document.querySelectorAll('.drawer-close').forEach(btn => btn.addEventListener('click', closeDrawer));
+    </script>
+</body>
+</html>

--- a/submissions/docs/saas-offcanvas-drawer-theming/style.css
+++ b/submissions/docs/saas-offcanvas-drawer-theming/style.css
@@ -1,0 +1,172 @@
+:root {
+    --bg-color: #f8fafc;
+    
+    /* Drawer Base Theme (Light) */
+    --drawer-bg: #ffffff;
+    --drawer-text: #0f172a;
+    --drawer-text-muted: #64748b;
+    --drawer-border: #e2e8f0;
+    --drawer-footer-bg: #f8fafc;
+    
+    --drawer-close-hover: #f1f5f9;
+    --input-bg: #ffffff;
+    
+    --primary: #3b82f6;
+    --focus-ring: #3b82f6;
+}
+
+/* 
+ * THEMING CONFIGURATION
+ * Dark Mode Theme Modifier 
+ */
+.drawer-theme-dark {
+    --drawer-bg: #0f172a;
+    --drawer-text: #f8fafc;
+    --drawer-text-muted: #94a3b8;
+    --drawer-border: #334155;
+    --drawer-footer-bg: #1e293b;
+    
+    --drawer-close-hover: #334155;
+    --input-bg: #1e293b;
+    
+    --primary: #60a5fa; /* Lighter blue for dark mode contrast */
+    --focus-ring: #60a5fa;
+}
+
+body {
+    margin: 0;
+    background-color: var(--bg-color);
+    font-family: system-ui, -apple-system, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.demo-actions {
+    display: flex;
+    gap: 1rem;
+}
+
+.saas-btn {
+    padding: 0.75rem 1.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid var(--primary);
+    background-color: var(--primary);
+    color: white;
+}
+
+.saas-btn.btn-dark {
+    background-color: #0f172a;
+    border-color: #0f172a;
+}
+
+.drawer-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(15, 23, 42, 0.4);
+    z-index: 40;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease;
+}
+
+.drawer-backdrop.is-active {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* The Drawer Component */
+.saas-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 100%;
+    max-width: 400px;
+    height: 100vh;
+    
+    /* Applying the variables */
+    background-color: var(--drawer-bg);
+    color: var(--drawer-text);
+    
+    box-shadow: -10px 0 25px -5px rgba(0, 0, 0, 0.1);
+    z-index: 50;
+    
+    display: flex;
+    flex-direction: column;
+    
+    transform: translateX(100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.saas-drawer.is-open {
+    transform: translateX(0);
+}
+
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--drawer-border);
+}
+
+.drawer-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.drawer-close {
+    background: none;
+    border: none;
+    color: var(--drawer-text-muted);
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.drawer-close:hover {
+    background-color: var(--drawer-close-hover);
+    color: var(--drawer-text);
+}
+
+.drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.5rem;
+}
+
+.saas-input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--input-bg);
+    color: var(--drawer-text);
+    border: 1px solid var(--drawer-border);
+    border-radius: 6px;
+    margin-top: 1rem;
+    box-sizing: border-box;
+}
+
+.drawer-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 1.25rem 1.5rem;
+    border-top: 1px solid var(--drawer-border);
+    background-color: var(--drawer-footer-bg);
+}
+
+/* Accessibility */
+.drawer-close:focus-visible,
+.saas-input:focus-visible,
+.saas-btn:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+}


### PR DESCRIPTION
fixes #85745 

## Pull Request Description

This PR introduces the Theming Configuration guide for the SaaS Modern Offcanvas Drawer component. Modern enterprise applications require the ability to rapidly toggle between light and dark modes without restructuring the underlying UI code. This documentation demonstrates a robust CSS Custom Property architecture that isolates the drawer's background, text, border, and focus-ring colors into root-level variables. It provides a modifier class (`.drawer-theme-dark`) that seamlessly overrides these variables to instantly convert the standard light drawer into a premium, high-contrast dark mode variant.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a guide on implementing scalable themes for offcanvas side panels. By defining the drawer's palette at the top of the CSS file as variables, developers can apply a modifier class directly to the `<aside>` element to flip the theme on the fly. Crucially, the guide documents the accessibility requirement of adjusting the `--focus-ring` variable specifically for dark mode (using a lighter blue) to ensure keyboard navigation outlines remain WCAG-compliant against dark backgrounds.

**How does a developer use it?**

```css
/* Core Variables */
:root {
    --drawer-bg: #ffffff;
    --drawer-text: #0f172a;
    --focus-ring: #3b82f6; /* Standard blue for light backgrounds */
}

/* Modifier Class overrides variables */
.drawer-theme-dark {
    --drawer-bg: #0f172a;
    --drawer-text: #f8fafc;
    --focus-ring: #60a5fa; /* Lighter blue for dark backgrounds */
}
