### PR TITLE
a11y(tooltip): implement WCAG 2.1 AA compliant tooltip with hover delay and escape key dismiss

### DIFF
--- a/submissions/examples/tooltip/README.md
+++ b/submissions/examples/tooltip/README.md
@@ -1,0 +1,28 @@
+# Tooltip Hover Delay & Escape Key Dismiss
+
+An audited, WCAG 2.1 AA compliant tooltip component implementing intentional hover delays, persistent pointer hover over tooltip content, immediate `Escape` key dismissal, and Windows High Contrast Mode support.
+
+## 🌟 Features & Accessibility Fixes
+
+* **Dismissible without moving focus (WCAG 1.4.13):** Pressing <kbd>Escape</kbd> dismisses the tooltip immediately while preserving keyboard focus on the triggering button.
+* **Hoverable Content (WCAG 1.4.13):** Users can move their mouse over the tooltip bubble without it disappearing, allowing zoom inspection and text selection.
+* **Hover Intent Delay:** Includes a 250ms delay before displaying on hover to avoid accidental activations during pointer sweeps.
+* **ARIA Description (WCAG 4.1.2):** Links trigger and tooltip via `aria-describedby` and `role="tooltip"`, read automatically by NVDA, VoiceOver, and JAWS.
+* **Dual-Layer Focus Ring (WCAG 2.4.7):** High-contrast focus indicator visible across dark and light surfaces.
+* **High Contrast Mode Support (`forced-colors: active`):** Binds borders and text to `CanvasText`, `ButtonText`, and `Highlight`.
+
+## 🚀 Usage
+
+```html
+<div class="tooltip-wrapper" id="tooltip-container">
+  <button 
+    type="button" 
+    class="tooltip-trigger" 
+    aria-describedby="tooltip-id"
+  >
+    Action
+  </button>
+  <div id="tooltip-id" class="tooltip-bubble" role="tooltip" aria-hidden="true">
+    Descriptive helper text
+  </div>
+</div>

--- a/submissions/examples/tooltip/demo.html
+++ b/submissions/examples/tooltip/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Hover Delay & Escape Key Dismiss Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Screen Reader Live Region for Real-Time Status Announcements -->
+  <div 
+    id="a11y-announcer" 
+    class="sr-only" 
+    role="status" 
+    aria-live="polite" 
+    aria-atomic="true"
+  ></div>
+
+  <main id="main-content" tabindex="-1">
+    <h1>Accessible Tooltip Component</h1>
+    <p>
+      Hover or focus the button below. Demonstrates an <strong>intent-delay timer (250ms)</strong> on hover, 
+      a directly hoverable tooltip body (WCAG 1.4.13), and immediate dismissal when pressing <kbd>Escape</kbd> 
+      without losing keyboard focus.
+    </p>
+
+    <!-- ACCESSIBLE TOOLTIP STRUCTURE -->
+    <div class="tooltip-wrapper" id="tooltip-container">
+      <button 
+        type="button" 
+        id="tooltip-btn" 
+        class="tooltip-trigger" 
+        aria-describedby="tooltip-content"
+      >
+        <span>Export Financial Report</span>
+      </button>
+
+      <!-- Tooltip Bubble (role="tooltip") -->
+      <div 
+        id="tooltip-content" 
+        class="tooltip-bubble" 
+        role="tooltip"
+        aria-hidden="true"
+      >
+        Generates CSV & PDF summaries for Q3 audit
+      </div>
+    </div>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const container = document.getElementById('tooltip-container');
+      const trigger = document.getElementById('tooltip-btn');
+      const bubble = document.getElementById('tooltip-content');
+      const announcer = document.getElementById('a11y-announcer');
+
+      if (!trigger || !bubble || !container) return;
+
+      let showTimeout = null;
+      let hideTimeout = null;
+      const HOVER_DELAY_MS = 250;
+      const INTENT_CLEAR_MS = 150;
+
+      function showTooltip(isKeyboard = false) {
+        clearTimeout(hideTimeout);
+        bubble.classList.add('is-visible');
+        bubble.setAttribute('aria-hidden', 'false');
+
+        if (isKeyboard && announcer) {
+          announcer.textContent = '';
+          setTimeout(() => {
+            announcer.textContent = 'Tooltip: ' + bubble.textContent.trim();
+          }, 50);
+        }
+      }
+
+      function hideTooltip() {
+        clearTimeout(showTimeout);
+        bubble.classList.remove('is-visible');
+        bubble.setAttribute('aria-hidden', 'true');
+      }
+
+      // Pointer / Hover Handlers (WCAG 1.4.13: Hoverable & Persistent)
+      container.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimeout);
+        showTimeout = setTimeout(() => {
+          showTooltip(false);
+        }, HOVER_DELAY_MS);
+      });
+
+      container.addEventListener('mouseleave', () => {
+        clearTimeout(showTimeout);
+        hideTimeout = setTimeout(() => {
+          hideTooltip();
+        }, INTENT_CLEAR_MS);
+      });
+
+      // Keyboard Focus Management
+      trigger.addEventListener('focus', () => {
+        showTooltip(true);
+      });
+
+      trigger.addEventListener('blur', () => {
+        hideTooltip();
+      });
+
+      // Keyboard Dismissal (Escape Key - WCAG 1.4.13: Dismissible)
+      window.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && bubble.classList.contains('is-visible')) {
+          e.preventDefault();
+          hideTooltip();
+          if (announcer) {
+            announcer.textContent = 'Tooltip dismissed.';
+          }
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/tooltip/style.css
+++ b/submissions/examples/tooltip/style.css
@@ -1,0 +1,198 @@
+/* ============================================================
+   Accessibility Improvement — Tooltip Hover Delay & Escape Dismiss
+   Path: submissions/examples/tooltip-hover-escape-dismiss/style.css
+   ============================================================ */
+
+/* ── 1. Base Variables & Theme Tokens ────────────────────── */
+:root {
+  --bg-primary: #0f172a;
+  --surface-card: #1e293b;
+  --surface-border: #334155;
+  --text-main: #f8fafc;
+  --text-muted: #cbd5e1;
+  --btn-bg: #0284c7;
+  --btn-hover: #0369a1;
+  --tooltip-bg: #020617;
+  --tooltip-border: #475569;
+  --tooltip-text: #f8fafc;
+
+  /* Focus Ring Tokens */
+  --focus-ring-inner: #ffffff;
+  --focus-ring-outer: #0f172a;
+  --focus-ring-glow: #00f3ff;
+
+  --transition-speed: 0.2s;
+  --transition-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  line-height: 1.5;
+}
+
+/* ── 2. Screen Reader Utility ────────────────────────────── */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* ── 3. Layout Card ──────────────────────────────────────── */
+main {
+  width: 100%;
+  max-width: 540px;
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.4);
+}
+
+h1 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-main);
+}
+
+p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ── 4. Accessible Tooltip Container & Trigger ───────────── */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+  margin-top: 1rem;
+}
+
+.tooltip-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background-color: var(--btn-bg);
+  color: #ffffff;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition: background-color var(--transition-speed) ease;
+}
+
+.tooltip-trigger:hover {
+  background-color: var(--btn-hover);
+}
+
+/* Dual-Layer Focus Ring (WCAG 2.4.7) */
+.tooltip-trigger:focus-visible {
+  outline: 3px solid var(--focus-ring-inner) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 5px var(--focus-ring-outer),
+              0 0 0 7px var(--focus-ring-glow) !important;
+}
+
+/* ── 5. Tooltip Element (WCAG 1.4.13 Content on Hover/Focus) ─ */
+.tooltip-bubble {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-text);
+  border: 1px solid var(--tooltip-border);
+  padding: 0.5rem 0.875rem;
+  border-radius: 6px;
+  font-size: 0.825rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  box-shadow: 0 10px 20px -5px rgba(0, 0, 0, 0.5);
+  pointer-events: auto; /* WCAG 1.4.13: Must be hoverable directly */
+  opacity: 0;
+  visibility: hidden;
+  will-change: opacity, transform;
+  transition: opacity var(--transition-speed) var(--transition-ease),
+              transform var(--transition-speed) var(--transition-ease),
+              visibility var(--transition-speed);
+  z-index: 100;
+}
+
+/* Tooltip Pointer Arrow */
+.tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-style: solid;
+  border-color: var(--tooltip-border) transparent transparent transparent;
+}
+
+/* Active State */
+.tooltip-bubble.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ── 6. Reduced Motion (WCAG 2.3.3) ──────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-trigger,
+  .tooltip-bubble {
+    transition: none !important;
+    transform: translateX(-50%) !important;
+  }
+}
+
+/* ── 7. Forced Colors / High Contrast Mode (WCAG 1.4.11) ─── */
+@media (forced-colors: active) {
+  .tooltip-trigger {
+    border: 2px solid ButtonText !important;
+    background-color: ButtonFace !important;
+    color: ButtonText !important;
+  }
+
+  .tooltip-trigger:focus-visible {
+    outline: 3px solid Highlight !important;
+    outline-offset: 4px !important;
+    box-shadow: none !important;
+  }
+
+  .tooltip-bubble {
+    border: 2px solid CanvasText !important;
+    background-color: Canvas !important;
+    color: CanvasText !important;
+  }
+
+  .tooltip-bubble::after {
+    border-color: CanvasText transparent transparent transparent !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- This PR introduces an accessible, WCAG 2.1 AA compliant **Tooltip Component** that implements intentional hover delays, persistent hoverable tooltip content, keyboard focus support, and instant `Escape` key dismissal without shifting keyboard focus. -->

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- A WCAG 2.1 AA compliant tooltip pattern resolving WCAG 1.4.13 (Content on Hover or Focus) issues by making tooltips dismissible with <kbd>Escape</kbd>, hoverable, persistent, and screen reader accessible via `aria-describedby`. -->

**How does a developer use it?**

```html
<!-- <div class="tooltip-wrapper">
  <button type="button" class="tooltip-trigger" aria-describedby="tip-1">Action</button>
  <div id="tip-1" class="tooltip-bubble" role="tooltip" aria-hidden="true">Helpful Info</div>
</div> -->
```

**Why does it fit EaseMotion CSS?**

<!-- It integrates subtle, GPU-accelerated CSS opacity and transform transitions with an accessible, keyboard-first interaction model that respects prefers-reduced-motion: reduce and High Contrast Mode.-->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #86292