### PR TITLE
feat: add toggle-knob-spring component

### DIFF
--- a/submissions/examples/toggle-knob-spring-sb/README.md
+++ b/submissions/examples/toggle-knob-spring-sb/README.md
@@ -1,0 +1,28 @@
+# EaseMotion: Spring Knob Toggle
+
+A checkbox-driven toggle whose knob travels with an overshoot spring curve and emits a status ripple when engaged.
+
+## How is it used?
+Use a native checkbox wrapped by `.spring-toggle`:
+```html
+<label class="spring-toggle">
+  <input type="checkbox" checked>
+  <span class="track"><span class="knob"></span><span class="ripple"></span></span>
+  <span class="label-text">Notifications</span>
+</label>
+```
+Add `.lg` for a larger variant.
+
+## Why is it useful?
+Native checkbox keeps it accessible and keyboard-operable; the spring easing (`cubic-bezier(.34,1.56,.64,1)`) gives the knob satisfying overshoot without JS, and `prefers-reduced-motion` flattens the curve.
+
+## Tailoring Variable Hooks
+
+| Variable | Baseline | Purpose |
+| :--- | :--- | :--- |
+| `--on` | `#34d399` | Engaged track / ripple color |
+| `--spring` | `cubic-bezier(.34,1.56,.64,1)` | Knob overshoot easing |
+
+
+---
+_Self-contained, dependency-free HTML + CSS. Open `demo.html` directly in a browser._

--- a/submissions/examples/toggle-knob-spring-sb/demo.html
+++ b/submissions/examples/toggle-knob-spring-sb/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion - Spring Knob Toggle</title>
+<link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+
+<main class="em-stage">
+  <h1>Spring Knob Toggle</h1>
+  <p>A physical, springy on/off switch with overshoot and a status ripple.</p>
+  <form class="toggles">
+    <label class="spring-toggle">
+      <input type="checkbox" checked>
+      <span class="track"><span class="knob"></span><span class="ripple"></span></span>
+      <span class="label-text">Notifications</span>
+    </label>
+    <label class="spring-toggle">
+      <input type="checkbox">
+      <span class="track"><span class="knob"></span><span class="ripple"></span></span>
+      <span class="label-text">Dark mode</span>
+    </label>
+    <label class="spring-toggle lg">
+      <input type="checkbox" checked>
+      <span class="track"><span class="knob"></span><span class="ripple"></span></span>
+      <span class="label-text">Large variant</span>
+    </label>
+  </form>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/toggle-knob-spring-sb/style.css
+++ b/submissions/examples/toggle-knob-spring-sb/style.css
@@ -1,0 +1,22 @@
+:root{--on:#34d399;--off:#475569;--knob:#fff;--bg:#0f172a;--ink:#e2e8f0;--spring:cubic-bezier(.34,1.56,.64,1)}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,sans-serif;min-height:100vh;display:grid;place-items:center}
+.em-stage{padding:2rem;max-width:640px}
+h1{font-size:1.6rem;margin:0 0 .3rem}
+p{color:#94a3b8;margin:0 0 1.5rem}
+.toggles{display:flex;flex-direction:column;gap:1.1rem}
+.spring-toggle{display:flex;align-items:center;gap:.9rem;cursor:pointer;user-select:none}
+.spring-toggle input{position:absolute;opacity:0;width:0;height:0}
+.track{position:relative;width:56px;height:30px;border-radius:999px;background:var(--off);transition:background .25s ease;flex-shrink:0;box-shadow:inset 0 2px 6px rgba(0,0,0,.4)}
+.knob{position:absolute;top:3px;left:3px;width:24px;height:24px;border-radius:50%;background:var(--knob);box-shadow:0 2px 6px rgba(0,0,0,.4);transition:left .45s var(--spring),transform .45s var(--spring)}
+.spring-toggle input:checked + .track{background:var(--on)}
+.spring-toggle input:checked + .track .knob{left:29px;transform:scale(1.05)}
+.spring-toggle input:active + .track .knob{transform:scale(.92)}
+.ripple{position:absolute;top:50%;left:3px;width:24px;height:24px;border-radius:50%;transform:translateY(-50%);background:var(--on);opacity:0;transition:left .45s var(--spring),opacity .3s ease}
+.spring-toggle input:checked + .track .ripple{left:29px;opacity:.0;animation:pop .5s ease}
+.label-text{font-size:.95rem}
+.spring-toggle.lg .track{width:72px;height:38px}
+.spring-toggle.lg .knob{width:30px;height:30px}
+.spring-toggle.lg input:checked + .track .knob{left:39px}
+@keyframes pop{0%{opacity:.45;transform:translateY(-50%) scale(1)}100%{opacity:0;transform:translateY(-50%) scale(2.4)}}
+@media(prefers-reduced-motion:reduce){.knob,.ripple{transition:left .2s ease,transform .2s ease}}


### PR DESCRIPTION
Closes #87296

## What
Adds the **Toggle knob spring** component to the EaseMotion gallery under `submissions/examples/toggle-knob-spring-sb/`.

## Files
- `submissions/examples/toggle-knob-spring-sb/demo.html` — self-contained, dependency-free demo
- `submissions/examples/toggle-knob-spring-sb/style.css` — original hand-crafted CSS
- `submissions/examples/toggle-knob-spring-sb/README.md` — what / how / why + variable hooks

Pure HTML + CSS, no JavaScript, respects `prefers-reduced-motion`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._