### PR TITLE
feat: add card-scratch-layer component

### DIFF
--- a/submissions/examples/card-scratch-layer/README.md
+++ b/submissions/examples/card-scratch-layer/README.md
@@ -1,0 +1,20 @@
+# Card Scratch Layer
+
+A scratched layer sits on top and fades away on hover like a lottery card.
+
+## Features
+- Reveal-on-hover layer
+- Dashed scratch texture
+- Prize text beneath
+- Pure CSS
+
+## Usage
+```html
+<div class="csl-card"><div class="csl-prize">Win</div><div class="csl-scratch"></div></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-scratch-layer/demo.html
+++ b/submissions/examples/card-scratch-layer/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Scratch Layer &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="csl-card">
+  <div class="csl-prize">You win!</div>
+  <div class="csl-scratch"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-scratch-layer/style.css
+++ b/submissions/examples/card-scratch-layer/style.css
@@ -1,0 +1,25 @@
+.csl-card {
+  position: relative;
+  width: 220px;
+  height: 140px;
+  margin: 60px auto;
+  border-radius: 14px;
+  background: repeating-linear-gradient(45deg, #ffd37a, #ffd37a 14px, #f5b93f 14px, #f5b93f 28px);
+  overflow: hidden;
+}
+.csl-prize {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #4a3a00;
+  font-weight: 800;
+  font-size: 1.3rem;
+}
+.csl-scratch {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, #3a3a3a, #3a3a3a 3px, #4a4a4a 3px, #4a4a4a 6px);
+  transition: transform 0.5s ease;
+}
+.csl-card:hover .csl-scratch { transform: translateY(-100%); }


### PR DESCRIPTION
## Summary

Add the **Card Scratch Layer** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** A scratched layer sits on top and fades away on hover like a lottery card.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-scratch-layer/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A scratched layer sits on top and fades away on hover like a lottery card.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Reveal-on-hover layer
- Dashed scratch texture
- Prize text beneath
- Pure CSS

### Demo
Open `submissions/examples/card-scratch-layer/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87535
