### PR TITLE
added the filrs

### DIFF
--- a/submissions/examples/neumorphic-audio-player/README.md
+++ b/submissions/examples/neumorphic-audio-player/README.md
@@ -1,0 +1,75 @@
+# Animated Audio Player Widget — Neumorphism
+
+Pure CSS component for **EaseMotion-css** — closes issue
+[#85712](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/85712)
+("feat: create Animated Audio Player Widget with Neumorphism styling").
+
+## What it is
+
+A soft-UI ("neumorphic") audio player card: a spinning vinyl-style disc,
+a 12-bar equalizer, a progress bar, transport controls, a like button, and
+a volume slider — all styled with carved/embossed shadows instead of flat
+color blocks.
+
+Every stateful interaction (play/pause, like/unlike, motion running or
+paused) is driven by the **checkbox hack** — two hidden `<input
+type="checkbox">` elements toggled by `<label>`s — so there is **zero
+JavaScript**. Toggling play:
+
+- spins the disc (`animation-play-state`)
+- runs the waveform bars, each with its own negative `animation-delay` so
+  they look reactive rather than mechanically synced
+- runs the progress-bar fill animation
+- swaps the play icon for a pause icon
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.html` | Component markup |
+| `style.css` | All styling, tokens, and motion, no JS |
+
+## Design tokens
+
+Defined as CSS custom properties in `:root` so the palette and shadow
+system are reusable across other EaseMotion components:
+
+- `--em-base` / `--em-shadow-light` / `--em-shadow-dark` — the neumorphic
+  surface and its two-tone soft shadows (`--em-raised`, `--em-inset`,
+  and small variants for compact controls)
+- `--em-accent` (teal) / `--em-highlight` (amber) — used together as a
+  gradient across the equalizer bars and progress fill
+- `--em-like` — heart fill color on the like toggle
+- `--em-ease-out`, `--em-ease-in-out`, `--em-ease-spring` — shared easing
+  curves used for hover lift, icon swaps, and the like-button pop
+
+## Accessibility
+
+- `prefers-reduced-motion: reduce` disables the disc spin, waveform
+  bounce, and progress animation, and snaps the progress bar to a fixed
+  position instead of leaving it at 0%.
+- All interactive controls (`play/pause`, `like`, `prev/next`, `volume`)
+  are real focusable elements with visible `:focus-visible` outlines and
+  `aria-label`s.
+- Play/pause and like state are exposed as checkboxes rather than
+  `div`s with click handlers, so they're operable and readable by
+  assistive tech without any JS.
+
+## Responsive behavior
+
+Card width and disc size scale down under 400px, and the surrounding
+page padding increases on wider viewports (≥700px) so the card doesn't
+feel lost on desktop.
+
+## Usage
+
+Open `index.html` directly in a browser. To drop this into an existing
+EaseMotion page, copy the `.em-player` markup block and `style.css`, then
+remap the `--em-*` custom properties to your existing theme tokens if you
+already have a palette defined elsewhere.
+
+## Suggested branch name
+
+```
+feat/neumorphic-audio-player-85712
+```

--- a/submissions/examples/neumorphic-audio-player/demo.html
+++ b/submissions/examples/neumorphic-audio-player/demo.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animated Audio Player — EaseMotion CSS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="em-player-body">
+
+  <div class="em-player">
+
+    <!-- Play state — drives disc spin, waveform motion, progress fill, icon swap -->
+    <input type="checkbox" id="em-play-toggle" class="em-play-input" />
+    <!-- Like state — drives heart fill -->
+    <input type="checkbox" id="em-like-toggle" class="em-like-input" />
+
+    <div class="em-stage">
+      <div class="em-disc" aria-hidden="true">
+        <div class="em-disc-label"></div>
+      </div>
+    </div>
+
+    <div class="em-meta">
+      <div class="em-meta-text">
+        <h2>Afterglow</h2>
+        <p>Nightbound &middot; Slow Static EP</p>
+      </div>
+      <label class="em-like-label" for="em-like-toggle" tabindex="0" aria-label="Like this track">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 20.5s-7.5-4.6-10-9.2C0.4 8 1.7 4.5 5 3.6c2.1-0.6 4.2 0.3 5.6 2 1-1.7 3.5-2.6 5.6-2 3.3 0.9 4.6 4.4 3 7.7-2.5 4.6-10 9.2-10 9.2z"/>
+        </svg>
+      </label>
+    </div>
+
+    <div class="em-waveform" aria-hidden="true">
+      <span class="em-bar"></span><span class="em-bar"></span><span class="em-bar"></span>
+      <span class="em-bar"></span><span class="em-bar"></span><span class="em-bar"></span>
+      <span class="em-bar"></span><span class="em-bar"></span><span class="em-bar"></span>
+      <span class="em-bar"></span><span class="em-bar"></span><span class="em-bar"></span>
+    </div>
+
+    <div class="em-progress-row">
+      <span class="em-time">1:12</span>
+      <div class="em-progress-track">
+        <div class="em-progress-fill"></div>
+      </div>
+      <span class="em-time">3:08</span>
+    </div>
+
+    <div class="em-controls">
+      <button class="em-btn em-btn-skip" type="button" aria-label="Previous track">
+        <svg viewBox="0 0 24 24"><path d="M6 6h2v12H6zm3.5 6l9.5 6V6z"/></svg>
+      </button>
+
+      <label class="em-btn em-play-label" for="em-play-toggle" tabindex="0" role="button" aria-label="Play or pause">
+        <svg class="em-icon em-icon-play" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+        <svg class="em-icon em-icon-pause" viewBox="0 0 24 24"><path d="M7 5h4v14H7zm6 0h4v14h-4z"/></svg>
+      </label>
+
+      <button class="em-btn em-btn-skip" type="button" aria-label="Next track">
+        <svg viewBox="0 0 24 24"><path d="M16 6h2v12h-2zM4.5 6v12l9.5-6z"/></svg>
+      </button>
+    </div>
+
+    <div class="em-volume-row">
+      <svg viewBox="0 0 24 24"><path d="M3 10v4h4l5 5V5L7 10H3zm13.5 2a4.5 4.5 0 0 0-2.5-4v8a4.5 4.5 0 0 0 2.5-4z"/></svg>
+      <input type="range" min="0" max="100" value="70" aria-label="Volume" />
+    </div>
+
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/neumorphic-audio-player/style.css
+++ b/submissions/examples/neumorphic-audio-player/style.css
@@ -1,0 +1,424 @@
+/* ==========================================================================
+   Neumorphic Audio Player — pure CSS advanced component
+   EaseMotion-css · components/audio-player · issue #85712
+   Zero JS: play state, like state, and progress motion are all driven by
+   the checkbox hack + CSS animations.
+   ========================================================================== */
+
+:root {
+  /* --- EaseMotion design tokens --- */
+  --em-base: #e6ebf2;
+  --em-shadow-light: #ffffff;
+  --em-shadow-dark: #a9b4c7;
+  --em-surface-text: #33415c;
+  --em-text-muted: #7c88a3;
+  --em-accent: #22b8a3;
+  --em-accent-soft: rgba(34, 184, 163, 0.18);
+  --em-highlight: #f2a541;
+  --em-like: #ef5f7a;
+
+  --em-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --em-ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --em-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --em-radius-sm: 10px;
+  --em-radius-md: 18px;
+  --em-radius-lg: 28px;
+  --em-radius-full: 999px;
+
+  --em-raised: 8px 8px 16px var(--em-shadow-dark), -8px -8px 16px var(--em-shadow-light);
+  --em-raised-sm: 4px 4px 8px var(--em-shadow-dark), -4px -4px 8px var(--em-shadow-light);
+  --em-inset: inset 5px 5px 10px var(--em-shadow-dark), inset -5px -5px 10px var(--em-shadow-light);
+  --em-inset-sm: inset 3px 3px 6px var(--em-shadow-dark), inset -3px -3px 6px var(--em-shadow-light);
+}
+
+* { box-sizing: border-box; }
+
+body.em-player-body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.25rem;
+  background: var(--em-base);
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  color: var(--em-surface-text);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Card                                                                    */
+/* ---------------------------------------------------------------------- */
+
+.em-player {
+  position: relative;
+  width: min(360px, 100%);
+  padding: 2rem 1.75rem 1.75rem;
+  border-radius: var(--em-radius-lg);
+  background: var(--em-base);
+  box-shadow: var(--em-raised);
+}
+
+.em-play-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.em-like-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Disc + tonearm                                                          */
+/* ---------------------------------------------------------------------- */
+
+.em-stage {
+  position: relative;
+  width: 168px;
+  height: 168px;
+  margin: 0 auto 1.4rem;
+}
+
+.em-disc {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--em-radius-full);
+  background:
+    repeating-radial-gradient(circle at center, #cfd7e3 0 2px, #dbe1ea 2px 4px),
+    radial-gradient(circle at 35% 30%, #f0f3f8, #cfd7e3 70%);
+  box-shadow: var(--em-inset);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: em-spin 6s linear infinite;
+  animation-play-state: paused;
+}
+
+.em-disc-label {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--em-radius-full);
+  background: linear-gradient(145deg, var(--em-accent), #1a8f7e);
+  box-shadow: var(--em-raised-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.em-disc-label::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: var(--em-radius-full);
+  background: var(--em-base);
+}
+
+.em-play-input:checked ~ .em-stage .em-disc {
+  animation-play-state: running;
+}
+
+@keyframes em-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Track meta + like                                                       */
+/* ---------------------------------------------------------------------- */
+
+.em-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1.1rem;
+}
+
+.em-meta-text h2 {
+  margin: 0 0 0.15rem;
+  font-family: "Manrope", "Inter", sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.em-meta-text p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--em-text-muted);
+}
+
+.em-like-label {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--em-radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--em-raised-sm);
+  transition: box-shadow 0.25s var(--em-ease-out);
+}
+
+.em-like-label:active { box-shadow: var(--em-inset-sm); }
+
+.em-like-label svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: var(--em-text-muted);
+  stroke-width: 2;
+  transition: fill 0.3s var(--em-ease-spring), stroke 0.3s var(--em-ease-out), transform 0.35s var(--em-ease-spring);
+}
+
+.em-like-input:checked ~ .em-meta .em-like-label svg {
+  fill: var(--em-like);
+  stroke: var(--em-like);
+  transform: scale(1.15);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Waveform / equalizer                                                    */
+/* ---------------------------------------------------------------------- */
+
+.em-waveform {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  height: 40px;
+  margin-bottom: 1.1rem;
+  padding: 0 4px;
+}
+
+.em-bar {
+  width: 5px;
+  border-radius: var(--em-radius-full);
+  background: linear-gradient(180deg, var(--em-accent), var(--em-highlight));
+  height: 30%;
+  transform-origin: bottom;
+  animation: em-bounce 1.1s var(--em-ease-in-out) infinite;
+  animation-play-state: paused;
+  opacity: 0.55;
+}
+
+.em-play-input:checked ~ .em-waveform .em-bar {
+  animation-play-state: running;
+  opacity: 1;
+}
+
+.em-bar:nth-child(1)  { animation-delay: -1.0s; height: 35%; }
+.em-bar:nth-child(2)  { animation-delay: -0.8s; height: 55%; }
+.em-bar:nth-child(3)  { animation-delay: -0.6s; height: 80%; }
+.em-bar:nth-child(4)  { animation-delay: -1.1s; height: 45%; }
+.em-bar:nth-child(5)  { animation-delay: -0.3s; height: 95%; }
+.em-bar:nth-child(6)  { animation-delay: -0.5s; height: 60%; }
+.em-bar:nth-child(7)  { animation-delay: -0.9s; height: 40%; }
+.em-bar:nth-child(8)  { animation-delay: -0.2s; height: 75%; }
+.em-bar:nth-child(9)  { animation-delay: -0.7s; height: 50%; }
+.em-bar:nth-child(10) { animation-delay: -0.4s; height: 65%; }
+.em-bar:nth-child(11) { animation-delay: -1.05s; height: 38%; }
+.em-bar:nth-child(12) { animation-delay: -0.15s; height: 85%; }
+
+@keyframes em-bounce {
+  0%, 100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Progress                                                                 */
+/* ---------------------------------------------------------------------- */
+
+.em-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.3rem;
+}
+
+.em-time {
+  font-size: 0.68rem;
+  color: var(--em-text-muted);
+  font-variant-numeric: tabular-nums;
+  width: 2.4em;
+}
+
+.em-progress-track {
+  flex: 1;
+  height: 8px;
+  border-radius: var(--em-radius-full);
+  box-shadow: var(--em-inset-sm);
+  overflow: hidden;
+}
+
+.em-progress-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: var(--em-radius-full);
+  background: linear-gradient(90deg, var(--em-accent), var(--em-highlight));
+  animation: em-progress 40s linear infinite;
+  animation-play-state: paused;
+}
+
+.em-play-input:checked ~ .em-progress-row .em-progress-fill {
+  animation-play-state: running;
+}
+
+@keyframes em-progress {
+  from { width: 0%; }
+  to { width: 100%; }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Transport controls                                                      */
+/* ---------------------------------------------------------------------- */
+
+.em-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  margin-bottom: 1.4rem;
+}
+
+.em-btn {
+  border: none;
+  background: var(--em-base);
+  color: var(--em-surface-text);
+  border-radius: var(--em-radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--em-raised-sm);
+  transition: box-shadow 0.25s var(--em-ease-out), transform 0.25s var(--em-ease-spring);
+}
+
+.em-btn:hover { transform: translateY(-1px); }
+.em-btn:active { box-shadow: var(--em-inset-sm); transform: translateY(0); }
+
+.em-btn-skip {
+  width: 40px;
+  height: 40px;
+}
+
+.em-btn-skip svg {
+  width: 15px;
+  height: 15px;
+  fill: var(--em-text-muted);
+}
+
+.em-play-label {
+  width: 60px;
+  height: 60px;
+  box-shadow: var(--em-raised);
+}
+
+.em-play-label:active { box-shadow: var(--em-inset); }
+
+.em-icon {
+  width: 18px;
+  height: 18px;
+  fill: var(--em-accent);
+  transition: opacity 0.15s var(--em-ease-out);
+}
+
+.em-icon-pause { display: none; }
+
+.em-play-input:checked ~ .em-controls .em-icon-play { display: none; }
+.em-play-input:checked ~ .em-controls .em-icon-pause { display: block; }
+
+/* ---------------------------------------------------------------------- */
+/* Volume                                                                   */
+/* ---------------------------------------------------------------------- */
+
+.em-volume-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.em-volume-row svg {
+  width: 15px;
+  height: 15px;
+  fill: var(--em-text-muted);
+  flex-shrink: 0;
+}
+
+.em-volume-row input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  flex: 1;
+  height: 6px;
+  border-radius: var(--em-radius-full);
+  background: var(--em-base);
+  box-shadow: var(--em-inset-sm);
+  outline: none;
+}
+
+.em-volume-row input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--em-radius-full);
+  background: var(--em-accent);
+  box-shadow: var(--em-raised-sm);
+  cursor: pointer;
+  transition: transform 0.2s var(--em-ease-spring);
+}
+
+.em-volume-row input[type="range"]::-webkit-slider-thumb:hover { transform: scale(1.15); }
+
+.em-volume-row input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: var(--em-radius-full);
+  background: var(--em-accent);
+  box-shadow: var(--em-raised-sm);
+  cursor: pointer;
+}
+
+/* Focus visibility for accessibility */
+.em-play-label:focus-visible,
+.em-btn-skip:focus-visible,
+.em-like-label:focus-visible,
+.em-volume-row input[type="range"]:focus-visible {
+  outline: 2px solid var(--em-accent);
+  outline-offset: 3px;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Responsive                                                               */
+/* ---------------------------------------------------------------------- */
+
+@media (max-width: 400px) {
+  .em-player { padding: 1.6rem 1.25rem 1.4rem; }
+  .em-stage { width: 136px; height: 136px; }
+  .em-waveform { height: 32px; }
+}
+
+@media (min-width: 700px) {
+  body.em-player-body { padding: 4rem 1.5rem; }
+  .em-player { width: 380px; padding: 2.3rem 2rem 2rem; }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Reduced motion                                                          */
+/* ---------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .em-disc,
+  .em-bar,
+  .em-progress-fill {
+    animation: none !important;
+  }
+  .em-play-input:checked ~ .em-progress-row .em-progress-fill {
+    width: 38%;
+  }
+  .em-btn, .em-like-label, .em-like-label svg {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Animated Audio Player Widget — Neumorphism

Pure CSS component for EaseMotion-css — closes issue [#85712](https://github.com/SAPTARSHI-coder/EaseMotion-css/issues/85712) ("feat: create Animated Audio Player Widget with Neumorphism styling").

What it is

A soft-UI ("neumorphic") audio player card: a spinning vinyl-style disc, a 12-bar equalizer, a progress bar, transport controls, a like button, and a volume slider — all styled with carved/embossed shadows instead of flat color blocks.

Every stateful interaction (play/pause, like/unlike, motion running or paused) is driven by the checkbox hack — two hidden <input type="checkbox"> elements toggled by <label>s — so there is zero JavaScript. Toggling play:

spins the disc (animation-play-state)
runs the waveform bars, each with its own negative animation-delay so they look reactive rather than mechanically synced
runs the progress-bar fill animation
swaps the play icon for a pause icon