### PR TITLE
feat(#88606): add dot-pagination component

### DIFF
--- a/submissions/examples/dot-pagination/README.md
+++ b/submissions/examples/dot-pagination/README.md
@@ -1,0 +1,5 @@
+# Dot Pagination
+
+1. What does this do? Compact dot pagination where the active dot stretches into a pill, and inactive dots scale up on hover.
+2. How is it used? Build a `.dot-pagination` nav of `.dot-pagination__dot` buttons; mark the current one with `.is-active` (and `aria-current="true"`). The active dot widens to a pill via width transition; others are small circles that scale on hover. Adjust the accent color and stretch speed via `--dp-accent` and `--dp-speed`.
+3. Why is it useful? It provides a minimal, tactile carousel/slide indicator using only CSS (the active styling is CSS-only; JS would toggle `.is-active`), with keyboard focus support and `prefers-reduced-motion` support.

--- a/submissions/examples/dot-pagination/demo.html
+++ b/submissions/examples/dot-pagination/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dot Pagination</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="dp-title">
+        <p class="eyebrow">Navigation</p>
+        <h1 id="dp-title">Dot pagination</h1>
+        <p class="demo-copy">
+          Compact dot pagination where the active dot stretches into a pill.
+        </p>
+        <nav class="dot-pagination" aria-label="Slides">
+          <button type="button" class="dot-pagination__dot" aria-label="Go to slide 1"></button>
+          <button type="button" class="dot-pagination__dot is-active" aria-current="true" aria-label="Go to slide 2"></button>
+          <button type="button" class="dot-pagination__dot" aria-label="Go to slide 3"></button>
+          <button type="button" class="dot-pagination__dot" aria-label="Go to slide 4"></button>
+          <button type="button" class="dot-pagination__dot" aria-label="Go to slide 5"></button>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/dot-pagination/style.css
+++ b/submissions/examples/dot-pagination/style.css
@@ -1,0 +1,117 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 38rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 28rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Dot Pagination
+   Compact dot pagination where the active dot stretches into a pill. Each dot
+   is a round button; the active (.is-active) dot widens via width transition
+   into a pill, while inactive dots are small circles that grow on hover.
+   --------------------------------------------------------------------------- */
+.dot-pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+}
+
+.dot-pagination__dot {
+  --dp-accent: #2563eb;
+  --dp-speed: 260ms;
+
+  width: 0.6rem;
+  height: 0.6rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: #cbd5e1;
+  cursor: pointer;
+  transition: width var(--dp-speed) cubic-bezier(0.22, 1, 0.36, 1),
+    background-color var(--dp-speed) ease, transform var(--dp-speed) ease;
+}
+
+.dot-pagination__dot:hover {
+  background: var(--dp-accent);
+  transform: scale(1.2);
+}
+
+.dot-pagination__dot:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
+}
+
+.dot-pagination__dot.is-active {
+  width: 1.9rem;
+  background: var(--dp-accent);
+}
+
+.dot-pagination__dot.is-active:hover {
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot-pagination__dot,
+  .dot-pagination__dot:hover {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88606 — add the **dot-pagination** component to the EaseMotion CSS gallery.

**Category:** Navigation
**Description:** Compact dot pagination where the active dot stretches into a pill.

## Changes

Adds `submissions/examples/dot-pagination/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._