### PR TITLE
feat: add card-flip-rotate component

### DIFF
--- a/submissions/examples/card-flip-rotate/README.md
+++ b/submissions/examples/card-flip-rotate/README.md
@@ -1,0 +1,20 @@
+# Card Flip Rotate
+
+A card flips while rotating, revealing alternate gradient faces.
+
+## Features
+- Flip + rotate combo
+- Two gradient faces
+- Continuous loop
+- Pure CSS
+
+## Usage
+```html
+<div class="cfr-card"><div class="cfr-a">A</div><div class="cfr-b">B</div></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-flip-rotate/demo.html
+++ b/submissions/examples/card-flip-rotate/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Flip Rotate &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cfr-scene">
+  <div class="cfr-card">
+    <div class="cfr-face cfr-a">A</div>
+    <div class="cfr-face cfr-b">B</div>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-flip-rotate/style.css
+++ b/submissions/examples/card-flip-rotate/style.css
@@ -1,0 +1,31 @@
+.cfr-scene {
+  perspective: 800px;
+  width: 190px;
+  height: 190px;
+  margin: 80px auto;
+}
+.cfr-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  animation: cfr-flip 4.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+.cfr-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0f1726;
+  border-radius: 50%;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+.cfr-a { background: radial-gradient(circle at 30% 30%, #ffd37a, #d9a23a); }
+.cfr-b { background: radial-gradient(circle at 70% 70%, #7ad4ff, #3a7ac4); transform: rotateY(180deg); }
+@keyframes cfr-flip {
+  0%, 100% { transform: rotateY(0) rotate(0); }
+  50% { transform: rotateY(180deg) rotate(180deg); }
+}


### PR DESCRIPTION
## Summary

Add the **Card Flip Rotate** component to the EaseMotion CSS gallery. This is a card demo rendered with plain HTML and CSS.

**Description:** A card flips while rotating, revealing alternate gradient faces.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-flip-rotate/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A card flips while rotating, revealing alternate gradient faces.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the card category in the gallery with a polished, reusable effect.

### Key features
- Flip + rotate combo
- Two gradient faces
- Continuous loop
- Pure CSS

### Demo
Open `submissions/examples/card-flip-rotate/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88183
