### PR TITLE
feat(#86775): add gradient-slide-button component

### DIFF
--- a/submissions/examples/gradient-slide-button/README.md
+++ b/submissions/examples/gradient-slide-button/README.md
@@ -1,0 +1,5 @@
+# Gradient Slide Button
+
+1. What does this do? Renders an outlined button whose two-tone gradient fills in from the left on hover, with a soft shimmer sweep across the surface.
+2. How is it used? Apply `.gradient-slide-button` to a button element. Customize the gradient stops with the `--gsb-from`, `--gsb-to`, and `--gsb-speed` custom properties.
+3. Why is it useful? It gives a clear directional fill cue on interaction using only CSS, no JavaScript, and respects `prefers-reduced-motion`.

--- a/submissions/examples/gradient-slide-button/demo.html
+++ b/submissions/examples/gradient-slide-button/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gradient Slide Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="gsb-title">
+        <p class="eyebrow">Button feedback</p>
+        <h1 id="gsb-title">Gradient slide</h1>
+        <p class="demo-copy">
+          An outlined button whose two-tone gradient fills in from the left on
+          hover, with a soft color sweep across the label.
+        </p>
+        <button class="gradient-slide-button" type="button">Get started</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/gradient-slide-button/style.css
+++ b/submissions/examples/gradient-slide-button/style.css
@@ -1,0 +1,167 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Gradient Slide Button
+   An outlined button. A two-tone gradient fill wipes in from the left on
+   hover/focus, and the label color sweeps to keep readable contrast.
+   --------------------------------------------------------------------------- */
+.gradient-slide-button {
+  --gsb-from: #6366f1;
+  --gsb-to: #ec4899;
+  --gsb-speed: 380ms;
+
+  position: relative;
+  isolation: isolate;
+  z-index: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: min(100%, 16rem);
+  margin: 0 auto;
+  border: 2px solid var(--gsb-from);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--gsb-from);
+  padding: 0.95rem 1.6rem;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    color var(--gsb-speed) ease,
+    border-color var(--gsb-speed) ease,
+    transform 160ms ease;
+}
+
+/* The gradient fill: positioned fully to the left (hidden), slides in on hover. */
+.gradient-slide-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(90deg, var(--gsb-from), var(--gsb-to));
+  transform: translateX(-101%);
+  transition: transform var(--gsb-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gradient-slide-button:hover,
+.gradient-slide-button:focus-visible,
+.gradient-slide-button:active {
+  color: #ffffff;
+  border-color: var(--gsb-to);
+  outline: none;
+  transform: translateY(-0.12rem);
+}
+
+.gradient-slide-button:hover::before,
+.gradient-slide-button:focus-visible::before,
+.gradient-slide-button:active::before {
+  transform: translateX(0);
+}
+
+/* Subtle label color sweep on hover, timed with the fill. */
+.gradient-slide-button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.28),
+    rgba(255, 255, 255, 0)
+  );
+  transform: translateX(-101%);
+  opacity: 0;
+}
+
+.gradient-slide-button:hover::after,
+.gradient-slide-button:focus-visible::after,
+.gradient-slide-button:active::after {
+  animation: gsb-shimmer var(--gsb-speed) ease;
+}
+
+@keyframes gsb-shimmer {
+  from {
+    transform: translateX(-101%);
+    opacity: 0.9;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-slide-button,
+  .gradient-slide-button::before,
+  .gradient-slide-button::after {
+    transition: none;
+    animation: none;
+  }
+
+  .gradient-slide-button:hover::before,
+  .gradient-slide-button:focus-visible::before,
+  .gradient-slide-button:active::before {
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
## What

Closes #86775 — add the **Gradient Slide Button** component to the EaseMotion CSS gallery.

**Category:** Button
**Description:** An outlined button whose two-tone gradient fills in from the left on hover.

## Changes

Adds `submissions/examples/gradient-slide-button/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

### How it works
- Outline-only at rest, with the gradient defined as two custom properties (`--gsb-from`, `--gsb-to`).
- On `:hover` / `:focus-visible` / `:active`, a `::before` gradient fill wipes in from the left (`translateX(-101%)` → `0`) over `--gsb-speed` (default 380ms).
- The label swaps to white and the border to the trailing gradient color for contrast.
- A `::after` shimmer sweeps across the surface, timed with the fill.
- Respects `prefers-reduced-motion` (disables the animation, keeps the fill on interaction).

All files are placed **only** under `submissions/examples/gradient-slide-button/`, matching the contributing guide.

## How it was verified
- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config (legacy color-function notation, etc.).
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._