### PR TITLE
feat(#86843): add tooltip-fade-arrow component

### DIFF
--- a/submissions/examples/tooltip-fade-arrow/README.md
+++ b/submissions/examples/tooltip-fade-arrow/README.md
@@ -1,0 +1,5 @@
+# Tooltip (Fade Arrow)
+
+1. What does this do? A smart tooltip that fades in above its target with a pointing arrow, revealed on hover and keyboard focus.
+2. How is it used? Wrap a `.tooltip-fade-arrow__target` button and a `.tooltip-fade-arrow__bubble` (containing a `.tooltip-fade-arrow__arrow`) inside a `.tooltip-fade-arrow` container. The bubble shows on `:hover` and `:focus-within`. Adjust colors and fade timing via the `--tfa-*` variables.
+3. Why is it useful? It is a dependency-free, accessible tooltip with a pointing arrow and a smooth combined opacity/translate fade, and it respects `prefers-reduced-motion`.

--- a/submissions/examples/tooltip-fade-arrow/demo.html
+++ b/submissions/examples/tooltip-fade-arrow/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tooltip Fade Arrow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="tip-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="tip-title">Tooltip</h1>
+        <p class="demo-copy">
+          A smart tooltip that fades in above its target with a pointing arrow.
+          Hover or focus the button to reveal it.
+        </p>
+        <p class="tooltip-fade-arrow-host">
+          <span class="tooltip-fade-arrow">
+            <button type="button" class="tooltip-fade-arrow__target" aria-describedby="tfa-label">Save</button>
+            <span class="tooltip-fade-arrow__bubble" role="tooltip" id="tfa-label">
+              Saves your draft automatically
+              <span class="tooltip-fade-arrow__arrow" aria-hidden="true"></span>
+            </span>
+          </span>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tooltip-fade-arrow/style.css
+++ b/submissions/examples/tooltip-fade-arrow/style.css
@@ -1,0 +1,136 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Tooltip (fade + arrow)
+   A tooltip that fades in above its target with a pointing arrow. It is
+   revealed on hover and on keyboard focus (:focus-within), and animated with
+   a combined opacity + translate fade so it feels smart, not jumpy.
+   --------------------------------------------------------------------------- */
+.tooltip-fade-arrow {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip-fade-arrow__target {
+  border: 1px solid #2563eb;
+  border-radius: 0.55rem;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0.55rem 1.2rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 180ms ease;
+}
+
+.tooltip-fade-arrow__target:hover,
+.tooltip-fade-arrow__target:focus-visible {
+  outline: none;
+  background: #1d4ed8;
+}
+
+.tooltip-fade-arrow__bubble {
+  position: absolute;
+  bottom: calc(100% + 0.6rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(0.4rem);
+  z-index: 5;
+  width: max-content;
+  max-width: 16rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.45rem;
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 200ms ease,
+    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Pointing arrow centered under the bubble. */
+.tooltip-fade-arrow__arrow {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 0.6rem;
+  height: 0.6rem;
+  margin-left: -0.3rem;
+  background: #0f172a;
+  transform: rotate(45deg);
+}
+
+.tooltip-fade-arrow:hover .tooltip-fade-arrow__bubble,
+.tooltip-fade-arrow:focus-within .tooltip-fade-arrow__bubble {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-fade-arrow__bubble {
+    transition: opacity 120ms ease;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## What

Closes #86843 — add the **tooltip-fade-arrow** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A smart tooltip that fades in above its target with a pointing arrow.

## Changes

Adds `submissions/examples/tooltip-fade-arrow/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._