### PR TITLE
feat(examples): add pure CSS 3D tilt card component

### DIFF
--- a/submissions/examples/css-3d-tilt-card-er/README.md
+++ b/submissions/examples/css-3d-tilt-card-er/README.md
@@ -1,0 +1,24 @@
+# 3D Tilt Card
+
+A pure CSS card component with a 3D perspective tilt effect and a dynamic shine overlay on hover.
+
+## What does this do?
+
+Creates a card that tilts in 3D space when hovered, with a moving radial-gradient shine effect that follows the tilt direction, giving a realistic depth and lighting feel without any JavaScript.
+
+## How is it used?
+
+```html
+<div class="tilt-card">
+    <div class="tilt-card__shine"></div>
+    <div class="tilt-card__content">
+        <h2 class="tilt-card__title">Card Title</h2>
+        <p class="tilt-card__text">Card description goes here.</p>
+        <span class="tilt-card__tag">Tag</span>
+    </div>
+</div>
+```
+
+## Why is it useful?
+
+It demonstrates how modern CSS properties like `perspective`, `transform-style: preserve-3d`, `translateZ`, and `radial-gradient` can be combined to create immersive 3D interactions that previously required JavaScript libraries. It fits EaseMotion CSS by providing a reusable, animation-driven UI component that enhances user engagement through motion and depth.

--- a/submissions/examples/css-3d-tilt-card-er/demo.html
+++ b/submissions/examples/css-3d-tilt-card-er/demo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Tilt Card</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="tilt-card">
+        <div class="tilt-card__shine"></div>
+        <div class="tilt-card__content">
+            <h2 class="tilt-card__title">3D Tilt Card</h2>
+            <p class="tilt-card__text">Hover over this card to see the 3D tilt effect with a dynamic shine overlay, all powered by pure CSS.</p>
+            <span class="tilt-card__tag">Pure CSS</span>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/css-3d-tilt-card-er/style.css
+++ b/submissions/examples/css-3d-tilt-card-er/style.css
@@ -1,0 +1,160 @@
+:root {
+    --card-width: 320px;
+    --card-height: 400px;
+    --card-bg: #1a1a2e;
+    --card-radius: 16px;
+    --tilt-angle: 15deg;
+    --shine-size: 250%;
+    --transition-speed: 0.4s;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: #0f0f1a;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+.tilt-card {
+    position: relative;
+    width: var(--card-width);
+    height: var(--card-height);
+    border-radius: var(--card-radius);
+    background: var(--card-bg);
+    overflow: hidden;
+    cursor: pointer;
+    transform-style: preserve-3d;
+    transition: transform var(--transition-speed) ease;
+}
+
+.tilt-card::before,
+.tilt-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: var(--card-radius);
+    transition: opacity var(--transition-speed) ease;
+    opacity: 0;
+}
+
+.tilt-card::before {
+    border: 2px solid rgba(99, 102, 241, 0.5);
+}
+
+.tilt-card::after {
+    background: radial-gradient(
+        circle at 50% 0%,
+        rgba(99, 102, 241, 0.15),
+        transparent 60%
+    );
+}
+
+.tilt-card:hover::before,
+.tilt-card:hover::after {
+    opacity: 1;
+}
+
+.tilt-card:hover {
+    transform: perspective(800px) rotateY(calc(var(--tilt-angle) * -1)) rotateX(var(--tilt-angle)) scale(1.05);
+}
+
+.tilt-card__shine {
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: var(--shine-size);
+    height: var(--shine-size);
+    background: radial-gradient(
+        circle,
+        rgba(255, 255, 255, 0.12) 0%,
+        transparent 60%
+    );
+    opacity: 0;
+    transition: opacity var(--transition-speed) ease;
+    pointer-events: none;
+    transform: translateZ(1px);
+}
+
+.tilt-card:hover .tilt-card__shine {
+    opacity: 1;
+    animation: ease-tilt-shine 3s ease-in-out infinite;
+}
+
+.tilt-card__content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    height: 100%;
+    padding: 32px;
+    transform: translateZ(40px);
+}
+
+.tilt-card__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #e2e8f0;
+    margin-bottom: 12px;
+    letter-spacing: -0.02em;
+}
+
+.tilt-card__text {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #94a3b8;
+    margin-bottom: 20px;
+}
+
+.tilt-card__tag {
+    display: inline-block;
+    align-self: flex-start;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(99, 102, 241, 0.2);
+    color: #818cf8;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+@keyframes ease-tilt-shine {
+    0%, 100% {
+        transform: translate(0%, 0%);
+    }
+    25% {
+        transform: translate(20%, 10%);
+    }
+    50% {
+        transform: translate(-10%, 20%);
+    }
+    75% {
+        transform: translate(10%, -10%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tilt-card,
+    .tilt-card::before,
+    .tilt-card::after,
+    .tilt-card__shine {
+        transition: none;
+        animation: none;
+    }
+
+    .tilt-card:hover {
+        transform: none;
+    }
+
+    .tilt-card:hover .tilt-card__shine {
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a pure CSS 3D tilt card component to `submissions/examples/css-3d-tilt-card-er/`. This component creates a card with a 3D perspective tilt effect and a dynamic shine overlay on hover using only CSS transforms, gradients, and animations.

Closes #88641

## What's included

- `demo.html` - Self-contained HTML demo, works by opening directly in a browser
- `style.css` - Pure CSS with no external dependencies, uses CSS custom properties, 3D transforms, and radial gradients
- `README.md` - Documentation answering what it does, how it's used, and why it's useful

## Checklist

- [x] Files are placed inside `submissions/examples/css-3d-tilt-card-er/`
- [x] No files outside the `submissions/` folder are modified
- [x] Demo works by opening `demo.html` directly in a browser
- [x] Includes `prefers-reduced-motion` media query for accessibility
- [x] Uses CSS custom properties for easy customization
- [x] Only one feature per PR