### PR TITLE
feat(#86838): add toast-notification component

### DIFF
--- a/submissions/examples/toast-notification/README.md
+++ b/submissions/examples/toast-notification/README.md
@@ -1,0 +1,5 @@
+# Toast Notification
+
+1. What does this do? A corner toast that slides in from the right with a draining progress bar across its base that indicates auto-dismiss timing.
+2. How is it used? Build a `.toast-notification` element with an `.toast-notification__icon`, a `.toast-notification__body` (title + message), a `.toast-notification__close` button, and a `.toast-notification__progress` span. The slide-in plays once; the progress bar drains on a loop. Customize the green, soft green, and dismiss duration via `--tn-green`, `--tn-green-soft`, and `--tn-duration`.
+3. Why is it useful? It conveys success feedback with a visible auto-dismiss cue using only CSS animations (no JavaScript), and respects `prefers-reduced-motion`.

--- a/submissions/examples/toast-notification/demo.html
+++ b/submissions/examples/toast-notification/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toast Notification</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="tn-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="tn-title">Toast notification</h1>
+        <p class="demo-copy">
+          A corner toast that slides in from the right with a progress bar
+          draining across its base.
+        </p>
+        <div class="toast-notification" role="status">
+          <span class="toast-notification__icon" aria-hidden="true">&#10003;</span>
+          <div class="toast-notification__body">
+            <p class="toast-notification__title">Saved</p>
+            <p class="toast-notification__msg">Your changes are live.</p>
+          </div>
+          <button type="button" class="toast-notification__close" aria-label="Dismiss">&times;</button>
+          <span class="toast-notification__progress" aria-hidden="true"></span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/toast-notification/style.css
+++ b/submissions/examples/toast-notification/style.css
@@ -1,0 +1,180 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #059669;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Toast Notification
+   A corner toast that slides in from the right with a progress bar draining
+   across its base. The slide-in plays once; the progress bar drains on a
+   loop so the auto-dismiss indicator is visible in the demo.
+   --------------------------------------------------------------------------- */
+.toast-notification {
+  --tn-green: #059669;
+  --tn-green-soft: #d1fae5;
+  --tn-duration: 4s;
+
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  width: min(100%, 20rem);
+  margin: 0 auto;
+  border: 1px solid var(--tn-green-soft);
+  border-radius: 0.6rem;
+  background: #ffffff;
+  padding: 0.85rem 0.9rem 1rem;
+  text-align: left;
+  box-shadow: 0 0.9rem 1.8rem rgba(5, 150, 105, 0.16);
+  overflow: hidden;
+  animation: tn-slide-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.toast-notification__icon {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: var(--tn-green);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 900;
+}
+
+.toast-notification__body {
+  flex: 1 1 auto;
+}
+
+.toast-notification__title {
+  margin: 0 0 0.1rem;
+  color: #065f46;
+  font-weight: 800;
+  font-size: 0.95rem;
+}
+
+.toast-notification__msg {
+  margin: 0;
+  color: #536173;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.toast-notification__close {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.toast-notification__close:hover,
+.toast-notification__close:focus-visible {
+  outline: none;
+  color: var(--tn-green);
+}
+
+/* Draining progress bar pinned across the base. */
+.toast-notification__progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 0.25rem;
+  background: var(--tn-green);
+  transform-origin: left center;
+  animation: tn-drain var(--tn-duration) linear infinite;
+}
+
+@keyframes tn-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateX(110%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes tn-drain {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast-notification {
+    animation: none;
+  }
+
+  .toast-notification__progress {
+    animation: none;
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## What

Closes #86838 — add the **toast-notification** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A corner toast that slides in with a progress bar draining across its base.

## Changes

Adds `submissions/examples/toast-notification/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._