### PR TITLE
feat(#88591): add copy-field component

### DIFF
--- a/submissions/examples/copy-field/README.md
+++ b/submissions/examples/copy-field/README.md
@@ -1,0 +1,5 @@
+# Copy Field
+
+1. What does this do? An input with a copy button that swaps to a checkmark label on active state.
+2. How is it used? Build a `.copy-field` label wrapping a `.copy-field__input` (readonly) and a `.copy-field__control` holding the input and a `.copy-field__btn` with a `.copy-field__icon` and `.copy-field__text`. On `:active` (a press), the icon collapses into a checkmark and the label swaps to "Copied" with a green tint. In a real app, JavaScript would copy to the clipboard and add a class to persist the state. Adjust the accent color via `--cf-accent`.
+3. Why is it useful? It provides a copy-to-clipboard affordance with a clear visual confirmation using only CSS for the interaction, and renders without motion under `prefers-reduced-motion`.

--- a/submissions/examples/copy-field/demo.html
+++ b/submissions/examples/copy-field/demo.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy Field</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="demo-card" aria-labelledby="cf-title">
+        <p class="eyebrow">Input</p>
+        <h1 id="cf-title">Copy field</h1>
+        <p class="demo-copy">
+          An input with a copy button that swaps to a checkmark label on
+          active state.
+        </p>
+        <label class="copy-field" for="cf-input">
+          <span class="copy-field__label">Share link</span>
+          <span class="copy-field__control">
+            <input
+              id="cf-input"
+              type="text"
+              class="copy-field__input"
+              value="https://example.com/invite/abc123"
+              readonly
+            />
+            <button type="button" class="copy-field__btn" aria-label="Copy link">
+              <span class="copy-field__icon" aria-hidden="true"></span>
+              <span class="copy-field__text" aria-hidden="true"></span>
+            </button>
+          </span>
+        </label>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/copy-field/style.css
+++ b/submissions/examples/copy-field/style.css
@@ -1,0 +1,197 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.demo-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.demo-card {
+  width: min(100%, 34rem);
+  border: 1px solid #dbe2ee;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.1);
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 0.8rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.demo-copy {
+  max-width: 24rem;
+  margin: 0 auto 1.8rem;
+  color: #536173;
+  line-height: 1.65;
+}
+
+/* ---------------------------------------------------------------------------
+   Copy Field
+   An input with a copy button that swaps to a checkmark label on active
+   state. The control is a flex row with the readonly input and a button; the
+   button holds an icon (two overlapping squares) and a label. On :active (a
+   press) the label swaps to "Copied" and the icon becomes a checkmark, with
+   a tinted fill. In a real app JS would copy to the clipboard and add a class.
+   --------------------------------------------------------------------------- */
+.copy-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  width: min(100%, 22rem);
+  margin: 0 auto;
+  text-align: left;
+}
+
+.copy-field__label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #475569;
+}
+
+.copy-field__control {
+  display: flex;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  background: #ffffff;
+  overflow: hidden;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.copy-field__control:focus-within {
+  border-color: var(--cf-accent, #2563eb);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+}
+
+.copy-field__input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.6rem 0.7rem;
+}
+
+.copy-field__btn {
+  --cf-accent: #2563eb;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 0;
+  border-left: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: var(--cf-accent);
+  padding: 0 0.9rem;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: background-color 200ms ease;
+}
+
+.copy-field__btn:hover {
+  background: #eff4ff;
+}
+
+/* Icon: two overlapping squares, drawn with pseudo-elements. */
+.copy-field__icon {
+  position: relative;
+  width: 0.8rem;
+  height: 0.8rem;
+}
+
+.copy-field__icon::before,
+.copy-field__icon::after {
+  content: "";
+  position: absolute;
+  border: 1.5px solid var(--cf-accent);
+  border-radius: 2px;
+  background: transparent;
+  transition: transform 180ms ease, border-color 180ms ease,
+    background-color 180ms ease, width 180ms ease, height 180ms ease;
+}
+
+.copy-field__icon::before {
+  inset: 0.18rem 0 0 0.18rem;
+}
+
+.copy-field__icon::after {
+  inset: 0 0.18rem 0.18rem 0;
+}
+
+/* On active (press), collapse the squares into a checkmark shape. */
+.copy-field__btn:active .copy-field__icon::before {
+  border-color: #16a34a;
+  border-top: 0;
+  border-right: 0;
+  background: transparent;
+  width: 0.5rem;
+  height: 0.85rem;
+  inset: auto;
+  top: 0;
+  left: 0.1rem;
+  transform: rotate(45deg);
+}
+
+.copy-field__btn:active .copy-field__icon::after {
+  opacity: 0;
+}
+
+.copy-field__btn:active .copy-field__text {
+  color: #16a34a;
+}
+
+.copy-field__btn:active .copy-field__text::before {
+  content: "Copied";
+}
+
+.copy-field__text::before {
+  content: "Copy";
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-field__icon::before,
+  .copy-field__icon::after,
+  .copy-field__control,
+  .copy-field__btn {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

Closes #88591 — add the **copy-field** component to the EaseMotion CSS gallery.

**Category:** Input
**Description:** An input with a copy button that swaps to a checkmark label on active state.

## Changes

Adds `submissions/examples/copy-field/` (dependency-free, per the contribution model):

- `demo.html` — interactive, no JavaScript
- `style.css` — original, hand-crafted CSS
- `README.md` — usage notes

## How it was verified

- `demo.html` is well-formed (matched tags, links `./style.css`, has doctype).
- `style.css` passes `stylelint` against the repo config.
- Folder name is unique in `submissions/examples/`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._