### PR TITLE
feat(#86828): add sidebar-drawer component

### DIFF
--- a/submissions/examples/sidebar-drawer/README.md
+++ b/submissions/examples/sidebar-drawer/README.md
@@ -1,0 +1,5 @@
+# Sidebar Drawer
+
+1. What does this do? Renders an off-canvas sidebar that slides in from the left with a dimmed backdrop, driven by a hidden checkbox and CSS sibling selectors (no JavaScript).
+2. How is it used? Wrap an `.open-toggle__input` checkbox, an `.open-toggle__btn` label, a `.sidebar-backdrop`, and an `.sidebar-drawer` aside inside a `.open-toggle` label. Clicking the button or focusing + Space/Enter flips the drawer open. Use `.sidebar-drawer__nav` and `.sidebar-drawer__link` (add `--active`) for the menu, and `.sidebar-drawer__close` for a close affordance. Customize the drawer width and slide speed via `--sd-width` and `--sd-speed`.
+3. Why is it useful? It is a dependency-free, accessible off-canvas menu with backdrop dimming, keyboard focus support, and `prefers-reduced-motion` handling.

--- a/submissions/examples/sidebar-drawer/demo.html
+++ b/submissions/examples/sidebar-drawer/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sidebar Drawer</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <label class="open-toggle">
+        <input type="checkbox" class="open-toggle__input" />
+        <span class="open-toggle__btn" tabindex="0">Open menu</span>
+        <span class="sidebar-backdrop" aria-hidden="true"></span>
+        <aside class="sidebar-drawer" aria-label="Navigation drawer">
+          <span class="sidebar-drawer__close" role="button" tabindex="0" aria-label="Close menu">&times;</span>
+          <nav class="sidebar-drawer__nav">
+            <a href="#" class="sidebar-drawer__link sidebar-drawer__link--active">Home</a>
+            <a href="#" class="sidebar-drawer__link">Discover</a>
+            <a href="#" class="sidebar-drawer__link">Library</a>
+            <a href="#" class="sidebar-drawer__link">Settings</a>
+          </nav>
+        </aside>
+      </label>
+      <section class="page__content">
+        <h1>Off-canvas drawer</h1>
+        <p>Click <em>Open menu</em> to slide the drawer in from the left with a dimmed backdrop.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/sidebar-drawer/style.css
+++ b/submissions/examples/sidebar-drawer/style.css
@@ -1,0 +1,188 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+/* ---------------------------------------------------------------------------
+   Page layout
+   The drawer is anchored to the viewport; page content sits beside it.
+   --------------------------------------------------------------------------- */
+.page {
+  position: relative;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.page__content h1 {
+  margin: 0 0 0.6rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.page__content p {
+  max-width: 32rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.page__content em {
+  font-style: italic;
+  color: #2563eb;
+}
+
+/* ---------------------------------------------------------------------------
+   Sidebar Drawer
+   An off-canvas sidebar that slides in from the left with a dimmed backdrop.
+   A hidden checkbox drives the open state; the label wrapper makes the whole
+   control clickable, and the backdrop/drawer respond via sibling selectors.
+   --------------------------------------------------------------------------- */
+.open-toggle {
+  display: inline-block;
+}
+
+.open-toggle__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.open-toggle__btn {
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid #2563eb;
+  border-radius: 0.6rem;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0.6rem 1.1rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 200ms ease, transform 200ms ease;
+}
+
+.open-toggle__btn:hover,
+.open-toggle__input:focus-visible + .open-toggle__btn {
+  outline: none;
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+/* Dimmed backdrop: transparent by default, visible when checked. */
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(15, 23, 42, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 320ms ease;
+}
+
+/* The drawer: translated off-screen left by default. */
+.sidebar-drawer {
+  --sd-width: 16rem;
+  --sd-speed: 320ms;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: var(--sd-width);
+  max-width: 84vw;
+  padding: 1.4rem 1rem;
+  background: #ffffff;
+  border-right: 1px solid #e2e8f0;
+  box-shadow: 0 0 2rem rgba(15, 23, 42, 0.18);
+  transform: translateX(-105%);
+  transition: transform var(--sd-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Checked state: backdrop dims, drawer slides in. */
+.open-toggle__input:checked ~ .sidebar-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.open-toggle__input:checked ~ .sidebar-drawer {
+  transform: translateX(0);
+}
+
+.sidebar-drawer__close {
+  align-self: flex-end;
+  color: #94a3b8;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 180ms ease;
+}
+
+.sidebar-drawer__close:hover,
+.sidebar-drawer__close:focus-visible {
+  outline: none;
+  color: #172033;
+}
+
+.sidebar-drawer__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.sidebar-drawer__link {
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.5rem;
+  color: #334155;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.sidebar-drawer__link:hover,
+.sidebar-drawer__link:focus-visible {
+  outline: none;
+  background: #eff4ff;
+  color: #2563eb;
+}
+
+.sidebar-drawer__link--active {
+  background: #eff4ff;
+  color: #2563eb;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .open-toggle__btn,
+  .sidebar-backdrop,
+  .sidebar-drawer,
+  .sidebar-drawer__close,
+  .sidebar-drawer__link {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86828 — add the **sidebar-drawer** component to the EaseMotion CSS gallery.

**Category:** Menu
**Description:** An off-canvas sidebar that slides in from the left with a dimmed backdrop.

## Changes

Adds `submissions/examples/sidebar-drawer/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._