### PR TITLE
feat(#88608): add badge-pulse component

### DIFF
--- a/submissions/examples/badge-pulse/README.md
+++ b/submissions/examples/badge-pulse/README.md
@@ -1,0 +1,5 @@
+# Badge Pulse
+
+1. What does this do? A status badge with a pulsing dot to signal a live state (online), with calm away and offline variants that do not pulse.
+2. How is it used? Build a `.badge-pulse` pill with a `.badge-pulse__dot`; the dot's `::before` ring expands and fades on a loop. Use modifiers `--online` (pulses, green), `--away` (static, amber), `--offline` (static, slate). Adjust the accent and tint via `--bp-accent` and `--bp-tint`.
+3. Why is it useful? It communicates liveness at a glance using only CSS keyframes (no JavaScript), and the pulse is disabled for non-live states and under `prefers-reduced-motion`.

--- a/submissions/examples/badge-pulse/demo.html
+++ b/submissions/examples/badge-pulse/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Badge Pulse</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="bp-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="bp-title">Badge pulse</h1>
+        <p class="demo-copy">
+          A status badge with a pulsing dot to signal a live state.
+        </p>
+        <div class="badge-row">
+          <span class="badge-pulse badge-pulse--online">
+            <span class="badge-pulse__dot" aria-hidden="true"></span>
+            Live
+          </span>
+          <span class="badge-pulse badge-pulse--away">
+            <span class="badge-pulse__dot" aria-hidden="true"></span>
+            Away
+          </span>
+          <span class="badge-pulse badge-pulse--offline">
+            <span class="badge-pulse__dot" aria-hidden="true"></span>
+            Offline
+          </span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/badge-pulse/style.css
+++ b/submissions/examples/badge-pulse/style.css
@@ -1,0 +1,148 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 38rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+}
+
+/* ---------------------------------------------------------------------------
+   Badge Pulse
+   A status badge with a pulsing dot to signal a live state. The badge is a
+   pill; its dot has an expanding, fading ring (::before) that loops to create
+   the pulse. Modifiers set the accent color and which states pulse.
+   --------------------------------------------------------------------------- */
+.badge-pulse {
+  --bp-accent: #16a34a;
+  --bp-tint: #ecfdf5;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 999px;
+  background: var(--bp-tint);
+  color: var(--bp-accent);
+  padding: 0.3rem 0.8rem 0.3rem 0.55rem;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.badge-pulse__dot {
+  position: relative;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--bp-accent);
+}
+
+.badge-pulse__dot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--bp-accent);
+  opacity: 0.5;
+  animation: bp-pulse 1.6s ease-out infinite;
+}
+
+.badge-pulse--online {
+  --bp-accent: #16a34a;
+  --bp-tint: #ecfdf5;
+}
+
+.badge-pulse--away {
+  --bp-accent: #d97706;
+  --bp-tint: #fffbeb;
+}
+
+.badge-pulse--offline {
+  --bp-accent: #94a3b8;
+  --bp-tint: #f1f5f9;
+}
+
+/* Only the "live" online badge actually pulses. */
+.badge-pulse--away .badge-pulse__dot::before,
+.badge-pulse--offline .badge-pulse__dot::before {
+  animation: none;
+  opacity: 0;
+}
+
+@keyframes bp-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+
+  100% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge-pulse__dot::before {
+    animation: none;
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## What

Closes #88608 — add the **badge-pulse** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A status badge with a pulsing dot to signal a live state.

## Changes

Adds `submissions/examples/badge-pulse/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._