### PR TITLE
feat: add checkbox-tick-draw component

### DIFF
--- a/submissions/examples/checkbox-tick-draw/README.md
+++ b/submissions/examples/checkbox-tick-draw/README.md
@@ -1,0 +1,20 @@
+# Checkbox Tick Draw
+
+A custom checkbox whose tick draws itself with a stroke animation.
+
+## Features
+- SVG stroke dash animation
+- Checked state via :checked
+- Smooth fill + glow
+- Pure CSS
+
+## Usage
+```html
+<label class="ctd-item"><input type="checkbox" /><span class="ctd-box">...</span></label>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/checkbox-tick-draw/demo.html
+++ b/submissions/examples/checkbox-tick-draw/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checkbox Tick Draw &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<label class="ctd-item">
+  <input type="checkbox" />
+  <span class="ctd-box">
+    <svg viewBox="0 0 24 24"><path d="M4 12.5 9.5 18 20 6"/></svg>
+  </span>
+  Accept terms
+</label>
+</body>
+</html>

--- a/submissions/examples/checkbox-tick-draw/style.css
+++ b/submissions/examples/checkbox-tick-draw/style.css
@@ -1,0 +1,33 @@
+.ctd-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  color: #c6d2e4;
+  max-width: 260px;
+  margin: 60px auto;
+  font-size: 0.95rem;
+}
+.ctd-item input { position: absolute; opacity: 0; }
+.ctd-box {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  border: 2px solid #3b4a6b;
+  background: #161d2c;
+  display: grid;
+  place-items: center;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.ctd-box svg { width: 18px; height: 18px; fill: none; stroke: #0d141f; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+.ctd-box path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  transition: stroke-dashoffset 0.28s ease;
+}
+.ctd-item input:checked ~ .ctd-box {
+  background: #6fb7ff;
+  border-color: #6fb7ff;
+  box-shadow: 0 0 0 5px rgba(111, 183, 255, 0.18);
+}
+.ctd-item input:checked ~ .ctd-box path { stroke-dashoffset: 0; }


### PR DESCRIPTION
## Summary

Add the **Checkbox Tick Draw** component to the EaseMotion CSS gallery. This is a forms demo rendered with plain HTML and CSS.

**Description:** A custom checkbox whose tick draws itself with a stroke animation.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/checkbox-tick-draw/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A custom checkbox whose tick draws itself with a stroke animation.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the forms category in the gallery with a polished, reusable effect.

### Key features
- SVG stroke dash animation
- Checked state via :checked
- Smooth fill + glow
- Pure CSS

### Demo
Open `submissions/examples/checkbox-tick-draw/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87512
