### PR TITLE
feat: add ease icon button example

### DIFF
--- a/submissions/examples/ease-icon-button-prithvibo/README.md
+++ b/submissions/examples/ease-icon-button-prithvibo/README.md
@@ -1,0 +1,24 @@
+# Ease Icon Button
+
+A compact icon-only button for toolbars, compact controls, and
+navigation interfaces.
+
+## Features
+
+- Icon-only button
+- Small, medium, and large sizes
+- Hover animation
+- Visible keyboard focus state
+- Accessible `aria-label` support
+- Pure HTML and CSS
+- No external dependencies
+
+## Usage
+
+```html
+<button
+    class="ease-icon-button ease-icon-button-medium"
+    type="button"
+    aria-label="Settings">
+    ⚙
+</button>

--- a/submissions/examples/ease-icon-button-prithvibo/demo.html
+++ b/submissions/examples/ease-icon-button-prithvibo/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ease Icon Button</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <main class="demo">
+        <h1>Ease Icon Button</h1>
+        <p>Compact icon-only buttons for toolbars and navigation.</p>
+
+        <section class="button-group" aria-label="Icon button examples">
+
+            <button class="ease-icon-button ease-icon-button-small" type="button" aria-label="Settings">
+                ⚙
+            </button>
+
+            <button class="ease-icon-button ease-icon-button-medium" type="button" aria-label="Favorite">
+                ♥
+            </button>
+
+            <button class="ease-icon-button ease-icon-button-large" type="button" aria-label="Add">
+                +
+            </button>
+
+        </section>
+    </main>
+</body>
+
+</html>

--- a/submissions/examples/ease-icon-button-prithvibo/style.css
+++ b/submissions/examples/ease-icon-button-prithvibo/style.css
@@ -1,0 +1,96 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    font-family: Arial, sans-serif;
+    background: #f5f5f5;
+    color: #222;
+}
+
+.demo {
+    width: min(90%, 700px);
+    text-align: center;
+    padding: 40px 20px;
+}
+
+.demo h1 {
+    margin: 0 0 10px;
+}
+
+.demo p {
+    margin: 0 0 32px;
+}
+
+.button-group {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.ease-icon-button {
+    display: inline-grid;
+    place-items: center;
+    padding: 0;
+    border: 1px solid #cfcfcf;
+    border-radius: 50%;
+    background: #ffffff;
+    color: #222222;
+    cursor: pointer;
+    font: inherit;
+
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease,
+        background-color 180ms ease;
+}
+
+.ease-icon-button:hover {
+    transform: translateY(-3px) scale(1.05);
+    background-color: #eeeeee;
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.14);
+}
+
+.ease-icon-button:focus-visible {
+    outline: 3px solid #222222;
+    outline-offset: 4px;
+}
+
+.ease-icon-button:active {
+    transform: scale(0.96);
+}
+
+.ease-icon-button-small {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+}
+
+.ease-icon-button-medium {
+    width: 48px;
+    height: 48px;
+    font-size: 20px;
+}
+
+.ease-icon-button-large {
+    width: 60px;
+    height: 60px;
+    font-size: 26px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ease-icon-button {
+        transition: none;
+    }
+
+    .ease-icon-button:hover,
+    .ease-icon-button:active {
+        transform: none;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

## Description

Added a new Ease Icon Button example under `submissions/examples/ease-icon-button-prithvibo/`.

The example demonstrates a compact, accessible icon-only button component using pure HTML and CSS.

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other

## Features

- Icon-only button
- Small, medium, and large sizes
- Hover animation
- Visible keyboard focus state
- Accessible `aria-label` support
- Responsive layout
- Pure HTML and CSS
- No external dependencies

## Testing

- Tested the demo locally in the browser.
- Verified the different button sizes.
- Verified the hover effect.
- Verified the keyboard focus state.
- Verified the accessible `aria-label`.

Closes #85282
