### PR TITLE
feat(examples): add six pure CSS advanced components (relates to #88581)

### DIFF
--- a/submissions/examples/advanced-components-88581/README.md
+++ b/submissions/examples/advanced-components-88581/README.md
@@ -1,0 +1,37 @@
+# Pure CSS Advanced Components
+
+## Summary
+
+Six pure-CSS components submitted for issue #88581. The original issue
+had no detailed spec ("advanced component iteration 123"), so this
+submission covers six commonly-needed primitives that fit the
+"advanced component" description, all built with no JS dependency:
+
+1. **Accordion** — native `<details>`/`<summary>`, keyboard accessible by default
+2. **Toast notifications** — checkbox-hack dismiss, no JS
+3. **Breadcrumbs** — simple list-based trail
+4. **Skeleton loader** — shimmer placeholder for text/avatar/block shapes
+5. **Pagination** — page links with active/disabled/ellipsis states
+6. **Stepper / progress indicator** — multi-step flow with complete/active states
+
+All token-driven via `--ease-*` variables, dark-mode aware, and
+`prefers-reduced-motion` respected on every animation.
+
+## Classes
+
+- Accordion: `ease-accordion`, `ease-accordion-item`, `ease-accordion-body`
+- Toast: `ease-toast-wrap`, `ease-toast-dismiss`, `ease-toast`,
+  `ease-toast-success/danger`, `ease-toast-icon`, `ease-toast-body`,
+  `ease-toast-close`
+- Breadcrumbs: `ease-breadcrumbs`
+- Skeleton: `ease-skeleton`, `ease-skeleton-text/avatar/block`
+- Pagination: `ease-pagination`, `ease-page-active/disabled/ellipsis`
+- Stepper: `ease-stepper`, `ease-step`, `ease-step-circle`,
+  `ease-step-label`, `ease-step-complete/active`
+
+## Files
+
+- `demo.html` — live demo of all six components
+- `style.css` — original CSS, all six components
+
+Relates to issue #88581.

--- a/submissions/examples/advanced-components-88581/demo.html
+++ b/submissions/examples/advanced-components-88581/demo.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Advanced Components — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 640px; margin: 40px auto; padding: 0 16px; }
+  section { margin-top: 40px; }
+  h2 { font-size: 1.1rem; margin-bottom: 12px; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Advanced Components</h1>
+<p style="color: var(--ease-color-muted)">
+  Accordion, Toast, Breadcrumbs, Skeleton Loader, Pagination, and Stepper —
+  all pure CSS, token-driven, dark-mode aware.
+</p>
+
+<section>
+  <h2>Accordion</h2>
+  <div class="ease-accordion">
+    <details class="ease-accordion-item" open>
+      <summary>What is EaseMotion CSS?</summary>
+      <div class="ease-accordion-body">A human-readable, animation-first CSS framework.</div>
+    </details>
+    <details class="ease-accordion-item">
+      <summary>Do I need a build step?</summary>
+      <div class="ease-accordion-body">No — link one file and it works.</div>
+    </details>
+    <details class="ease-accordion-item">
+      <summary>Is it accessible?</summary>
+      <div class="ease-accordion-body">Built on native details/summary, so keyboard and screen reader support come for free.</div>
+    </details>
+  </div>
+</section>
+
+<section>
+  <h2>Toast Notifications</h2>
+  <div class="ease-toast-wrap">
+    <input type="checkbox" id="toast-1" class="ease-toast-dismiss" />
+    <div class="ease-toast ease-toast-success">
+      <span class="ease-toast-icon">✓</span>
+      <span class="ease-toast-body">Changes saved successfully.</span>
+      <label for="toast-1" class="ease-toast-close">✕</label>
+    </div>
+  </div>
+  <div class="ease-toast-wrap" style="margin-top: 10px;">
+    <input type="checkbox" id="toast-2" class="ease-toast-dismiss" />
+    <div class="ease-toast ease-toast-danger">
+      <span class="ease-toast-icon">✕</span>
+      <span class="ease-toast-body">Something went wrong.</span>
+      <label for="toast-2" class="ease-toast-close">✕</label>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>Breadcrumbs</h2>
+  <ul class="ease-breadcrumbs">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Components</a></li>
+    <li>Breadcrumbs</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Skeleton Loader</h2>
+  <div style="display: flex; gap: 14px; align-items: center;">
+    <div class="ease-skeleton ease-skeleton-avatar"></div>
+    <div style="flex: 1;">
+      <div class="ease-skeleton ease-skeleton-text"></div>
+      <div class="ease-skeleton ease-skeleton-text"></div>
+    </div>
+  </div>
+  <div class="ease-skeleton ease-skeleton-block" style="margin-top: 14px;"></div>
+</section>
+
+<section>
+  <h2>Pagination</h2>
+  <ul class="ease-pagination">
+    <li><a href="#" class="ease-page-disabled">‹</a></li>
+    <li><a href="#" class="ease-page-active">1</a></li>
+    <li><a href="#">2</a></li>
+    <li><a href="#">3</a></li>
+    <li><span class="ease-page-ellipsis">…</span></li>
+    <li><a href="#">12</a></li>
+    <li><a href="#">›</a></li>
+  </ul>
+</section>
+
+<section>
+  <h2>Stepper / Progress Indicator</h2>
+  <ul class="ease-stepper">
+    <li class="ease-step ease-step-complete">
+      <div class="ease-step-circle">✓</div>
+      <div class="ease-step-label">Account</div>
+    </li>
+    <li class="ease-step ease-step-active">
+      <div class="ease-step-circle">2</div>
+      <div class="ease-step-label">Details</div>
+    </li>
+    <li class="ease-step">
+      <div class="ease-step-circle">3</div>
+      <div class="ease-step-label">Review</div>
+    </li>
+    <li class="ease-step">
+      <div class="ease-step-circle">4</div>
+      <div class="ease-step-label">Done</div>
+    </li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/submissions/examples/advanced-components-88581/style.css
+++ b/submissions/examples/advanced-components-88581/style.css
@@ -1,0 +1,300 @@
+/* Pure CSS Advanced Components — Accordion, Toast, Breadcrumbs,
+   Skeleton Loader, Pagination, Stepper/Progress Indicator
+   Token-driven via --ease-* variables, dark-mode aware, no JS required
+   except where noted (toast dismiss uses a checkbox hack, no real JS). */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-surface: #f9fafb;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-border: #e5e7eb;
+  --ease-color-primary: #6366f1;
+  --ease-color-success: #22c55e;
+  --ease-color-danger: #ef4444;
+  --ease-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-border: #334155;
+    --ease-color-primary: #818cf8;
+    --ease-shadow-md: 0 4px 20px rgba(0, 0, 0, 0.4);
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.ease-accordion {
+  border: 1px solid var(--ease-color-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.ease-accordion-item {
+  border-bottom: 1px solid var(--ease-color-border);
+}
+.ease-accordion-item:last-child { border-bottom: none; }
+
+.ease-accordion-item > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  background: var(--ease-color-surface);
+  transition: background 150ms ease;
+}
+.ease-accordion-item > summary::-webkit-details-marker { display: none; }
+.ease-accordion-item > summary:hover { background: var(--ease-color-border); }
+
+.ease-accordion-item > summary::after {
+  content: "+";
+  font-size: 1.2rem;
+  color: var(--ease-color-muted);
+  transition: transform 200ms ease;
+}
+.ease-accordion-item[open] > summary::after {
+  transform: rotate(45deg);
+}
+
+.ease-accordion-body {
+  padding: 14px 18px;
+  color: var(--ease-color-muted);
+  border-top: 1px solid var(--ease-color-border);
+}
+
+.ease-toast-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-toast-dismiss {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ease-toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 280px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  box-shadow: var(--ease-shadow-md);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.ease-toast-success { border-left: 4px solid var(--ease-color-success); }
+.ease-toast-danger { border-left: 4px solid var(--ease-color-danger); }
+
+.ease-toast-icon { font-weight: 700; flex-shrink: 0; }
+.ease-toast-success .ease-toast-icon { color: var(--ease-color-success); }
+.ease-toast-danger .ease-toast-icon { color: var(--ease-color-danger); }
+
+.ease-toast-body { flex: 1; font-size: 0.9rem; }
+
+.ease-toast-close {
+  all: unset;
+  cursor: pointer;
+  color: var(--ease-color-muted);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.ease-toast-close:hover { background: var(--ease-color-border); }
+
+.ease-toast-dismiss:checked ~ .ease-toast {
+  opacity: 0;
+  transform: translateX(12px);
+  height: 0;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  overflow: hidden;
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-toast { transition: none; }
+}
+
+.ease-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.ease-breadcrumbs li { display: flex; align-items: center; gap: 8px; }
+
+.ease-breadcrumbs a {
+  color: var(--ease-color-muted);
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+.ease-breadcrumbs a:hover { color: var(--ease-color-primary); }
+
+.ease-breadcrumbs li:last-child {
+  color: var(--ease-color-text);
+  font-weight: 600;
+}
+
+.ease-breadcrumbs li:not(:last-child)::after {
+  content: "/";
+  color: var(--ease-color-border);
+  margin-left: 8px;
+}
+
+.ease-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--ease-color-border) 25%,
+    var(--ease-color-surface) 50%,
+    var(--ease-color-border) 75%
+  );
+  background-size: 200% 100%;
+  animation: ease-skeleton-shimmer 1.4s ease-in-out infinite;
+  border-radius: 6px;
+}
+
+.ease-skeleton-text { height: 12px; margin-bottom: 8px; }
+.ease-skeleton-text:last-child { width: 60%; }
+.ease-skeleton-avatar { width: 48px; height: 48px; border-radius: 50%; }
+.ease-skeleton-block { height: 120px; border-radius: 10px; }
+
+@keyframes ease-skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skeleton { animation: none; }
+}
+
+.ease-pagination {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-pagination a,
+.ease-pagination span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 8px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--ease-color-text);
+  border: 1px solid var(--ease-color-border);
+  font-size: 0.9rem;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.ease-pagination a:hover {
+  background: var(--ease-color-surface);
+}
+
+.ease-pagination .ease-page-active {
+  background: var(--ease-color-primary);
+  border-color: var(--ease-color-primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+.ease-pagination .ease-page-ellipsis {
+  border: none;
+  color: var(--ease-color-muted);
+}
+
+.ease-pagination .ease-page-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.ease-stepper {
+  display: flex;
+  align-items: flex-start;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ease-step {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+
+.ease-step-circle {
+  width: 32px;
+  height: 32px;
+  margin: 0 auto 8px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  background: var(--ease-color-surface);
+  border: 2px solid var(--ease-color-border);
+  color: var(--ease-color-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.ease-step::before {
+  content: "";
+  position: absolute;
+  top: 16px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: var(--ease-color-border);
+  z-index: 0;
+}
+.ease-step:first-child::before { display: none; }
+
+.ease-step-label {
+  font-size: 0.8rem;
+  color: var(--ease-color-muted);
+}
+
+.ease-step-complete .ease-step-circle {
+  background: var(--ease-color-success);
+  border-color: var(--ease-color-success);
+  color: #fff;
+}
+.ease-step-complete::before { background: var(--ease-color-success); }
+.ease-step-complete .ease-step-label { color: var(--ease-color-text); }
+
+.ease-step-active .ease-step-circle {
+  background: var(--ease-color-primary);
+  border-color: var(--ease-color-primary);
+  color: #fff;
+}
+.ease-step-active .ease-step-label {
+  color: var(--ease-color-text);
+  font-weight: 600;
+}


### PR DESCRIPTION
The original issue (#88581) had no detailed spec — just "advanced component iteration 123" with generic filler text. This submission covers six commonly-needed pure-CSS primitives to give it real substance: accordion (native details/summary), toast notifications (checkbox-hack dismiss), breadcrumbs, skeleton loader, pagination, and a stepper/progress indicator.

All no-JS, token-driven via --ease-* variables (dark mode automatic), and prefers-reduced-motion respected throughout.

Fully self-contained under submissions/examples/advanced-components-88581/ — demo.html, style.css, README.md only.

Relates to #88581.