### PR TITLE
feat: add scroll-fade-blur component

### DIFF
--- a/submissions/examples/scroll-fade-blur/README.md
+++ b/submissions/examples/scroll-fade-blur/README.md
@@ -1,0 +1,20 @@
+# Scroll Fade Blur
+
+Blocks start blurry and out of focus, sharpening as they scroll into view.
+
+## Features
+- Blur + opacity driven by scroll position
+- Smooth focus transition per block
+- Fallback keeps text readable
+- Pure CSS
+
+## Usage
+```html
+<div class="sfb-item">...</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/scroll-fade-blur/demo.html
+++ b/submissions/examples/scroll-fade-blur/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Fade Blur &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<section class="sfb-stack">
+  <div class="sfb-item">
+    <h2>01 / Clear when seen</h2>
+    <p>Each block unblurs as it enters the reading window.</p>
+  </div>
+  <div class="sfb-item">
+    <h2>02 / Focus on scroll</h2>
+    <p>The blur amount is bound to the scroll timeline.</p>
+  </div>
+  <div class="sfb-item">
+    <h2>03 / Simple &amp; light</h2>
+    <p>No libraries, just <code>filter: blur()</code> and a timeline.</p>
+  </div>
+</section>
+</body>
+</html>

--- a/submissions/examples/scroll-fade-blur/style.css
+++ b/submissions/examples/scroll-fade-blur/style.css
@@ -1,0 +1,26 @@
+.sfb-stack {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 60px 20px;
+  color: #dfe7f2;
+}
+.sfb-item {
+  background: rgba(30, 40, 58, 0.7);
+  border: 1px solid #2c3850;
+  border-radius: 14px;
+  padding: 24px;
+  margin-bottom: 22px;
+  opacity: 0.25;
+  filter: blur(8px);
+  animation: sfb-focus linear;
+  animation-timeline: view();
+  animation-range: entry 5% cover 45%;
+}
+.sfb-item h2 { margin: 0 0 6px; color: #8fd0ff; }
+.sfb-item p { margin: 0; color: #b7c3d6; }
+@keyframes sfb-focus {
+  to { opacity: 1; filter: blur(0); }
+}
+@supports not (animation-timeline: view()) {
+  .sfb-item { opacity: 1; filter: none; }
+}


### PR DESCRIPTION
## Summary

Add the **Scroll Fade Blur** component to the EaseMotion CSS gallery. This is a scroll demo rendered with plain HTML and CSS.

**Description:** Blocks start blurry and out of focus, sharpening as they scroll into view.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/scroll-fade-blur/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Blocks start blurry and out of focus, sharpening as they scroll into view.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the scroll category in the gallery with a polished, reusable effect.

### Key features
- Blur + opacity driven by scroll position
- Smooth focus transition per block
- Fallback keeps text readable
- Pure CSS

### Demo
Open `submissions/examples/scroll-fade-blur/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87480
