### PR TITLE
feat: add ease-scroll-blur-text-focus-sap

### DIFF
--- a/submissions/examples/ease-scroll-blur-text-focus-sap/README.md
+++ b/submissions/examples/ease-scroll-blur-text-focus-sap/README.md
@@ -1,0 +1,10 @@
+# ease-scroll-blur-text-focus-sap
+
+Text where each word sharpens into focus from a blurred state as the paragraph scrolls into view, like a camera racking focus.
+
+## Usage
+Include `style.css`, wrap each word in a `.bf-word` span, attach the `IntersectionObserver` from `demo.html`.
+
+## Notes
+- Uses `filter: blur()` rather than opacity alone, giving a true optical "coming into focus" read distinct from a plain fade.
+- Respects `prefers-reduced-motion`: blur filter is removed entirely (no blur even at rest), leaving only an opacity transition as the reveal cue.

--- a/submissions/examples/ease-scroll-blur-text-focus-sap/demo.html
+++ b/submissions/examples/ease-scroll-blur-text-focus-sap/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-blur-text-focus-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f4f4f5; }
+    .spacer { height: 70vh; display: flex; align-items: center; justify-content: center; color: #94a3b8; }
+    .page { display: flex; justify-content: center; padding-bottom: 300px; }
+  </style>
+</head>
+<body>
+  <div class="spacer">Scroll down</div>
+  <div class="page">
+    <p class="blur-focus-sap" id="text">
+      <span class="bf-word">Great</span> <span class="bf-word">design</span> <span class="bf-word">happens</span>
+      <span class="bf-word">when</span> <span class="bf-word">clarity</span> <span class="bf-word">meets</span>
+      <span class="bf-word">intention.</span>
+    </p>
+  </div>
+  <script>
+    const words = [...document.querySelectorAll('.bf-word')];
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('focused');
+      });
+    }, { threshold: 0.9 });
+    words.forEach(w => observer.observe(w));
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-blur-text-focus-sap/style.css
+++ b/submissions/examples/ease-scroll-blur-text-focus-sap/style.css
@@ -1,0 +1,26 @@
+.blur-focus-sap {
+  font-family: system-ui, sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  max-width: 460px;
+  line-height: 1.6;
+}
+
+.blur-focus-sap .bf-word {
+  display: inline-block;
+  filter: blur(6px);
+  opacity: 0.3;
+  transition: filter 0.4s ease, opacity 0.4s ease;
+}
+
+.blur-focus-sap .bf-word.focused {
+  filter: blur(0);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blur-focus-sap .bf-word {
+    transition: opacity 0.2s ease;
+    filter: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-blur-text-focus-sap`, a scroll-triggered blur-to-focus text reveal.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-scroll-blur-text-focus-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `filter: blur()` produces a true optical focus effect rather than a plain opacity fade.
- `prefers-reduced-motion` removes blur entirely (even at rest state), leaving only opacity as the reveal mechanism.

## Feature Description

Adds a reusable scroll-triggered blur-focus text reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.