### PR TITLE
feat: add ease-animated-radio-card-select-sap

### DIFF
--- a/submissions/examples/ease-animated-radio-card-select-sap/README.md
+++ b/submissions/examples/ease-animated-radio-card-select-sap/README.md
@@ -1,0 +1,11 @@
+# ease-animated-radio-card-select-sap
+
+Selectable option cards built on native radio inputs, where the selected card lifts and gains a highlighted border/ring.
+
+## Usage
+Include `style.css`, add `<label>` wrapping a hidden `<input type="radio">` + card content.
+
+## Notes
+- Uses the `:has()` relational selector (`label:has(input:checked)`) to style the label based on its child input's state, avoiding the need for a wrapping-element `:checked + label` sibling structure.
+- Native radio inputs preserve full keyboard/screen-reader accessibility.
+- Respects `prefers-reduced-motion`: the lift transform is removed, border/ring transitions remain.

--- a/submissions/examples/ease-animated-radio-card-select-sap/demo.html
+++ b/submissions/examples/ease-animated-radio-card-select-sap/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-animated-radio-card-select-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="radio-card-sap">
+    <label><input type="radio" name="plan" checked><div class="rc-title">Basic</div><div class="rc-desc">$9/mo</div></label>
+    <label><input type="radio" name="plan"><div class="rc-title">Pro</div><div class="rc-desc">$29/mo</div></label>
+    <label><input type="radio" name="plan"><div class="rc-title">Team</div><div class="rc-desc">$59/mo</div></label>
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-animated-radio-card-select-sap/style.css
+++ b/submissions/examples/ease-animated-radio-card-select-sap/style.css
@@ -1,0 +1,48 @@
+.radio-card-sap {
+  display: flex;
+  gap: 12px;
+  font-family: system-ui, sans-serif;
+}
+
+.radio-card-sap label {
+  position: relative;
+  width: 120px;
+  padding: 16px;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
+}
+
+.radio-card-sap input {
+  position: absolute;
+  opacity: 0;
+}
+
+.radio-card-sap input:checked + label,
+.radio-card-sap label:has(input:checked) {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  transform: translateY(-2px);
+}
+
+.radio-card-sap .rc-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #111;
+}
+
+.radio-card-sap .rc-desc {
+  font-size: 11px;
+  color: #64748b;
+  margin-top: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radio-card-sap label {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .radio-card-sap label:has(input:checked) {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-animated-radio-card-select-sap`, animated selectable radio option cards.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-animated-radio-card-select-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses `:has()` to style the label from its child input's checked state, avoiding extra sibling-selector markup structure.
- Native radio inputs preserve full accessibility.
- `prefers-reduced-motion` removes the lift transform, keeping border/ring transitions.

## Feature Description

Adds a reusable animated radio card selector component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.v