### PR TITLE
feat(#86760): add ring-sweep-loader component

### DIFF
--- a/submissions/examples/ring-sweep-loader/README.md
+++ b/submissions/examples/ring-sweep-loader/README.md
@@ -1,0 +1,5 @@
+# Ring Sweep Loader
+
+1. What does this do? Shows a conic-gradient arc that sweeps around a thin ring, leaving a glowing trailing tail — a pure-CSS spinner.
+2. How is it used? Add a `.ring-sweep-loader` element (optionally with a `.ring-sweep-loader__label` child). Customize size, ring thickness, colors, and speed via `--rsl-size`, `--rsl-ring`, `--rsl-from`, `--rsl-to`, `--rsl-track`, and `--rsl-speed`.
+3. Why is it useful? It is a lightweight, dependency-free loading indicator with a comet-trail sweep, and it respects `prefers-reduced-motion`.

--- a/submissions/examples/ring-sweep-loader/demo.html
+++ b/submissions/examples/ring-sweep-loader/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ring Sweep Loader</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="rsl-title">
+        <p class="eyebrow">Loader</p>
+        <h1 id="rsl-title">Ring sweep</h1>
+        <p class="demo-copy">
+          A conic-gradient arc sweeps around a thin ring, leaving a glowing
+          trail behind it.
+        </p>
+        <div class="ring-sweep-loader" role="status" aria-label="Loading">
+          <span class="ring-sweep-loader__label">Loading</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ring-sweep-loader/style.css
+++ b/submissions/examples/ring-sweep-loader/style.css
@@ -1,0 +1,163 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Ring Sweep Loader
+   A conic-gradient arc sweeps around a thin ring, leaving a glowing trail.
+   The conic gradient is painted on a spinning mask so the bright arc orbits
+   the ring, while a static glow softens the trailing edge.
+   --------------------------------------------------------------------------- */
+.ring-sweep-loader {
+  --rsl-size: 6rem;
+  --rsl-ring: 0.5rem;
+  --rsl-from: #6366f1;
+  --rsl-to: #ec4899;
+  --rsl-track: #e2e8f0;
+  --rsl-speed: 1.1s;
+
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: var(--rsl-size);
+  height: var(--rsl-size);
+  border-radius: 50%;
+
+  /* The sweep: a conic arc that starts bright and fades to transparent,
+     creating the comet trail. Rotated by the keyframe below. */
+  background: conic-gradient(
+    from 0deg,
+    var(--rsl-to) 0deg,
+    var(--rsl-from) 40deg,
+    rgba(99, 102, 241, 0.18) 120deg,
+    transparent 220deg,
+    transparent 360deg
+  );
+  -webkit-mask: radial-gradient(
+    circle,
+    transparent calc(50% - var(--rsl-ring)),
+    #000 calc(50% - var(--rsl-ring) + 0.5px)
+  );
+  mask: radial-gradient(
+    circle,
+    transparent calc(50% - var(--rsl-ring)),
+    #000 calc(50% - var(--rsl-ring) + 0.5px)
+  );
+  animation: rsl-spin var(--rsl-speed) linear infinite;
+}
+
+/* Faint static track behind the sweep for context. */
+.ring-sweep-loader::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--rsl-track);
+  -webkit-mask: radial-gradient(
+    circle,
+    transparent calc(50% - var(--rsl-ring)),
+    #000 calc(50% - var(--rsl-ring) + 0.5px)
+  );
+  mask: radial-gradient(
+    circle,
+    transparent calc(50% - var(--rsl-ring)),
+    #000 calc(50% - var(--rsl-ring) + 0.5px)
+  );
+  z-index: -1;
+}
+
+/* Soft outer glow that follows the bright arc. */
+.ring-sweep-loader::after {
+  content: "";
+  position: absolute;
+  inset: -0.4rem;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    rgba(236, 72, 153, 0.35) 0deg,
+    rgba(99, 102, 241, 0.2) 60deg,
+    transparent 160deg,
+    transparent 360deg
+  );
+  filter: blur(6px);
+  animation: rsl-spin var(--rsl-speed) linear infinite;
+  z-index: -2;
+}
+
+.ring-sweep-loader__label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #536173;
+}
+
+@keyframes rsl-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring-sweep-loader,
+  .ring-sweep-loader::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86760 — add the **ring-sweep-loader** component to the EaseMotion CSS gallery.

**Category:** Loader
**Description:** A conic-gradient arc that sweeps around a thin ring, leaving a glowing trail.

## Changes

Adds `submissions/examples/ring-sweep-loader/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._