### PR TITLE
feat: add split-reveal-hero component

### DIFF
--- a/submissions/examples/split-reveal-hero/README.md
+++ b/submissions/examples/split-reveal-hero/README.md
@@ -1,0 +1,23 @@
+# Split Reveal Hero
+
+A hero panel whose two halves slide apart on hover to reveal the headline inside.
+
+## Features
+- Left and right panels split apart
+- Headline scales up between the halves
+- Backdrop gradient glows through the seam
+
+## Usage
+```html
+<div class="sr-card">
+  <div class="sr-half l"></div>
+  <div class="sr-half r"></div>
+  <div class="sr-word">REVEAL</div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/split-reveal-hero/demo.html
+++ b/submissions/examples/split-reveal-hero/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Split Reveal Hero &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Hero &amp; Landing</p>
+    <h1>Split Reveal Hero</h1>
+    <p class="sub">Two purple halves slide apart to unveil the headline between them.</p>
+  </header>
+  <main class="stage">
+    <div class="sr-card">
+      <div class="sr-half l"></div>
+      <div class="sr-half r"></div>
+      <div class="sr-word">SPLIT&#128640;REVEAL</div>
+    </div>
+  </main>
+  <p class="stage-caption">Hover the panel to split it open.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Split panels</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/split-reveal-hero/style.css
+++ b/submissions/examples/split-reveal-hero/style.css
@@ -1,0 +1,78 @@
+/* Split Reveal Hero — EaseMotion CSS demo */
+:root {
+  --sr-accent: #8b5cf6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #eef2ff, #ede9fe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--sr-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #4c1d95; }
+.sub { color: #7c3aed; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 660px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(139, 92, 246, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(76, 29, 149, 0.14);
+  display: grid;
+  place-items: center;
+  min-height: 360px;
+  padding: 48px;
+}
+
+.sr-card {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  height: 220px;
+  border-radius: 18px;
+  overflow: hidden;
+  cursor: pointer;
+}
+.sr-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, #a78bfa, #c4b5fd 50%, #f0abfc);
+  transition: opacity 0.5s ease;
+}
+.sr-half {
+  position: absolute;
+  inset: 0;
+  width: 50%;
+  background: linear-gradient(135deg, #4c1d95, #6d28d9);
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.sr-half.l { left: 0; }
+.sr-half.r { right: 0; background: linear-gradient(225deg, #a21caf, #c026d3); }
+.sr-card:hover .sr-half.l { transform: translateX(-52%); }
+.sr-card:hover .sr-half.r { transform: translateX(52%); }
+.sr-word {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 34px;
+  font-weight: 900;
+  color: #4c1d95;
+  transform: scale(0.7);
+  opacity: 0;
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.4s ease 0.15s;
+}
+.sr-card:hover .sr-word { transform: scale(1); opacity: 1; }
+
+.stage-caption { text-align: center; margin-top: 26px; color: #8b5cf6; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #a78bfa; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Split Reveal Hero** component to the EaseMotion CSS gallery. This is a Hero & Landing demo rendered with plain HTML and CSS.

**Description:** A hero panel whose two halves slide apart on hover to reveal the headline inside.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/split-reveal-hero/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A hero panel whose two halves slide apart on hover to reveal the headline inside.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Hero & Landing category in the gallery with a polished, reusable effect.

### Key features
- Left and right panels split apart
- Headline scales up between the halves
- Backdrop gradient glows through the seam

### Demo
Open `submissions/examples/split-reveal-hero/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87270
