### PR TITLE
feat: add image-cover-slide component

### DIFF
--- a/submissions/examples/image-cover-slide/README.md
+++ b/submissions/examples/image-cover-slide/README.md
@@ -1,0 +1,20 @@
+# Image Cover Slide
+
+A cover image slides laterally revealing itself from behind a solid panel.
+
+## Features
+- Panel slide reveal
+- Crisp edge wipe
+- Loops with hold
+- Pure CSS
+
+## Usage
+```html
+<div class="ics-panel"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/image-cover-slide/demo.html
+++ b/submissions/examples/image-cover-slide/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Cover Slide &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="ics-frame">
+  <div class="ics-img"></div>
+  <div class="ics-panel"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/image-cover-slide/style.css
+++ b/submissions/examples/image-cover-slide/style.css
@@ -1,0 +1,24 @@
+.ics-frame {
+  position: relative;
+  width: min(460px, 90vw);
+  height: 300px;
+  margin: 60px auto;
+  border-radius: 18px;
+  overflow: hidden;
+}
+.ics-img {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 70% 30%, #7ad4ff, #3a4d7a 55%, #1a2440 100%);
+}
+.ics-panel {
+  position: absolute;
+  inset: 0;
+  background: #101827;
+  animation: ics-slide 3.2s ease-in-out infinite;
+}
+@keyframes ics-slide {
+  0% { transform: translateX(0); }
+  55% { transform: translateX(100%); }
+  85%, 100% { transform: translateX(100%); }
+}


### PR DESCRIPTION
## Summary

Add the **Image Cover Slide** component to the EaseMotion CSS gallery. This is a media demo rendered with plain HTML and CSS.

**Description:** A cover image slides laterally revealing itself from behind a solid panel.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/image-cover-slide/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A cover image slides laterally revealing itself from behind a solid panel.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the media category in the gallery with a polished, reusable effect.

### Key features
- Panel slide reveal
- Crisp edge wipe
- Loops with hold
- Pure CSS

### Demo
Open `submissions/examples/image-cover-slide/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87549
