### PR TITLE
feat: add CSS animation chip group wrap example

### DIFF
--- a/submissions/examples/chip-group-wrap-drp/README.md
+++ b/submissions/examples/chip-group-wrap-drp/README.md
@@ -1,0 +1,10 @@
+# Chip Group Wrap
+
+A simple CSS-only chip group that wraps neatly across screen sizes and keeps actions easy to scan.
+
+## Features
+
+- Flexible chip row
+- Wrap-aware spacing
+- Touch-friendly sizing
+- Accessible semantic markup

--- a/submissions/examples/chip-group-wrap-drp/demo.html
+++ b/submissions/examples/chip-group-wrap-drp/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chip Group Wrap</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="shell" aria-labelledby="title">
+    <section class="card">
+      <p class="eyebrow">filters</p>
+      <h1 id="title">Chip Group Wrap</h1>
+      <p class="summary">A simple CSS-only chip group that wraps neatly across screen sizes and keeps actions easy to scan.</p>
+      <div class="stage" role="img" aria-label="Animated Chip Group Wrap">
+        <div class="orb orb-one"></div>
+        <div class="orb orb-two"></div>
+        <article class="tile tile-1"><strong>01</strong><span>Flexible chip row</span></article>
+        <article class="tile tile-2"><strong>02</strong><span>Wrap-aware spacing</span></article>
+        <article class="tile tile-3"><strong>03</strong><span>Touch-friendly sizing</span></article>
+        <article class="tile tile-4"><strong>04</strong><span>Accessible semantic markup</span></article>
+        <div class="accent">Flexible chip row</div>
+      </div>
+      <div class="tags" aria-label="Chip Group Wrap features">
+        <span>Flexible chip row</span>
+        <span>Wrap-aware spacing</span>
+        <span>Touch-friendly sizing</span>
+        <span>Accessible semantic markup</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/chip-group-wrap-drp/style.css
+++ b/submissions/examples/chip-group-wrap-drp/style.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: dark;
+  --bg: #0a1220;
+  --card: #101a2b;
+  --line: rgba(175, 198, 255, 0.14);
+  --text: #eff4ff;
+  --muted: #94a8c8;
+  --accent: #84e0bc;
+  --accent-2: #87a8ff;
+  --warn: #ffd36f;
+}
+
+* { box-sizing: border-box; }
+html, body { min-height: 100%; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(135, 168, 255, 0.16), transparent 28%),
+    radial-gradient(circle at 80% 24%, rgba(132, 224, 188, 0.14), transparent 26%),
+    linear-gradient(180deg, #08111d 0%, #0b1220 100%);
+  color: var(--text);
+}
+
+.shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.card {
+  width: min(860px, 100%);
+  background: rgba(16, 26, 43, 0.96);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: clamp(20px, 3vw, 32px);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.05;
+}
+
+.summary {
+  margin: 12px 0 22px;
+  max-width: 66ch;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.stage {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+  min-height: 300px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.03), transparent 24%),
+    rgba(8, 14, 24, 0.84);
+}
+
+.orb {
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(12px);
+  opacity: 0.8;
+}
+
+.orb-one {
+  width: 190px;
+  height: 190px;
+  left: -28px;
+  top: -30px;
+  background: rgba(135, 168, 255, 0.22);
+  animation: drift 8s ease-in-out infinite;
+}
+
+.orb-two {
+  width: 220px;
+  height: 220px;
+  right: -54px;
+  bottom: -54px;
+  background: rgba(132, 224, 188, 0.16);
+  animation: drift 10s ease-in-out infinite reverse;
+}
+
+.tile {
+  position: relative;
+  z-index: 1;
+  border-radius: 14px;
+  border: 1px solid rgba(153, 188, 255, 0.16);
+  background: rgba(13, 22, 36, 0.86);
+  padding: 18px;
+  min-height: 92px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.tile strong { color: var(--warn); }
+.tile span,
+.tags span { color: var(--text); font-size: 0.95rem; }
+
+.accent {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  z-index: 1;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(132, 224, 188, 0.16);
+  border: 1px solid rgba(132, 224, 188, 0.35);
+  color: #bbf8e1;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.tags span {
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,0.03);
+  color: var(--muted);
+}
+
+.tile-1 { animation: float 5s ease-in-out infinite; }
+.tile-2 { animation: float 5s ease-in-out infinite 0.8s; }
+.tile-3 { animation: float 5s ease-in-out infinite 1.6s; }
+.tile-4 { animation: float 5s ease-in-out infinite 2.4s; }
+
+@keyframes drift {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(14px, 10px, 0) scale(1.05); }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@media (max-width: 700px) {
+  .stage { grid-template-columns: 1fr; min-height: auto; }
+  .accent { position: static; justify-self: start; margin-top: 8px; }
+}


### PR DESCRIPTION
## Summary
- add Chip Group Wrap example
- include responsive accessible demo markup
- add original normal CSS animation coverage

## Validation
- checked duplicate slug
- verified generated files are non-empty