### PR TITLE
feat(examples): add badge, tag, avatar, progress bar demo (relates to #88693)

### DIFF
--- a/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/README.md
+++ b/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/README.md
@@ -1,0 +1,33 @@
+# Badge, Tag, Avatar & Progress Bar Components
+
+## Summary
+
+Proposed implementation for the v1.3 roadmap item "Badge, tag, avatar,
+progress bar" (issue #88693). Self-contained under submissions/examples/
+per CONTRIBUTING.md — no files outside submissions/ are modified.
+
+## Why this is a submissions/example, not a components/ edit
+
+The repo's contribution guard only allows changes inside `submissions/`;
+a previous attempt that added `components/badges.css` directly was
+auto-closed for touching files outside that folder. This version keeps
+everything self-contained in `style.css`, for the maintainer to fold
+into `components/badges.css` as they see fit.
+
+## Classes
+
+- Badge: `ease-badge`, `ease-badge-primary`, `ease-badge-success`,
+  `ease-badge-danger`, `ease-badge-outline`, `ease-badge-pill`
+- Tag: `ease-tag`, `ease-tag-removable`, `ease-tag-remove`
+- Avatar: `ease-avatar`, `ease-avatar-sm/md/lg`, `ease-avatar-group`,
+  `ease-avatar-overflow`
+- Progress: `ease-progress`, `ease-progress-bar`,
+  `ease-progress-bar-success/danger`, `ease-progress-striped`,
+  `ease-progress-animated`
+
+## Files
+
+- `demo.html` — live demo of all four components
+- `style.css` — token declarations + all component styles
+
+Relates to issue #88693.

--- a/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/demo.html
+++ b/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Badge / Tag / Avatar / Progress — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 640px; margin: 40px auto; padding: 0 16px; }
+  section { margin-top: 32px; }
+  .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-top: 12px; }
+</style>
+</head>
+<body>
+
+<h1>Badge, Tag, Avatar & Progress Bar</h1>
+
+<section>
+  <h3>Badges</h3>
+  <div class="row">
+    <span class="ease-badge ease-badge-primary">New</span>
+    <span class="ease-badge ease-badge-success">Active</span>
+    <span class="ease-badge ease-badge-danger">Urgent</span>
+    <span class="ease-badge ease-badge-outline">Draft</span>
+    <span class="ease-badge ease-badge-pill">Featured</span>
+  </div>
+</section>
+
+<section>
+  <h3>Tags</h3>
+  <div class="row">
+    <span class="ease-tag">JavaScript</span>
+    <span class="ease-tag ease-tag-removable">React <button class="ease-tag-remove" aria-label="Remove">×</button></span>
+  </div>
+</section>
+
+<section>
+  <h3>Avatars</h3>
+  <div class="row">
+    <div class="ease-avatar ease-avatar-sm">JD</div>
+    <div class="ease-avatar ease-avatar-md">AB</div>
+    <div class="ease-avatar ease-avatar-lg">XY</div>
+    <div class="ease-avatar-group">
+      <div class="ease-avatar ease-avatar-sm">AA</div>
+      <div class="ease-avatar ease-avatar-sm">BB</div>
+      <div class="ease-avatar ease-avatar-sm ease-avatar-overflow">+3</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h3>Progress bars</h3>
+  <div class="ease-progress" style="margin-top:12px;">
+    <div class="ease-progress-bar" style="--ease-progress: 65%"></div>
+  </div>
+  <div class="ease-progress ease-progress-striped ease-progress-animated" style="margin-top:12px;">
+    <div class="ease-progress-bar ease-progress-bar-success" style="--ease-progress: 80%"></div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/style.css
+++ b/submissions/examples/badge-tag-avatar-progress-88693/submissions/examples/badge-tag-avatar-progress-88693/style.css
@@ -1,0 +1,169 @@
+/* Badge, Tag, Avatar, Progress bar — proposed components/badges.css
+   Token-driven via --ease-* variables, dark-mode aware.
+   Submitted as a self-contained demo per CONTRIBUTING.md —
+   maintainer can fold into components/badges.css directly. */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-surface: #f9fafb;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-border: #e5e7eb;
+  --ease-color-primary: #6366f1;
+  --ease-color-success: #22c55e;
+  --ease-color-danger: #ef4444;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-border: #334155;
+    --ease-color-primary: #818cf8;
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+/* ---------- Badge ---------- */
+.ease-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.6;
+  border-radius: 6px;
+  background: var(--ease-color-border);
+  color: var(--ease-color-text);
+}
+
+.ease-badge-primary { background: var(--ease-color-primary); color: #fff; }
+.ease-badge-success { background: var(--ease-color-success); color: #fff; }
+.ease-badge-danger { background: var(--ease-color-danger); color: #fff; }
+
+.ease-badge-outline {
+  background: transparent;
+  border: 1px solid var(--ease-color-border);
+  color: var(--ease-color-text);
+}
+
+.ease-badge-pill {
+  border-radius: 999px;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+/* ---------- Tag ---------- */
+.ease-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border-radius: 6px;
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  color: var(--ease-color-text);
+}
+
+.ease-tag-removable { padding-right: 6px; }
+
+.ease-tag-remove {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ease-color-muted);
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.ease-tag-remove:hover {
+  background: var(--ease-color-border);
+  color: var(--ease-color-text);
+}
+
+/* ---------- Avatar ---------- */
+.ease-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--ease-color-primary);
+  color: #fff;
+  font-weight: 600;
+  object-fit: cover;
+  vertical-align: middle;
+  border: 2px solid var(--ease-color-bg);
+  overflow: hidden;
+}
+
+.ease-avatar-sm { width: 28px; height: 28px; font-size: 0.7rem; }
+.ease-avatar-md { width: 40px; height: 40px; font-size: 0.85rem; }
+.ease-avatar-lg { width: 56px; height: 56px; font-size: 1.1rem; }
+
+.ease-avatar-overflow { background: var(--ease-color-muted); font-size: 0.65rem; }
+
+.ease-avatar-group { display: inline-flex; }
+.ease-avatar-group .ease-avatar { margin-left: -10px; }
+.ease-avatar-group .ease-avatar:first-child { margin-left: 0; }
+
+/* ---------- Progress bar ---------- */
+.ease-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--ease-color-border);
+  overflow: hidden;
+}
+
+.ease-progress-bar {
+  height: 100%;
+  width: var(--ease-progress, 0%);
+  background: var(--ease-color-primary);
+  border-radius: inherit;
+  transition: width 300ms ease;
+}
+
+.ease-progress-bar-success { background: var(--ease-color-success); }
+.ease-progress-bar-danger { background: var(--ease-color-danger); }
+
+.ease-progress-striped .ease-progress-bar {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 1rem 1rem;
+}
+
+.ease-progress-animated .ease-progress-bar {
+  animation: ease-progress-stripes 1s linear infinite;
+}
+
+@keyframes ease-progress-stripes {
+  from { background-position: 1rem 0; }
+  to { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress-bar { transition: none; }
+  .ease-progress-animated .ease-progress-bar { animation: none; }
+}


### PR DESCRIPTION
Resubmission of #88791-style PR for #88693. Previous attempt was auto-closed for adding `components/badges.css` outside `submissions/` — this version is fully self-contained under `submissions/examples/badge-tag-avatar-progress-88693/`, no files outside `submissions/` are touched.

Implements badges (5 variants), removable tags, avatars (3 sizes + group/overflow), and progress bars (solid/striped/animated). Token-driven via --ease-* variables (dark mode automatic), striped/animated progress respects prefers-reduced-motion.

Relates to #88693.