### PR TITLE
feat: add text-clip-reveal component

### DIFF
--- a/submissions/examples/text-clip-reveal/README.md
+++ b/submissions/examples/text-clip-reveal/README.md
@@ -1,0 +1,20 @@
+# Text Clip Reveal
+
+A block of text reveals word by word through a moving clip window.
+
+## Features
+- Clip-path window wipe
+- Word-percentage reveal
+- Looping autonomous play
+- Pure CSS
+
+## Usage
+```html
+<h2 class="tcr-line">Revealed text</h2>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/text-clip-reveal/demo.html
+++ b/submissions/examples/text-clip-reveal/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Clip Reveal &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="tcr-wrap">
+  <h2 class="tcr-line">Revealed text in a clip window</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/text-clip-reveal/style.css
+++ b/submissions/examples/text-clip-reveal/style.css
@@ -1,0 +1,13 @@
+.tcr-wrap { min-height: 50vh; display: grid; place-items: center; padding: 0 20px; }
+.tcr-line {
+  font-size: clamp(1.8rem, 5vw, 3rem);
+  font-weight: 800;
+  color: #dfe7f2;
+  animation: tcr-wipe 4s steps(9, end) infinite;
+  clip-path: inset(0 0 0 0);
+}
+@keyframes tcr-wipe {
+  0%, 100% { clip-path: inset(0 100% 0 0); }
+  45% { clip-path: inset(0 0 0 0); }
+  70% { clip-path: inset(0 0 0 0); }
+}


### PR DESCRIPTION
## Summary

Add the **Text Clip Reveal** component to the EaseMotion CSS gallery. This is a text demo rendered with plain HTML and CSS.

**Description:** A block of text reveals word by word through a moving clip window.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/text-clip-reveal/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A block of text reveals word by word through a moving clip window.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the text category in the gallery with a polished, reusable effect.

### Key features
- Clip-path window wipe
- Word-percentage reveal
- Looping autonomous play
- Pure CSS

### Demo
Open `submissions/examples/text-clip-reveal/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87541
