### PR TITLE
feat: add image-zoom-pan component

### DIFF
--- a/submissions/examples/image-zoom-pan/README.md
+++ b/submissions/examples/image-zoom-pan/README.md
@@ -1,0 +1,20 @@
+# Image Zoom Pan
+
+A Ken Burns style pan and zoom drifts across the image.
+
+## Features
+- Simultaneous zoom + pan
+- Alternating drift direction
+- Smooth transform easing
+- Pure CSS
+
+## Usage
+```html
+<div class="izp-img"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/image-zoom-pan/demo.html
+++ b/submissions/examples/image-zoom-pan/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Zoom Pan &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="izp-frame">
+  <div class="izp-img"></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/image-zoom-pan/style.css
+++ b/submissions/examples/image-zoom-pan/style.css
@@ -1,0 +1,17 @@
+.izp-frame {
+  width: min(460px, 90vw);
+  height: 300px;
+  margin: 60px auto;
+  border-radius: 18px;
+  overflow: hidden;
+}
+.izp-img {
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at 30% 40%, #f7b35c, #d15c3c 55%, #5c2a3c 100%);
+  animation: izp-kenburns 9s ease-in-out infinite alternate;
+}
+@keyframes izp-kenburns {
+  from { transform: scale(1) translate(0, 0); }
+  to { transform: scale(1.3) translate(-5%, 4%); }
+}


### PR DESCRIPTION
## Summary

Add the **Image Zoom Pan** component to the EaseMotion CSS gallery. This is a media demo rendered with plain HTML and CSS.

**Description:** A Ken Burns style pan and zoom drifts across the image.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/image-zoom-pan/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A Ken Burns style pan and zoom drifts across the image.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the media category in the gallery with a polished, reusable effect.

### Key features
- Simultaneous zoom + pan
- Alternating drift direction
- Smooth transform easing
- Pure CSS

### Demo
Open `submissions/examples/image-zoom-pan/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87550
