### PR TITLE
feat: add image-zoom-hover component

### DIFF
--- a/submissions/examples/image-zoom-hover/README.md
+++ b/submissions/examples/image-zoom-hover/README.md
@@ -1,0 +1,22 @@
+# Image Zoom Hover
+
+A photo card that zooms its artwork on hover with a soft gradient caption slide-up.
+
+## Features
+- Smooth scale zoom on the artwork inside a clipped frame
+- Caption slides up over a darkening gradient
+- Box-shadow lift for an interactive card feel
+
+## Usage
+```html
+<div class="zoom-card">
+  <div class="art"></div>
+  <div class="cap"><strong>Title</strong><span>Caption</span></div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/image-zoom-hover/demo.html
+++ b/submissions/examples/image-zoom-hover/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Zoom Hover &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Media &amp; Gallery</p>
+    <h1>Image Zoom Hover</h1>
+    <p class="sub">Artwork zooms smoothly inside its frame while the caption glides up from below.</p>
+  </header>
+  <main class="stage">
+    <div class="zoom-card">
+      <div class="art art-a"></div>
+      <div class="cap"><strong>Alpine Peaks</strong><span>Hover to zoom</span></div>
+    </div>
+    <div class="zoom-card">
+      <div class="art art-b"></div>
+      <div class="cap"><strong>Deep Waters</strong><span>Hover to zoom</span></div>
+    </div>
+  </main>
+  <p class="stage-caption">Move your cursor over a card to see the artwork breathe.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Scale + caption reveal</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/image-zoom-hover/style.css
+++ b/submissions/examples/image-zoom-hover/style.css
@@ -1,0 +1,72 @@
+/* Image Zoom Hover — EaseMotion CSS demo */
+:root {
+  --iz-accent: #2563eb;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #eff6ff, #dbeafe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--iz-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #1e3a8a; }
+.sub { color: #64748b; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 720px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(30, 64, 175, 0.12);
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 40px 24px;
+}
+
+.zoom-card {
+  width: 280px;
+  border-radius: 16px;
+  overflow: hidden;
+  position: relative;
+  cursor: zoom-in;
+  box-shadow: 0 10px 26px rgba(30, 64, 175, 0.18);
+  transition: box-shadow 0.35s ease, transform 0.35s ease;
+}
+.zoom-card:hover { box-shadow: 0 18px 40px rgba(30, 64, 175, 0.28); transform: translateY(-6px); }
+
+.zoom-card .art {
+  height: 220px;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.art-a { background-image: linear-gradient(135deg, #6366f1 0%, #a855f7 45%, #ec4899 100%); }
+.art-b { background-image: linear-gradient(135deg, #06b6d4 0%, #3b82f6 55%, #8b5cf6 100%); }
+.zoom-card:hover .art { transform: scale(1.18); }
+
+.zoom-card .cap {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 34px 16px 14px;
+  background: linear-gradient(transparent, rgba(2, 6, 23, 0.82));
+  color: #fff;
+  transform: translateY(100%);
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.zoom-card:hover .cap { transform: translateY(0); }
+.zoom-card .cap strong { display: block; font-size: 16px; }
+.zoom-card .cap span { font-size: 12px; opacity: 0.85; }
+
+.stage-caption { text-align: center; margin-top: 26px; color: #64748b; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #94a3b8; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Image Zoom Hover** component to the EaseMotion CSS gallery. This is a Media & Gallery demo rendered with plain HTML and CSS.

**Description:** A photo card that zooms its artwork on hover with a soft gradient caption slide-up.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/image-zoom-hover/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A photo card that zooms its artwork on hover with a soft gradient caption slide-up.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Media & Gallery category in the gallery with a polished, reusable effect.

### Key features
- Smooth scale zoom on the artwork inside a clipped frame
- Caption slides up over a darkening gradient
- Box-shadow lift for an interactive card feel

### Demo
Open `submissions/examples/image-zoom-hover/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87223
