### PR TITLE
feat(scss): Add SCSS Perspective Origin Helper helper mixins #81289

### DIFF
--- a/submissions/scss/perspective-origin-helper-ps/README.md
+++ b/submissions/scss/perspective-origin-helper-ps/README.md
@@ -1,0 +1,60 @@
+# SCSS Perspective Origin & Transform Origin Helpers (`#81289`)
+
+A comprehensive suite of SCSS helper mixins for managing 3D spatial perspective origin and transform origin alignment in EaseMotion CSS.
+
+## What does this do?
+
+Provides modular SCSS mixins for controlling 3D `perspective-origin` and `transform-origin` with browser fallbacks, dynamic CSS custom property integration (`--ease-perspective-origin-*`), and preset spatial alignments.
+
+## Parameters
+
+| Mixin | Parameter | Type | Default | Description |
+|-------|-----------|------|---------|-------------|
+| `@mixin ease-perspective-origin` | `$x` | `Length / Keyword` | `center` | Horizontal perspective origin position |
+| | `$y` | `Length / Keyword` | `center` | Vertical perspective origin position |
+| | `$use-vars` | `Boolean` | `true` | Incorporates CSS variables for runtime configuration |
+| `@mixin ease-transform-origin-3d` | `$x` | `Length / Keyword` | `center` | X-axis transform origin position |
+| | `$y` | `Length / Keyword` | `center` | Y-axis transform origin position |
+| | `$z` | `Length` | `0px` | Z-axis (depth) origin position |
+| | `$use-vars` | `Boolean` | `true` | Enables CSS variable integration |
+| `@mixin ease-spatial-stage` | `$perspective` | `Length` | `1000px` | 3D perspective viewport distance |
+| | `$origin-x` | `Length / Keyword` | `center` | Horizontal perspective focal point |
+| | `$origin-y` | `Length / Keyword` | `center` | Vertical perspective focal point |
+| `@mixin ease-perspective-origin-preset` | `$preset` | `String` | `'center'` | Preset position (`top-left`, `top-right`, `bottom-left`, `bottom-right`, `center`, `top-center`, `bottom-center`) |
+
+## Usage Examples
+
+### 1. Basic 3D Perspective Stage Setup
+
+```scss
+@use 'perspective-origin-helper' as *;
+
+.card-container {
+  @include ease-spatial-stage(1200px, center, top);
+}
+
+.card-element {
+  @include ease-transform-origin-3d(50%, 50%, -50px);
+}
+```
+
+### 2. Using Preset Alignments
+
+```scss
+.hero-scene {
+  @include ease-perspective-origin-preset('top-right');
+}
+```
+
+### 3. Dynamic CSS Variable Overrides
+
+```scss
+.interactive-viewport {
+  @include ease-set-perspective-vars(30%, 70%);
+  @include ease-perspective-origin();
+}
+```
+
+## Why is it useful?
+
+Precise 3D spatial alignment requires syncing `perspective-origin` and `transform-origin` across multi-layer CSS 3D transforms. This helper suite simplifies dynamic 3D spatial positioning and fits directly into EaseMotion's modular CSS motion framework.

--- a/submissions/scss/perspective-origin-helper-ps/_perspective-origin-helper.scss
+++ b/submissions/scss/perspective-origin-helper-ps/_perspective-origin-helper.scss
@@ -1,0 +1,82 @@
+// ==========================================================================
+// EaseMotion CSS - SCSS Perspective Origin & Transform Origin Helpers
+// Issue #81289 - 3D Spatial Alignment Mixins
+// ==========================================================================
+
+/// CSS Variable Default Tokens for Perspective Origin
+:root {
+  --ease-perspective-origin-x: 50%;
+  --ease-perspective-origin-y: 50%;
+  --ease-perspective-origin-z: 0px;
+  --ease-transform-origin-x: 50%;
+  --ease-transform-origin-y: 50%;
+  --ease-transform-origin-z: 0px;
+}
+
+/// Applies 3D perspective-origin with CSS Custom Properties and vendor fallbacks.
+/// @param {Length|Keyword} $x [center] - Horizontal origin position (e.g., left, center, right, 50%, 100px)
+/// @param {Length|Keyword} $y [center] - Vertical origin position (e.g., top, center, bottom, 50%, 100px)
+/// @param {Boolean} $use-vars [true] - Whether to incorporate CSS custom property fallbacks
+@mixin ease-perspective-origin($x: center, $y: center, $use-vars: true) {
+  @if $use-vars {
+    -webkit-perspective-origin: var(--ease-perspective-origin-x, #{$x}) var(--ease-perspective-origin-y, #{$y});
+    perspective-origin: var(--ease-perspective-origin-x, #{$x}) var(--ease-perspective-origin-y, #{$y});
+  } @else {
+    -webkit-perspective-origin: $x $y;
+    perspective-origin: $x $y;
+  }
+}
+
+/// Applies 3D transform-origin with 3D spatial axis alignment.
+/// @param {Length|Keyword} $x [center] - Horizontal axis origin (X)
+/// @param {Length|Keyword} $y [center] - Vertical axis origin (Y)
+/// @param {Length} $z [0px] - Depth axis origin (Z)
+/// @param {Boolean} $use-vars [true] - Integrate CSS variables for dynamic runtime updates
+@mixin ease-transform-origin-3d($x: center, $y: center, $z: 0px, $use-vars: true) {
+  @if $use-vars {
+    -webkit-transform-origin: var(--ease-transform-origin-x, #{$x}) var(--ease-transform-origin-y, #{$y}) var(--ease-transform-origin-z, #{$z});
+    transform-origin: var(--ease-transform-origin-x, #{$x}) var(--ease-transform-origin-y, #{$y}) var(--ease-transform-origin-z, #{$z});
+  } @else {
+    -webkit-transform-origin: $x $y $z;
+    transform-origin: $x $y $z;
+  }
+}
+
+/// Helper mixin to set 3D viewport spatial perspective and perspective-origin on container elements.
+/// @param {Length} $perspective [1000px] - Perspective distance value (e.g. 800px, 1200px)
+/// @param {Length|Keyword} $origin-x [center] - Horizontal perspective origin
+/// @param {Length|Keyword} $origin-y [center] - Vertical perspective origin
+@mixin ease-spatial-stage($perspective: 1000px, $origin-x: center, $origin-y: center) {
+  -webkit-perspective: $perspective;
+  perspective: $perspective;
+  @include ease-perspective-origin($origin-x, $origin-y);
+}
+
+/// Preset 3D perspective origin alignments
+@mixin ease-perspective-origin-preset($preset: 'center') {
+  @if $preset == 'top-left' {
+    @include ease-perspective-origin(0%, 0%);
+  } @else if $preset == 'top-right' {
+    @include ease-perspective-origin(100%, 0%);
+  } @else if $preset == 'bottom-left' {
+    @include ease-perspective-origin(0%, 100%);
+  } @else if $preset == 'bottom-right' {
+    @include ease-perspective-origin(100%, 100%);
+  } @else if $preset == 'center' {
+    @include ease-perspective-origin(50%, 50%);
+  } @else if $preset == 'top-center' {
+    @include ease-perspective-origin(50%, 0%);
+  } @else if $preset == 'bottom-center' {
+    @include ease-perspective-origin(50%, 100%);
+  } @else {
+    @include ease-perspective-origin(50%, 50%);
+  }
+}
+
+/// Utility mixin to configure custom perspective origin CSS variables dynamically
+/// @param {Length|Keyword} $x - X coordinate value
+/// @param {Length|Keyword} $y - Y coordinate value
+@mixin ease-set-perspective-vars($x, $y) {
+  --ease-perspective-origin-x: #{$x};
+  --ease-perspective-origin-y: #{$y};
+}


### PR DESCRIPTION
## Pull Request Description

Adds SCSS Perspective Origin Helper helper mixins for 3D spatial alignment in EaseMotion CSS (`#81289`). Provides modular mixins for `perspective-origin` and 3D `transform-origin` with CSS custom property integration and browser fallbacks.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: SCSS Integration Track Mixins

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (`submissions/scss/perspective-origin-helper-ps/`)
- [x] Includes `_perspective-origin-helper.scss` — modular SCSS mixins partial
- [x] Includes `README.md` — what it does, parameter reference, how to use it with `@include`, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds reusable SCSS mixins (`@mixin ease-perspective-origin`, `@mixin ease-transform-origin-3d`, `@mixin ease-spatial-stage`) for configuring 3D perspective and spatial origin coordinates.

**How does a developer use it?**

```scss
@use 'perspective-origin-helper' as *;

.card-container {
  @include ease-spatial-stage(1200px, center, top);
}

.card-element {
  @include ease-transform-origin-3d(50%, 50%, -50px);
}
