### PR TITLE
feat: implement accessibility audit fixes for focus ring outline visi…

### DIFF
--- a/submissions/examples/focus-ring-a11y/README.md
+++ b/submissions/examples/focus-ring-a11y/README.md
@@ -1,0 +1,50 @@
+# Accessible Focus Rings (`outline` and `:focus-visible`)
+
+This submission demonstrates how to implement highly visible, WCAG 2.1 AA compliant focus rings that adapt to complex backgrounds and support Windows High Contrast Mode.
+
+## The Problem: `outline: none`
+
+The most common accessibility failure on the web is developers globally setting `*:focus { outline: none; }` because they dislike how the default blue/black browser focus ring looks when a mouse user clicks a button.
+
+By removing the focus ring entirely, you completely lock out keyboard-only users, as they have absolutely no way to see which element on the page they are currently interacting with.
+
+## The Solution: `:focus-visible`
+
+Modern CSS provides the `:focus-visible` pseudo-class. It allows you to style focus rings *only* when the browser determines the user needs them (e.g., when navigating via the `Tab` key), while hiding them when a mouse user clicks the element.
+
+```css
+/* 1. Remove focus for mouse users */
+.btn:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* 2. Provide a beautiful, highly-visible focus ring for keyboard users */
+.btn:focus-visible {
+    outline: 3px solid #2563eb;
+    outline-offset: 3px;
+}
+```
+
+## Why `outline`, not `box-shadow`?
+
+Many developers prefer to use `box-shadow` for focus rings because it respects `border-radius`. **However, `box-shadow` is completely stripped away in Windows High Contrast (Forced Colors) Mode.** 
+
+The CSS `outline` property is strictly preferred for accessibility because the browser automatically maps it to the system's `Highlight` color in High Contrast Mode. 
+
+*If you must use `box-shadow`, you are required to use a media query to fallback to an `outline` in forced-colors mode.*
+
+## Dealing with Complex Backgrounds (Gradients)
+
+If your button sits on a solid blue background, a blue focus ring will be completely invisible. 
+If your button sits on a complex gradient, you cannot guarantee that *any* single color focus ring will have sufficient 3:1 contrast against the background.
+
+**The Fix:** Use `outline-offset`.
+
+By setting `outline-offset: 3px`, you create a transparent gap between the button and the focus ring. This "halo" effect guarantees that the focus ring will always have contrast against the button itself, and the background will show through the gap, ensuring visibility regardless of how complex the gradient is.
+
+```css
+.btn:focus-visible {
+    outline: 3px solid white;
+    outline-offset: 3px; /* Creates the necessary contrast gap */
+}
+```

--- a/submissions/examples/focus-ring-a11y/demo.html
+++ b/submissions/examples/focus-ring-a11y/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessible Focus Ring Visibility Demo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    
+    <main class="demo-container">
+        <h1>Accessible Focus Rings</h1>
+        <p>Keyboard users MUST be able to see which element currently has focus. The most common accessibility failure is developers writing <code>outline: none</code> because they don't like how the default blue ring looks when they click a button.</p>
+        
+        <p>Press the <strong>Tab</strong> key to navigate through the interactive elements below. Notice how the focus ring is highly visible even against complex gradient backgrounds.</p>
+        
+        <div class="demo-grid">
+            
+            <section class="demo-section">
+                <h2>1. Standard Solid Background</h2>
+                <div class="card solid-bg">
+                    <button class="custom-btn">Action Button</button>
+                    <a href="#" class="custom-link">Read more about this action</a>
+                </div>
+            </section>
+
+            <!-- 
+                CRITICAL ACCESSIBILITY: Complex Backgrounds (Gradients)
+                A standard blue focus ring might be completely invisible against a blue gradient.
+                To solve this, we use a dual-color focus strategy:
+                An `outline` combined with an `outline-offset` creates a gap, ensuring contrast 
+                regardless of the background behind the element.
+            -->
+            <section class="demo-section">
+                <h2>2. Complex Gradient Background</h2>
+                <div class="card gradient-bg">
+                    <button class="custom-btn btn-light">Action Button</button>
+                    <a href="#" class="custom-link link-light">Read more about this action</a>
+                </div>
+            </section>
+            
+            <section class="demo-section">
+                <h2>3. Form Inputs</h2>
+                <div class="card solid-bg">
+                    <label for="demo-input" class="form-label">Email Address</label>
+                    <input type="email" id="demo-input" class="custom-input" placeholder="you@example.com">
+                </div>
+            </section>
+
+        </div>
+    </main>
+
+</body>
+</html>

--- a/submissions/examples/focus-ring-a11y/style.css
+++ b/submissions/examples/focus-ring-a11y/style.css
@@ -1,0 +1,167 @@
+:root {
+    --bg-color: #f8fafc;
+    --text-color: #0f172a;
+    --card-bg: #ffffff;
+    --focus-ring-color: #2563eb;
+    --focus-ring-light: #ffffff;
+}
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.demo-container {
+    padding: 3rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.demo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.card {
+    padding: 2rem;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.solid-bg {
+    background-color: var(--card-bg);
+}
+
+.gradient-bg {
+    /* A complex background where a standard blue focus ring would become invisible */
+    background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 50%, #06b6d4 100%);
+    color: #ffffff;
+}
+
+/* 
+ * BASE INTERACTIVE STYLES 
+ */
+.custom-btn {
+    padding: 0.75rem 1.5rem;
+    background-color: #0f172a;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s, transform 0.1s;
+}
+
+.custom-btn:hover {
+    background-color: #334155;
+}
+
+.custom-btn:active {
+    transform: scale(0.98);
+}
+
+.custom-link {
+    color: #2563eb;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+}
+
+.custom-link:hover {
+    text-decoration: none;
+}
+
+.btn-light {
+    background-color: #ffffff;
+    color: #0f172a;
+}
+.btn-light:hover {
+    background-color: #f1f5f9;
+}
+
+.link-light {
+    color: #ffffff;
+}
+
+.form-label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: -1rem;
+}
+
+.custom-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.75rem 1rem;
+    border: 2px solid #cbd5e1;
+    border-radius: 6px;
+    font-size: 1rem;
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: The :focus-visible Pseudo-class
+ * DO NOT use :focus { outline: none; }. 
+ * If you want to remove the focus ring for mouse users, use :focus-visible for keyboard users.
+ */
+
+/* 1. Remove the default focus ring ONLY for mouse users */
+.custom-btn:focus:not(:focus-visible),
+.custom-link:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* 2. Define a highly visible focus ring for keyboard users */
+.custom-btn:focus-visible,
+.custom-link:focus-visible {
+    /* We use outline instead of box-shadow because outline automatically 
+       translates to High Contrast Mode in Windows. */
+    outline: 3px solid var(--focus-ring-color);
+    
+    /* outline-offset creates a gap between the element and the ring. 
+       This guarantees that even if the background color matches the outline color, 
+       the gap provides the necessary visual contrast. */
+    outline-offset: 3px;
+    border-radius: 2px;
+}
+
+/* 3. Adapting to complex dark/gradient backgrounds */
+.gradient-bg .custom-btn:focus-visible,
+.gradient-bg .custom-link:focus-visible {
+    outline-color: var(--focus-ring-light);
+}
+
+/* 4. Inputs should always show focus, even for mouse users */
+.custom-input:focus {
+    outline: none;
+    border-color: var(--focus-ring-color);
+    /* For inputs, a box-shadow is often preferred aesthetically and is acceptable 
+       as long as the border-color also changes for High Contrast mode. */
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+/* 
+ * CRITICAL ACCESSIBILITY: High Contrast (Forced Colors) Support 
+ */
+@media (forced-colors: active) {
+    .custom-btn:focus-visible,
+    .custom-link:focus-visible {
+        /* In HC mode, we map the outline to the system Highlight color */
+        outline: 3px solid Highlight;
+    }
+    
+    .custom-input:focus {
+        /* box-shadow is stripped in HC mode, so we rely on the outline here instead */
+        outline: 3px solid Highlight;
+        outline-offset: 2px;
+    }
+}


### PR DESCRIPTION
fixes #86264 

## Pull Request Description

This PR introduces a highly accessible implementation of Keyboard Focus Rings. A severe and common WCAG failure occurs when developers globally apply `outline: none` to buttons to suppress focus rings for mouse users, inadvertently locking out keyboard-only users who can no longer see what they are interacting with. Furthermore, standard single-color focus rings often fail the 3:1 contrast ratio requirement when placed against complex backgrounds (like gradients). This submission resolves these critical issues by leveraging the modern `:focus-visible` pseudo-class and utilizing `outline-offset` to guarantee visibility across any background context.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a best-in-class accessible Focus Management strategy. Features include:
1. **The `:focus-visible` Pattern:** Demonstrates how to safely suppress focus rings for mouse clicks (`:focus:not(:focus-visible) { outline: none; }`) while providing beautiful, highly prominent focus indicators for keyboard navigation (`:focus-visible`).
2. **Complex Background Contrast (`outline-offset`):** Solves the "invisible focus ring on a gradient" problem. By applying an `outline-offset` to push the focus ring away from the element, it creates a transparent gap. This "halo" effect guarantees that the focus ring will contrast with both the button and the background, regardless of how complex the gradient behind it is.
3. **`outline` over `box-shadow`:** Explicitly relies on the CSS `outline` property rather than `box-shadow`. While `box-shadow` is popular because it curves with `border-radius`, it is completely stripped away by Windows High Contrast Mode. `outline`, however, is a native accessibility feature that the OS automatically maps to system colors.
4. **High Contrast Support:** Utilizes the `forced-colors` media query to ensure that any custom focus states fallback cleanly to the system `Highlight` color.

**How does a developer use it?**

```css
/* 1. Remove the default focus ring ONLY for mouse users */
.btn:focus:not(:focus-visible) {
    outline: none;
}

/* 2. Define a highly visible focus ring for keyboard users */
.btn:focus-visible {
    outline: 3px solid #2563eb;
    
    /* outline-offset creates a gap between the element and the ring,
       guaranteeing contrast against complex gradient backgrounds */
    outline-offset: 3px; 
}
