### PR TITLE
fix(ui): add spacing to Live Studio sidebar icon

### DIFF
--- a/submissions/examples/sidebar-space/README.md
+++ b/submissions/examples/sidebar-space/README.md
@@ -1,0 +1,10 @@
+# Bug 2 Fix: Sidebar Icon Spacing
+
+## Overview
+Corrects the cramped `🎮Live Studio` text in the sidebar navigation.
+
+## Changes
+1. Wrapped the text and icon in separate `<span>` tags for better control.
+2. Applied `display: flex` to the parent list item container.
+3. Used `gap: 8px` to create a standard, un-collapsible space between the icon and text.
+4. Added an alignment rule to keep them vertically centered.

--- a/submissions/examples/sidebar-space/demo.html
+++ b/submissions/examples/sidebar-space/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 2: Sidebar Icon Spacing</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <aside class="sidebar">
+        <ul class="nav-list">
+            <li>Overview</li>
+            <li>em= Syntax</li>
+            <!-- Item with missing space -->
+            <li class="icon-link">
+                <span class="icon">🎮</span> 
+                <span class="text">Live Studio</span>
+            </li>
+        </ul>
+    </aside>
+</body>
+</html>

--- a/submissions/examples/sidebar-space/style.css
+++ b/submissions/examples/sidebar-space/style.css
@@ -1,0 +1,21 @@
+/* Boilerplate */
+body { background: #0b0b13; color: #a0a0b0; font-family: sans-serif; padding: 2rem; }
+.nav-list { list-style: none; padding: 0; }
+.nav-list li { margin-bottom: 1rem; cursor: pointer; }
+
+/* Fix: Flex layout for precise icon spacing */
+.icon-link {
+    display: flex;
+    align-items: center;
+    gap: 8px; /* Adds consistent spacing between emoji and text */
+    transition: color 0.2s ease;
+}
+
+.icon-link:hover {
+    color: #ffffff;
+}
+
+.icon {
+    font-size: 1.1rem;
+    line-height: 1; /* Normalizes icon bounding box */
+}


### PR DESCRIPTION
fixes #88335
Description: This PR resolves a typography bug in the sidebar where the gamepad icon was rendering without a trailing space, causing it to touch the "Live Studio" text. Added a standard 8px gap using Flexbox.
<img width="1280" height="580" alt="Screenshot 2026-08-09 at 10 58 22 AM" src="https://github.com/user-attachments/assets/4ce7c844-abfe-4b36-a8a8-46a47f7b3bc2" />
