### PR TITLE
feat(#88599): add accordion-panels component

### DIFF
--- a/submissions/examples/accordion-panels/README.md
+++ b/submissions/examples/accordion-panels/README.md
@@ -1,0 +1,5 @@
+# Accordion Panels
+
+1. What does this do? An accordion where each panel content slides open with a smooth grow (animated via CSS grid-rows 0fr to 1fr), and the "+" icon rotates into an "x" when open.
+2. How is it used? Build a `.accordion-panels` container of `.accordion-panels__item` (`<details>`) blocks, each with a `.accordion-panels__summary` (`<summary>`) holding a `.accordion-panels__title` and `.accordion-panels__icon`, and a `.accordion-panels__panel` wrapping the content. The native `open` attribute drives open/close; the panel grows via grid-template-rows and the icon rotates. No JavaScript needed.
+3. Why is it useful? It gives an accessible accordion with native semantics (keyboard and screen-reader friendly), a smooth height animation without JavaScript, and `prefers-reduced-motion` support.

--- a/submissions/examples/accordion-panels/demo.html
+++ b/submissions/examples/accordion-panels/demo.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion Panels</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ap-title">
+        <p class="eyebrow">Layout</p>
+        <h1 id="ap-title">Accordion panels</h1>
+        <p class="demo-copy">
+          An accordion where the panel content slides open with a smooth grow.
+        </p>
+        <div class="accordion-panels">
+          <details class="accordion-panels__item is-open" open>
+            <summary class="accordion-panels__summary">
+              <span class="accordion-panels__title">What is EaseMotion?</span>
+              <span class="accordion-panels__icon" aria-hidden="true"></span>
+            </summary>
+            <div class="accordion-panels__panel">
+              <p>
+                EaseMotion is a collection of dependency-free HTML and CSS
+                interface examples you can drop straight into a project.
+              </p>
+            </div>
+          </details>
+          <details class="accordion-panels__item">
+            <summary class="accordion-panels__summary">
+              <span class="accordion-panels__title">Do I need JavaScript?</span>
+              <span class="accordion-panels__icon" aria-hidden="true"></span>
+            </summary>
+            <div class="accordion-panels__panel">
+              <p>
+                No. Every example is pure HTML and CSS, using the native
+                details element for interactions where helpful.
+              </p>
+            </div>
+          </details>
+          <details class="accordion-panels__item">
+            <summary class="accordion-panels__summary">
+              <span class="accordion-panels__title">Is it responsive?</span>
+              <span class="accordion-panels__icon" aria-hidden="true"></span>
+            </summary>
+            <div class="accordion-panels__panel">
+              <p>
+                Yes. Examples use fluid sizing and clamp values so they adapt
+                gracefully from phones to wide desktops.
+              </p>
+            </div>
+          </details>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/accordion-panels/style.css
+++ b/submissions/examples/accordion-panels/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Accordion Panels
+   An accordion where the panel content slides open with a smooth grow. Each
+   item is a native <details>; the summary is a flex row with a title and an
+   icon (a rotated "+" made from two bars) that rotates into an "x" when open.
+   The panel grows in via a grid-rows (0fr -> 1fr) transition, which animates
+   height without JavaScript.
+   --------------------------------------------------------------------------- */
+.accordion-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: left;
+}
+
+.accordion-panels__item {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.6rem;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.accordion-panels__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: background-color 180ms ease;
+}
+
+.accordion-panels__summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-panels__summary:hover {
+  background: #f8fafc;
+}
+
+.accordion-panels__title {
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.accordion-panels__icon {
+  position: relative;
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+}
+
+/* A "+" that rotates 45deg into an "x" when open. */
+.accordion-panels__icon::before,
+.accordion-panels__icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.7rem;
+  height: 2px;
+  border-radius: 2px;
+  background: #475569;
+  transform: translate(-50%, -50%);
+  transition: transform 220ms ease, background-color 220ms ease;
+}
+
+.accordion-panels__icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.accordion-panels__item[open] .accordion-panels__icon::after {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.accordion-panels__item[open] .accordion-panels__icon::before,
+.accordion-panels__item[open] .accordion-panels__icon::after {
+  background: #2563eb;
+}
+
+/* Smooth grow using grid-template-rows 0fr -> 1fr. */
+.accordion-panels__panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 300ms ease;
+}
+
+.accordion-panels__item[open] .accordion-panels__panel {
+  grid-template-rows: 1fr;
+}
+
+.accordion-panels__panel > p {
+  overflow: hidden;
+  margin: 0;
+  padding: 0 1rem;
+  color: #536173;
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+/* Keep padding visible when open; apply via inner wrapper trick. */
+.accordion-panels__item[open] .accordion-panels__panel > p {
+  padding: 0 1rem 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .accordion-panels__panel,
+  .accordion-panels__icon::before,
+  .accordion-panels__icon::after,
+  .accordion-panels__summary {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88599 — add the **accordion-panels** component to the EaseMotion CSS gallery.

**Category:** Layout
**Description:** An accordion where the panel content slides open with a smooth grow.

## Changes

Adds `submissions/examples/accordion-panels/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._