### PR TITLE
feat(examples): add pure CSS accordion (relates to #88584)

### DIFF
--- a/submissions/examples/pure-css-accordion/README.md
+++ b/submissions/examples/pure-css-accordion/README.md
@@ -1,0 +1,40 @@
+# Pure CSS Accordion
+
+## Summary
+
+A fully JavaScript-free accordion component. Panels expand and collapse with
+a smooth height animation, driven entirely by CSS using the
+`grid-template-rows: 0fr → 1fr` technique.
+
+## Why "advanced"
+
+`height: auto` cannot be animated by CSS transitions, which is why most
+accordions either skip the animation or reach for JavaScript to measure
+`scrollHeight`. This component sidesteps that entirely:
+
+- Each panel is wrapped in a single-column CSS grid.
+- The grid's row track transitions between `0fr` (collapsed) and `1fr`
+  (expanded) — grid track sizes are animatable, so the browser interpolates
+  the height smoothly with no measurement and no JS.
+- Hidden radio inputs (`name="pca-group"`) track which panel is open,
+  giving native, exclusive open/close behavior and full keyboard support
+  (`Tab` + `Space`/`Enter`) for free.
+
+## Files
+
+- `demo.html` — 3-item FAQ-style accordion
+- `style.css` — accordion structure, grid animation, focus states
+
+## Accessibility
+
+- Uses real `<label for>` / `<input type="radio">` pairing, so it's operable
+  by keyboard and works with screen readers without extra ARIA wiring.
+- `:focus-visible` outline included for keyboard users.
+
+## Notes for maintainer review
+
+Filed against issue #88584 ("Add pure CSS advanced component"). The original
+issue body didn't specify which component to build, so this submission picks
+a concrete, genuinely advanced pure-CSS pattern (animatable accordion via
+grid tracks) rather than a placeholder. Happy to adjust naming/structure to
+match `ease-*` conventions if the maintainer wants to standardize it.

--- a/submissions/examples/pure-css-accordion/demo.html
+++ b/submissions/examples/pure-css-accordion/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pure CSS Accordion — Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body style="font-family: Inter, system-ui, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px;">
+
+<h1>Pure CSS Accordion</h1>
+<p>No JavaScript. Radio inputs track which panel is open, and
+   <code>grid-template-rows</code> animates the height smoothly.</p>
+
+<div class="pca-accordion">
+
+  <div class="pca-item">
+    <input type="radio" name="pca-group" id="pca-1" checked />
+    <div class="pca-header">
+      <label for="pca-1">
+        What is EaseMotion CSS?
+        <span class="pca-icon">+</span>
+      </label>
+    </div>
+    <div class="pca-panel">
+      <div class="pca-panel-inner">
+        <div class="pca-panel-content">
+          A zero-dependency, animation-first CSS framework with human-readable
+          class names. No build step, just link the stylesheet.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="pca-item">
+    <input type="radio" name="pca-group" id="pca-2" />
+    <div class="pca-header">
+      <label for="pca-2">
+        How does this accordion work without JS?
+        <span class="pca-icon">+</span>
+      </label>
+    </div>
+    <div class="pca-panel">
+      <div class="pca-panel-inner">
+        <div class="pca-panel-content">
+          Each panel sits inside a grid whose row track animates between
+          <code>0fr</code> and <code>1fr</code>. Since grid tracks are
+          animatable (unlike <code>height: auto</code>), the browser can
+          smoothly transition the panel's height on its own.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="pca-item">
+    <input type="radio" name="pca-group" id="pca-3" />
+    <div class="pca-header">
+      <label for="pca-3">
+        Can more than one panel be open at once?
+        <span class="pca-icon">+</span>
+      </label>
+    </div>
+    <div class="pca-panel">
+      <div class="pca-panel-inner">
+        <div class="pca-panel-content">
+          Not with radio inputs sharing one <code>name</code> — that's what
+          makes it exclusive, like native accordion behavior. Swap the
+          radios for checkboxes if you want independently expandable panels.
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/pure-css-accordion/style.css
+++ b/submissions/examples/pure-css-accordion/style.css
@@ -1,0 +1,86 @@
+/* Pure CSS Accordion — no JavaScript required
+   Technique: hidden radio inputs drive :checked state,
+   panel height animates via grid-template-rows (0fr -> 1fr),
+   which is smoothly animatable unlike height:auto. */
+
+.pca-accordion {
+  max-width: 560px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  overflow: hidden;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.pca-item {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.pca-item:last-child {
+  border-bottom: none;
+}
+
+.pca-item input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pca-header {
+  display: block;
+  cursor: pointer;
+}
+
+.pca-header label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  font-weight: 600;
+  color: #111827;
+  background: #f9fafb;
+  transition: background 150ms ease;
+}
+
+.pca-header label:hover {
+  background: #f3f4f6;
+}
+
+.pca-icon {
+  transition: transform 200ms ease;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.pca-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 250ms ease;
+}
+
+.pca-panel-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.pca-panel-content {
+  padding: 0 18px;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.pca-item input[type="radio"]:checked ~ .pca-panel {
+  grid-template-rows: 1fr;
+}
+
+.pca-item input[type="radio"]:checked ~ .pca-panel .pca-panel-content {
+  padding: 14px 18px 18px;
+}
+
+.pca-item input[type="radio"]:checked ~ .pca-header .pca-icon {
+  transform: rotate(45deg);
+}
+
+.pca-item input[type="radio"]:focus-visible ~ .pca-header label {
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}


### PR DESCRIPTION
Adds submissions/examples/pure-css-accordion/ — a JS-free accordion using grid-template-rows (0fr → 1fr) for smoothly animatable height, radio-driven exclusive open/close, and keyboard/focus support.

Relates to #88584. The original issue body didn't specify which component to build ('Add pure CSS advanced component iteration 126'), so this PR proposes a concrete, genuinely advanced pure-CSS pattern rather than a placeholder — happy to adjust naming/structure if you'd rather standardize it differently.