### PR TITLE
feat: add text-flicker-noise component

### DIFF
--- a/submissions/examples/text-flicker-noise/README.md
+++ b/submissions/examples/text-flicker-noise/README.md
@@ -1,0 +1,20 @@
+# Text Flicker Noise
+
+A VHS-style flicker with RGB split jitters across the title.
+
+## Features
+- Subtle RGB channel split
+- Random-looking flicker steps
+- Teal/orange ghost layers
+- Pure CSS
+
+## Usage
+```html
+<h2 class="tfn-title">Signal</h2>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/text-flicker-noise/demo.html
+++ b/submissions/examples/text-flicker-noise/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text Flicker Noise &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="tfn-wrap">
+  <h2 class="tfn-title">Signal</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/text-flicker-noise/style.css
+++ b/submissions/examples/text-flicker-noise/style.css
@@ -1,0 +1,32 @@
+.tfn-wrap { min-height: 50vh; display: grid; place-items: center; }
+.tfn-title {
+  position: relative;
+  font-size: clamp(2.6rem, 9vw, 5rem);
+  font-weight: 900;
+  color: #e6edf6;
+  letter-spacing: 2px;
+  animation: tfn-flicker 3s linear infinite;
+}
+.tfn-title::before,
+.tfn-title::after {
+  content: "Signal";
+  position: absolute;
+  inset: 0;
+  opacity: 0.6;
+}
+.tfn-title::before { color: #ff7a7a; transform: translate(-3px, 0); animation: tfn-split 3s linear infinite; }
+.tfn-title::after { color: #7ad4ff; transform: translate(3px, 0); animation: tfn-split 3s linear infinite reverse; }
+@keyframes tfn-flicker {
+  0%, 91%, 100% { opacity: 1; }
+  92% { opacity: 0.5; }
+  94% { opacity: 0.9; }
+  96% { opacity: 0.4; }
+  98% { opacity: 1; }
+}
+@keyframes tfn-split {
+  0%, 100% { transform: translate(0, 0); opacity: 0.6; }
+  8% { transform: translate(-4px, 0); }
+  12% { transform: translate(4px, 0); }
+  40% { transform: translate(0, 0); }
+  88% { transform: translate(-2px, 1px); }
+}


### PR DESCRIPTION
## Summary

Add the **Text Flicker Noise** component to the EaseMotion CSS gallery. This is a text demo rendered with plain HTML and CSS.

**Description:** A VHS-style flicker with RGB split jitters across the title.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/text-flicker-noise/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A VHS-style flicker with RGB split jitters across the title.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the text category in the gallery with a polished, reusable effect.

### Key features
- Subtle RGB channel split
- Random-looking flicker steps
- Teal/orange ghost layers
- Pure CSS

### Demo
Open `submissions/examples/text-flicker-noise/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87540
