### PR TITLE
feat(#86799): add handwritten-underline-text component

### DIFF
--- a/submissions/examples/handwritten-underline-text/README.md
+++ b/submissions/examples/handwritten-underline-text/README.md
@@ -1,0 +1,5 @@
+# Handwritten Underline Text
+
+1. What does this do? Draws an underline beneath a headline like a marker swipe, animating the stroke from left to right on load (and replaying on hover).
+2. How is it used? Wrap the headline text in a `.handwritten-underline` span and include the inline SVG with a hand-drawn path. The path length is driven by `stroke-dasharray` / `stroke-dashoffset`.
+3. Why is it useful? It adds an organic, hand-crafted emphasis to headings using only CSS and a static SVG path, with no JavaScript, and respects `prefers-reduced-motion`.

--- a/submissions/examples/handwritten-underline-text/demo.html
+++ b/submissions/examples/handwritten-underline-text/demo.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Handwritten Underline Text</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="hut-title">
+        <p class="eyebrow">Text effect</p>
+        <h1 id="hut-title">
+          <span class="handwritten-underline" data-text="Crafted by hand"
+            >Crafted by hand
+            <svg viewBox="0 0 100 12" preserveAspectRatio="none" aria-hidden="true">
+              <path d="M2 7 C 14 2, 26 11, 38 6 S 62 3, 74 7 S 92 9, 98 5" />
+            </svg>
+          </span>
+        </h1>
+        <p class="demo-copy">
+          On load, an underline strokes itself beneath the headline like a
+          marker swipe. Hover the headline to replay the draw.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/handwritten-underline-text/style.css
+++ b/submissions/examples/handwritten-underline-text/style.css
@@ -1,0 +1,115 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 5vw, 3rem);
+  line-height: 1.2;
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.95rem auto 0;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Handwritten Underline Text
+   An underline draws itself beneath the text like a marker swipe, using an
+   SVG path stroke-dashoffset animation. Hover replays the draw.
+   --------------------------------------------------------------------------- */
+.handwritten-underline {
+  position: relative;
+  display: inline-block;
+  padding: 0 0.2em 0.1em;
+  color: #172033;
+}
+
+/* The SVG sits beneath the text and is sized to the element. */
+.handwritten-underline > svg {
+  position: absolute;
+  left: 0;
+  bottom: -0.12em;
+  width: 100%;
+  height: 0.55em;
+  overflow: visible;
+  fill: none;
+}
+
+.handwritten-underline > svg path {
+  stroke: #2563eb;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+
+  /* The dashed path is fully hidden at start, then "drawn" on load/hover. */
+  stroke-dasharray: 320;
+  stroke-dashoffset: 320;
+  animation: handwritten-draw 720ms ease-out 250ms forwards;
+}
+
+.handwritten-underline:hover > svg path,
+.handwritten-underline:focus-visible > svg path {
+  animation: handwritten-draw 640ms ease-out forwards;
+}
+
+@keyframes handwritten-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .handwritten-underline > svg path {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+}


### PR DESCRIPTION
## What

Closes #86799 — add the **handwritten-underline-text** component to the EaseMotion CSS gallery.

**Category:** Text
**Description:** An underline draws itself beneath the headline like a marker swipe.

## Changes

Adds `submissions/examples/handwritten-underline-text/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._