### PR TITLE
feat(#86798): add pop-text-letter component

### DIFF
--- a/submissions/examples/pop-text-letter/README.md
+++ b/submissions/examples/pop-text-letter/README.md
@@ -1,0 +1,5 @@
+# Pop Text Letter
+
+1. What does this do? On page load, each letter of the headline pops up one at a time with a springy overshoot; hovering the headline replays the sequence.
+2. How is it used? Wrap each letter in a `<span>` inside a `.pop-text` element and set an incrementing `--i` inline style on each span to control the stagger delay. Use `.pop-text__space` for whitespace spans.
+3. Why is it useful? It adds a lively, attention-grabbing entrance animation to headings using only CSS (the overshoot comes from a `cubic-bezier` easing), with no JavaScript, and it respects `prefers-reduced-motion`.

--- a/submissions/examples/pop-text-letter/demo.html
+++ b/submissions/examples/pop-text-letter/demo.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pop Text Letter</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ptl-title">
+        <p class="eyebrow">Text effect</p>
+        <h1 id="ptl-title" class="pop-text" aria-label="Pop in">
+          <span style="--i: 0">P</span><span style="--i: 1">o</span><span style="--i: 2">p</span><span class="pop-text__space">&nbsp;</span><span style="--i: 3">i</span><span style="--i: 4">n</span>
+        </h1>
+        <p class="demo-copy">
+          On page load, each letter pops up one at a time with a springy
+          overshoot. Hover the headline to replay the animation.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/pop-text-letter/style.css
+++ b/submissions/examples/pop-text-letter/style.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 3.6rem);
+  line-height: 1.2;
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.95rem auto 0;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Pop Text Letter
+   Each letter pops up one at a time with a springy overshoot. The stagger is
+   driven by a per-letter --i custom property set inline in the markup.
+   --------------------------------------------------------------------------- */
+.pop-text span {
+  display: inline-block;
+  color: #172033;
+  opacity: 0;
+  transform: translateY(0.8rem) scale(0.6);
+  animation: pop-in 520ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation-delay: calc(var(--i) * 90ms + 150ms);
+}
+
+.pop-text__space {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
+}
+
+/* Hovering the headline replays the pop-in sequence. */
+.pop-text:hover span {
+  animation: pop-in 520ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation-delay: calc(var(--i) * 90ms);
+}
+
+@keyframes pop-in {
+  0% {
+    opacity: 0;
+    transform: translateY(0.8rem) scale(0.6);
+  }
+
+  60% {
+    opacity: 1;
+    transform: translateY(-0.18rem) scale(1.12);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pop-text span {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86798 — add the **pop-text-letter** component to the EaseMotion CSS gallery.

**Category:** Text
**Description:** Letters pop up one at a time on page load with a springy overshoot.

## Changes

Adds `submissions/examples/pop-text-letter/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._