### PR TITLE
feat: add focus ring showcase

### DIFF
--- a/submissions/examples/focus-ring-showcase-ts02/README.md
+++ b/submissions/examples/focus-ring-showcase-ts02/README.md
@@ -1,0 +1,13 @@
+# Focus Ring Showcase
+
+## What does this do?
+Accessible focus rings for keyboard-first interfaces.
+
+## How is it used?
+
+```html
+<button class="focus-action primary">Create project</button>
+```
+
+## Why is it useful?
+It gives EaseMotion CSS a practical, browser-ready pattern that combines expressive visual feedback with readable HTML and accessible interaction states.

--- a/submissions/examples/focus-ring-showcase-ts02/demo.html
+++ b/submissions/examples/focus-ring-showcase-ts02/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Focus Ring Showcase</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<main class="demo-shell">
+  <section class="intro-panel">
+    <p class="eyebrow">Accessibility pattern</p>
+    <h1>Focus states that are visible without feeling heavy.</h1>
+    <p>Tab through the controls to see a clear, animated ring that helps keyboard users keep their place.</p>
+  </section>
+
+  <section class="control-grid" aria-label="Focusable control examples">
+    <button class="focus-action primary">Create project</button>
+    <button class="focus-action secondary">View report</button>
+    <a class="focus-link" href="#details">Read details</a>
+    <label class="focus-field">
+      Search
+      <input type="search" placeholder="Motion tokens" />
+    </label>
+  </section>
+</main>
+</body>
+</html>

--- a/submissions/examples/focus-ring-showcase-ts02/style.css
+++ b/submissions/examples/focus-ring-showcase-ts02/style.css
@@ -1,0 +1,26 @@
+:root {
+  color-scheme: light;
+  --ink: #15202b;
+  --muted: #52616b;
+  --surface: #ffffff;
+  --line: #cbd5df;
+  --accent: #1d7afc;
+  --accent-soft: rgba(29, 122, 252, 0.18);
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; font-family: Inter, system-ui, sans-serif; color: var(--ink); background: linear-gradient(135deg, #f7fbff, #eef4f7); display: grid; place-items: center; padding: 32px; }
+.demo-shell { width: min(920px, 100%); display: grid; grid-template-columns: 1fr 1.1fr; gap: 28px; align-items: center; }
+.intro-panel h1 { margin: 8px 0 12px; font-size: clamp(2rem, 5vw, 4rem); line-height: 1; letter-spacing: 0; }
+.intro-panel p { color: var(--muted); font-size: 1rem; line-height: 1.7; }
+.eyebrow { text-transform: uppercase; font-weight: 800; letter-spacing: .12em; color: var(--accent) !important; }
+.control-grid { background: var(--surface); border: 1px solid var(--line); border-radius: 18px; padding: 24px; display: grid; gap: 16px; box-shadow: 0 24px 60px rgba(21, 32, 43, 0.12); }
+.focus-action, .focus-link, input { border: 1px solid var(--line); border-radius: 14px; min-height: 52px; padding: 0 18px; font: inherit; transition: transform .22s ease, box-shadow .22s ease, border-color .22s ease; }
+.focus-action { cursor: pointer; font-weight: 800; }
+.primary { background: var(--accent); border-color: var(--accent); color: white; }
+.secondary, .focus-link, input { background: white; color: var(--ink); }
+.focus-link { display: inline-flex; align-items: center; text-decoration: none; }
+.focus-field { display: grid; gap: 8px; color: var(--muted); font-weight: 700; }
+.focus-action:focus-visible, .focus-link:focus-visible, input:focus-visible { outline: 4px solid var(--accent-soft); outline-offset: 4px; border-color: var(--accent); box-shadow: 0 0 0 8px rgba(29, 122, 252, .08); transform: translateY(-2px); }
+@media (max-width: 760px) { .demo-shell { grid-template-columns: 1fr; } body { padding: 20px; } }
+@media (prefers-reduced-motion: reduce) { * { transition-duration: .01ms !important; } }


### PR DESCRIPTION
## What changed

Added a self-contained EaseMotion CSS submission for $slug under submissions/examples/.

## Why it matters

This contributes a focused browser-ready pattern with readable markup, original CSS, accessible states, and reduced-motion handling where animation is used.

## Validation

- Confirmed the submission contains demo.html, style.css, and README.md
- Confirmed the files live only under submissions/examples/focus-ring-showcase-ts02/
- Scanned the submission for disallowed attribution text
