### PR TITLE
feat: add text marquee stroke component

### DIFF
--- a/submissions/examples/text-marquee-stroke-87543/README.md
+++ b/submissions/examples/text-marquee-stroke-87543/README.md
@@ -1,0 +1,15 @@
+# Text Marquee Stroke
+
+A dependency-free EaseMotion text component that scrolls stroked headline text
+across a ticker lane with a dashed animated underline.
+
+## Files
+
+- `demo.html` contains the accessible marquee example.
+- `style.css` defines the stroked text, marquee track, dashed underline, focus
+  treatment, and reduced-motion fallback.
+
+## Accessibility
+
+The visual ticker is wrapped in a labeled button so keyboard users can focus the
+component. Motion is disabled when `prefers-reduced-motion` is enabled.

--- a/submissions/examples/text-marquee-stroke-87543/demo.html
+++ b/submissions/examples/text-marquee-stroke-87543/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Marquee Stroke</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="frame" aria-labelledby="title">
+      <section class="intro">
+        <p class="kicker">EaseMotion text component</p>
+        <h1 id="title">Text Marquee Stroke</h1>
+        <p>
+          A stroked headline ticker with a dashed underline that keeps motion
+          smooth, focusable, and dependency-free.
+        </p>
+      </section>
+
+      <section class="marquee-card" aria-label="Scrolling text marquee">
+        <button class="marquee" aria-label="Launch studio scrolling marquee">
+          <span class="marquee-track" aria-hidden="true">
+            <span>Launch Studio</span>
+            <span>Motion System</span>
+            <span>Design Sprint</span>
+            <span>Launch Studio</span>
+            <span>Motion System</span>
+            <span>Design Sprint</span>
+          </span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/text-marquee-stroke-87543/style.css
+++ b/submissions/examples/text-marquee-stroke-87543/style.css
@@ -1,0 +1,152 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(
+      circle at 18% 20%,
+      rgba(20, 184, 166, 0.22),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 82% 78%,
+      rgba(250, 204, 21, 0.16),
+      transparent 24rem
+    ),
+    #11131b;
+  color: #f8fafc;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.frame {
+  width: min(1060px, calc(100vw - 32px));
+  padding: clamp(28px, 5vw, 58px);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(14, 18, 29, 0.82);
+  box-shadow: 0 26px 80px rgba(0, 0, 0, 0.36);
+}
+
+.intro {
+  max-width: 720px;
+}
+
+.kicker {
+  margin: 0 0 10px;
+  color: #5eead4;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 6vw, 5.6rem);
+  line-height: 0.95;
+}
+
+.intro p:last-child {
+  max-width: 60ch;
+  margin: 18px 0 0;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.marquee-card {
+  margin-top: clamp(34px, 6vw, 70px);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.marquee {
+  width: 100%;
+  min-height: 210px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.marquee-track {
+  display: flex;
+  width: max-content;
+  gap: clamp(1.5rem, 5vw, 4rem);
+  align-items: center;
+  animation: marquee-slide 15s linear infinite;
+}
+
+.marquee-track span {
+  position: relative;
+  color: transparent;
+  font-size: clamp(3rem, 10vw, 8rem);
+  font-weight: 950;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+  -webkit-text-stroke: 2px #fef3c7;
+  text-shadow: 0 0 30px rgba(94, 234, 212, 0.18);
+}
+
+.marquee-track span::after {
+  position: absolute;
+  right: 0;
+  bottom: -0.18em;
+  left: 0;
+  height: 4px;
+  background-image: repeating-linear-gradient(
+    90deg,
+    #5eead4 0 18px,
+    transparent 18px 30px
+  );
+  content: "";
+  transform: scaleX(0.72);
+  transform-origin: left;
+  transition: transform 220ms ease;
+}
+
+.marquee:hover .marquee-track,
+.marquee:focus-visible .marquee-track {
+  animation-duration: 9s;
+}
+
+.marquee:hover .marquee-track span::after,
+.marquee:focus-visible .marquee-track span::after {
+  transform: scaleX(1);
+}
+
+.marquee:focus-visible {
+  outline: 3px solid #5eead4;
+  outline-offset: -8px;
+}
+
+@keyframes marquee-slide {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a text marquee stroke component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers stroked scrolling text, dashed underline, keyboard focus, and reduced-motion support.

Fixes #87543

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.