### PR TITLE
feat: add depth-tilt-parallax component

### DIFF
--- a/submissions/examples/depth-tilt-parallax/README.md
+++ b/submissions/examples/depth-tilt-parallax/README.md
@@ -1,0 +1,20 @@
+# Depth Tilt Parallax
+
+Layered shapes move at different depths, producing a parallax tilt.
+
+## Features
+- translateZ depth layers
+- Rotate on hover to expose parallax
+- Colourful floating orbs
+- Pure CSS
+
+## Usage
+```html
+<div class="dtp-orb" style="--d:80px;--c:#7ad4ff;--s:42px"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/depth-tilt-parallax/demo.html
+++ b/submissions/examples/depth-tilt-parallax/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Depth Tilt Parallax &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="dtp-scene">
+  <div class="dtp-orb" style="--d:30px;--c:#ff7a7a;--s:60px;top:22%;left:18%"></div>
+  <div class="dtp-orb" style="--d:80px;--c:#7ad4ff;--s:42px;top:58%;left:70%"></div>
+  <div class="dtp-orb" style="--d:50px;--c:#7bffb0;--s:32px;top:72%;left:24%"></div>
+  <div class="dtp-orb" style="--d:110px;--c:#ffd37a;--s:26px;top:26%;left:64%"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/depth-tilt-parallax/style.css
+++ b/submissions/examples/depth-tilt-parallax/style.css
@@ -1,0 +1,25 @@
+.dtp-scene {
+  position: relative;
+  height: 60vh;
+  overflow: hidden;
+  transform-style: preserve-3d;
+  perspective: 800px;
+  transition: transform 0.5s ease;
+  background: radial-gradient(circle at 30% 30%, #1a2440, #0d1220);
+}
+.dtp-scene:hover { transform: rotateX(8deg) rotateY(-10deg); }
+.dtp-orb {
+  position: absolute;
+  width: var(--s);
+  height: var(--s);
+  border-radius: 50%;
+  background: var(--c);
+  opacity: 0.85;
+  filter: blur(1px);
+  transform: translateZ(var(--d));
+  animation: dtp-float 5s ease-in-out infinite alternate;
+}
+@keyframes dtp-float {
+  from { margin-top: 0; }
+  to { margin-top: 26px; }
+}


### PR DESCRIPTION
## Summary

Add the **Depth Tilt Parallax** component to the EaseMotion CSS gallery. This is a 3d demo rendered with plain HTML and CSS.

**Description:** Layered shapes move at different depths, producing a parallax tilt.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/depth-tilt-parallax/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Layered shapes move at different depths, producing a parallax tilt.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the 3d category in the gallery with a polished, reusable effect.

### Key features
- translateZ depth layers
- Rotate on hover to expose parallax
- Colourful floating orbs
- Pure CSS

### Demo
Open `submissions/examples/depth-tilt-parallax/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87494
