### PR TITLE
feat(#86783): add expandable-card component

### DIFF
--- a/submissions/examples/expandable-card/README.md
+++ b/submissions/examples/expandable-card/README.md
@@ -1,0 +1,5 @@
+# Expandable Card
+
+1. What does this do? A compact card that expands smoothly on hover to reveal a full description panel and a call-to-action button.
+2. How is it used? Build an `.expandable-card` with a `.expandable-card__media` block and a `.expandable-card__body` containing the eyebrow, title, summary, a `.expandable-card__details` panel (clipped by default), and a `.expandable-card__btn`. On hover/focus-within the details `max-height` grows and the button fades in. Adjust the accent color and expand speed via `--ec-accent` and `--ec-speed`.
+3. Why is it useful? It keeps the default view compact and reveals richer content on hover using only CSS (`max-height` + opacity transitions, no JavaScript), with keyboard focus support and `prefers-reduced-motion` support.

--- a/submissions/examples/expandable-card/demo.html
+++ b/submissions/examples/expandable-card/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Expandable Card</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="expandable-card" aria-labelledby="ec-title">
+        <div class="expandable-card__media" aria-hidden="true"></div>
+        <div class="expandable-card__body">
+          <p class="expandable-card__eyebrow">Article</p>
+          <h1 id="ec-title">Designing calm interfaces</h1>
+          <p class="expandable-card__summary">
+            Small choices, big calm.
+          </p>
+          <p class="expandable-card__details">
+            Restraint in motion, generous spacing, and predictable focus states
+            make software feel trustworthy. This expanded panel reveals the full
+            description on hover without overwhelming the layout.
+          </p>
+          <button type="button" class="expandable-card__btn">Read more</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/expandable-card/style.css
+++ b/submissions/examples/expandable-card/style.css
@@ -1,0 +1,146 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Expandable Card
+   A compact card that expands smoothly on hover to reveal a full description
+   panel. The details text and the action button are clipped (max-height 0 +
+   opacity 0) until hover/focus-within, then the panel grows and they fade in.
+   --------------------------------------------------------------------------- */
+.expandable-card {
+  --ec-accent: #2563eb;
+  --ec-speed: 360ms;
+
+  width: min(100%, 22rem);
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  background: #ffffff;
+  overflow: hidden;
+  box-shadow: 0 1.2rem 2.4rem rgba(15, 23, 42, 0.1);
+  transition: box-shadow var(--ec-speed) ease, transform var(--ec-speed) ease;
+}
+
+.expandable-card:hover,
+.expandable-card:focus-within {
+  transform: translateY(-0.3rem);
+  box-shadow: 0 1.8rem 3rem rgba(37, 99, 235, 0.18);
+}
+
+.expandable-card__media {
+  height: 7rem;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+}
+
+.expandable-card__body {
+  padding: 1.2rem 1.4rem 1.4rem;
+}
+
+.expandable-card__eyebrow {
+  margin: 0 0 0.3rem;
+  color: var(--ec-accent);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.expandable-card h1 {
+  margin: 0 0 0.3rem;
+  font-size: 1.2rem;
+}
+
+.expandable-card__summary {
+  margin: 0;
+  color: #536173;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.expandable-card__details {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+  color: #536173;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  overflow: hidden;
+  transition: max-height var(--ec-speed) ease, opacity var(--ec-speed) ease,
+    margin var(--ec-speed) ease;
+}
+
+.expandable-card__btn {
+  display: inline-block;
+  margin-top: 0;
+  border: 1px solid var(--ec-accent);
+  border-radius: 0.5rem;
+  background: var(--ec-accent);
+  color: #ffffff;
+  padding: 0.5rem 1.1rem;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity var(--ec-speed) ease, transform var(--ec-speed) ease,
+    margin var(--ec-speed) ease, background-color 200ms ease;
+}
+
+.expandable-card:hover .expandable-card__details,
+.expandable-card:focus-within .expandable-card__details {
+  max-height: 12rem;
+  opacity: 1;
+  margin: 0.8rem 0 0;
+}
+
+.expandable-card:hover .expandable-card__btn,
+.expandable-card:focus-within .expandable-card__btn {
+  opacity: 1;
+  transform: translateY(0);
+  margin-top: 1rem;
+}
+
+.expandable-card__btn:hover,
+.expandable-card__btn:focus-visible {
+  outline: none;
+  background: #1d4ed8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expandable-card,
+  .expandable-card__details,
+  .expandable-card__btn {
+    transition: none;
+  }
+
+  .expandable-card:hover,
+  .expandable-card:focus-within {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #86783 — add the **expandable-card** component to the EaseMotion CSS gallery.

**Category:** Card
**Description:** A compact card that expands smoothly on hover to reveal a full description panel.

## Changes

Adds `submissions/examples/expandable-card/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._