### PR TITLE
feat: add bar-race-loader component

### DIFF
--- a/submissions/examples/bar-race-loader/README.md
+++ b/submissions/examples/bar-race-loader/README.md
@@ -1,0 +1,24 @@
+# Bar Race Loader
+
+Four bars race across a soft track, shrink back, and run again like lane athletes.
+
+## Features
+- Keyframed translateX progress animates each bar across a visible track
+- Per-lane stagger gives a satisfying sequential start
+- Track design doubles as a progress rail
+
+## Usage
+```html
+<div class="br-loader" role="status" aria-label="Loading">
+  <div class="br-lane"><span></span></div>
+  <div class="br-lane"><span></span></div>
+  <div class="br-lane"><span></span></div>
+  <div class="br-lane"><span></span></div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/bar-race-loader/demo.html
+++ b/submissions/examples/bar-race-loader/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bar Race Loader &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Loader</p>
+    <h1>Bar Race Loader</h1>
+    <p class="sub">Four lanes sprint across a warm track — each bar restarts just as the next one catches up.</p>
+  </header>
+  <main class="stage">
+    <div class="br-loader" aria-label="Loading" role="status">
+      <div class="br-lane"><span></span></div>
+      <div class="br-lane"><span></span></div>
+      <div class="br-lane"><span></span></div>
+      <div class="br-lane"><span></span></div>
+    </div>
+  </main>
+  <p class="stage-caption">The track length scales with <code>--br-len</code>.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/bar-race-loader/style.css
+++ b/submissions/examples/bar-race-loader/style.css
@@ -1,0 +1,62 @@
+/* Bar Race Loader — EaseMotion CSS demo */
+:root {
+  --br-track: #ffedd5;
+  --br-bar: #ea580c;
+  --br-len: 340px;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Georgia", "Times New Roman", serif;
+  background: linear-gradient(180deg, #fff7ed 0%, #ffedd5 100%);
+  color: #7c2d12;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; }
+.kicker { color: var(--br-bar); font-weight: 700; letter-spacing: 3px; font-size: 12px; text-transform: uppercase; }
+.page-head h1 { font-size: 36px; margin: 10px 0 8px; }
+.sub { max-width: 540px; line-height: 1.6; color: #9a3412; }
+
+.stage {
+  width: 100%;
+  max-width: 560px;
+  background: #ffffff;
+  border: 2px solid #fdba74;
+  border-radius: 18px;
+  padding: 40px 28px;
+  box-shadow: 0 18px 40px rgba(234, 88, 12, 0.14);
+}
+
+.br-loader { display: flex; flex-direction: column; gap: 16px; }
+.br-lane { height: 14px; border-radius: 999px; background: var(--br-track); overflow: hidden; }
+.br-lane span {
+  display: block;
+  width: 38%;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #fb923c, var(--br-bar));
+  animation: br-run 1.8s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+}
+.br-lane:nth-child(2) span { animation-delay: 0.15s; }
+.br-lane:nth-child(3) span { animation-delay: 0.3s; }
+.br-lane:nth-child(4) span { animation-delay: 0.45s; }
+
+@keyframes br-run {
+  0%   { transform: translateX(-110%); }
+  55%  { transform: translateX(calc(var(--br-len) - 38%)); }
+  70%  { transform: translateX(calc(var(--br-len) - 38%)) scaleX(0.6); }
+  100% { transform: translateX(-110%); }
+}
+
+.stage-caption { margin-top: 26px; text-align: center; color: #c2410c; font-size: 14px; }
+.page-foot { margin-top: 40px; color: #fdba74; font-size: 13px; display: flex; gap: 16px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .br-lane span { animation: none; transform: translateX(0); }
+}


### PR DESCRIPTION
## Summary

Add the **Bar Race Loader** component to the EaseMotion CSS gallery. This is a Loader demo rendered with plain HTML and CSS.

**Description:** Four bars race across a soft track, shrink back, and run again like lane athletes.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/bar-race-loader/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Four bars race across a soft track, shrink back, and run again like lane athletes.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Loader category in the gallery with a polished, reusable effect.

### Key features
- Keyframed translateX progress animates each bar across a visible track
- Per-lane stagger gives a satisfying sequential start
- Track design doubles as a progress rail

### Demo
Open `submissions/examples/bar-race-loader/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #86759
