### PR TITLE
a11y(button): implement WCAG 2.1 AA compliant aria-disabled button with pointer event interception`

### DIFF
--- a/submissions/examples/disabled-button-pointer-events-aria/README.md
+++ b/submissions/examples/disabled-button-pointer-events-aria/README.md
@@ -1,0 +1,24 @@
+# Disabled Button Pointer-Events & ARIA Disabled
+
+An audited, WCAG 2.1 AA compliant disabled button pattern utilizing `aria-disabled="true"` with `pointer-events: auto` to prevent focus starvation, convey contextual requirements to screen readers, and support Windows High Contrast Mode.
+
+## 🌟 Features & Accessibility Fixes
+
+* **Keyboard Focus Retention (WCAG 2.1.1):** Preserves the button in the keyboard tab sequence, allowing keyboard and screen reader users to discover unavailable controls.
+* **Contextual Help via `aria-describedby` (WCAG 1.3.1 & 4.1.2):** Links the button to an explanatory note, automatically announced when NVDA, VoiceOver, or JAWS focuses the control.
+* **Non-Silent Pointer Clicks:** Retaining pointer events enables click intercept handlers to announce remaining requirements and guide focus to the invalid field.
+* **Dual-Layer Focus Ring (WCAG 2.4.7):** Ensures focus outline contrast across varied backgrounds even while disabled.
+* **High Contrast Mode Support (`forced-colors: active`):** Binds disabled text and borders to `GrayText` and `ButtonText`.
+
+## 🚀 Usage
+
+```html
+<button 
+  type="submit" 
+  class="btn-accessible" 
+  aria-disabled="true" 
+  aria-describedby="help-id"
+>
+  Submit
+</button>
+<span id="help-id">Complete required fields to submit.</span>

--- a/submissions/examples/disabled-button-pointer-events-aria/demo.html
+++ b/submissions/examples/disabled-button-pointer-events-aria/demo.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Disabled Button Pointer-Events & ARIA Disabled Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Screen Reader Live Region for Dynamic Announcements -->
+  <div 
+    id="btn-live-announcer" 
+    class="sr-only" 
+    role="status" 
+    aria-live="polite" 
+    aria-atomic="true"
+  ></div>
+
+  <main id="main-content" tabindex="-1">
+    <h1>Accessible Disabled Button</h1>
+    <p>
+      Tab to the button below. Unlike native <code>disabled</code> buttons or 
+      <code>pointer-events: none</code>, this control remains discoverable in the tab sequence, 
+      announces its state and explanatory help text, and guides users on activation.
+    </p>
+
+    <form id="accessible-form" novalidate>
+      <div style="margin-bottom: 1.25rem;">
+        <label for="terms-agreement" style="display: inline-flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+          <input type="checkbox" id="terms-agreement" style="width: 1.1rem; height: 1.1rem;">
+          <span style="font-size: 0.9rem;">I agree to the License Terms</span>
+        </label>
+      </div>
+
+      <!-- ACCESSIBLE ARIA DISABLED BUTTON -->
+      <button 
+        type="submit" 
+        id="submit-action-btn" 
+        class="btn-accessible" 
+        aria-disabled="true" 
+        aria-describedby="disabled-reason-note"
+      >
+        <span>Complete Deployment</span>
+      </button>
+
+      <div id="disabled-reason-note" class="help-text" role="note">
+        <span>⚠️ License terms must be accepted to enable deployment.</span>
+      </div>
+    </form>
+  </main>
+
+  <script>
+    // Inline Accessible Disabled Button Controller
+    document.addEventListener('DOMContentLoaded', () => {
+      const checkbox = document.getElementById('terms-agreement');
+      const submitBtn = document.getElementById('submit-action-btn');
+      const helpNote = document.getElementById('disabled-reason-note');
+      const announcer = document.getElementById('btn-live-announcer');
+
+      if (!checkbox || !submitBtn) return;
+
+      function announce(message) {
+        if (!announcer) return;
+        announcer.textContent = '';
+        setTimeout(() => {
+          announcer.textContent = message;
+        }, 50);
+      }
+
+      // Checkbox state listener
+      checkbox.addEventListener('change', () => {
+        const isChecked = checkbox.checked;
+
+        if (isChecked) {
+          submitBtn.removeAttribute('aria-disabled');
+          if (helpNote) helpNote.style.display = 'none';
+          announce('Deployment button is now enabled.');
+        } else {
+          submitBtn.setAttribute('aria-disabled', 'true');
+          if (helpNote) helpNote.style.display = 'flex';
+          announce('Deployment button is disabled. License terms required.');
+        }
+      });
+
+      // Intercept activation on click / Enter / Space
+      submitBtn.addEventListener('click', (e) => {
+        if (submitBtn.getAttribute('aria-disabled') === 'true') {
+          e.preventDefault();
+          e.stopPropagation();
+
+          announce('Cannot submit: Please check the License Terms checkbox first.');
+          checkbox.focus();
+        } else {
+          e.preventDefault();
+          announce('Deployment completed successfully!');
+          alert('Deployment completed successfully!');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/disabled-button-pointer-events-aria/style.css
+++ b/submissions/examples/disabled-button-pointer-events-aria/style.css
@@ -1,0 +1,162 @@
+/* ============================================================
+   Accessibility Improvement — Disabled Button aria-disabled State
+   Path: submissions/examples/disabled-button-pointer-events-aria/style.css
+   ============================================================ */
+
+/* ── 1. Base Variables & Theme Tokens ────────────────────── */
+:root {
+  --bg-primary: #0f172a;
+  --surface-card: #1e293b;
+  --surface-border: #334155;
+  --text-main: #f8fafc;
+  --text-muted: #cbd5e1;
+  --primary-btn-bg: #0284c7;
+  --primary-btn-hover: #0369a1;
+
+  /* Accessible Disabled Tokens */
+  --disabled-bg: #334155;
+  --disabled-text: #94a3b8;
+  --disabled-border: #475569;
+
+  /* Focus Ring Tokens */
+  --focus-ring-inner: #ffffff;
+  --focus-ring-outer: #0f172a;
+  --focus-ring-glow: #00f3ff;
+
+  --transition-speed: 0.2s;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  line-height: 1.5;
+}
+
+/* ── 2. Screen Reader Only Utility ───────────────────────── */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* ── 3. Layout Card ──────────────────────────────────────── */
+main {
+  width: 100%;
+  max-width: 520px;
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+h1 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-main);
+}
+
+p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ── 4. Accessible Button & aria-disabled States ─────────── */
+.btn-accessible {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.75rem 1.25rem;
+  background-color: var(--primary-btn-bg);
+  color: #ffffff;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  pointer-events: auto; /* Preserves click feedback & screen magnifier inspection */
+  transition: background-color var(--transition-speed) ease, border-color var(--transition-speed) ease;
+}
+
+.btn-accessible:hover:not([aria-disabled="true"]) {
+  background-color: var(--primary-btn-hover);
+}
+
+/* Preserved Visible Focus Ring (WCAG 2.4.7) */
+.btn-accessible:focus-visible {
+  outline: 3px solid var(--focus-ring-inner) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 5px var(--focus-ring-outer),
+              0 0 0 7px var(--focus-ring-glow) !important;
+  z-index: 10;
+}
+
+/* Disabled State Visual Styling */
+.btn-accessible[aria-disabled="true"] {
+  background-color: var(--disabled-bg);
+  color: var(--disabled-text);
+  border-color: var(--disabled-border);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.help-text {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #f87171;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+/* ── 5. Reduced Motion (WCAG 2.3.3) ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .btn-accessible {
+    transition: none !important;
+  }
+}
+
+/* ── 6. Forced Colors / High Contrast Mode (WCAG 1.4.11) ─── */
+@media (forced-colors: active) {
+  .btn-accessible {
+    border: 1px solid ButtonText !important;
+  }
+
+  .btn-accessible[aria-disabled="true"] {
+    color: GrayText !important;
+    border-color: GrayText !important;
+    background-color: Canvas !important;
+  }
+
+  .btn-accessible:focus-visible {
+    outline: 3px solid Highlight !important;
+    outline-offset: 3px !important;
+    box-shadow: none !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- This PR introduces an accessible, WCAG 2.1 AA compliant **Disabled Button Component** utilizing `aria-disabled="true"`, `aria-describedby`, preserved keyboard focusability, pointer event interception, and Windows High Contrast Mode support. -->

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- A WCAG 2.1 AA compliant disabled button pattern using `aria-disabled="true"` and `aria-describedby` to eliminate focus starvation and communicate requirements to assistive technologies. -->

**How does a developer use it?**

```html
<!-- <button type="submit" class="btn-accessible" aria-disabled="true" aria-describedby="reason-id">
  Submit
</button>
<span id="reason-id">Terms must be accepted.</span> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It avoids hard visual/functional dropouts caused by pointer-events: none and native disabled, pairing smooth CSS transitions with accessible keyboard and screen reader interactions. -->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #86276