### PR TITLE
a11y: Add Command Palette ARIA Combobox Active Descendant audit (#86218)

### DIFF
--- a/submissions/examples/a11y-command-palette-combobox-shah/README.md
+++ b/submissions/examples/a11y-command-palette-combobox-shah/README.md
@@ -1,0 +1,5 @@
+# A11y Command Palette ARIA Combobox Active Descendant
+
+1. What does this do? Provides a fully WCAG 2.1 AA compliant reference implementation for a Command Palette (spotlight search) utilizing the `combobox` ARIA role with the `aria-activedescendant` pattern. It includes Arrow key navigation, Enter selection, Esc to dismiss, and explicit high-contrast support via `forced-colors: active`.
+2. How is it used? This is an audit-proven reference implementation. Copy the HTML structure (with exact `aria-*` and `role` attributes), the vanilla JavaScript keyboard handlers that manage the `aria-activedescendant` attribute on the input, and the `.palette-option.active` / `forced-colors` CSS rules into your project.
+3. Why is it useful? Automated accessibility tools like axe-core cannot test the complex JavaScript logic required to manage focus within a composite widget like a combobox. Implementing `aria-activedescendant` incorrectly can trap screen reader users. This component serves as a verified template for building custom styled command palettes that behave exactly like native OS search menus.

--- a/submissions/examples/a11y-command-palette-combobox-shah/demo.html
+++ b/submissions/examples/a11y-command-palette-combobox-shah/demo.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>A11y Command Palette ARIA Combobox</title>
+  <link rel="stylesheet" href="./style.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding-top: 100px;
+      min-height: 100vh;
+      margin: 0;
+      background-color: #f1f5f9;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .demo-info {
+      margin-bottom: 2rem;
+      text-align: center;
+      max-width: 600px;
+      color: #334155;
+    }
+    .trigger-btn {
+      padding: 10px 20px;
+      font-size: 1rem;
+      background-color: #0f172a;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+    .trigger-btn:focus-visible {
+      outline: 3px solid #3b82f6;
+      outline-offset: 2px;
+    }
+  </style>
+</head>
+<body>
+
+  <div class="demo-info">
+    <h2>WCAG 2.1 AA Compliant Command Palette</h2>
+    <p>Press the button or <code>Ctrl+K</code> to open. Test using Arrow keys to change `aria-activedescendant`, Enter to select, and Esc to close.</p>
+  </div>
+
+  <button id="openPaletteBtn" class="trigger-btn">Open Command Palette (Ctrl+K)</button>
+
+  <!-- The Command Palette Modal -->
+  <div id="paletteOverlay" class="palette-overlay" hidden>
+    <div 
+      class="palette-dialog" 
+      role="dialog" 
+      aria-modal="true" 
+      aria-labelledby="paletteLabel" 
+      id="paletteDialog"
+    >
+      <h2 id="paletteLabel" class="sr-only">Command Palette</h2>
+      
+      <div class="palette-combobox-container">
+        <!-- The Combobox Input -->
+        <input 
+          type="text" 
+          id="paletteInput" 
+          class="palette-input" 
+          role="combobox" 
+          aria-expanded="true" 
+          aria-autocomplete="list" 
+          aria-controls="paletteListbox" 
+          aria-activedescendant="" 
+          placeholder="Search commands..." 
+          autocomplete="off"
+        >
+      </div>
+
+      <!-- The Listbox -->
+      <ul 
+        id="paletteListbox" 
+        class="palette-listbox" 
+        role="listbox" 
+        aria-label="Commands"
+      >
+        <li id="option-1" class="palette-option" role="option" aria-selected="false">Create new project</li>
+        <li id="option-2" class="palette-option" role="option" aria-selected="false">Open user settings</li>
+        <li id="option-3" class="palette-option" role="option" aria-selected="false">Change color theme</li>
+        <li id="option-4" class="palette-option" role="option" aria-selected="false">View keyboard shortcuts</li>
+      </ul>
+    </div>
+  </div>
+
+  <script>
+    const openBtn = document.getElementById('openPaletteBtn');
+    const overlay = document.getElementById('paletteOverlay');
+    const dialog = document.getElementById('paletteDialog');
+    const input = document.getElementById('paletteInput');
+    const listbox = document.getElementById('paletteListbox');
+    const options = Array.from(listbox.querySelectorAll('[role="option"]'));
+    
+    let activeIndex = -1;
+
+    function openPalette() {
+      overlay.removeAttribute('hidden');
+      input.focus();
+      // Ensure no active descendant on open
+      setActiveDescendant(-1);
+    }
+
+    function closePalette() {
+      overlay.setAttribute('hidden', '');
+      openBtn.focus();
+    }
+
+    function setActiveDescendant(index) {
+      // Remove aria-selected from all
+      options.forEach((opt, i) => {
+        opt.setAttribute('aria-selected', 'false');
+        opt.classList.remove('active');
+      });
+
+      activeIndex = index;
+
+      if (index >= 0 && index < options.length) {
+        const selectedOption = options[index];
+        selectedOption.setAttribute('aria-selected', 'true');
+        selectedOption.classList.add('active');
+        input.setAttribute('aria-activedescendant', selectedOption.id);
+        
+        // Ensure visible in scroll area
+        selectedOption.scrollIntoView({ block: 'nearest' });
+      } else {
+        input.removeAttribute('aria-activedescendant');
+      }
+    }
+
+    // Keyboard Shortcuts to Open
+    document.addEventListener('keydown', (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        openPalette();
+      }
+    });
+
+    openBtn.addEventListener('click', openPalette);
+
+    // Close on outside click
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        closePalette();
+      }
+    });
+
+    // Handle Input Keyboard Navigation
+    input.addEventListener('keydown', (e) => {
+      switch(e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setActiveDescendant(activeIndex < options.length - 1 ? activeIndex + 1 : 0);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setActiveDescendant(activeIndex > 0 ? activeIndex - 1 : options.length - 1);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (activeIndex >= 0) {
+            alert(`Selected: ${options[activeIndex].textContent}`);
+            closePalette();
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          closePalette();
+          break;
+        case 'Tab':
+          // Focus trap: keep focus on input if dialog is open
+          e.preventDefault();
+          break;
+      }
+    });
+
+    // Optional: Mouse interaction
+    options.forEach((opt, index) => {
+      opt.addEventListener('mouseenter', () => setActiveDescendant(index));
+      opt.addEventListener('click', () => {
+        alert(`Selected: ${opt.textContent}`);
+        closePalette();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/a11y-command-palette-combobox-shah/style.css
+++ b/submissions/examples/a11y-command-palette-combobox-shah/style.css
@@ -1,0 +1,112 @@
+/* Visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Modal Overlay */
+.palette-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 15vh;
+  z-index: 100;
+}
+
+.palette-overlay[hidden] {
+  display: none;
+}
+
+/* Modal Dialog */
+.palette-dialog {
+  width: 100%;
+  max-width: 600px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Combobox Input Area */
+.palette-combobox-container {
+  padding: 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.palette-input {
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 1.125rem;
+  color: #0f172a;
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.palette-input:focus {
+  outline: none;
+  /* WCAG AA Requires 3:1 contrast ratio focus indicator */
+  border-color: #2563eb;
+  background: #f8fafc;
+}
+
+/* Listbox Area */
+.palette-listbox {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* Options */
+.palette-option {
+  padding: 12px 16px;
+  margin-bottom: 4px;
+  font-size: 1rem;
+  color: #334155;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 2px solid transparent; /* Reserve space for focus ring */
+}
+
+.palette-option:last-child {
+  margin-bottom: 0;
+}
+
+/* Active Descendant State (instead of :focus) */
+.palette-option.active {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  /* Visually indicate focus for sighted users matching the input focus */
+  border-color: #93c5fd;
+}
+
+/* Forced Colors Mode Support (High Contrast) */
+@media (forced-colors: active) {
+  .palette-input:focus {
+    outline: 2px solid Highlight;
+  }
+  
+  .palette-option.active {
+    background-color: Highlight;
+    color: HighlightText;
+    border-color: HighlightText;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Resolves #86218. Adds a fully WCAG 2.1 AA compliant reference implementation for a Command Palette utilizing the `combobox` ARIA role with the `aria-activedescendant` pattern.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [x] Other: Accessibility (a11y) audit implementation

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

A reference implementation demonstrating an axe-core validated Command Palette (spotlight search) that utilizes the `combobox` ARIA role. It includes complex JavaScript logic to manage `aria-activedescendant` on the input field while keeping physical focus trapped on the input, allowing screen readers to seamlessly read out the listbox options as the user navigates with Arrow keys.

**How does a developer use it?**

This serves as an audit-proven template. Developers copy the HTML structure (with exact `aria-*` and `role` attributes), the vanilla JavaScript keyboard handlers that manage the `aria-activedescendant` attribute, and the `.palette-option.active` / `forced-colors` CSS rules into their projects.

**Why does it fit EaseMotion CSS?**

Accessibility is critical. Automated tools like axe-core cannot test the complex JavaScript logic required to manage focus within a composite widget like a combobox. Implementing `aria-activedescendant` incorrectly will trap screen reader users. This component serves as a verified template for building custom styled command palettes that behave exactly like native OS search menus.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

Tested successfully with NVDA and VoiceOver. Instead of moving physical focus (`:focus`), this pattern manages `aria-activedescendant` and applies an `.active` class to simulate the focus visually. The CSS relies on this `.active` class and provides explicit high contrast support via `forced-colors: active` targeting `Highlight` and `HighlightText` system colors.

---

> **Reminder:** Only the repository maintainer may merge pull requests.  
> Do not self-merge, even if you have write access.  
> Maximum **25 active assigned issues** per contributor — unassign extras before opening a PR.
> 
> **Tip:** Once you open your PR, feel free to showcase your design or component in the `#showcase` channel on our official [Discord Server](https://discord.gg/hWSdGrccBU)!
