### PR TITLE
feat: add cyberpunk hud target reticle component

### DIFF
--- a/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/README.md
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/README.md
@@ -1,0 +1,23 @@
+# Cyberpunk HUD Tactical Target Reticle (GSSoC 2026)
+
+## 1. What does this do?
+The **Cyberpunk HUD Tactical Target Reticle** component presents a sci-fi tactical targeting reticle featuring animated conic radar sweep overlays (`conic-gradient`), rotating crosshair tick rings, lock-on core pulse scaling (`@keyframes pulseLock`), and telemetry readouts.
+
+## 2. How is it used?
+Include the CSS stylesheet in your project:
+```html
+<link rel="stylesheet" href="style.css">
+```
+Embed the reticle container markup inside your HUD display or game menu component:
+```html
+<div class="reticle-container">
+  <div class="radar-sweep"></div>
+  <div class="crosshair-ring">...</div>
+  <div class="lock-on-core"></div>
+</div>
+```
+
+## 3. Why is it useful?
+- **High Visual Impact**: Brings gaming and cyberpunk UI visual flair without heavy Canvas or WebGL dependencies.
+- **Hardware-Accelerated CSS Keyframes**: Runs smooth 60 FPS rotation and scaling transitions.
+- **Modular HUD Aesthetics**: High contrast neon telemetry panels designed for dark mode futuristic web interfaces.

--- a/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/demo.html
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk HUD Tactical Target Reticle | EaseMotion CSS Showcase</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="hud-wrapper">
+    <header class="header">
+      <span class="badge">GSSoC 2026 Innovation</span>
+      <h1 class="title">CYBERPUNK TAC-HUD RETICLE</h1>
+      <p class="subtitle">Sci-fi tactical targeting reticle with animated radar crosshairs, telemetry tick marks, and lock-on focus pulse effects.</p>
+    </header>
+
+    <div class="hud-card">
+      <div class="reticle-container">
+        <div class="radar-sweep"></div>
+        <div class="outer-bracket top-left"></div>
+        <div class="outer-bracket top-right"></div>
+        <div class="outer-bracket bottom-left"></div>
+        <div class="outer-bracket bottom-right"></div>
+
+        <div class="crosshair-ring">
+          <div class="tick t-top"></div>
+          <div class="tick t-right"></div>
+          <div class="tick t-bottom"></div>
+          <div class="tick t-left"></div>
+        </div>
+
+        <div class="lock-on-core">
+          <span class="core-dot"></span>
+        </div>
+      </div>
+
+      <div class="telemetry-panel">
+        <div class="telemetry-item">
+          <span class="label">TARGET ID</span>
+          <span class="val">NX-8809-DELTA</span>
+        </div>
+        <div class="telemetry-item">
+          <span class="label">DISTANCE</span>
+          <span class="val">1,420 M</span>
+        </div>
+        <div class="telemetry-item">
+          <span class="label">LOCK STATUS</span>
+          <span class="val highlight">ENGAGED [98.4%]</span>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/style.css
+++ b/submissions/examples/gssoc-2026-cyberpunk-hud-target-reticle-bb/style.css
@@ -1,0 +1,209 @@
+:root {
+  --bg-dark: #020408;
+  --hud-cyan: #00f0ff;
+  --hud-yellow: #ffea00;
+  --hud-red: #ff0055;
+  --hud-bg: rgba(6, 15, 25, 0.85);
+  --font-mono: 'Share Tech Mono', monospace;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-mono);
+  background-color: var(--bg-dark);
+  background-image: 
+    linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px;
+  color: var(--hud-cyan);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.hud-wrapper {
+  max-width: 580px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.header {
+  text-align: center;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.35rem 0.9rem;
+  background: rgba(0, 240, 255, 0.1);
+  border: 1px solid var(--hud-cyan);
+  color: var(--hud-cyan);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: #ffffff;
+  text-shadow: 0 0 10px var(--hud-cyan);
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #7090a8;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.hud-card {
+  width: 100%;
+  background: var(--hud-bg);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(0, 240, 255, 0.3);
+  box-shadow: 0 0 30px rgba(0, 240, 255, 0.15), inset 0 0 15px rgba(0, 240, 255, 0.05);
+  border-radius: 16px;
+  padding: 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+  position: relative;
+}
+
+/* Reticle Target Display */
+.reticle-container {
+  width: 220px;
+  height: 220px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Outer Corner Brackets */
+.outer-bracket {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--hud-cyan);
+}
+
+.top-left { top: 0; left: 0; border-right: none; border-bottom: none; }
+.top-right { top: 0; right: 0; border-left: none; border-bottom: none; }
+.bottom-left { bottom: 0; left: 0; border-right: none; border-top: none; }
+.bottom-right { bottom: 0; right: 0; border-left: none; border-top: none; }
+
+/* Radar Sweep Line */
+.radar-sweep {
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 240, 255, 0.2);
+  background: conic-gradient(from 0deg at 50% 50%, rgba(0, 240, 255, 0.25) 0deg, transparent 60deg, transparent 360deg);
+  animation: sweep 4s linear infinite;
+}
+
+@keyframes sweep {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Crosshair Ring */
+.crosshair-ring {
+  width: 140px;
+  height: 140px;
+  border: 2px dashed rgba(0, 240, 255, 0.6);
+  border-radius: 50%;
+  position: relative;
+  animation: rotateCrosshair 10s linear infinite reverse;
+}
+
+@keyframes rotateCrosshair {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.tick {
+  position: absolute;
+  background: var(--hud-cyan);
+}
+
+.t-top { top: -10px; left: calc(50% - 1px); width: 2px; height: 12px; }
+.t-bottom { bottom: -10px; left: calc(50% - 1px); width: 2px; height: 12px; }
+.t-left { left: -10px; top: calc(50% - 1px); width: 12px; height: 2px; }
+.t-right { right: -10px; top: calc(50% - 1px); width: 12px; height: 2px; }
+
+/* Lock-on Core Pulse */
+.lock-on-core {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  border: 2px solid var(--hud-red);
+  transform: rotate(45deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulseLock 1.5s ease-in-out infinite alternate;
+}
+
+.core-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--hud-red);
+  border-radius: 50%;
+  box-shadow: 0 0 10px var(--hud-red);
+}
+
+@keyframes pulseLock {
+  0% { transform: rotate(45deg) scale(0.9); box-shadow: 0 0 5px var(--hud-red); }
+  100% { transform: rotate(45deg) scale(1.15); box-shadow: 0 0 20px var(--hud-red); }
+}
+
+/* Telemetry Info Board */
+.telemetry-panel {
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  background: rgba(0, 240, 255, 0.04);
+  border: 1px solid rgba(0, 240, 255, 0.15);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.telemetry-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.label {
+  font-size: 0.7rem;
+  color: #7090a8;
+  letter-spacing: 0.08em;
+}
+
+.val {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.val.highlight {
+  color: var(--hud-yellow);
+  text-shadow: 0 0 8px var(--hud-yellow);
+}


### PR DESCRIPTION
# Related Issue
Closes #86923

# Summary
Adds a Cyberpunk Tactical Target Reticle component with radar sweep animations, rotating crosshairs, and lock-on core pulse effects.

# Changes Made
- Created `demo.html` with tactical reticle structure and telemetry status readouts.
- Created `style.css` with conic radar sweep, crosshair rotation, and lock-on scaling.
- Created `README.md` with usage instructions.

# Testing
- Tested locally across desktop and mobile screens.
- Verified clean GPU layer execution without layout reflows.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] Isolated brand-new feature directory
