### PR TITLE
feat(#88610): add divider-grow component

### DIFF
--- a/submissions/examples/divider-grow/README.md
+++ b/submissions/examples/divider-grow/README.md
@@ -1,0 +1,5 @@
+# Divider Grow
+
+1. What does this do? A divider line that grows outward from the center, with a label (or dot) in the middle that fades in after the lines finish growing.
+2. How is it used? Build a `.divider-grow` flex row with two `.divider-grow__line` gradient bars flanking a `.divider-grow__label` (text) or `.divider-grow__label--dot`. The lines scale from `scaleX(0)` to `scaleX(1)` from center on load, then the label fades in. Adjust the grow speed via `--dg-speed`.
+3. Why is it useful? It adds a polished section-divider reveal using only CSS keyframes (no JavaScript), and renders fully static under `prefers-reduced-motion`.

--- a/submissions/examples/divider-grow/demo.html
+++ b/submissions/examples/divider-grow/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Divider Grow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="dg-title">
+        <p class="eyebrow">Layout</p>
+        <h1 id="dg-title">Divider grow</h1>
+        <p class="demo-copy">
+          A divider line that grows outward from the center with a label in
+          the middle.
+        </p>
+        <div class="divider-grow">
+          <span class="divider-grow__line" aria-hidden="true"></span>
+          <span class="divider-grow__label">or</span>
+          <span class="divider-grow__line" aria-hidden="true"></span>
+        </div>
+        <p class="demo-sub">Continue with email</p>
+        <div class="divider-grow">
+          <span class="divider-grow__line" aria-hidden="true"></span>
+          <span class="divider-grow__label divider-grow__label--dot" aria-hidden="true"></span>
+          <span class="divider-grow__line" aria-hidden="true"></span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/divider-grow/style.css
+++ b/submissions/examples/divider-grow/style.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 38rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.demo-sub {
+  margin: 1.4rem 0 1.6rem;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+/* ---------------------------------------------------------------------------
+   Divider Grow
+   A divider line that grows outward from the center with a label in the
+   middle. The container is a flex row; each line is a gradient bar that
+   scales from the center (transform-origin center, scaleX 0 -> 1) on load.
+   --------------------------------------------------------------------------- */
+.divider-grow {
+  --dg-speed: 700ms;
+
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.divider-grow__line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, #cbd5e1, transparent);
+  transform: scaleX(0);
+  transform-origin: center;
+  animation: dg-grow var(--dg-speed) ease forwards;
+}
+
+.divider-grow__label {
+  flex: none;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0;
+  animation: dg-fade 400ms ease var(--dg-speed) forwards;
+}
+
+.divider-grow__label--dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #cbd5e1;
+}
+
+@keyframes dg-grow {
+  0% {
+    transform: scaleX(0);
+  }
+
+  100% {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes dg-fade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .divider-grow__line,
+  .divider-grow__label {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #88610 — add the **divider-grow** component to the EaseMotion CSS gallery.

**Category:** Layout
**Description:** A divider line that grows outward from center with a label in the middle.

## Changes

Adds `submissions/examples/divider-grow/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._