### PR TITLE
feat: add bottom-nav-bar component

### DIFF
--- a/submissions/examples/bottom-nav-bar/README.md
+++ b/submissions/examples/bottom-nav-bar/README.md
@@ -1,0 +1,21 @@
+# Bottom Nav Bar
+
+A phone-style bottom navigation where the active icon lifts and tints.
+
+## Features
+- Active item raises with a small bounce
+- Label color follows the active state
+- Indicator chip under the selected icon
+
+## Usage
+```html
+<nav class="bn-bar">
+  <a class="bn-item bn-active" href="#"> <span class="bn-ico">&#10133;</span> <span class="bn-label">Create</span> </a>
+</nav>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/bottom-nav-bar/demo.html
+++ b/submissions/examples/bottom-nav-bar/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bottom Nav Bar &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Menu</p>
+    <h1>Bottom Nav Bar</h1>
+    <p class="sub">The active tab pops its icon and lights a pulsing dot below.</p>
+  </header>
+  <main class="stage">
+    <nav class="bn-bar">
+      <a class="bn-item" href="#"> <span class="bn-ico">&#127968;</span> <span class="bn-label">Home</span> </a>
+      <a class="bn-item" href="#"> <span class="bn-ico">&#128269;</span> <span class="bn-label">Search</span> </a>
+      <a class="bn-item bn-active" href="#"> <span class="bn-ico">&#10133;</span> <span class="bn-label">Create</span> </a>
+      <a class="bn-item" href="#"> <span class="bn-ico">&#128276;</span> <span class="bn-label">Inbox</span> </a>
+      <a class="bn-item" href="#"> <span class="bn-ico">&#128100;</span> <span class="bn-label">Profile</span> </a>
+    </nav>
+  </main>
+  <p class="stage-note">The icon uses an elastic overshoot easing for that handheld feel.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/bottom-nav-bar/style.css
+++ b/submissions/examples/bottom-nav-bar/style.css
@@ -1,0 +1,82 @@
+/* Bottom Nav Bar — EaseMotion CSS demo */
+:root {
+  --bn-violet: #8b5cf6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 50% 100%, #ede9fe 0%, #f5f3ff 60%);
+  color: #4c1d95;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 52px; }
+.kicker { color: var(--bn-violet); font-weight: 700; letter-spacing: 4px; font-size: 12px; text-transform: uppercase; }
+.page-head h1 { font-size: 32px; margin: 10px 0; }
+.sub { color: #7c3aed; max-width: 480px; line-height: 1.7; }
+
+.stage { width: 100%; max-width: 480px; }
+
+.bn-bar {
+  background: #ffffff;
+  border: 1px solid #ddd6fe;
+  border-radius: 24px;
+  display: flex;
+  justify-content: space-around;
+  padding: 12px 8px;
+  box-shadow: 0 20px 44px rgba(76, 29, 149, 0.16);
+}
+.bn-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 0;
+  border-radius: 16px;
+  color: #a78bfa;
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+  position: relative;
+  transition: color 0.25s ease;
+}
+.bn-ico {
+  width: 40px; height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  background: transparent;
+  transition: background 0.25s ease, transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.bn-item.bn-active { color: var(--bn-violet); }
+.bn-active .bn-ico { background: #ede9fe; transform: translateY(-6px) scale(1.12); box-shadow: 0 8px 16px rgba(139, 92, 246, 0.3); }
+.bn-active .bn-label::after {
+  content: "";
+  display: block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--bn-violet);
+  margin: 5px auto 0;
+  animation: bn-dot 1.6s ease-in-out infinite;
+}
+
+@keyframes bn-dot {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.4); }
+}
+
+.stage-note { margin-top: 32px; color: #7c3aed; font-size: 14px; text-align: center; }
+.page-foot { margin-top: 32px; color: #c4b5fd; font-size: 13px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .bn-item, .bn-ico, .bn-label::after { transition: none; animation: none; }
+}


### PR DESCRIPTION
## Summary

Add the **Bottom Nav Bar** component to the EaseMotion CSS gallery. This is a Menu demo rendered with plain HTML and CSS.

**Description:** A phone-style bottom navigation where the active icon lifts and tints.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/bottom-nav-bar/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A phone-style bottom navigation where the active icon lifts and tints.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Menu category in the gallery with a polished, reusable effect.

### Key features
- Active item raises with a small bounce
- Label color follows the active state
- Indicator chip under the selected icon

### Demo
Open `submissions/examples/bottom-nav-bar/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #86832
