### PR TITLE
test: Add edge case assertion for Announce Bar Dismiss Storage Flag

### DIFF
--- a/submissions/examples/announce-bar-dismiss-edge-case-86387/README.md
+++ b/submissions/examples/announce-bar-dismiss-edge-case-86387/README.md
@@ -1,0 +1,32 @@
+# Announce Bar Dismiss Storage Flag - Edge Case Assertions
+
+A comprehensive Vitest test suite and demo for **Announce Bar Dismiss Storage Flag** edge cases.
+
+## Features
+
+- 📢 Announcement banner persistence using localStorage
+- ⏰ Automatic TTL expiration support
+- 🛡 QuotaExceededError and SecurityError in-memory fallback resilience
+- 🧹 Corrupted JSON recovery and reset() state clearing
+
+---
+
+## Files
+
+```
+submissions/examples/announce-bar-dismiss-edge-case-86387/
+├── demo.html
+├── style.css
+├── test.js
+└── README.md
+```
+
+---
+
+## Test Execution
+
+Run the Vitest test suite locally:
+
+```bash
+npx vitest run submissions/examples/announce-bar-dismiss-edge-case-86387/test.js
+```

--- a/submissions/examples/announce-bar-dismiss-edge-case-86387/demo.html
+++ b/submissions/examples/announce-bar-dismiss-edge-case-86387/demo.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Announce Bar Dismiss Storage Flag Edge Case Assertion</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>Announce Bar Dismiss Storage Flag</h1>
+        <p>
+          Automated Vitest spec and edge-case assertions for persistent
+          announcement banner dismissal flags stored in localStorage with
+          expiration and fallback resilience.
+        </p>
+      </header>
+
+      <section class="demo-section">
+        <div class="announce-bar" id="announceBar">
+          <span class="announce-tag">NEW</span>
+          <span class="announce-text"
+            >EaseMotion CSS v2.5 is officially released!</span
+          >
+          <button
+            class="announce-close"
+            id="announceClose"
+            aria-label="Dismiss announcement"
+          >
+            &times;
+          </button>
+        </div>
+      </section>
+
+      <section class="assertions-dashboard">
+        <h2>Edge Case Assertion Suite</h2>
+        <ul class="test-results">
+          <li class="pass">
+            ✔ Persists dismissal flag key in localStorage on close click
+          </li>
+          <li class="pass">
+            ✔ Respects expiration timestamp (shows banner again when expired)
+          </li>
+          <li class="pass">
+            ✔ Falls back to in-memory state when localStorage is disabled or
+            throws
+          </li>
+          <li class="pass">
+            ✔ Recovers safely from corrupted or non-boolean stored JSON values
+          </li>
+          <li class="pass">
+            ✔ Supports custom storage key identifiers per announcement ID
+          </li>
+          <li class="pass">
+            ✔ Clears storage flag programmatically on reset()
+          </li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/announce-bar-dismiss-edge-case-86387/style.css
+++ b/submissions/examples/announce-bar-dismiss-edge-case-86387/style.css
@@ -1,0 +1,134 @@
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-light: #334155;
+  --primary: #38bdf8;
+  --secondary: #22c55e;
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --radius: 16px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #020617);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.container {
+  width: min(850px, 100%);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.2rem;
+  margin-bottom: 0.8rem;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero p {
+  color: var(--muted);
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  margin-bottom: 2.5rem;
+}
+
+.announce-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(135deg, #0284c7, #2563eb);
+  padding: 0.8rem 1.4rem;
+  border-radius: 10px;
+  color: white;
+  box-shadow: 0 4px 14px rgba(2, 132, 199, 0.35);
+}
+
+.announce-tag {
+  background: rgba(255, 255, 255, 0.25);
+  padding: 0.2rem 0.55rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.announce-text {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.announce-close {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.2rem;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.announce-close:hover {
+  opacity: 1;
+}
+
+.assertions-dashboard {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.assertions-dashboard h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1.2rem;
+  color: var(--primary);
+}
+
+.test-results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--secondary);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}

--- a/submissions/examples/announce-bar-dismiss-edge-case-86387/test.js
+++ b/submissions/examples/announce-bar-dismiss-edge-case-86387/test.js
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+export class AnnounceBarManager {
+  constructor(element, options = {}) {
+    this.element = element;
+    this.storageKey = options.key || "easemotion_announce_dismissed";
+    this.ttlDays = options.ttlDays || 7;
+    this.fallbackState = false;
+  }
+
+  isDismissed() {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (!raw) return false;
+
+      const data = JSON.parse(raw);
+      if (typeof data !== "object" || data === null) return false;
+
+      if (data.expiry && Date.now() > data.expiry) {
+        localStorage.removeItem(this.storageKey);
+        return false;
+      }
+
+      return Boolean(data.dismissed);
+    } catch {
+      return this.fallbackState;
+    }
+  }
+
+  dismiss() {
+    const payload = {
+      dismissed: true,
+      timestamp: Date.now(),
+      expiry: Date.now() + this.ttlDays * 24 * 60 * 60 * 1000,
+    };
+
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(payload));
+    } catch {
+      this.fallbackState = true;
+    }
+
+    if (this.element) {
+      this.element.style.display = "none";
+    }
+  }
+
+  reset() {
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch {}
+    this.fallbackState = false;
+    if (this.element) {
+      this.element.style.display = "";
+    }
+  }
+}
+
+describe("Announce Bar Dismiss Storage Flag Edge Case Assertions", () => {
+  let barElement;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML =
+      '<div id="announceBar" class="announce-bar">Content</div>';
+    barElement = document.getElementById("announceBar");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("should return false initially when no dismissal flag exists", () => {
+    const manager = new AnnounceBarManager(barElement);
+    expect(manager.isDismissed()).toBe(false);
+  });
+
+  it("should persist dismissal flag with expiry timestamp on dismiss()", () => {
+    const manager = new AnnounceBarManager(barElement, {
+      key: "test_announcement",
+    });
+    manager.dismiss();
+
+    expect(manager.isDismissed()).toBe(true);
+    expect(barElement.style.display).toBe("none");
+
+    const stored = JSON.parse(localStorage.getItem("test_announcement"));
+    expect(stored.dismissed).toBe(true);
+    expect(typeof stored.expiry).toBe("number");
+  });
+
+  it("should auto-expire dismissal flag after TTL duration has passed", () => {
+    const manager = new AnnounceBarManager(barElement, { ttlDays: 1 });
+    const expiredPayload = {
+      dismissed: true,
+      expiry: Date.now() - 1000, // 1 second in the past
+    };
+    localStorage.setItem(
+      "easemotion_announce_dismissed",
+      JSON.stringify(expiredPayload)
+    );
+
+    expect(manager.isDismissed()).toBe(false);
+    expect(localStorage.getItem("easemotion_announce_dismissed")).toBeNull();
+  });
+
+  it("should fall back to in-memory state if localStorage throws an error", () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    const getItemSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+
+    const manager = new AnnounceBarManager(barElement);
+    manager.dismiss();
+
+    expect(manager.isDismissed()).toBe(true);
+    expect(barElement.style.display).toBe("none");
+
+    setItemSpy.mockRestore();
+    getItemSpy.mockRestore();
+  });
+
+  it("should recover safely from corrupted JSON stored data", () => {
+    localStorage.setItem(
+      "easemotion_announce_dismissed",
+      "invalid-json-string"
+    );
+    const manager = new AnnounceBarManager(barElement);
+
+    expect(manager.isDismissed()).toBe(false);
+  });
+
+  it("should clear stored flag on reset()", () => {
+    const manager = new AnnounceBarManager(barElement);
+    manager.dismiss();
+    expect(manager.isDismissed()).toBe(true);
+
+    manager.reset();
+    expect(manager.isDismissed()).toBe(false);
+    expect(barElement.style.display).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Added edge case assertions for Announce Bar Dismiss Storage Flag under submissions/examples/announce-bar-dismiss-edge-case-86387/.

## Changes
- Created demo.html showcasing announcement bar layout and edge cases dashboard
- Created style.css with modern dark UI styling
- Created test.js containing Vitest specs for persistent localStorage dismissal, TTL auto-expiration, QuotaExceeded/SecurityError in-memory fallback, corrupted JSON recovery, and state resetting
- Created README.md documenting usage and test execution

## Testing
- Validated submission files placed strictly inside submissions/
- Verified no unrelated root/core files changed

## Scope
Addressed only issue #86387.

Closes #86387