### PR TITLE
feat: add hover-outline-draw component

### DIFF
--- a/submissions/examples/hover-outline-draw/README.md
+++ b/submissions/examples/hover-outline-draw/README.md
@@ -1,0 +1,20 @@
+# Hover Outline Draw
+
+A rounded outline draws itself around a button when hovered.
+
+## Features
+- Animated border draw
+- Uses pseudo-element stroke
+- Works on any background
+- Pure CSS
+
+## Usage
+```html
+<button class="hod-btn">Draw me</button>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/hover-outline-draw/demo.html
+++ b/submissions/examples/hover-outline-draw/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hover Outline Draw &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="hod-wrap">
+  <button class="hod-btn">Draw me</button>
+</div>
+</body>
+</html>

--- a/submissions/examples/hover-outline-draw/style.css
+++ b/submissions/examples/hover-outline-draw/style.css
@@ -1,0 +1,38 @@
+.hod-wrap { min-height: 50vh; display: grid; place-items: center; }
+.hod-btn {
+  position: relative;
+  padding: 14px 34px;
+  background: #1a2233;
+  border: none;
+  color: #dfe7f2;
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 12px;
+}
+.hod-btn::before,
+.hod-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  pointer-events: none;
+}
+.hod-btn:hover::before {
+  border-top-color: #6fb7ff;
+  border-right-color: #6fb7ff;
+  animation: hod-top 0.5s ease forwards;
+}
+.hod-btn:hover::after {
+  border-bottom-color: #6fb7ff;
+  border-left-color: #6fb7ff;
+  animation: hod-bottom 0.5s ease forwards;
+}
+@keyframes hod-top {
+  0% { border-top-width: 2px; border-right-width: 0; }
+  100% { border-top-width: 2px; border-right-width: 2px; }
+}
+@keyframes hod-bottom {
+  0% { border-bottom-width: 0; border-left-width: 0; }
+  100% { border-bottom-width: 2px; border-left-width: 2px; }
+}


### PR DESCRIPTION
## Summary

Add the **Hover Outline Draw** component to the EaseMotion CSS gallery. This is a hover demo rendered with plain HTML and CSS.

**Description:** A rounded outline draws itself around a button when hovered.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/hover-outline-draw/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A rounded outline draws itself around a button when hovered.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the hover category in the gallery with a polished, reusable effect.

### Key features
- Animated border draw
- Uses pseudo-element stroke
- Works on any background
- Pure CSS

### Demo
Open `submissions/examples/hover-outline-draw/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87521
