### PR TITLE
feat(#88598): add empty-state-graphic component

### DIFF
--- a/submissions/examples/empty-state-graphic/README.md
+++ b/submissions/examples/empty-state-graphic/README.md
@@ -1,0 +1,5 @@
+# Empty State Graphic
+
+1. What does this do? A friendly empty state with an animated icon (a pulsing halo ring and a bobbing core emoji), explanatory copy, and a call-to-action button that fills on hover.
+2. How is it used? Build an `.empty-state-graphic` block with an `.empty-state-graphic__art` container holding a `.empty-state-graphic__ring` (the animated halo) and a `.empty-state-graphic__core` (emoji), followed by a heading, `.empty-state-graphic__copy`, and an `.empty-state-graphic__cta` button. The ring expands and fades while the core bobs. Adjust the accent color and speed via `--es-accent` and `--es-speed`.
+3. Why is it useful? It turns an empty/no-results state into an inviting moment using only CSS animations (no JavaScript), and renders statically under `prefers-reduced-motion`.

--- a/submissions/examples/empty-state-graphic/demo.html
+++ b/submissions/examples/empty-state-graphic/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Empty State Graphic</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="es-title">
+        <p class="eyebrow">Layout</p>
+        <h1 id="es-title">Empty state graphic</h1>
+        <p class="demo-copy">
+          A friendly empty state with an animated icon and a call to action.
+        </p>
+        <div class="empty-state-graphic">
+          <div class="empty-state-graphic__art" aria-hidden="true">
+            <span class="empty-state-graphic__ring"></span>
+            <span class="empty-state-graphic__core">&#128269;</span>
+          </div>
+          <h2 class="empty-state-graphic__heading">No results yet</h2>
+          <p class="empty-state-graphic__copy">
+            Try adjusting your search or filters to find what you are looking
+            for.
+          </p>
+          <button type="button" class="empty-state-graphic__cta">Clear filters</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/empty-state-graphic/style.css
+++ b/submissions/examples/empty-state-graphic/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 26rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Empty State Graphic
+   A friendly empty state with an animated icon and a call to action. The art
+   is a circle that holds a ring (an expanding/fading halo) and a core emoji;
+   the ring loops to draw attention while the core gently bobs. A CTA button
+   fills on hover.
+   --------------------------------------------------------------------------- */
+.empty-state-graphic {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1.5rem 0 0.5rem;
+}
+
+.empty-state-graphic__art {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 5rem;
+  height: 5rem;
+  margin-bottom: 0.4rem;
+}
+
+.empty-state-graphic__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid #c7d2fe;
+  background: #eef2ff;
+  animation: es-halo 2.4s ease-out infinite;
+}
+
+.empty-state-graphic__core {
+  position: relative;
+  font-size: 2rem;
+  line-height: 1;
+  animation: es-bob 2.4s ease-in-out infinite;
+}
+
+.empty-state-graphic__heading {
+  margin: 0.3rem 0 0;
+  font-size: 1.15rem;
+}
+
+.empty-state-graphic__copy {
+  max-width: 22rem;
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.empty-state-graphic__cta {
+  --es-accent: #2563eb;
+  --es-speed: 200ms;
+
+  margin-top: 0.8rem;
+  border: 1px solid var(--es-accent);
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: var(--es-accent);
+  padding: 0.55rem 1.2rem;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color var(--es-speed) ease, color var(--es-speed) ease,
+    transform var(--es-speed) ease;
+}
+
+.empty-state-graphic__cta:hover,
+.empty-state-graphic__cta:focus-visible {
+  outline: none;
+  background: var(--es-accent);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+@keyframes es-halo {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.7;
+  }
+
+  70% {
+    opacity: 0;
+  }
+
+  100% {
+    transform: scale(1.25);
+    opacity: 0;
+  }
+}
+
+@keyframes es-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-state-graphic__ring,
+  .empty-state-graphic__core,
+  .empty-state-graphic__cta {
+    animation: none;
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88598 — add the **empty-state-graphic** component to the EaseMotion CSS gallery.

**Category:** Layout
**Description:** A friendly empty state with an animated icon and a call to action.

## Changes

Adds `submissions/examples/empty-state-graphic/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._