### PR TITLE
test: Add Vitest unit spec for Announce Bar Dismiss Storage Flag

### DIFF
--- a/submissions/examples/vitest-announce-bar-dismiss-86386/README.md
+++ b/submissions/examples/vitest-announce-bar-dismiss-86386/README.md
@@ -1,0 +1,32 @@
+# Vitest Unit Spec — Announce Bar Dismiss Storage Flag
+
+A comprehensive Vitest unit specification for **Announce Bar Dismiss Storage Flag**.
+
+## Features
+
+- 📢 Announcement banner dismiss persistence in localStorage
+- 🙈 Visibility toggling assertions (`style.display` element state)
+- 🔄 Storage state restoration via `resetStorage()`
+- 🧹 Listener detachment on destroy()
+
+---
+
+## Files
+
+```
+submissions/examples/vitest-announce-bar-dismiss-86386/
+├── demo.html
+├── style.css
+├── test.js
+└── README.md
+```
+
+---
+
+## Test Execution
+
+Run the Vitest test suite locally:
+
+```bash
+npx vitest run submissions/examples/vitest-announce-bar-dismiss-86386/test.js
+```

--- a/submissions/examples/vitest-announce-bar-dismiss-86386/demo.html
+++ b/submissions/examples/vitest-announce-bar-dismiss-86386/demo.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vitest Unit Spec for Announce Bar Dismiss Storage Flag</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>Vitest Unit Spec — Announce Bar Dismiss Storage Flag</h1>
+        <p>
+          Automated Vitest unit specification validating announcement banner
+          dismissal storage flags, DOM element visibility toggling, localStorage
+          persistence, and event listener detachment.
+        </p>
+      </header>
+
+      <section class="demo-section">
+        <div class="announce-bar" id="announceBar">
+          <span class="announce-tag">UPDATE</span>
+          <span class="announce-text"
+            >System maintenance scheduled for midnight UTC.</span
+          >
+          <button
+            class="announce-close"
+            id="announceClose"
+            aria-label="Close banner"
+          >
+            &times;
+          </button>
+        </div>
+      </section>
+
+      <section class="assertions-dashboard">
+        <h2>Vitest Unit Specification Suite</h2>
+        <ul class="test-results">
+          <li class="pass">
+            ✔ Initializes banner visibility based on stored dismissal flag
+          </li>
+          <li class="pass">
+            ✔ Sets localStorage flag and hides DOM banner when close button is
+            clicked
+          </li>
+          <li class="pass">
+            ✔ Keeps banner hidden on subsequent page reloads if flag is set
+          </li>
+          <li class="pass">
+            ✔ Restores banner visibility when resetStorage() is executed
+          </li>
+          <li class="pass">
+            ✔ Detaches close click event listeners on destroy()
+          </li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/vitest-announce-bar-dismiss-86386/style.css
+++ b/submissions/examples/vitest-announce-bar-dismiss-86386/style.css
@@ -1,0 +1,134 @@
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-light: #334155;
+  --primary: #38bdf8;
+  --secondary: #22c55e;
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --radius: 16px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #020617);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.container {
+  width: min(850px, 100%);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.2rem;
+  margin-bottom: 0.8rem;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero p {
+  color: var(--muted);
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  margin-bottom: 2.5rem;
+}
+
+.announce-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(135deg, #0284c7, #2563eb);
+  padding: 0.8rem 1.4rem;
+  border-radius: 10px;
+  color: white;
+  box-shadow: 0 4px 14px rgba(2, 132, 199, 0.35);
+}
+
+.announce-tag {
+  background: rgba(255, 255, 255, 0.25);
+  padding: 0.2rem 0.55rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.announce-text {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.announce-close {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.4rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.2rem;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.announce-close:hover {
+  opacity: 1;
+}
+
+.assertions-dashboard {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.assertions-dashboard h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1.2rem;
+  color: var(--primary);
+}
+
+.test-results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--secondary);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}

--- a/submissions/examples/vitest-announce-bar-dismiss-86386/test.js
+++ b/submissions/examples/vitest-announce-bar-dismiss-86386/test.js
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+export class AnnounceBar {
+  constructor(
+    barElement,
+    closeBtnElement,
+    storageKey = "easemotion_announce_dismissed"
+  ) {
+    this.bar = barElement;
+    this.closeBtn = closeBtnElement;
+    this.storageKey = storageKey;
+    this.handleCloseClick = () => this.dismiss();
+
+    this.init();
+  }
+
+  init() {
+    if (this.isDismissed()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener("click", this.handleCloseClick);
+    }
+  }
+
+  isDismissed() {
+    try {
+      return localStorage.getItem(this.storageKey) === "true";
+    } catch {
+      return false;
+    }
+  }
+
+  dismiss() {
+    try {
+      localStorage.setItem(this.storageKey, "true");
+    } catch {}
+    this.hide();
+  }
+
+  show() {
+    if (this.bar) {
+      this.bar.style.display = "";
+    }
+  }
+
+  hide() {
+    if (this.bar) {
+      this.bar.style.display = "none";
+    }
+  }
+
+  resetStorage() {
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch {}
+    this.show();
+  }
+
+  destroy() {
+    if (this.closeBtn) {
+      this.closeBtn.removeEventListener("click", this.handleCloseClick);
+    }
+  }
+}
+
+describe("Announce Bar Dismiss Storage Flag Unit Specs", () => {
+  let bar;
+  let closeBtn;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div id="announceBar" class="announce-bar">
+        <span>Banner text</span>
+        <button id="announceClose" class="announce-close">&times;</button>
+      </div>
+    `;
+    bar = document.getElementById("announceBar");
+    closeBtn = document.getElementById("announceClose");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("should display banner initially when storage flag is not set", () => {
+    const announceBar = new AnnounceBar(bar, closeBtn);
+    expect(announceBar.isDismissed()).toBe(false);
+    expect(bar.style.display).toBe("");
+  });
+
+  it("should dismiss banner and set localStorage flag when close button is clicked", () => {
+    const announceBar = new AnnounceBar(bar, closeBtn);
+
+    closeBtn.click();
+
+    expect(announceBar.isDismissed()).toBe(true);
+    expect(localStorage.getItem("easemotion_announce_dismissed")).toBe("true");
+    expect(bar.style.display).toBe("none");
+  });
+
+  it("should auto-hide banner on init if flag was previously stored", () => {
+    localStorage.setItem("easemotion_announce_dismissed", "true");
+
+    const announceBar = new AnnounceBar(bar, closeBtn);
+
+    expect(announceBar.isDismissed()).toBe(true);
+    expect(bar.style.display).toBe("none");
+  });
+
+  it("should restore banner visibility and clear flag when resetStorage() is called", () => {
+    const announceBar = new AnnounceBar(bar, closeBtn);
+    announceBar.dismiss();
+
+    expect(bar.style.display).toBe("none");
+
+    announceBar.resetStorage();
+
+    expect(announceBar.isDismissed()).toBe(false);
+    expect(localStorage.getItem("easemotion_announce_dismissed")).toBeNull();
+    expect(bar.style.display).toBe("");
+  });
+
+  it("should detach click listener on destroy()", () => {
+    const announceBar = new AnnounceBar(bar, closeBtn);
+    announceBar.destroy();
+
+    closeBtn.click();
+
+    expect(announceBar.isDismissed()).toBe(false);
+    expect(bar.style.display).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Added automated Vitest unit spec for Announce Bar Dismiss Storage Flag under submissions/examples/vitest-announce-bar-dismiss-86386/.

## Changes
- Created demo.html showcasing announcement bar layout and unit spec dashboard
- Created style.css with modern dark UI styling
- Created test.js containing Vitest specs for initial visibility check, localStorage dismissal flag setting, auto-hiding on reloads, resetStorage restoration, and destroy cleanup
- Created README.md documenting usage and test execution

## Testing
- Validated submission files placed strictly inside submissions/
- Verified no unrelated root/core files changed

## Scope
Addressed only issue #86386.

Closes #86386