### PR TITLE
Added orbit-easing menu

### DIFF
--- a/submissions/examples/orbit-easing-menu/README.md
+++ b/submissions/examples/orbit-easing-menu/README.md
@@ -1,0 +1,50 @@
+# Orbit Menu
+
+A pure CSS advanced component for **EaseMotion-css** — closes issue [#88614](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/88614) ("Add pure CSS advanced component iteration 156").
+
+## What it is
+
+A central "Menu" button that, on hover or keyboard focus, blooms into five
+satellite action buttons arranged in a circle. Each satellite travels on a
+**different named easing curve** — `linear`, `ease-out`, `ease-in-out`,
+`spring`, and `bounce` — with a staggered `transition-delay` so the
+difference between curves is easy to see side by side. Since this repo is
+an easing/motion library, the component doubles as a live demo of the
+curves themselves rather than just another animated menu.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.html` | Component markup |
+| `style.css` | All styling and motion, no JS |
+
+## How it works
+
+- No JavaScript. State is driven entirely by `:hover` and `:focus-within`
+  on the `.em-orbit` container.
+- Satellite buttons sit at the center of the stage (`position: absolute`,
+  centered) and are translated outward with `transform: translate()` when
+  the parent is hovered/focused — this keeps the animation on
+  `transform`/`opacity` only, so it stays on the compositor thread.
+- Each satellite defines its own `transition-timing-function` as a custom
+  property from a shared curve palette (`--em-ease-out`, `--em-ease-spring`,
+  etc.), so the curves are reusable tokens rather than one-off values.
+- `prefers-reduced-motion: reduce` collapses all transitions to near-zero
+  duration.
+- Fully keyboard operable: `Tab` reaches the core button, `:focus-within`
+  reveals the satellites, and each satellite is itself focusable and
+  `title`-labeled.
+
+## Usage
+
+Open `index.html` directly in a browser, or drop `style.css` + the
+`.em-orbit` markup block into an existing page. Update the CSS custom
+properties in `:root` (`--em-accent`, `--em-secondary`, etc.) to match your
+theme.
+
+## Suggested branch name
+
+```
+feat/orbit-easing-menu-156
+```

--- a/submissions/examples/orbit-easing-menu/demo.html
+++ b/submissions/examples/orbit-easing-menu/demo.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Orbit Menu — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="em-orbit-body">
+
+  <header class="em-heading">
+    <span class="em-eyebrow">EaseMotion CSS · Component 156</span>
+    <h1>Orbit Menu</h1>
+    <p>
+      Hover or focus the core button. Five actions bloom outward, each
+      riding a different easing curve so you can feel the difference
+      between <em>linear</em>, <em>ease-out</em>, <em>ease-in-out</em>,
+      a <em>spring</em>, and a <em>bounce</em>.
+    </p>
+  </header>
+
+  <div class="em-orbit">
+    <span class="em-orbit-ring" aria-hidden="true"></span>
+
+    <button class="em-core" type="button" aria-haspopup="true">
+      Menu
+    </button>
+
+    <button class="em-satellite em-satellite--1" type="button" title="Ease Out">
+      ▲
+      <span class="em-satellite-tag">ease-out</span>
+    </button>
+
+    <button class="em-satellite em-satellite--2" type="button" title="Spring">
+      ★
+      <span class="em-satellite-tag">spring</span>
+    </button>
+
+    <button class="em-satellite em-satellite--3" type="button" title="Bounce">
+      ●
+      <span class="em-satellite-tag">bounce</span>
+    </button>
+
+    <button class="em-satellite em-satellite--4" type="button" title="Ease In-Out">
+      ■
+      <span class="em-satellite-tag">ease-in-out</span>
+    </button>
+
+    <button class="em-satellite em-satellite--5" type="button" title="Linear">
+      ✦
+      <span class="em-satellite-tag">linear</span>
+    </button>
+  </div>
+
+  <div class="em-legend">
+    <span class="em-legend-item"><span class="em-legend-dot"></span>Keyboard accessible via Tab + focus-within</span>
+    <span class="em-legend-item"><span class="em-legend-dot"></span>Respects prefers-reduced-motion</span>
+    <span class="em-legend-item"><span class="em-legend-dot"></span>Pure CSS — no JavaScript</span>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/orbit-easing-menu/style.css
+++ b/submissions/examples/orbit-easing-menu/style.css
@@ -1,0 +1,285 @@
+/* ==========================================================================
+   Orbit Menu — pure CSS advanced component (EaseMotion-css, iteration 156)
+   A central action button that blooms into five satellite actions, each
+   traveling on a distinct easing curve so the curve itself is legible.
+   ========================================================================== */
+
+:root {
+  --em-bg: #150c28;
+  --em-bg-soft: #1f1440;
+  --em-accent: #8b5cf6;
+  --em-accent-strong: #a855f7;
+  --em-secondary: #f5b942;
+  --em-text: #f3effc;
+  --em-text-muted: #a89bc9;
+  --em-ring: rgba(139, 92, 246, 0.35);
+
+  --em-ease-linear: linear;
+  --em-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --em-ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --em-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --em-ease-bounce: cubic-bezier(0.68, -0.55, 0.27, 1.55);
+
+  --em-radius-sm: 10px;
+  --em-radius-md: 16px;
+  --em-radius-full: 999px;
+}
+
+* { box-sizing: border-box; }
+
+body.em-orbit-body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 4rem 1.5rem;
+  background:
+    radial-gradient(circle at 50% 20%, rgba(139, 92, 246, 0.18), transparent 55%),
+    var(--em-bg);
+  font-family: "Space Grotesk", "Segoe UI", system-ui, sans-serif;
+  color: var(--em-text);
+}
+
+.em-heading {
+  text-align: center;
+  max-width: 34rem;
+}
+
+.em-eyebrow {
+  display: inline-block;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--em-secondary);
+  font-weight: 600;
+  margin-bottom: 0.65rem;
+}
+
+.em-heading h1 {
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  line-height: 1.2;
+  margin: 0 0 0.6rem;
+  font-weight: 600;
+}
+
+.em-heading p {
+  margin: 0;
+  color: var(--em-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Orbit stage                                                            */
+/* ---------------------------------------------------------------------- */
+
+.em-orbit {
+  --em-orbit-size: 320px;
+  position: relative;
+  width: var(--em-orbit-size);
+  height: var(--em-orbit-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.em-orbit-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--em-radius-full);
+  border: 1px dashed var(--em-ring);
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity 0.5s var(--em-ease-out), transform 0.5s var(--em-ease-out);
+  pointer-events: none;
+}
+
+.em-orbit:hover .em-orbit-ring,
+.em-orbit:focus-within .em-orbit-ring {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Core trigger button */
+.em-core {
+  position: relative;
+  z-index: 5;
+  width: 84px;
+  height: 84px;
+  border-radius: var(--em-radius-full);
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(145deg, var(--em-accent-strong), var(--em-accent));
+  color: var(--em-text);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 0 var(--em-ring), 0 10px 30px -10px rgba(139, 92, 246, 0.6);
+  transition: box-shadow 0.4s var(--em-ease-out), transform 0.3s var(--em-ease-spring);
+}
+
+.em-core:hover,
+.em-core:focus-visible {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 10px var(--em-ring), 0 10px 30px -6px rgba(139, 92, 246, 0.75);
+  outline: none;
+}
+
+.em-core:active {
+  transform: scale(0.97);
+}
+
+/* Satellite buttons — positioned at stage center, translated out on hover */
+.em-satellite {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 58px;
+  height: 58px;
+  margin: -29px 0 0 -29px;
+  border-radius: var(--em-radius-md);
+  border: 1px solid rgba(245, 239, 252, 0.12);
+  background: var(--em-bg-soft);
+  color: var(--em-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  cursor: pointer;
+  opacity: 0;
+  transform: translate(0, 0) scale(0.4);
+  transition-property: transform, opacity;
+  transition-duration: 0.55s;
+  pointer-events: none;
+}
+
+.em-orbit:hover .em-satellite,
+.em-orbit:focus-within .em-satellite,
+.em-satellite:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.em-satellite:hover,
+.em-satellite:focus-visible {
+  border-color: var(--em-secondary);
+  outline: none;
+}
+
+/* Five satellites placed at 0°, 72°, 144°, 216°, 288° on a 130px radius,
+   each demoing a different named easing curve. */
+
+.em-satellite--1 { transition-timing-function: var(--em-ease-out); }
+.em-orbit:hover .em-satellite--1,
+.em-orbit:focus-within .em-satellite--1 {
+  transform: translate(0px, -130px) scale(1);
+  transition-delay: 0.02s;
+}
+
+.em-satellite--2 { transition-timing-function: var(--em-ease-spring); }
+.em-orbit:hover .em-satellite--2,
+.em-orbit:focus-within .em-satellite--2 {
+  transform: translate(123px, -40px) scale(1);
+  transition-delay: 0.08s;
+}
+
+.em-satellite--3 { transition-timing-function: var(--em-ease-bounce); }
+.em-orbit:hover .em-satellite--3,
+.em-orbit:focus-within .em-satellite--3 {
+  transform: translate(76px, 105px) scale(1);
+  transition-delay: 0.14s;
+}
+
+.em-satellite--4 { transition-timing-function: var(--em-ease-in-out); }
+.em-orbit:hover .em-satellite--4,
+.em-orbit:focus-within .em-satellite--4 {
+  transform: translate(-76px, 105px) scale(1);
+  transition-delay: 0.2s;
+}
+
+.em-satellite--5 { transition-timing-function: var(--em-ease-linear); }
+.em-orbit:hover .em-satellite--5,
+.em-orbit:focus-within .em-satellite--5 {
+  transform: translate(-123px, -40px) scale(1);
+  transition-delay: 0.26s;
+}
+
+/* Curve label chip beneath each satellite */
+.em-satellite-tag {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 6px);
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: var(--em-text-muted);
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.4s var(--em-ease-out) 0.3s;
+}
+
+.em-orbit:hover .em-satellite-tag,
+.em-orbit:focus-within .em-satellite-tag {
+  opacity: 1;
+}
+
+/* Legend */
+.em-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1rem;
+  max-width: 30rem;
+}
+
+.em-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  color: var(--em-text-muted);
+}
+
+.em-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--em-radius-full);
+  background: var(--em-secondary);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .em-core,
+  .em-satellite,
+  .em-orbit-ring,
+  .em-satellite-tag {
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Mobile */
+@media (max-width: 420px) {
+  .em-orbit { --em-orbit-size: 260px; }
+
+  .em-orbit:hover .em-satellite--1,
+  .em-orbit:focus-within .em-satellite--1 { transform: translate(0px, -105px) scale(1); }
+
+  .em-orbit:hover .em-satellite--2,
+  .em-orbit:focus-within .em-satellite--2 { transform: translate(100px, -32px) scale(1); }
+
+  .em-orbit:hover .em-satellite--3,
+  .em-orbit:focus-within .em-satellite--3 { transform: translate(62px, 85px) scale(1); }
+
+  .em-orbit:hover .em-satellite--4,
+  .em-orbit:focus-within .em-satellite--4 { transform: translate(-62px, 85px) scale(1); }
+
+  .em-orbit:hover .em-satellite--5,
+  .em-orbit:focus-within .em-satellite--5 { transform: translate(-100px, -32px) scale(1); }
+}


### PR DESCRIPTION
Orbit Menu

A pure CSS advanced component for EaseMotion-css — closes issue [#88614](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/88614) ("Add pure CSS advanced component iteration 156").

What it is

A central "Menu" button that, on hover or keyboard focus, blooms into five satellite action buttons arranged in a circle. Each satellite travels on a different named easing curve — linear, ease-out, ease-in-out, spring, and bounce — with a staggered transition-delay so the difference between curves is easy to see side by side. Since this repo is an easing/motion library, the component doubles as a live demo of the curves themselves rather than just another animated menu.