### PR TITLE
feat: add card-split-reveal component

### DIFF
--- a/submissions/examples/card-split-reveal/README.md
+++ b/submissions/examples/card-split-reveal/README.md
@@ -1,0 +1,20 @@
+# Card Split Reveal
+
+Two halves of a card slide apart to reveal content beneath.
+
+## Features
+- Split halves slide on hover
+- Content revealed in the gap
+- Smooth clip edges
+- Pure CSS
+
+## Usage
+```html
+<div class="csr-card"><div class="csr-top"></div><div class="csr-bottom"></div><div class="csr-inner">...</div></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-split-reveal/demo.html
+++ b/submissions/examples/card-split-reveal/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Split Reveal &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="csr-card">
+  <div class="csr-top"><span>Hover to split</span></div>
+  <div class="csr-bottom"></div>
+  <div class="csr-inner">Surprise!</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-split-reveal/style.css
+++ b/submissions/examples/card-split-reveal/style.css
@@ -1,0 +1,30 @@
+.csr-card {
+  position: relative;
+  width: 260px;
+  height: 200px;
+  margin: 60px auto;
+  overflow: hidden;
+  border-radius: 16px;
+}
+.csr-top, .csr-bottom {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: linear-gradient(140deg, #3a4d7a, #22304f);
+  transition: transform 0.5s cubic-bezier(0.3, 0.8, 0.2, 1);
+  z-index: 2;
+}
+.csr-top { top: 0; display: grid; place-items: center; color: #dfe7f2; }
+.csr-bottom { bottom: 0; }
+.csr-inner {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #0d141f;
+  color: #7bffb0;
+  font-weight: 700;
+}
+.csr-card:hover .csr-top { transform: translateY(-100%); }
+.csr-card:hover .csr-bottom { transform: translateY(100%); }


### PR DESCRIPTION
## Summary

Add the **Card Split Reveal** component to the EaseMotion CSS gallery. This is a cards demo rendered with plain HTML and CSS.

**Description:** Two halves of a card slide apart to reveal content beneath.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-split-reveal/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Two halves of a card slide apart to reveal content beneath.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the cards category in the gallery with a polished, reusable effect.

### Key features
- Split halves slide on hover
- Content revealed in the gap
- Smooth clip edges
- Pure CSS

### Demo
Open `submissions/examples/card-split-reveal/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87530
