### PR TITLE
feat: add card-stack-overlap component

### DIFF
--- a/submissions/examples/card-stack-overlap/README.md
+++ b/submissions/examples/card-stack-overlap/README.md
@@ -1,0 +1,20 @@
+# Card Stack Overlap
+
+A stack of cards fanned backward settles into neat overlap.
+
+## Features
+- Fanned stack
+- Offset layers
+- Settle entrance
+- Pure CSS
+
+## Usage
+```html
+<div class="cso-card" style="--i:0">A</div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/card-stack-overlap/demo.html
+++ b/submissions/examples/card-stack-overlap/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Card Stack Overlap &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="cso-stack">
+  <div class="cso-card" style="--i:0">A</div>
+  <div class="cso-card" style="--i:1">B</div>
+  <div class="cso-card" style="--i:2">C</div>
+  <div class="cso-card" style="--i:3">D</div>
+</div>
+</body>
+</html>

--- a/submissions/examples/card-stack-overlap/style.css
+++ b/submissions/examples/card-stack-overlap/style.css
@@ -1,0 +1,24 @@
+.cso-stack {
+  position: relative;
+  width: 150px;
+  height: 200px;
+  margin: 80px auto;
+}
+.cso-card {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.3rem;
+  font-weight: 800;
+  border-radius: 12px;
+  color: #0f1726;
+  background: linear-gradient(140deg, hsl(calc(210 + var(--i) * 30) 70% 65%), hsl(calc(210 + var(--i) * 30) 60% 45%));
+  animation: cso-settle 3.2s cubic-bezier(0.3, 1.2, 0.4, 1) infinite;
+  animation-delay: calc(var(--i) * 0.18s);
+  transform-origin: bottom center;
+}
+@keyframes cso-settle {
+  0%, 100% { transform: translateY(calc(var(--i) * -8px)) scale(calc(1 - var(--i) * 0.06)); }
+  40% { transform: translateY(calc(var(--i) * -24px)) rotate(calc(var(--i) * 4deg)); }
+}


### PR DESCRIPTION
## Summary

Add the **Card Stack Overlap** component to the EaseMotion CSS gallery. This is a card demo rendered with plain HTML and CSS.

**Description:** A stack of cards fanned backward settles into neat overlap.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/card-stack-overlap/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A stack of cards fanned backward settles into neat overlap.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the card category in the gallery with a polished, reusable effect.

### Key features
- Fanned stack
- Offset layers
- Settle entrance
- Pure CSS

### Demo
Open `submissions/examples/card-stack-overlap/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88180
