### PR TITLE
feat: add stat-pulse-ring component

### DIFF
--- a/submissions/examples/stat-pulse-ring/README.md
+++ b/submissions/examples/stat-pulse-ring/README.md
@@ -1,0 +1,20 @@
+# Stat Pulse Ring
+
+A KPI number breathes while concentric rings pulse outward.
+
+## Features
+- Radiating pulse rings
+- Breathing value
+- Dashboard framing
+- Pure CSS
+
+## Usage
+```html
+<div class="spr-ring" style="--d:0s"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/stat-pulse-ring/demo.html
+++ b/submissions/examples/stat-pulse-ring/demo.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Pulse Ring &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="spr-wrap">
+  <div class="spr-ring" style="--d:0s"></div>
+  <div class="spr-ring" style="--d:0.8s"></div>
+  <div class="spr-core">
+    <strong>98%</strong>
+    <span>uptime</span>
+  </div>
+</div>
+</body>
+</html>

--- a/submissions/examples/stat-pulse-ring/style.css
+++ b/submissions/examples/stat-pulse-ring/style.css
@@ -1,0 +1,39 @@
+.spr-wrap {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  margin: 60px auto;
+  display: grid;
+  place-items: center;
+}
+.spr-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid rgba(123, 255, 176, 0.7);
+  animation: spr-pulse 2.4s ease-out infinite;
+  animation-delay: var(--d);
+}
+.spr-core {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  animation: spr-breathe 2.4s ease-in-out infinite;
+}
+.spr-core strong { font-size: 1.6rem; color: #7bffb0; }
+.spr-core span { font-size: 0.8rem; color: #8fa4c4; }
+@keyframes spr-pulse {
+  0% { transform: scale(0.7); opacity: 1; }
+  100% { transform: scale(1.5); opacity: 0; }
+}
+@keyframes spr-breathe {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.06); }
+}


### PR DESCRIPTION
## Summary

Add the **Stat Pulse Ring** component to the EaseMotion CSS gallery. This is a stats demo rendered with plain HTML and CSS.

**Description:** A KPI number breathes while concentric rings pulse outward.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/stat-pulse-ring/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A KPI number breathes while concentric rings pulse outward.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the stats category in the gallery with a polished, reusable effect.

### Key features
- Radiating pulse rings
- Breathing value
- Dashboard framing
- Pure CSS

### Demo
Open `submissions/examples/stat-pulse-ring/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #88203
