### PR TITLE
feat(scss): Add SCSS Perspective 3D Transform helper mixins (#81287)

### DIFF
--- a/submissions/examples/perspective-3d-scss/README.md
+++ b/submissions/examples/perspective-3d-scss/README.md
@@ -1,0 +1,17 @@
+# SCSS Perspective 3D Transform Helper Mixins
+
+An SCSS helper mixin suite for configuring 3D perspective depth (`perspective`), preserving 3D nested layouts (`transform-style: preserve-3d`), and building smooth card tilt and flip animations.
+
+## Overview & Features
+- `perspective($value)`: Sets 3D perspective depth with WebKit vendor prefix support.
+- `preserve-3d()`: Enables nested 3D element rendering space.
+- `perspective-container($depth)`: Shorthand combination mixin for depth staging.
+- `perspective-theme($variant)`: Preset theme selectors supporting default, deep, and shallow depth variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+.card-scene {
+  @include perspective-theme('default');
+}

--- a/submissions/examples/perspective-3d-scss/_mixins.scss
+++ b/submissions/examples/perspective-3d-scss/_mixins.scss
@@ -1,0 +1,35 @@
+// ==========================================================================
+// Perspective 3D Transform Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Sets 3D perspective for an element's children to establish depth.
+/// @param {Length | String} $value [1000px] - Perspective depth value.
+@mixin perspective($value: 1000px) {
+  perspective: $value;
+  -webkit-perspective: $value;
+}
+
+/// Preserves 3D positioning for nested children elements during transformations.
+@mixin preserve-3d {
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
+}
+
+/// Combines perspective and preserve-3d for advanced 3D card tilt and flip effects.
+/// @param {Length | String} $depth [1000px] - Perspective depth value.
+@mixin perspective-container($depth: 1000px) {
+  @include perspective($depth);
+  @include preserve-3d();
+}
+
+/// Applies preset perspective 3D theme variations.
+/// @param {String} $variant [default] - Preset variant (default, deep, shallow).
+@mixin perspective-theme($variant: 'default') {
+  @if $variant == 'default' {
+    @include perspective-container(1000px);
+  } @else if $variant == 'deep' {
+    @include perspective-container(1500px);
+  } @else if $variant == 'shallow' {
+    @include perspective-container(600px);
+  }
+}

--- a/submissions/examples/perspective-3d-scss/demo.html
+++ b/submissions/examples/perspective-3d-scss/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Perspective 3D Transform — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-3d-scene">
+        <div class="ease-3d-box">
+          <h3>3D Tilt Container</h3>
+          <p>Hover to interact with perspective depth and 3D transform animations.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/perspective-3d-scss/style.css
+++ b/submissions/examples/perspective-3d-scss/style.css
@@ -1,0 +1,78 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.ease-3d-scene {
+  width: 100%;
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1000px;
+  -webkit-perspective: 1000px;
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
+}
+
+.ease-3d-box {
+  width: 220px;
+  height: 140px;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1.25rem;
+  text-align: center;
+  transform: rotateX(12deg) rotateY(-18deg);
+  transition: transform 0.4s ease, border-color 0.4s ease;
+  box-shadow: 0 15px 30px -10px rgba(6, 182, 212, 0.2);
+}
+.ease-3d-box:hover {
+  transform: rotateX(0deg) rotateY(0deg) scale(1.05);
+  border-color: var(--ease-cyan);
+}
+.ease-3d-box h3 {
+  margin: 0 0 0.4rem;
+  color: var(--ease-cyan);
+  font-size: 1.05rem;
+}
+.ease-3d-box p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.85rem;
+}

--- a/submissions/examples/perspective-3d-scss/style.scss
+++ b/submissions/examples/perspective-3d-scss/style.scss
@@ -1,0 +1,79 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.ease-3d-scene {
+  width: 100%;
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  @include perspective-theme('default');
+}
+
+.ease-3d-box {
+  width: 220px;
+  height: 140px;
+  background: #030712;
+  border: 1px solid var(--ease-border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1.25rem;
+  text-align: center;
+  transform: rotateX(12deg) rotateY(-18deg);
+  transition: transform 0.4s ease, border-color 0.4s ease;
+  box-shadow: 0 15px 30px -10px rgba(6, 182, 212, 0.2);
+
+  &:hover {
+    transform: rotateX(0deg) rotateY(0deg) scale(1.05);
+    border-color: var(--ease-cyan);
+  }
+
+  h3 {
+    margin: 0 0 0.4rem;
+    color: var(--ease-cyan);
+    font-size: 1.05rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81287

Adds custom SCSS perspective 3D transform helper mixins (`perspective()`, `preserve-3d()`, `perspective-container()`, and `perspective-theme()`) under `submissions/examples/perspective-3d-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/perspective-3d-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for 3D perspective depth and transformation contexts (`perspective` and `transform-style: preserve-3d`) tailored for card tilt and 3D animations.
**Why does it fit?** Expands developer 3D spatial layout utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari