### PR TITLE
feat(#86776): add stamp-button component

### DIFF
--- a/submissions/examples/stamp-button/README.md
+++ b/submissions/examples/stamp-button/README.md
@@ -1,0 +1,5 @@
+# Stamp Button
+
+1. What does this do? Renders a rubber-stamp style button that presses down with a squash and blooms an ink-blot grain texture on press.
+2. How is it used? Apply `.stamp-button` to a button element. Customize the ink and paper colors and the press speed via `--sb-ink`, `--sb-paper`, and `--sb-speed`.
+3. Why is it useful? It gives click feedback a tactile, physical "stamping" feel using only CSS layered radial gradients and transforms, with no JavaScript, and respects `prefers-reduced-motion`.

--- a/submissions/examples/stamp-button/demo.html
+++ b/submissions/examples/stamp-button/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stamp Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="sb-title">
+        <p class="eyebrow">Button feedback</p>
+        <h1 id="sb-title">Stamp button</h1>
+        <p class="demo-copy">
+          A playful rubber-stamp button that presses down with an ink-blot
+          texture. Press it to stamp.
+        </p>
+        <button class="stamp-button" type="button">Approved</button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/stamp-button/style.css
+++ b/submissions/examples/stamp-button/style.css
@@ -1,0 +1,151 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Stamp Button
+   A rubber-stamp style button. At rest it sits slightly raised; on press it
+   drives down with a quick squash, and an ink-blot texture blooms behind the
+   label via a radial-grain pseudo-element.
+   --------------------------------------------------------------------------- */
+.stamp-button {
+  --sb-ink: #1d4ed8;
+  --sb-paper: #ffffff;
+  --sb-speed: 240ms;
+
+  position: relative;
+  isolation: isolate;
+  z-index: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: min(100%, 12rem);
+  margin: 0 auto;
+  border: 2px solid var(--sb-ink);
+  border-radius: 0.5rem;
+  background: var(--sb-paper);
+  color: var(--sb-ink);
+  padding: 0.9rem 1.5rem;
+  font: inherit;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+
+  /* A slightly irregular, hand-stamped edge feel. */
+  box-shadow:
+    0 0.3rem 0 var(--sb-ink),
+    0 0.4rem 0.1rem rgba(29, 78, 216, 0.25);
+  transform: translateY(0);
+  transition:
+    transform var(--sb-speed) cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow var(--sb-speed) ease,
+    color var(--sb-speed) ease;
+}
+
+/* Ink-blot grain: layered radials create a mottled stamp texture. */
+.stamp-button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 20% 30%, var(--sb-ink) 0 1px, transparent 2px),
+    radial-gradient(circle at 70% 60%, var(--sb-ink) 0 1px, transparent 2px),
+    radial-gradient(circle at 40% 80%, var(--sb-ink) 0 1px, transparent 2px),
+    radial-gradient(circle at 85% 25%, var(--sb-ink) 0 1px, transparent 2px),
+    radial-gradient(circle at 55% 45%, var(--sb-ink) 0 1px, transparent 2px);
+  background-size: 14px 14px, 18px 18px, 12px 12px, 16px 16px, 20px 20px;
+  opacity: 0;
+  transition: opacity var(--sb-speed) ease;
+}
+
+.stamp-button:hover,
+.stamp-button:focus-visible {
+  outline: none;
+  color: var(--sb-ink);
+}
+
+.stamp-button:hover::before,
+.stamp-button:focus-visible::before {
+  opacity: 0.18;
+}
+
+/* The press: drive down into the paper, lose the shadow lift, bloom the ink. */
+.stamp-button:active {
+  transform: translateY(0.3rem);
+  box-shadow:
+    0 0 0 var(--sb-ink),
+    0 0 0.1rem rgba(29, 78, 216, 0.25);
+  color: var(--sb-paper);
+  background: var(--sb-ink);
+}
+
+.stamp-button:active::before {
+  opacity: 0.35;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stamp-button,
+  .stamp-button::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86776 — add the **stamp-button** component to the EaseMotion CSS gallery.

**Category:** Button
**Description:** A playful rubber-stamp button that presses down with an ink-blot texture.

## Changes

Adds `submissions/examples/stamp-button/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._