### PR TITLE
feat: add button-scratch-reveal component

### DIFF
--- a/submissions/examples/button-scratch-reveal/README.md
+++ b/submissions/examples/button-scratch-reveal/README.md
@@ -1,0 +1,20 @@
+# Button Scratch Reveal
+
+Hovering scrapes away a solid layer to reveal color underneath.
+
+## Features
+- Scratch-away layer
+- Clip-path reveal
+- Hand-drawn edge
+- Pure CSS
+
+## Usage
+```html
+<button class="bsr-btn">Scratch</button>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/button-scratch-reveal/demo.html
+++ b/submissions/examples/button-scratch-reveal/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button Scratch Reveal &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<button class="bsr-btn">Scratch</button>
+</body>
+</html>

--- a/submissions/examples/button-scratch-reveal/style.css
+++ b/submissions/examples/button-scratch-reveal/style.css
@@ -1,0 +1,28 @@
+.bsr-btn {
+  display: block;
+  margin: 80px auto;
+  padding: 15px 40px;
+  font-size: 1rem;
+  font-weight: 800;
+  border: 2px solid #c07aff;
+  border-radius: 10px;
+  background: #1a2233;
+  color: #fff;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.3s;
+}
+.bsr-btn::after {
+  content: "Scratch";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: linear-gradient(120deg, #c07aff, #6fb7ff);
+  color: #0f1726;
+  clip-path: inset(0 100% 0 0);
+  transition: clip-path 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.bsr-btn:hover { border-color: #c07aff; }
+.bsr-btn:hover::after { clip-path: inset(0 0 0 0); }


### PR DESCRIPTION
## Summary

Add the **Button Scratch Reveal** component to the EaseMotion CSS gallery. This is a button demo rendered with plain HTML and CSS.

**Description:** Hovering scrapes away a solid layer to reveal color underneath.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/button-scratch-reveal/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Hovering scrapes away a solid layer to reveal color underneath.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the button category in the gallery with a polished, reusable effect.

### Key features
- Scratch-away layer
- Clip-path reveal
- Hand-drawn edge
- Pure CSS

### Demo
Open `submissions/examples/button-scratch-reveal/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88176
