### PR TITLE
feat: add ranked leaderboard component

### DIFF
--- a/submissions/examples/leaderboard-86856/README.md
+++ b/submissions/examples/leaderboard-86856/README.md
@@ -1,0 +1,15 @@
+# Ranked Leaderboard
+
+A responsive leaderboard with a pinned champion row, animated rank accents, and clear score movement.
+
+## Features
+
+- Gold crown treatment for the top rank
+- Hover and keyboard-focus interactions
+- Responsive player rows
+- Accessible ordered ranking
+- Reduced-motion support
+
+## Usage
+
+Open `demo.html`, then hover or tab through the ranked players.

--- a/submissions/examples/leaderboard-86856/demo.html
+++ b/submissions/examples/leaderboard-86856/demo.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ranked Leaderboard</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="board">
+      <header class="board__header">
+        <div>
+          <p class="eyebrow">Weekly sprint</p>
+          <h1>Top contributors</h1>
+        </div>
+        <span class="season">Season 08</span>
+      </header>
+
+      <ol class="ranking">
+        <li class="player player--champion" tabindex="0">
+          <span class="rank"><i aria-hidden="true">&#9819;</i> 01</span>
+          <span class="avatar avatar--gold" aria-hidden="true">AK</span>
+          <span class="identity"
+            ><strong>Aarav Kapoor</strong><small>24 wins</small></span
+          >
+          <span class="trend trend--up">&#8593; 3</span>
+          <strong class="score">9,840</strong>
+        </li>
+        <li class="player" tabindex="0">
+          <span class="rank">02</span>
+          <span class="avatar avatar--cyan" aria-hidden="true">MR</span>
+          <span class="identity"
+            ><strong>Maya Rao</strong><small>21 wins</small></span
+          >
+          <span class="trend trend--up">&#8593; 1</span>
+          <strong class="score">9,210</strong>
+        </li>
+        <li class="player" tabindex="0">
+          <span class="rank">03</span>
+          <span class="avatar avatar--rose" aria-hidden="true">ZS</span>
+          <span class="identity"
+            ><strong>Zoya Shah</strong><small>19 wins</small></span
+          >
+          <span class="trend trend--down">&#8595; 1</span>
+          <strong class="score">8,760</strong>
+        </li>
+        <li class="player" tabindex="0">
+          <span class="rank">04</span>
+          <span class="avatar avatar--violet" aria-hidden="true">RN</span>
+          <span class="identity"
+            ><strong>Rohan Nair</strong><small>17 wins</small></span
+          >
+          <span class="trend">-</span>
+          <strong class="score">8,190</strong>
+        </li>
+      </ol>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/leaderboard-86856/style.css
+++ b/submissions/examples/leaderboard-86856/style.css
@@ -1,0 +1,237 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: #f6f7fb;
+  background: #090c12;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: radial-gradient(circle at 50% 0, #242035 0, #090c12 48%);
+}
+
+.board {
+  width: min(720px, 100%);
+  padding: clamp(20px, 5vw, 34px);
+  border: 1px solid #2b303b;
+  border-radius: 8px;
+  background: rgba(16, 20, 28, 0.96);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.46);
+}
+
+.board__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 26px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #808a9e;
+  font-size: 0.72rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.45rem, 5vw, 2rem);
+  letter-spacing: 0;
+}
+
+.season {
+  padding: 6px 9px;
+  border: 1px solid #353c49;
+  border-radius: 6px;
+  color: #a4aec0;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.ranking {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.player {
+  position: relative;
+  display: grid;
+  grid-template-columns: 52px 42px minmax(0, 1fr) 56px 70px;
+  align-items: center;
+  gap: 12px;
+  min-height: 68px;
+  padding: 12px 16px;
+  overflow: hidden;
+  border: 1px solid #272d38;
+  border-radius: 7px;
+  background: #151a23;
+  transition:
+    border-color 200ms ease,
+    transform 200ms ease,
+    background 200ms ease;
+}
+
+.player::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: #65d8ba;
+  transform: scaleY(0);
+  transition: transform 220ms ease;
+}
+
+.player:hover,
+.player:focus-visible {
+  border-color: #485264;
+  outline: none;
+  background: #1a202b;
+  transform: translateX(5px);
+}
+
+.player:hover::after,
+.player:focus-visible::after {
+  transform: scaleY(1);
+}
+
+.player--champion {
+  border-color: rgba(251, 191, 36, 0.36);
+  background: linear-gradient(90deg, rgba(251, 191, 36, 0.12), #171a22 55%);
+  box-shadow: 0 12px 34px rgba(251, 191, 36, 0.08);
+}
+
+.player--champion::after {
+  background: #fbbf24;
+  transform: scaleY(1);
+}
+
+.rank {
+  color: #7d8799;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.rank i {
+  display: inline-block;
+  margin-right: 3px;
+  color: #fbbf24;
+  font-size: 1rem;
+  font-style: normal;
+  filter: drop-shadow(0 0 7px rgba(251, 191, 36, 0.42));
+}
+
+.player--champion:hover .rank i,
+.player--champion:focus-visible .rank i {
+  animation: crown-bounce 520ms ease;
+}
+
+.avatar {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: 50%;
+  color: #0b1017;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.avatar--gold {
+  background: #fbbf24;
+}
+
+.avatar--cyan {
+  background: #67e8d2;
+}
+
+.avatar--rose {
+  background: #fb8fa3;
+}
+
+.avatar--violet {
+  background: #b7a2f7;
+}
+
+.identity {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.identity strong {
+  overflow: hidden;
+  font-size: 0.9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.identity small {
+  color: #737e91;
+  font-size: 0.72rem;
+}
+
+.trend {
+  color: #737e91;
+  font-size: 0.75rem;
+  font-weight: 750;
+  text-align: center;
+}
+
+.trend--up {
+  color: #65d8ba;
+}
+
+.trend--down {
+  color: #fb7185;
+}
+
+.score {
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+@keyframes crown-bounce {
+  50% {
+    transform: translateY(-4px) rotate(-9deg) scale(1.12);
+  }
+}
+
+@media (max-width: 560px) {
+  .player {
+    grid-template-columns: 34px 38px minmax(0, 1fr) 62px;
+    gap: 9px;
+    padding: 11px;
+  }
+
+  .trend {
+    display: none;
+  }
+
+  .avatar {
+    width: 36px;
+    height: 36px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds a responsive ranked leaderboard component demo under submissions/examples.
- Includes the required README, demo, and stylesheet.
- Covers a pinned champion row, gold crown motion, keyboard focus, and reduced motion.

Fixes #86856

## Checklist
- [x] I have followed the contribution guidelines.
- [x] I have tested my changes locally.
- [x] My changes are scoped to the linked issue.