### PR TITLE
feat: add hover-pulse-ring component

### DIFF
--- a/submissions/examples/hover-pulse-ring/README.md
+++ b/submissions/examples/hover-pulse-ring/README.md
@@ -1,0 +1,20 @@
+# Hover Pulse Ring
+
+A pulsing ring expands from a trigger as an attention cue on hover.
+
+## Features
+- Expanding ripple ring
+- Hover-triggered
+- Accent colour match
+- Pure CSS
+
+## Usage
+```html
+<button class="hpr-btn"><span class="hpr-ring"></span>Hover me</button>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/hover-pulse-ring/demo.html
+++ b/submissions/examples/hover-pulse-ring/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hover Pulse Ring &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="hpr-wrap">
+  <button class="hpr-btn">
+    <span class="hpr-ring"></span>
+    Hover me
+  </button>
+</div>
+</body>
+</html>

--- a/submissions/examples/hover-pulse-ring/style.css
+++ b/submissions/examples/hover-pulse-ring/style.css
@@ -1,0 +1,25 @@
+.hpr-wrap { min-height: 50vh; display: grid; place-items: center; }
+.hpr-btn {
+  position: relative;
+  padding: 15px 36px;
+  border-radius: 12px;
+  border: 2px solid #7bffb0;
+  background: #0e1f18;
+  color: #7bffb0;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  overflow: hidden;
+}
+.hpr-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  border: 2px solid rgba(123, 255, 176, 0.8);
+  opacity: 0;
+}
+.hpr-btn:hover .hpr-ring { animation: hpr-ring 0.9s ease-out infinite; }
+@keyframes hpr-ring {
+  0% { transform: scale(0.9); opacity: 0.9; }
+  100% { transform: scale(1.5); opacity: 0; }
+}


### PR DESCRIPTION
## Summary

Add the **Hover Pulse Ring** component to the EaseMotion CSS gallery. This is a hover demo rendered with plain HTML and CSS.

**Description:** A pulsing ring expands from a trigger as an attention cue on hover.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/hover-pulse-ring/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A pulsing ring expands from a trigger as an attention cue on hover.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the hover category in the gallery with a polished, reusable effect.

### Key features
- Expanding ripple ring
- Hover-triggered
- Accent colour match
- Pure CSS

### Demo
Open `submissions/examples/hover-pulse-ring/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87527
