### PR TITLE
feat: add cyberpunk sci-fi tactical HUD reticle scanner component

### DIFF
--- a/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/README.md
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/README.md
@@ -1,0 +1,27 @@
+# Cyberpunk Sci-Fi Tactical HUD Target Reticle Scanner
+
+An interactive sci-fi HUD targeting interface component built with pure CSS keyframes, concentric ring rotations, and lock-on telemetry state transitions.
+
+## 1. What does this do?
+This component renders a high-tech tactical HUD reticle featuring dual-directional rotating dashed rings, pulsating crosshairs, telemetry readouts, and an interactive state toggle that shrinks lock-on corner brackets while changing neon telemetry themes from Cyan to Threat Red.
+
+## 2. How is it used?
+Link `style.css` in your HTML document and include the `.hud-target-card` structure:
+
+```html
+<div class="hud-target-card" id="targetCard">
+  <div class="reticle-wrapper">
+    <div class="outer-ring ring-spin-cw"></div>
+    <div class="mid-ring ring-spin-ccw"></div>
+    <div class="lock-bracket top-left"></div>
+    <div class="center-core"></div>
+  </div>
+</div>
+```
+
+Toggle the `.lock-acquired` class dynamically via JavaScript or button events.
+
+## 3. Why is it useful?
+- **Pure CSS Keyframe Rotations**: Uses hardware-accelerated CSS keyframe animations for smooth 60fps rotational motion.
+- **Cyberpunk Gaming UI Aesthetic**: Perfect for gaming dashboards, sci-fi landing pages, security status monitors, and futuristic Web3/AI landing applications.
+- **Dynamic Lock-On Transitions**: Clean CSS transition properties enable smooth locking movement on target activation.

--- a/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/demo.html
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Tactical HUD Target Reticle Scanner | EaseMotion CSS</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Orbitron:wght@600;800;900&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="hud-container">
+    <header class="hud-header">
+      <div class="sys-status"><span class="blink">●</span> SYS_ONLINE // TARGETING_SUBSYSTEM</div>
+      <h1 class="hud-title">TACTICAL HUD RETICLE</h1>
+      <p class="hud-subtitle">Interactive Cyberpunk Lock-On Reticle with Concentric Scanning Motion</p>
+    </header>
+
+    <section class="reticle-stage">
+      <div class="hud-target-card" id="targetCard">
+        <!-- Grid Background overlay -->
+        <div class="hud-grid-overlay"></div>
+        
+        <!-- Concentric Reticle Layers -->
+        <div class="reticle-wrapper">
+          <div class="outer-ring ring-spin-cw"></div>
+          <div class="mid-ring ring-spin-ccw"></div>
+          <div class="tech-dashes ring-spin-cw-fast"></div>
+          <div class="crosshair-h"></div>
+          <div class="crosshair-v"></div>
+          
+          <div class="lock-bracket top-left"></div>
+          <div class="lock-bracket top-right"></div>
+          <div class="lock-bracket bottom-left"></div>
+          <div class="lock-bracket bottom-right"></div>
+
+          <div class="center-core"></div>
+
+          <!-- Target Telemetry Text -->
+          <div class="target-tag tag-top">SYS.LOCK // 99.4%</div>
+          <div class="target-tag tag-bottom">DIST: 420m | ALT: 120m</div>
+        </div>
+
+        <div class="hud-controls">
+          <button class="hud-btn" onclick="document.getElementById('targetCard').classList.toggle('lock-acquired')">TOGGLE LOCK-ON</button>
+        </div>
+      </div>
+    </section>
+
+    <footer class="hud-footer">
+      <span>EASEMOTION CSS HUD LIBRARY v2.4</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/style.css
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/style.css
@@ -1,0 +1,275 @@
+:root {
+  --bg-cyber: #050811;
+  --hud-cyan: #00f0ff;
+  --hud-red: #ff0055;
+  --hud-yellow: #ffb700;
+  --hud-dark: rgba(10, 15, 30, 0.85);
+  --font-orbitron: 'Orbitron', sans-serif;
+  --font-mono: 'Share Tech Mono', monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: var(--bg-cyber);
+  color: var(--hud-cyan);
+  font-family: var(--font-mono);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: 
+    radial-gradient(circle at 50% 50%, rgba(0, 240, 255, 0.08) 0%, transparent 70%),
+    linear-gradient(rgba(0, 240, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.03) 1px, transparent 1px);
+  background-size: 100% 100%, 40px 40px, 40px 40px;
+}
+
+.hud-container {
+  width: 100%;
+  max-width: 750px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.hud-header {
+  text-align: center;
+}
+
+.sys-status {
+  font-size: 0.8rem;
+  color: var(--hud-yellow);
+  letter-spacing: 2px;
+  margin-bottom: 0.5rem;
+}
+
+.blink {
+  animation: hud-blink 1s infinite alternate;
+}
+
+@keyframes hud-blink {
+  0% { opacity: 0.2; }
+  100% { opacity: 1; }
+}
+
+.hud-title {
+  font-family: var(--font-orbitron);
+  font-size: 2.2rem;
+  font-weight: 900;
+  letter-spacing: 3px;
+  color: #fff;
+  text-shadow: 0 0 15px var(--hud-cyan);
+}
+
+.hud-subtitle {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  margin-top: 0.4rem;
+}
+
+.reticle-stage {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hud-target-card {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  height: 440px;
+  background: var(--hud-dark);
+  border: 1px solid rgba(0, 240, 255, 0.3);
+  border-radius: 16px;
+  box-shadow: 0 0 30px rgba(0, 240, 255, 0.15), inset 0 0 20px rgba(0, 240, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
+  transition: all 0.4s ease;
+}
+
+.hud-grid-overlay {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+                    linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+
+.reticle-wrapper {
+  position: relative;
+  width: 240px;
+  height: 240px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Concentric Rings */
+.outer-ring {
+  position: absolute;
+  inset: 0;
+  border: 2px dashed var(--hud-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 15px rgba(0, 240, 255, 0.3);
+}
+
+.mid-ring {
+  position: absolute;
+  inset: 20px;
+  border: 2px solid transparent;
+  border-top-color: var(--hud-cyan);
+  border-bottom-color: var(--hud-cyan);
+  border-radius: 50%;
+}
+
+.tech-dashes {
+  position: absolute;
+  inset: 40px;
+  border: 1px dotted var(--hud-yellow);
+  border-radius: 50%;
+}
+
+/* Rotations */
+.ring-spin-cw {
+  animation: spinCW 12s linear infinite;
+}
+
+.ring-spin-ccw {
+  animation: spinCCW 8s linear infinite;
+}
+
+.ring-spin-cw-fast {
+  animation: spinCW 5s linear infinite;
+}
+
+@keyframes spinCW {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes spinCCW {
+  from { transform: rotate(360deg); }
+  to { transform: rotate(0deg); }
+}
+
+/* Crosshairs */
+.crosshair-h, .crosshair-v {
+  position: absolute;
+  background: rgba(0, 240, 255, 0.6);
+}
+
+.crosshair-h {
+  width: 100%;
+  height: 1px;
+}
+
+.crosshair-v {
+  width: 1px;
+  height: 100%;
+}
+
+/* Corner Lock Brackets */
+.lock-bracket {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  border: 2px solid var(--hud-cyan);
+  transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.top-left { top: -10px; left: -10px; border-right: none; border-bottom: none; }
+.top-right { top: -10px; right: -10px; border-left: none; border-bottom: none; }
+.bottom-left { bottom: -10px; left: -10px; border-right: none; border-top: none; }
+.bottom-right { bottom: -10px; right: -10px; border-left: none; border-top: none; }
+
+.center-core {
+  width: 16px;
+  height: 16px;
+  background: var(--hud-cyan);
+  border-radius: 50%;
+  box-shadow: 0 0 15px var(--hud-cyan);
+  animation: core-pulse 1.5s infinite alternate;
+}
+
+@keyframes core-pulse {
+  0% { transform: scale(0.8); opacity: 0.6; }
+  100% { transform: scale(1.2); opacity: 1; }
+}
+
+/* Target Telemetry */
+.target-tag {
+  position: absolute;
+  font-size: 0.75rem;
+  letter-spacing: 1px;
+  color: var(--hud-cyan);
+  background: rgba(5, 8, 17, 0.8);
+  padding: 2px 6px;
+  border: 1px solid rgba(0, 240, 255, 0.4);
+}
+
+.tag-top { top: -40px; }
+.tag-bottom { bottom: -40px; }
+
+/* LOCK-ON ACQUIRED STATE */
+.hud-target-card.lock-acquired {
+  border-color: var(--hud-red);
+  box-shadow: 0 0 40px rgba(255, 0, 85, 0.3);
+}
+
+.hud-target-card.lock-acquired .outer-ring,
+.hud-target-card.lock-acquired .lock-bracket {
+  border-color: var(--hud-red);
+}
+
+.hud-target-card.lock-acquired .lock-bracket {
+  top: 30px;
+  bottom: 30px;
+  left: 30px;
+  right: 30px;
+}
+
+.hud-target-card.lock-acquired .center-core {
+  background: var(--hud-red);
+  box-shadow: 0 0 20px var(--hud-red);
+}
+
+.hud-controls {
+  position: absolute;
+  bottom: 20px;
+}
+
+.hud-btn {
+  background: transparent;
+  border: 1px solid var(--hud-cyan);
+  color: var(--hud-cyan);
+  font-family: var(--font-orbitron);
+  font-size: 0.8rem;
+  padding: 8px 18px;
+  cursor: pointer;
+  letter-spacing: 1px;
+  transition: all 0.3s ease;
+}
+
+.hud-btn:hover {
+  background: var(--hud-cyan);
+  color: var(--bg-cyber);
+  box-shadow: 0 0 15px var(--hud-cyan);
+}
+
+.hud-footer {
+  font-size: 0.75rem;
+  color: rgba(0, 240, 255, 0.5);
+  letter-spacing: 1px;
+}


### PR DESCRIPTION
# Related Issue
Closes #86666 

# Summary
Adds a Cyberpunk Sci-Fi Tactical HUD Target Reticle Scanner component under `submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/`.

# Changes Made
- Created `submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/demo.html` with concentric reticle elements and interactive toggle control.
- Created `submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/style.css` with dual-directional keyframe spin animations and lock-on transitions.
- Created `submissions/examples/gssoc-2026-cyberpunk-hud-reticle-bb/README.md` with implementation guidelines.

# Testing
- Tested local rendering on Chrome, Firefox, and Safari.
- Verified interactive lock-on state transition on button click.
- Verified responsive layout down to mobile screen sizes.

# Impact
Enables developers to easily embed futuristic, interactive HUD targeting reticles in Web3, gaming, and AI application interfaces.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
