### PR TITLE
feat: add text wavy hover component

### DIFF
--- a/submissions/examples/text-wavy-hover-87538/README.md
+++ b/submissions/examples/text-wavy-hover-87538/README.md
@@ -1,0 +1,15 @@
+# Text Wavy Hover
+
+A dependency-free EaseMotion text component where letters lift into a staggered
+wave on hover or keyboard focus, then settle back onto the baseline.
+
+## Files
+
+- `demo.html` contains two accessible wavy text examples.
+- `style.css` defines the staggered letter movement, hover and focus states,
+  responsive sizing, and reduced-motion fallback.
+
+## Accessibility
+
+The examples are focusable buttons with visible outlines. Motion-sensitive users
+receive an instant state change through the `prefers-reduced-motion` fallback.

--- a/submissions/examples/text-wavy-hover-87538/demo.html
+++ b/submissions/examples/text-wavy-hover-87538/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Wavy Hover</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shell" aria-labelledby="title">
+      <section class="intro">
+        <p class="eyebrow">EaseMotion text component</p>
+        <h1 id="title">Text Wavy Hover</h1>
+        <p>
+          Hover or focus each heading to lift letters into a soft wave, then
+          settle them back into the baseline.
+        </p>
+      </section>
+
+      <section class="wave-list" aria-label="Wavy hover text examples">
+        <button class="wave-word" aria-label="Studio wave text">
+          <span style="--i: 0">S</span>
+          <span style="--i: 1">T</span>
+          <span style="--i: 2">U</span>
+          <span style="--i: 3">D</span>
+          <span style="--i: 4">I</span>
+          <span style="--i: 5">O</span>
+        </button>
+
+        <button class="wave-word coral" aria-label="Signal wave text">
+          <span style="--i: 0">S</span>
+          <span style="--i: 1">I</span>
+          <span style="--i: 2">G</span>
+          <span style="--i: 3">N</span>
+          <span style="--i: 4">A</span>
+          <span style="--i: 5">L</span>
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/text-wavy-hover-87538/style.css
+++ b/submissions/examples/text-wavy-hover-87538/style.css
@@ -1,0 +1,161 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(
+      circle at 20% 18%,
+      rgba(56, 189, 248, 0.2),
+      transparent 26rem
+    ),
+    radial-gradient(
+      circle at 85% 82%,
+      rgba(251, 113, 133, 0.18),
+      transparent 26rem
+    ),
+    #10141f;
+  color: #f8fafc;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.shell {
+  width: min(980px, calc(100vw - 32px));
+  padding: clamp(28px, 5vw, 58px);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(13, 18, 30, 0.82);
+  box-shadow: 0 28px 84px rgba(0, 0, 0, 0.34);
+}
+
+.intro {
+  max-width: 700px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #7dd3fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 6vw, 5.8rem);
+  line-height: 0.95;
+}
+
+.intro p:last-child {
+  max-width: 58ch;
+  margin: 18px 0 0;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.wave-list {
+  display: grid;
+  gap: 18px;
+  margin-top: clamp(34px, 6vw, 66px);
+}
+
+.wave-word {
+  --accent: #38bdf8;
+  min-height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.1rem, 1vw, 0.35rem);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f8fafc;
+  cursor: pointer;
+  font-size: clamp(3rem, 10vw, 7.4rem);
+  font-weight: 950;
+  line-height: 1;
+  overflow: hidden;
+  text-transform: uppercase;
+  transition:
+    border-color 220ms ease,
+    background 220ms ease,
+    transform 220ms ease;
+}
+
+.wave-word span {
+  --lift: -0.35rem;
+  --twist: -2deg;
+  display: inline-block;
+  text-shadow: 0 0 26px rgba(56, 189, 248, 0.16);
+  transform: translateY(0) rotate(0deg);
+  transition:
+    color 220ms ease,
+    transform 560ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition-delay: calc(var(--i) * 45ms);
+}
+
+.wave-word:hover,
+.wave-word:focus-visible {
+  border-color: color-mix(in srgb, var(--accent), white 24%);
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateY(-3px);
+}
+
+.wave-word:hover span,
+.wave-word:focus-visible span {
+  color: var(--accent);
+  transform: translateY(var(--lift)) rotate(var(--twist));
+}
+
+.wave-word span:nth-child(2) {
+  --lift: -0.95rem;
+  --twist: -1deg;
+}
+
+.wave-word span:nth-child(3) {
+  --lift: -1.25rem;
+  --twist: 1deg;
+}
+
+.wave-word span:nth-child(4) {
+  --lift: -0.85rem;
+  --twist: 2deg;
+}
+
+.wave-word span:nth-child(5) {
+  --lift: -0.45rem;
+  --twist: 1deg;
+}
+
+.wave-word span:nth-child(6) {
+  --lift: -0.75rem;
+  --twist: -1deg;
+}
+
+.wave-word:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.coral {
+  --accent: #fb7185;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wave-word,
+  .wave-word span {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a text wavy hover component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers staggered letter wave motion, keyboard focus, responsive sizing, and reduced-motion support.

Fixes #87538

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.