### PR TITLE
feat(#86484): add cyberpunk-code-terminal-block component

### DIFF
--- a/submissions/examples/cyberpunk-code-terminal-block/README.md
+++ b/submissions/examples/cyberpunk-code-terminal-block/README.md
@@ -1,0 +1,5 @@
+# Cyberpunk Code Terminal Block
+
+1. What does this do? Renders a neon-glow developer code terminal with window control dots, line numbers, syntax color tokens, active line highlighting, and a blinking prompt cursor.
+2. How is it used? Build a `.cyberpunk-terminal` container with a `.cyberpunk-terminal__bar` (window dots + title) and a `<pre class="cyberpunk-terminal__body"><code>...</code></pre>` block. Each line is a `.cyberpunk-terminal__line` (add `--active` to highlight it) with a `.cyberpunk-terminal__ln` number. Wrap tokens in `.tok--kw`, `.tok--var`, `.tok--fn`, `.tok--str`, `.tok--num`, `.tok--op`, `.tok--com` classes. Drop a `.cyberpunk-terminal__cursor` after the active-line content for the blinking cursor. Customize colors and the mono stack via the `--cct-*` variables.
+3. Why is it useful? It styles code snippets for technical docs and SDK landing pages with a distinctive cyberpunk aesthetic using only HTML/CSS, and the cursor respects `prefers-reduced-motion`.

--- a/submissions/examples/cyberpunk-code-terminal-block/demo.html
+++ b/submissions/examples/cyberpunk-code-terminal-block/demo.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cyberpunk Code Terminal Block</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="cct-title">
+        <p class="eyebrow">Code block</p>
+        <h1 id="cct-title">Cyberpunk terminal</h1>
+        <p class="demo-copy">
+          A neon-glow code terminal with window control dots, line numbers,
+          syntax color tokens, active line highlighting, and a blinking
+          prompt cursor.
+        </p>
+        <div class="cyberpunk-terminal" role="region" aria-label="Code terminal demo">
+          <div class="cyberpunk-terminal__bar">
+            <span class="cyberpunk-terminal__dot cyberpunk-terminal__dot--red"></span>
+            <span class="cyberpunk-terminal__dot cyberpunk-terminal__dot--amber"></span>
+            <span class="cyberpunk-terminal__dot cyberpunk-terminal__dot--green"></span>
+            <span class="cyberpunk-terminal__title">~/projects/neon&nbsp;&mdash; zsh</span>
+          </div>
+          <pre class="cyberpunk-terminal__body"><code><span class="cyberpunk-terminal__line"><span class="cyberpunk-terminal__ln">1</span><span class="tok tok--kw">const</span> <span class="tok tok--var">grid</span> <span class="tok tok--op">=</span> <span class="tok tok--fn">connect</span><span class="tok tok--op">(</span><span class="tok tok--str">'mainframe'</span><span class="tok tok--op">);</span></span>
+<span class="cyberpunk-terminal__line cyberpunk-terminal__line--active"><span class="cyberpunk-terminal__ln">2</span><span class="tok tok--var">grid</span><span class="tok tok--op">.</span><span class="tok tok--fn">boot</span><span class="tok tok--op">(</span><span class="tok tok--num">9001</span><span class="tok tok--op">);</span><span class="cyberpunk-terminal__cursor"></span></span>
+<span class="cyberpunk-terminal__line"><span class="cyberpunk-terminal__ln">3</span><span class="tok tok--com">// neon online</span></span></code></pre>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/cyberpunk-code-terminal-block/style.css
+++ b/submissions/examples/cyberpunk-code-terminal-block/style.css
@@ -1,0 +1,223 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #070b18;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 44rem);
+  border: 1px solid #1e293b;
+  border-radius: 0.85rem;
+  background: #0b1220;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.5);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #22d3ee;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+  color: #f0fdff;
+}
+
+.demo-copy {
+  max-width: 32rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #93a4c0;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Cyberpunk Code Terminal Block
+   A neon-glow code terminal: window control dots, line numbers, syntax color
+   tokens, active line highlighting, and a blinking prompt cursor.
+   --------------------------------------------------------------------------- */
+.cyberpunk-terminal {
+  --cct-bg: #0b1220;
+  --cct-bar: #0f1a2e;
+  --cct-border: #1e293b;
+  --cct-neon: #22d3ee;
+  --cct-neon-2: #f472b6;
+  --cct-text: #c8d6f5;
+  --cct-mono:
+    "JetBrains Mono", "Fira Code", ui-monospace, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+
+  text-align: left;
+  border: 1px solid var(--cct-border);
+  border-radius: 0.7rem;
+  background: var(--cct-bg);
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(34, 211, 238, 0.12),
+    0 0 2.2rem rgba(34, 211, 238, 0.18),
+    0 0 3.4rem rgba(244, 114, 182, 0.12);
+  font-family: var(--cct-mono);
+}
+
+.cyberpunk-terminal__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  background: var(--cct-bar);
+  border-bottom: 1px solid var(--cct-border);
+}
+
+.cyberpunk-terminal__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+}
+
+.cyberpunk-terminal__dot--red {
+  background: #ff5f57;
+  box-shadow: 0 0 0.5rem rgba(255, 95, 87, 0.6);
+}
+
+.cyberpunk-terminal__dot--amber {
+  background: #febc2e;
+  box-shadow: 0 0 0.5rem rgba(254, 188, 46, 0.6);
+}
+
+.cyberpunk-terminal__dot--green {
+  background: #28c840;
+  box-shadow: 0 0 0.5rem rgba(40, 200, 64, 0.6);
+}
+
+.cyberpunk-terminal__title {
+  margin-left: 0.6rem;
+  color: #5f7896;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.cyberpunk-terminal__body {
+  margin: 0;
+  padding: 0.9rem 0;
+  overflow-x: auto;
+  font-family: var(--cct-mono);
+  font-size: 0.92rem;
+  line-height: 1.9;
+  color: var(--cct-text);
+}
+
+.cyberpunk-terminal__body code {
+  display: block;
+  font-family: inherit;
+}
+
+.cyberpunk-terminal__line {
+  display: block;
+  padding: 0 1rem 0 0.5rem;
+  white-space: pre;
+}
+
+.cyberpunk-terminal__line--active {
+  background: linear-gradient(90deg, rgba(34, 211, 238, 0.12), transparent);
+  border-left: 2px solid var(--cct-neon);
+  padding-left: calc(0.5rem - 2px);
+}
+
+.cyberpunk-terminal__ln {
+  display: inline-block;
+  width: 2rem;
+  margin-right: 1rem;
+  color: #3f5170;
+  text-align: right;
+  user-select: none;
+}
+
+/* Syntax tokens */
+.tok--kw {
+  color: var(--cct-neon-2);
+}
+
+.tok--var {
+  color: #f0fdff;
+}
+
+.tok--fn {
+  color: var(--cct-neon);
+}
+
+.tok--str {
+  color: #4ade80;
+}
+
+.tok--num {
+  color: #fbbf24;
+}
+
+.tok--op {
+  color: #64748b;
+}
+
+.tok--com {
+  color: #475569;
+  font-style: italic;
+}
+
+/* Blinking prompt cursor on the active line. */
+.cyberpunk-terminal__cursor {
+  display: inline-block;
+  width: 0.6rem;
+  height: 1.1rem;
+  margin-left: 0.1rem;
+  vertical-align: text-bottom;
+  background: var(--cct-neon);
+  box-shadow: 0 0 0.4rem var(--cct-neon);
+  animation: cct-blink 1.1s steps(2, end) infinite;
+}
+
+@keyframes cct-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cyberpunk-terminal__cursor {
+    animation: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #86484 — add the **cyberpunk-code-terminal-block** component to the EaseMotion CSS gallery.

**Category:** Code block
**Description:** A neon-glow code terminal with window dots, line numbers, syntax tokens, active line highlighting, and a blinking cursor.

## Changes

Adds `submissions/examples/cyberpunk-code-terminal-block/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._