### PR TITLE
feat: add swatch picker component

### DIFF
--- a/submissions/examples/swatch-picker-86866/README.md
+++ b/submissions/examples/swatch-picker-86866/README.md
@@ -1,0 +1,16 @@
+# Swatch Picker
+
+A dependency-free EaseMotion input component where selecting a color swatch adds
+a clear ring, lift, and pop animation.
+
+## Files
+
+- `demo.html` contains the accessible radio-based swatch group.
+- `style.css` defines the swatch colors, selected ring, pop animation,
+  responsive grid, focus treatment, and reduced-motion fallback.
+
+## Accessibility
+
+The component uses native radio inputs wrapped in labels, preserving keyboard
+selection and screen reader semantics. A visible focus outline is shown on each
+swatch.

--- a/submissions/examples/swatch-picker-86866/demo.html
+++ b/submissions/examples/swatch-picker-86866/demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Swatch Picker</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="surface" aria-labelledby="title">
+      <section class="intro">
+        <p class="eyebrow">EaseMotion input component</p>
+        <h1 id="title">Swatch Picker</h1>
+        <p>
+          A compact color picker row where each selected swatch gains a bright
+          ring, lift, and pop animation.
+        </p>
+      </section>
+
+      <fieldset class="picker">
+        <legend>Choose accent color</legend>
+        <label class="swatch rose">
+          <input type="radio" name="accent" checked />
+          <span>Rose</span>
+        </label>
+        <label class="swatch sky">
+          <input type="radio" name="accent" />
+          <span>Sky</span>
+        </label>
+        <label class="swatch lime">
+          <input type="radio" name="accent" />
+          <span>Lime</span>
+        </label>
+        <label class="swatch amber">
+          <input type="radio" name="accent" />
+          <span>Amber</span>
+        </label>
+      </fieldset>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/swatch-picker-86866/style.css
+++ b/submissions/examples/swatch-picker-86866/style.css
@@ -1,0 +1,195 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(
+      circle at 18% 20%,
+      rgba(244, 114, 182, 0.2),
+      transparent 27rem
+    ),
+    radial-gradient(
+      circle at 86% 78%,
+      rgba(34, 211, 238, 0.18),
+      transparent 25rem
+    ),
+    #10131d;
+  color: #f8fafc;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.surface {
+  width: min(920px, calc(100vw - 32px));
+  padding: clamp(28px, 5vw, 58px);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(13, 18, 30, 0.84);
+  box-shadow: 0 28px 84px rgba(0, 0, 0, 0.34);
+}
+
+.intro {
+  max-width: 680px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: #f9a8d4;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 6vw, 5.6rem);
+  line-height: 0.95;
+}
+
+.intro p:last-child {
+  max-width: 58ch;
+  margin: 18px 0 0;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.picker {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin: clamp(34px, 6vw, 66px) 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.picker legend {
+  margin-bottom: 16px;
+  color: #e2e8f0;
+  font-weight: 800;
+}
+
+.swatch {
+  --swatch: #fb7185;
+  min-height: 138px;
+  display: grid;
+  place-items: end center;
+  position: relative;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background:
+    radial-gradient(
+      circle at center 38%,
+      var(--swatch) 0 30px,
+      transparent 31px
+    ),
+    rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition:
+    border-color 220ms ease,
+    box-shadow 220ms ease,
+    transform 220ms ease;
+}
+
+.swatch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.swatch::before {
+  position: absolute;
+  top: 32px;
+  width: 64px;
+  height: 64px;
+  border: 3px solid transparent;
+  border-radius: 50%;
+  content: "";
+  transition:
+    border-color 220ms ease,
+    transform 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.swatch span {
+  color: #e2e8f0;
+  font-weight: 800;
+}
+
+.swatch:hover,
+.swatch:focus-within {
+  border-color: color-mix(in srgb, var(--swatch), white 30%);
+  transform: translateY(-3px);
+}
+
+.swatch:has(input:checked) {
+  box-shadow: 0 18px 46px color-mix(in srgb, var(--swatch), transparent 70%);
+}
+
+.swatch:has(input:checked)::before {
+  border-color: #ffffff;
+  transform: scale(1.16);
+  animation: swatch-pop 520ms ease;
+}
+
+.swatch:focus-within {
+  outline: 3px solid var(--swatch);
+  outline-offset: 4px;
+}
+
+.sky {
+  --swatch: #38bdf8;
+}
+
+.lime {
+  --swatch: #a3e635;
+}
+
+.amber {
+  --swatch: #f59e0b;
+}
+
+@keyframes swatch-pop {
+  0% {
+    transform: scale(0.82);
+  }
+
+  60% {
+    transform: scale(1.22);
+  }
+
+  100% {
+    transform: scale(1.16);
+  }
+}
+
+@media (max-width: 700px) {
+  .picker {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swatch,
+  .swatch::before {
+    transition: none;
+  }
+
+  .swatch:has(input:checked)::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a swatch picker component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers native radio selection, selected-ring pop motion, keyboard focus, responsive layout, and reduced-motion support.

Fixes #86866

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.