### PR TITLE
feat(#88589): add progress-circle component

### DIFF
--- a/submissions/examples/progress-circle/README.md
+++ b/submissions/examples/progress-circle/README.md
@@ -1,0 +1,5 @@
+# Progress Circle
+
+1. What does this do? A circular progress ring that fills from 0 to a target percentage via an animated SVG stroke (stroke-dashoffset), with the percentage shown in the center.
+2. How is it used? Build a `.progress-circle` container holding an `.progress-circle__svg` (viewBox 0 0 120 120) with a `.progress-circle__track` circle and a `.progress-circle__value` circle (set its fill via the `--pc-value` custom property, 0-100), plus a `.progress-circle__label`. The value circle's dash offset animates from full circumference (empty) to circumference minus the filled portion. Set `role="progressbar"` and `aria-valuenow` on the container for accessibility. Adjust colors via `--pc-accent` and `--pc-track`.
+3. Why is it useful? It renders a determinate circular progress indicator using only CSS (no JavaScript), and shows the final filled ring statically under `prefers-reduced-motion`.

--- a/submissions/examples/progress-circle/demo.html
+++ b/submissions/examples/progress-circle/demo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Progress Circle</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="pc-title">
+        <p class="eyebrow">Feedback</p>
+        <h1 id="pc-title">Progress circle</h1>
+        <p class="demo-copy">
+          A circular progress ring that fills via an animated SVG stroke.
+        </p>
+        <div class="progress-circle" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100">
+          <svg class="progress-circle__svg" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="progress-circle__track" cx="60" cy="60" r="52" />
+            <circle class="progress-circle__value" cx="60" cy="60" r="52" style="--pc-value: 70" />
+          </svg>
+          <span class="progress-circle__label">70%</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/progress-circle/style.css
+++ b/submissions/examples/progress-circle/style.css
@@ -1,0 +1,128 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Progress Circle
+   A circular progress ring that fills via stroke-dashoffset on an SVG circle.
+   The value circle's stroke length equals the circumference (2*pi*r); the dash
+   offset starts at full circumference (empty) and animates to circumference
+   minus (value/100 * circumference) (filled). Set the fill with the --pc-value
+   custom property (0-100) inline on the value circle.
+   --------------------------------------------------------------------------- */
+.progress-circle {
+  --pc-accent: #2563eb;
+  --pc-track: #e2e8f0;
+  --pc-value: 0;
+  --pc-circumference: 326.726; /* 2 * pi * 52 */
+
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 8rem;
+  height: 8rem;
+}
+
+.progress-circle__svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.progress-circle__track {
+  fill: none;
+  stroke: var(--pc-track);
+  stroke-width: 12;
+}
+
+.progress-circle__value {
+  fill: none;
+  stroke: var(--pc-accent);
+  stroke-width: 12;
+  stroke-linecap: round;
+  stroke-dasharray: var(--pc-circumference);
+  stroke-dashoffset: var(--pc-circumference);
+  animation: pc-fill 1400ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.progress-circle__label {
+  position: relative;
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+@keyframes pc-fill {
+  to {
+    stroke-dashoffset: calc(
+      var(--pc-circumference) - var(--pc-value) / 100 * var(--pc-circumference)
+    );
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-circle__value {
+    animation: none;
+    stroke-dashoffset: calc(
+      var(--pc-circumference) - var(--pc-value) / 100 * var(--pc-circumference)
+    );
+  }
+}


### PR DESCRIPTION
## What

Closes #88589 — add the **progress-circle** component to the EaseMotion CSS gallery.

**Category:** Feedback
**Description:** A circular progress ring that fills via an animated SVG stroke.

## Changes

Adds `submissions/examples/progress-circle/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._