### PR TITLE
feat: add card-grid-expand component

### DIFF
--- a/submissions/examples/card-grid-expand/README.md
+++ b/submissions/examples/card-grid-expand/README.md
@@ -1,0 +1,20 @@
+# Card Grid Expand
+
+Hovering a tile expands it across the grid while neighbours recede.
+
+## Features
+- Flexible grid expansion
+- Neighbours dim + shrink
+- Layout stays fluid
+- Pure CSS
+
+## Usage
+```html
+<div class="cge-tile" style="--c:#6fb7ff">1</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-grid-expand/demo.html
+++ b/submissions/examples/card-grid-expand/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Grid Expand &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cge-grid">
+  <div class="cge-tile" style="--c:#6fb7ff">1</div>
+  <div class="cge-tile" style="--c:#7bffb0">2</div>
+  <div class="cge-tile" style="--c:#ffd37a">3</div>
+  <div class="cge-tile" style="--c:#ff7a7a">4</div>
+  <div class="cge-tile" style="--c:#c07aff">5</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-grid-expand/style.css
+++ b/submissions/examples/card-grid-expand/style.css
@@ -1,0 +1,22 @@
+.cge-grid {
+  display: flex;
+  gap: 12px;
+  height: 180px;
+  max-width: 640px;
+  margin: 60px auto;
+  padding: 0 20px;
+}
+.cge-tile {
+  flex: 1;
+  border-radius: 14px;
+  background: linear-gradient(150deg, var(--c), #1a2233);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  font-weight: 800;
+  transition: flex 0.45s cubic-bezier(0.3, 0.8, 0.2, 1), filter 0.45s, transform 0.45s;
+  filter: saturate(0.85);
+}
+.cge-grid:hover .cge-tile { flex: 0.7; filter: grayscale(0.5); }
+.cge-grid .cge-tile:hover { flex: 3.2; filter: none; }


### PR DESCRIPTION
## Summary

Add the **Card Grid Expand** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** Hovering a tile expands it across the grid while neighbours recede.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-grid-expand/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Hovering a tile expands it across the grid while neighbours recede.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Flexible grid expansion
- Neighbours dim + shrink
- Layout stays fluid
- Pure CSS

### Demo
Open `submissions/examples/card-grid-expand/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87533
