### PR TITLE
test: Add Vitest unit spec for Connection Status Online Offline Event

### DIFF
--- a/submissions/examples/vitest-connection-status-86382/README.md
+++ b/submissions/examples/vitest-connection-status-86382/README.md
@@ -1,0 +1,32 @@
+# Vitest Unit Spec — Connection Status Online/Offline Event
+
+A comprehensive Vitest unit specification for **Connection Status Online Offline Event**.
+
+## Features
+
+- 🌐 `navigator.onLine` initial status detection
+- 📡 `window` `online` & `offline` event listener binding
+- 🎨 UI connection toast attribute and label updates (`data-status="online|offline"`)
+- 🧹 Complete event listener detachment on `destroy()`
+
+---
+
+## Files
+
+```
+submissions/examples/vitest-connection-status-86382/
+├── demo.html
+├── style.css
+├── test.js
+└── README.md
+```
+
+---
+
+## Test Execution
+
+Run the Vitest test suite locally:
+
+```bash
+npx vitest run submissions/examples/vitest-connection-status-86382/test.js
+```

--- a/submissions/examples/vitest-connection-status-86382/demo.html
+++ b/submissions/examples/vitest-connection-status-86382/demo.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vitest Unit Spec for Connection Status Online Offline Event</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>Vitest Unit Spec — Connection Status Online/Offline Event</h1>
+        <p>
+          Automated Vitest unit specification validating window online and
+          offline event handling, connection state toast indicator updates, and
+          listener detachment.
+        </p>
+      </header>
+
+      <section class="demo-section">
+        <div class="connection-toast" id="connectionToast" data-status="online">
+          <span class="status-dot"></span>
+          <span class="status-text" id="statusText"
+            >You are connected online</span
+          >
+        </div>
+      </section>
+
+      <section class="assertions-dashboard">
+        <h2>Vitest Unit Specification Suite</h2>
+        <ul class="test-results">
+          <li class="pass">
+            ✔ Detects navigator.onLine initial network connection status
+          </li>
+          <li class="pass">
+            ✔ Handles window 'offline' event and updates UI indicator to offline
+            state
+          </li>
+          <li class="pass">
+            ✔ Handles window 'online' event and updates UI indicator to online
+            state
+          </li>
+          <li class="pass">
+            ✔ Triggers custom state change callbacks (onOnline / onOffline)
+          </li>
+          <li class="pass">✔ Detaches window event listeners on destroy()</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/vitest-connection-status-86382/style.css
+++ b/submissions/examples/vitest-connection-status-86382/style.css
@@ -1,0 +1,126 @@
+:root {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-light: #334155;
+  --primary: #38bdf8;
+  --secondary: #22c55e;
+  --danger: #ef4444;
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --radius: 16px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e3a8a, #020617);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.container {
+  width: min(850px, 100%);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.2rem;
+  margin-bottom: 0.8rem;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero p {
+  color: var(--muted);
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+  line-height: 1.6;
+}
+
+.demo-section {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  margin-bottom: 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.connection-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: 30px;
+  background: var(--surface-light);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transition: all 0.3s ease;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--secondary);
+  box-shadow: 0 0 8px var(--secondary);
+}
+
+.connection-toast[data-status="offline"] .status-dot {
+  background: var(--danger);
+  box-shadow: 0 0 8px var(--danger);
+}
+
+.status-text {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.assertions-dashboard {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+
+.assertions-dashboard h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1.2rem;
+  color: var(--primary);
+}
+
+.test-results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.test-results li {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--secondary);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}

--- a/submissions/examples/vitest-connection-status-86382/test.js
+++ b/submissions/examples/vitest-connection-status-86382/test.js
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+export class ConnectionStatusMonitor {
+  constructor(toastElement, textElement, options = {}) {
+    this.toast = toastElement;
+    this.text = textElement;
+    this.onOnline = options.onOnline || null;
+    this.onOffline = options.onOffline || null;
+    this.isOnline = typeof navigator !== "undefined" ? navigator.onLine : true;
+
+    this.handleOnline = () => this.updateStatus(true);
+    this.handleOffline = () => this.updateStatus(false);
+
+    this.init();
+  }
+
+  init() {
+    this.updateStatus(this.isOnline);
+
+    window.addEventListener("online", this.handleOnline);
+    window.addEventListener("offline", this.handleOffline);
+  }
+
+  updateStatus(online) {
+    this.isOnline = online;
+
+    if (this.toast) {
+      this.toast.setAttribute("data-status", online ? "online" : "offline");
+    }
+    if (this.text) {
+      this.text.textContent = online
+        ? "You are connected online"
+        : "You are currently offline";
+    }
+
+    if (online && this.onOnline) this.onOnline();
+    if (!online && this.onOffline) this.onOffline();
+  }
+
+  destroy() {
+    window.removeEventListener("online", this.handleOnline);
+    window.removeEventListener("offline", this.handleOffline);
+  }
+}
+
+describe("Connection Status Online Offline Event Unit Specs", () => {
+  let toast;
+  let text;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="connectionToast" class="connection-toast" data-status="online">
+        <span id="statusText" class="status-text">You are connected online</span>
+      </div>
+    `;
+    toast = document.getElementById("connectionToast");
+    text = document.getElementById("statusText");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should initialize with current navigator.onLine state", () => {
+    const monitor = new ConnectionStatusMonitor(toast, text);
+    expect(typeof monitor.isOnline).toBe("boolean");
+    expect(toast.getAttribute("data-status")).toBe(
+      monitor.isOnline ? "online" : "offline"
+    );
+  });
+
+  it("should handle window offline event correctly", () => {
+    const onOfflineSpy = vi.fn();
+    const monitor = new ConnectionStatusMonitor(toast, text, {
+      onOffline: onOfflineSpy,
+    });
+
+    window.dispatchEvent(new Event("offline"));
+
+    expect(monitor.isOnline).toBe(false);
+    expect(toast.getAttribute("data-status")).toBe("offline");
+    expect(text.textContent).toBe("You are currently offline");
+    expect(onOfflineSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle window online event correctly", () => {
+    const onOnlineSpy = vi.fn();
+    const monitor = new ConnectionStatusMonitor(toast, text, {
+      onOnline: onOnlineSpy,
+    });
+
+    // Set offline first
+    window.dispatchEvent(new Event("offline"));
+    expect(monitor.isOnline).toBe(false);
+
+    // Now trigger online
+    window.dispatchEvent(new Event("online"));
+
+    expect(monitor.isOnline).toBe(true);
+    expect(toast.getAttribute("data-status")).toBe("online");
+    expect(text.textContent).toBe("You are connected online");
+    expect(onOnlineSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should detach event listeners on destroy()", () => {
+    const onOfflineSpy = vi.fn();
+    const monitor = new ConnectionStatusMonitor(toast, text, {
+      onOffline: onOfflineSpy,
+    });
+
+    monitor.destroy();
+    window.dispatchEvent(new Event("offline"));
+
+    expect(onOfflineSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Added automated Vitest unit spec for Connection Status Online Offline Event under submissions/examples/vitest-connection-status-86382/.

## Changes
- Created demo.html showcasing connection status toast and unit spec dashboard
- Created style.css with modern dark UI styling
- Created test.js containing Vitest specs for navigator.onLine initial status, window online/offline event handling, UI indicator data-status attribute toggling, and destroy cleanup
- Created README.md documenting usage and test execution

## Testing
- Validated submission files placed strictly inside submissions/
- Verified no unrelated root/core files changed

## Scope
Addressed only issue #86382.

Closes #86382