### PR TITLE
feat: add chart-radar-draw component

### DIFF
--- a/submissions/examples/chart-radar-draw/README.md
+++ b/submissions/examples/chart-radar-draw/README.md
@@ -1,0 +1,20 @@
+# Chart Radar Draw
+
+A radar chart's grid and data polygon draw themselves out.
+
+## Features
+- SVG path draw
+- Grid + data layers
+- Stroke dash timing
+- Pure CSS
+
+## Usage
+```html
+<svg class="crd-svg"><polygon class="crd-data" .../></svg>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/chart-radar-draw/demo.html
+++ b/submissions/examples/chart-radar-draw/demo.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chart Radar Draw &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="crd-wrap">
+  <svg class="crd-svg" viewBox="0 0 200 200">
+    <polygon class="crd-grid" points="100,20 175,68 152,152 48,152 25,68"/>
+    <polygon class="crd-data" points="100,50 150,80 130,130 70,130 55,80"/>
+  </svg>
+</div>
+</body>
+</html>

--- a/submissions/examples/chart-radar-draw/style.css
+++ b/submissions/examples/chart-radar-draw/style.css
@@ -1,0 +1,18 @@
+.crd-wrap {
+  width: min(260px, 80vw);
+  margin: 60px auto;
+}
+.crd-svg { width: 100%; display: block; }
+.crd-grid, .crd-data { fill: none; stroke-width: 2; stroke-linejoin: round; }
+.crd-grid { stroke: #2b3855; stroke-dasharray: 400; stroke-dashoffset: 400; animation: crd-draw 1.6s linear infinite; }
+.crd-data {
+  stroke: #6fb7ff;
+  fill: rgba(111, 183, 255, 0.25);
+  stroke-dasharray: 320;
+  stroke-dashoffset: 320;
+  animation: crd-draw 2.4s linear infinite;
+  animation-delay: 0.8s;
+}
+@keyframes crd-draw {
+  to { stroke-dashoffset: 0; }
+}


### PR DESCRIPTION
## Summary

Add the **Chart Radar Draw** component to the EaseMotion CSS gallery. This is a charts demo rendered with plain HTML and CSS.

**Description:** A radar chart's grid and data polygon draw themselves out.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/chart-radar-draw/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A radar chart's grid and data polygon draw themselves out.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the charts category in the gallery with a polished, reusable effect.

### Key features
- SVG path draw
- Grid + data layers
- Stroke dash timing
- Pure CSS

### Demo
Open `submissions/examples/chart-radar-draw/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88201
