### PR TITLE
feat: add image-duotone-hover component

### DIFF
--- a/submissions/examples/image-duotone-hover/README.md
+++ b/submissions/examples/image-duotone-hover/README.md
@@ -1,0 +1,20 @@
+# Image Duotone Hover
+
+A grayscale image gains a vivid duotone colour grade on hover.
+
+## Features
+- Grayscale to duotone shift
+- Mix-blend colour layer
+- Smooth crossfade
+- Pure CSS
+
+## Usage
+```html
+<div class="idh-tint"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/image-duotone-hover/demo.html
+++ b/submissions/examples/image-duotone-hover/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Duotone Hover &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="idh-frame">
+  <div class="idh-img"></div>
+  <div class="idh-tint"></div>
+  <span class="idh-label">Hover</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/image-duotone-hover/style.css
+++ b/submissions/examples/image-duotone-hover/style.css
@@ -1,0 +1,38 @@
+.idh-frame {
+  position: relative;
+  width: min(460px, 90vw);
+  height: 300px;
+  margin: 60px auto;
+  border-radius: 18px;
+  overflow: hidden;
+}
+.idh-img {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 40% 30%, #ffcf7a, #e08a5c 45%, #3a2440 100%);
+  filter: grayscale(1) contrast(1.05);
+  transition: filter 0.5s ease, transform 0.5s ease;
+}
+.idh-frame:hover .idh-img { filter: grayscale(0); transform: scale(1.05); }
+.idh-tint {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(255, 45, 85, 0.55), rgba(0, 160, 255, 0.55));
+  mix-blend-mode: multiply;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+.idh-frame:hover .idh-tint { opacity: 1; }
+.idh-label {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.4s;
+}
+.idh-frame:hover .idh-label { opacity: 1; }


### PR DESCRIPTION
## Summary

Add the **Image Duotone Hover** component to the EaseMotion CSS gallery. This is a media demo rendered with plain HTML and CSS.

**Description:** A grayscale image gains a vivid duotone colour grade on hover.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/image-duotone-hover/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A grayscale image gains a vivid duotone colour grade on hover.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the media category in the gallery with a polished, reusable effect.

### Key features
- Grayscale to duotone shift
- Mix-blend colour layer
- Smooth crossfade
- Pure CSS

### Demo
Open `submissions/examples/image-duotone-hover/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87551
