### PR TITLE
feat: add code-card-typing component

### DIFF
--- a/submissions/examples/code-card-typing/README.md
+++ b/submissions/examples/code-card-typing/README.md
@@ -1,0 +1,22 @@
+# Code Card Typing
+
+A syntax-highlighted code snippet that types itself out with a caret, line by line.
+
+## Features
+- Language-tinted code palette
+- Lines appear with a typing caret
+- Card header shows the file name
+
+## Usage
+```html
+<div class="cc-card">
+  <div class="cc-bar"><span class="cc-name">motion.css</span></div>
+  <div class="cc-code"><span class="cc-line"><span class="cc-key">.hero</span> <span class="cc-punc">{</span></span></div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/code-card-typing/demo.html
+++ b/submissions/examples/code-card-typing/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Code Card Typing &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Dev Tools</p>
+    <h1>Code Card Typing</h1>
+    <p class="sub">A snippet that types itself into existence.</p>
+  </header>
+  <main class="stage">
+    <div class="cc-card">
+      <div class="cc-bar">
+        <span class="cc-dot r"></span><span class="cc-dot y"></span><span class="cc-dot g"></span>
+        <span class="cc-name">motion.css</span>
+      </div>
+      <div class="cc-code">
+        <span class="cc-line"><span class="cc-punc">.</span><span class="cc-key">hero</span> <span class="cc-punc">{</span></span>
+        <span class="cc-line">  <span class="cc-prop">animation</span><span class="cc-punc">:</span> <span class="cc-str">float 3s infinite</span><span class="cc-punc">;</span></span>
+        <span class="cc-line">  <span class="cc-prop">transform-origin</span><span class="cc-punc">:</span> <span class="cc-str">center</span><span class="cc-punc">;</span></span>
+        <span class="cc-line"><span class="cc-punc">}</span><span class="cc-comment"> &#47;&#47; that's it!</span><span class="cc-caret"></span></span>
+      </div>
+    </div>
+  </main>
+  <p class="stage-caption">Lines cascade in with a blinking caret.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Syntax typing</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/code-card-typing/style.css
+++ b/submissions/examples/code-card-typing/style.css
@@ -1,0 +1,86 @@
+/* Code Card Typing — EaseMotion CSS demo */
+:root {
+  --cc-accent: #8b5cf6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #f5f3ff, #ede9fe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--cc-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #4c1d95; }
+.sub { color: #7c3aed; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 620px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(139, 92, 246, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(76, 29, 149, 0.12);
+  display: grid;
+  place-items: center;
+  padding: 40px;
+}
+
+.cc-card {
+  width: 100%;
+  max-width: 480px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #1e1b4b;
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  box-shadow: 0 20px 44px rgba(76, 29, 149, 0.28);
+}
+.cc-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(139, 92, 246, 0.2);
+}
+.cc-dot { width: 11px; height: 11px; border-radius: 50%; }
+.cc-dot.r { background: #f87171; }
+.cc-dot.y { background: #fbbf24; }
+.cc-dot.g { background: #34d399; }
+.cc-name { margin-left: 10px; font-size: 12px; color: #c4b5fd; }
+.cc-code { padding: 18px; font-family: "Cascadia Code", "Fira Code", "Courier New", monospace; font-size: 14px; line-height: 1.8; }
+.cc-code .cc-line { display: block; white-space: pre; opacity: 0; animation: cc-in 0.5s ease forwards; }
+.cc-code .cc-line:nth-child(1) { animation-delay: 0.3s; }
+.cc-code .cc-line:nth-child(2) { animation-delay: 0.9s; }
+.cc-code .cc-line:nth-child(3) { animation-delay: 1.5s; }
+.cc-code .cc-line:nth-child(4) { animation-delay: 2.1s; }
+.cc-key { color: #c4b5fd; }
+.cc-prop { color: #93c5fd; }
+.cc-str { color: #86efac; }
+.cc-punc { color: #a5b4fc; }
+.cc-comment { color: #64748b; font-style: italic; }
+.cc-caret {
+  display: inline-block;
+  width: 8px;
+  height: 15px;
+  background: #a78bfa;
+  vertical-align: text-bottom;
+  animation: cc-blink 0.9s step-end infinite;
+}
+
+@keyframes cc-in {
+  to { opacity: 1; }
+}
+@keyframes cc-blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+
+.stage-caption { text-align: center; margin-top: 26px; color: #8b5cf6; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #a78bfa; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Code Card Typing** component to the EaseMotion CSS gallery. This is a Dev Tools demo rendered with plain HTML and CSS.

**Description:** A syntax-highlighted code snippet that types itself out with a caret, line by line.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/code-card-typing/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A syntax-highlighted code snippet that types itself out with a caret, line by line.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Dev Tools category in the gallery with a polished, reusable effect.

### Key features
- Language-tinted code palette
- Lines appear with a typing caret
- Card header shows the file name

### Demo
Open `submissions/examples/code-card-typing/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87272
