### PR TITLE
feat: add radio-bounce-select component

### DIFF
--- a/submissions/examples/radio-bounce-select/README.md
+++ b/submissions/examples/radio-bounce-select/README.md
@@ -1,0 +1,20 @@
+# Radio Bounce Select
+
+Radio pills that bounce when selected, with a travelling dot.
+
+## Features
+- Bouncy selected dot
+- Pill-style labels
+- Sibling selector styling
+- Pure CSS
+
+## Usage
+```html
+<label class="rbs-opt"><input type="radio" /><span><i></i>Small</span></label>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/radio-bounce-select/demo.html
+++ b/submissions/examples/radio-bounce-select/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radio Bounce Select &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="rbs-group">
+  <label class="rbs-opt">
+    <input type="radio" name="rbs" checked />
+    <span><i></i>Small</span>
+  </label>
+  <label class="rbs-opt">
+    <input type="radio" name="rbs" />
+    <span><i></i>Medium</span>
+  </label>
+  <label class="rbs-opt">
+    <input type="radio" name="rbs" />
+    <span><i></i>Large</span>
+  </label>
+</div>
+</body>
+</html>

--- a/submissions/examples/radio-bounce-select/style.css
+++ b/submissions/examples/radio-bounce-select/style.css
@@ -1,0 +1,37 @@
+.rbs-group { display: flex; gap: 10px; justify-content: center; margin: 60px auto; }
+.rbs-opt { cursor: pointer; }
+.rbs-opt input { position: absolute; opacity: 0; }
+.rbs-opt span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 2px solid #31405c;
+  background: #161d2c;
+  color: #b8c4d8;
+  transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+.rbs-opt i {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 3px solid #3b4a6b;
+  background: transparent;
+  transition: background 0.2s, transform 0.2s;
+}
+.rbs-opt input:checked ~ span {
+  border-color: #6fb7ff;
+  background: #12243c;
+  color: #e6edf6;
+}
+.rbs-opt input:checked ~ span i {
+  background: #6fb7ff;
+  transform: scale(1.35);
+  animation: rbs-bounce 0.4s ease;
+}
+@keyframes rbs-bounce {
+  0% { transform: scale(0.6); }
+  60% { transform: scale(1.5); }
+  100% { transform: scale(1.35); }
+}


### PR DESCRIPTION
## Summary

Add the **Radio Bounce Select** component to the EaseMotion CSS gallery. This is a forms demo rendered with plain HTML and CSS.

**Description:** Radio pills that bounce when selected, with a travelling dot.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/radio-bounce-select/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Radio pills that bounce when selected, with a travelling dot.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the forms category in the gallery with a polished, reusable effect.

### Key features
- Bouncy selected dot
- Pill-style labels
- Sibling selector styling
- Pure CSS

### Demo
Open `submissions/examples/radio-bounce-select/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87513
