### PR TITLE
feat(components): add CSS-only modal and tooltip components (closes #88691)

### DIFF
--- a/components/modal.css
+++ b/components/modal.css
@@ -1,0 +1,89 @@
+/* CSS-only Modal — uses :target, no JS required
+   Markup: <a href="#my-modal">...</a> ... <div id="my-modal" class="ease-modal">
+*/
+
+.ease-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  opacity: 0;
+}
+
+.ease-modal:target {
+  display: flex;
+  opacity: 1;
+}
+
+.ease-modal-box {
+  background: var(--ease-color-surface, #fff);
+  color: var(--ease-color-text, #111827);
+  border: 1px solid var(--ease-color-border, #e5e7eb);
+  border-radius: 12px;
+  box-shadow: var(--ease-shadow-md, 0 4px 20px rgba(0, 0, 0, 0.2));
+  width: min(90vw, 480px);
+  max-height: 85vh;
+  overflow-y: auto;
+  transform: translateY(-16px) scale(0.97);
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.ease-modal:target .ease-modal-box {
+  transform: translateY(0) scale(1);
+}
+
+.ease-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--ease-color-border, #e5e7eb);
+}
+
+.ease-modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.ease-modal-close {
+  color: var(--ease-color-muted, #6b7280);
+  text-decoration: none;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 150ms ease;
+}
+
+.ease-modal-close:hover {
+  background: var(--ease-color-border, #e5e7eb);
+}
+
+.ease-modal-body {
+  padding: 20px;
+}
+
+.ease-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--ease-color-border, #e5e7eb);
+}
+
+.ease-modal-overlay-close {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-modal,
+  .ease-modal-box {
+    transition: none;
+  }
+}

--- a/components/tooltip.css
+++ b/components/tooltip.css
@@ -1,0 +1,130 @@
+/* CSS-only Tooltip — uses [data-tip] + ::before/::after, no JS required
+   Markup: <button class="ease-tooltip" data-tip="Text">Hover me</button>
+*/
+
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip::before,
+.ease-tooltip::after {
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 150ms ease, transform 150ms ease;
+  z-index: 1100;
+}
+
+.ease-tooltip::after {
+  content: attr(data-tip);
+  background: var(--ease-color-text, #111827);
+  color: var(--ease-color-bg, #fff);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  padding: 6px 10px;
+  border-radius: 6px;
+  box-shadow: var(--ease-shadow-md, 0 2px 8px rgba(0, 0, 0, 0.15));
+}
+
+.ease-tooltip::before {
+  content: "";
+  border: 5px solid transparent;
+}
+
+.ease-tooltip::after,
+.ease-tooltip-top::after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -6px);
+  margin-bottom: 6px;
+}
+.ease-tooltip::before,
+.ease-tooltip-top::before {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--ease-color-text, #111827);
+}
+
+.ease-tooltip-bottom::after {
+  top: 100%;
+  bottom: auto;
+  left: 50%;
+  transform: translate(-50%, 6px);
+  margin-top: 6px;
+  margin-bottom: 0;
+}
+.ease-tooltip-bottom::before {
+  top: 100%;
+  bottom: auto;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--ease-color-text, #111827);
+  border-top-color: transparent;
+}
+
+.ease-tooltip-left::after {
+  right: 100%;
+  top: 50%;
+  bottom: auto;
+  left: auto;
+  transform: translate(-6px, -50%);
+  margin-right: 6px;
+}
+.ease-tooltip-left::before {
+  right: 100%;
+  top: 50%;
+  bottom: auto;
+  left: auto;
+  transform: translateY(-50%);
+  border-left-color: var(--ease-color-text, #111827);
+  border-top-color: transparent;
+}
+
+.ease-tooltip-right::after {
+  left: 100%;
+  top: 50%;
+  bottom: auto;
+  transform: translate(6px, -50%);
+  margin-left: 6px;
+}
+.ease-tooltip-right::before {
+  left: 100%;
+  top: 50%;
+  bottom: auto;
+  transform: translateY(-50%);
+  border-right-color: var(--ease-color-text, #111827);
+  border-top-color: transparent;
+}
+
+.ease-tooltip:hover::before,
+.ease-tooltip:hover::after,
+.ease-tooltip:focus-visible::before,
+.ease-tooltip:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
+.ease-tooltip:hover::after,
+.ease-tooltip:focus-visible::after,
+.ease-tooltip-bottom:hover::after,
+.ease-tooltip-bottom:focus-visible::after {
+  transform: translate(-50%, 0);
+}
+.ease-tooltip-left:hover::after,
+.ease-tooltip-left:focus-visible::after {
+  transform: translate(0, -50%);
+}
+.ease-tooltip-right:hover::after,
+.ease-tooltip-right:focus-visible::after {
+  transform: translate(0, -50%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tooltip::before,
+  .ease-tooltip::after {
+    transition: none;
+  }
+}

--- a/submissions/examples/modal-tooltip-components-88691/README.md
+++ b/submissions/examples/modal-tooltip-components-88691/README.md
@@ -1,0 +1,35 @@
+# Modal & Tooltip Components
+
+## Summary
+
+Implements the "Modal & tooltip components" v1.2 roadmap item (issue #88691)
+as CSS-only, zero-JS components:
+
+- `components/modal.css` — dialog built on the `:target` pseudo-class
+- `components/tooltip.css` — hover/focus tooltips built on `[data-tip]` +
+  `::before`/`::after`
+
+Both use the existing `--ease-*` token set (colors, shadows) so they follow
+dark mode automatically, and both respect `prefers-reduced-motion`.
+
+## Classes
+
+- Modal: `ease-modal`, `ease-modal-box`, `ease-modal-header`,
+  `ease-modal-title`, `ease-modal-body`, `ease-modal-footer`,
+  `ease-modal-close`, `ease-modal-overlay-close`
+- Tooltip: `ease-tooltip`, `ease-tooltip-top`, `ease-tooltip-bottom`,
+  `ease-tooltip-left`, `ease-tooltip-right`
+
+## Known limitation
+
+`:target` modals have no focus trap and no `Esc`-to-close since there's no
+JS. `role="dialog"` / `aria-modal="true"` are included in the demo markup
+to help screen readers, but full keyboard accessibility would need a small
+JS enhancement layer as a future follow-up.
+
+## Files
+
+- `components/modal.css`, `components/tooltip.css` — the components
+- `submissions/examples/modal-tooltip-components-88691/demo.html` — live demo
+
+Relates to issue #88691.

--- a/submissions/examples/modal-tooltip-components-88691/demo.html
+++ b/submissions/examples/modal-tooltip-components-88691/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Modal & Tooltip — Demo</title>
+<link rel="stylesheet" href="../../../components/modal.css" />
+<link rel="stylesheet" href="../../../components/tooltip.css" />
+<style>
+  body { max-width: 640px; margin: 40px auto; padding: 0 16px; font-family: Inter, system-ui, sans-serif; }
+  .row { display: flex; gap: 16px; margin-top: 24px; flex-wrap: wrap; }
+</style>
+</head>
+<body>
+
+<h1>Modal & Tooltip Components</h1>
+
+<a href="#my-modal" class="ease-btn ease-btn-primary">Open Modal</a>
+
+<div id="my-modal" class="ease-modal" role="dialog" aria-modal="true" aria-labelledby="my-modal-title">
+  <a href="#" class="ease-modal-overlay-close" aria-label="Close"></a>
+  <div class="ease-modal-box">
+    <div class="ease-modal-header">
+      <h3 class="ease-modal-title" id="my-modal-title">Modal Title</h3>
+      <a href="#" class="ease-modal-close" aria-label="Close">✕</a>
+    </div>
+    <div class="ease-modal-body"><p>Modal content here.</p></div>
+    <div class="ease-modal-footer">
+      <a href="#" class="ease-btn ease-btn-outline">Cancel</a>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-top" data-tip="Top tooltip">Top</button>
+  <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-bottom" data-tip="Bottom tooltip">Bottom</button>
+  <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-left" data-tip="Left tooltip">Left</button>
+  <button class="ease-btn ease-btn-primary ease-tooltip ease-tooltip-right" data-tip="Right tooltip">Right</button>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Adds `components/modal.css` (`:target`-based dialog, no JS) and `components/tooltip.css` (`[data-tip]`-based tooltip, 4 directions: top/bottom/left/right), per the v1.2 roadmap item in #88691.

Both components use the existing `--ease-*` token set for colors/shadows, so they pick up dark mode automatically, and both respect `prefers-reduced-motion`.

Demo included at `submissions/examples/modal-tooltip-components-88691/demo.html`.

**Known limitation:** `:target` modals have no focus trap or `Esc`-to-close without JS — flagging this for review rather than silently shipping partial a11y. `role="dialog"`/`aria-modal` are included in the demo markup as a partial mitigation.

Closes #88691.