### PR TITLE
feat(core): Add Image Cover Slide component (#87549)

### DIFF
--- a/submissions/examples/image-cover-slide-ag/README.md
+++ b/submissions/examples/image-cover-slide-ag/README.md
@@ -1,0 +1,5 @@
+# Image Cover Slide
+
+1. What does this do? Creates an interactive hover effect where a solid cover panel slides laterally to reveal an image underneath, paired with a subtle image zoom out.
+2. How is it used? Apply `.image-cover-slide` to a figure or container that holds an `img` tag.
+3. Why is it useful? It adds a sleek, modern reveal effect commonly used in premium portfolios and editorial designs. By using CSS pseudo-elements and hardware-accelerated transforms (`scaleX`), it achieves an incredibly smooth transition without relying on JavaScript or extra wrapper divs.

--- a/submissions/examples/image-cover-slide-ag/demo.html
+++ b/submissions/examples/image-cover-slide-ag/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Cover Slide Component</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f4f4f5;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .instruction {
+      margin-top: 2rem;
+      color: #555;
+      font-weight: 500;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- The Component -->
+  <figure class="image-cover-slide">
+    <!-- Using a placeholder image for the demo -->
+    <img src="https://picsum.photos/600/400" alt="Scenic Landscape">
+  </figure>
+  
+  <p class="instruction">Hover over the image to reveal it</p>
+
+</body>
+</html>

--- a/submissions/examples/image-cover-slide-ag/style.css
+++ b/submissions/examples/image-cover-slide-ag/style.css
@@ -1,0 +1,51 @@
+.image-cover-slide {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  margin: 0;
+  border-radius: 8px; /* Optional rounded corners */
+  cursor: pointer;
+  background-color: #2c2c2c; /* The solid panel color behind the image, if needed */
+}
+
+.image-cover-slide img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  transition: transform 0.6s cubic-bezier(0.8, 0, 0.2, 1);
+  transform: scale(1.1); /* Slight zoom for dramatic reveal */
+}
+
+/* The solid cover panel */
+.image-cover-slide::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #18181b; /* Dark cover panel */
+  transform-origin: left;
+  transition: transform 0.6s cubic-bezier(0.8, 0, 0.2, 1);
+  z-index: 1;
+}
+
+/* On hover, slide the panel to the right and scale the image to normal size */
+.image-cover-slide:hover::after {
+  transform: scaleX(0);
+  transform-origin: right;
+}
+
+.image-cover-slide:hover img {
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .image-cover-slide::after {
+    display: none; /* Remove cover panel */
+  }
+  .image-cover-slide img {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #87549. Adds an `Image Cover Slide` component to the media gallery. It creates a sleek, interactive effect where a solid cover panel slides laterally to reveal an image underneath on hover, providing a premium presentation layer.

---

## Type of Change

- [x] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

An interactive hover effect where a solid pseudo-element cover panel slides laterally via `transform: scaleX(0)` to reveal an image underneath, paired with a subtle image zoom out.

**How does a developer use it?**

```html
<figure class="image-cover-slide">
  <img src="your-image.jpg" alt="Description">
</figure>
