### PR TITLE
feat: add interactive command palette modal component

### DIFF
--- a/submissions/examples/interactive-command-palette-modal-gssoc26/README.md
+++ b/submissions/examples/interactive-command-palette-modal-gssoc26/README.md
@@ -1,0 +1,14 @@
+# Interactive Command Palette (Spotlight Search) Modal Component
+
+An accessible, keyboard-first CSS Command Palette overlay (⌘K style spotlight search modal) with smooth scale-in transitions, glassmorphic backdrop filters, and item highlight states.
+
+## What does this do?
+Provides a centered command menu overlay featuring search inputs, categorized command groups, keyboard shortcut indicators (`⌘D`, `⌘T`), and spring-scale modal entrance keyframe animations.
+
+## How is it used?
+1. Open `demo.html` to preview the command palette layout and entry transitions.
+2. Incorporate the `.cmd-dialog` container into your global application layout or modal portal.
+3. Import `style.css` to enable backdrop blur and entrance animation keyframes.
+
+## Why is it useful?
+Command palettes are essential power-user navigation patterns in modern web applications (like VS Code, Linear, and Raycast). CSS-driven scale keyframes guarantee smooth 60fps presentation upon activation.

--- a/submissions/examples/interactive-command-palette-modal-gssoc26/demo.html
+++ b/submissions/examples/interactive-command-palette-modal-gssoc26/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Command Palette Modal - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="cmd-palette-wrapper">
+    <div class="cmd-backdrop"></div>
+    <div class="cmd-dialog" role="dialog" aria-modal="true" aria-label="Command Palette">
+      <div class="cmd-search-bar">
+        <span class="search-icon">🔍</span>
+        <input type="text" class="cmd-input" placeholder="Type a command or search documentation..." autofocus>
+        <span class="cmd-kbd">ESC</span>
+      </div>
+
+      <div class="cmd-results">
+        <div class="cmd-group-label">Quick Actions</div>
+        
+        <div class="cmd-item active">
+          <span class="cmd-icon">🚀</span>
+          <div class="cmd-text">
+            <span class="cmd-title">Deploy Production Motion Build</span>
+            <span class="cmd-sub">Trigger CI/CD deployment pipeline</span>
+          </div>
+          <span class="cmd-shortcut">⌘D</span>
+        </div>
+
+        <div class="cmd-item">
+          <span class="cmd-icon">🎨</span>
+          <div class="cmd-text">
+            <span class="cmd-title">Toggle Dark / Light Theme Tokens</span>
+            <span class="cmd-sub">Switch active CSS variables</span>
+          </div>
+          <span class="cmd-shortcut">⌘T</span>
+        </div>
+
+        <div class="cmd-group-label">Navigation</div>
+
+        <div class="cmd-item">
+          <span class="cmd-icon">📚</span>
+          <div class="cmd-text">
+            <span class="cmd-title">View Motion Engine Docs</span>
+            <span class="cmd-sub">Explore easing curve presets</span>
+          </div>
+          <span class="cmd-shortcut">⌘G</span>
+        </div>
+      </div>
+      
+      <div class="cmd-footer">
+        <span>Use <kbd>↑</kbd> <kbd>↓</kbd> to navigate</span>
+        <span><kbd>↵</kbd> to select</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/interactive-command-palette-modal-gssoc26/style.css
+++ b/submissions/examples/interactive-command-palette-modal-gssoc26/style.css
@@ -1,0 +1,162 @@
+:root {
+  --modal-bg: rgba(15, 23, 42, 0.85);
+  --modal-border: rgba(255, 255, 255, 0.15);
+  --modal-blur: blur(24px);
+  --item-active-bg: rgba(99, 102, 241, 0.25);
+  --item-active-border: #6366f1;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: #090d16;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #f8fafc;
+}
+
+.cmd-palette-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  padding: 1rem;
+}
+
+.cmd-dialog {
+  background: var(--modal-bg);
+  backdrop-filter: var(--modal-blur);
+  -webkit-backdrop-filter: var(--modal-blur);
+  border: 1px solid var(--modal-border);
+  border-radius: 20px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+  animation: modalScaleIn 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes modalScaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.cmd-search-bar {
+  display: flex;
+  align-items: center;
+  padding: 1.2rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  gap: 0.8rem;
+}
+
+.search-icon {
+  font-size: 1.2rem;
+  opacity: 0.6;
+}
+
+.cmd-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 1.1rem;
+}
+
+.cmd-input::placeholder {
+  color: #64748b;
+}
+
+.cmd-kbd {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.cmd-results {
+  padding: 1rem;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.cmd-group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin: 0.5rem 0.5rem 0.5rem;
+}
+
+.cmd-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.cmd-item:hover,
+.cmd-item.active {
+  background: var(--item-active-bg);
+  border-left: 3px solid var(--item-active-border);
+}
+
+.cmd-icon {
+  font-size: 1.3rem;
+}
+
+.cmd-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.cmd-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.cmd-sub {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.cmd-shortcut {
+  font-size: 0.8rem;
+  color: #818cf8;
+  font-weight: 600;
+}
+
+.cmd-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.8rem 1.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+kbd {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  color: #cbd5e1;
+}


### PR DESCRIPTION
# Related Issue
Closes #86562

# Summary
Adds a keyboard-first Command Palette Modal component with scale-in entrance keyframes and glassmorphic backdrop filters.

# Changes Made
- Added `submissions/examples/interactive-command-palette-modal-gssoc26/demo.html`
- Added `submissions/examples/interactive-command-palette-modal-gssoc26/style.css`
- Added `submissions/examples/interactive-command-palette-modal-gssoc26/README.md`

# Testing
- Tested modal entrance keyframe smoothness and responsive viewport bounds.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
