### PR TITLE
feat: add image-blur-reveal component

### DIFF
--- a/submissions/examples/image-blur-reveal/README.md
+++ b/submissions/examples/image-blur-reveal/README.md
@@ -1,0 +1,20 @@
+# Image Blur Reveal
+
+A blurred placeholder sharpens into the final image with a scale-in.
+
+## Features
+- Blur-to-sharp transition
+- Scale settle
+- Poster gradient stand-in
+- Pure CSS
+
+## Usage
+```html
+<div class="ibr-img"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/image-blur-reveal/demo.html
+++ b/submissions/examples/image-blur-reveal/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Blur Reveal &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ibr-frame">
+  <div class="ibr-img"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/image-blur-reveal/style.css
+++ b/submissions/examples/image-blur-reveal/style.css
@@ -1,0 +1,20 @@
+.ibr-frame {
+  width: min(460px, 90vw);
+  height: 300px;
+  margin: 60px auto;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #101827;
+}
+.ibr-img {
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at 25% 20%, #ff9d5c, #c23a64 60%, #2a1b3a 100%);
+  transform: scale(1.15);
+  filter: blur(18px) saturate(0.7);
+  animation: ibr-reveal 2.4s ease-out infinite;
+}
+@keyframes ibr-reveal {
+  0% { filter: blur(18px) saturate(0.7); transform: scale(1.15); }
+  70%, 100% { filter: blur(0) saturate(1.1); transform: scale(1); }
+}


### PR DESCRIPTION
## Summary

Add the **Image Blur Reveal** component to the EaseMotion CSS gallery. This is a media demo rendered with plain HTML and CSS.

**Description:** A blurred placeholder sharpens into the final image with a scale-in.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/image-blur-reveal/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A blurred placeholder sharpens into the final image with a scale-in.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the media category in the gallery with a polished, reusable effect.

### Key features
- Blur-to-sharp transition
- Scale settle
- Poster gradient stand-in
- Pure CSS

### Demo
Open `submissions/examples/image-blur-reveal/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87548
