### PR TITLE
feat: add scroll-rotate-in component

### DIFF
--- a/submissions/examples/scroll-rotate-in/README.md
+++ b/submissions/examples/scroll-rotate-in/README.md
@@ -1,0 +1,20 @@
+# Scroll Rotate In
+
+Bento tiles swing from a slight rotation into their resting angle on scroll.
+
+## Features
+- Rotation tied to scroll progress
+- Opposing angles for a playful entrance
+- Keeps transform history clean
+- Pure CSS
+
+## Usage
+```html
+<div class="sri-tile" style="--r:-6deg">A</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/scroll-rotate-in/demo.html
+++ b/submissions/examples/scroll-rotate-in/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Rotate In &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<section class="sri-grid">
+  <div class="sri-tile" style="--r:-6deg">A</div>
+  <div class="sri-tile" style="--r:5deg">B</div>
+  <div class="sri-tile" style="--r:-3deg">C</div>
+  <div class="sri-tile" style="--r:7deg">D</div>
+  <div class="sri-tile" style="--r:-5deg">E</div>
+</section>
+</body>
+</html>

--- a/submissions/examples/scroll-rotate-in/style.css
+++ b/submissions/examples/scroll-rotate-in/style.css
@@ -1,0 +1,30 @@
+.sri-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 18px;
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 70px 20px;
+}
+.sri-tile {
+  aspect-ratio: 1;
+  background: linear-gradient(135deg, #243149, #161d2b);
+  border: 1px solid #31405c;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 800;
+  color: #fff;
+  opacity: 0.2;
+  transform: rotate(var(--r)) scale(0.85);
+  animation: sri-in linear;
+  animation-timeline: view();
+  animation-range: entry 0% cover 40%;
+}
+@keyframes sri-in {
+  to { opacity: 1; transform: rotate(0deg) scale(1); }
+}
+@supports not (animation-timeline: view()) {
+  .sri-tile { opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## Summary

Add the **Scroll Rotate In** component to the EaseMotion CSS gallery. This is a scroll demo rendered with plain HTML and CSS.

**Description:** Bento tiles swing from a slight rotation into their resting angle on scroll.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/scroll-rotate-in/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Bento tiles swing from a slight rotation into their resting angle on scroll.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the scroll category in the gallery with a polished, reusable effect.

### Key features
- Rotation tied to scroll progress
- Opposing angles for a playful entrance
- Keeps transform history clean
- Pure CSS

### Demo
Open `submissions/examples/scroll-rotate-in/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87481
