### PR TITLE
feat: add coin-stack-tilt component

### DIFF
--- a/submissions/examples/coin-stack-tilt/README.md
+++ b/submissions/examples/coin-stack-tilt/README.md
@@ -1,0 +1,20 @@
+# Coin Stack Tilt
+
+Coins stack up and wobble with a toppling tease.
+
+## Features
+- Coin stack build
+- Wobble animation
+- Edge-shine accent
+- Pure CSS
+
+## Usage
+```html
+<div class="cst-coin" style="--i:0"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/coin-stack-tilt/demo.html
+++ b/submissions/examples/coin-stack-tilt/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Coin Stack Tilt &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cst-stack">
+  <div class="cst-coin" style="--i:0"></div>
+  <div class="cst-coin" style="--i:1"></div>
+  <div class="cst-coin" style="--i:2"></div>
+  <div class="cst-coin" style="--i:3"></div>
+  <div class="cst-coin" style="--i:4"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/coin-stack-tilt/style.css
+++ b/submissions/examples/coin-stack-tilt/style.css
@@ -1,0 +1,29 @@
+.cst-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin: 60px auto;
+  width: 120px;
+  transform-origin: bottom center;
+  animation: cst-wobble 2.8s ease-in-out infinite;
+}
+.cst-coin {
+  width: 110px;
+  height: 22px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ffd37a, #d9a23a);
+  border: 1px solid #a87a24;
+  box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.5);
+  animation: cst-drop 2.8s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.12s);
+}
+@keyframes cst-drop {
+  0%, 100% { transform: translateY(0); }
+  30% { transform: translateY(-6px); }
+}
+@keyframes cst-wobble {
+  0%, 100% { transform: rotate(0); }
+  45% { transform: rotate(-3deg); }
+  55% { transform: rotate(3deg); }
+}


### PR DESCRIPTION
## Summary

Add the **Coin Stack Tilt** component to the EaseMotion CSS gallery. This is a play demo rendered with plain HTML and CSS.

**Description:** Coins stack up and wobble with a toppling tease.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/coin-stack-tilt/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Coins stack up and wobble with a toppling tease.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the play category in the gallery with a polished, reusable effect.

### Key features
- Coin stack build
- Wobble animation
- Edge-shine accent
- Pure CSS

### Demo
Open `submissions/examples/coin-stack-tilt/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87574
