### PR TITLE
feat: add breakpoint-bar component

### DIFF
--- a/submissions/examples/breakpoint-bar/README.md
+++ b/submissions/examples/breakpoint-bar/README.md
@@ -1,0 +1,26 @@
+# Breakpoint Bar
+
+A responsive-design strip showing mobile, tablet and desktop breakpoints with an active marker.
+
+## Features
+- Segment widths grow with the breakpoint
+- Active marker slides between tiers
+- Labels pop in above the bar
+
+## Usage
+```html
+<div class="bb-wrap">
+  <div class="bb-bar">
+    <div class="bb-seg bb-s1"></div>
+    <div class="bb-seg bb-s2"></div>
+    <div class="bb-seg bb-s3"></div>
+    <span class="bb-marker"></span>
+  </div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/breakpoint-bar/demo.html
+++ b/submissions/examples/breakpoint-bar/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breakpoint Bar &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Dev Tools</p>
+    <h1>Breakpoint Bar</h1>
+    <p class="sub">Watch the active breakpoint glide across your layout plan.</p>
+  </header>
+  <main class="stage">
+    <div class="bb-wrap">
+      <div class="bb-labels">
+        <span class="bb-label">Mobile 375</span>
+        <span class="bb-label">Tablet 768</span>
+        <span class="bb-label">Desktop 1440</span>
+      </div>
+      <div class="bb-bar">
+        <div class="bb-seg bb-s1"></div>
+        <div class="bb-seg bb-s2"></div>
+        <div class="bb-seg bb-s3"></div>
+        <span class="bb-marker"></span>
+      </div>
+    </div>
+  </main>
+  <p class="stage-caption">The amber marker patrols every viewport tier.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Sliding marker</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/breakpoint-bar/style.css
+++ b/submissions/examples/breakpoint-bar/style.css
@@ -1,0 +1,83 @@
+/* Breakpoint Bar — EaseMotion CSS demo */
+:root {
+  --bb-accent: #6366f1;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #f5f3ff, #e0e7ff);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--bb-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #312e81; }
+.sub { color: #4f46e5; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 640px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(99, 102, 241, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(49, 46, 129, 0.14);
+  display: grid;
+  place-items: center;
+  min-height: 320px;
+  padding: 48px;
+}
+
+.bb-wrap { width: 100%; max-width: 460px; }
+.bb-labels { display: flex; justify-content: space-between; margin-bottom: 10px; }
+.bb-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: #6b7280;
+  opacity: 0;
+  animation: bb-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.bb-label:nth-child(1) { animation-delay: 0.3s; }
+.bb-label:nth-child(2) { animation-delay: 0.6s; }
+.bb-label:nth-child(3) { animation-delay: 0.9s; }
+.bb-bar {
+  position: relative;
+  height: 40px;
+  border-radius: 999px;
+  background: #e0e7ff;
+  border: 2px solid #c7d2fe;
+  overflow: hidden;
+  display: flex;
+}
+.bb-seg { height: 100%; border-right: 2px solid #fff; }
+.bb-s1 { width: 28%; background: #a5b4fc; }
+.bb-s2 { width: 32%; background: #818cf8; }
+.bb-s3 { flex: 1; background: #6366f1; }
+.bb-marker {
+  position: absolute;
+  top: -6px;
+  bottom: -6px;
+  width: 4px;
+  border-radius: 4px;
+  background: #f59e0b;
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.7);
+  left: 28%;
+  animation: bb-slide 6s ease-in-out infinite;
+}
+
+@keyframes bb-slide {
+  0%, 100% { left: 4%; }
+  33%      { left: 42%; }
+  66%      { left: 88%; }
+}
+@keyframes bb-pop {
+  to { opacity: 1; transform: translateY(-4px); }
+}
+
+.stage-caption { text-align: center; margin-top: 26px; color: #6366f1; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #a5b4fc; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Breakpoint Bar** component to the EaseMotion CSS gallery. This is a Dev Tools demo rendered with plain HTML and CSS.

**Description:** A responsive-design strip showing mobile, tablet and desktop breakpoints with an active marker.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/breakpoint-bar/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A responsive-design strip showing mobile, tablet and desktop breakpoints with an active marker.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Dev Tools category in the gallery with a polished, reusable effect.

### Key features
- Segment widths grow with the breakpoint
- Active marker slides between tiers
- Labels pop in above the bar

### Demo
Open `submissions/examples/breakpoint-bar/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87279
