### PR TITLE
feat: add scroll-sticky-stack component

### DIFF
--- a/submissions/examples/scroll-sticky-stack/README.md
+++ b/submissions/examples/scroll-sticky-stack/README.md
@@ -1,0 +1,20 @@
+# Scroll Sticky Stack
+
+Cards stick to the top and pile up as you scroll through the sequence.
+
+## Features
+- position: sticky stacking behaviour
+- Each card pins over the previous one
+- Pure CSS layering
+- No scroll listener
+
+## Usage
+```html
+<section class="sss-card">Layer</section>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/scroll-sticky-stack/demo.html
+++ b/submissions/examples/scroll-sticky-stack/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Sticky Stack &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="sss-scroll">
+  <section class="sss-card" style="--bg:#3d5a80">Layer 1</section>
+  <section class="sss-card" style="--bg:#5a7d9a">Layer 2</section>
+  <section class="sss-card" style="--bg:#7a5c9a">Layer 3</section>
+</main>
+</body>
+</html>

--- a/submissions/examples/scroll-sticky-stack/style.css
+++ b/submissions/examples/scroll-sticky-stack/style.css
@@ -1,0 +1,30 @@
+.sss-scroll {
+  display: block;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 30px 16px 200px;
+}
+.sss-card {
+  position: sticky;
+  top: 24px;
+  height: 340px;
+  margin-top: -90px;
+  border-radius: 18px;
+  background: var(--bg);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+.sss-card:first-child { margin-top: 0; }
+.sss-card:nth-child(2) { top: 44px; }
+.sss-card:nth-child(3) { top: 64px; }
+.sss-scroll::after {
+  content: "Scroll to stack";
+  display: block;
+  text-align: center;
+  color: #8b99ad;
+  padding: 30px 0 0;
+}


### PR DESCRIPTION
## Summary

Add the **Scroll Sticky Stack** component to the EaseMotion CSS gallery. This is a scroll demo rendered with plain HTML and CSS.

**Description:** Cards stick to the top and pile up as you scroll through the sequence.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/scroll-sticky-stack/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Cards stick to the top and pile up as you scroll through the sequence.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the scroll category in the gallery with a polished, reusable effect.

### Key features
- position: sticky stacking behaviour
- Each card pins over the previous one
- Pure CSS layering
- No scroll listener

### Demo
Open `submissions/examples/scroll-sticky-stack/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87483
