### PR TITLE
Css custom property override runtime submission 86357

### DIFF
--- a/submissions/examples/css-custom-property-override/README.md
+++ b/submissions/examples/css-custom-property-override/README.md
@@ -1,0 +1,20 @@
+# Documentation: CSS Custom Property Override Runtime (#86357)
+
+Comprehensive guide, API reference, and Vitest unit test suite for the EaseMotion **CSS Custom Property Override Runtime** component (`#86357`), placed inside the required `submissions/examples/` folder.
+
+## 🚀 Overview & Features
+
+- **Runtime Custom Property Management:** Programmatically set, retrieve, and reset CSS custom properties on any DOM element with robust input validation.
+- **Automated Vitest Suite:** Full test coverage covering happy paths, multi-hyphen edge cases, and invalid inputs.
+
+## 🛠️ Usage Example
+
+```typescript
+import { CSSPropertyOverrideRuntime } from "./css-property-override";
+
+const element = document.getElementById("my-card")!;
+const runtime = new CSSPropertyOverrideRuntime(element);
+
+runtime.setProperty("--em-speed", "0.4s");
+console.log(runtime.getProperty("--em-speed")); // "0.4s"
+runtime.resetProperty("--em-speed");

--- a/submissions/examples/css-custom-property-override/css-custom-property-override.test.ts
+++ b/submissions/examples/css-custom-property-override/css-custom-property-override.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { CSSPropertyOverrideRuntime } from "./css-property-override";
+
+describe("CSSPropertyOverrideRuntime", () => {
+  let container: HTMLElement;
+  let runtime: CSSPropertyOverrideRuntime;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    runtime = new CSSPropertyOverrideRuntime(container);
+  });
+
+  describe("Happy Path", () => {
+    it("should successfully set and get a custom CSS property", () => {
+      runtime.setProperty("--em-speed", "0.5s");
+      expect(runtime.getProperty("--em-speed")).toBe("0.5s");
+    });
+
+    it("should allow overriding multiple properties", () => {
+      runtime.setProperty("--em-color", "#8b5cf6");
+      runtime.setProperty("--em-radius", "16px");
+      expect(runtime.getProperty("--em-color")).toBe("#8b5cf6");
+      expect(runtime.getProperty("--em-radius")).toBe("16px");
+    });
+
+    it("should reset custom properties correctly", () => {
+      runtime.setProperty("--em-speed", "0.4s");
+      expect(runtime.getProperty("--em-speed")).toBe("0.4s");
+      runtime.resetProperty("--em-speed");
+      expect(runtime.getProperty("--em-speed")).toBe("");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle property names with multiple hyphens", () => {
+      runtime.setProperty("--em-card-bg-opacity", "0.9");
+      expect(runtime.getProperty("--em-card-bg-opacity")).toBe("0.9");
+    });
+
+    it("should handle numerical string values correctly", () => {
+      runtime.setProperty("--em-zIndex", "1050");
+      expect(runtime.getProperty("--em-zIndex")).toBe("1050");
+    });
+  });
+
+  describe("Invalid Inputs & Error Handling", () => {
+    it("should throw an error when initialized with an invalid element", () => {
+      expect(() => new CSSPropertyOverrideRuntime(null as any)).toThrowError(
+        /Invalid element provided/
+      );
+    });
+
+    it("should throw an error for property names not starting with '--'", () => {
+      expect(() => runtime.setProperty("color", "red")).toThrowError(
+        /Invalid custom property name/
+      );
+      expect(() => runtime.getProperty("background")).toThrowError(
+        /Invalid custom property name/
+      );
+      expect(() => runtime.resetProperty("padding")).toThrowError(
+        /Invalid custom property name/
+      );
+    });
+
+    it("should throw an error when assigning empty or null values", () => {
+      expect(() => runtime.setProperty("--em-speed", "")).toThrowError(
+        /Invalid value for custom property/
+      );
+      expect(() => runtime.setProperty("--em-speed", null as any)).toThrowError(
+        /Invalid value for custom property/
+      );
+    });
+  });
+});

--- a/submissions/examples/css-custom-property-override/css-property-override.ts
+++ b/submissions/examples/css-custom-property-override/css-property-override.ts
@@ -1,0 +1,55 @@
+/**
+ * EaseMotion CSS Custom Property Override Runtime
+ * Issue #86357
+ */
+
+export class CSSPropertyOverrideRuntime {
+  private element: HTMLElement;
+  private defaultValues: Map<string, string> = new Map();
+
+  constructor(element: HTMLElement) {
+    if (!element || !(element instanceof HTMLElement)) {
+      throw new Error("Invalid element provided to CSSPropertyOverrideRuntime");
+    }
+    this.element = element;
+  }
+
+  public setProperty(property: string, value: string): void {
+    if (!property || typeof property !== "string" || !property.startsWith("--")) {
+      throw new Error(`Invalid custom property name: "${property}". Must start with "--".`);
+    }
+    if (value === undefined || value === null || (typeof value === "string" && value.trim() === "")) {
+      throw new Error(`Invalid value for custom property "${property}"`);
+    }
+
+    if (!this.defaultValues.has(property)) {
+      const current = getComputedStyle(this.element).getPropertyValue(property).trim();
+      this.defaultValues.set(property, current);
+    }
+
+    this.element.style.setProperty(property, value);
+  }
+
+  public getProperty(property: string): string {
+    if (!property || !property.startsWith("--")) {
+      throw new Error(`Invalid custom property name: "${property}"`);
+    }
+    return this.element.style.getPropertyValue(property).trim() || getComputedStyle(this.element).getPropertyValue(property).trim();
+  }
+
+  public resetProperty(property: string): void {
+    if (!property || !property.startsWith("--")) {
+      throw new Error(`Invalid custom property name: "${property}"`);
+    }
+    if (this.defaultValues.has(property)) {
+      const defaultVal = this.defaultValues.get(property);
+      if (defaultVal) {
+        this.element.style.setProperty(property, defaultVal);
+      } else {
+        this.element.style.removeProperty(property);
+      }
+    } else {
+      this.element.style.removeProperty(property);
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Description

This PR introduces the automated Vitest unit tests and runtime implementation for the EaseMotion **CSS Custom Property Override Runtime** component (`#86357`), placed strictly inside the required `submissions/examples/css-custom-property-override/` folder to comply with CI guardrails.

**Key Additions:**
* **Runtime Implementation (`submissions/examples/css-custom-property-override/css-property-override.ts`)**: Added robust class handling custom property setting, retrieval, default fallback caching, and strict input validation.
* **Vitest Unit Spec (`submissions/examples/css-custom-property-override/css-custom-property-override.test.ts`)**: Implemented complete test coverage spanning happy paths, multi-hyphen edge cases, and robust validation for invalid element/property/value inputs.
* **Documentation (`submissions/examples/css-custom-property-override/README.md`)**: Comprehensive guide and usage instructions.

---

## Type of Change

- [x] 🧪 Testing & Unit Specs (`test`)
- [x] ✨ Runtime Feature & Implementation (`feat`)
- [ ] 🐛 Bug fix
- [ ] Other (describe below)

---

## Submission Checklist

- [x] Placed all submission files strictly inside `submissions/examples/css-custom-property-override/`.
- [x] Covered happy path, edge cases, and invalid input error handling.
- [x] Verified 100% test assertions pass successfully with clean test runs.

Closes #86357