### PR TITLE
feat(#86800): add text-stroke-animation component

### DIFF
--- a/submissions/examples/text-stroke-animation/README.md
+++ b/submissions/examples/text-stroke-animation/README.md
@@ -1,0 +1,5 @@
+# Text Stroke Animation
+
+1. What does this do? Outlined display text that fills with a vertical gradient in a top-to-bottom sweep, looping alternate.
+2. How is it used? Build a `.text-stroke-animation` heading (transparent fill with a thick outline via `-webkit-text-stroke`) containing an absolutely positioned `.text-stroke-animation__fill` duplicate that holds the colored gradient fill and is revealed by animating `clip-path` from `inset(0 0 100% 0)` to `inset(0 0 0 0)`. Adjust the fill gradient and sweep speed via `--tsa-fill` and `--tsa-speed`.
+3. Why is it useful? It creates a striking vertical color-fill text reveal using only CSS (no images or JavaScript), and freezes to a fully filled state under `prefers-reduced-motion`.

--- a/submissions/examples/text-stroke-animation/demo.html
+++ b/submissions/examples/text-stroke-animation/demo.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text Stroke Animation</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="tsa-title">
+        <p class="eyebrow">Text</p>
+        <h1 id="tsa-title">Text stroke animation</h1>
+        <p class="demo-copy">
+          Outlined display text that fills with color in a vertical sweep.
+        </p>
+        <h2 class="text-stroke-animation" aria-label="Sweep">
+          <span class="text-stroke-animation__fill" aria-hidden="true">Sweep</span>
+          Sweep
+        </h2>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/text-stroke-animation/style.css
+++ b/submissions/examples/text-stroke-animation/style.css
@@ -1,0 +1,111 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0b1020;
+  color: #e2e8f0;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 40rem);
+  border: 1px solid #1e293b;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.5);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #22d3ee;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 30rem;
+  margin: 0 auto 1.8rem;
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Text Stroke Animation
+   Outlined display text that fills with color in a vertical sweep. The base
+   heading shows a transparent fill with a thick outline; an absolutely
+   positioned duplicate holds the colored fill and is revealed top-to-bottom by
+   animating its clip-path (a vertical wipe).
+   --------------------------------------------------------------------------- */
+.text-stroke-animation {
+  --tsa-fill: linear-gradient(180deg, #22d3ee, #818cf8);
+  --tsa-speed: 2.6s;
+
+  position: relative;
+  margin: 0;
+  font-size: clamp(3.5rem, 12vw, 7rem);
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  color: transparent;
+  -webkit-text-stroke: 2px #475569;
+  line-height: 1;
+}
+
+.text-stroke-animation__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--tsa-fill);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-stroke: 0;
+  clip-path: inset(0 0 100% 0);
+  animation: tsa-sweep var(--tsa-speed) ease-in-out infinite alternate;
+}
+
+@keyframes tsa-sweep {
+  0% {
+    clip-path: inset(0 0 100% 0);
+  }
+
+  100% {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .text-stroke-animation__fill {
+    animation: none;
+    clip-path: inset(0 0 0 0);
+  }
+}


### PR DESCRIPTION
## What

Closes #86800 — add the **text-stroke-animation** component to the EaseMotion CSS gallery.

**Category:** Text
**Description:** Outlined display text that fills with color in a vertical sweep.

## Changes

Adds `submissions/examples/text-stroke-animation/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._