### PR TITLE
feat: add form-field-lift component

### DIFF
--- a/submissions/examples/form-field-lift/README.md
+++ b/submissions/examples/form-field-lift/README.md
@@ -1,0 +1,20 @@
+# Form Field Lift
+
+Labels float above fields as they gain focus or hold a value.
+
+## Features
+- Floating label via :placeholder-shown
+- Smooth translate + scale
+- Focus accent underline
+- Pure CSS
+
+## Usage
+```html
+<div class="ffl-field"><input placeholder=" " /><label>Name</label></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/form-field-lift/demo.html
+++ b/submissions/examples/form-field-lift/demo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Form Field Lift &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ffl-wrap">
+  <div class="ffl-field">
+    <input id="ffl-name" placeholder=" " />
+    <label for="ffl-name">Your name</label>
+    <span class="ffl-line"></span>
+  </div>
+  <div class="ffl-field">
+    <input id="ffl-mail" placeholder=" " type="email" />
+    <label for="ffl-mail">Email address</label>
+    <span class="ffl-line"></span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/form-field-lift/style.css
+++ b/submissions/examples/form-field-lift/style.css
@@ -1,0 +1,38 @@
+.ffl-wrap { max-width: 340px; margin: 60px auto; display: flex; flex-direction: column; gap: 22px; }
+.ffl-field { position: relative; }
+.ffl-field input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 16px 12px 10px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid #31405c;
+  color: #e6edf6;
+  outline: none;
+  font-size: 1rem;
+}
+.ffl-field label {
+  position: absolute;
+  left: 12px;
+  top: 14px;
+  color: #8fa4c4;
+  pointer-events: none;
+  transition: transform 0.22s ease, font-size 0.22s ease, color 0.22s ease;
+  transform-origin: left;
+}
+.ffl-field input:focus ~ label,
+.ffl-field input:not(:placeholder-shown) ~ label {
+  transform: translateY(-14px) scale(0.78);
+  color: #6fb7ff;
+}
+.ffl-line {
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  height: 2px;
+  width: 100%;
+  background: #6fb7ff;
+  transform: scaleX(0);
+  transition: transform 0.3s ease;
+}
+.ffl-field input:focus ~ .ffl-line { transform: scaleX(1); }


### PR DESCRIPTION
## Summary

Add the **Form Field Lift** component to the EaseMotion CSS gallery. This is a forms demo rendered with plain HTML and CSS.

**Description:** Labels float above fields as they gain focus or hold a value.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/form-field-lift/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Labels float above fields as they gain focus or hold a value.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the forms category in the gallery with a polished, reusable effect.

### Key features
- Floating label via :placeholder-shown
- Smooth translate + scale
- Focus accent underline
- Pure CSS

### Demo
Open `submissions/examples/form-field-lift/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87511
