### PR TITLE
feat: add prefers-reduced-motion support for accessibility compliance

### DIFF
--- a/core/animations.css
+++ b/core/animations.css
@@ -1459,5 +1459,56 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: var(--ease-radius-lg, 12px);
   }
+
+  /* ── Reduced Motion ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+
+    .ease-fade-in,
+    .ease-fade-out,
+    .ease-slide-up,
+    .ease-slide-down,
+    .ease-slide-left,
+    .ease-slide-right,
+    .ease-scale-in,
+    .ease-scale-out,
+    .ease-bounce-in,
+    .ease-flip-in,
+    .ease-rotate-in,
+    .ease-blur-in,
+    .ease-zoom-in,
+    .ease-pop-in,
+    .ease-float,
+    .ease-wobble,
+    .ease-shake,
+    .ease-pulse,
+    .ease-swing,
+    .ease-jello,
+    .ease-heartbeat {
+      animation: none !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+
+    .ease-text-strikethrough-draw::after {
+      width: 100% !important;
+      animation: none !important;
+    }
+
+    .ease-text-gradient-flow {
+      animation: none !important;
+    }
+
+    .ease-ambient-glow {
+      animation: none !important;
+    }
+  }
 }
 


### PR DESCRIPTION
## Description
Added `@media (prefers-reduced-motion: reduce)` support to `core/animations.css` so the framework respects OS-level accessibility settings.

### Changes
- Added reduced motion media query block at end of animations.css
- Disables all animations and transitions when user prefers reduced motion
- Sets `animation-duration` and `transition-duration` to `0.01ms`
- Resets transform and opacity for all animation classes
- Prevents animation on text effects (strikethrough, gradient flow, ambient glow)

### Why
Users with vestibular disorders, epilepsy, or motion sensitivity who enable "Reduce Motion" in their OS settings currently see all EaseMotion animations play regardless. This violates WCAG 2.1 guideline 2.3.3 (Level AAA).

## Related Issue
Closes #88687

## Type of Change
- [x] Enhancement (non-breaking change which adds functionality)
