### PR TITLE
feat: add chart-line-draw component

### DIFF
--- a/submissions/examples/chart-line-draw/README.md
+++ b/submissions/examples/chart-line-draw/README.md
@@ -1,0 +1,20 @@
+# Chart Line Draw
+
+A line chart's path draws itself stroke by stroke with a trailing dot.
+
+## Features
+- SVG stroke-dashoffset draw
+- Trailing progress dot
+- Smooth polyline
+- Pure CSS
+
+## Usage
+```html
+<svg class="cld-svg"><polyline class="cld-grid" .../></svg>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/chart-line-draw/demo.html
+++ b/submissions/examples/chart-line-draw/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chart Line Draw &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cld-wrap">
+  <svg class="cld-svg" viewBox="0 0 400 160">
+    <polyline class="cld-grid" points="0,120 80,90 160,110 240,50 320,80 400,30"/>
+  </svg>
+  <div class="cld-dot"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/chart-line-draw/style.css
+++ b/submissions/examples/chart-line-draw/style.css
@@ -1,0 +1,41 @@
+.cld-wrap {
+  position: relative;
+  width: min(460px, 90vw);
+  margin: 60px auto;
+}
+.cld-svg {
+  width: 100%;
+  display: block;
+  background: #121a29;
+  border: 1px solid #24304a;
+  border-radius: 12px;
+}
+.cld-grid {
+  fill: none;
+  stroke: #6fb7ff;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-dasharray: 700;
+  stroke-dashoffset: 700;
+  animation: cld-draw 3s ease-in-out infinite;
+}
+.cld-dot {
+  position: absolute;
+  top: 10%;
+  left: 98%;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffd37a;
+  box-shadow: 0 0 0 4px rgba(255, 211, 122, 0.3);
+  animation: cld-hop 3s ease-in-out infinite;
+}
+@keyframes cld-draw {
+  0%, 100% { stroke-dashoffset: 700; }
+  60% { stroke-dashoffset: 0; }
+}
+@keyframes cld-hop {
+  0%, 100% { opacity: 0; transform: translate(-100%, 0); }
+  30%, 70% { opacity: 1; }
+  55% { transform: translate(-60%, -40%); }
+}


### PR DESCRIPTION
## Summary

Add the **Chart Line Draw** component to the EaseMotion CSS gallery. This is a charts demo rendered with plain HTML and CSS.

**Description:** A line chart's path draws itself stroke by stroke with a trailing dot.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/chart-line-draw/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A line chart's path draws itself stroke by stroke with a trailing dot.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the charts category in the gallery with a polished, reusable effect.

### Key features
- SVG stroke-dashoffset draw
- Trailing progress dot
- Smooth polyline
- Pure CSS

### Demo
Open `submissions/examples/chart-line-draw/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87560
