### PR TITLE
feat(#88590): add switch-pill component

### DIFF
--- a/submissions/examples/switch-pill/README.md
+++ b/submissions/examples/switch-pill/README.md
@@ -1,0 +1,5 @@
+# Switch Pill
+
+1. What does this do? A pill-shaped toggle switch that slides its knob to the opposite end when checked, and swaps the "On"/"Off" labels while filling the track with the accent color.
+2. How is it used? Build a `.switch-pill` label wrapping a native `.switch-pill__input` checkbox and a `.switch-pill__track` containing a `.switch-pill__knob`, `.switch-pill__on`, and `.switch-pill__off`. The checkbox's `:checked` state drives the knob translate, label swap, and track fill. Adjust the accent color and slide speed via `--sp-accent` and `--sp-speed`.
+3. Why is it useful? It provides an accessible toggle using a real checkbox (keyboard and screen-reader friendly) styled as a labeled pill, with `prefers-reduced-motion` support.

--- a/submissions/examples/switch-pill/demo.html
+++ b/submissions/examples/switch-pill/demo.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Switch Pill</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="sp-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="sp-title">Switch pill</h1>
+        <p class="demo-copy">
+          A pill-shaped toggle switch that slides its knob when checked.
+        </p>
+        <ul class="switch-pill__list">
+          <li>
+            <label class="switch-pill">
+              <input type="checkbox" class="switch-pill__input" checked />
+              <span class="switch-pill__track">
+                <span class="switch-pill__knob" aria-hidden="true"></span>
+                <span class="switch-pill__on">On</span>
+                <span class="switch-pill__off">Off</span>
+              </span>
+              <span class="switch-pill__label">Email notifications</span>
+            </label>
+          </li>
+          <li>
+            <label class="switch-pill">
+              <input type="checkbox" class="switch-pill__input" />
+              <span class="switch-pill__track">
+                <span class="switch-pill__knob" aria-hidden="true"></span>
+                <span class="switch-pill__on">On</span>
+                <span class="switch-pill__off">Off</span>
+              </span>
+              <span class="switch-pill__label">Auto-save drafts</span>
+            </label>
+          </li>
+          <li>
+            <label class="switch-pill">
+              <input type="checkbox" class="switch-pill__input" checked />
+              <span class="switch-pill__track">
+                <span class="switch-pill__knob" aria-hidden="true"></span>
+                <span class="switch-pill__on">On</span>
+                <span class="switch-pill__off">Off</span>
+              </span>
+              <span class="switch-pill__label">Compact mode</span>
+            </label>
+          </li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/switch-pill/style.css
+++ b/submissions/examples/switch-pill/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Switch Pill
+   A pill-shaped toggle switch that slides its knob when checked. The native
+   checkbox is visually hidden but stays focusable; the visible track is a
+   flex row with the knob, an "On" label, and an "Off" label. When checked,
+   the knob translates to the opposite end, the "On" label shows, and the
+   "Off" label hides; the track fills with the accent color.
+   --------------------------------------------------------------------------- */
+.switch-pill__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  text-align: left;
+}
+
+.switch-pill {
+  --sp-accent: #2563eb;
+  --sp-speed: 220ms;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+}
+
+.switch-pill__input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.switch-pill__track {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  width: 4.4rem;
+  height: 1.7rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #ffffff;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  transition: background-color var(--sp-speed) ease;
+}
+
+.switch-pill__knob {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 0.1rem 0.2rem rgba(15, 23, 42, 0.3);
+  transition: transform var(--sp-speed) cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.switch-pill__on,
+.switch-pill__off {
+  flex: 1;
+  line-height: 1.2rem;
+  text-align: center;
+  transition: opacity var(--sp-speed) ease;
+}
+
+.switch-pill__on {
+  opacity: 0;
+}
+
+.switch-pill__off {
+  opacity: 1;
+  color: #94a3b8;
+}
+
+.switch-pill__input:checked + .switch-pill__track {
+  background: var(--sp-accent);
+}
+
+.switch-pill__input:checked + .switch-pill__track .switch-pill__knob {
+  transform: translateX(2rem);
+}
+
+.switch-pill__input:checked + .switch-pill__track .switch-pill__on {
+  opacity: 1;
+}
+
+.switch-pill__input:checked + .switch-pill__track .switch-pill__off {
+  opacity: 0;
+}
+
+.switch-pill__input:focus-visible + .switch-pill__track {
+  outline: 2px solid var(--sp-accent);
+  outline-offset: 2px;
+}
+
+.switch-pill__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-pill__knob,
+  .switch-pill__track,
+  .switch-pill__on,
+  .switch-pill__off {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88590 — add the **switch-pill** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** A pill-shaped toggle switch that slides its knob when checked.

## Changes

Adds `submissions/examples/switch-pill/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._