### PR TITLE
feat: add flip-match-cards component

### DIFF
--- a/submissions/examples/flip-match-cards/README.md
+++ b/submissions/examples/flip-match-cards/README.md
@@ -1,0 +1,20 @@
+# Flip Match Cards
+
+Cards flip face-down to face-up, echoing a memory match game reveal.
+
+## Features
+- 3D card flip with delay cascade
+- Symmetric back design
+- Hover to flip each card
+- Preserve-3d depth
+
+## Usage
+```html
+<div class="fmc-card"><span>1</span></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/flip-match-cards/demo.html
+++ b/submissions/examples/flip-match-cards/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flip Match Cards &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="fmc-grid">
+  <div class="fmc-card" style="--i:0"><span>1</span></div>
+  <div class="fmc-card" style="--i:1"><span>2</span></div>
+  <div class="fmc-card" style="--i:2"><span>3</span></div>
+  <div class="fmc-card" style="--i:3"><span>4</span></div>
+  <div class="fmc-card" style="--i:4"><span>5</span></div>
+  <div class="fmc-card" style="--i:5"><span>6</span></div>
+  <div class="fmc-card" style="--i:6"><span>7</span></div>
+  <div class="fmc-card" style="--i:7"><span>8</span></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/flip-match-cards/style.css
+++ b/submissions/examples/flip-match-cards/style.css
@@ -1,0 +1,33 @@
+.fmc-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 90px);
+  gap: 14px;
+  justify-content: center;
+  padding: 60px 20px;
+  perspective: 700px;
+}
+.fmc-card {
+  height: 110px;
+  border-radius: 12px;
+  background: repeating-linear-gradient(45deg, #2b3c63, #2b3c63 10px, #31456f 10px, #31456f 20px);
+  border: 1px solid #40598e;
+  display: grid;
+  place-items: center;
+  transform-style: preserve-3d;
+  transition: transform 0.55s cubic-bezier(0.3, 0.7, 0.2, 1) calc(var(--i) * 40ms);
+}
+.fmc-card span {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  background: linear-gradient(140deg, #f76b8a, #c23a64);
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 800;
+  transform: rotateY(180deg);
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+.fmc-card:hover { transform: rotateY(180deg); }


### PR DESCRIPTION
## Summary

Add the **Flip Match Cards** component to the EaseMotion CSS gallery. This is a 3d demo rendered with plain HTML and CSS.

**Description:** Cards flip face-down to face-up, echoing a memory match game reveal.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/flip-match-cards/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Cards flip face-down to face-up, echoing a memory match game reveal.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the 3d category in the gallery with a polished, reusable effect.

### Key features
- 3D card flip with delay cascade
- Symmetric back design
- Hover to flip each card
- Preserve-3d depth

### Demo
Open `submissions/examples/flip-match-cards/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87493
