### PR TITLE
fix(ui): stop inline code snippets from wrapping internally

### DIFF
--- a/submissions/examples/nav-under/README.md
+++ b/submissions/examples/nav-under/README.md
@@ -1,0 +1,10 @@
+# Bug 4 Fix: Inline Code Snippet Wrapping
+
+## Overview
+Prevents inline code blocks containing hyphens from breaking across multiple lines.
+
+## Changes
+1. Targeted the `.inline-code` blocks inside description text.
+2. Applied `white-space: nowrap` so the browser treats the snippet as a single unbreakable word.
+3. Added `word-break: keep-all` as a fallback for strict environments.
+4. This ensures the background color renders as a single contiguous pill shape.    

--- a/submissions/examples/nav-under/demo.html
+++ b/submissions/examples/nav-under/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 4: Code Snippet Wrap</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="table-container">
+        <table>
+            <tr>
+                <td>Class names read like plain English, e.g. <code class="inline-code">ease-fade-in</code>.</td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/submissions/examples/nav-under/style.css
+++ b/submissions/examples/nav-under/style.css
@@ -1,0 +1,18 @@
+/* Boilerplate */
+body { background: #0b0b13; color: #a0a0b0; font-family: sans-serif; padding: 2rem; max-width: 400px; /* Simulate narrow container */ }
+table { width: 100%; }
+
+/* Fix: Protect inline code blocks from hyphen-breaks */
+.inline-code {
+    background: #1e1d32;
+    color: #9c8cfc;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: monospace;
+    white-space: nowrap; /* Prevents ease-fade-in from splitting */
+    word-break: keep-all; /* Secondary protection against aggressive breaking */
+}
+
+td {
+    line-height: 1.5;
+}


### PR DESCRIPTION
fixes #88337
Description: This PR fixes a bug where inline code tags (like ease-fade-in) were word-wrapping at hyphens, resulting in broken block styling. Forced nowrap on code elements inside table descriptions.
<img width="1280" height="580" alt="Screenshot 2026-08-09 at 10 58 22 AM" src="https://github.com/user-attachments/assets/ec9445dd-3439-4e60-9fa8-5a1480cb5e2b" />
