### PR TITLE
feat(#86761): add wave-bars-loader component

### DIFF
--- a/submissions/examples/wave-bars-loader/README.md
+++ b/submissions/examples/wave-bars-loader/README.md
@@ -1,0 +1,5 @@
+# Wave Bars Loader
+
+1. What does this do? Shows five equalizer bars that swell and fall in sequence, like sound waves taking shape — a pure-CSS loading indicator.
+2. How is it used? Add a `.wave-bars-loader` element containing five empty `<span>` children. Customize bar width, gap, gradient, and speed via `--wbl-bar`, `--wbl-gap`, `--wbl-from`, `--wbl-to`, and `--wbl-speed`.
+3. Why is it useful? It is a lightweight, dependency-free loader with a traveling-wave rhythm, and it respects `prefers-reduced-motion`.

--- a/submissions/examples/wave-bars-loader/demo.html
+++ b/submissions/examples/wave-bars-loader/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wave Bars Loader</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="wbl-title">
+        <p class="eyebrow">Loader</p>
+        <h1 id="wbl-title">Wave bars</h1>
+        <p class="demo-copy">
+          Five equalizer bars swell and fall in sequence, like sound waves
+          taking shape.
+        </p>
+        <div class="wave-bars-loader" role="status" aria-label="Loading">
+          <span></span><span></span><span></span><span></span><span></span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/wave-bars-loader/style.css
+++ b/submissions/examples/wave-bars-loader/style.css
@@ -1,0 +1,128 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Wave Bars Loader
+   Five equalizer bars swell and fall in sequence, like sound waves taking
+   shape. Each bar shares one keyframe; the stagger comes from a per-bar
+   negative animation-delay so the wave travels left to right.
+   --------------------------------------------------------------------------- */
+.wave-bars-loader {
+  --wbl-bar: 0.5rem;
+  --wbl-gap: 0.4rem;
+  --wbl-from: #6366f1;
+  --wbl-to: #ec4899;
+  --wbl-speed: 1s;
+
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wbl-gap);
+  height: 3rem;
+}
+
+.wave-bars-loader span {
+  display: block;
+  width: var(--wbl-bar);
+  height: 20%;
+  border-radius: 999px;
+  background: linear-gradient(var(--wbl-from), var(--wbl-to));
+  transform-origin: center;
+  animation: wbl-wave var(--wbl-speed) ease-in-out infinite;
+}
+
+/* Stagger each bar so the swell travels across the row. */
+.wave-bars-loader span:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.wave-bars-loader span:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.wave-bars-loader span:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+.wave-bars-loader span:nth-child(4) {
+  animation-delay: 0.36s;
+}
+
+.wave-bars-loader span:nth-child(5) {
+  animation-delay: 0.48s;
+}
+
+@keyframes wbl-wave {
+  0%,
+  100% {
+    height: 20%;
+  }
+
+  50% {
+    height: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wave-bars-loader span {
+    animation: none;
+    height: 60%;
+  }
+}


### PR DESCRIPTION
## What

Closes #86761 — add the **wave-bars-loader** component to the EaseMotion CSS gallery.

**Category:** Loader
**Description:** Five equalizer bars swell and fall in sequence, like sound waves taking shape.

## Changes

Adds `submissions/examples/wave-bars-loader/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._