### PR TITLE
feat: add macOS-style magnetic floating dock navigation component

### DIFF
--- a/submissions/examples/magnetic-dock-navigation-gssoc26/README.md
+++ b/submissions/examples/magnetic-dock-navigation-gssoc26/README.md
@@ -1,0 +1,14 @@
+# macOS-Style Magnetic Floating Dock Component
+
+A CSS-powered floating dock navigation component with magnetic scale physics, neighbor magnification, backdrop blur, and custom tooltips.
+
+## What does this do?
+This component replicates the sleek macOS dock bar behavior using pure CSS custom transitions, `:has()` selectors, transform scaling, and backdrop filters for floating navigation menus.
+
+## How is it used?
+1. Open `demo.html` to preview the magnetic magnification effect.
+2. Integrate the `.magnetic-dock` structural markup into your navigation header or footer.
+3. Import `style.css` into your stylesheet or web project.
+
+## Why is it useful?
+Provides an intuitive, desktop-class navigation pattern for web dashboards and portfolios. Operating without JavaScript event listeners keeps layout recalculations off the main thread, maintaining smooth 60fps animations.

--- a/submissions/examples/magnetic-dock-navigation-gssoc26/demo.html
+++ b/submissions/examples/magnetic-dock-navigation-gssoc26/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Magnetic Dock Navigation - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="dock-demo-container">
+    <div class="demo-header">
+      <h2>macOS-Style Magnetic Floating Dock</h2>
+      <p>Hover over items to observe smooth CSS magnification scale curves & physics tooltips.</p>
+    </div>
+
+    <nav class="magnetic-dock" aria-label="Application Dock">
+      <div class="dock-item" data-tooltip="Finder">
+        <span class="dock-icon">📁</span>
+        <span class="active-dot"></span>
+      </div>
+      <div class="dock-item" data-tooltip="Launchpad">
+        <span class="dock-icon">🚀</span>
+      </div>
+      <div class="dock-item" data-tooltip="Terminal">
+        <span class="dock-icon">💻</span>
+        <span class="active-dot"></span>
+      </div>
+      <div class="dock-item" data-tooltip="Code Editor">
+        <span class="dock-icon">📝</span>
+      </div>
+      <div class="dock-separator"></div>
+      <div class="dock-item" data-tooltip="Settings">
+        <span class="dock-icon">⚙️</span>
+      </div>
+      <div class="dock-item" data-tooltip="Trash">
+        <span class="dock-icon">🗑️</span>
+      </div>
+    </nav>
+  </div>
+</body>
+</html>

--- a/submissions/examples/magnetic-dock-navigation-gssoc26/style.css
+++ b/submissions/examples/magnetic-dock-navigation-gssoc26/style.css
@@ -1,0 +1,133 @@
+:root {
+  --dock-bg: rgba(15, 23, 42, 0.75);
+  --dock-border: rgba(255, 255, 255, 0.15);
+  --dock-blur: blur(20px);
+  --item-bg: rgba(255, 255, 255, 0.08);
+  --item-hover-bg: rgba(255, 255, 255, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at 50% 100%, #1e293b 0%, #020617 100%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #f8fafc;
+}
+
+.dock-demo-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
+  width: 100%;
+}
+
+.demo-header {
+  text-align: center;
+}
+
+.demo-header h2 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.demo-header p {
+  color: #94a3b8;
+}
+
+.magnetic-dock {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--dock-bg);
+  backdrop-filter: var(--dock-blur);
+  -webkit-backdrop-filter: var(--dock-blur);
+  border: 1px solid var(--dock-border);
+  border-radius: 24px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+}
+
+.dock-item {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  background: var(--item-bg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transform-origin: bottom center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.2s ease;
+}
+
+.dock-icon {
+  font-size: 1.6rem;
+  user-select: none;
+  transition: transform 0.2s ease;
+}
+
+.dock-item:hover {
+  transform: scale(1.4) translateY(-12px);
+  background: var(--item-hover-bg);
+  z-index: 10;
+}
+
+/* Neighbor hover scaling emulation */
+.dock-item:hover + .dock-item,
+.dock-item:has(+ .dock-item:hover) {
+  transform: scale(1.2) translateY(-6px);
+}
+
+.active-dot {
+  position: absolute;
+  bottom: -6px;
+  width: 4px;
+  height: 4px;
+  background: #38bdf8;
+  border-radius: 50%;
+  box-shadow: 0 0 8px #38bdf8;
+}
+
+/* Tooltip */
+.dock-item::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: -42px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.dock-item:hover::before {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.dock-separator {
+  width: 1px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 0 0.25rem;
+  align-self: center;
+}


### PR DESCRIPTION
# Related Issue
Closes #86557

# Summary
Adds a macOS-inspired floating dock navigation component using pure CSS transform scaling.

# Changes Made
- Added `submissions/examples/magnetic-dock-navigation-gssoc26/demo.html`
- Added `submissions/examples/magnetic-dock-navigation-gssoc26/style.css`
- Added `submissions/examples/magnetic-dock-navigation-gssoc26/README.md`

# Testing
- Tested hover magnification and tooltip visibility across modern desktop browsers.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
