### PR TITLE
feat: add textarea-dots-resize component

### DIFF
--- a/submissions/examples/textarea-dots-resize/README.md
+++ b/submissions/examples/textarea-dots-resize/README.md
@@ -1,0 +1,20 @@
+# Textarea Dots Resize
+
+A textarea with a hand-drawn dotted border and animated corner dots.
+
+## Features
+- Playful dotted border
+- Animated corner accents
+- Auto-focus glow
+- Pure CSS
+
+## Usage
+```html
+<div class="tdr-wrap"><textarea></textarea><span class="tdr-dot"></span></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/textarea-dots-resize/demo.html
+++ b/submissions/examples/textarea-dots-resize/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Textarea Dots Resize &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="tdr-wrap">
+  <textarea placeholder="Write a note..." rows="4"></textarea>
+  <span class="tdr-dot" style="--i:0"></span>
+  <span class="tdr-dot" style="--i:1"></span>
+  <span class="tdr-dot" style="--i:2"></span>
+  <span class="tdr-dot" style="--i:3"></span>
+</div>
+</body>
+</html>

--- a/submissions/examples/textarea-dots-resize/style.css
+++ b/submissions/examples/textarea-dots-resize/style.css
@@ -1,0 +1,28 @@
+.tdr-wrap { position: relative; max-width: 380px; margin: 60px auto; }
+.tdr-wrap textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 14px;
+  border-radius: 12px;
+  border: 2px dashed #3b4a6b;
+  background: #161d2c;
+  color: #e6edf6;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.tdr-wrap textarea:focus { border-color: #6fb7ff; }
+.tdr-dot {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #6fb7ff;
+  animation: tdr-pulse 1.6s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.2s);
+}
+.tdr-dot:nth-child(2) { top: -5px; left: -5px; }
+.tdr-dot:nth-child(3) { top: -5px; right: -5px; }
+.tdr-dot:nth-child(4) { bottom: -5px; left: -5px; }
+.tdr-dot:nth-child(5) { bottom: -5px; right: -5px; }
+@keyframes tdr-pulse { 0%, 100% { transform: scale(1); opacity: 0.9; } 50% { transform: scale(1.6); opacity: 0.4; } }


### PR DESCRIPTION
## Summary

Add the **Textarea Dots Resize** component to the EaseMotion CSS gallery. This is a forms demo rendered with plain HTML and CSS.

**Description:** A textarea with a hand-drawn dotted border and animated corner dots.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/textarea-dots-resize/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A textarea with a hand-drawn dotted border and animated corner dots.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the forms category in the gallery with a polished, reusable effect.

### Key features
- Playful dotted border
- Animated corner accents
- Auto-focus glow
- Pure CSS

### Demo
Open `submissions/examples/textarea-dots-resize/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87509
