### PR TITLE
feat: add ease-drag-slider-price-range-sap

### DIFF
--- a/submissions/examples/ease-drag-slider-price-range-sap/README.md
+++ b/submissions/examples/ease-drag-slider-price-range-sap/README.md
@@ -1,0 +1,8 @@
+# ease-drag-slider-price-range-sap
+
+A dual-thumb price range slider — drag either thumb independently, with the fill bar tracking the selected range between them.
+
+## Notes
+- Each thumb is clamped against the other (`minPct` can't pass `maxPct - 2`, and vice versa), preventing the handles from crossing or overlapping.
+- Fill bar uses `left`/`right` percentages rather than `left`/`width`, which naturally follows both thumbs without recalculating width separately.
+- Respects `prefers-reduced-motion`: thumb press-scale transition is disabled; drag itself remains functional as direct input.

--- a/submissions/examples/ease-drag-slider-price-range-sap/demo.html
+++ b/submissions/examples/ease-drag-slider-price-range-sap/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ease-drag-slider-price-range-sap demo</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body { height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: #f4f4f5; }
+  </style>
+</head>
+<body>
+  <div class="price-range-sap">
+    <div class="range-labels"><span id="minLabel">$20</span><span id="maxLabel">$75</span></div>
+    <div class="range-track" id="track">
+      <div class="range-fill" id="fill"></div>
+      <div class="range-thumb thumb-min" id="thumbMin"></div>
+      <div class="range-thumb thumb-max" id="thumbMax"></div>
+    </div>
+  </div>
+  <script>
+    const track = document.getElementById('track');
+    const fill = document.getElementById('fill');
+    const thumbMin = document.getElementById('thumbMin');
+    const thumbMax = document.getElementById('thumbMax');
+    const minLabel = document.getElementById('minLabel');
+    const maxLabel = document.getElementById('maxLabel');
+    let minPct = 20, maxPct = 75;
+    let dragTarget = null;
+
+    function render() {
+      thumbMin.style.left = minPct + '%';
+      thumbMax.style.left = maxPct + '%';
+      fill.style.left = minPct + '%';
+      fill.style.right = (100 - maxPct) + '%';
+      minLabel.textContent = '$' + Math.round(minPct);
+      maxLabel.textContent = '$' + Math.round(maxPct);
+    }
+
+    function pctFromX(x) {
+      const rect = track.getBoundingClientRect();
+      return Math.max(0, Math.min(100, ((x - rect.left) / rect.width) * 100));
+    }
+
+    thumbMin.addEventListener('mousedown', () => dragTarget = 'min');
+    thumbMax.addEventListener('mousedown', () => dragTarget = 'max');
+    window.addEventListener('mousemove', (e) => {
+      if (!dragTarget) return;
+      const pct = pctFromX(e.clientX);
+      if (dragTarget === 'min') minPct = Math.min(pct, maxPct - 2);
+      else maxPct = Math.max(pct, minPct + 2);
+      render();
+    });
+    window.addEventListener('mouseup', () => dragTarget = null);
+    render();
+  </script>
+</body>
+</html>

--- a/submissions/examples/ease-drag-slider-price-range-sap/style.css
+++ b/submissions/examples/ease-drag-slider-price-range-sap/style.css
@@ -1,0 +1,54 @@
+.price-range-sap {
+  width: 280px;
+  font-family: system-ui, sans-serif;
+}
+
+.price-range-sap .range-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 700;
+  color: #111;
+  margin-bottom: 12px;
+}
+
+.price-range-sap .range-track {
+  position: relative;
+  height: 6px;
+  border-radius: 3px;
+  background: #e2e8f0;
+}
+
+.price-range-sap .range-fill {
+  position: absolute;
+  height: 100%;
+  border-radius: 3px;
+  background: #2563eb;
+  left: 20%;
+  right: 25%;
+}
+
+.price-range-sap .range-thumb {
+  position: absolute;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  border: 3px solid #2563eb;
+  transform: translate(-50%, -50%);
+  cursor: grab;
+  transition: transform 0.15s ease;
+}
+
+.price-range-sap .range-thumb:active {
+  cursor: grabbing;
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.price-range-sap .thumb-min { left: 20%; }
+.price-range-sap .thumb-max { left: 75%; }
+
+@media (prefers-reduced-motion: reduce) {
+  .price-range-sap .range-thumb { transition: none; }
+}


### PR DESCRIPTION
## Pull Request Description

Adds `ease-drag-slider-price-range-sap`, a draggable dual-thumb price range slider.

---

## Type of Change
- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix

---

## Submission Checklist
- [x] All changes are inside `submissions/examples/ease-drag-slider-price-range-sap/`
- [x] Includes complete `demo.html`
- [x] Includes `style.css`
- [x] Includes `README.md`
- [x] Includes reduced-motion support
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR

---

## Implementation notes
- `demo.html` includes full `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
- Thumbs are mutually clamped to prevent crossing/overlapping.
- Fill bar uses `left`/`right` percentages, naturally tracking both thumbs without separate width math.
- `prefers-reduced-motion` disables the thumb press-scale transition; drag remains functional.

## Feature Description

Adds a reusable dual-thumb price range slider component.

Level: Advanced

@SAPTARSHI-coder Please review the submission and validator requirements.

@github-actions Please validate the submission structure and required files.