### PR TITLE
feat(examples): add dark mode token layer demo (relates to #88689)

### DIFF
--- a/submissions/examples/dark-mode-token-layer-88689/README.md
+++ b/submissions/examples/dark-mode-token-layer-88689/README.md
@@ -1,0 +1,48 @@
+# Dark Mode Token Layer
+
+## Summary
+
+A proposed dark-mode token layer for EaseMotion CSS, addressing the "Dark
+mode token layer" item on the README's v1.1 roadmap (issue #88689). Instead
+of new component classes, this overrides the existing `--ease-*` custom
+property values so every current component (`ease-card`, `ease-btn`, etc.)
+gets dark styling automatically, with zero markup changes.
+
+## Activation
+
+Two ways to activate, both included in `style.css`:
+
+1. **Automatic** — `@media (prefers-color-scheme: dark)` follows the user's
+   OS-level setting with no JavaScript required.
+2. **Manual override** — a `[data-theme="dark"]` (or `"light"`) attribute
+   on `<html>` takes priority over the media query, for apps that want a
+   user-facing toggle. `demo.html` includes a working toggle button that
+   cycles system → dark → light → system.
+
+## Why this is a submissions/example, not a core/ edit
+
+Per `CONTRIBUTING.md`, `core/` is maintainer-only and direct edits get
+closed without review. Following the precedent set by PR #25657 (merged
+theme-toggle contribution, also submitted under `submissions/examples/`),
+this submission is self-contained: `style.css` re-declares the light-mode
+token values it needs so the demo works standalone, and proposes the dark
+overrides for the maintainer to fold into `core/variables.css` /
+`core/dark-mode.css` as they see fit. **No files under `core/` or
+`components/` are modified by this PR.**
+
+## Files
+
+- `demo.html` — live toggle demo (card, button, muted text, all token-driven)
+- `style.css` — token declarations + dark overrides + demo styling
+
+## Notes for maintainer review
+
+The token names used here (`--ease-color-bg`, `--ease-color-surface`,
+`--ease-color-text`, `--ease-color-muted`, `--ease-color-border`,
+`--ease-color-primary`, `--ease-shadow-md`) follow the naming pattern shown
+in the README's Customization section. If `core/variables.css` uses
+different exact names, the override block only needs the variable names
+adjusted to match — the `prefers-color-scheme` / `[data-theme]` activation
+strategy stays the same.
+
+Relates to issue #88689.

--- a/submissions/examples/dark-mode-token-layer-88689/demo.html
+++ b/submissions/examples/dark-mode-token-layer-88689/demo.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Dark Mode Token Layer — Demo</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body style="max-width: 560px; margin: 40px auto; padding: 0 16px;">
+
+<h1>Dark Mode Token Layer</h1>
+<p class="dmtl-muted">
+  Automatically follows your OS color scheme via
+  <code>prefers-color-scheme</code>. Use the button below to override it
+  manually via <code>[data-theme]</code>.
+</p>
+
+<button class="dmtl-btn" id="dmtl-toggle">Toggle theme</button>
+
+<div class="dmtl-card">
+  <h3>Sample card</h3>
+  <p>This card, the page background, and this button all read from the
+     same <code>--ease-*</code> token set. Only the token <em>values</em>
+     change between light and dark — no component markup or class names
+     change.</p>
+</div>
+
+<script>
+  const toggle = document.getElementById('dmtl-toggle');
+  const root = document.documentElement;
+  const states = [null, 'dark', 'light'];
+  let index = 0;
+
+  toggle.addEventListener('click', () => {
+    index = (index + 1) % states.length;
+    const theme = states[index];
+    if (theme) {
+      root.setAttribute('data-theme', theme);
+    } else {
+      root.removeAttribute('data-theme');
+    }
+    toggle.textContent = theme
+      ? `Theme: ${theme} (click to cycle)`
+      : 'Theme: system default (click to cycle)';
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/dark-mode-token-layer-88689/style.css
+++ b/submissions/examples/dark-mode-token-layer-88689/style.css
@@ -1,0 +1,78 @@
+/* Dark Mode Token Layer — proposed core/dark-mode.css
+   Mirrors the existing --ease-* token set from core/variables.css
+   (as documented in README's Customization section) with dark values.
+
+   Two activation paths, matching the issue's proposed solution:
+   1. @media (prefers-color-scheme: dark) — automatic, respects OS setting
+   2. [data-theme="dark"] — manual override for a JS-controlled toggle,
+      takes priority over the media query since it's more specific intent
+*/
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-surface: #f9fafb;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-border: #e5e7eb;
+  --ease-color-primary: #6366f1;
+  --ease-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-border: #334155;
+    --ease-color-primary: #818cf8;
+    --ease-shadow-md: 0 4px 20px rgba(0, 0, 0, 0.4);
+  }
+}
+
+[data-theme="dark"] {
+  --ease-color-bg: #0f172a;
+  --ease-color-surface: #1e293b;
+  --ease-color-text: #f1f5f9;
+  --ease-color-muted: #94a3b8;
+  --ease-color-border: #334155;
+  --ease-color-primary: #818cf8;
+  --ease-shadow-md: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  transition: background 200ms ease, color 200ms ease;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.dmtl-card {
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 10px;
+  box-shadow: var(--ease-shadow-md);
+  padding: 20px;
+  margin-top: 16px;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.dmtl-muted {
+  color: var(--ease-color-muted);
+}
+
+.dmtl-btn {
+  background: var(--ease-color-primary);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 150ms ease;
+}
+
+.dmtl-btn:hover {
+  opacity: 0.9;
+}


### PR DESCRIPTION
Adds submissions/examples/dark-mode-token-layer-88689/ — a self-contained demo of a dark-mode token override layer, activated automatically via `prefers-color-scheme` and manually via `[data-theme]` (with a working toggle button in the demo).

Relates to #88689 (roadmap: 'Dark mode token layer'). Per CONTRIBUTING.md, core/ is maintainer-only, so this follows the precedent of merged PR #25657 by proposing the token overrides as a self-contained submissions/examples/ entry rather than editing core/variables.css directly. Token names follow the --ease-* pattern shown in the README's Customization section — happy to adjust exact names to match core/variables.css once reviewed.