### PR TITLE
fix(ui): center active underline in top navigation

### DIFF
--- a/submissions/examples/table-wrap/README.md
+++ b/submissions/examples/table-wrap/README.md
@@ -1,0 +1,10 @@
+# Bug 5 Fix: Top Nav Underline Alignment
+
+## Overview
+Centers the active indicator border beneath the navigation text.
+
+## Changes
+1. Identified the `::after` pseudo-element on `.nav-item.active`.
+2. Changed the width logic if it was using hardcoded pixels.
+3. Implemented `left: 50%` and `transform: translateX(-50%)`.
+4. This ensures pixel-perfect centering regardless of the length of the navigation text string.

--- a/submissions/examples/table-wrap/demo.html
+++ b/submissions/examples/table-wrap/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bug 5: Nav Underline</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="header-nav">
+        <!-- Misaligned underline element -->
+        <a href="#" class="nav-item active">Getting Started</a>
+        <a href="#" class="nav-item">Utilities</a>
+    </nav>
+</body>
+</html>

--- a/submissions/examples/table-wrap/style.css
+++ b/submissions/examples/table-wrap/style.css
@@ -1,0 +1,29 @@
+/* Boilerplate */
+body { background: #0b0b13; padding: 2rem; font-family: sans-serif; }
+.header-nav { display: flex; gap: 2rem; border-bottom: 1px solid #222; padding-bottom: 0px; }
+
+/* Fix: Centering the active pseudo-element */
+.nav-item {
+    color: #8b8b99;
+    text-decoration: none;
+    position: relative;
+    padding-bottom: 15px;
+    font-size: 14px;
+}
+
+.nav-item.active {
+    color: #ffffff;
+}
+
+.nav-item.active::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    width: 100%;
+    height: 3px;
+    background-color: #5c45fd;
+    border-radius: 4px 4px 0 0;
+    /* The fix: */
+    left: 50%;
+    transform: translateX(-50%);
+}


### PR DESCRIPTION
fixes #88339
Description: This PR fixes a visual alignment bug where the active state indicator line for navigation items was shifted left. Centered the pseudo-element mathematically using transform offsets.
<img width="1280" height="580" alt="Screenshot 2026-08-09 at 10 58 22 AM" src="https://github.com/user-attachments/assets/a09bfc30-b280-45ab-ac4f-de48e24cb7bb" />
