### PR TITLE
feat: add text track spread component

### DIFF
--- a/submissions/examples/text-track-spread-87546/README.md
+++ b/submissions/examples/text-track-spread-87546/README.md
@@ -1,0 +1,18 @@
+# Text Track Spread
+
+A dependency-free EaseMotion text component where individual letters widen from
+the center on hover or keyboard focus, then return with a smooth breathing
+motion.
+
+## Files
+
+- `demo.html` contains the accessible text effect examples.
+- `style.css` defines the spread distances, focus state, responsive sizing, and
+  reduced-motion fallback.
+
+## Accessibility
+
+Each visual word is exposed through an `aria-label`, while individual decorative
+letters are hidden from assistive technology. The component supports
+`:focus-visible` for keyboard users and disables transitions when
+`prefers-reduced-motion` is enabled.

--- a/submissions/examples/text-track-spread-87546/demo.html
+++ b/submissions/examples/text-track-spread-87546/demo.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Track Spread</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="stage" aria-labelledby="demo-title">
+      <section class="intro">
+        <p class="eyebrow">EaseMotion text effect</p>
+        <h1 id="demo-title">Text Track Spread</h1>
+        <p>
+          Hover or focus each wordmark to widen the letter tracks with a smooth
+          breathing return.
+        </p>
+      </section>
+
+      <section class="showcase" aria-label="Text track spread examples">
+        <button class="track-word calm" aria-label="Aurora labs text effect">
+          <span aria-hidden="true">A</span>
+          <span aria-hidden="true">U</span>
+          <span aria-hidden="true">R</span>
+          <span aria-hidden="true">O</span>
+          <span aria-hidden="true">R</span>
+          <span aria-hidden="true">A</span>
+        </button>
+
+        <button class="track-word vivid" aria-label="Signal deck text effect">
+          <span aria-hidden="true">S</span>
+          <span aria-hidden="true">I</span>
+          <span aria-hidden="true">G</span>
+          <span aria-hidden="true">N</span>
+          <span aria-hidden="true">A</span>
+          <span aria-hidden="true">L</span>
+        </button>
+
+        <button class="track-word warm" aria-label="Motion grid text effect">
+          <span aria-hidden="true">M</span>
+          <span aria-hidden="true">O</span>
+          <span aria-hidden="true">T</span>
+          <span aria-hidden="true">I</span>
+          <span aria-hidden="true">O</span>
+          <span aria-hidden="true">N</span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/text-track-spread-87546/style.css
+++ b/submissions/examples/text-track-spread-87546/style.css
@@ -1,0 +1,173 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(
+      circle at 12% 18%,
+      rgba(69, 184, 172, 0.22),
+      transparent 28rem
+    ),
+    linear-gradient(135deg, #151720 0%, #111827 52%, #221f2f 100%);
+  color: #f8fafc;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.stage {
+  width: min(1040px, calc(100vw - 32px));
+  padding: clamp(28px, 5vw, 56px);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(12, 16, 26, 0.72);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.35);
+}
+
+.intro {
+  max-width: 680px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #67e8f9;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 6vw, 6rem);
+  line-height: 0.9;
+}
+
+.intro p:last-child {
+  max-width: 58ch;
+  margin: 18px 0 0;
+  color: #cbd5e1;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.showcase {
+  display: grid;
+  gap: 18px;
+  margin-top: clamp(34px, 7vw, 72px);
+}
+
+.track-word {
+  --spread-distance: 0.08em;
+  --tilt: 0deg;
+  --track-bg: rgba(255, 255, 255, 0.08);
+  --track-border: rgba(255, 255, 255, 0.16);
+  width: 100%;
+  min-height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.12rem, 1vw, 0.45rem);
+  border: 1px solid var(--track-border);
+  border-radius: 8px;
+  background: var(--track-bg);
+  color: #ffffff;
+  cursor: pointer;
+  font-size: clamp(2.35rem, 8vw, 7rem);
+  font-weight: 900;
+  line-height: 0.85;
+  overflow: hidden;
+  text-transform: uppercase;
+  transition:
+    border-color 240ms ease,
+    background 240ms ease,
+    box-shadow 240ms ease,
+    transform 240ms ease;
+}
+
+.track-word span {
+  display: inline-block;
+  transform: translateX(0) rotate(var(--tilt));
+  transition:
+    transform 620ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 240ms ease;
+}
+
+.track-word span:nth-child(1),
+.track-word span:nth-child(6) {
+  --spread-distance: -0.72em;
+}
+
+.track-word span:nth-child(2),
+.track-word span:nth-child(5) {
+  --spread-distance: -0.36em;
+}
+
+.track-word span:nth-child(3) {
+  --spread-distance: -0.12em;
+}
+
+.track-word span:nth-child(4) {
+  --spread-distance: 0.12em;
+}
+
+.track-word:hover,
+.track-word:focus-visible {
+  border-color: rgba(255, 255, 255, 0.38);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+  transform: translateY(-3px);
+}
+
+.track-word:hover span,
+.track-word:focus-visible span {
+  color: #fef3c7;
+  transform: translateX(var(--spread-distance)) rotate(var(--tilt));
+}
+
+.track-word:focus-visible {
+  outline: 3px solid #67e8f9;
+  outline-offset: 4px;
+}
+
+.calm {
+  --track-bg: linear-gradient(
+    110deg,
+    rgba(20, 184, 166, 0.18),
+    rgba(59, 130, 246, 0.16)
+  );
+}
+
+.vivid {
+  --tilt: -1deg;
+  --track-bg: linear-gradient(
+    110deg,
+    rgba(244, 63, 94, 0.18),
+    rgba(168, 85, 247, 0.18)
+  );
+}
+
+.warm {
+  --tilt: 1deg;
+  --track-bg: linear-gradient(
+    110deg,
+    rgba(245, 158, 11, 0.2),
+    rgba(34, 197, 94, 0.16)
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track-word,
+  .track-word span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a text track spread component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers hover/focus interaction, keyboard access, responsive styling, and reduced-motion support.

Fixes #87546

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.