### PR TITLE
feat(#88612): add notification-stack component

### DIFF
--- a/submissions/examples/notification-stack/README.md
+++ b/submissions/examples/notification-stack/README.md
@@ -1,0 +1,5 @@
+# Notification Stack
+
+1. What does this do? A stack of toast notifications that slide in from the right and stagger their arrival with cascading delays.
+2. How is it used? Build a `.notification-stack` region of `.notification-stack__toast` articles, each with an icon, title, and copy. Modifiers set the accent color: `--success` (green), `--info` (blue), `--warn` (amber). Each toast uses the `ns-slide-in` entrance keyframe with an increasing `animation-delay` so they cascade in. Adjust accent/tint via `--ns-accent` and `--ns-tint`.
+3. Why is it useful? It produces a polished staggered toast entrance with pure CSS (no JavaScript), supports semantic `aria-live` for screen readers, and respects `prefers-reduced-motion`.

--- a/submissions/examples/notification-stack/demo.html
+++ b/submissions/examples/notification-stack/demo.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notification Stack</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ns-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="ns-title">Notification stack</h1>
+        <p class="demo-copy">
+          A stack of toast notifications that slide in from the right and
+          stagger their arrival.
+        </p>
+      </section>
+      <div class="notification-stack" role="region" aria-label="Notifications" aria-live="polite">
+        <article class="notification-stack__toast notification-stack__toast--success">
+          <span class="notification-stack__icon" aria-hidden="true">&#10003;</span>
+          <div class="notification-stack__body">
+            <p class="notification-stack__title">Saved</p>
+            <p class="notification-stack__copy">Your changes were saved.</p>
+          </div>
+        </article>
+        <article class="notification-stack__toast notification-stack__toast--info">
+          <span class="notification-stack__icon" aria-hidden="true">&#8505;</span>
+          <div class="notification-stack__body">
+            <p class="notification-stack__title">New comment</p>
+            <p class="notification-stack__copy">Priya replied to your thread.</p>
+          </div>
+        </article>
+        <article class="notification-stack__toast notification-stack__toast--warn">
+          <span class="notification-stack__icon" aria-hidden="true">&#9888;</span>
+          <div class="notification-stack__body">
+            <p class="notification-stack__title">Storage almost full</p>
+            <p class="notification-stack__copy">92% of your quota is used.</p>
+          </div>
+        </article>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/notification-stack/style.css
+++ b/submissions/examples/notification-stack/style.css
@@ -1,0 +1,164 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 35rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0.85rem auto 0;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Notification Stack
+   A stack of toast notifications that slide in from the right and stagger
+   their arrival. The stack is fixed to the top-right; each toast uses an
+   entrance keyframe with an increasing animation-delay so they cascade in.
+   --------------------------------------------------------------------------- */
+.notification-stack {
+  position: fixed;
+  top: 1.2rem;
+  right: 1.2rem;
+  display: grid;
+  gap: 0.6rem;
+  width: min(20rem, calc(100vw - 2rem));
+  z-index: 50;
+}
+
+.notification-stack__toast {
+  --ns-accent: #2563eb;
+  --ns-tint: #eff4ff;
+
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  border: 1px solid #e2e8f0;
+  border-left: 4px solid var(--ns-accent);
+  border-radius: 0.6rem;
+  background: #ffffff;
+  padding: 0.7rem 0.9rem;
+  box-shadow: 0 0.8rem 1.6rem rgba(15, 23, 42, 0.16);
+  animation: ns-slide-in 460ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
+}
+
+.notification-stack__toast:nth-child(2) {
+  animation-delay: 200ms;
+}
+
+.notification-stack__toast:nth-child(3) {
+  animation-delay: 400ms;
+}
+
+.notification-stack__toast--success {
+  --ns-accent: #16a34a;
+  --ns-tint: #ecfdf5;
+}
+
+.notification-stack__toast--info {
+  --ns-accent: #2563eb;
+  --ns-tint: #eff4ff;
+}
+
+.notification-stack__toast--warn {
+  --ns-accent: #d97706;
+  --ns-tint: #fffbeb;
+}
+
+.notification-stack__icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: none;
+  border-radius: 50%;
+  background: var(--ns-tint);
+  color: var(--ns-accent);
+  font-weight: 900;
+  font-size: 0.85rem;
+}
+
+.notification-stack__body {
+  flex: 1;
+}
+
+.notification-stack__title {
+  margin: 0 0 0.1rem;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.notification-stack__copy {
+  margin: 0;
+  color: #536173;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+@keyframes ns-slide-in {
+  0% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notification-stack__toast {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88612 — add the **notification-stack** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A stack of toasts that slide in from the right with staggered arrival.

## Changes

Adds `submissions/examples/notification-stack/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._