### PR TITLE
feat: add ease-drag-note-pin-board-sap

### DIFF
--- a/submissions/examples/ease-drag-note-pin-board-sap/README.md
+++ b/submissions/examples/ease-drag-note-pin-board-sap/README.md
@@ -1,0 +1,11 @@
+# ease-drag-note-pin-board-sap
+
+A corkboard with freely draggable sticky notes that can be repositioned anywhere within the board.
+
+## Usage
+Include `style.css`, add `.board-note` elements with inline `top`/`left` positions inside `.pin-board-sap`.
+
+## Notes
+- Drag offset is calculated once at `mousedown` (cursor position minus current element position) so the note doesn't "jump" to align with the cursor when drag starts.
+- Dragged note gets a deeper shadow and raised `z-index`, visually lifting it above other notes.
+- Respects `prefers-reduced-motion`: shadow transition is disabled; free-drag positioning is unaffected as direct input.

--- a/submissions/examples/ease-drag-note-pin-board-sap/demo.html
+++ b/submissions/examples/ease-drag-note-pin-board-sap/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-note-pin-board-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="pin-board-sap" id="board">
+    <div class="board-note" style="top:20px;left:20px;">Buy milk</div>
+    <div class="board-note" style="top:60px;left:150px;">Call Alex</div>
+    <div class="board-note" style="top:130px;left:40px;">Team sync 3pm</div>
+  </div>
+  <script>
+    document.querySelectorAll('.board-note').forEach(note => {
+      let dragging = false, offX = 0, offY = 0;
+      note.addEventListener('mousedown', (e) => {
+        dragging = true;
+        note.classList.add('dragging');
+        offX = e.clientX - note.offsetLeft;
+        offY = e.clientY - note.offsetTop;
+      });
+      window.addEventListener('mousemove', (e) => {
+        if (!dragging) return;
+        note.style.left = (e.clientX - offX) + 'px';
+        note.style.top = (e.clientY - offY) + 'px';
+      });
+      window.addEventListener('mouseup', () => {
+        dragging = false;
+        note.classList.remove('dragging');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-note-pin-board-sap/style.css
+++ b/submissions/examples/ease-drag-note-pin-board-sap/style.css
@@ -1,0 +1,34 @@
+.pin-board-sap {
+  position: relative;
+  width: 340px;
+  height: 240px;
+  background: #d6c6a8;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.pin-board-sap .board-note {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: #fde047;
+  padding: 10px;
+  box-sizing: border-box;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  box-shadow: 2px 4px 8px rgba(0,0,0,0.2);
+  cursor: grab;
+  transition: box-shadow 0.2s ease;
+}
+
+.pin-board-sap .board-note.dragging {
+  cursor: grabbing;
+  box-shadow: 4px 10px 20px rgba(0,0,0,0.3);
+  z-index: 10;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pin-board-sap .board-note {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-note-pin-board-sap`, a freely draggable sticky note corkboard.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-note-pin-board-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Drag offset computed once at mousedown, preventing the note from jumping to the cursor position on drag start.
- Dragging raises z-index and deepens shadow for a lifted visual state.
- `prefers-reduced-motion` disables the shadow transition; free-drag itself is unaffected.

## Feature Description

Adds a reusable freely-draggable sticky note board component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.