### PR TITLE
feat(#88604): add stepper-progress component

### DIFF
--- a/submissions/examples/stepper-progress/README.md
+++ b/submissions/examples/stepper-progress/README.md
@@ -1,0 +1,5 @@
+# Stepper Progress
+
+1. What does this do? A horizontal stepper where completed steps fill with the accent color, connector lines draw between completed steps, and the current step pulses.
+2. How is it used? Build a `.stepper-progress` ordered list of `.stepper-progress__step` items, each with a `.stepper-progress__node` (check or number) and `.stepper-progress__label`. Mark finished steps with `.is-done` (fills the node and draws its outgoing connector) and the active one with `.is-current` (pulses). Adjust the accent, track, and draw speed via `--sp-accent`, `--sp-track`, and `--sp-speed`.
+3. Why is it useful? It renders a multi-step progress indicator with animated connectors using only CSS (no JavaScript), and disables animations under `prefers-reduced-motion`.

--- a/submissions/examples/stepper-progress/demo.html
+++ b/submissions/examples/stepper-progress/demo.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stepper Progress</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="sp-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="sp-title">Stepper progress</h1>
+        <p class="demo-copy">
+          A horizontal stepper where completed steps fill and the connector
+          lines draw between them.
+        </p>
+        <ol class="stepper-progress" aria-label="Checkout steps">
+          <li class="stepper-progress__step is-done">
+            <span class="stepper-progress__node" aria-hidden="true">&#10003;</span>
+            <span class="stepper-progress__label">Cart</span>
+          </li>
+          <li class="stepper-progress__step is-done">
+            <span class="stepper-progress__node" aria-hidden="true">&#10003;</span>
+            <span class="stepper-progress__label">Shipping</span>
+          </li>
+          <li class="stepper-progress__step is-current">
+            <span class="stepper-progress__node" aria-hidden="true">3</span>
+            <span class="stepper-progress__label">Payment</span>
+          </li>
+          <li class="stepper-progress__step">
+            <span class="stepper-progress__node" aria-hidden="true">4</span>
+            <span class="stepper-progress__label">Review</span>
+          </li>
+        </ol>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/stepper-progress/style.css
+++ b/submissions/examples/stepper-progress/style.css
@@ -1,0 +1,189 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 42rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 30rem;
+  margin: 0 auto 2.2rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Stepper Progress
+   A horizontal stepper where completed steps fill and the connector lines draw
+   between them. Each step is a node (circle) + label; the connector is a
+   flex-spacer line that fills (scaleX) only when the previous step is done.
+   --------------------------------------------------------------------------- */
+.stepper-progress {
+  --sp-accent: #2563eb;
+  --sp-track: #e2e8f0;
+  --sp-speed: 600ms;
+
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stepper-progress__step {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Connector line sits between nodes, behind them. */
+.stepper-progress__step::before {
+  content: "";
+  position: absolute;
+  top: 1rem;
+  left: calc(50% + 1.1rem);
+  right: calc(-50% + 1.1rem);
+  height: 2px;
+  background: var(--sp-track);
+  z-index: 0;
+}
+
+.stepper-progress__step:last-child::before {
+  display: none;
+}
+
+/* A colored overlay draws over the connector when this step is done. */
+.stepper-progress__step.is-done::after {
+  content: "";
+  position: absolute;
+  top: 1rem;
+  left: calc(50% + 1.1rem);
+  right: calc(-50% + 1.1rem);
+  height: 2px;
+  background: var(--sp-accent);
+  transform: scaleX(0);
+  transform-origin: left center;
+  animation: sp-draw var(--sp-speed) ease forwards;
+  z-index: 1;
+}
+
+.stepper-progress__node {
+  position: relative;
+  z-index: 2;
+  display: inline-grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 2px solid var(--sp-track);
+  background: #ffffff;
+  color: #94a3b8;
+  font-size: 0.82rem;
+  font-weight: 800;
+  transition: border-color var(--sp-speed) ease, background-color var(--sp-speed) ease,
+    color var(--sp-speed) ease;
+}
+
+.stepper-progress__step.is-done .stepper-progress__node {
+  border-color: var(--sp-accent);
+  background: var(--sp-accent);
+  color: #ffffff;
+}
+
+.stepper-progress__step.is-current .stepper-progress__node {
+  border-color: var(--sp-accent);
+  color: var(--sp-accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  animation: sp-pulse 1.8s ease-in-out infinite;
+}
+
+.stepper-progress__label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #64748b;
+}
+
+.stepper-progress__step.is-current .stepper-progress__label,
+.stepper-progress__step.is-done .stepper-progress__label {
+  color: #172033;
+}
+
+@keyframes sp-draw {
+  0% {
+    transform: scaleX(0);
+  }
+
+  100% {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes sp-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  }
+
+  50% {
+    box-shadow: 0 0 0 8px rgba(37, 99, 235, 0.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stepper-progress__step.is-done::after,
+  .stepper-progress__step.is-current .stepper-progress__node {
+    animation: none;
+    transform: scaleX(1);
+  }
+}


### PR DESCRIPTION
## What

Closes #88604 — add the **stepper-progress** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A horizontal stepper where completed steps fill and connectors draw between them.

## Changes

Adds `submissions/examples/stepper-progress/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._