### PR TITLE
feat: add text-fill-outline component

### DIFF
--- a/submissions/examples/text-fill-outline/README.md
+++ b/submissions/examples/text-fill-outline/README.md
@@ -1,0 +1,20 @@
+# Text Fill Outline
+
+Outlined text fills with colour from left to right on hover.
+
+## Features
+- Stroke-to-fill gradient wipe
+- background-clip text trick
+- Smooth directional fill
+- Pure CSS
+
+## Usage
+```html
+<h2 class="tfo-title">Fill me</h2>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/text-fill-outline/demo.html
+++ b/submissions/examples/text-fill-outline/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Fill Outline &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="tfo-wrap">
+  <h2 class="tfo-title">Fill me</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/text-fill-outline/style.css
+++ b/submissions/examples/text-fill-outline/style.css
@@ -1,0 +1,15 @@
+.tfo-wrap { min-height: 50vh; display: grid; place-items: center; }
+.tfo-title {
+  font-size: clamp(2.4rem, 8vw, 4.6rem);
+  font-weight: 900;
+  margin: 0;
+  -webkit-text-stroke: 2px #6fb7ff;
+  color: transparent;
+  background: linear-gradient(90deg, #6fb7ff 50%, transparent 50%);
+  background-size: 200% 100%;
+  background-position: 100% 0;
+  -webkit-background-clip: text;
+  background-clip: text;
+  transition: background-position 0.7s cubic-bezier(0.3, 0.8, 0.2, 1);
+}
+.tfo-wrap:hover .tfo-title { background-position: 0 0; }


### PR DESCRIPTION
## Summary

Add the **Text Fill Outline** component to the EaseMotion CSS gallery. This is a text demo rendered with plain HTML and CSS.

**Description:** Outlined text fills with colour from left to right on hover.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/text-fill-outline/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Outlined text fills with colour from left to right on hover.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the text category in the gallery with a polished, reusable effect.

### Key features
- Stroke-to-fill gradient wipe
- background-clip text trick
- Smooth directional fill
- Pure CSS

### Demo
Open `submissions/examples/text-fill-outline/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87539
