### PR TITLE
feat: add loading-ring-sequence component

### DIFF
--- a/submissions/examples/loading-ring-sequence/README.md
+++ b/submissions/examples/loading-ring-sequence/README.md
@@ -1,0 +1,20 @@
+# Loading Ring Sequence
+
+Concentric rings expand and fade in sequence, like sonar pings.
+
+## Features
+- Expanding ripple rings
+- Staggered delays
+- Transparent centre keeps focus
+- Pure CSS
+
+## Usage
+```html
+<span class="lrs-ring" style="--i:0"></span>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/loading-ring-sequence/demo.html
+++ b/submissions/examples/loading-ring-sequence/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Loading Ring Sequence &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="lrs-wrap">
+  <span class="lrs-ring" style="--i:0"></span>
+  <span class="lrs-ring" style="--i:1"></span>
+  <span class="lrs-ring" style="--i:2"></span>
+  <span class="lrs-dot"></span>
+</div>
+</body>
+</html>

--- a/submissions/examples/loading-ring-sequence/style.css
+++ b/submissions/examples/loading-ring-sequence/style.css
@@ -1,0 +1,28 @@
+.lrs-wrap {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 60px auto;
+  display: grid;
+  place-items: center;
+}
+.lrs-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #7ad4ff;
+  animation: lrs-blink 1.8s ease-in-out infinite;
+}
+.lrs-ring {
+  position: absolute;
+  inset: 0;
+  border: 3px solid rgba(122, 212, 255, 0.7);
+  border-radius: 50%;
+  animation: lrs-ping 1.8s ease-out infinite;
+  animation-delay: calc(var(--i) * 0.6s);
+}
+@keyframes lrs-ping {
+  0% { transform: scale(0.25); opacity: 0.9; }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+@keyframes lrs-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }


### PR DESCRIPTION
## Summary

Add the **Loading Ring Sequence** component to the EaseMotion CSS gallery. This is a loading demo rendered with plain HTML and CSS.

**Description:** Concentric rings expand and fade in sequence, like sonar pings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/loading-ring-sequence/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Concentric rings expand and fade in sequence, like sonar pings.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the loading category in the gallery with a polished, reusable effect.

### Key features
- Expanding ripple rings
- Staggered delays
- Transparent centre keeps focus
- Pure CSS

### Demo
Open `submissions/examples/loading-ring-sequence/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87501
