### PR TITLE
feat: add wiggle-bounce-mascot component

### DIFF
--- a/submissions/examples/wiggle-bounce-mascot-sb/README.md
+++ b/submissions/examples/wiggle-bounce-mascot-sb/README.md
@@ -1,0 +1,24 @@
+# EaseMotion: Wiggle Bounce Mascot
+
+A friendly CSS-only blob mascot that bounces idle, wiggles its ears, blinks, and reacts faster when hovered/focused.
+
+## How is it used?
+Drop the `.mascot-wrap` block anywhere; the mascot is pure CSS divs:
+```html
+<div class="mascot-wrap"><div class="shadow"></div><div class="mascot" tabindex="0">...</div></div>
+```
+Hover or focus to wake it.
+
+## Why is it useful?
+Adds personality with zero JavaScript — body bounce, ear wiggle and eye blink are independent keyframes so the motion feels organic. Accessible via `tabindex`/`role` and respects reduced-motion.
+
+## Tailoring Variable Hooks
+
+| Variable | Baseline | Purpose |
+| :--- | :--- | :--- |
+| `--body` | `#ffd23f` | Mascot body color |
+| `--accent` | `#7c5bff` | Scene accent |
+
+
+---
+_Self-contained, dependency-free HTML + CSS. Open `demo.html` directly in a browser._

--- a/submissions/examples/wiggle-bounce-mascot-sb/demo.html
+++ b/submissions/examples/wiggle-bounce-mascot-sb/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion - Wiggle Bounce Mascot</title>
+<link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+
+<main class="em-stage">
+  <h1>Wiggle Bounce Mascot</h1>
+  <p>Hover the mascot to wake it; it wiggles and bounces idle.</p>
+  <div class="mascot-wrap">
+    <div class="shadow"></div>
+    <div class="mascot" tabindex="0" role="img" aria-label="Friendly blob mascot">
+      <div class="ears"><span></span><span></span></div>
+      <div class="face">
+        <div class="eyes"><span></span><span></span></div>
+        <div class="mouth"></div>
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/wiggle-bounce-mascot-sb/style.css
+++ b/submissions/examples/wiggle-bounce-mascot-sb/style.css
@@ -1,0 +1,24 @@
+:root{--body:#ffd23f;--body-2:#ffb648;--bg:#15132b;--ink:#f3efff;--accent:#7c5bff}
+*{box-sizing:border-box}
+body{margin:0;background:radial-gradient(circle at 50% 30%,#241d44 0%,var(--bg) 60%);color:var(--ink);font-family:system-ui,sans-serif;min-height:100vh;display:grid;place-items:center}
+.em-stage{text-align:center}
+h1{font-size:1.6rem;margin:0 0 .2rem}
+p{color:#b3a6e0;margin:0 0 1.5rem}
+.mascot-wrap{position:relative;width:200px;height:220px;margin:0 auto}
+.shadow{position:absolute;bottom:-6px;left:50%;transform:translateX(-50%);width:120px;height:22px;background:radial-gradient(ellipse,rgba(0,0,0,.5),transparent 70%);border-radius:50%;animation:shadowPulse 2s ease-in-out infinite}
+.mascot{position:absolute;bottom:0;left:50%;width:170px;height:180px;transform:translateX(-50%);animation:bounce 2s ease-in-out infinite;transform-origin:bottom center;cursor:pointer;outline:none}
+.mascot .face{position:absolute;inset:0;background:linear-gradient(160deg,var(--body),var(--body-2));border-radius:46% 46% 50% 50%/52% 52% 48% 48%;box-shadow:inset -10px -16px 30px rgba(0,0,0,.18),0 8px 20px rgba(0,0,0,.3)}
+.ears{position:absolute;top:-14px;left:0;right:0;display:flex;justify-content:space-between;padding:0 18px;z-index:0}
+.ears span{width:42px;height:42px;background:var(--body-2);border-radius:50% 50% 30% 30%;transform-origin:bottom center;animation:wiggle 2s ease-in-out infinite}
+.ears span:last-child{animation-delay:.1s}
+.eyes{position:absolute;top:62px;left:0;right:0;display:flex;justify-content:center;gap:34px}
+.eyes span{width:18px;height:22px;background:#2a1b05;border-radius:50%;animation:blink 4s infinite}
+.eyes span::after{content:'';position:absolute}
+.mouth{position:absolute;top:108px;left:50%;transform:translateX(-50%);width:40px;height:22px;border-bottom:5px solid #2a1b05;border-radius:0 0 40px 40px}
+.mascot:hover .ears span,.mascot:focus .ears span{animation:wiggle .5s ease-in-out infinite}
+.mascot:hover,.mascot:focus{animation:bounce .6s ease-in-out infinite}
+@keyframes bounce{0%,100%{transform:translateX(-50%) translateY(0) scaleY(1)}50%{transform:translateX(-50%) translateY(-22px) scaleY(1.03)}}
+@keyframes wiggle{0%,100%{transform:rotate(0)}50%{transform:rotate(12deg)}}
+@keyframes blink{0%,92%,100%{transform:scaleY(1)}96%{transform:scaleY(.1)}}
+@keyframes shadowPulse{0%,100%{transform:translateX(-50%) scale(1);opacity:.5}50%{transform:translateX(-50%) scale(.8);opacity:.35}}
+@media(prefers-reduced-motion:reduce){.mascot,.ears span,.eyes span,.shadow{animation:none}}


### PR DESCRIPTION
Closes #87288

## What
Adds the **Wiggle bounce mascot** component to the EaseMotion gallery under `submissions/examples/wiggle-bounce-mascot-sb/`.

## Files
- `submissions/examples/wiggle-bounce-mascot-sb/demo.html` — self-contained, dependency-free demo
- `submissions/examples/wiggle-bounce-mascot-sb/style.css` — original hand-crafted CSS
- `submissions/examples/wiggle-bounce-mascot-sb/README.md` — what / how / why + variable hooks

Pure HTML + CSS, no JavaScript, respects `prefers-reduced-motion`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._