### PR TITLE
feat(#88613): add context-menu component

### DIFF
--- a/submissions/examples/context-menu/README.md
+++ b/submissions/examples/context-menu/README.md
@@ -1,0 +1,5 @@
+# Context Menu
+
+1. What does this do? A right-click-style menu with icons, separators, keyboard shortcuts, and a hover highlight bar that slides smoothly between rows (turning red over the Delete action).
+2. How is it used? Build a `.context-menu` nav with a `.context-menu__list` of `.context-menu__item` rows (each a `.context-menu__action` button with icon, label, and `kbd` shortcut), separated by `.context-menu__separator` dividers. The sliding highlight is a `::before` bar on the list that moves to each row on hover via `:has()`. Use `.context-menu__action--danger` for destructive actions.
+3. Why is it useful? It renders an authentic desktop-style context menu with a sliding highlight using only CSS `:has()` (no JavaScript), and respects `prefers-reduced-motion`.

--- a/submissions/examples/context-menu/demo.html
+++ b/submissions/examples/context-menu/demo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Context Menu</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="cm-title">
+        <p class="eyebrow">Navigation</p>
+        <h1 id="cm-title">Context menu</h1>
+        <p class="demo-copy">
+          A right-click-style menu with icons, separators, and a hover
+          highlight that slides between items.
+        </p>
+        <nav class="context-menu" aria-label="Context actions">
+          <ul class="context-menu__list">
+            <li class="context-menu__item">
+              <button type="button" class="context-menu__action is-active">
+                <span class="context-menu__icon" aria-hidden="true">&#9998;</span>
+                <span class="context-menu__label">Edit</span>
+                <kbd class="context-menu__shortcut">E</kbd>
+              </button>
+            </li>
+            <li class="context-menu__item">
+              <button type="button" class="context-menu__action">
+                <span class="context-menu__icon" aria-hidden="true">&#9999;</span>
+                <span class="context-menu__label">Duplicate</span>
+                <kbd class="context-menu__shortcut">D</kbd>
+              </button>
+            </li>
+            <li class="context-menu__item">
+              <button type="button" class="context-menu__action">
+                <span class="context-menu__icon" aria-hidden="true">&#128203;</span>
+                <span class="context-menu__label">Copy link</span>
+                <kbd class="context-menu__shortcut">C</kbd>
+              </button>
+            </li>
+            <li class="context-menu__separator" aria-hidden="true"></li>
+            <li class="context-menu__item">
+              <button type="button" class="context-menu__action context-menu__action--danger">
+                <span class="context-menu__icon" aria-hidden="true">&#128465;</span>
+                <span class="context-menu__label">Delete</span>
+                <kbd class="context-menu__shortcut">&#9003;</kbd>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/context-menu/style.css
+++ b/submissions/examples/context-menu/style.css
@@ -1,0 +1,186 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 1.7rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Context Menu
+   A right-click-style menu with icons, separators, and a hover highlight that
+   slides between items. The list is the positioning context; a sliding
+   highlight bar sits behind the items and moves to the hovered row's offset
+   via the `--cm-hover-top` custom property (set per-item on :hover).
+   --------------------------------------------------------------------------- */
+.context-menu {
+  display: inline-block;
+  text-align: left;
+}
+
+.context-menu__list {
+  --cm-hover-top: 0.4rem;
+
+  position: relative;
+  width: 15rem;
+  margin: 0;
+  padding: 0.4rem;
+  list-style: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.16);
+}
+
+/* Sliding highlight bar; default at the first row, moved per-item on :hover. */
+.context-menu__list::before {
+  content: "";
+  position: absolute;
+  left: 0.4rem;
+  right: 0.4rem;
+  top: var(--cm-hover-top);
+  height: 2.35rem;
+  border-radius: 0.5rem;
+  background: #eff4ff;
+  transition: top 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 0;
+}
+
+.context-menu__list:has(.context-menu__item:nth-child(1):hover)::before {
+  --cm-hover-top: 0.4rem;
+
+  top: 0.4rem;
+}
+
+.context-menu__list:has(.context-menu__item:nth-child(2):hover)::before {
+  top: 2.95rem;
+}
+
+.context-menu__list:has(.context-menu__item:nth-child(3):hover)::before {
+  top: 5.5rem;
+}
+
+.context-menu__list:has(.context-menu__item:nth-child(5):hover)::before {
+  top: 8.55rem;
+  background: #fee2e2;
+}
+
+.context-menu__item {
+  position: relative;
+  z-index: 1;
+}
+
+.context-menu__action {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #172033;
+  padding: 0.55rem 0.6rem;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-size: 0.9rem;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+}
+
+.context-menu__action.is-active,
+.context-menu__action:hover,
+.context-menu__action:focus-visible {
+  outline: none;
+  color: #1d4ed8;
+}
+
+.context-menu__action--danger,
+.context-menu__action--danger:hover,
+.context-menu__action--danger:focus-visible {
+  color: #b91c1c;
+}
+
+.context-menu__icon {
+  width: 1.1rem;
+  text-align: center;
+}
+
+.context-menu__label {
+  flex: 1;
+}
+
+.context-menu__shortcut {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.3rem;
+  background: #f8fafc;
+  padding: 0.05rem 0.35rem;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.context-menu__separator {
+  height: 1px;
+  margin: 0.4rem 0.6rem;
+  background: #e2e8f0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .context-menu__list::before {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88613 — add the **context-menu** component to the EaseMotion CSS gallery.

**Category:** Navigation
**Description:** A right-click-style menu with icons, separators, and a sliding hover highlight.

## Changes

Adds `submissions/examples/context-menu/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._