### PR TITLE
feat: add card-fold-corner component

### DIFF
--- a/submissions/examples/card-fold-corner/README.md
+++ b/submissions/examples/card-fold-corner/README.md
@@ -1,0 +1,20 @@
+# Card Fold Corner
+
+A page-corner folds down on hover, revealing a tab beneath.
+
+## Features
+- Corner fold via pseudo-element
+- Gradient shading on fold
+- Underlying tab reveal
+- Pure CSS
+
+## Usage
+```html
+<div class="cfc-card"><span class="cfc-tab">Note</span></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-fold-corner/demo.html
+++ b/submissions/examples/card-fold-corner/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Fold Corner &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cfc-card">
+  <p>Hover the corner to fold it down.</p>
+  <span class="cfc-tab">Note</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-fold-corner/style.css
+++ b/submissions/examples/card-fold-corner/style.css
@@ -1,0 +1,39 @@
+.cfc-card {
+  position: relative;
+  max-width: 300px;
+  margin: 60px auto;
+  padding: 24px;
+  border-radius: 12px;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  color: #dfe7f2;
+  overflow: hidden;
+}
+.cfc-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, #ffd37a 0%, #ffd37a 50%, #22304f 50%, #22304f 100%);
+  transform-origin: top right;
+  transition: transform 0.4s ease;
+}
+.cfc-card:hover::after { transform: rotate(90deg) translateX(100%); }
+.cfc-tab {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  color: #0d141f;
+  font-size: 0.7rem;
+  font-weight: 800;
+  writing-mode: vertical-rl;
+  opacity: 0;
+  transition: opacity 0.3s 0.1s;
+}
+.cfc-card:hover .cfc-tab { opacity: 1; }


### PR DESCRIPTION
## Summary

Add the **Card Fold Corner** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** A page-corner folds down on hover, revealing a tab beneath.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-fold-corner/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A page-corner folds down on hover, revealing a tab beneath.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Corner fold via pseudo-element
- Gradient shading on fold
- Underlying tab reveal
- Pure CSS

### Demo
Open `submissions/examples/card-fold-corner/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87531
