### PR TITLE
feat: add nav-mega-dropdown component

### DIFF
--- a/submissions/examples/nav-mega-dropdown/README.md
+++ b/submissions/examples/nav-mega-dropdown/README.md
@@ -1,0 +1,20 @@
+# Nav Mega Dropdown
+
+A navigation item opens a wide mega-menu panel with stagger.
+
+## Features
+- Wide mega panel
+- Staggered link reveal
+- Caret flip
+- Pure CSS
+
+## Usage
+```html
+<nav class="nmd-nav"><div class="nmd-trigger">Products</div><div class="nmd-panel">...</div></nav>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/nav-mega-dropdown/demo.html
+++ b/submissions/examples/nav-mega-dropdown/demo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nav Mega Dropdown &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<nav class="nmd-nav">
+  <div class="nmd-trigger">Products <span class="nmd-caret"></span></div>
+  <div class="nmd-panel">
+    <a href="#">Analytics</a>
+    <a href="#">Integrations</a>
+    <a href="#">Automations</a>
+    <a href="#">Reports</a>
+  </div>
+</nav>
+</body>
+</html>

--- a/submissions/examples/nav-mega-dropdown/style.css
+++ b/submissions/examples/nav-mega-dropdown/style.css
@@ -1,0 +1,66 @@
+.nmd-nav {
+  position: relative;
+  width: fit-content;
+  margin: 80px auto;
+}
+.nmd-trigger {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  border-radius: 10px;
+  color: #cfe0f5;
+  font-weight: 700;
+  cursor: pointer;
+}
+.nmd-caret {
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 7px solid #8fd0ff;
+  transition: transform 0.3s;
+  animation: nmd-flip 3.5s steps(1) infinite;
+}
+.nmd-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 420px;
+  max-width: 90vw;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 14px;
+  background: #141a28;
+  border: 1px solid #2b3855;
+  border-radius: 12px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition: opacity 0.25s, transform 0.25s, visibility 0.25s;
+}
+.nmd-panel a {
+  padding: 10px;
+  border-radius: 8px;
+  color: #cfe0f5;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.nmd-panel a:hover { background: #1f2b44; }
+.nmd-nav:hover .nmd-panel { opacity: 1; visibility: visible; transform: translateY(0); }
+.nmd-nav:hover .nmd-panel a { animation: nmd-in 0.3s ease both; }
+.nmd-panel a:nth-child(1) { animation-delay: 0.05s; }
+.nmd-panel a:nth-child(2) { animation-delay: 0.1s; }
+.nmd-panel a:nth-child(3) { animation-delay: 0.15s; }
+.nmd-panel a:nth-child(4) { animation-delay: 0.2s; }
+@keyframes nmd-flip {
+  0%, 45% { transform: rotate(0); }
+  60%, 100% { transform: rotate(180deg); }
+}
+@keyframes nmd-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary

Add the **Nav Mega Dropdown** component to the EaseMotion CSS gallery. This is a nav demo rendered with plain HTML and CSS.

**Description:** A navigation item opens a wide mega-menu panel with stagger.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/nav-mega-dropdown/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A navigation item opens a wide mega-menu panel with stagger.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the nav category in the gallery with a polished, reusable effect.

### Key features
- Wide mega panel
- Staggered link reveal
- Caret flip
- Pure CSS

### Demo
Open `submissions/examples/nav-mega-dropdown/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88186
