### PR TITLE
feat: add badge-ripple-pop component

### DIFF
--- a/submissions/examples/badge-ripple-pop/README.md
+++ b/submissions/examples/badge-ripple-pop/README.md
@@ -1,0 +1,20 @@
+# Badge Ripple Pop
+
+A notification badge pops with concentric ripple rings.
+
+## Features
+- Pop entrance
+- Ripple rings
+- Alert counter
+- Pure CSS
+
+## Usage
+```html
+<div class="brp-badge">3</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/badge-ripple-pop/demo.html
+++ b/submissions/examples/badge-ripple-pop/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Badge Ripple Pop &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="brp-wrap">
+  <div class="brp-badge">3</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/badge-ripple-pop/style.css
+++ b/submissions/examples/badge-ripple-pop/style.css
@@ -1,0 +1,39 @@
+.brp-wrap {
+  width: 70px;
+  height: 70px;
+  margin: 60px auto;
+  display: grid;
+  place-items: center;
+}
+.brp-badge {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: linear-gradient(140deg, #ff7a7a, #c23a64);
+  color: #fff;
+  font-weight: 800;
+  display: grid;
+  place-items: center;
+  font-size: 0.95rem;
+  animation: brp-pop 2.4s cubic-bezier(0.3, 1.6, 0.4, 1) infinite;
+}
+.brp-badge::before, .brp-badge::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 122, 122, 0.8);
+  animation: brp-ripple 2.4s ease-out infinite;
+}
+.brp-badge::after { animation-delay: 1.2s; }
+@keyframes brp-pop {
+  0%, 100% { transform: scale(1); }
+  25% { transform: scale(1.25); }
+  40% { transform: scale(0.9); }
+  55% { transform: scale(1.1); }
+}
+@keyframes brp-ripple {
+  0% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(2.2); opacity: 0; }
+}


### PR DESCRIPTION
## Summary

Add the **Badge Ripple Pop** component to the EaseMotion CSS gallery. This is a badge demo rendered with plain HTML and CSS.

**Description:** A notification badge pops with concentric ripple rings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/badge-ripple-pop/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A notification badge pops with concentric ripple rings.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the badge category in the gallery with a polished, reusable effect.

### Key features
- Pop entrance
- Ripple rings
- Alert counter
- Pure CSS

### Demo
Open `submissions/examples/badge-ripple-pop/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88205
