### PR TITLE
test: add Vitest spec for fullscreen toggle state

### DIFF
--- a/submissions/examples/86394-video-player-fullscreen-toggle-state/README.md
+++ b/submissions/examples/86394-video-player-fullscreen-toggle-state/README.md
@@ -1,0 +1,18 @@
+# Video Player — Fullscreen Toggle State
+
+## Overview
+
+This submission demonstrates a simple Video Player fullscreen toggle state
+using pure HTML, CSS, and JavaScript.
+
+A focused Vitest unit specification validates the state transition logic,
+including normal toggles, repeated toggles, boundary conditions, and invalid
+inputs.
+
+## State Model
+
+The fullscreen state is represented by a boolean:
+
+```text
+false → not fullscreen
+true  → fullscreen

--- a/submissions/examples/86394-video-player-fullscreen-toggle-state/demo.html
+++ b/submissions/examples/86394-video-player-fullscreen-toggle-state/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Video Player Fullscreen Toggle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="player-wrapper">
+    <section class="video-player" id="videoPlayer">
+      <div class="video-content">
+        <span class="play-icon" aria-hidden="true">▶</span>
+        <h1>Demo Video</h1>
+        <p>Fullscreen toggle state demonstration</p>
+      </div>
+
+      <div class="controls">
+        <button
+          id="fullscreenButton"
+          type="button"
+          aria-pressed="false"
+          aria-label="Enter fullscreen"
+        >
+          ⛶ Fullscreen
+        </button>
+      </div>
+    </section>
+
+    <p id="status" class="status" aria-live="polite">
+      Fullscreen: Off
+    </p>
+  </main>
+
+  <script>
+    const player = document.querySelector("#videoPlayer");
+    const button = document.querySelector("#fullscreenButton");
+    const status = document.querySelector("#status");
+
+    let isFullscreen = false;
+
+    function toggleFullscreenState(currentState) {
+      return !currentState;
+    }
+
+    function render() {
+      player.classList.toggle("fullscreen", isFullscreen);
+
+      button.setAttribute(
+        "aria-pressed",
+        String(isFullscreen)
+      );
+
+      button.setAttribute(
+        "aria-label",
+        isFullscreen
+          ? "Exit fullscreen"
+          : "Enter fullscreen"
+      );
+
+      button.textContent = isFullscreen
+        ? "⛶ Exit Fullscreen"
+        : "⛶ Fullscreen";
+
+      status.textContent = `Fullscreen: ${
+        isFullscreen ? "On" : "Off"
+      }`;
+    }
+
+    button.addEventListener("click", () => {
+      isFullscreen = toggleFullscreenState(isFullscreen);
+      render();
+    });
+
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/examples/86394-video-player-fullscreen-toggle-state/fullscreen-toggle.test.js
+++ b/submissions/examples/86394-video-player-fullscreen-toggle-state/fullscreen-toggle.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Toggles the fullscreen state.
+ * A valid fullscreen state is always represented by a boolean.
+ */
+function toggleFullscreenState(currentState) {
+  return !currentState;
+}
+
+describe("Video Player fullscreen toggle state", () => {
+  describe("initial state", () => {
+    it("starts in the non-fullscreen state", () => {
+      const state = false;
+
+      expect(state).toBe(false);
+    });
+
+    it("represents the initial state as a boolean", () => {
+      const state = false;
+
+      expect(typeof state).toBe("boolean");
+    });
+  });
+
+  describe("happy path", () => {
+    it("enters fullscreen when toggled from false", () => {
+      expect(toggleFullscreenState(false)).toBe(true);
+    });
+
+    it("exits fullscreen when toggled from true", () => {
+      expect(toggleFullscreenState(true)).toBe(false);
+    });
+
+    it("changes the state on every toggle", () => {
+      let state = false;
+
+      state = toggleFullscreenState(state);
+
+      expect(state).toBe(true);
+
+      state = toggleFullscreenState(state);
+
+      expect(state).toBe(false);
+    });
+  });
+
+  describe("repeated toggles", () => {
+    it("returns to the original state after two toggles", () => {
+      const initialState = false;
+
+      const finalState = toggleFullscreenState(
+        toggleFullscreenState(initialState)
+      );
+
+      expect(finalState).toBe(initialState);
+    });
+
+    it("returns to the original state after four toggles", () => {
+      let state = false;
+
+      for (let index = 0; index < 4; index += 1) {
+        state = toggleFullscreenState(state);
+      }
+
+      expect(state).toBe(false);
+    });
+
+    it("returns to fullscreen after an odd number of toggles", () => {
+      let state = false;
+
+      for (let index = 0; index < 5; index += 1) {
+        state = toggleFullscreenState(state);
+      }
+
+      expect(state).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles the false boundary correctly", () => {
+      expect(toggleFullscreenState(false)).toBe(true);
+    });
+
+    it("handles the true boundary correctly", () => {
+      expect(toggleFullscreenState(true)).toBe(false);
+    });
+
+    it("does not produce a value outside the boolean states", () => {
+      const states = [false, true];
+
+      states.forEach((state) => {
+        const result = toggleFullscreenState(state);
+
+        expect([false, true]).toContain(result);
+      });
+    });
+
+    it("preserves boolean output after repeated toggles", () => {
+      let state = false;
+
+      for (let index = 0; index < 10; index += 1) {
+        state = toggleFullscreenState(state);
+        expect(typeof state).toBe("boolean");
+      }
+    });
+
+    it("supports consecutive calls without shared state", () => {
+      expect(toggleFullscreenState(false)).toBe(true);
+      expect(toggleFullscreenState(false)).toBe(true);
+      expect(toggleFullscreenState(true)).toBe(false);
+      expect(toggleFullscreenState(true)).toBe(false);
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("converts undefined to the fullscreen state true", () => {
+      expect(toggleFullscreenState(undefined)).toBe(true);
+    });
+
+    it("converts null to the fullscreen state true", () => {
+      expect(toggleFullscreenState(null)).toBe(true);
+    });
+
+    it("handles numeric zero", () => {
+      expect(toggleFullscreenState(0)).toBe(true);
+    });
+
+    it("handles numeric one", () => {
+      expect(toggleFullscreenState(1)).toBe(false);
+    });
+
+    it("handles an empty string", () => {
+      expect(toggleFullscreenState("")).toBe(true);
+    });
+
+    it("handles a non-empty string", () => {
+      expect(toggleFullscreenState("fullscreen")).toBe(false);
+    });
+
+    it("handles an object input", () => {
+      expect(toggleFullscreenState({})).toBe(false);
+    });
+
+    it("handles an array input", () => {
+      expect(toggleFullscreenState([])).toBe(false);
+    });
+  });
+
+  describe("state invariants", () => {
+    it("flips false to true", () => {
+      const result = toggleFullscreenState(false);
+
+      expect(result).not.toBe(false);
+      expect(result).toBe(true);
+    });
+
+    it("flips true to false", () => {
+      const result = toggleFullscreenState(true);
+
+      expect(result).not.toBe(true);
+      expect(result).toBe(false);
+    });
+
+    it("is deterministic for false", () => {
+      expect(toggleFullscreenState(false)).toBe(
+        toggleFullscreenState(false)
+      );
+    });
+
+    it("is deterministic for true", () => {
+      expect(toggleFullscreenState(true)).toBe(
+        toggleFullscreenState(true)
+      );
+    });
+  });
+});

--- a/submissions/examples/86394-video-player-fullscreen-toggle-state/style.css
+++ b/submissions/examples/86394-video-player-fullscreen-toggle-state/style.css
@@ -1,0 +1,125 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  padding: 24px;
+  display: grid;
+  place-items: center;
+  font-family: Arial, Helvetica, sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.player-wrapper {
+  width: min(100%, 760px);
+  text-align: center;
+}
+
+.video-player {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border: 1px solid #334155;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at center, #334155, #111827 70%);
+  box-shadow: 0 24px 50px rgb(0 0 0 / 35%);
+  transition:
+    border-radius 200ms ease,
+    transform 200ms ease;
+}
+
+.video-player.fullscreen {
+  border-radius: 0;
+  transform: scale(1.01);
+}
+
+.video-content {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  padding: 24px;
+}
+
+.play-icon {
+  width: 70px;
+  height: 70px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #4f46e5;
+  font-size: 1.5rem;
+}
+
+.video-content h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.video-content p {
+  margin: 8px 0 0;
+  color: #cbd5e1;
+}
+
+.controls {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  left: 18px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+button {
+  border: 1px solid #6366f1;
+  border-radius: 9px;
+  padding: 10px 16px;
+  background: #4f46e5;
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+button:hover {
+  background: #4338ca;
+}
+
+button:focus-visible {
+  outline: 3px solid #a5b4fc;
+  outline-offset: 3px;
+}
+
+.status {
+  margin: 18px 0 0;
+  color: #a5b4fc;
+  font-weight: 700;
+}
+
+@media (max-width: 520px) {
+  body {
+    padding: 16px;
+  }
+
+  .video-content h1 {
+    font-size: 1.5rem;
+  }
+
+  .play-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  button {
+    padding: 8px 12px;
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a self-contained Video Player example with a Vitest unit specification
for validating fullscreen toggle state transitions.

The test suite covers the initial state, normal enter/exit transitions,
repeated toggles, boundary conditions, invalid inputs, and state invariants.

## Type of Change

- [x] 🧪 Test improvement
- [ ] ✨ New example
- [ ] 🎨 UI enhancement
- [ ] 🐛 Bug fix
- [x] 📝 Documentation

## Submission Checklist

- [x] All changes are inside `submissions/`
- [x] Includes `demo.html`
- [x] Includes `style.css`
- [x] Includes `fullscreen-toggle.test.js`
- [x] Includes `README.md`
- [x] No changes to `core/`
- [x] No changes to `scss/`
- [x] One feature per PR

## Test Coverage

- [x] Initial fullscreen state
- [x] Enter fullscreen
- [x] Exit fullscreen
- [x] Repeated toggles
- [x] Even toggle count
- [x] Odd toggle count
- [x] Boolean state boundaries
- [x] Invalid inputs
- [x] State invariants
- [x] 100% passing assertions

## Edge Cases

- [x] `undefined`
- [x] `null`
- [x] `0`
- [x] `1`
- [x] Empty string
- [x] Non-empty string
- [x] Object input
- [x] Array input
- [x] Repeated state transitions

## Features

- Video player-style interface
- Fullscreen toggle button
- Accessible `aria-pressed` state
- Accessible button labels
- Visual fullscreen state
- Responsive styling
- Vitest unit tests
- Pure HTML, CSS, and JavaScript
- No external UI libraries

## Demo

- [x] Demo included
- [x] Opens directly in a browser
- [x] Interactive fullscreen toggle
- [x] Visual state feedback

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari

## Notes for Maintainers

This submission is fully self-contained inside:

`submissions/examples/86394-video-player-fullscreen-toggle-state/`

The implementation keeps the fullscreen state as a deterministic boolean so
the transition logic can be tested reliably without depending on the browser's
native Fullscreen API.

No existing files outside the submission directory have been modified.

Closes #86394