### PR TITLE
feat(#86870): add otp-code-input component

### DIFF
--- a/submissions/examples/otp-code-input/README.md
+++ b/submissions/examples/otp-code-input/README.md
@@ -1,0 +1,5 @@
+# OTP Code Input
+
+1. What does this do? Six one-time-code boxes where the active slot glows and the code assembles, with a dashed separator between the third and fourth digits.
+2. How is it used? Build an `.otp-code-input` form of `.otp-code-input__slot` inputs (each `maxlength="1"`, `inputmode="numeric"`), separated by an `.otp-code-input__dash` span after the third slot. Any focused or `.is-active` slot gets the accent glow; filled slots tint to a soft accent background. Adjust the accent color and glow speed via `--oci-accent` and `--oci-speed`.
+3. Why is it useful? It gives a polished OTP entry presentation with pure CSS focus/glow styling (the styling itself is CSS-only; JS would handle tab-advance), and respects `prefers-reduced-motion`.

--- a/submissions/examples/otp-code-input/demo.html
+++ b/submissions/examples/otp-code-input/demo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OTP Code Input</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="oci-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="oci-title">OTP code input</h1>
+        <p class="demo-copy">
+          Six one-time-code boxes where the active slot glows and the code
+          assembles.
+        </p>
+        <form class="otp-code-input" aria-label="Enter one-time code" onsubmit="return false">
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot" aria-label="Digit 1" value="4" />
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot" aria-label="Digit 2" value="2" />
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot" aria-label="Digit 3" value="0" />
+          <span class="otp-code-input__dash" aria-hidden="true">&ndash;</span>
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot" aria-label="Digit 4" value="1" />
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot" aria-label="Digit 5" value="9" />
+          <input type="text" inputmode="numeric" maxlength="1" class="otp-code-input__slot is-active" aria-label="Digit 6" />
+        </form>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/otp-code-input/style.css
+++ b/submissions/examples/otp-code-input/style.css
@@ -1,0 +1,124 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   OTP Code Input
+   Six one-time-code boxes where the active slot glows and the code assembles.
+   Each slot is a centered single-char input; the active slot (or any focused
+   slot via :focus) gets an accent ring and a soft glow.
+   --------------------------------------------------------------------------- */
+.otp-code-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.otp-code-input__slot {
+  --oci-accent: #2563eb;
+  --oci-speed: 200ms;
+
+  width: 3rem;
+  height: 3.4rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.6rem;
+  background: #ffffff;
+  color: #172033;
+  text-align: center;
+  font: inherit;
+  font-size: 1.4rem;
+  font-weight: 800;
+  caret-color: var(--oci-accent);
+  transition: border-color var(--oci-speed) ease, box-shadow var(--oci-speed) ease,
+    transform var(--oci-speed) ease;
+}
+
+.otp-code-input__slot:focus,
+.otp-code-input__slot.is-active {
+  outline: none;
+  border-color: var(--oci-accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  transform: translateY(-2px);
+}
+
+.otp-code-input__slot:not(:placeholder-shown),
+.otp-code-input__slot[value]:not([value=""]) {
+  border-color: rgba(37, 99, 235, 0.55);
+  background: #eff4ff;
+}
+
+.otp-code-input__dash {
+  color: #94a3b8;
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .otp-code-input__slot {
+    transition: none;
+  }
+
+  .otp-code-input__slot:focus,
+  .otp-code-input__slot.is-active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86870 — add the **otp-code-input** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** Six one-time-code boxes where the active slot glows and the code assembles.

## Changes

Adds `submissions/examples/otp-code-input/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._