### PR TITLE
feat(#88602): add range-slider-tooltip component

### DIFF
--- a/submissions/examples/range-slider-tooltip/README.md
+++ b/submissions/examples/range-slider-tooltip/README.md
@@ -1,0 +1,5 @@
+# Range Slider Tooltip
+
+1. What does this do? A custom range slider whose thumb shows a floating tooltip that pops in (scale + fade) on hover or keyboard focus.
+2. How is it used? Build a `.range-slider-tooltip` wrapper containing a `.range-slider-tooltip__input` (range) and a `.range-slider-tooltip__tooltip` (`<output>`). The track fills with the accent up to `--rst-thumb-x` (the thumb position, set by JS in a real app) and the tooltip anchors above it. The thumb scales on hover and the tooltip pops in. Adjust the accent and speed via `--rst-accent` and `--rst-speed`.
+3. Why is it useful? It delivers a polished slider with a live value tooltip using only CSS for styling/animation (JS would sync the value/position), cross-browser thumb styling, and `prefers-reduced-motion` support.

--- a/submissions/examples/range-slider-tooltip/demo.html
+++ b/submissions/examples/range-slider-tooltip/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Range Slider Tooltip</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="rst-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="rst-title">Range slider tooltip</h1>
+        <p class="demo-copy">
+          A range slider whose thumb shows a floating tooltip that pops on
+          hover.
+        </p>
+        <div class="range-slider-tooltip">
+          <input
+            type="range"
+            class="range-slider-tooltip__input"
+            min="0"
+            max="100"
+            value="62"
+            aria-label="Volume"
+          />
+          <output class="range-slider-tooltip__tooltip" for="volume">62</output>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/range-slider-tooltip/style.css
+++ b/submissions/examples/range-slider-tooltip/style.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 2rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Range Slider Tooltip
+   A range slider whose thumb shows a floating tooltip that pops on hover. The
+   container is the positioning context for the tooltip (an <output>); the
+   tooltip is hidden by default and pops in (scale + fade) on hover/focus of
+   the input. The track and thumb are custom-styled with a filled accent.
+   The tooltip's horizontal position would be driven by JS in a real app; here
+   it is anchored at ~62% via a custom property for the static demo.
+   --------------------------------------------------------------------------- */
+.range-slider-tooltip {
+  --rst-accent: #2563eb;
+  --rst-speed: 220ms;
+  --rst-thumb-x: 62%;
+
+  position: relative;
+  width: min(100%, 22rem);
+  margin: 0 auto;
+  padding: 2.4rem 0 0.5rem;
+}
+
+.range-slider-tooltip__input {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: var(--rst-accent);
+  background-image: linear-gradient(var(--rst-accent), var(--rst-accent));
+  background-size: var(--rst-thumb-x) 100%;
+  background-repeat: no-repeat;
+  background-color: #e2e8f0;
+  outline: none;
+  cursor: pointer;
+}
+
+.range-slider-tooltip__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid var(--rst-accent);
+  box-shadow: 0 0.2rem 0.5rem rgba(37, 99, 235, 0.35);
+  transition: transform var(--rst-speed) ease;
+}
+
+.range-slider-tooltip__input::-moz-range-thumb {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid var(--rst-accent);
+  box-shadow: 0 0.2rem 0.5rem rgba(37, 99, 235, 0.35);
+  transition: transform var(--rst-speed) ease;
+}
+
+.range-slider-tooltip__input:hover::-webkit-slider-thumb,
+.range-slider-tooltip__input:focus-visible::-webkit-slider-thumb {
+  transform: scale(1.18);
+}
+
+.range-slider-tooltip__input:hover::-moz-range-thumb,
+.range-slider-tooltip__input:focus-visible::-moz-range-thumb {
+  transform: scale(1.18);
+}
+
+.range-slider-tooltip__tooltip {
+  position: absolute;
+  top: 0;
+  left: var(--rst-thumb-x);
+  transform: translateX(-50%) scale(0.6);
+  transform-origin: bottom center;
+  border-radius: 0.4rem;
+  background: var(--rst-accent);
+  color: #ffffff;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--rst-speed) ease, transform var(--rst-speed) ease;
+}
+
+.range-slider-tooltip__tooltip::after {
+  content: "";
+  position: absolute;
+  bottom: -0.3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 0.3rem solid transparent;
+  border-top-color: var(--rst-accent);
+  border-bottom: 0;
+}
+
+.range-slider-tooltip:hover .range-slider-tooltip__tooltip,
+.range-slider-tooltip__input:focus-visible + .range-slider-tooltip__tooltip {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .range-slider-tooltip__input::-webkit-slider-thumb,
+  .range-slider-tooltip__input::-moz-range-thumb,
+  .range-slider-tooltip__tooltip {
+    transition: none;
+    transform: translateX(-50%) scale(1);
+  }
+
+  .range-slider-tooltip__tooltip {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #88602 — add the **range-slider-tooltip** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** A range slider whose thumb shows a floating tooltip that pops on hover.

## Changes

Adds `submissions/examples/range-slider-tooltip/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._