### PR TITLE
feat: add hover-lift-shadow-ui component

### DIFF
--- a/submissions/examples/hover-lift-shadow-ui/README.md
+++ b/submissions/examples/hover-lift-shadow-ui/README.md
@@ -1,0 +1,20 @@
+# Hover Lift Shadow
+
+Cards gently lift with a deepened, tinted shadow on hover.
+
+## Features
+- translateY lift
+- Shadow colour follows accent
+- Springy easing
+- Pure CSS
+
+## Usage
+```html
+<div class="hls-card" style="--ac:#6fb7ff">...</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/hover-lift-shadow-ui/demo.html
+++ b/submissions/examples/hover-lift-shadow-ui/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hover Lift Shadow &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="hls-grid">
+  <div class="hls-card" style="--ac:#6fb7ff">
+    <h3>Float</h3>
+    <p>Hover to lift this card.</p>
+  </div>
+  <div class="hls-card" style="--ac:#7bffb0">
+    <h3>Drift</h3>
+    <p>The shadow deepens under you.</p>
+  </div>
+  <div class="hls-card" style="--ac:#ffd37a">
+    <h3>Rise</h3>
+    <p>Colour bleeds into the glow.</p>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/hover-lift-shadow-ui/style.css
+++ b/submissions/examples/hover-lift-shadow-ui/style.css
@@ -1,0 +1,23 @@
+.hls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+  max-width: 760px;
+  margin: 60px auto;
+  padding: 0 20px;
+}
+.hls-card {
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  border-radius: 14px;
+  padding: 22px;
+  transition: transform 0.3s cubic-bezier(0.2, 0.9, 0.3, 1.3), box-shadow 0.3s;
+  transform: translateY(0);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+.hls-card:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 26px 44px -10px var(--ac);
+}
+.hls-card h3 { margin: 0 0 6px; color: var(--ac); }
+.hls-card p { margin: 0; color: #aebbd0; font-size: 0.9rem; }


### PR DESCRIPTION
## Summary

Add the **Hover Lift Shadow** component to the EaseMotion CSS gallery. This is a hover demo rendered with plain HTML and CSS.

**Description:** Cards gently lift with a deepened, tinted shadow on hover.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/hover-lift-shadow-ui/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Cards gently lift with a deepened, tinted shadow on hover.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the hover category in the gallery with a polished, reusable effect.

### Key features
- translateY lift
- Shadow colour follows accent
- Springy easing
- Pure CSS

### Demo
Open `submissions/examples/hover-lift-shadow-ui/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87520
