### PR TITLE
feat: add metric tiles component

### DIFF
--- a/submissions/examples/metric-tiles-86860/README.md
+++ b/submissions/examples/metric-tiles-86860/README.md
@@ -1,0 +1,15 @@
+# Metric Tiles
+
+A responsive KPI dashboard row with animated trend indicators and icons that spin on hover or keyboard focus.
+
+## Features
+
+- Responsive three-tile layout
+- Hover and keyboard-focus motion
+- Positive, neutral, and negative trend states
+- Reduced-motion support
+- Dependency-free HTML and CSS
+
+## Usage
+
+Open `demo.html` in a browser and hover or focus a metric tile.

--- a/submissions/examples/metric-tiles-86860/demo.html
+++ b/submissions/examples/metric-tiles-86860/demo.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Metric Tiles</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="dashboard">
+      <header class="dashboard__header">
+        <div>
+          <p class="eyebrow">Weekly overview</p>
+          <h1>Product pulse</h1>
+        </div>
+        <span class="status"><span aria-hidden="true"></span> Live</span>
+      </header>
+
+      <section class="metric-grid" aria-label="Key performance indicators">
+        <article class="metric" tabindex="0">
+          <div class="metric__top">
+            <span class="metric__icon" aria-hidden="true">&#8599;</span>
+            <span class="delta delta--up">+12.4%</span>
+          </div>
+          <p class="metric__label">Monthly revenue</p>
+          <p class="metric__value">$84.2K</p>
+          <p class="metric__context">$9.3K above last month</p>
+        </article>
+
+        <article class="metric" tabindex="0">
+          <div class="metric__top">
+            <span class="metric__icon metric__icon--amber" aria-hidden="true"
+              >&#9678;</span
+            >
+            <span class="delta delta--steady">+0.8%</span>
+          </div>
+          <p class="metric__label">Conversion rate</p>
+          <p class="metric__value">7.6%</p>
+          <p class="metric__context">Holding above target</p>
+        </article>
+
+        <article class="metric" tabindex="0">
+          <div class="metric__top">
+            <span class="metric__icon metric__icon--rose" aria-hidden="true"
+              >&#8645;</span
+            >
+            <span class="delta delta--down">-3.1%</span>
+          </div>
+          <p class="metric__label">Support backlog</p>
+          <p class="metric__value">126</p>
+          <p class="metric__context">4 fewer unresolved tickets</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/metric-tiles-86860/style.css
+++ b/submissions/examples/metric-tiles-86860/style.css
@@ -1,0 +1,228 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: #090d14;
+  color: #f7f9fc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    #090d14;
+  background-size: 32px 32px;
+}
+
+.dashboard {
+  width: min(1040px, 100%);
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.metric__label,
+.metric__value,
+.metric__context {
+  margin: 0;
+}
+
+.eyebrow {
+  margin-bottom: 6px;
+  color: #7f8a9f;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.65rem, 4vw, 2.4rem);
+  letter-spacing: 0;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #aeb7c8;
+  font-size: 0.85rem;
+}
+
+.status span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #35d59a;
+  box-shadow: 0 0 0 5px rgba(53, 213, 154, 0.12);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.metric {
+  position: relative;
+  min-width: 0;
+  padding: 22px;
+  overflow: hidden;
+  border: 1px solid #252c39;
+  border-radius: 8px;
+  background: #111721;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.22);
+  transition:
+    border-color 220ms ease,
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.metric::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #67e8b9, transparent);
+  transform: scaleX(0);
+  transition: transform 300ms ease;
+}
+
+.metric:hover,
+.metric:focus-visible {
+  border-color: #435064;
+  outline: none;
+  transform: translateY(-5px);
+  box-shadow: 0 22px 54px rgba(0, 0, 0, 0.32);
+}
+
+.metric:hover::after,
+.metric:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.metric__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.metric__icon {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: 8px;
+  background: rgba(53, 213, 154, 0.12);
+  color: #67e8b9;
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.metric__icon--amber {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.metric__icon--rose {
+  background: rgba(251, 113, 133, 0.12);
+  color: #fb7185;
+}
+
+.metric:hover .metric__icon,
+.metric:focus-visible .metric__icon {
+  animation: icon-spin 600ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.delta {
+  padding: 5px 8px;
+  border-radius: 6px;
+  font-size: 0.76rem;
+  font-weight: 800;
+  transition: transform 220ms ease;
+}
+
+.metric:hover .delta,
+.metric:focus-visible .delta {
+  transform: translateY(-3px);
+}
+
+.delta--up {
+  background: rgba(53, 213, 154, 0.12);
+  color: #67e8b9;
+}
+
+.delta--steady {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.delta--down {
+  background: rgba(251, 113, 133, 0.12);
+  color: #fb7185;
+}
+
+.metric__label {
+  color: #8f9aae;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.metric__value {
+  margin-top: 7px;
+  font-size: clamp(1.8rem, 4vw, 2.35rem);
+  font-weight: 800;
+}
+
+.metric__context {
+  margin-top: 8px;
+  color: #687386;
+  font-size: 0.8rem;
+}
+
+@keyframes icon-spin {
+  70% {
+    transform: rotate(390deg) scale(1.08);
+  }
+
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}
+
+@media (max-width: 760px) {
+  body {
+    padding: 24px 18px;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a responsive metric tiles component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers icon spin, animated deltas, keyboard focus, and reduced motion.

Fixes #86860

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.