### PR TITLE
feat: add card-glow-border component

### DIFF
--- a/submissions/examples/card-glow-border/README.md
+++ b/submissions/examples/card-glow-border/README.md
@@ -1,0 +1,20 @@
+# Card Glow Border
+
+A card border glows in a travelling gradient while the card floats.
+
+## Features
+- Animated gradient border
+- Glow bleeds via drop-shadow
+- Soft float animation
+- Pure CSS
+
+## Usage
+```html
+<div class="cgb-card">...</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-glow-border/demo.html
+++ b/submissions/examples/card-glow-border/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Glow Border &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cgb-card">
+  <h3>Glow border</h3>
+  <p>The border gradient orbits the card.</p>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-glow-border/style.css
+++ b/submissions/examples/card-glow-border/style.css
@@ -1,0 +1,29 @@
+.cgb-card {
+  position: relative;
+  max-width: 300px;
+  margin: 60px auto;
+  padding: 28px;
+  border-radius: 16px;
+  background: #121a29;
+  color: #dfe7f2;
+  animation: cgb-float 4s ease-in-out infinite;
+}
+.cgb-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 18px;
+  padding: 2px;
+  background: linear-gradient(120deg, #ff7a7a, #7ad4ff, #7bffb0, #ffd37a, #ff7a7a);
+  background-size: 300% 100%;
+  animation: cgb-flow 4s linear infinite;
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  z-index: -1;
+}
+.cgb-card:hover::before { filter: drop-shadow(0 0 12px rgba(122, 212, 255, 0.7)); }
+.cgb-card h3 { margin: 0 0 8px; }
+.cgb-card p { margin: 0; color: #aebbd0; font-size: 0.92rem; }
+@keyframes cgb-flow { to { background-position: 300% 0; } }
+@keyframes cgb-float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }


### PR DESCRIPTION
## Summary

Add the **Card Glow Border** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** A card border glows in a travelling gradient while the card floats.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-glow-border/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A card border glows in a travelling gradient while the card floats.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Animated gradient border
- Glow bleeds via drop-shadow
- Soft float animation
- Pure CSS

### Demo
Open `submissions/examples/card-glow-border/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87528
