### PR TITLE
feat(examples): add pure CSS toggle switch (relates to #88616)

### DIFF
--- a/submissions/examples/pure-css-toggle-switch/README.md
+++ b/submissions/examples/pure-css-toggle-switch/README.md
@@ -1,0 +1,35 @@
+# Pure CSS Toggle Switch
+
+## Summary
+
+An animated toggle switch built entirely with CSS — a real `<input type="checkbox">`
+styled to look and behave like a switch. No JavaScript, fully keyboard accessible,
+and screen-reader friendly since it's a genuine checkbox under the hood.
+
+## How it works
+
+- The checkbox itself is visually hidden (not `display: none`, so it stays
+  focusable and operable) but remains the actual interactive/accessible element.
+- A sibling `.pcts-track` + `.pcts-thumb` pair is purely decorative and styled
+  based on the checkbox's `:checked` state via the `~` sibling combinator.
+- The thumb slides with `transform: translateX(...)`, and the track's
+  background color transitions — both animatable with a plain CSS `transition`.
+
+## Files
+
+- `demo.html` — off, on-by-default, disabled, and small-size examples
+- `style.css` — switch structure, checked/disabled/focus states, size variant
+
+## Accessibility
+
+- Uses a real `<input type="checkbox">`, so screen readers announce it as a
+  checkbox with its current state — no custom ARIA roles needed.
+- `:focus-visible` outline for keyboard navigation.
+- `:disabled` state is respected and visually distinct.
+
+## Notes for maintainer review
+
+Filed against issue #88616 ("Add pure CSS advanced component iteration 158").
+As with #88584, the issue body was a generic auto-generated template with no
+concrete spec, so this submission proposes a genuinely useful, commonly-needed
+component (checkbox-based animated toggle) rather than a placeholder.

--- a/submissions/examples/pure-css-toggle-switch/demo.html
+++ b/submissions/examples/pure-css-toggle-switch/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pure CSS Toggle Switch — Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body style="font-family: Inter, system-ui, sans-serif; max-width: 480px; margin: 40px auto; padding: 0 16px;">
+
+<h1>Pure CSS Toggle Switch</h1>
+<p>No JavaScript — a real checkbox styled as an animated switch,
+   fully keyboard operable.</p>
+
+<div style="display: flex; flex-direction: column; gap: 20px;">
+
+  <label class="pcts-switch">
+    <input type="checkbox" />
+    <span class="pcts-track">
+      <span class="pcts-thumb"></span>
+    </span>
+    <span class="pcts-label">Enable notifications</span>
+  </label>
+
+  <label class="pcts-switch">
+    <input type="checkbox" checked />
+    <span class="pcts-track">
+      <span class="pcts-thumb"></span>
+    </span>
+    <span class="pcts-label">Dark mode (default on)</span>
+  </label>
+
+  <label class="pcts-switch">
+    <input type="checkbox" disabled />
+    <span class="pcts-track">
+      <span class="pcts-thumb"></span>
+    </span>
+    <span class="pcts-label">Locked setting (disabled)</span>
+  </label>
+
+  <label class="pcts-switch pcts-sm">
+    <input type="checkbox" />
+    <span class="pcts-track">
+      <span class="pcts-thumb"></span>
+    </span>
+    <span class="pcts-label">Small variant</span>
+  </label>
+
+</div>
+
+</body>
+</html>

--- a/submissions/examples/pure-css-toggle-switch/style.css
+++ b/submissions/examples/pure-css-toggle-switch/style.css
@@ -1,0 +1,85 @@
+/* Pure CSS Toggle Switch — no JavaScript required
+   A styled checkbox: the native input drives :checked state,
+   a sibling <span> is styled to look and animate like a switch. */
+
+.pcts-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.pcts-switch input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.pcts-track {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  background: #d1d5db;
+  border-radius: 999px;
+  transition: background 200ms ease;
+  flex-shrink: 0;
+}
+
+.pcts-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background: #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 200ms ease;
+}
+
+.pcts-switch input[type="checkbox"]:checked ~ .pcts-track {
+  background: #22c55e;
+}
+
+.pcts-switch input[type="checkbox"]:checked ~ .pcts-track .pcts-thumb {
+  transform: translateX(20px);
+}
+
+.pcts-switch input[type="checkbox"]:disabled ~ .pcts-track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pcts-switch:has(input:disabled) {
+  cursor: not-allowed;
+}
+
+.pcts-switch input[type="checkbox"]:focus-visible ~ .pcts-track {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.pcts-label {
+  font-size: 14px;
+  color: #111827;
+}
+
+.pcts-switch.pcts-sm .pcts-track {
+  width: 36px;
+  height: 20px;
+}
+
+.pcts-switch.pcts-sm .pcts-thumb {
+  width: 14px;
+  height: 14px;
+  top: 3px;
+  left: 3px;
+}
+
+.pcts-switch.pcts-sm input[type="checkbox"]:checked ~ .pcts-track .pcts-thumb {
+  transform: translateX(16px);
+}


### PR DESCRIPTION
Adds submissions/examples/pure-css-toggle-switch/ — an animated, JS-free toggle switch built on a real checkbox input (styled via sibling selectors), with off/on-default/disabled/small-size examples and keyboard focus support.

Relates to #88616. The issue body was a generic auto-generated template ('Add pure CSS advanced component iteration 158') with no concrete spec, so this proposes a genuinely useful, commonly-needed pure-CSS pattern rather than a placeholder.