### PR TITLE
feat: add stat-glow-card component

### DIFF
--- a/submissions/examples/stat-glow-card/README.md
+++ b/submissions/examples/stat-glow-card/README.md
@@ -1,0 +1,20 @@
+# Stat Glow Card
+
+A KPI card pulses with a glow while the metric breathes.
+
+## Features
+- Soft pulsing glow
+- Breathing headline metric
+- Delta chip accent
+- Pure CSS
+
+## Usage
+```html
+<div class="sgc-card"><strong class="sgc-value">128k</strong></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/stat-glow-card/demo.html
+++ b/submissions/examples/stat-glow-card/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Glow Card &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="sgc-card">
+  <span class="sgc-label">Monthly active users</span>
+  <strong class="sgc-value">128k</strong>
+  <span class="sgc-delta">+12%</span>
+</div>
+</body>
+</html>

--- a/submissions/examples/stat-glow-card/style.css
+++ b/submissions/examples/stat-glow-card/style.css
@@ -1,0 +1,38 @@
+.sgc-card {
+  max-width: 280px;
+  margin: 60px auto;
+  padding: 26px;
+  border-radius: 16px;
+  background: linear-gradient(150deg, #1a2440, #101827);
+  border: 1px solid #2b3a5c;
+  position: relative;
+  overflow: hidden;
+}
+.sgc-card::before {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(circle at 30% 20%, rgba(111, 183, 255, 0.25), transparent 60%);
+  animation: sgc-glow 3s ease-in-out infinite;
+}
+.sgc-label { color: #8fa4c4; font-size: 0.85rem; position: relative; }
+.sgc-value {
+  display: block;
+  font-size: 2.8rem;
+  font-weight: 900;
+  color: #e6edf6;
+  margin: 8px 0;
+  position: relative;
+  animation: sgc-breathe 3s ease-in-out infinite;
+}
+.sgc-delta {
+  position: relative;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(123, 255, 176, 0.15);
+  color: #7bffb0;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+@keyframes sgc-glow { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
+@keyframes sgc-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.04); } }


### PR DESCRIPTION
## Summary

Add the **Stat Glow Card** component to the EaseMotion CSS gallery. This is a charts demo rendered with plain HTML and CSS.

**Description:** A KPI card pulses with a glow while the metric breathes.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/stat-glow-card/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A KPI card pulses with a glow while the metric breathes.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the charts category in the gallery with a polished, reusable effect.

### Key features
- Soft pulsing glow
- Breathing headline metric
- Delta chip accent
- Pure CSS

### Demo
Open `submissions/examples/stat-glow-card/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87562
