### PR TITLE
a11y(skip-link): implement WCAG 2.1 AA compliant skip navigation with anchor target programmatic focus`

### DIFF
--- a/submissions/examples/skip-link-target-focus/README.md
+++ b/submissions/examples/skip-link-target-focus/README.md
@@ -1,0 +1,22 @@
+# Skip Link Navigation Anchor Target Focus
+
+An audited, WCAG 2.1 AA compliant skip link pattern ensuring programmatic focus transfer to `<main tabindex="-1">`, smooth reveal on keyboard focus, and Windows High Contrast Mode support.
+
+## 🌟 Features & Accessibility Fixes
+
+* **Programmatic Focus Transfer (WCAG 2.4.1):** Pairs `href="#main-content"` with `mainContent.focus()`, ensuring screen readers and keyboard cursors shift directly past repetitive navigation landmarks.
+* **Accessible Landmark Container (WCAG 1.3.1):** Encapsulates the skip link inside `<nav aria-label="Skip links">`.
+* **Offscreen-to-Focus Animation (WCAG 2.4.7):** Positioned offscreen by default and slides into view upon `:focus-visible` with a dual-layer focus outline.
+* **Live Region Status Announcements (WCAG 4.1.3):** Relays navigation confirmation (*"Navigated to main content."*) to NVDA, VoiceOver, and JAWS via a polite live region.
+* **High Contrast Mode Support (`forced-colors: active`):** Binds borders and outlines to `ButtonText`, `ButtonFace`, and `Highlight`.
+
+## 🚀 Usage
+
+```html
+<nav aria-label="Skip links">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+</nav>
+
+<main id="main-content" tabindex="-1">
+  <!-- Primary page content -->
+</main>

--- a/submissions/examples/skip-link-target-focus/demo.html
+++ b/submissions/examples/skip-link-target-focus/demo.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skip Link Navigation Anchor Target Focus Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Screen Reader Live Region for Announcements -->
+  <div 
+    id="skip-live-announcer" 
+    class="sr-only" 
+    role="status" 
+    aria-live="polite" 
+    aria-atomic="true"
+  ></div>
+
+  <!-- ACCESSIBLE SKIP NAVIGATION LANDMARK -->
+  <nav class="skip-link-nav" aria-label="Skip links">
+    <a href="#main-content" id="skip-link" class="skip-link">
+      <span>Skip to main content</span>
+      <span aria-hidden="true">↓</span>
+    </a>
+  </nav>
+
+  <!-- REPETITIVE HEADER NAVIGATION -->
+  <header class="site-header" role="banner">
+    <strong style="color: var(--text-main); font-size: 0.95rem;">App Branding</strong>
+    <nav aria-label="Header Menu">
+      <ul class="nav-list">
+        <li><a href="#link-1" class="nav-link">Features</a></li>
+        <li><a href="#link-2" class="nav-link">Docs</a></li>
+        <li><a href="#link-3" class="nav-link">Pricing</a></li>
+        <li><a href="#link-4" class="nav-link">Support</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <!-- MAIN TARGET CONTAINER (tabindex="-1" for programmatic focus) -->
+  <main id="main-content" class="main-content" tabindex="-1" aria-labelledby="main-heading">
+    <h1 id="main-heading">Main Content Destination</h1>
+    <p>
+      Press <kbd>Tab</kbd> from the address bar to reveal the skip link at the top left. 
+      Activating the link with <kbd>Enter</kbd> or <kbd>Space</kbd> bypasses repetitive header links, 
+      transfers programmatic focus directly to this <code>&lt;main&gt;</code> container, and 
+      announces the location shift to screen readers.
+    </p>
+    <div>
+      <button type="button" class="action-btn">Primary Action in Main</button>
+    </div>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const skipLink = document.getElementById('skip-link');
+      const mainContent = document.getElementById('main-content');
+      const announcer = document.getElementById('skip-live-announcer');
+
+      if (!skipLink || !mainContent) return;
+
+      skipLink.addEventListener('click', (e) => {
+        e.preventDefault();
+
+        // Shift programmatic focus directly to the target landmark (WCAG 2.4.1)
+        mainContent.focus();
+        mainContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        if (announcer) {
+          announcer.textContent = '';
+          setTimeout(() => {
+            announcer.textContent = 'Navigated to main content.';
+          }, 50);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/skip-link-target-focus/style.css
+++ b/submissions/examples/skip-link-target-focus/style.css
@@ -1,0 +1,225 @@
+/* ============================================================
+   Accessibility Improvement — Skip Link Navigation Target Focus
+   Path: submissions/examples/skip-link-target-focus/style.css
+   ============================================================ */
+
+:root {
+  --bg-primary: #0f172a;
+  --surface-card: #1e293b;
+  --surface-border: #334155;
+  --text-main: #f8fafc;
+  --text-muted: #cbd5e1;
+  --accent-cyan: #38bdf8;
+  --btn-bg: #0284c7;
+  --btn-hover: #0369a1;
+
+  --focus-ring-inner: #ffffff;
+  --focus-ring-outer: #0f172a;
+  --focus-ring-glow: #00f3ff;
+
+  --transition-speed: 0.2s;
+  --transition-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-main);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2rem 1.5rem;
+  line-height: 1.6;
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* ── Accessible Skip Link Navigation ─────────────────────── */
+.skip-link-nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background-color: var(--btn-bg);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-decoration: none;
+  border-radius: 0 0 8px 8px;
+  border: 2px solid var(--accent-cyan);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  transition: top var(--transition-speed) var(--transition-ease);
+}
+
+/* Focus Visible State (Slides into View on Tab) */
+.skip-link:focus-visible {
+  top: 0;
+  outline: 3px solid var(--focus-ring-inner) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 5px var(--focus-ring-outer),
+              0 0 0 7px var(--focus-ring-glow),
+              0 10px 25px rgba(0, 0, 0, 0.6) !important;
+}
+
+/* ── Header Navigation Banner ────────────────────────────── */
+.site-header {
+  width: 100%;
+  max-width: 680px;
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-list {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+}
+
+.nav-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  transition: color var(--transition-speed) ease, background-color var(--transition-speed) ease;
+}
+
+.nav-link:hover {
+  color: var(--text-main);
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
+
+/* ── Main Content Target ─────────────────────────────────── */
+.main-content {
+  width: 100%;
+  max-width: 680px;
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.4);
+  outline: none;
+}
+
+/* Visual cue when main content receives programmatic focus */
+.main-content:focus-visible {
+  border-color: var(--accent-cyan);
+  box-shadow: 0 0 0 2px var(--accent-cyan),
+              0 10px 25px -5px rgba(0, 0, 0, 0.5);
+}
+
+h1 {
+  font-size: 1.45rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--text-main);
+}
+
+p {
+  color: var(--text-muted);
+  font-size: 0.925rem;
+  margin-bottom: 1.25rem;
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.2rem;
+  background-color: var(--btn-bg);
+  color: #ffffff;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition: background-color var(--transition-speed) ease;
+}
+
+.action-btn:hover {
+  background-color: var(--btn-hover);
+}
+
+.action-btn:focus-visible {
+  outline: 3px solid var(--focus-ring-inner) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 4px var(--focus-ring-outer),
+              0 0 0 6px var(--focus-ring-glow) !important;
+}
+
+/* ── Reduced Motion (WCAG 2.3.3) ─────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .skip-link,
+  .nav-link,
+  .action-btn {
+    transition: none !important;
+  }
+}
+
+/* ── Forced Colors Mode (WCAG 1.4.11) ────────────────────── */
+@media (forced-colors: active) {
+  .site-header,
+  .main-content {
+    border: 2px solid CanvasText !important;
+  }
+
+  .skip-link {
+    background-color: ButtonFace !important;
+    color: ButtonText !important;
+    border: 2px solid ButtonText !important;
+  }
+
+  .skip-link:focus-visible {
+    outline: 3px solid Highlight !important;
+    outline-offset: 3px !important;
+    box-shadow: none !important;
+  }
+
+  .main-content:focus-visible {
+    outline: 3px solid Highlight !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

<!-- This PR introduces an accessible, WCAG 2.1 AA compliant **Skip Link Navigation Component** that resolves bypass block requirements (WCAG 2.4.1) by ensuring programmatic focus shifts directly to `<main tabindex="-1">` upon activation, while providing keyboard visibility and High Contrast Mode support. -->

---

## Type of Change

- [x] ✨ New animation / hover effect
- [x] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

<!-- A WCAG 2.1 AA compliant skip link component utilizing `<main tabindex="-1">` programmatic focus management, offscreen-to-visible keyboard slide transitions, and dynamic `aria-live` navigation announcements. -->

**How does a developer use it?**

```html
<!-- <nav aria-label="Skip links">
  <a href="#main-content" class="skip-link">Skip to main content</a>
</nav>
<main id="main-content" tabindex="-1">...</main> -->
```

**Why does it fit EaseMotion CSS?**

<!--It pairs smooth CSS top/transform slide transitions with an essential accessibility pattern, fully supporting prefers-reduced-motion: reduce and High Contrast Mode with zero external dependencies. Explain how this fits the human-readable, animation-first philosophy -->

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [x] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---
close #86267