### PR TITLE
docs: add theming configuration guide for claymorphism hero section

### DIFF
--- a/submissions/docs/claymorphism-hero-theming/README.md
+++ b/submissions/docs/claymorphism-hero-theming/README.md
@@ -1,0 +1,77 @@
+# Claymorphism Hero Banner (Theming Configuration Guide)
+
+This guide explains how to build a robust theming system for Claymorphism components. Claymorphism is uniquely challenging to theme because a single element's visual state relies on multiple, precisely tuned `box-shadow` layers (an outer drop shadow for elevation, and two inner shadows for 3D highlights and depth). 
+
+If you hardcode these hex colors into your CSS classes, changing the theme requires recalculating and overriding dozens of shadow properties. The solution is CSS Custom Properties (variables).
+
+## Theming Architecture
+
+Instead of writing specific shadow colors in your component CSS, map the required colors to root variables. 
+
+A complete Claymorphic theme requires 4 distinct color variables for the component itself:
+1. `--clay-bg`: The base background color of the element.
+2. `--clay-shadow-outer`: The color of the drop shadow.
+3. `--clay-shadow-inner-dark`: The color of the depth shadow (bottom/right inset).
+4. `--clay-shadow-inner-light`: The color of the highlight shadow (top/left inset).
+
+### Step 1: Define Theme Modifier Classes
+
+Create CSS classes that act as color palettes. When one of these classes is applied to a parent container (like the `.hero-section`), all child elements will inherit these variable values.
+
+```css
+/* Light / Pastel Theme */
+.theme-blue {
+    --clay-bg: #bae6fd;
+    --clay-shadow-outer: rgba(2, 132, 199, 0.2);
+    --clay-shadow-inner-dark: rgba(2, 132, 199, 0.3);
+    --clay-shadow-inner-light: rgba(255, 255, 255, 0.8);
+    
+    --focus-ring: #0284c7;
+}
+
+/* Dark Theme */
+.theme-dark {
+    --clay-bg: #334155;
+    /* Dark mode requires pure black for shadows, and subtle whites for highlights */
+    --clay-shadow-outer: rgba(0, 0, 0, 0.5);
+    --clay-shadow-inner-dark: rgba(0, 0, 0, 0.6);
+    --clay-shadow-inner-light: rgba(255, 255, 255, 0.1);
+    
+    --focus-ring: #a5b4fc;
+}
+```
+
+### Step 2: Apply Variables to the Component
+
+Construct the complex `box-shadow` using the variables. 
+
+```css
+.clay-card, .clay-btn {
+    background-color: var(--clay-bg);
+    
+    box-shadow: 
+        8px 8px 16px var(--clay-shadow-outer),
+        inset -4px -4px 8px var(--clay-shadow-inner-dark),
+        inset 4px 4px 8px var(--clay-shadow-inner-light);
+}
+
+/* Accessibility */
+.clay-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px;
+}
+```
+
+## How to Switch Themes
+
+To change the theme of the entire Hero Banner (and all the clay objects within it), simply swap the modifier class on the parent element via JavaScript or your backend templating engine.
+
+```html
+<!-- The entire section, including cards and buttons, is now blue -->
+<header class="hero-section theme-blue">
+    <div class="clay-card">...</div>
+    <button class="clay-btn">...</button>
+</header>
+```
+
+*Note: This documentation submission is indexed automatically by the EaseMotion documentation engine.*

--- a/submissions/docs/claymorphism-hero-theming/demo.html
+++ b/submissions/docs/claymorphism-hero-theming/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claymorphism Hero Banner (Theming) Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <!-- Theme Switcher Controls for Demo -->
+    <div class="theme-controls">
+        <button type="button" class="clay-btn theme-btn" onclick="setTheme('theme-blue')">Blue Theme</button>
+        <button type="button" class="clay-btn theme-btn" onclick="setTheme('theme-pink')">Pink Theme</button>
+        <button type="button" class="clay-btn theme-btn" onclick="setTheme('theme-dark')">Dark Theme</button>
+    </div>
+
+    <!-- 
+        The Hero Section 
+        We apply the theme class here to cascade CSS variables down to all clay components.
+    -->
+    <header class="hero-section theme-blue" id="hero">
+        
+        <div class="hero-content">
+            <h1 class="hero-title">Customizable Clay UI</h1>
+            <p class="hero-text">
+                Easily swap the entire color palette of your 3D clay components by modifying just a few CSS Custom Properties at the root level.
+            </p>
+            <div class="hero-actions">
+                <button type="button" class="clay-btn primary-btn">Primary Action</button>
+                <button type="button" class="clay-btn secondary-btn">Secondary</button>
+            </div>
+        </div>
+
+        <div class="hero-visual" aria-hidden="true">
+            <div class="clay-card">
+                <div class="clay-object"></div>
+            </div>
+        </div>
+
+    </header>
+
+    <script>
+        function setTheme(themeClass) {
+            const hero = document.getElementById('hero');
+            // Remove existing theme classes
+            hero.classList.remove('theme-blue', 'theme-pink', 'theme-dark');
+            // Add new theme
+            hero.classList.add(themeClass);
+        }
+    </script>
+</body>
+</html>

--- a/submissions/docs/claymorphism-hero-theming/style.css
+++ b/submissions/docs/claymorphism-hero-theming/style.css
@@ -1,0 +1,209 @@
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    line-height: 1.5;
+    background-color: #f8fafc;
+}
+
+.theme-controls {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    background: #e2e8f0;
+    border-bottom: 2px solid #cbd5e1;
+}
+
+.theme-btn {
+    padding: 0.5rem 1rem !important;
+    font-size: 0.875rem !important;
+}
+
+/* 
+ * THEMING ARCHITECTURE 
+ * We define the palette for each theme using CSS variables.
+ * A complete claymorphism theme requires:
+ * 1. Background color (base)
+ * 2. Primary accent color
+ * 3. Text color
+ * 4. Outer drop shadow (for elevation)
+ * 5. Dark inner shadow (for depth)
+ * 6. Light inner shadow (for highlights)
+ */
+
+/* Theme 1: Pastel Blue (Default) */
+.theme-blue {
+    --hero-bg: #e0f2fe;
+    --hero-text: #0369a1;
+    --primary: #38bdf8;
+    --primary-text: #ffffff;
+    
+    --clay-bg: #bae6fd;
+    --clay-shadow-outer: rgba(2, 132, 199, 0.2);
+    --clay-shadow-inner-dark: rgba(2, 132, 199, 0.3);
+    --clay-shadow-inner-light: rgba(255, 255, 255, 0.8);
+    
+    --focus-ring: #0284c7;
+}
+
+/* Theme 2: Pastel Pink */
+.theme-pink {
+    --hero-bg: #fce7f3;
+    --hero-text: #be185d;
+    --primary: #f472b6;
+    --primary-text: #ffffff;
+    
+    --clay-bg: #fbcfe8;
+    --clay-shadow-outer: rgba(190, 24, 93, 0.15);
+    --clay-shadow-inner-dark: rgba(190, 24, 93, 0.25);
+    --clay-shadow-inner-light: rgba(255, 255, 255, 0.9);
+    
+    --focus-ring: #db2777;
+}
+
+/* Theme 3: Dark Mode */
+.theme-dark {
+    --hero-bg: #1e293b;
+    --hero-text: #f8fafc;
+    --primary: #818cf8;
+    --primary-text: #ffffff;
+    
+    --clay-bg: #334155;
+    /* Shadows in dark mode rely on pure black for depth and very subtle whites for highlights */
+    --clay-shadow-outer: rgba(0, 0, 0, 0.5);
+    --clay-shadow-inner-dark: rgba(0, 0, 0, 0.6);
+    --clay-shadow-inner-light: rgba(255, 255, 255, 0.1);
+    
+    --focus-ring: #a5b4fc;
+}
+
+
+/* 
+ * Applying Variables to the Layout 
+ */
+.hero-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    min-height: calc(100vh - 80px);
+    
+    /* Dynamically updating based on the applied theme class */
+    background-color: var(--hero-bg);
+    color: var(--hero-text);
+    transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+@media (min-width: 768px) {
+    .hero-section {
+        flex-direction: row;
+        padding: 6rem 4rem;
+        justify-content: space-between;
+    }
+}
+
+.hero-content {
+    flex: 1;
+    max-width: 500px;
+}
+
+.hero-title {
+    font-size: 3rem;
+    margin: 0 0 1rem 0;
+    line-height: 1.1;
+}
+
+.hero-text {
+    font-size: 1.125rem;
+    margin: 0 0 2rem 0;
+    opacity: 0.9;
+}
+
+.hero-actions {
+    display: flex;
+    gap: 1rem;
+}
+
+.hero-visual {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* 
+ * Applying Variables to Clay Elements
+ */
+.clay-btn, .clay-card {
+    background-color: var(--clay-bg);
+    color: var(--hero-text);
+    border: none;
+    
+    /* The core claymorphism shadow structure powered by CSS variables */
+    box-shadow: 
+        8px 8px 16px var(--clay-shadow-outer),
+        inset -4px -4px 8px var(--clay-shadow-inner-dark),
+        inset 4px 4px 8px var(--clay-shadow-inner-light);
+        
+    transition: all 0.3s ease;
+}
+
+.clay-btn {
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 700;
+    border-radius: 16px;
+    cursor: pointer;
+}
+
+.clay-btn.primary-btn {
+    background-color: var(--primary);
+    color: var(--primary-text);
+}
+
+.clay-btn:hover {
+    transform: translateY(-2px);
+}
+
+.clay-btn:active {
+    transform: translateY(2px);
+    /* Invert inner shadows on press */
+    box-shadow: 
+        4px 4px 8px var(--clay-shadow-outer),
+        inset -2px -2px 4px var(--clay-shadow-inner-dark),
+        inset 2px 2px 4px var(--clay-shadow-inner-light);
+}
+
+.clay-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 4px;
+}
+
+.clay-card {
+    width: 300px;
+    height: 300px;
+    border-radius: 32px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.clay-object {
+    width: 150px;
+    height: 150px;
+    background-color: var(--primary);
+    border-radius: 50%;
+    
+    box-shadow: 
+        10px 10px 20px var(--clay-shadow-outer),
+        inset -6px -6px 12px rgba(0,0,0,0.2),
+        inset 6px 6px 12px rgba(255,255,255,0.4);
+        
+    animation: float 4s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-15px); }
+}


### PR DESCRIPTION
fixes #85766 

## Pull Request Description

This PR introduces the Theming Configuration guide for the Claymorphism Hero Banner Section. Claymorphism is a visually complex aesthetic that achieves its signature 3D inflated look by stacking an outer drop shadow with two distinct inner shadows (a highlight and a depth shadow). Hardcoding these shadow colors directly into CSS rules makes theming practically impossible. This documentation details a powerful CSS Custom Property architecture that maps these shadow layers to root variables, allowing developers to flip the entire component's color palette (e.g., from Pastel Blue to a high-contrast Dark Mode) simply by swapping a single modifier class on the parent container.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a comprehensive guide on architecting multi-layered shadow themes. It breaks down the exact variables required for a complete claymorphic theme (`--clay-bg`, `--clay-shadow-outer`, `--clay-shadow-inner-dark`, `--clay-shadow-inner-light`). It provides three distinct theme modifier classes (Blue, Pink, and Dark Mode) and explains the critical differences in shadow opacity requirements—specifically how dark mode necessitates pure black shadows and highly transparent white highlights to maintain the illusion of physical depth.

**How does a developer use it?**

```css
/* Modifier Class overrides the shadow palette */
.theme-dark {
    --clay-bg: #334155;
    
    /* Dark mode requires deep blacks and subtle whites */
    --clay-shadow-outer: rgba(0, 0, 0, 0.5);
    --clay-shadow-inner-dark: rgba(0, 0, 0, 0.6);
    --clay-shadow-inner-light: rgba(255, 255, 255, 0.1);
    
    --focus-ring: #a5b4fc; /* Contrast-adjusted focus ring */
}
