### PR TITLE
feat: implement accessibility audit fixes for audio player play pause…

### DIFF
--- a/submissions/examples/audio-player-aria-a11y/README.md
+++ b/submissions/examples/audio-player-aria-a11y/README.md
@@ -1,0 +1,65 @@
+# Accessible Audio Player Toggle (ARIA Pressed State)
+
+This submission demonstrates how to implement a fully accessible Play/Pause toggle button that complies with WCAG 2.1 AA standards, supporting screen readers, keyboard navigation, and high contrast modes.
+
+## Core Accessibility Features
+
+### 1. The Toggle Button Pattern (`aria-pressed`)
+
+A Play/Pause button is fundamentally a "toggle". It switches between two states: Playing and Paused. 
+
+Many developers mistakenly change the `aria-label` dynamically (e.g., from "Play" to "Pause"). This can confuse screen reader users because the identity of the button changes underneath them.
+
+The correct specification is to keep the label static (e.g., "Play or pause track") and use `aria-pressed` to indicate the current state.
+
+```html
+<!-- Correct implementation -->
+<button 
+    aria-label="Play or pause track" 
+    aria-pressed="false"
+>
+    <!-- SVGs go here -->
+</button>
+```
+
+When `aria-pressed="false"`, the track is paused (the button is not pressed down).
+When `aria-pressed="true"`, the track is playing (the button is pressed down).
+
+Screen readers will announce: *"Play or pause track, toggle button, not pressed"* or *"Play or pause track, toggle button, pressed"*.
+
+### 2. Semantic Visual States
+
+To guarantee that the visual state of the component never falls out of sync with its accessibility state, we strictly forbid the use of JavaScript classes like `.is-playing` in our CSS. Instead, we style the component and swap icons by targeting the ARIA attribute directly:
+
+```css
+/* The CSS selector IS the accessibility attribute */
+.play-btn[aria-pressed="true"] {
+    background-color: var(--btn-pressed-bg);
+}
+
+/* Swap icons strictly based on the ARIA state */
+.play-btn[aria-pressed="false"] .icon-pause { display: none; }
+.play-btn[aria-pressed="true"] .icon-play { display: none; }
+```
+
+### 3. Accessible SVGs
+
+Icons are meaningless to a screen reader. We must explicitly hide the Play and Pause SVGs from the accessibility tree so they don't generate noise.
+
+```html
+<svg aria-hidden="true">...</svg>
+```
+
+### 4. High Contrast (Forced Colors) Support
+
+In Windows High Contrast Mode, standard background colors are stripped away. The "playing" state (`aria-pressed="true"`) will become visually indistinguishable from the "paused" state if you only rely on `background-color`. We use the `forced-colors` media query to map the active state to the system's `Highlight` color.
+
+```css
+@media (forced-colors: active) {
+    .play-btn[aria-pressed="true"] {
+        border: 2px solid Highlight;
+        background-color: Highlight;
+        color: HighlightText;
+    }
+}
+```

--- a/submissions/examples/audio-player-aria-a11y/demo.html
+++ b/submissions/examples/audio-player-aria-a11y/demo.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Audio Player Toggle Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <main class="demo-container">
+        <h1>Audio Player Controls</h1>
+        <p>This demo illustrates the correct usage of <code>aria-pressed</code> for a Play/Pause toggle button.</p>
+        
+        <div class="player-card">
+            <div class="track-info">
+                <h2>Lofi Hip Hop Chill</h2>
+                <p>Unknown Artist</p>
+            </div>
+            
+            <div class="player-controls">
+                <!-- 
+                    CRITICAL ACCESSIBILITY: Toggle Button 
+                    We use aria-pressed="false" to indicate the button is a toggle, and it is currently OFF (paused).
+                    The aria-label remains static. Screen readers will announce "Play, toggle button, not pressed" 
+                    or "Play, toggle button, pressed".
+                -->
+                <button type="button" id="play-pause-btn" class="play-btn" aria-pressed="false" aria-label="Play or pause track">
+                    <!-- Play Icon (visible when aria-pressed is false) -->
+                    <svg class="icon-play" aria-hidden="true" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                        <polygon points="5 3 19 12 5 21 5 3"></polygon>
+                    </svg>
+                    
+                    <!-- Pause Icon (visible when aria-pressed is true) -->
+                    <svg class="icon-pause" aria-hidden="true" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                        <rect x="6" y="4" width="4" height="16"></rect>
+                        <rect x="14" y="4" width="4" height="16"></rect>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const btn = document.getElementById('play-pause-btn');
+
+            btn.addEventListener('click', () => {
+                // Get the current state
+                const isPressed = btn.getAttribute('aria-pressed') === 'true';
+                
+                // Toggle the state
+                // This single attribute change updates the accessibility tree AND triggers the CSS visual updates
+                btn.setAttribute('aria-pressed', !isPressed ? 'true' : 'false');
+                
+                // (In a real app, you would also trigger the audio.play() or audio.pause() here)
+            });
+        });
+    </script>
+</body>
+</html>

--- a/submissions/examples/audio-player-aria-a11y/style.css
+++ b/submissions/examples/audio-player-aria-a11y/style.css
@@ -1,0 +1,129 @@
+:root {
+    --bg-color: #f1f5f9;
+    --text-color: #0f172a;
+    --card-bg: #ffffff;
+    --btn-bg: #3b82f6;
+    --btn-hover: #2563eb;
+    --btn-pressed-bg: #10b981; /* Green when playing */
+    --btn-pressed-hover: #059669;
+    --focus-ring: #3b82f6;
+    --icon-color: #ffffff;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.5;
+}
+
+.demo-container {
+    padding: 3rem;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.player-card {
+    background-color: var(--card-bg);
+    border-radius: 16px;
+    padding: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    margin-top: 2rem;
+}
+
+.track-info h2 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1.25rem;
+}
+
+.track-info p {
+    margin: 0;
+    color: #64748b;
+}
+
+/* 
+ * PLAY/PAUSE BUTTON STYLES 
+ */
+.play-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: none;
+    background-color: var(--btn-bg);
+    color: var(--icon-color);
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.5);
+}
+
+.play-btn:hover {
+    background-color: var(--btn-hover);
+    transform: scale(1.05);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Semantic Styling via ARIA
+ * We use aria-pressed="true" as the CSS selector. 
+ * This guarantees visual state matches accessibility state.
+ */
+.play-btn[aria-pressed="true"] {
+    background-color: var(--btn-pressed-bg);
+    box-shadow: 0 4px 6px -1px rgba(16, 185, 129, 0.5);
+}
+
+.play-btn[aria-pressed="true"]:hover {
+    background-color: var(--btn-pressed-hover);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: Focus Visibility 
+ */
+.play-btn:focus-visible {
+    outline: 4px solid var(--focus-ring);
+    outline-offset: 4px;
+}
+
+/* 
+ * ICON TOGGLING 
+ * Rely on aria-pressed to swap icons.
+ */
+.icon-play, 
+.icon-pause {
+    transition: transform 0.2s, opacity 0.2s;
+}
+
+.play-btn[aria-pressed="false"] .icon-pause {
+    display: none;
+}
+
+.play-btn[aria-pressed="true"] .icon-play {
+    display: none;
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: High Contrast (Forced Colors) Support 
+ */
+@media (forced-colors: active) {
+    .play-btn {
+        border: 2px solid ButtonText;
+        background-color: ButtonFace;
+        color: ButtonText;
+    }
+    
+    .play-btn:focus-visible {
+        outline: 4px solid Highlight;
+    }
+    
+    .play-btn[aria-pressed="true"] {
+        border: 2px solid Highlight;
+        background-color: Highlight;
+        color: HighlightText;
+    }
+}


### PR DESCRIPTION
fixes #86308 

## Pull Request Description

This PR introduces a highly accessible implementation of a Play/Pause toggle button for an Audio Player, resolving critical issues around dynamic state announcements for screen readers. A common anti-pattern in media players is dynamically changing the button's `aria-label` from "Play" to "Pause". This confuses screen reader users by changing the identity of the element underneath them. This submission mandates the use of the Toggle Button pattern via the `aria-pressed` attribute, keeping the label static while correctly broadcasting state changes.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a best-in-class accessible Play/Pause toggle interface. Features include:
1. **Toggle Button Semantics:** Utilizes `aria-pressed="false"` (paused) and `aria-pressed="true"` (playing) rather than swapping out `aria-label`s. This allows screen readers to announce "Play or pause track, toggle button, not pressed".
2. **Accessible SVGs:** Explicitly hides the decorative Play and Pause SVG icons from the accessibility tree using `aria-hidden="true"`, preventing screen readers from attempting to read the raw vector paths.
3. **Semantic CSS Enforcement:** Abandons non-semantic `.is-playing` classes in favor of styling directly off the ARIA attribute. Uses the attribute selector `.play-btn[aria-pressed="true"]` for visual styling and for swapping the visible SVG icons, guaranteeing that developers cannot visually change the button state without also exposing that state to assistive technology.
4. **High Contrast Support:** Utilizes the `forced-colors` media query and system `Highlight` colors to ensure the "pressed" (playing) state remains visually distinct in Windows High Contrast Mode.

**How does a developer use it?**

```html
<!-- Correct implementation using aria-pressed and a static aria-label -->
<button 
    id="play-pause-btn" 
    class="play-btn" 
    aria-pressed="false" 
    aria-label="Play or pause track"
>
    <svg class="icon-play" aria-hidden="true">...</svg>
    <svg class="icon-pause" aria-hidden="true">...</svg>
</button>
