### PR TITLE
feat: add claymorphic dashboard metric widgets component

### DIFF
--- a/submissions/examples/claymorphic-dashboard-widgets-gssoc26/README.md
+++ b/submissions/examples/claymorphic-dashboard-widgets-gssoc26/README.md
@@ -1,0 +1,14 @@
+# Claymorphic Dashboard Metric Widgets Component
+
+A tactile, inflated 3D Claymorphic Dashboard Widget collection featuring dual inner/drop shadow physics and spring hover scaling.
+
+## What does this do?
+This component renders soft 3D claymorphic UI card widgets using CSS dual `inset` and outer `box-shadow` properties, rounded border radiuses, and floating metric badges.
+
+## How is it used?
+1. Open `demo.html` to preview the claymorphic card grid.
+2. Incorporate `.clay-card` elements into your analytics dashboard or SaaS control panel.
+3. Include `style.css` in your project stylesheet.
+
+## Why is it useful?
+Claymorphism adds a modern, friendly touch to dashboard interfaces. By utilizing hardware-accelerated CSS spring transforms (`scale`, `translateY`), widgets remain smooth and responsive across viewports.

--- a/submissions/examples/claymorphic-dashboard-widgets-gssoc26/demo.html
+++ b/submissions/examples/claymorphic-dashboard-widgets-gssoc26/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Claymorphic Dashboard Widgets - EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="clay-dashboard">
+    <header class="clay-header">
+      <h1>Claymorphic Analytics Dashboard</h1>
+      <p>Soft 3D inner shadows and floating micro-interaction widgets.</p>
+    </header>
+
+    <div class="clay-grid">
+      <div class="clay-card clay-purple">
+        <div class="clay-icon">📈</div>
+        <div class="clay-info">
+          <h3>Total Revenue</h3>
+          <span class="clay-value">$142,850</span>
+          <span class="clay-badge positive">+18.4%</span>
+        </div>
+      </div>
+
+      <div class="clay-card clay-blue">
+        <div class="clay-icon">👥</div>
+        <div class="clay-info">
+          <h3>Active Users</h3>
+          <span class="clay-value">28,490</span>
+          <span class="clay-badge positive">+12.1%</span>
+        </div>
+      </div>
+
+      <div class="clay-card clay-pink">
+        <div class="clay-icon">⚡</div>
+        <div class="clay-info">
+          <h3>Motion FPS</h3>
+          <span class="clay-value">59.9 FPS</span>
+          <span class="clay-badge neutral">Stable</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/submissions/examples/claymorphic-dashboard-widgets-gssoc26/style.css
+++ b/submissions/examples/claymorphic-dashboard-widgets-gssoc26/style.css
@@ -1,0 +1,130 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: #f0f4f9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  color: #1e293b;
+}
+
+.clay-dashboard {
+  max-width: 960px;
+  width: 100%;
+}
+
+.clay-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.clay-header h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #334155;
+}
+
+.clay-header p {
+  color: #64748b;
+  margin-top: 0.5rem;
+}
+
+.clay-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.clay-card {
+  position: relative;
+  padding: 2rem;
+  border-radius: 32px;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  cursor: pointer;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.3s ease;
+}
+
+/* Claymorphic dual inner-and-drop shadows */
+.clay-purple {
+  background: #e0e7ff;
+  box-shadow: 
+    16px 16px 32px #c7d2fe, 
+    -16px -16px 32px #ffffff,
+    inset 4px 4px 8px rgba(255, 255, 255, 0.8),
+    inset -4px -4px 8px rgba(99, 102, 241, 0.2);
+}
+
+.clay-blue {
+  background: #e0f2fe;
+  box-shadow: 
+    16px 16px 32px #bae6fd, 
+    -16px -16px 32px #ffffff,
+    inset 4px 4px 8px rgba(255, 255, 255, 0.8),
+    inset -4px -4px 8px rgba(14, 165, 233, 0.2);
+}
+
+.clay-pink {
+  background: #fce7f3;
+  box-shadow: 
+    16px 16px 32px #fbcfe8, 
+    -16px -16px 32px #ffffff,
+    inset 4px 4px 8px rgba(255, 255, 255, 0.8),
+    inset -4px -4px 8px rgba(236, 72, 153, 0.2);
+}
+
+.clay-card:hover {
+  transform: translateY(-8px) scale(1.02);
+}
+
+.clay-icon {
+  font-size: 2.2rem;
+  width: 60px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: inset 2px 2px 4px rgba(255, 255, 255, 1), inset -2px -2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.clay-info h3 {
+  font-size: 0.9rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.clay-value {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #1e293b;
+  margin: 0.2rem 0;
+}
+
+.clay-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+}
+
+.clay-badge.positive {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.clay-badge.neutral {
+  background: #f1f5f9;
+  color: #475569;
+}


### PR DESCRIPTION
# Related Issue
Closes #86569

# Summary
Adds a set of Claymorphic Analytics Dashboard Metric Widgets with soft 3D inner shadow physics.

# Changes Made
- Added `submissions/examples/claymorphic-dashboard-widgets-gssoc26/demo.html`
- Added `submissions/examples/claymorphic-dashboard-widgets-gssoc26/style.css`
- Added `submissions/examples/claymorphic-dashboard-widgets-gssoc26/README.md`

# Testing
- Tested clay shadow rendering and responsive card grid layouts.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
