### PR TITLE
feat: add prefers-reduced-motion demo

### DIFF
--- a/submissions/examples/prefers-reduced-motion-demo/README.md
+++ b/submissions/examples/prefers-reduced-motion-demo/README.md
@@ -1,0 +1,22 @@
+# Prefers Reduced Motion Demo
+
+A self-contained demo showcasing how EaseMotion CSS respects the `prefers-reduced-motion` media query.
+
+## What it demonstrates
+
+- Animation classes (`ease-bounce-in`, `ease-flip-in`, `ease-scale-in`) are disabled when the user prefers reduced motion
+- Continuous animations (`ease-float`, `ease-pulse`) are also suppressed
+- Fallback styles ensure content remains visible without animation
+
+## How to test
+
+1. Open `demo.html` in a browser
+2. Enable "Reduce Motion" in your OS accessibility settings:
+   - **macOS**: System Settings → Accessibility → Display → Reduce Motion
+   - **Windows**: Settings → Accessibility → Visual Effects → Animation effects
+   - **Linux**: Varies by desktop environment
+3. Refresh the page — all animations should be disabled
+
+## Relates to
+
+- Issue #88687 — Add prefers-reduced-motion support to all animation classes

--- a/submissions/examples/prefers-reduced-motion-demo/demo.html
+++ b/submissions/examples/prefers-reduced-motion-demo/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Prefers Reduced Motion Demo</title>
+  <link rel="stylesheet" href="../../core/variables.css">
+  <link rel="stylesheet" href="../../core/animations.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <h1 class="ease-fade-in">Prefers Reduced Motion Demo</h1>
+    <p class="ease-slide-up">Enable "Reduce Motion" in your OS accessibility settings to see the effect.</p>
+
+    <div class="card-grid">
+      <div class="demo-card ease-bounce-in">
+        <h3>Bounce In</h3>
+        <p>This card uses ease-bounce-in animation.</p>
+      </div>
+      <div class="demo-card ease-flip-in">
+        <h3>Flip In</h3>
+        <p>This card uses ease-flip-in animation.</p>
+      </div>
+      <div class="demo-card ease-scale-in">
+        <h3>Scale In</h3>
+        <p>This card uses ease-scale-in animation.</p>
+      </div>
+    </div>
+
+    <button class="ease-float demo-btn">Hover me — I float!</button>
+    <button class="ease-pulse demo-btn">I pulse continuously</button>
+  </div>
+</body>
+</html>

--- a/submissions/examples/prefers-reduced-motion-demo/style.css
+++ b/submissions/examples/prefers-reduced-motion-demo/style.css
@@ -1,0 +1,64 @@
+/* Reduced Motion Demo Styles */
+body {
+  font-family: system-ui, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  margin: 0;
+  padding: 2rem;
+}
+
+.demo-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.demo-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: var(--ease-radius-md, 8px);
+  padding: 1.5rem;
+}
+
+.demo-card h3 {
+  margin: 0 0 0.5rem;
+}
+
+.demo-btn {
+  display: inline-block;
+  margin: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  border: none;
+  border-radius: var(--ease-radius-md, 8px);
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+/* Reduced motion fallback */
+@media (prefers-reduced-motion: reduce) {
+  .ease-bounce-in,
+  .ease-flip-in,
+  .ease-scale-in {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .ease-float,
+  .ease-pulse {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Added a self-contained demo showing how EaseMotion CSS respects the `prefers-reduced-motion` media query.

### What it demonstrates
- Animation classes (`ease-bounce-in`, `ease-flip-in`, `ease-scale-in`) are disabled when user prefers reduced motion
- Continuous animations (`ease-float`, `ease-pulse`) are also suppressed
- Fallback styles ensure content remains visible without animation

### How to test
1. Open `demo.html` in a browser
2. Enable "Reduce Motion" in OS accessibility settings
3. Refresh — all animations should be disabled

## Related Issue
Relates to #88687

## Type of Change
- [x] Feature (non-breaking change which adds functionality)
