### PR TITLE
docs: document Brutalism Segmented Switch responsive breakpoints layout

### DIFF
--- a/submissions/docs/ease-brutal-switch-responsive-ss/README.md
+++ b/submissions/docs/ease-brutal-switch-responsive-ss/README.md
@@ -1,0 +1,102 @@
+# Brutalism Segmented Switch Control - Responsive Breakpoints Layout
+
+## Overview
+
+The **Brutalism Segmented Switch Control** (`.ease-switch-brutal`) is a tactile segmented toggle built from a
+`role="radiogroup"` container and `role="radio"` segment buttons (`.ease-switch-btn`). This guide documents
+`.ease-switch-brutal-responsive`, a layout modifier that adapts the switch's width and segment sizing across
+three breakpoint bands so it stays usable from a wide desktop viewport down to a narrow phone screen, instead of
+overflowing or clipping segment labels.
+
+This complements the existing quickstart and theming guides for the same component:
+- `submissions/docs/ease-brutalist-switch-ss/` — base markup, variants, and keyboard interaction
+- `submissions/docs/ease-brutal-switch-theming-ss/` — CSS custom property theming
+
+## HTML Structure
+
+The markup is unchanged from the base component. `.ease-switch-brutal-responsive` is added alongside
+`.ease-switch-brutal` on the same container:
+
+```html
+<div class="ease-switch-brutal ease-switch-brutal-responsive" role="radiogroup" aria-label="Billing Cycle">
+  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Monthly</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Quarterly</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Annual</button>
+</div>
+```
+
+No extra wrapper elements or data attributes are required. The roving-tabindex/arrow-key script from the base
+quickstart guide works unmodified with this modifier.
+
+## Class Reference
+
+| CSS Selector | Description |
+| :--- | :--- |
+| `.ease-switch-brutal` | Base container: border, hard drop shadow, inline-flex layout. |
+| `.ease-switch-btn` | Individual segment button. |
+| `.ease-switch-brutal-responsive` | Adds the breakpoint-driven width/sizing behavior documented here. |
+| `.ease-switch-vertical` | Existing, unrelated modifier that *manually* forces a fixed vertical stack at every viewport width. It does not respond to breakpoints and is shown in `demo.html` only as a point of comparison. |
+
+## Responsive Breakpoint Behavior
+
+`.ease-switch-brutal-responsive` uses three width bands, defined in `style.css`:
+
+| Viewport | Behavior |
+| :--- | :--- |
+| `min-width: 768px` (tablet and desktop) | Switch sits at its natural inline width (`width: auto`); segment buttons size to their content, matching the default `.ease-switch-brutal` behavior. |
+| `480px` &ndash; `767px` (mobile) | Switch stretches to `width: 100%` of its container; each segment button grows equally (`flex: 1`) so all segments share the available width and remain easy to tap. |
+| `max-width: 479px` (narrow mobile) | Segments wrap onto a second row (`flex-wrap: wrap`), two per row (`flex: 1 1 calc(50% - 4px)`), instead of shrinking button text to fit one row. |
+
+The two thresholds (`768px`, `480px`) are plain CSS media queries, mobile-first (base rules apply below 768px,
+overridden with `min-width` above it). No JavaScript is involved in the layout changes — resizing the browser or
+using a device toolbar is enough to see each band take effect.
+
+## Usage Example
+
+```html
+<link rel="stylesheet" href="style.css">
+
+<div class="ease-switch-brutal ease-switch-brutal-responsive" role="radiogroup" aria-label="View Mode">
+  <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Editor</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Split</button>
+  <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Preview</button>
+</div>
+```
+
+## Testing the Responsive Behavior
+
+1. Open `demo.html` directly in a browser (no server or build step needed).
+2. Resize the browser window slowly from wide to narrow, or open the browser's device toolbar and pick preset
+   widths.
+3. Watch the switch under "`.ease-switch-brutal-responsive`" at the top of the page:
+   - At 1024px+ and 768px&ndash;1023px it stays at its natural width.
+   - Between 480px and 767px it stretches full-width with equal segment widths.
+   - Below 480px the segments wrap into a 2-per-row grid.
+4. The label at the top of the card (`Mobile` / `Tablet` / `Desktop`) reflects which band is currently active, so
+   you can confirm the breakpoint without opening dev tools.
+5. Compare against the `.ease-switch-vertical` example lower on the page, which stays stacked regardless of
+   width, to see the difference between a fixed layout and a responsive one.
+
+## Accessibility Considerations
+
+- Layout changes are pure CSS (flex sizing / wrapping); the DOM order and the `role="radiogroup"` /
+  `role="radio"` structure never change across breakpoints, so screen reader announcement order stays
+  consistent.
+- Because only sizing and wrapping change, the roving-`tabindex` and Arrow Key navigation described in the
+  quickstart guide keep working identically at every width.
+- Wrapped segments (below 480px) remain individually tappable buttons at a comfortable size — none of the
+  breakpoints shrink font size or padding to force content into a single row.
+
+## Browser / Testing Notes
+
+- Uses standard CSS `flex`, `flex-wrap`, and `min-width`/`max-width` media queries; no vendor prefixes or
+  experimental features are required.
+- Verified visually at 1280px, 900px, 600px, and 375px widths using the browser's responsive device toolbar.
+- `demo.html` has no external dependencies, CDNs, or build step — it opens directly in any modern browser.
+
+## Files
+
+- `demo.html` — standalone example with the responsive switch, a fixed-vertical comparison switch, and a
+  viewport-band indicator.
+- `style.css` — base switch styles plus the `.ease-switch-brutal-responsive` breakpoint rules.
+- `README.md` — this guide.

--- a/submissions/docs/ease-brutal-switch-responsive-ss/demo.html
+++ b/submissions/docs/ease-brutal-switch-responsive-ss/demo.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brutalism Segmented Switch - Responsive Breakpoints Guide</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="ease-brutal-card" aria-labelledby="guide-title">
+    <header>
+      <span class="viewport-flag" data-band="mobile">Below 768px: Mobile</span>
+      <span class="viewport-flag" data-band="tablet">768px&ndash;1023px: Tablet</span>
+      <span class="viewport-flag" data-band="desktop">1024px and up: Desktop</span>
+      <h1 id="guide-title" style="font-size: 1.75rem; font-weight: 900; margin: 0.75rem 0 0.25rem 0; text-transform: uppercase;">Segmented Switch: Responsive Breakpoints</h1>
+      <p style="color: #4b5563; font-size: 0.875rem; margin: 0; line-height: 1.5;">
+        Resize this window (or open dev tools' device toolbar) to see the switch below adapt at 480px and 768px.
+      </p>
+    </header>
+
+    <section class="ease-switch-stack">
+      <div style="width: 100%;">
+        <h2 style="font-size: 0.875rem; font-weight: 800; text-transform: uppercase; margin: 0 0 0.5rem 0;">
+          .ease-switch-brutal .ease-switch-brutal-responsive
+        </h2>
+        <div class="ease-switch-brutal ease-switch-brutal-responsive" role="radiogroup" aria-label="Billing Cycle">
+          <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Monthly</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Quarterly</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Annual</button>
+        </div>
+        <p style="color: #4b5563; font-size: 0.8125rem; margin: 0.75rem 0 0 0; line-height: 1.5;">
+          &ge; 768px: switch keeps its natural inline width.<br>
+          480px&ndash;767px: segments stretch to share the full width equally.<br>
+          &lt; 480px: segments wrap onto two rows, two per row.
+        </p>
+      </div>
+
+      <div>
+        <h2 style="font-size: 0.875rem; font-weight: 800; text-transform: uppercase; margin: 0 0 0.5rem 0;">
+          .ease-switch-brutal .ease-switch-vertical (unaffected reference)
+        </h2>
+        <div class="ease-switch-brutal ease-switch-vertical" role="radiogroup" aria-label="View Mode">
+          <button type="button" class="ease-switch-btn is-active" role="radio" aria-checked="true" tabindex="0">Editor</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Split</button>
+          <button type="button" class="ease-switch-btn" role="radio" aria-checked="false" tabindex="-1">Preview</button>
+        </div>
+        <p style="color: #4b5563; font-size: 0.8125rem; margin: 0.75rem 0 0 0; line-height: 1.5;">
+          <code>.ease-switch-vertical</code> is a fixed manual layout, not a breakpoint-driven one &mdash; it stays
+          stacked at every viewport width. It is shown here only for comparison.
+        </p>
+      </div>
+    </section>
+
+    <footer style="border-top: 2px dashed #000; padding-top: 1.25rem; font-size: 0.8125rem; color: #4b5563;">
+      Navigate using <strong>Tab</strong> to focus and <strong>Left / Right Arrow Keys</strong> or <strong>Click</strong> to switch segments.
+    </footer>
+  </main>
+
+  <script>
+    // Interactive WAI-ARIA Roving Tabindex & Arrow Key Engine
+    const switchGroups = document.querySelectorAll('.ease-switch-brutal');
+
+    switchGroups.forEach(group => {
+      const buttons = Array.from(group.querySelectorAll('.ease-switch-btn'));
+
+      function selectButton(btn) {
+        buttons.forEach(b => {
+          b.classList.remove('is-active');
+          b.setAttribute('aria-checked', 'false');
+          b.setAttribute('tabindex', '-1');
+        });
+        btn.classList.add('is-active');
+        btn.setAttribute('aria-checked', 'true');
+        btn.setAttribute('tabindex', '0');
+        btn.focus();
+      }
+
+      buttons.forEach((btn, index) => {
+        btn.addEventListener('click', () => selectButton(btn));
+
+        btn.addEventListener('keydown', (e) => {
+          let targetIndex = null;
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            targetIndex = (index + 1) % buttons.length;
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            targetIndex = (index - 1 + buttons.length) % buttons.length;
+          }
+
+          if (targetIndex !== null) {
+            e.preventDefault();
+            selectButton(buttons[targetIndex]);
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/submissions/docs/ease-brutal-switch-responsive-ss/style.css
+++ b/submissions/docs/ease-brutal-switch-responsive-ss/style.css
@@ -1,0 +1,177 @@
+/* Neo-Brutalist CSS Custom Properties Tokens */
+:root {
+  --brutal-bg: #fffbeb;
+  --brutal-surface: #ffffff;
+  --brutal-border: #000000;
+  --brutal-shadow: #000000;
+  --brutal-accent: #facc15;
+  --brutal-text: #000000;
+  --brutal-border-width: 3px;
+  --brutal-shadow-offset: 4px;
+  --brutal-radius: 6px;
+}
+
+/* Layout & Background Grid */
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--brutal-bg);
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--brutal-text);
+  padding: 2rem;
+  box-sizing: border-box;
+  background-image: radial-gradient(#000000 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+/* Showcase Container */
+.ease-brutal-card {
+  background: var(--brutal-surface);
+  border: var(--brutal-border-width) solid var(--brutal-border);
+  border-radius: var(--brutal-radius);
+  padding: 2rem;
+  max-width: 780px;
+  width: 100%;
+  margin: 0 auto;
+  box-shadow: 8px 8px 0 var(--brutal-shadow);
+  box-sizing: border-box;
+}
+
+/* Viewport indicator: shows which breakpoint band is active.
+   Only one label is visible at a time via the media queries below. */
+.viewport-flag {
+  display: none;
+  background: #000;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 4px 8px;
+  margin-bottom: 0.75rem;
+}
+
+.viewport-flag[data-band="mobile"] { display: inline-block; }
+
+@media (min-width: 768px) {
+  .viewport-flag[data-band="mobile"] { display: none; }
+  .viewport-flag[data-band="tablet"] { display: inline-block; }
+}
+
+@media (min-width: 1024px) {
+  .viewport-flag[data-band="tablet"] { display: none; }
+  .viewport-flag[data-band="desktop"] { display: inline-block; }
+}
+
+.ease-switch-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: flex-start;
+  margin: 1.5rem 0;
+}
+
+/* Segmented Switch Component (base, from ease-switch-brutal) */
+.ease-switch-brutal {
+  display: inline-flex;
+  background: #ffffff;
+  border: var(--brutal-border-width) solid var(--brutal-border);
+  border-radius: var(--brutal-radius);
+  box-shadow: var(--brutal-shadow-offset) var(--brutal-shadow-offset) 0 var(--brutal-shadow);
+  padding: 4px;
+  gap: 4px;
+  position: relative;
+  user-select: none;
+  box-sizing: border-box;
+}
+
+.ease-switch-btn {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--brutal-text);
+  cursor: pointer;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
+  outline: none;
+}
+
+.ease-switch-btn:hover:not(.is-active) {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.ease-switch-btn.is-active {
+  background: var(--brutal-accent);
+  border: 2px solid var(--brutal-border);
+  box-shadow: 2px 2px 0 var(--brutal-shadow);
+  font-weight: 900;
+}
+
+.ease-switch-btn:focus-visible {
+  outline: 3px solid #000000;
+  outline-offset: 2px;
+}
+
+/* Existing manual modifier: forces vertical stacking regardless of viewport */
+.ease-switch-vertical {
+  flex-direction: column;
+  width: 100%;
+  max-width: 220px;
+}
+
+/*
+ * Responsive breakpoint layout.
+ * Mobile-first: below 768px the switch fills the available width and
+ * each segment button grows equally (flex: 1) so touch targets stay
+ * large. From 768px up, the switch returns to its natural inline size.
+ */
+.ease-switch-brutal-responsive {
+  width: 100%;
+}
+
+.ease-switch-brutal-responsive .ease-switch-btn {
+  flex: 1;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .ease-switch-brutal-responsive {
+    width: auto;
+  }
+
+  .ease-switch-brutal-responsive .ease-switch-btn {
+    flex: initial;
+  }
+}
+
+/*
+ * Below 480px there is not enough horizontal room for three labeled
+ * segments without truncation, so the switch wraps onto a second row.
+ * flex-wrap keeps every segment usable instead of shrinking text.
+ */
+@media (max-width: 479px) {
+  .ease-switch-brutal-responsive {
+    flex-wrap: wrap;
+  }
+
+  .ease-switch-brutal-responsive .ease-switch-btn {
+    flex: 1 1 calc(50% - 4px);
+  }
+}
+
+/* Accessibility & High-Contrast Fallbacks */
+@media (forced-colors: active) {
+  .ease-brutal-card,
+  .ease-switch-brutal {
+    border: 3px solid CanvasText;
+  }
+  .ease-switch-btn.is-active {
+    border: 2px solid Highlight;
+    background: Highlight;
+    color: HighlightText;
+  }
+}


### PR DESCRIPTION
Adds a docs/examples guide for the .ease-switch-brutal-responsive modifier, covering breakpoint behavior at 768px/480px, HTML usage, and accessibility notes. Closes #85968.

## Pull Request Description

Adds documentation and a live example for the existing Brutalism Segmented Switch responsive modifier, showing how the layout changes across the 768px and 480px breakpoints.

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [x] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

> ⚠️ PRs that fail this checklist will be **closed without review**.

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Documentation and a responsive demo for the existing .ease-switch-brutal-responsive modifier, demonstrating its breakpoint-specific layout behavior at 768px and 480px.

**How does a developer use it?**

```html
<div class="ease-switch-brutal ease-switch-brutal-responsive">
  <!-- segmented switch items -->
</div>

**Why does it fit EaseMotion CSS?**

This documents an existing EaseMotion CSS pattern using readable utility-style classes and CSS media queries to demonstrate responsive segmented-switch behavior without requiring JavaScript or additional dependencies.

---

## Demo

- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari *(optional but appreciated)*

---

## Notes for Maintainer

The demo documents the existing responsive modifier at the repository's 768px and 480px breakpoints and includes the existing vertical switch as an unaffected reference for comparison. The documented classes and behavior were cross-checked against the source implementation.

---
