### PR TITLE
feat: add stat-roll-number component

### DIFF
--- a/submissions/examples/stat-roll-number/README.md
+++ b/submissions/examples/stat-roll-number/README.md
@@ -1,0 +1,20 @@
+# Stat Roll Number
+
+A big number rolls through digits with a vertical ticker reel.
+
+## Features
+- Vertical digit reel
+- Rounded frames
+- Looping roll
+- Pure CSS
+
+## Usage
+```html
+<div class="srn-reel"><i>0</i><i>1</i>...</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/stat-roll-number/demo.html
+++ b/submissions/examples/stat-roll-number/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Roll Number &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="srn-wrap">
+  <div class="srn-reel"><i>0</i><i>1</i><i>2</i><i>3</i><i>4</i><i>5</i><i>6</i><i>7</i><i>8</i><i>9</i><i>0</i></div>
+</div>
+</body>
+</html>

--- a/submissions/examples/stat-roll-number/style.css
+++ b/submissions/examples/stat-roll-number/style.css
@@ -1,0 +1,30 @@
+.srn-wrap {
+  width: 140px;
+  height: 90px;
+  margin: 60px auto;
+  overflow: hidden;
+  border-radius: 14px;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  display: grid;
+  place-items: center;
+}
+.srn-reel {
+  display: flex;
+  flex-direction: column;
+  animation: srn-roll 3s cubic-bezier(0.2, 0.8, 0.3, 1) infinite;
+}
+.srn-reel i {
+  height: 90px;
+  display: grid;
+  place-items: center;
+  font-size: 3.2rem;
+  font-weight: 900;
+  color: #8fd0ff;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+@keyframes srn-roll {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(-990px); }
+}


### PR DESCRIPTION
## Summary

Add the **Stat Roll Number** component to the EaseMotion CSS gallery. This is a charts demo rendered with plain HTML and CSS.

**Description:** A big number rolls through digits with a vertical ticker reel.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/stat-roll-number/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A big number rolls through digits with a vertical ticker reel.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the charts category in the gallery with a polished, reusable effect.

### Key features
- Vertical digit reel
- Rounded frames
- Looping roll
- Pure CSS

### Demo
Open `submissions/examples/stat-roll-number/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87561
