### PR TITLE
feat(#86769): add magnetic-pull-button component

### DIFF
--- a/submissions/examples/magnetic-pull-button/README.md
+++ b/submissions/examples/magnetic-pull-button/README.md
@@ -1,0 +1,5 @@
+# Magnetic Pull Button
+
+1. What does this do? A primary button whose surface pulls toward the cursor on hover and snaps back on leave, with a springy easing curve.
+2. How is it used? Wrap a `.magnetic-pull-button__btn` in a `.magnetic-pull-button` span (the wrapper gives a larger hover hit area). On hover/focus the button translates by `--tx`/`--ty` and snaps back on leave. To make it track the pointer for real, set `--tx`/`--ty` from a small mousemove script on the wrapper; otherwise the CSS defaults apply. Adjust the accent and snap speed via `--mpb-accent` and `--mpb-speed`.
+3. Why is it useful? It adds a playful magnetic pull effect with pure CSS defaults (no JavaScript required for the hover behavior), keyboard focus support, and `prefers-reduced-motion` support that disables the translate.

--- a/submissions/examples/magnetic-pull-button/demo.html
+++ b/submissions/examples/magnetic-pull-button/demo.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Magnetic Pull Button</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="mpb-title">
+        <p class="eyebrow">Button</p>
+        <h1 id="mpb-title">Magnetic pull button</h1>
+        <p class="demo-copy">
+          A primary button whose surface pulls toward the cursor on hover and
+          snaps back on leave.
+        </p>
+        <p class="magnetic-pull-host">
+          <span class="magnetic-pull-button">
+            <button type="button" class="magnetic-pull-button__btn">Get started</button>
+          </span>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/magnetic-pull-button/style.css
+++ b/submissions/examples/magnetic-pull-button/style.css
@@ -1,0 +1,120 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.magnetic-pull-host {
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Magnetic Pull Button
+   A primary button whose surface pulls toward the cursor on hover and snaps
+   back on leave. The wrapper provides a larger hit area; the button translates
+   up-left on hover to suggest being pulled toward an approaching pointer from
+   the lower-right. (For true pointer tracking, set --tx/--ty custom props
+   from a small mousemove script; see README.)
+   --------------------------------------------------------------------------- */
+.magnetic-pull-button {
+  --mpb-accent: #2563eb;
+  --mpb-speed: 240ms;
+
+  display: inline-block;
+  padding: 0.6rem;
+}
+
+.magnetic-pull-button__btn {
+  --tx: -6px;
+  --ty: -6px;
+
+  border: 1px solid var(--mpb-accent);
+  border-radius: 0.6rem;
+  background: var(--mpb-accent);
+  color: #ffffff;
+  padding: 0.75rem 1.8rem;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  transform: translate(0, 0);
+  transition: transform var(--mpb-speed) cubic-bezier(0.34, 1.56, 0.64, 1),
+    background-color 200ms ease, box-shadow 200ms ease;
+}
+
+.magnetic-pull-button:hover .magnetic-pull-button__btn,
+.magnetic-pull-button:focus-within .magnetic-pull-button__btn {
+  transform: translate(var(--tx), var(--ty));
+  background: #1d4ed8;
+  box-shadow: 0 0.8rem 1.4rem rgba(37, 99, 235, 0.3);
+}
+
+.magnetic-pull-button__btn:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .magnetic-pull-button__btn {
+    transition: background-color 120ms ease, box-shadow 120ms ease;
+  }
+
+  .magnetic-pull-button:hover .magnetic-pull-button__btn,
+  .magnetic-pull-button:focus-within .magnetic-pull-button__btn {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86769 — add the **magnetic-pull-button** component to the EaseMotion CSS gallery.

**Category:** Button
**Description:** A primary button whose surface pulls toward the cursor and snaps back on leave.

## Changes

Adds `submissions/examples/magnetic-pull-button/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._