### PR TITLE
feat(#86778): add underline-slide-button component

### DIFF
--- a/submissions/examples/underline-slide-button/README.md
+++ b/submissions/examples/underline-slide-button/README.md
@@ -1,0 +1,5 @@
+# Underline Slide Button
+
+1. What does this do? A text-only link button whose underline slides in from the left on hover, with a soft color sweep across the label.
+2. How is it used? Apply `.underline-slide-button` to an anchor (or button). Customize the muted base color, accent color, and speed via `--usb-base`, `--usb-accent`, and `--usb-speed`.
+3. Why is it useful? It gives text links a clear, directional hover affordance using only CSS, with no JavaScript, and respects `prefers-reduced-motion`.

--- a/submissions/examples/underline-slide-button/demo.html
+++ b/submissions/examples/underline-slide-button/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Underline Slide Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="usb-title">
+        <p class="eyebrow">Button feedback</p>
+        <h1 id="usb-title">Underline slide</h1>
+        <p class="demo-copy">
+          A text-only link button whose underline slides in from the left with
+          a color sweep across the label.
+        </p>
+        <a class="underline-slide-button" href="#">Read more</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/underline-slide-button/style.css
+++ b/submissions/examples/underline-slide-button/style.css
@@ -1,0 +1,134 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Underline Slide Button
+   A text-only link button. The underline slides in from the left on hover
+   and the label color sweeps from a muted tone to the accent.
+   --------------------------------------------------------------------------- */
+.underline-slide-button {
+  --usb-base: #536173;
+  --usb-accent: #2563eb;
+  --usb-speed: 320ms;
+
+  position: relative;
+  display: inline-block;
+  padding: 0 0.2em 0.25em;
+  color: var(--usb-base);
+  text-decoration: none;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color var(--usb-speed) ease;
+}
+
+/* The underline: anchored bottom-left, width grows from 0 to 100% on hover. */
+.underline-slide-button::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--usb-accent);
+  transition: width var(--usb-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* The color sweep: a thin accent gradient that wipes across the label. */
+.underline-slide-button::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--usb-accent), rgba(37, 99, 235, 0));
+  transition: width var(--usb-speed) ease var(--usb-speed);
+}
+
+.underline-slide-button:hover,
+.underline-slide-button:focus-visible {
+  color: var(--usb-accent);
+  outline: none;
+}
+
+.underline-slide-button:hover::before,
+.underline-slide-button:focus-visible::before {
+  width: 100%;
+}
+
+.underline-slide-button:hover::after,
+.underline-slide-button:focus-visible::after {
+  width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .underline-slide-button,
+  .underline-slide-button::before,
+  .underline-slide-button::after {
+    transition: none;
+  }
+
+  .underline-slide-button:hover::before,
+  .underline-slide-button:focus-visible::before {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## What

Closes #86778 — add the **underline-slide-button** component to the EaseMotion CSS gallery.

**Category:** Button
**Description:** A text-only link button whose underline slides in from the left with a color sweep.

## Changes

Adds `submissions/examples/underline-slide-button/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._