### PR TITLE
feat: add tooltip-fade-caret component

### DIFF
--- a/submissions/examples/tooltip-fade-caret-sb/README.md
+++ b/submissions/examples/tooltip-fade-caret-sb/README.md
@@ -1,0 +1,25 @@
+# EaseMotion: Fade Tooltip with Caret
+
+A directional tooltip that fades + slides into view with a pointer caret; triggered by hover or keyboard focus on a sibling target.
+
+## How is it used?
+Place a `.tooltip` immediately after its target and link them with `aria-describedby`:
+```html
+<button class="tip-target" aria-describedby="t1">Top</button>
+<span class="tooltip top" id="t1" role="tooltip">Saves to your workspace</span>
+```
+Directions: `.top`, `.right`, `.bottom`.
+
+## Why is it useful?
+Pure-CSS reveal via sibling combinator keeps it dependency-free, keyboard-focusable, and screen-reader friendly (`role=tooltip`). The caret is a rotated border so it inherits the tooltip background automatically.
+
+## Tailoring Variable Hooks
+
+| Variable | Baseline | Purpose |
+| :--- | :--- | :--- |
+| `--dur` | `.22s` | Fade + slide duration |
+| `--tip-bg` | `#1e293b` | Tooltip + caret background |
+
+
+---
+_Self-contained, dependency-free HTML + CSS. Open `demo.html` directly in a browser._

--- a/submissions/examples/tooltip-fade-caret-sb/demo.html
+++ b/submissions/examples/tooltip-fade-caret-sb/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EaseMotion - Fade Tooltip with Caret</title>
+<link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+
+<main class="em-stage">
+  <h1>Fade Tooltip with Caret</h1>
+  <p>Hover or focus the targets to reveal directional tooltips.</p>
+  <div class="demo-row">
+    <button class="tip-target" aria-describedby="t1">Top</button>
+    <span class="tooltip top" id="t1" role="tooltip">Saves to your workspace</span>
+  </div>
+  <div class="demo-row">
+    <button class="tip-target" aria-describedby="t2">Right</button>
+    <span class="tooltip right" id="t2" role="tooltip">Opens sharing options</span>
+  </div>
+  <div class="demo-row">
+    <button class="tip-target" aria-describedby="t3">Bottom</button>
+    <span class="tooltip bottom" id="t3" role="tooltip">Exports as PDF</span>
+  </div>
+</main>
+
+</body>
+</html>

--- a/submissions/examples/tooltip-fade-caret-sb/style.css
+++ b/submissions/examples/tooltip-fade-caret-sb/style.css
@@ -1,0 +1,22 @@
+:root{--bg:#0f172a;--ink:#e2e8f0;--tip-bg:#1e293b;--tip-ink:#f8fafc;--accent:#7c5bff;--dur:.22s}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,sans-serif;min-height:100vh;display:grid;place-items:center}
+.em-stage{padding:2rem;max-width:520px}
+h1{font-size:1.5rem;margin:0 0 .2rem}
+p{color:#94a3b8;margin:0 0 1.4rem}
+.demo-row{position:relative;display:inline-flex;align-items:center;gap:1rem;margin:.7rem 0}
+.tip-target{background:#1e293b;color:var(--ink);border:1px solid #334155;border-radius:8px;padding:.5rem 1rem;cursor:pointer}
+.tip-target:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.tooltip{position:absolute;background:var(--tip-bg);color:var(--tip-ink);padding:.45rem .7rem;border-radius:6px;font-size:.8rem;white-space:nowrap;opacity:0;visibility:hidden;transition:opacity var(--dur) ease,transform var(--dur) ease;box-shadow:0 6px 18px rgba(0,0,0,.4);z-index:5;pointer-events:none}
+.tooltip::after{content:'';position:absolute;border:6px solid transparent}
+.tip-target:hover + .tooltip,.tip-target:focus + .tooltip{opacity:1;visibility:visible}
+.tooltip.top{bottom:calc(100% + 10px);left:50%;transform:translate(-50%,4px)}
+.tooltip.top::after{top:100%;left:50%;transform:translateX(-50%);border-top-color:var(--tip-bg)}
+.tooltip.right{left:calc(100% + 10px);top:50%;transform:translate(-4px,-50%)}
+.tooltip.right::after{right:100%;top:50%;transform:translateY(-50%);border-right-color:var(--tip-bg)}
+.tooltip.bottom{top:calc(100% + 10px);left:50%;transform:translate(-50%,-4px)}
+.tooltip.bottom::after{bottom:100%;left:50%;transform:translateX(-50%);border-bottom-color:var(--tip-bg)}
+.tip-target:hover + .tooltip.top,.tip-target:focus + .tooltip.top{transform:translate(-50%,0)}
+.tip-target:hover + .tooltip.right,.tip-target:focus + .tooltip.right{transform:translate(0,-50%)}
+.tip-target:hover + .tooltip.bottom,.tip-target:focus + .tooltip.bottom{transform:translate(-50%,0)}
+@media(prefers-reduced-motion:reduce){.tooltip{transition:opacity .1s ease}}


### PR DESCRIPTION
Closes #87275

## What
Adds the **Tooltip fade caret** component to the EaseMotion gallery under `submissions/examples/tooltip-fade-caret-sb/`.

## Files
- `submissions/examples/tooltip-fade-caret-sb/demo.html` — self-contained, dependency-free demo
- `submissions/examples/tooltip-fade-caret-sb/style.css` — original hand-crafted CSS
- `submissions/examples/tooltip-fade-caret-sb/README.md` — what / how / why + variable hooks

Pure HTML + CSS, no JavaScript, respects `prefers-reduced-motion`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._