### PR TITLE
feat: add size-picker-pill component

### DIFF
--- a/submissions/examples/size-picker-pill/README.md
+++ b/submissions/examples/size-picker-pill/README.md
@@ -1,0 +1,21 @@
+# Size Picker Pill
+
+A segmented size selector where the chosen pill slides into the accent color.
+
+## Features
+- Radio-driven pill selection
+- Active pill fills with a smooth transition
+- Small hover lift on every option
+
+## Usage
+```html
+<div class="sp-row">
+  <div class="sp-pill"><input type="radio" name="size" id="sp-s" /><label for="sp-s">S</label></div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/size-picker-pill/demo.html
+++ b/submissions/examples/size-picker-pill/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Size Picker Pill &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; E-commerce</p>
+    <h1>Size Picker Pill</h1>
+    <p class="sub">Pick your size &mdash; the selected pill fills in instantly.</p>
+  </header>
+  <main class="stage">
+    <div class="sp-row">
+      <div class="sp-pill"><input type="radio" name="size" id="sp-s" /><label for="sp-s">S</label></div>
+      <div class="sp-pill"><input type="radio" name="size" id="sp-m" checked /><label for="sp-m">M</label></div>
+      <div class="sp-pill"><input type="radio" name="size" id="sp-l" /><label for="sp-l">L</label></div>
+      <div class="sp-pill"><input type="radio" name="size" id="sp-xl" /><label for="sp-xl">XL</label></div>
+    </div>
+  </main>
+  <p class="stage-caption">Hover any pill for a lift; select it to see it fill.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Radio pill fill</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/size-picker-pill/style.css
+++ b/submissions/examples/size-picker-pill/style.css
@@ -1,0 +1,61 @@
+/* Size Picker Pill — EaseMotion CSS demo */
+:root {
+  --sp-accent: #7c3aed;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #f5f3ff, #ede9fe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--sp-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #4c1d95; }
+.sub { color: #6d28d9; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 560px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(76, 29, 149, 0.12);
+  display: grid;
+  place-items: center;
+  min-height: 300px;
+  padding: 48px;
+}
+
+.sp-row { display: flex; gap: 12px; }
+.sp-pill { position: relative; }
+.sp-pill input { position: absolute; opacity: 0; }
+.sp-pill label {
+  display: inline-block;
+  min-width: 58px;
+  padding: 12px 18px;
+  text-align: center;
+  border-radius: 999px;
+  background: #fff;
+  border: 2px solid #e9d5ff;
+  color: #6d28d9;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.25s ease, background 0.25s ease, color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+}
+.sp-pill:hover label { transform: translateY(-3px); border-color: #c4b5fd; }
+.sp-pill input:checked + label {
+  background: var(--sp-accent);
+  border-color: var(--sp-accent);
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(124, 58, 237, 0.4);
+}
+
+.stage-caption { text-align: center; margin-top: 26px; color: #7c3aed; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #c4b5fd; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Size Picker Pill** component to the EaseMotion CSS gallery. This is a E-commerce demo rendered with plain HTML and CSS.

**Description:** A segmented size selector where the chosen pill slides into the accent color.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/size-picker-pill/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A segmented size selector where the chosen pill slides into the accent color.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the E-commerce category in the gallery with a polished, reusable effect.

### Key features
- Radio-driven pill selection
- Active pill fills with a smooth transition
- Small hover lift on every option

### Demo
Open `submissions/examples/size-picker-pill/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87247
