### PR TITLE
feat(#86871): add search-expand component

### DIFF
--- a/submissions/examples/search-expand/README.md
+++ b/submissions/examples/search-expand/README.md
@@ -1,0 +1,5 @@
+# Search Expand
+
+1. What does this do? A round search button that widens into a full input on hover (or when focused), then collapses back when the pointer leaves and the field loses focus.
+2. How is it used? Build a `.search-expand` form with a `.search-expand__input` and a round `.search-expand__btn` containing an SVG icon. On hover/focus-within the input width grows and the placeholder fades in. Adjust the accent color and expand speed via `--se-accent` and `--se-speed`.
+3. Why is it useful? It saves space with a compact round button that expands into a usable search field using only CSS transitions (no JavaScript), supports keyboard focus to keep the field open, and respects `prefers-reduced-motion` (renders fully expanded).

--- a/submissions/examples/search-expand/demo.html
+++ b/submissions/examples/search-expand/demo.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Search Expand</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="se-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="se-title">Search expand</h1>
+        <p class="demo-copy">
+          A round search button that widens into a full input on hover. Hover
+          to open, click to keep it, move away to collapse.
+        </p>
+        <form class="search-expand" role="search" onsubmit="return false">
+          <input
+            type="search"
+            class="search-expand__input"
+            placeholder="Search the docs&hellip;"
+            aria-label="Search"
+          />
+          <button type="submit" class="search-expand__btn" aria-label="Search">
+            <svg viewBox="0 0 24 24" class="search-expand__icon" aria-hidden="true" focusable="false">
+              <circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="2"></circle>
+              <line x1="16.5" y1="16.5" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"></line>
+            </svg>
+          </button>
+        </form>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/search-expand/style.css
+++ b/submissions/examples/search-expand/style.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Search Expand
+   A round search button that widens into a full input on hover. The form is
+   narrow by default showing only the round button; on hover/focus-within the
+   input width grows and the placeholder fades in. Clicking the button keeps
+   focus so the field stays open via :focus-within.
+   --------------------------------------------------------------------------- */
+.search-expand {
+  --se-accent: #2563eb;
+  --se-speed: 280ms;
+
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #dbe2ee;
+  border-radius: 999px;
+  background: #ffffff;
+  padding: 0.25rem 0.25rem 0.25rem 0.5rem;
+  box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.08);
+  transition: box-shadow var(--se-speed) ease, border-color var(--se-speed) ease;
+}
+
+.search-expand:hover,
+.search-expand:focus-within {
+  border-color: var(--se-accent);
+  box-shadow: 0 0.6rem 1.4rem rgba(37, 99, 235, 0.18);
+}
+
+.search-expand__input {
+  width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: #172033;
+  font: inherit;
+  font-size: 0.95rem;
+  padding: 0.4rem 0;
+  opacity: 0;
+  transition: width var(--se-speed) ease, opacity var(--se-speed) ease;
+}
+
+.search-expand:hover .search-expand__input,
+.search-expand:focus-within .search-expand__input {
+  width: 14rem;
+  opacity: 1;
+  padding: 0.4rem 0.5rem;
+}
+
+.search-expand__btn {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border: 0;
+  border-radius: 50%;
+  background: var(--se-accent);
+  color: #ffffff;
+  cursor: pointer;
+  transition: background-color 200ms ease, transform 200ms ease;
+}
+
+.search-expand__btn:hover,
+.search-expand__btn:focus-visible {
+  outline: none;
+  background: #1d4ed8;
+  transform: scale(1.05);
+}
+
+.search-expand__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-expand,
+  .search-expand__input,
+  .search-expand__btn {
+    transition: none;
+  }
+
+  .search-expand__input {
+    width: 14rem;
+    opacity: 1;
+    padding: 0.4rem 0.5rem;
+  }
+}


### PR DESCRIPTION
## What

Closes #86871 — add the **search-expand** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** A round search button that widens into a full input on hover.

## Changes

Adds `submissions/examples/search-expand/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._