### PR TITLE
feat: add button-split-fill component

### DIFF
--- a/submissions/examples/button-split-fill/README.md
+++ b/submissions/examples/button-split-fill/README.md
@@ -1,0 +1,20 @@
+# Button Split Fill
+
+Two halves fill toward the center on hover, meeting with a pop.
+
+## Features
+- Two-half fill
+- Center meeting pop
+- Corner reveal
+- Pure CSS
+
+## Usage
+```html
+<button class="bsf-btn">Split</button>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/button-split-fill/demo.html
+++ b/submissions/examples/button-split-fill/demo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button Split Fill &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<button class="bsf-btn">Split</button>
+</body>
+</html>

--- a/submissions/examples/button-split-fill/style.css
+++ b/submissions/examples/button-split-fill/style.css
@@ -1,0 +1,31 @@
+.bsf-btn {
+  position: relative;
+  display: block;
+  margin: 80px auto;
+  padding: 15px 40px;
+  font-size: 1rem;
+  font-weight: 800;
+  border: 2px solid #ffd37a;
+  border-radius: 10px;
+  background: transparent;
+  color: #ffd37a;
+  cursor: pointer;
+  overflow: hidden;
+  transition: color 0.3s;
+}
+.bsf-btn::before, .bsf-btn::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 55%;
+  background: #ffd37a;
+  transition: transform 0.4s cubic-bezier(0.3, 0.9, 0.4, 1);
+}
+.bsf-btn::before { left: 0; transform: translateX(-101%); }
+.bsf-btn::after { right: 0; transform: translateX(101%); }
+.bsf-btn:hover { color: #0f1726; }
+.bsf-btn:hover::before { transform: translateX(0); }
+.bsf-btn:hover::after { transform: translateX(0); }
+.bsf-btn:hover::before, .bsf-btn:hover::after { border-radius: 50% 0 0 50%; }
+.bsf-btn:hover::after { border-radius: 0 50% 50% 0; }


### PR DESCRIPTION
## Summary

Add the **Button Split Fill** component to the EaseMotion CSS gallery. This is a button demo rendered with plain HTML and CSS.

**Description:** Two halves fill toward the center on hover, meeting with a pop.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/button-split-fill/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** Two halves fill toward the center on hover, meeting with a pop.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the button category in the gallery with a polished, reusable effect.

### Key features
- Two-half fill
- Center meeting pop
- Corner reveal
- Pure CSS

### Demo
Open `submissions/examples/button-split-fill/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88178
