### PR TITLE
docs: add cyberpunk vertical timeline responsive guide (#85735)

### DIFF
--- a/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/README.md
+++ b/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/README.md
@@ -1,0 +1,95 @@
+# Cyberpunk Vertical Timeline Responsive Breakpoints Guide
+
+This example demonstrates responsive breakpoint configuration for the
+Cyberpunk Vertical Timeline.
+
+## HTML Markup
+
+```html
+<section
+  class="cyberpunk-timeline"
+  aria-label="Project timeline"
+>
+  <article class="timeline-item">
+    <h2>2077</h2>
+    <p>Project initialization.</p>
+  </article>
+</section>
+```
+
+## CSS Custom Properties
+
+```css
+:root {
+  --timeline-bg: #0d1117;
+  --timeline-accent: #00e5ff;
+  --timeline-text: #ffffff;
+  --timeline-spacing: 2rem;
+  --timeline-line-width: 3px;
+}
+```
+
+These properties can be overridden to customize the timeline theme.
+
+## Modifier Classes
+
+### Compact
+
+```html
+<div class="cyberpunk-timeline compact">
+  ...
+</div>
+```
+
+Reduces spacing between timeline entries.
+
+### Neon
+
+```html
+<div class="cyberpunk-timeline neon">
+  ...
+</div>
+```
+
+Changes the timeline accent color.
+
+## Responsive Breakpoints
+
+### Tablet
+
+```css
+@media (max-width: 768px) {
+  .cyberpunk-timeline {
+    padding-left: 1.5rem;
+  }
+}
+```
+
+### Mobile
+
+```css
+@media (max-width: 480px) {
+  .cyberpunk-timeline {
+    padding-left: 1rem;
+  }
+}
+```
+
+The breakpoints reduce spacing and marker positioning on smaller screens.
+
+## Accessibility
+
+- Use semantic elements for timeline content.
+- Provide a descriptive label for the timeline.
+- Maintain sufficient color contrast.
+- Do not rely only on color to communicate information.
+- Keep focus indicators visible for interactive elements.
+
+## Keyboard Navigation
+
+When timeline entries contain interactive controls:
+
+- `Tab` moves focus forward.
+- `Shift + Tab` moves focus backward.
+- `Enter` or `Space` activates focused controls.
+- Focus order should remain logical at every breakpoint.

--- a/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/demo.html
+++ b/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cyberpunk Vertical Timeline - Responsive</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<main>
+  <h1>Responsive Cyberpunk Timeline</h1>
+
+  <section
+    class="cyberpunk-timeline"
+    aria-label="Project timeline"
+  >
+    <article class="timeline-item">
+      <h2>2077</h2>
+      <p>Project initialization.</p>
+    </article>
+
+    <article class="timeline-item">
+      <h2>2078</h2>
+      <p>Development and testing.</p>
+    </article>
+
+    <article class="timeline-item">
+      <h2>2079</h2>
+      <p>Production release.</p>
+    </article>
+  </section>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/style.css
+++ b/submissions/examples/cyberpunk-vertical-timeline-responsive-85735/style.css
@@ -1,0 +1,94 @@
+:root {
+  --timeline-bg: #0d1117;
+  --timeline-accent: #00e5ff;
+  --timeline-text: #ffffff;
+  --timeline-spacing: 2rem;
+  --timeline-line-width: 3px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: var(--timeline-bg);
+  color: var(--timeline-text);
+  font-family: Arial, sans-serif;
+}
+
+main {
+  width: min(100%, 800px);
+  margin: 0 auto;
+}
+
+.cyberpunk-timeline {
+  border-left: var(--timeline-line-width) solid var(--timeline-accent);
+  padding-left: var(--timeline-spacing);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: var(--timeline-spacing);
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  left: -2.45rem;
+  top: 0.35rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--timeline-accent);
+}
+
+.timeline-item h2 {
+  margin-top: 0;
+  color: var(--timeline-accent);
+}
+
+.cyberpunk-timeline.compact {
+  --timeline-spacing: 1rem;
+}
+
+.cyberpunk-timeline.neon {
+  --timeline-accent: #ff00ff;
+}
+
+/* Tablet */
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .cyberpunk-timeline {
+    padding-left: 1.5rem;
+  }
+
+  .timeline-item::before {
+    left: -1.95rem;
+  }
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  body {
+    padding: 1rem;
+  }
+
+  .cyberpunk-timeline {
+    padding-left: 1rem;
+  }
+
+  .timeline-item::before {
+    left: -1.45rem;
+    width: 10px;
+    height: 10px;
+  }
+
+  .timeline-item {
+    margin-bottom: 1.25rem;
+  }
+}


### PR DESCRIPTION
# PR Description

## Summary

Adds documentation for the **Cyberpunk Vertical Timeline responsive breakpoints layout**.

## Changes Made

* Added `submissions/examples/cyberpunk-vertical-timeline-responsive-85735/`
* Added `demo.html` with responsive timeline markup.
* Added `style.css` with:

  * CSS custom property overrides
  * Modifier classes
  * Tablet responsive breakpoint
  * Mobile responsive breakpoint
* Added `README.md` covering:

  * HTML markup examples
  * Theme customization
  * Modifier classes
  * Responsive breakpoints
  * Accessibility guidance
  * Keyboard navigation guidance

## Testing

* Verified the demo HTML structure.
* Verified responsive behavior for tablet and mobile breakpoints.
* Verified CSS custom property overrides.
* Verified modifier classes.
* Reviewed accessibility and keyboard navigation guidance.

## Related Issue

Closes #85735
