### PR TITLE
feat(#86841): add error-toast component

### DIFF
--- a/submissions/examples/error-toast/README.md
+++ b/submissions/examples/error-toast/README.md
@@ -1,0 +1,5 @@
+# Error Toast
+
+1. What does this do? A red alert toast that shakes once on appear with an attention-grabbing glow; hovering the toast replays the shake.
+2. How is it used? Build a `.error-toast` element with an `.error-toast__icon`, a `.error-toast__body` (title + message), and an `.error-toast__close` button. Customize the red and soft red and the shake speed via `--et-red`, `--et-red-soft`, and `--et-speed`.
+3. Why is it useful? It conveys errors with a clear, physical urgency using only CSS animations (no JavaScript), and respects `prefers-reduced-motion`.

--- a/submissions/examples/error-toast/demo.html
+++ b/submissions/examples/error-toast/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Error Toast</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="et-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="et-title">Error toast</h1>
+        <p class="demo-copy">
+          A red alert toast with a shaking card and an attention-grabbing glow.
+          Hover to replay the shake.
+        </p>
+        <div class="error-toast" role="alert">
+          <span class="error-toast__icon" aria-hidden="true">!</span>
+          <div class="error-toast__body">
+            <p class="error-toast__title">Upload failed</p>
+            <p class="error-toast__msg">The file &ldquo;report.pdf&rdquo; exceeded the size limit.</p>
+          </div>
+          <button type="button" class="error-toast__close" aria-label="Dismiss">&times;</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/error-toast/style.css
+++ b/submissions/examples/error-toast/style.css
@@ -1,0 +1,173 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #dc2626;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Error Toast
+   A red alert toast that shakes once on appear and glows. Hovering the toast
+   replays the shake so the effect is observable in the demo.
+   --------------------------------------------------------------------------- */
+.error-toast {
+  --et-red: #dc2626;
+  --et-red-soft: #fee2e2;
+  --et-speed: 420ms;
+
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  width: min(100%, 22rem);
+  margin: 0 auto;
+  border: 1px solid var(--et-red);
+  border-left: 5px solid var(--et-red);
+  border-radius: 0.6rem;
+  background: linear-gradient(180deg, #ffffff, #fff5f5);
+  padding: 0.85rem 0.9rem;
+  text-align: left;
+  box-shadow: 0 0.9rem 1.8rem rgba(220, 38, 38, 0.18);
+  animation: et-shake var(--et-speed) cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+.error-toast:hover {
+  animation: et-shake var(--et-speed) cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+.error-toast__icon {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 50%;
+  background: var(--et-red);
+  color: #ffffff;
+  font-weight: 900;
+  font-size: 1rem;
+  box-shadow: 0 0 0.7rem var(--et-red);
+}
+
+.error-toast__body {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+.error-toast__title {
+  margin: 0 0 0.1rem;
+  color: var(--et-red);
+  font-weight: 800;
+  font-size: 0.95rem;
+}
+
+.error-toast__msg {
+  margin: 0;
+  color: #7f1d1d;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.error-toast__close {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: #b91c1c;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.error-toast__close:hover,
+.error-toast__close:focus-visible {
+  outline: none;
+  color: var(--et-red);
+}
+
+@keyframes et-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  15% {
+    transform: translateX(-0.5rem);
+  }
+
+  30% {
+    transform: translateX(0.45rem);
+  }
+
+  45% {
+    transform: translateX(-0.3rem);
+  }
+
+  60% {
+    transform: translateX(0.2rem);
+  }
+
+  75% {
+    transform: translateX(-0.1rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-toast,
+  .error-toast:hover {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86841 — add the **error-toast** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A red alert toast with a shaking card and an attention-grabbing glow.

## Changes

Adds `submissions/examples/error-toast/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._