### PR TITLE
feat(scss): Add SCSS Keyframe Animation Generator helper mixins (#81286)

### DIFF
--- a/submissions/examples/keyframe-animation-generator-scss/README.md
+++ b/submissions/examples/keyframe-animation-generator-scss/README.md
@@ -1,0 +1,21 @@
+# SCSS Keyframe Animation Generator Helper Mixins
+
+An SCSS helper mixin suite for automating cross-browser `@keyframes` rule creation and animation property assignments.
+
+## Overview & Features
+- `keyframes($name)`: Generates both standard and `-webkit-` vendor-prefixed `@keyframes` declarations.
+- `animate(...)`: Applies comprehensive animation timing, duration, delay, and iteration properties.
+- `animation-theme($variant)`: Preset theme selectors supporting pulse, float, and bounce variations.
+
+## Usage Example
+```scss
+@use 'mixins' as *;
+
+@include keyframes(fade-in) {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.element {
+  @include animate(fade-in, 1s, ease);
+}

--- a/submissions/examples/keyframe-animation-generator-scss/_mixins.scss
+++ b/submissions/examples/keyframe-animation-generator-scss/_mixins.scss
@@ -1,0 +1,52 @@
+// ==========================================================================
+// Keyframe Animation Generator Helper Mixins — EaseMotion SCSS Suite
+// ==========================================================================
+
+/// Generates cross-browser `@keyframes` rules with standard and WebKit vendor prefixes.
+/// @param {String} $name - Animation identifier name.
+@mixin keyframes($name) {
+  @-webkit-keyframes #{$name} {
+    @content;
+  }
+  @keyframes #{$name} {
+    @content;
+  }
+}
+
+/// Applies animation properties to an element with customizable duration, timing, and iteration settings.
+/// @param {String} $animation-name - Name of the keyframe animation.
+/// @param {Duration} $duration [1s] - Animation duration.
+/// @param {String} $timing [ease] - Animation timing function.
+/// @param {Duration} $delay [0s] - Animation delay.
+/// @param {Number | String} $iteration [infinite] - Iteration count.
+/// @param {String} $direction [normal] - Animation direction.
+/// @param {String} $fill-mode [both] - Animation fill mode.
+@mixin animate(
+  $animation-name,
+  $duration: 1s,
+  $timing: ease,
+  $delay: 0s,
+  $iteration: infinite,
+  $direction: normal,
+  $fill-mode: both
+) {
+  animation-name: $animation-name;
+  animation-duration: $duration;
+  animation-timing-function: $timing;
+  animation-delay: $delay;
+  animation-iteration-count: $iteration;
+  animation-direction: $direction;
+  animation-fill-mode: $fill-mode;
+}
+
+/// Applies preset keyframe animation theme variations.
+/// @param {String} $variant [pulse] - Preset animation variant (pulse, float, bounce).
+@mixin animation-theme($variant: 'pulse') {
+  @if $variant == 'pulse' {
+    @include animate(ease-pulse, 2s, ease-in-out, 0s, infinite);
+  } @else if $variant == 'float' {
+    @include animate(ease-float, 3s, ease-in-out, 0s, infinite);
+  } @else if $variant == 'bounce' {
+    @include animate(ease-bounce, 1.5s, ease-in-out, 0s, infinite);
+  }
+}

--- a/submissions/examples/keyframe-animation-generator-scss/demo.html
+++ b/submissions/examples/keyframe-animation-generator-scss/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCSS Keyframe Animation Generator — Showcase & Usage</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="ease-container">
+    <div class="ease-card">
+      <div class="ease-animated-box">
+        <h3>Pulse Animation</h3>
+        <p>Demonstrates automated keyframe generation and animation properties.</p>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/keyframe-animation-generator-scss/style.css
+++ b/submissions/examples/keyframe-animation-generator-scss/style.css
@@ -1,0 +1,86 @@
+@charset "UTF-8";
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+@-webkit-keyframes ease-pulse {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 15px rgba(6, 182, 212, 0.2);
+  }
+  50% {
+    transform: scale(1.03);
+    box-shadow: 0 0 30px rgba(6, 182, 212, 0.5);
+  }
+}
+@keyframes ease-pulse {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 15px rgba(6, 182, 212, 0.2);
+  }
+  50% {
+    transform: scale(1.03);
+    box-shadow: 0 0 30px rgba(6, 182, 212, 0.5);
+  }
+}
+.ease-animated-box {
+  width: 220px;
+  height: 140px;
+  background: #030712;
+  border: 1px solid var(--ease-cyan);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1.25rem;
+  text-align: center;
+  animation-name: ease-pulse;
+  animation-duration: 2s;
+  animation-timing-function: ease-in-out;
+  animation-delay: 0s;
+  animation-iteration-count: infinite;
+  animation-direction: normal;
+  animation-fill-mode: both;
+}
+.ease-animated-box h3 {
+  margin: 0 0 0.4rem;
+  color: var(--ease-cyan);
+  font-size: 1.05rem;
+}
+.ease-animated-box p {
+  margin: 0;
+  color: var(--ease-muted);
+  font-size: 0.85rem;
+}

--- a/submissions/examples/keyframe-animation-generator-scss/style.scss
+++ b/submissions/examples/keyframe-animation-generator-scss/style.scss
@@ -1,0 +1,75 @@
+@use 'mixins' as *;
+
+:root {
+  --ease-bg: #030712;
+  --ease-card-bg: #0b0f19;
+  --ease-border: #1f293d;
+  --ease-text: #f3f4f6;
+  --ease-cyan: #06b6d4;
+  --ease-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--ease-bg);
+  color: var(--ease-text);
+  padding: 3rem 1.5rem;
+  line-height: 1.5;
+}
+
+.ease-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ease-card {
+  padding: 2.5rem;
+  background: var(--ease-card-bg);
+  border: 1px solid var(--ease-border);
+  border-radius: 16px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+// Generate Keyframe Rules via Mixin
+@include keyframes(ease-pulse) {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 15px rgba(6, 182, 212, 0.2);
+  }
+  50% {
+    transform: scale(1.03);
+    box-shadow: 0 0 30px rgba(6, 182, 212, 0.5);
+  }
+}
+
+.ease-animated-box {
+  width: 220px;
+  height: 140px;
+  background: #030712;
+  border: 1px solid var(--ease-cyan);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 1.25rem;
+  text-align: center;
+  @include animation-theme('pulse');
+
+  h3 {
+    margin: 0 0 0.4rem;
+    color: var(--ease-cyan);
+    font-size: 1.05rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ease-muted);
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Pull Request Description
Closes #81286

Adds custom SCSS keyframe animation generator helper mixins (`keyframes()`, `animate()`, and `animation-theme()`) under `submissions/examples/keyframe-animation-generator-scss/`.

## Type of Change
- [x] ✨ New animation / hover effect / SCSS helper mixin
- [x] 🧩 New component example

## Submission Checklist
- [x] All submission files inside `submissions/examples/keyframe-animation-generator-scss/`
- [x] Includes `_mixins.scss`, `style.scss`, `style.css`, `demo.html`, and `README.md`
- [x] Clean SCSS compilation using Dart Sass (`npx sass style.scss style.css`)
- [x] Zero changes to root `core/` or `scss/` directories
- [x] Full compatibility with core EaseMotion CSS tokens

## Feature Description
**What does this add?** Reusable SCSS mixins for automated cross-browser `@keyframes` generation and animation property bindings.
**Why does it fit?** Expands developer animation and motion utilities inside the `submissions/` directory.

## Demo
- [x] Demo added

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari