### PR TITLE
feat(#88600): add tooltip-grow component

### DIFF
--- a/submissions/examples/tooltip-grow/README.md
+++ b/submissions/examples/tooltip-grow/README.md
@@ -1,0 +1,5 @@
+# Tooltip Grow
+
+1. What does this do? A hover/focus tooltip that grows into view (scale + fade) above its target, with a pointer arrow.
+2. How is it used? Build a `.tooltip-grow` wrapper containing a `.tooltip-grow__target` (button) and a `.tooltip-grow__bubble` (`role="tooltip"`) with a `.tooltip-grow__arrow`. The bubble scales from 0.6 to 1 and fades in on hover/focus. Adjust the accent color and speed via `--tg-accent` and `--tg-speed`.
+3. Why is it useful? It delivers an accessible tooltip with keyboard focus support using only CSS (no JavaScript), and renders statically under `prefers-reduced-motion`.

--- a/submissions/examples/tooltip-grow/demo.html
+++ b/submissions/examples/tooltip-grow/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tooltip Grow</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="tg-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="tg-title">Tooltip grow</h1>
+        <p class="demo-copy">
+          A hover tooltip that grows into view with a pointer arrow.
+        </p>
+        <div class="tooltip-grow">
+          <button type="button" class="tooltip-grow__target">Hover me</button>
+          <span class="tooltip-grow__bubble" role="tooltip">
+            Helpful tip
+            <span class="tooltip-grow__arrow" aria-hidden="true"></span>
+          </span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/tooltip-grow/style.css
+++ b/submissions/examples/tooltip-grow/style.css
@@ -1,0 +1,141 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 30rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 3rem 2rem 2.5rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Tooltip Grow
+   A hover tooltip that grows into view with a pointer arrow. The bubble is
+   absolutely positioned above the target and hidden (scale 0.6, opacity 0);
+   on hover/focus of the wrapper it scales to 1 and fades in. The arrow is a
+   rotated square that sits at the bubble's bottom center.
+   --------------------------------------------------------------------------- */
+.tooltip-grow {
+  --tg-accent: #1e293b;
+  --tg-speed: 220ms;
+
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip-grow__target {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #1e293b;
+  padding: 0.55rem 1.1rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color var(--tg-speed) ease, color var(--tg-speed) ease;
+}
+
+.tooltip-grow__target:hover,
+.tooltip-grow__target:focus-visible {
+  outline: none;
+  border-color: var(--tg-accent);
+  color: var(--tg-accent);
+}
+
+.tooltip-grow__bubble {
+  position: absolute;
+  bottom: calc(100% + 0.7rem);
+  left: 50%;
+  transform: translateX(-50%) scale(0.6);
+  transform-origin: bottom center;
+  border-radius: 0.4rem;
+  background: var(--tg-accent);
+  color: #ffffff;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--tg-speed) ease, transform var(--tg-speed) ease;
+}
+
+.tooltip-grow__arrow {
+  position: absolute;
+  bottom: -0.25rem;
+  left: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  background: var(--tg-accent);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tooltip-grow:hover .tooltip-grow__bubble,
+.tooltip-grow__target:focus-visible + .tooltip-grow__bubble {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-grow__bubble,
+  .tooltip-grow__target {
+    transition: none;
+    transform: translateX(-50%) scale(1);
+  }
+
+  .tooltip-grow__bubble {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #88600 — add the **tooltip-grow** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A hover tooltip that grows into view with a pointer arrow.

## Changes

Adds `submissions/examples/tooltip-grow/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._