### PR TITLE
feat(#86802): add knob-toggle component

### DIFF
--- a/submissions/examples/knob-toggle/README.md
+++ b/submissions/examples/knob-toggle/README.md
@@ -1,0 +1,5 @@
+# Knob Toggle
+
+1. What does this do? A rotary knob-style toggle that switches from OFF to ON with a quarter turn of the knob face, with the track and glow shifting to the ON color.
+2. How is it used? Wrap a hidden `.knob-toggle__input` checkbox and a `.knob-toggle__dial` (containing a `.knob-toggle__pointer` and OFF/ON `.knob-toggle__tick` labels) inside a `.knob-toggle` label. Clicking the label or focusing + Space/Enter flips the state. Customize the off color, on color, glow, dial face, and turn speed via `--kt-off`, `--kt-on`, `--kt-on-glow`, `--kt-dial`, and `--kt-speed`.
+3. Why is it useful? It is an accessible, dependency-free toggle with a tactile rotary feel and a visible focus ring, and it respects `prefers-reduced-motion`.

--- a/submissions/examples/knob-toggle/demo.html
+++ b/submissions/examples/knob-toggle/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Knob Toggle</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="kt-title">
+        <p class="eyebrow">Toggle</p>
+        <h1 id="kt-title">Knob toggle</h1>
+        <p class="demo-copy">
+          A rotary knob-style toggle that switches from OFF to ON with a
+          quarter turn. Click the knob or its label to flip the state.
+        </p>
+        <label class="knob-toggle">
+          <input type="checkbox" class="knob-toggle__input" />
+          <span class="knob-toggle__dial">
+            <span class="knob-toggle__pointer" aria-hidden="true"></span>
+            <span class="knob-toggle__tick knob-toggle__tick--off">OFF</span>
+            <span class="knob-toggle__tick knob-toggle__tick--on">ON</span>
+          </span>
+        </label>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/knob-toggle/style.css
+++ b/submissions/examples/knob-toggle/style.css
@@ -1,0 +1,186 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Knob Toggle
+   A rotary knob-style toggle. A checkbox input is visually hidden; the dial
+   (.knob-toggle__dial) is the clickable surface. When checked, the dial face
+   and its pointer rotate 90 degrees (a quarter turn) and the track/glow shift
+   to the ON color.
+   --------------------------------------------------------------------------- */
+.knob-toggle {
+  --kt-off: #cbd5e1;
+  --kt-on: #7c3aed;
+  --kt-on-glow: rgba(124, 58, 237, 0.45);
+  --kt-dial: #ffffff;
+  --kt-speed: 320ms;
+
+  display: inline-block;
+  cursor: pointer;
+}
+
+.knob-toggle__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* The outer track the knob sits in. */
+.knob-toggle__dial {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  background: conic-gradient(var(--kt-off) 0 270deg, transparent 270deg 360deg);
+  box-shadow: inset 0 0 0 2px #e2e8f0;
+  transition: background-image var(--kt-speed) ease,
+    box-shadow var(--kt-speed) ease;
+}
+
+/* The rotating knob face. */
+.knob-toggle__pointer {
+  position: relative;
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 50%;
+  background: var(--kt-dial);
+  box-shadow: 0 0.4rem 0.8rem rgba(15, 23, 42, 0.18);
+  transform: rotate(-45deg);
+  transition: transform var(--kt-speed) cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* A pointer notch on the knob face. */
+.knob-toggle__pointer::after {
+  content: "";
+  position: absolute;
+  top: 0.45rem;
+  left: 50%;
+  width: 0.34rem;
+  height: 0.9rem;
+  margin-left: -0.17rem;
+  border-radius: 0.17rem;
+  background: var(--kt-off);
+  transition: background-color var(--kt-speed) ease;
+}
+
+/* OFF and ON labels around the dial. */
+.knob-toggle__tick {
+  position: absolute;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.knob-toggle__tick--off {
+  top: 0.3rem;
+  right: 0.6rem;
+}
+
+.knob-toggle__tick--on {
+  bottom: 0.3rem;
+  left: 0.6rem;
+  color: var(--kt-on);
+  opacity: 0.45;
+  transition: opacity var(--kt-speed) ease;
+}
+
+/* Checked state: quarter turn to the right, ON color + glow. */
+.knob-toggle__input:checked + .knob-toggle__dial {
+  background: conic-gradient(var(--kt-on) 0 270deg, transparent 270deg 360deg);
+  box-shadow: inset 0 0 0 2px var(--kt-on), 0 0 1.4rem var(--kt-on-glow);
+}
+
+.knob-toggle__input:checked + .knob-toggle__dial .knob-toggle__pointer {
+  transform: rotate(45deg);
+}
+
+.knob-toggle__input:checked + .knob-toggle__dial .knob-toggle__pointer::after {
+  background: var(--kt-on);
+}
+
+.knob-toggle__input:checked + .knob-toggle__dial .knob-toggle__tick--on {
+  opacity: 1;
+}
+
+/* Keyboard focus ring on the dial. */
+.knob-toggle__input:focus-visible + .knob-toggle__dial {
+  outline: 3px solid var(--kt-on);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .knob-toggle__dial,
+  .knob-toggle__pointer,
+  .knob-toggle__pointer::after,
+  .knob-toggle__tick--on {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86802 — add the **knob-toggle** component to the EaseMotion CSS gallery.

**Category:** Toggle
**Description:** A rotary knob-style toggle that switches from OFF to ON with a quarter turn.

## Changes

Adds `submissions/examples/knob-toggle/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._