### PR TITLE
feat: add pure CSS star-rating toggle component (#86805)

### DIFF
--- a/submissions/examples/star-rating/README.md
+++ b/submissions/examples/star-rating/README.md
@@ -1,44 +1,39 @@
-# Animated Star Rating Widget
+# Star Rating
 
-A fully interactive 5-star rating widget using the radio-button CSS trick — no JavaScript required for selection, hover preview, or animation.
+## Summary
 
-## Features
+A pure CSS star rating component submitted for issue #86805 (Category:
+Toggle). Hoverable, fills left to right, with a pop animation on
+selection — no JS dependency.
 
-- ⭐ Click any star to select a rating; hover previews the rating before committing
-- ✨ Stars pop with a small bounce animation on hover
-- 🎯 Built on real `<input type="radio">` elements, so it's keyboard-accessible and form-submittable
-- 📱 Responsive — star size scales down on small screens
-- ♿ Respects `prefers-reduced-motion`
-- 🧩 Pure HTML + CSS — no JavaScript dependencies
+## How it works
 
-## Usage
+- Five `<input type="radio">` + `<label>` pairs share one `name`, so
+  only one can be selected (native toggle behavior).
+- The container uses `flex-direction: row-reverse`, so the *last*
+  radio in the DOM renders as the *first* (leftmost) star on screen.
+- `label:hover ~ label` and `input:checked ~ label` use the general
+  sibling combinator to color every star that comes *after* the
+  hovered/checked one in the DOM — which, thanks to the reversed flex
+  order, are the stars visually to its *left*. This produces the
+  left-to-right fill effect with zero JS.
+- `input:checked + label` (adjacent sibling) isolates just the
+  specifically selected star so only it gets the `ease-star-pop`
+  keyframe animation, rather than every filled star re-popping.
+- `prefers-reduced-motion` disables both the pop animation and hover
+  transform for users who request reduced motion.
 
-Stars must be written in **descending value order** (5 down to 1) in the HTML, then laid out with `flex-direction: row-reverse` so they display left-to-right correctly — this is what allows the sibling selector trick to highlight "this star and everything before it":
+## Classes
 
-```html
-<div class="star-rating">
-  <input type="radio" id="star5" name="rating" value="5" />
-  <label for="star5" title="5 stars">★</label>
-
-  <input type="radio" id="star4" name="rating" value="4" />
-  <label for="star4" title="4 stars">★</label>
-
-  <!-- ...down to star1 -->
-</div>
-```
-
-Give each `<div class="star-rating">` instance a unique `name` attribute if you have multiple rating widgets on the same page (radio groups must not collide).
-
-## Why it fits EaseMotion CSS
-
-Selection state, hover preview, and the pop animation are handled entirely by CSS `:checked`, `:hover`, and the `~` general sibling selector — no JavaScript needed. Class-free, semantic `<input>`/`<label>` markup keeps it accessible by default.
+- `ease-star-rating` — flex container (row-reverse), holds the
+  radio/label pairs
+- `ease-star-rating label` — individual star glyph
+- `ease-star-rating-value` — optional helper text under the stars
 
 ## Files
 
-- `demo.html` — a working 5-star widget defaulted to 3 stars
-- `style.css` — all styles and the hover pop animation
-- `README.md` — this file
+- `demo.html` — live demo with an unrated example and a pre-selected
+  (checked) example
+- `style.css` — original CSS, single component
 
-## Notes
-
-Reading the selected value (e.g. to submit it) works exactly like any radio group — check `document.querySelector('input[name="rating"]:checked').value` in JavaScript, or submit it as part of a real `<form>`.
+Relates to issue #86805.

--- a/submissions/examples/star-rating/demo.html
+++ b/submissions/examples/star-rating/demo.html
@@ -1,36 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Animated Star Rating — Demo</title>
-  <link rel="stylesheet" href="style.css" />
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Star Rating — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 480px; margin: 40px auto; padding: 0 16px; }
+  section { margin-top: 40px; }
+  h2 { font-size: 1.1rem; margin-bottom: 12px; }
+</style>
 </head>
 <body>
 
-  <p class="demo-title">Hover or click to rate (pure CSS)</p>
+<h1>Pure CSS Star Rating</h1>
+<p style="color: var(--ease-color-muted)">
+  A hoverable, dependency-free star rating that fills left to right and
+  pops on selection. No JavaScript required.
+</p>
 
-  <!--
-    Radio-button trick: hidden radios track the selected rating,
-    labels are the visible stars. CSS sibling selectors highlight
-    all stars up to the hovered/checked one, with no JS required.
-  -->
-  <div class="star-rating">
-    <input type="radio" id="star5" name="rating" value="5" />
-    <label for="star5" title="5 stars">★</label>
+<section>
+  <h2>Default (unrated)</h2>
+  <fieldset class="ease-star-rating" style="border:none;">
+    <input type="radio" name="rating-1" id="r1-5" value="5" />
+    <label for="r1-5" aria-label="5 stars">★</label>
+    <input type="radio" name="rating-1" id="r1-4" value="4" />
+    <label for="r1-4" aria-label="4 stars">★</label>
+    <input type="radio" name="rating-1" id="r1-3" value="3" />
+    <label for="r1-3" aria-label="3 stars">★</label>
+    <input type="radio" name="rating-1" id="r1-2" value="2" />
+    <label for="r1-2" aria-label="2 stars">★</label>
+    <input type="radio" name="rating-1" id="r1-1" value="1" />
+    <label for="r1-1" aria-label="1 star">★</label>
+  </fieldset>
+  <div class="ease-star-rating-value">Hover or click to rate</div>
+</section>
 
-    <input type="radio" id="star4" name="rating" value="4" />
-    <label for="star4" title="4 stars">★</label>
-
-    <input type="radio" id="star3" name="rating" value="3" checked />
-    <label for="star3" title="3 stars">★</label>
-
-    <input type="radio" id="star2" name="rating" value="2" />
-    <label for="star2" title="2 stars">★</label>
-
-    <input type="radio" id="star1" name="rating" value="1" />
-    <label for="star1" title="1 star">★</label>
-  </div>
+<section>
+  <h2>Pre-selected (3 stars)</h2>
+  <fieldset class="ease-star-rating" style="border:none;">
+    <input type="radio" name="rating-2" id="r2-5" value="5" />
+    <label for="r2-5" aria-label="5 stars">★</label>
+    <input type="radio" name="rating-2" id="r2-4" value="4" />
+    <label for="r2-4" aria-label="4 stars">★</label>
+    <input type="radio" name="rating-2" id="r2-3" value="3" checked />
+    <label for="r2-3" aria-label="3 stars">★</label>
+    <input type="radio" name="rating-2" id="r2-2" value="2" />
+    <label for="r2-2" aria-label="2 stars">★</label>
+    <input type="radio" name="rating-2" id="r2-1" value="1" />
+    <label for="r2-1" aria-label="1 star">★</label>
+  </fieldset>
+  <div class="ease-star-rating-value">Current rating: 3 / 5</div>
+</section>
 
 </body>
 </html>

--- a/submissions/examples/star-rating/style.css
+++ b/submissions/examples/star-rating/style.css
@@ -1,91 +1,92 @@
-/* ============================================
-   Animated Star Rating Widget
-   Pure CSS — no JavaScript required
-   ============================================ */
+/* Pure CSS Star Rating — Toggle component
+   Hoverable, fills left-to-right, pop animation on selection.
+   No JS: uses the radio-input + row-reverse + ~ sibling-combinator trick.
+   Token-driven via --ease-* variables, dark-mode aware. */
 
-* {
-  box-sizing: border-box;
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-surface: #f9fafb;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-border: #e5e7eb;
+  --ease-color-star-empty: #d1d5db;
+  --ease-color-star-filled: #f59e0b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-border: #334155;
+    --ease-color-star-empty: #475569;
+    --ease-color-star-filled: #fbbf24;
+  }
 }
 
 body {
-  min-height: 100vh;
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-  background: #0f1115;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  padding: 40px 16px;
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
 }
 
-.demo-title {
-  color: #8a8f98;
-  font-size: 0.85rem;
-}
-
-/* ---------- Star rating ---------- */
-/* Stars are rendered in reverse DOM order (5,4,3,2,1) and laid out
-   with row-reverse, so the CSS "~" general sibling selector can
-   highlight every star from the checked/hovered one onward. */
-.star-rating {
+.ease-star-rating {
   display: inline-flex;
   flex-direction: row-reverse;
   gap: 4px;
+  padding: 4px;
+  border: none;
 }
 
-.star-rating input {
+.ease-star-rating input {
   position: absolute;
   opacity: 0;
   pointer-events: none;
+  width: 0;
+  height: 0;
 }
 
-.star-rating label {
-  font-size: 2.2rem;
-  line-height: 1;
-  color: #2a2e38;
+.ease-star-rating label {
   cursor: pointer;
-  transition: color 0.25s ease, transform 0.25s ease;
+  font-size: 2rem;
+  line-height: 1;
+  color: var(--ease-color-star-empty);
+  transition: color 150ms ease, transform 150ms ease;
+  user-select: none;
 }
 
-/* Highlight the checked star and everything after it in DOM order
-   (i.e. every star with a lower or equal value, visually to its left) */
-.star-rating input:checked ~ label,
-.star-rating label:hover,
-.star-rating label:hover ~ label {
-  color: #f5a623;
+.ease-star-rating label:hover,
+.ease-star-rating label:hover ~ label,
+.ease-star-rating input:checked ~ label {
+  color: var(--ease-color-star-filled);
 }
 
-/* Pop animation on hover */
-.star-rating label:hover {
-  transform: scale(1.15);
-  animation: star-pop 0.3s ease;
+.ease-star-rating label:hover {
+  transform: scale(1.12);
 }
 
-@keyframes star-pop {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.3);
-  }
-  100% {
-    transform: scale(1.15);
-  }
+.ease-star-rating input:checked + label {
+  animation: ease-star-pop 320ms ease;
 }
 
-/* ---------- Responsive ---------- */
-@media (max-width: 340px) {
-  .star-rating label {
-    font-size: 1.8rem;
-  }
+@keyframes ease-star-pop {
+  0%   { transform: scale(1); }
+  35%  { transform: scale(1.35); }
+  60%  { transform: scale(0.92); }
+  100% { transform: scale(1); }
 }
 
-/* ---------- Reduced motion ---------- */
 @media (prefers-reduced-motion: reduce) {
-  .star-rating label {
-    transition: none;
+  .ease-star-rating label,
+  .ease-star-rating input:checked + label {
     animation: none;
+    transition: none;
   }
+}
+
+.ease-star-rating-value {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: var(--ease-color-muted);
 }


### PR DESCRIPTION
Relates to #86805

Pure CSS star rating — hoverable, fills left to right via the row-reverse + sibling-combinator radio trick, pop animation isolated to the selected star. No JS dependency.

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge