### PR TITLE
feat: add ease-scroll-reveal-clip-circle-sap

### DIFF
--- a/submissions/examples/ease-scroll-reveal-clip-circle-sap/README.md
+++ b/submissions/examples/ease-scroll-reveal-clip-circle-sap/README.md
@@ -1,0 +1,7 @@
+# ease-scroll-reveal-clip-circle-sap
+
+An image that reveals through an expanding circular iris wipe as it scrolls into view, like a camera aperture opening.
+
+## Notes
+- `clip-path: circle()` animates its radius from 0% to 75% (slightly beyond half the diagonal isn't needed since the container clips excess), producing an iris-style reveal.
+- Respects `prefers-reduced-motion`: transition removed, image displays fully revealed immediately.

--- a/submissions/examples/ease-scroll-reveal-clip-circle-sap/demo.html
+++ b/submissions/examples/ease-scroll-reveal-clip-circle-sap/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-scroll-reveal-clip-circle-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f4f4f5; }
+    .spacer { height: 80vh; display: flex; align-items: center; justify-content: center; color: #94a3b8; }
+    .page { display: flex; justify-content: center; padding-bottom: 300px; }
+  </style>
+</head>
+<body>
+  <div class="spacer">Scroll down</div>
+  <div class="page">
+    <div class="clip-circle-sap" id="revealBox">
+      <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=600" alt="Landscape">
+    </div>
+  </div>
+  <script>
+    const box = document.getElementById('revealBox');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) box.classList.add('in-view'); });
+    }, { threshold: 0.4 });
+    observer.observe(box);
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-scroll-reveal-clip-circle-sap/style.css
+++ b/submissions/examples/ease-scroll-reveal-clip-circle-sap/style.css
@@ -1,0 +1,26 @@
+.clip-circle-sap {
+  width: 300px;
+  height: 200px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.clip-circle-sap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  clip-path: circle(0% at 50% 50%);
+  transition: clip-path 1s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.clip-circle-sap.in-view img {
+  clip-path: circle(75% at 50% 50%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .clip-circle-sap img {
+    transition: none;
+    clip-path: circle(75% at 50% 50%);
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-scroll-reveal-clip-circle-sap`, a scroll-triggered circular iris-wipe image reveal.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-scroll-reveal-clip-circle-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- `clip-path: circle()` radius animates from 0% to 75%, producing a camera-iris style reveal.
- `prefers-reduced-motion` removes the transition, showing the image fully revealed instantly.

## Feature Description

Adds a reusable scroll-triggered circular reveal component.

Level: Intermediate

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.