### PR TITLE
fix(ui): prevent code badge wrapping in Design Philosophy table

### DIFF
--- a/submissions/examples/fix-wrap/README.md
+++ b/submissions/examples/fix-wrap/README.md
@@ -1,0 +1,10 @@
+# Bug 3 Fix: Principle Code Badge Wrapping
+
+## Overview
+Fixes the issue where long badges like `Human-readable` would break into two lines in the table.
+
+## Changes
+1. Added a specific class `.principle-col` to the first column.
+2. Applied `white-space: nowrap` to stop text breaking inside the table cell.
+3. Used `width: 1%` hack on the column to tell the table to auto-size based on content width.
+4. Set `.badge` to `inline-block` to respect padding uniformly.

--- a/submissions/examples/fix-wrap/demo.html
+++ b/submissions/examples/fix-wrap/demo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 3: Table Badge Wrap</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <table class="design-table">
+        <thead>
+            <tr>
+                <th>PRINCIPLE</th>
+                <th>WHAT IT MEANS</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <!-- Wrapping tag -->
+                <td class="principle-col"><code class="badge">Human-readable</code></td>
+                <td>Class names read like plain English.</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/submissions/examples/fix-wrap/style.css
+++ b/submissions/examples/fix-wrap/style.css
@@ -1,0 +1,19 @@
+/* Boilerplate */
+body { background: #0b0b13; color: #d1d1d6; font-family: sans-serif; padding: 2rem; }
+.design-table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 1rem; border-bottom: 1px solid #1f202e; }
+
+/* Fix: Stop badge wrapping in column 1 */
+.principle-col {
+    width: 1%; /* Forces column to be as narrow as possible while fitting content */
+    white-space: nowrap; /* Prevents the cell from wrapping */
+}
+
+.badge {
+    background: #1e1d32;
+    color: #9c8cfc;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-family: monospace;
+    display: inline-block; /* Helps maintain structural integrity of the badge */
+}


### PR DESCRIPTION
fixes #88334
Description: This PR fixes a visual bug where the principle tags in the Design Philosophy table were aggressively wrapping to multiple lines. I forced white-space: nowrap on these specific elements to maintain readability.