### PR TITLE
feat: add ease-hover-image-grayscale-color-sap

### DIFF
--- a/submissions/examples/ease-hover-image-grayscale-color-sap/README.md
+++ b/submissions/examples/ease-hover-image-grayscale-color-sap/README.md
@@ -1,0 +1,7 @@
+# ease-hover-image-grayscale-color-sap
+
+An image that transitions from grayscale to full color on hover, paired with a slight zoom.
+
+## Notes
+- `filter: grayscale()` is a smoothly animatable CSS property, giving a clean color transition without any image-swap trick.
+- Respects `prefers-reduced-motion`: zoom transform removed, grayscale-to-color transition remains as the primary (non-motion) hover cue.

--- a/submissions/examples/ease-hover-image-grayscale-color-sap/demo.html
+++ b/submissions/examples/ease-hover-image-grayscale-color-sap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-hover-image-grayscale-color-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="grayscale-hover-sap">
+    <img src="https://images.unsplash.com/photo-1501594907352-04cda38ebc29?w=600" alt="Mountain">
+  </div>
+</body>
+</html>

--- a/submissions/examples/ease-hover-image-grayscale-color-sap/style.css
+++ b/submissions/examples/ease-hover-image-grayscale-color-sap/style.css
@@ -1,0 +1,29 @@
+.grayscale-hover-sap {
+  width: 260px;
+  height: 180px;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.grayscale-hover-sap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: grayscale(100%);
+  transition: filter 0.5s ease, transform 0.5s ease;
+}
+
+.grayscale-hover-sap:hover img {
+  filter: grayscale(0%);
+  transform: scale(1.05);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grayscale-hover-sap img {
+    transition: filter 0.3s ease;
+  }
+  .grayscale-hover-sap:hover img {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-hover-image-grayscale-color-sap`, a hover grayscale-to-color image reveal.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-hover-image-grayscale-color-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Uses `filter: grayscale()` for a smooth color transition without any asset-swap trick.
- `prefers-reduced-motion` removes the zoom transform, keeping the grayscale-to-color filter transition as the primary cue.

## Feature Description

Adds a reusable hover grayscale-to-color image component.

Level: Beginner

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.