### PR TITLE
feat(#88592): add dropdown-select component

### DIFF
--- a/submissions/examples/dropdown-select/README.md
+++ b/submissions/examples/dropdown-select/README.md
@@ -1,0 +1,5 @@
+# Dropdown Select
+
+1. What does this do? A select-style dropdown whose menu panel fades and slides down on hover (and keyboard focus of the wrapper), with a rotating chevron and a selected highlight.
+2. How is it used? Build a `.dropdown-select` wrapper (focusable) containing a `.dropdown-select__trigger` button (with `.dropdown-select__value` and a `.dropdown-select__chevron`) and a `.dropdown-select__menu` list of `.dropdown-select__item` options; mark the chosen one `.is-selected`. The menu reveals on `:hover`/`:focus-within`. Adjust the accent color and speed via `--ds-accent` and `--ds-speed`.
+3. Why is it useful? It gives a lightweight custom select affordance using only CSS (no JavaScript for the open/close animation), with keyboard focus support and `prefers-reduced-motion` support.

--- a/submissions/examples/dropdown-select/demo.html
+++ b/submissions/examples/dropdown-select/demo.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dropdown Select</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="ds-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="ds-title">Dropdown select</h1>
+        <p class="demo-copy">
+          A select-style dropdown whose panel fades and slides down on hover.
+        </p>
+        <div class="dropdown-select" tabindex="0">
+          <button type="button" class="dropdown-select__trigger">
+            <span class="dropdown-select__value">Sort: Newest</span>
+            <span class="dropdown-select__chevron" aria-hidden="true"></span>
+          </button>
+          <ul class="dropdown-select__menu" role="listbox">
+            <li class="dropdown-select__item is-selected" role="option" aria-selected="true">Newest</li>
+            <li class="dropdown-select__item" role="option">Oldest</li>
+            <li class="dropdown-select__item" role="option">Most popular</li>
+            <li class="dropdown-select__item" role="option">A &rarr; Z</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/dropdown-select/style.css
+++ b/submissions/examples/dropdown-select/style.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 32rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Dropdown Select
+   A select-style dropdown whose panel fades and slides down on hover (and on
+   keyboard focus of the wrapper). The trigger is a pill with a chevron that
+   rotates when open; the menu is absolutely positioned and revealed via
+   opacity + translateY. The wrapper keeps focus and shows the menu while
+   hovered or focused.
+   --------------------------------------------------------------------------- */
+.dropdown-select {
+  --ds-accent: #2563eb;
+  --ds-speed: 200ms;
+
+  position: relative;
+  display: inline-block;
+  outline: none;
+}
+
+.dropdown-select__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #1e293b;
+  padding: 0.55rem 0.9rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color var(--ds-speed) ease;
+}
+
+.dropdown-select:hover .dropdown-select__trigger,
+.dropdown-select:focus-within .dropdown-select__trigger {
+  border-color: var(--ds-accent);
+}
+
+.dropdown-select__value {
+  pointer-events: none;
+}
+
+.dropdown-select__chevron {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid #64748b;
+  border-bottom: 2px solid #64748b;
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform var(--ds-speed) ease;
+}
+
+.dropdown-select:hover .dropdown-select__chevron,
+.dropdown-select:focus-within .dropdown-select__chevron {
+  transform: rotate(225deg) translateY(0);
+}
+
+.dropdown-select__menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  margin: 0;
+  padding: 0.3rem;
+  width: max-content;
+  min-width: 100%;
+  list-style: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  box-shadow: 0 0.8rem 1.8rem rgba(15, 23, 42, 0.14);
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition: opacity var(--ds-speed) ease, transform var(--ds-speed) ease;
+}
+
+.dropdown-select:hover .dropdown-select__menu,
+.dropdown-select:focus-within .dropdown-select__menu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.dropdown-select__item {
+  border-radius: 0.35rem;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #475569;
+  cursor: pointer;
+  transition: background-color var(--ds-speed) ease, color var(--ds-speed) ease;
+}
+
+.dropdown-select__item:hover {
+  background: #eff4ff;
+  color: var(--ds-accent);
+}
+
+.dropdown-select__item.is-selected {
+  background: #eff4ff;
+  color: var(--ds-accent);
+  font-weight: 800;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-select__chevron,
+  .dropdown-select__menu,
+  .dropdown-select__trigger,
+  .dropdown-select__item {
+    transition: none;
+    transform: translateY(0);
+  }
+
+  .dropdown-select__menu {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## What

Closes #88592 — add the **dropdown-select** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** A select-style dropdown whose panel fades and slides down on hover.

## Changes

Adds `submissions/examples/dropdown-select/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._