### PR TITLE
feat(#88593): add modal-sheet component

### DIFF
--- a/submissions/examples/modal-sheet/README.md
+++ b/submissions/examples/modal-sheet/README.md
@@ -1,0 +1,5 @@
+# Modal Sheet
+
+1. What does this do? A bottom sheet modal that slides up over a dimmed, blurred backdrop, with a grab handle, heading, copy, and two action buttons.
+2. How is it used? Build a `.modal-sheet` container with a `.modal-sheet__backdrop` and a `.modal-sheet__sheet`. The backdrop fades in (opacity) and the sheet slides up (translateY 100% to 0) on load. Use `.modal-sheet__btn--ghost` and `.modal-sheet__btn--primary` for actions. Adjust the accent color and slide speed via `--ms-accent` and `--ms-speed`.
+3. Why is it useful? It provides a mobile-style sheet dialog using only CSS (no JavaScript for the entrance animation), and renders statically under `prefers-reduced-motion`.

--- a/submissions/examples/modal-sheet/demo.html
+++ b/submissions/examples/modal-sheet/demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Modal Sheet</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ms-title">
+        <p class="eyebrow">Layout</p>
+        <h1 id="ms-title">Modal sheet</h1>
+        <p class="demo-copy">
+          A bottom sheet modal that slides up over a dimmed backdrop.
+        </p>
+      </section>
+      <div class="modal-sheet" role="dialog" aria-modal="true" aria-labelledby="ms-heading">
+        <div class="modal-sheet__backdrop" aria-hidden="true"></div>
+        <div class="modal-sheet__sheet">
+          <span class="modal-sheet__grab" aria-hidden="true"></span>
+          <h2 id="ms-heading" class="modal-sheet__heading">Choose a plan</h2>
+          <p class="modal-sheet__copy">
+            Upgrade to Pro for unlimited projects and priority support.
+          </p>
+          <div class="modal-sheet__actions">
+            <button type="button" class="modal-sheet__btn modal-sheet__btn--ghost">Maybe later</button>
+            <button type="button" class="modal-sheet__btn modal-sheet__btn--primary">Upgrade now</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/modal-sheet/style.css
+++ b/submissions/examples/modal-sheet/style.css
@@ -1,0 +1,191 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: 1fr auto;
+}
+
+.demo-card {
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0.85rem auto 0;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Modal Sheet
+   A bottom sheet modal that slides up over a dimmed backdrop. The container
+   is fixed and full-screen; the backdrop fades in (opacity), and the sheet
+   slides up from below the viewport (translateY) on load. The sheet has a
+   grab handle and two action buttons.
+   --------------------------------------------------------------------------- */
+.modal-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.modal-sheet__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  animation: ms-fade 360ms ease forwards;
+}
+
+.modal-sheet__sheet {
+  --ms-accent: #2563eb;
+  --ms-speed: 420ms;
+
+  position: relative;
+  width: 100%;
+  max-width: 32rem;
+  margin: 0 auto;
+  border-radius: 1rem 1rem 0 0;
+  background: #ffffff;
+  padding: 0.7rem 1.4rem 1.6rem;
+  text-align: center;
+  box-shadow: 0 -1rem 2.5rem rgba(15, 23, 42, 0.22);
+  transform: translateY(100%);
+  animation: ms-up var(--ms-speed) cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.modal-sheet__grab {
+  display: block;
+  width: 2.6rem;
+  height: 0.25rem;
+  margin: 0 auto 1rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+}
+
+.modal-sheet__heading {
+  margin: 0 0 0.4rem;
+  font-size: 1.2rem;
+}
+
+.modal-sheet__copy {
+  margin: 0 0 1.4rem;
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.modal-sheet__actions {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.modal-sheet__btn {
+  --ms-speed: 200ms;
+
+  border-radius: 0.55rem;
+  padding: 0.6rem 1.2rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color var(--ms-speed) ease, color var(--ms-speed) ease,
+    transform var(--ms-speed) ease;
+}
+
+.modal-sheet__btn--ghost {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #475569;
+}
+
+.modal-sheet__btn--ghost:hover {
+  border-color: #94a3b8;
+  color: #172033;
+}
+
+.modal-sheet__btn--primary {
+  border: 1px solid var(--ms-accent);
+  background: var(--ms-accent);
+  color: #ffffff;
+}
+
+.modal-sheet__btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0.5rem 1rem rgba(37, 99, 235, 0.3);
+}
+
+@keyframes ms-up {
+  0% {
+    transform: translateY(100%);
+  }
+
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes ms-fade {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-sheet__sheet,
+  .modal-sheet__backdrop,
+  .modal-sheet__btn {
+    animation: none;
+    transition: none;
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #88593 — add the **modal-sheet** component to the EaseMotion CSS gallery.

**Category:** Layout
**Description:** A bottom sheet modal that slides up over a dimmed backdrop.

## Changes

Adds `submissions/examples/modal-sheet/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._