### PR TITLE
feat(#86834): add cookie-banner component

### DIFF
--- a/submissions/examples/cookie-banner/README.md
+++ b/submissions/examples/cookie-banner/README.md
@@ -1,0 +1,5 @@
+# Cookie Banner
+
+1. What does this do? A consent banner that slides up from the bottom of the viewport with a smooth settle, with an icon, message, and Decline/Accept actions.
+2. How is it used? Place a `.cookie-banner` element (with `.cookie-banner__body` containing an `.cookie-banner__icon` and `.cookie-banner__text`, plus `.cookie-banner__actions` with `.cookie-banner__btn` buttons) at the end of your page. Customize the accent color and settle speed via `--cb-accent` and `--cb-speed`.
+3. Why is it useful? It provides an accessible consent UX with a polished slide-up animation using only CSS (no JavaScript), and respects `prefers-reduced-motion`.

--- a/submissions/examples/cookie-banner/demo.html
+++ b/submissions/examples/cookie-banner/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cookie Banner</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <section class="page__hero" aria-labelledby="cb-title">
+        <h1 id="cb-title">Cookie banner demo</h1>
+        <p>The consent banner slides up from the bottom with a smooth settle.</p>
+      </section>
+      <div class="cookie-banner" role="dialog" aria-label="Cookie consent" aria-live="polite">
+        <div class="cookie-banner__body">
+          <span class="cookie-banner__icon" aria-hidden="true">&#9749;</span>
+          <p class="cookie-banner__text">
+            We use cookies to improve your experience. By continuing, you
+            agree to our cookie policy.
+          </p>
+        </div>
+        <div class="cookie-banner__actions">
+          <button type="button" class="cookie-banner__btn cookie-banner__btn--ghost">Decline</button>
+          <button type="button" class="cookie-banner__btn cookie-banner__btn--solid">Accept all</button>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/cookie-banner/style.css
+++ b/submissions/examples/cookie-banner/style.css
@@ -1,0 +1,156 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+/* ---------------------------------------------------------------------------
+   Page layout for the demo (so the banner has content to overlay).
+   --------------------------------------------------------------------------- */
+.page {
+  position: relative;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.page__hero h1 {
+  margin: 0 0 0.6rem;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.page__hero p {
+  max-width: 32rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Cookie Banner
+   A consent banner that slides up from the bottom with a smooth settle. It
+   animates in once on load using a combined translate + opacity settle.
+   --------------------------------------------------------------------------- */
+.cookie-banner {
+  --cb-accent: #2563eb;
+  --cb-speed: 560ms;
+
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  z-index: 50;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(92vw, 46rem);
+  margin-left: calc(-1 * min(92vw, 46rem) / 2);
+  border: 1px solid #e2e8f0;
+  border-radius: 0.8rem;
+  background: #ffffff;
+  padding: 1rem 1.2rem;
+  box-shadow: 0 1.2rem 2.4rem rgba(15, 23, 42, 0.18);
+  opacity: 0;
+  transform: translateY(120%);
+  animation: cb-settle var(--cb-speed) cubic-bezier(0.22, 1, 0.36, 1) 220ms both;
+}
+
+.cookie-banner__body {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex: 1 1 22rem;
+}
+
+.cookie-banner__icon {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.cookie-banner__text {
+  margin: 0;
+  color: #475569;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.cookie-banner__actions {
+  display: flex;
+  gap: 0.6rem;
+  flex: 0 0 auto;
+}
+
+.cookie-banner__btn {
+  border-radius: 0.55rem;
+  padding: 0.55rem 1.1rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, background-color 180ms ease, color 180ms ease;
+}
+
+.cookie-banner__btn--ghost {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+}
+
+.cookie-banner__btn--ghost:hover,
+.cookie-banner__btn--ghost:focus-visible {
+  outline: none;
+  background: #f1f5f9;
+}
+
+.cookie-banner__btn--solid {
+  border: 1px solid var(--cb-accent);
+  background: var(--cb-accent);
+  color: #ffffff;
+}
+
+.cookie-banner__btn--solid:hover,
+.cookie-banner__btn--solid:focus-visible {
+  outline: none;
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+@keyframes cb-settle {
+  0% {
+    opacity: 0;
+    transform: translateY(120%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cookie-banner,
+  .cookie-banner__btn {
+    animation: none;
+    transition: none;
+  }
+
+  .cookie-banner {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## What

Closes #86834 — add the **cookie-banner** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A consent banner that slides up from the bottom with a smooth settle.

## Changes

Adds `submissions/examples/cookie-banner/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._