### PR TITLE
feat: add dark mode token layer demo

### DIFF
--- a/submissions/examples/dark-mode-token-demo-88689/README.md
+++ b/submissions/examples/dark-mode-token-demo-88689/README.md
@@ -1,0 +1,17 @@
+# Dark Mode Token Layer Demo
+
+Demonstrates how EaseMotion CSS dark mode tokens work with `prefers-color-scheme` and `[data-theme]`.
+
+## Features
+- Automatic dark mode via `prefers-color-scheme: dark`
+- Manual toggle via `[data-theme="dark"]`
+- Tokens: bg, surface, text, muted, alpha, glass
+- Smooth transitions between themes
+
+## How to test
+1. Open `demo.html`
+2. Dark mode activates automatically if your OS is in dark mode
+3. Click "Toggle Theme" to switch manually
+
+## Relates to
+- Issue #88689 — Dark mode CSS token layer

--- a/submissions/examples/dark-mode-token-demo-88689/demo.html
+++ b/submissions/examples/dark-mode-token-demo-88689/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EaseMotion — Dark Mode Token Demo</title>
+  <link rel="stylesheet" href="../../core/variables.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container">
+    <div class="header">
+      <h1 class="ease-fade-in">Dark Mode Token Layer Demo</h1>
+      <button id="theme-toggle" class="toggle-btn">Toggle Theme</button>
+    </div>
+    <p class="ease-slide-up">Automatically follows OS preference. Use the button to override.</p>
+
+    <div class="card-grid">
+      <div class="demo-card">
+        <h3>Primary Card</h3>
+        <p>Uses <code>--ease-color-bg</code> and <code>--ease-color-text</code> tokens.</p>
+      </div>
+      <div class="demo-card demo-card-accent">
+        <h3>Accent Card</h3>
+        <p>Uses <code>--ease-color-primary-alpha</code> for subtle background.</p>
+      </div>
+      <div class="demo-card demo-card-glass">
+        <h3>Glass Card</h3>
+        <p>Uses <code>--ease-glass-bg</code> for glassmorphism effect.</p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const html = document.documentElement;
+      const current = html.getAttribute('data-theme');
+      html.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
+    });
+  </script>
+</body>
+</html>

--- a/submissions/examples/dark-mode-token-demo-88689/style.css
+++ b/submissions/examples/dark-mode-token-demo-88689/style.css
@@ -1,0 +1,40 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: var(--ease-color-bg, #f8fafc);
+  color: var(--ease-color-text, #1e293b);
+  margin: 0;
+  padding: 2rem;
+  transition: background 0.3s, color 0.3s;
+}
+
+.demo-container { max-width: 800px; margin: 0 auto; }
+.header { display: flex; justify-content: space-between; align-items: center; }
+.toggle-btn {
+  padding: 0.5rem 1rem;
+  background: var(--ease-color-primary, #6c63ff);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+.demo-card {
+  background: var(--ease-color-surface, #fff);
+  border: 1px solid var(--ease-color-neutral-200, #e2e8f0);
+  border-radius: 8px;
+  padding: 1.5rem;
+  transition: background 0.3s, border-color 0.3s;
+}
+.demo-card-accent {
+  background: var(--ease-color-primary-alpha, rgba(108,99,255,0.15));
+}
+.demo-card-glass {
+  background: var(--ease-glass-bg, rgba(255,255,255,0.12));
+  backdrop-filter: blur(12px);
+  border-color: var(--ease-glass-border, rgba(255,255,255,0.2));
+}


### PR DESCRIPTION
## Description
Added a self-contained demo showing how EaseMotion CSS dark mode tokens work with `prefers-color-scheme` and `[data-theme]`.

### Features
- Automatic dark mode via `prefers-color-scheme: dark`
- Manual toggle via `[data-theme="dark"]`
- Tokens: bg, surface, text, muted, alpha, glass
- Smooth transitions between themes

### How to test
1. Open `demo.html`
2. Dark mode activates automatically if OS is in dark mode
3. Click "Toggle Theme" to switch manually

## Related Issue
Relates to #88689

## Type of Change
- [x] Feature (non-breaking change which adds functionality)
