### PR TITLE
feat: add text-rgb-split component

### DIFF
--- a/submissions/examples/text-rgb-split/README.md
+++ b/submissions/examples/text-rgb-split/README.md
@@ -1,0 +1,20 @@
+# Text RGB Split
+
+The title splits into RGB channels that drift apart and return.
+
+## Features
+- Red/green/blue layer split
+- Periodic drift
+- Chromatic aberration feel
+- Pure CSS
+
+## Usage
+```html
+<h2 class="trs-title">RGB</h2>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/text-rgb-split/demo.html
+++ b/submissions/examples/text-rgb-split/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Text RGB Split &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="trs-wrap">
+  <h2 class="trs-title">RGB</h2>
+</div>
+</body>
+</html>

--- a/submissions/examples/text-rgb-split/style.css
+++ b/submissions/examples/text-rgb-split/style.css
@@ -1,0 +1,14 @@
+.trs-wrap { min-height: 50vh; display: grid; place-items: center; }
+.trs-title {
+  position: relative;
+  font-size: clamp(2.8rem, 10vw, 5.6rem);
+  font-weight: 900;
+  color: #f3f6fa;
+  text-shadow: 2px 0 0 #ff2d55, -2px 0 0 #00d9ff, 0 0 0 #00ff9d;
+  animation: trs-drift 5s ease-in-out infinite;
+}
+@keyframes trs-drift {
+  0%, 100% { text-shadow: 2px 0 0 #ff2d55, -2px 0 0 #00d9ff, 0 0 0 #00ff9d; }
+  30% { text-shadow: 6px 0 0 #ff2d55, -6px 0 0 #00d9ff, 0 0 0 #00ff9d; }
+  60% { text-shadow: -4px 0 0 #ff2d55, 4px 0 0 #00d9ff, 0 0 0 #00ff9d; }
+}


### PR DESCRIPTION
## Summary

Add the **Text RGB Split** component to the EaseMotion CSS gallery. This is a text demo rendered with plain HTML and CSS.

**Description:** The title splits into RGB channels that drift apart and return.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/text-rgb-split/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** The title splits into RGB channels that drift apart and return.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the text category in the gallery with a polished, reusable effect.

### Key features
- Red/green/blue layer split
- Periodic drift
- Chromatic aberration feel
- Pure CSS

### Demo
Open `submissions/examples/text-rgb-split/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #87547
