### PR TITLE
test: Add Vitest unit spec for Hover Preview Card Delay Timeout Check

### DIFF
--- a/submissions/examples/vitest-hover-preview-delay-86410/README.md
+++ b/submissions/examples/vitest-hover-preview-delay-86410/README.md
@@ -1,0 +1,32 @@
+# Vitest Unit Spec — Hover Preview Card Delay Timeout Check
+
+A comprehensive Vitest unit specification for **Hover Preview Card Delay Timeout Check**.
+
+## Features
+
+- ⏱ Vitest timer mocks testing showDelay and hideDelay timeouts
+- 🚫 Mouseleave timer cancellation assertions
+- 🛡 Re-enter preview card hide cancellation verification
+- 🧹 Complete event listener and timer cleanup on destroy()
+
+---
+
+## Files
+
+```
+submissions/examples/vitest-hover-preview-delay-86410/
+├── demo.html
+├── style.css
+├── test.js
+└── README.md
+```
+
+---
+
+## Test Execution
+
+Run the Vitest test suite locally:
+
+```bash
+npx vitest run submissions/examples/vitest-hover-preview-delay-86410/test.js
+```

--- a/submissions/examples/vitest-hover-preview-delay-86410/demo.html
+++ b/submissions/examples/vitest-hover-preview-delay-86410/demo.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vitest Unit Spec for Hover Preview Card Delay Timeout Check</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>Vitest Unit Spec — Hover Preview Card Delay Timeout Check</h1>
+        <p>
+          Automated Vitest unit specification validating hover delay timers,
+          mouseleave cancellation, custom delay thresholds, and event listener
+          lifecycle management.
+        </p>
+      </header>
+
+      <section class="demo-section">
+        <div class="card-trigger-wrapper">
+          <a href="#" id="preview-trigger" class="profile-link">
+            <img
+              src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&auto=format&fit=crop&q=80"
+              alt="Avatar"
+              class="avatar"
+            />
+            <span>Hover Profile Trigger</span>
+          </a>
+
+          <div id="preview-card" class="hover-preview-card" aria-hidden="true">
+            <div class="preview-header">
+              <img
+                src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=120&auto=format&fit=crop&q=80"
+                alt="Avatar"
+                class="preview-avatar"
+              />
+              <div>
+                <h3>Alex Mercer</h3>
+                <p>@alex_dev</p>
+              </div>
+            </div>
+            <p class="preview-bio">
+              Core Motion Engine Contributor. Specializing in high-performance
+              CSS keyframe animations.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="assertions-dashboard">
+        <h2>Vitest Unit Specification Suite</h2>
+        <ul class="test-results" id="testResults">
+          <li class="pass">✔ Initializes preview card state correctly</li>
+          <li class="pass">✔ Triggers show delay timeout on mouseenter</li>
+          <li class="pass">✔ Cancels pending show timer on mouseleave</li>
+          <li class="pass">
+            ✔ Triggers hide delay timeout when leaving preview card
+          </li>
+          <li class="pass">
+            ✔ Clears hide timer when mouse re-enters preview card
+          </li>
+          <li class="pass">✔ Properly detaches event listeners on destroy</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/vitest-hover-preview-delay-86410/style.css
+++ b/submissions/examples/vitest-hover-preview-delay-86410/style.css
@@ -1,0 +1,180 @@
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-light: #334155;
+  --primary: #38bdf8;
+  --secondary: #22c55e;
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --radius: 16px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #020617);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.container {
+  width: min(850px, 100%);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.2rem;
+  margin-bottom: 0.8rem;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero p {
+  color: var(--muted);
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 3rem 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.card-trigger-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.profile-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1.2rem;
+  background: var(--surface-light);
+  border-radius: 30px;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
+.profile-link:hover {
+  background: #475569;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.hover-preview-card {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  width: 280px;
+  background: #1e293b;
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  border-radius: 14px;
+  padding: 1.2rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+  z-index: 100;
+  text-align: left;
+}
+
+.hover-preview-card.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.8rem;
+}
+
+.preview-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.preview-header h3 {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.preview-header p {
+  font-size: 0.85rem;
+  color: var(--primary);
+}
+
+.preview-bio {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.assertions-dashboard {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.assertions-dashboard h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1.2rem;
+  color: var(--primary);
+}
+
+.test-results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--secondary);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}

--- a/submissions/examples/vitest-hover-preview-delay-86410/test.js
+++ b/submissions/examples/vitest-hover-preview-delay-86410/test.js
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+export class HoverPreviewCardController {
+  constructor(trigger, preview, options = {}) {
+    this.trigger = trigger;
+    this.preview = preview;
+    this.showDelay = options.showDelay ?? 300;
+    this.hideDelay = options.hideDelay ?? 200;
+    this.showTimer = null;
+    this.hideTimer = null;
+    this.isOpen = false;
+
+    this.init();
+  }
+
+  init() {
+    if (!this.trigger || !this.preview) return;
+
+    this.handleTriggerEnter = () => this.startShowTimer();
+    this.handleTriggerLeave = () => this.startHideTimer();
+    this.handlePreviewEnter = () => this.cancelHideTimer();
+    this.handlePreviewLeave = () => this.startHideTimer();
+
+    this.trigger.addEventListener("mouseenter", this.handleTriggerEnter);
+    this.trigger.addEventListener("mouseleave", this.handleTriggerLeave);
+    this.preview.addEventListener("mouseenter", this.handlePreviewEnter);
+    this.preview.addEventListener("mouseleave", this.handlePreviewLeave);
+  }
+
+  startShowTimer() {
+    this.cancelHideTimer();
+    if (this.isOpen) return;
+
+    this.cancelShowTimer();
+    this.showTimer = setTimeout(() => {
+      this.open();
+    }, this.showDelay);
+  }
+
+  startHideTimer() {
+    this.cancelShowTimer();
+    if (!this.isOpen) return;
+
+    this.cancelHideTimer();
+    this.hideTimer = setTimeout(() => {
+      this.close();
+    }, this.hideDelay);
+  }
+
+  open() {
+    this.cancelShowTimer();
+    this.isOpen = true;
+    if (this.preview) {
+      this.preview.classList.add("is-active");
+      this.preview.setAttribute("aria-hidden", "false");
+    }
+  }
+
+  close() {
+    this.cancelHideTimer();
+    this.isOpen = false;
+    if (this.preview) {
+      this.preview.classList.remove("is-active");
+      this.preview.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  cancelShowTimer() {
+    if (this.showTimer !== null) {
+      clearTimeout(this.showTimer);
+      this.showTimer = null;
+    }
+  }
+
+  cancelHideTimer() {
+    if (this.hideTimer !== null) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+  }
+
+  destroy() {
+    this.cancelShowTimer();
+    this.cancelHideTimer();
+    if (this.trigger) {
+      this.trigger.removeEventListener("mouseenter", this.handleTriggerEnter);
+      this.trigger.removeEventListener("mouseleave", this.handleTriggerLeave);
+    }
+    if (this.preview) {
+      this.preview.removeEventListener("mouseenter", this.handlePreviewEnter);
+      this.preview.removeEventListener("mouseleave", this.handlePreviewLeave);
+    }
+  }
+}
+
+describe("Hover Preview Card Delay Timeout Check Unit Specs", () => {
+  let trigger;
+  let preview;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <a id="preview-trigger" href="#">Trigger Link</a>
+      <div id="preview-card" class="hover-preview-card" aria-hidden="true">Preview Card Content</div>
+    `;
+    trigger = document.getElementById("preview-trigger");
+    preview = document.getElementById("preview-card");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("should initialize with preview card hidden", () => {
+    const controller = new HoverPreviewCardController(trigger, preview);
+    expect(controller.isOpen).toBe(false);
+    expect(preview.classList.contains("is-active")).toBe(false);
+    expect(preview.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("should open preview card after showDelay timeout when mouse enters trigger", () => {
+    const controller = new HoverPreviewCardController(trigger, preview, {
+      showDelay: 300,
+    });
+
+    trigger.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(controller.isOpen).toBe(false);
+
+    vi.advanceTimersByTime(299);
+    expect(controller.isOpen).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.isOpen).toBe(true);
+    expect(preview.classList.contains("is-active")).toBe(true);
+    expect(preview.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("should cancel pending show timer if mouse leaves before timeout completes", () => {
+    const controller = new HoverPreviewCardController(trigger, preview, {
+      showDelay: 300,
+    });
+
+    trigger.dispatchEvent(new MouseEvent("mouseenter"));
+    vi.advanceTimersByTime(150);
+
+    trigger.dispatchEvent(new MouseEvent("mouseleave"));
+    vi.advanceTimersByTime(200);
+
+    expect(controller.isOpen).toBe(false);
+    expect(preview.classList.contains("is-active")).toBe(false);
+  });
+
+  it("should close preview card after hideDelay timeout when mouse leaves", () => {
+    const controller = new HoverPreviewCardController(trigger, preview, {
+      showDelay: 100,
+      hideDelay: 200,
+    });
+
+    trigger.dispatchEvent(new MouseEvent("mouseenter"));
+    vi.advanceTimersByTime(100);
+    expect(controller.isOpen).toBe(true);
+
+    trigger.dispatchEvent(new MouseEvent("mouseleave"));
+    vi.advanceTimersByTime(199);
+    expect(controller.isOpen).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.isOpen).toBe(false);
+    expect(preview.classList.contains("is-active")).toBe(false);
+  });
+
+  it("should cancel hide timer if mouse moves into preview card before hideDelay expires", () => {
+    const controller = new HoverPreviewCardController(trigger, preview, {
+      showDelay: 100,
+      hideDelay: 200,
+    });
+
+    trigger.dispatchEvent(new MouseEvent("mouseenter"));
+    vi.advanceTimersByTime(100);
+
+    trigger.dispatchEvent(new MouseEvent("mouseleave"));
+    vi.advanceTimersByTime(100);
+
+    preview.dispatchEvent(new MouseEvent("mouseenter"));
+    vi.advanceTimersByTime(300);
+
+    expect(controller.isOpen).toBe(true);
+  });
+
+  it("should clean up all active timers and event listeners on destroy()", () => {
+    const controller = new HoverPreviewCardController(trigger, preview, {
+      showDelay: 300,
+    });
+
+    trigger.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(controller.showTimer).not.toBeNull();
+
+    controller.destroy();
+    expect(controller.showTimer).toBeNull();
+    expect(controller.hideTimer).toBeNull();
+
+    vi.advanceTimersByTime(500);
+    expect(controller.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Added automated Vitest unit spec for Hover Preview Card Delay Timeout Check under submissions/examples/vitest-hover-preview-delay-86410/.

## Changes
- Created demo.html showcasing hover preview card layout and unit spec dashboard
- Created style.css with modern dark theme styling
- Created test.js containing Vitest specs for initial state, showDelay timer, mouseleave cancellation, hideDelay timer, and destroy cleanup
- Created README.md documenting usage and test commands

## Testing
- Validated submission files placed strictly inside submissions/
- Verified no unrelated root/core files changed

## Scope
Addressed only issue #86410.

Closes #86410