### PR TITLE
feat: add typing-indicator-ui component

### DIFF
--- a/submissions/examples/typing-indicator-ui/README.md
+++ b/submissions/examples/typing-indicator-ui/README.md
@@ -1,0 +1,21 @@
+# Typing Indicator
+
+The classic three-dot typing indicator that bounces inside a soft chat bubble.
+
+## Features
+- Three dots bob in sequence with gentle timing
+- Rounded bubble with a notched tail
+- Pure keyframes, no scripting involved
+
+## Usage
+```html
+<div class="ti-bubble" aria-label="Someone is typing">
+  <span></span><span></span><span></span>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/typing-indicator-ui/demo.html
+++ b/submissions/examples/typing-indicator-ui/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typing Indicator &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="page-head">
+    <p class="kicker">EaseMotion CSS &middot; Social &amp; Chat</p>
+    <h1>Typing Indicator</h1>
+    <p class="sub">The universal signal that someone is about to say something.</p>
+  </header>
+  <main class="stage">
+    <div class="ti-bubble" aria-label="Someone is typing">
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+  </main>
+  <p class="stage-caption">Three dots bounce on a shared rhythm with staggered delays.</p>
+  <footer class="page-foot">
+    <span>Pure CSS &middot; zero dependencies</span>
+    <span>Staggered dot bounce</span>
+  </footer>
+</body>
+</html>

--- a/submissions/examples/typing-indicator-ui/style.css
+++ b/submissions/examples/typing-indicator-ui/style.css
@@ -1,0 +1,62 @@
+/* Typing Indicator — EaseMotion CSS demo */
+:root {
+  --ti-accent: #6d28d9;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  min-height: 100vh;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  background: linear-gradient(160deg, #f5f3ff, #ede9fe);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 56px 20px;
+}
+
+.page-head { text-align: center; margin-bottom: 40px; max-width: 620px; }
+.kicker { color: var(--ti-accent); font-weight: 700; letter-spacing: 2px; font-size: 13px; text-transform: uppercase; }
+.page-head h1 { font-size: 34px; margin: 10px 0 8px; color: #4c1d95; }
+.sub { color: #6d28d9; line-height: 1.6; }
+
+.stage {
+  width: 100%;
+  max-width: 600px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(109, 40, 217, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(76, 29, 149, 0.12);
+  display: grid;
+  place-items: center;
+  min-height: 320px;
+  padding: 48px;
+}
+
+.ti-bubble {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #fff;
+  border-radius: 18px;
+  border-bottom-left-radius: 4px;
+  padding: 18px 20px;
+  box-shadow: 0 12px 30px rgba(76, 29, 149, 0.16);
+}
+.ti-bubble span {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ti-accent);
+  animation: ti-bounce 1.2s ease-in-out infinite;
+}
+.ti-bubble span:nth-child(2) { animation-delay: 0.18s; }
+.ti-bubble span:nth-child(3) { animation-delay: 0.36s; }
+
+@keyframes ti-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.45; }
+  30%           { transform: translateY(-10px); opacity: 1; }
+}
+
+.stage-caption { text-align: center; margin-top: 26px; color: #7c3aed; font-size: 14px; }
+.page-foot { margin-top: 40px; display: flex; gap: 18px; color: #c4b5fd; font-size: 13px; flex-wrap: wrap; justify-content: center; }


### PR DESCRIPTION
## Summary

Add the **Typing Indicator** component to the EaseMotion CSS gallery. This is a Social & Chat demo rendered with plain HTML and CSS.

**Description:** The classic three-dot typing indicator that bounces inside a soft chat bubble.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/typing-indicator-ui/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** The classic three-dot typing indicator that bounces inside a soft chat bubble.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the Social & Chat category in the gallery with a polished, reusable effect.

### Key features
- Three dots bob in sequence with gentle timing
- Rounded bubble with a notched tail
- Pure keyframes, no scripting involved

### Demo
Open `submissions/examples/typing-indicator-ui/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87232
