### PR TITLE
feat: add stat-delta-arrow component

### DIFF
--- a/submissions/examples/stat-delta-arrow/README.md
+++ b/submissions/examples/stat-delta-arrow/README.md
@@ -1,0 +1,20 @@
+# Stat Delta Arrow
+
+An arrow jolts upward signalling positive delta beside a stat.
+
+## Features
+- Upward jolt arrow
+- Colour-coded delta
+- Springy overshoot
+- Pure CSS
+
+## Usage
+```html
+<span class="sda-arrow"></span>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/stat-delta-arrow/demo.html
+++ b/submissions/examples/stat-delta-arrow/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Delta Arrow &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="sda-row">
+  <span class="sda-arrow"></span>
+  <div>
+    <strong class="sda-value">+18.4%</strong>
+    <small class="sda-caption">vs last week</small>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/stat-delta-arrow/style.css
+++ b/submissions/examples/stat-delta-arrow/style.css
@@ -1,0 +1,27 @@
+.sda-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  justify-content: center;
+  margin: 60px auto;
+}
+.sda-arrow {
+  width: 22px;
+  height: 22px;
+  border-right: 4px solid #7bffb0;
+  border-top: 4px solid #7bffb0;
+  transform: rotate(-45deg);
+  animation: sda-jolt 1.6s ease-in-out infinite;
+}
+.sda-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 900;
+  color: #7bffb0;
+}
+.sda-caption { color: #8fa4c4; font-size: 0.8rem; }
+@keyframes sda-jolt {
+  0%, 100% { transform: rotate(-45deg) translate(0, 0); }
+  30% { transform: rotate(-45deg) translate(4px, -4px); }
+  50% { transform: rotate(-45deg) translate(-2px, 2px); }
+}


### PR DESCRIPTION
## Summary

Add the **Stat Delta Arrow** component to the EaseMotion CSS gallery. This is a charts demo rendered with plain HTML and CSS.

**Description:** An arrow jolts upward signalling positive delta beside a stat.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/stat-delta-arrow/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** An arrow jolts upward signalling positive delta beside a stat.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the charts category in the gallery with a polished, reusable effect.

### Key features
- Upward jolt arrow
- Colour-coded delta
- Springy overshoot
- Pure CSS

### Demo
Open `submissions/examples/stat-delta-arrow/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87564
