### PR TITLE
feat: add flip-scene-card component

### DIFF
--- a/submissions/examples/flip-scene-card/README.md
+++ b/submissions/examples/flip-scene-card/README.md
@@ -1,0 +1,23 @@
+# Flip Scene Card
+
+A two-sided card flips in 3D to reveal a second scene on the back.
+
+## Features
+- rotateY 180deg flip
+- backface-visibility to hide the reverse
+- Perspective for depth
+- Pure CSS toggle on hover
+
+## Usage
+```html
+<div class="fsc-card">
+  <div class="fsc-face fsc-front">Front</div>
+  <div class="fsc-face fsc-back">Back</div>
+</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/flip-scene-card/demo.html
+++ b/submissions/examples/flip-scene-card/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flip Scene Card &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="fsc-scene">
+  <div class="fsc-card">
+    <div class="fsc-face fsc-front">Front</div>
+    <div class="fsc-face fsc-back">Back</div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/flip-scene-card/style.css
+++ b/submissions/examples/flip-scene-card/style.css
@@ -1,0 +1,31 @@
+.fsc-scene {
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+  perspective: 1000px;
+}
+.fsc-card {
+  width: 260px;
+  height: 320px;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.7s cubic-bezier(0.3, 0.7, 0.2, 1);
+}
+.fsc-scene:hover .fsc-card { transform: rotateY(180deg); }
+.fsc-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fff;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+.fsc-front { background: linear-gradient(140deg, #4a6cf7, #22c1c3); }
+.fsc-back {
+  background: linear-gradient(140deg, #f76b8a, #f7a74a);
+  transform: rotateY(180deg);
+}


### PR DESCRIPTION
## Summary

Add the **Flip Scene Card** component to the EaseMotion CSS gallery. This is a 3d demo rendered with plain HTML and CSS.

**Description:** A two-sided card flips in 3D to reveal a second scene on the back.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/flip-scene-card/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A two-sided card flips in 3D to reveal a second scene on the back.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the 3d category in the gallery with a polished, reusable effect.

### Key features
- rotateY 180deg flip
- backface-visibility to hide the reverse
- Perspective for depth
- Pure CSS toggle on hover

### Demo
Open `submissions/examples/flip-scene-card/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87489
