### PR TITLE
a11y(switch-toggle): add WCAG 2.1 AA compliant switch toggle with Space key press handler

### DIFF
--- a/submissions/examples/switch-toggle-space-handler/README.md
+++ b/submissions/examples/switch-toggle-space-handler/README.md
@@ -1,0 +1,25 @@
+# Switch Toggle Space Key Press Handler
+
+An audited, WCAG 2.1 AA compliant switch toggle component with explicit `Space` and `Enter` keypress handling, `role="switch"` ARIA semantics, and Windows High Contrast Mode support.
+
+## 🌟 Features & Accessibility Fixes
+
+* **Space Key Scroll Prevention (WCAG 2.1.1):** Intercepts `Space` keypress events (`e.preventDefault()`) on `<button role="switch">` to prevent default page scrolling while updating `aria-checked`.
+* **WAI-ARIA Switch Pattern (WCAG 4.1.2):** Implements `role="switch"` and `aria-checked="true|false"`, properly linked to visual labels via `aria-labelledby` and `aria-describedby`.
+* **Screen Reader Live Feedback (WCAG 4.1.3):** Employs an `aria-live="polite"` region to broadcast dynamic state changes across NVDA, VoiceOver, and JAWS.
+* **Dual-Layer Focus Ring (WCAG 2.4.7):** Ensures a visible 3:1+ contrast focus indicator across light and dark backgrounds.
+* **High Contrast Mode Support (`forced-colors: active`):** Explicitly maps `ButtonFace`, `ButtonText`, `Highlight`, and `HighlightText` to maintain visible thumb and track boundaries in Windows High Contrast Mode.
+
+## 🚀 Usage
+
+```html
+<button 
+  type="button" 
+  role="switch" 
+  id="my-switch" 
+  class="switch-button" 
+  aria-checked="false" 
+  aria-labelledby="label-id"
+>
+  <span class="switch-thumb" aria-hidden="true"></span>
+</button>

--- a/submissions/examples/switch-toggle-space-handler/demo.html
+++ b/submissions/examples/switch-toggle-space-handler/demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Switch Toggle Space Key Press Handler Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Screen Reader Live Region for Status Feedback -->
+  <div 
+    id="a11y-announcer" 
+    class="sr-only" 
+    role="status" 
+    aria-live="polite" 
+    aria-atomic="true"
+  ></div>
+
+  <main id="main-content" tabindex="-1">
+    <h1>Accessible Switch Toggle</h1>
+    <p>
+      Tab to the switch toggle below. Use <kbd>Space</kbd> or <kbd>Enter</kbd> to activate. 
+      Prevents default page scroll on Space keypress while toggling <code>aria-checked</code> and announcing state changes.
+    </p>
+
+    <div class="toggle-wrapper">
+      <div class="toggle-label-group">
+        <span id="dark-mode-label" class="toggle-title">System Push Notifications</span>
+        <span id="dark-mode-desc" class="toggle-description">Receive real-time alerts for updates</span>
+      </div>
+
+      <!-- ACCESSIBLE SWITCH TOGGLE (WAI-ARIA Pattern) -->
+      <button 
+        type="button" 
+        role="switch" 
+        id="switch-notifications" 
+        class="switch-button" 
+        aria-checked="false" 
+        aria-labelledby="dark-mode-label" 
+        aria-describedby="dark-mode-desc"
+      >
+        <span class="switch-thumb" aria-hidden="true"></span>
+      </button>
+    </div>
+  </main>
+
+  <script>
+    // Inline Accessible Switch Toggle & Space Key Press Handler
+    document.addEventListener('DOMContentLoaded', () => {
+      const switchBtn = document.getElementById('switch-notifications');
+      const announcer = document.getElementById('a11y-announcer');
+
+      if (!switchBtn) return;
+
+      function toggleSwitchState() {
+        const isChecked = switchBtn.getAttribute('aria-checked') === 'true';
+        const newState = !isChecked;
+
+        switchBtn.setAttribute('aria-checked', String(newState));
+
+        // Screen reader announcement
+        if (announcer) {
+          announcer.textContent = '';
+          setTimeout(() => {
+            announcer.textContent = `System Push Notifications switched ${newState ? 'on' : 'off'}.`;
+          }, 50);
+        }
+      }
+
+      // Click event handler
+      switchBtn.addEventListener('click', (e) => {
+        toggleSwitchState();
+      });
+
+      // Keyboard handler (Explicit Space and Enter key management)
+      switchBtn.addEventListener('keydown', (e) => {
+        // Space or Enter key
+        if (e.key === ' ' || e.key === 'Spacebar' || e.key === 'Enter') {
+          // Prevent browser window from scrolling down when pressing Space
+          e.preventDefault();
+          toggleSwitchState();
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/switch-toggle-space-handler/style.css
+++ b/submissions/examples/switch-toggle-space-handler/style.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   Accessibility Improvement — Switch Toggle Space Key Handler
+   Path: submissions/examples/switch-toggle-space-handler/style.css
+   ============================================================ */
+
+/* ── 1. Base Variables & Theme Tokens ────────────────────── */
+:root {
+  --bg-primary: #0f172a;
+  --surface-card: #1e293b;
+  --surface-border: #334155;
+  --text-main: #f8fafc;
+  --text-muted: #cbd5e1;
+  --switch-off-bg: #475569;
+  --switch-on-bg: #0284c7;
+  --switch-thumb: #ffffff;
+  
+  /* Focus Ring Tokens */
+  --focus-ring-inner: #ffffff;
+  --focus-ring-outer: #0f172a;
+  --focus-ring-glow: #00f3ff;
+  
+  --transition-speed: 0.2s;
+  --transition-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  line-height: 1.5;
+}
+
+/* ── 2. Screen Reader Only Utility ───────────────────────── */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* ── 3. Component Container ──────────────────────────────── */
+main {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+h1 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-main);
+}
+
+p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ── 4. Accessible Switch Toggle Component ────────────────── */
+.toggle-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: #0f172a;
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+}
+
+.toggle-label-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.toggle-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.toggle-description {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* Base Switch Button */
+.switch-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 52px;
+  height: 30px;
+  padding: 3px;
+  background-color: var(--switch-off-bg);
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  cursor: pointer;
+  outline: none;
+  flex-shrink: 0;
+  transition: background-color var(--transition-speed) var(--transition-ease),
+              border-color var(--transition-speed) var(--transition-ease);
+}
+
+/* Thumb Circle */
+.switch-thumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  background-color: var(--switch-thumb);
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+  transform: translateX(0);
+  will-change: transform;
+  transition: transform var(--transition-speed) var(--transition-ease);
+}
+
+/* Checked State (aria-checked="true") */
+.switch-button[aria-checked="true"] {
+  background-color: var(--switch-on-bg);
+}
+
+.switch-button[aria-checked="true"] .switch-thumb {
+  transform: translateX(22px);
+}
+
+/* Dual-Layer Visible Focus Ring (WCAG 2.4.7) */
+.switch-button:focus-visible {
+  outline: 3px solid var(--focus-ring-inner) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 5px var(--focus-ring-outer),
+              0 0 0 7px var(--focus-ring-glow) !important;
+}
+
+/* ── 5. Reduced Motion (WCAG 2.3.3) ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .switch-button,
+  .switch-thumb {
+    transition: none !important;
+  }
+}
+
+/* ── 6. Forced Colors / High Contrast Mode (WCAG 1.4.11) ─── */
+@media (forced-colors: active) {
+  .switch-button {
+    border: 2px solid ButtonText !important;
+    background-color: ButtonFace !important;
+    forced-color-adjust: none;
+  }
+
+  .switch-thumb {
+    background-color: ButtonText !important;
+  }
+
+  .switch-button[aria-checked="true"] {
+    background-color: Highlight !important;
+    border-color: Highlight !important;
+  }
+
+  .switch-button[aria-checked="true"] .switch-thumb {
+    background-color: HighlightText !important;
+  }
+
+  .switch-button:focus-visible {
+    outline: 3px solid Highlight !important;
+    outline-offset: 4px !important;
+    box-shadow: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- This PR introduces an accessible Switch Toggle Component with explicit Space and Enter keypress handling, preventing default page scrolling while managing WAI-ARIA role="switch" states, live screen reader announcements, and Windows High Contrast Mode support. -->

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- A WCAG 2.1 AA compliant switch toggle component implementing role="switch", aria-checked, scroll-preventing Space key interception, and dynamic screen reader live announcements. -->

**How does a developer use it?**

```html
<!-- <button 
  type="button" 
  role="switch" 
  id="switch-notifications" 
  class="switch-button" 
  aria-checked="false" 
  aria-labelledby="dark-mode-label" 
  aria-describedby="dark-mode-desc"
>
  <span class="switch-thumb" aria-hidden="true"></span>
</button> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It pairs smooth, hardware-accelerated CSS transition animations with an accessible, keyboard-first interaction model that respects prefers-reduced-motion: reduce and High Contrast Mode without relying on heavy external dependencies. -->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #86299