### PR TITLE
feat: add scroll-skew-reveal component

### DIFF
--- a/submissions/examples/scroll-skew-reveal/README.md
+++ b/submissions/examples/scroll-skew-reveal/README.md
@@ -1,0 +1,20 @@
+# Scroll Skew Reveal
+
+A skewed reveal strip wipes text across as the section scrolls past.
+
+## Features
+- Skew wipe driven by view() timeline
+- Crisp diagonal sweep edge
+- Reusable heading treatment
+- Pure CSS
+
+## Usage
+```html
+<h2 class="ssr-title"><span>Skewed</span></h2>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/scroll-skew-reveal/demo.html
+++ b/submissions/examples/scroll-skew-reveal/demo.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Skew Reveal &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<section class="ssr-stage">
+  <h2 class="ssr-title"><span>Skewed</span></h2>
+  <h2 class="ssr-title"><span>Wipe Reveal</span></h2>
+</section>
+</body>
+</html>

--- a/submissions/examples/scroll-skew-reveal/style.css
+++ b/submissions/examples/scroll-skew-reveal/style.css
@@ -1,0 +1,36 @@
+.ssr-stage {
+  min-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  background: #0e131c;
+  overflow: hidden;
+}
+.ssr-title {
+  font-size: clamp(2.2rem, 7vw, 4rem);
+  margin: 0;
+  color: #fff;
+}
+.ssr-title span {
+  display: inline-block;
+  padding: 0 8px;
+  background: linear-gradient(90deg, #7ee787, #79c0ff, #d2a8ff);
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  transform: skewX(-8deg);
+  animation: ssr-wipe linear;
+  animation-timeline: view();
+  animation-range: entry 0% cover 45%;
+  opacity: 0;
+}
+@keyframes ssr-wipe {
+  0% { opacity: 0; clip-path: inset(0 100% 0 0); }
+  60% { opacity: 1; }
+  100% { opacity: 1; clip-path: inset(0 0 0 0); }
+}
+@supports not (animation-timeline: view()) {
+  .ssr-title span { opacity: 1; clip-path: none; }
+}


### PR DESCRIPTION
## Summary

Add the **Scroll Skew Reveal** component to the EaseMotion CSS gallery. This is a scroll demo rendered with plain HTML and CSS.

**Description:** A skewed reveal strip wipes text across as the section scrolls past.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/scroll-skew-reveal/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A skewed reveal strip wipes text across as the section scrolls past.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the scroll category in the gallery with a polished, reusable effect.

### Key features
- Skew wipe driven by view() timeline
- Crisp diagonal sweep edge
- Reusable heading treatment
- Pure CSS

### Demo
Open `submissions/examples/scroll-skew-reveal/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87482
