### PR TITLE
feat: add card-list-slide component

### DIFF
--- a/submissions/examples/card-list-slide/README.md
+++ b/submissions/examples/card-list-slide/README.md
@@ -1,0 +1,20 @@
+# Card List Slide
+
+List rows slide in from alternating sides as they animate through.
+
+## Features
+- Alternating slide-in
+- Staggered delay
+- Row hover emphasis
+- Pure CSS
+
+## Usage
+```html
+<div class="cls-row" style="--i:0"><span>01</span> Alpha</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-list-slide/demo.html
+++ b/submissions/examples/card-list-slide/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card List Slide &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cls-list">
+  <div class="cls-row" style="--i:0"><span>01</span> Alpha</div>
+  <div class="cls-row" style="--i:1"><span>02</span> Beta</div>
+  <div class="cls-row" style="--i:2"><span>03</span> Gamma</div>
+  <div class="cls-row" style="--i:3"><span>04</span> Delta</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-list-slide/style.css
+++ b/submissions/examples/card-list-slide/style.css
@@ -1,0 +1,41 @@
+.cls-list {
+  max-width: 420px;
+  margin: 60px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 20px;
+}
+.cls-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  color: #dfe7f2;
+  animation: cls-slide 4s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.35s);
+  opacity: 0.75;
+  transition: opacity 0.3s, transform 0.3s, border-color 0.3s;
+}
+.cls-row span {
+  color: #6fb7ff;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.cls-row:hover { opacity: 1; transform: scale(1.02); border-color: #6fb7ff; }
+@keyframes cls-slide {
+  0%, 100% { opacity: 0.75; transform: translateX(0); }
+  30% { opacity: 1; }
+  45% { transform: translateX(14px); }
+  70% { transform: translateX(-14px); }
+}
+.cls-row:nth-child(even) { animation-name: cls-slide-r; }
+@keyframes cls-slide-r {
+  0%, 100% { opacity: 0.75; transform: translateX(0); }
+  30% { opacity: 1; }
+  45% { transform: translateX(-14px); }
+  70% { transform: translateX(14px); }
+}


### PR DESCRIPTION
## Summary

Add the **Card List Slide** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** List rows slide in from alternating sides as they animate through.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-list-slide/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** List rows slide in from alternating sides as they animate through.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Alternating slide-in
- Staggered delay
- Row hover emphasis
- Pure CSS

### Demo
Open `submissions/examples/card-list-slide/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87537
