### PR TITLE
feat: add mention-chip component

### DIFF
--- a/submissions/examples/mention-chip/README.md
+++ b/submissions/examples/mention-chip/README.md
@@ -1,0 +1,19 @@
+# Mention Chip
+
+An at-mention pill that highlights on hover, used inline inside a sentence.
+
+## Features
+- Inline pill that sits naturally within text
+- Hover accent fill with a tiny pop
+- Distinct color for a highlighted handle
+
+## Usage
+```html
+<p>Thanks <span class="mc-chip">@team</span> for the help!</p>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/mention-chip/demo.html
+++ b/submissions/examples/mention-chip/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mention Chip &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Social &amp; Chat</p>
+    <h1>Mention Chip</h1>
+    <p class="sub">Ping someone in a sentence and the handle becomes a tap-ready pill.</p>
+  </header>
+  <main class="stage">
+    <p class="mc-note">
+      Big shout-out to <span class="mc-chip">@designcrew</span> and
+      <span class="mc-chip">@cssmasters</span> for the incredible gallery,
+      plus <span class="mc-chip">@theteam</span> for reviewing everything!
+    </p>
+  </main>
+  <p class="stage-caption">Hover any handle to fill it with the accent color.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Inline pill highlight</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/mention-chip/style.css
+++ b/submissions/examples/mention-chip/style.css
@@ -1,0 +1,54 @@
+/* Mention Chip — EaseMotion CSS demo */
+:root {
+  --mc-accent: #8b5cf6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #f5f3ff, #ede9fe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--mc-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #4c1d95; }
+.sub { color: #6d28d9; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 620px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(139, 92, 246, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(76, 29, 149, 0.12);
+  padding: 44px 28px;
+}
+
+.mc-note {
+  font-size: 17px;
+  line-height: 2.1;
+  color: #4b5563;
+}
+.mc-chip {
+  display: inline-block;
+  padding: 2px 12px;
+  border-radius: 999px;
+  background: #ede9fe;
+  color: #6d28d9;
+  font-weight: 700;
+  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+.mc-chip:hover {
+  background: var(--mc-accent);
+  color: #fff;
+  transform: scale(1.08);
+}
+
+.stage-caption { text-align: center; margin-top: 26px; color: #8b5cf6; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #c4b5fd; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Mention Chip** component to the EaseMotion CSS gallery. This is a Social & Chat demo rendered with plain HTML and CSS.

**Description:** An at-mention pill that highlights on hover, used inline inside a sentence.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/mention-chip/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** An at-mention pill that highlights on hover, used inline inside a sentence.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Social & Chat category in the gallery with a polished, reusable effect.

### Key features
- Inline pill that sits naturally within text
- Hover accent fill with a tiny pop
- Distinct color for a highlighted handle

### Demo
Open `submissions/examples/mention-chip/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87238
