### PR TITLE
feat: add pure CSS segmented tabs component (#88583)

### DIFF
--- a/submissions/examples/segmented-tabs/README.md
+++ b/submissions/examples/segmented-tabs/README.md
@@ -1,0 +1,32 @@
+# Segmented Tabs
+
+## Summary
+
+A pure CSS segmented tab switcher submitted for issue #88583. No spec
+was given beyond "advanced component," so this covers a commonly
+requested pattern: an accessible, animated tab switcher with zero JS.
+
+## How it works
+
+- Three `<input type="radio">` (one `name`, so mutually exclusive)
+  live at the top of `.ease-tabs`, before the nav and panels in the
+  DOM, so they can be targeted by later siblings via `~`.
+- Each radio's `id` matches a `label[for]` in the nav and a
+  `data-tab` value on its panel, so `#tab-N:checked ~ ... label[for="tab-N"]`
+  highlights the active tab, and `#tab-N:checked ~ ... [data-tab="N"]`
+  reveals the matching panel — all pure CSS, no JS.
+- Panels fade in on switch via `ease-tabs-fade`, disabled under
+  `prefers-reduced-motion`.
+
+## Classes
+
+- `ease-tabs` — wrapper, holds the hidden radios
+- `ease-tabs-nav` — pill-style tab bar
+- `ease-tabs-panels`, `ease-tabs-panel` — content panels
+
+## Files
+
+- `demo.html` — live 3-tab demo
+- `style.css` — original CSS, single component
+
+Relates to issue #88583.

--- a/submissions/examples/segmented-tabs/demo.html
+++ b/submissions/examples/segmented-tabs/demo.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Segmented Tabs — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 560px; margin: 40px auto; padding: 0 16px; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Segmented Tabs</h1>
+<p style="color: var(--ease-color-muted)">
+  A tab switcher built with the radio-input + sibling-combinator trick.
+  No JavaScript required.
+</p>
+
+<div class="ease-tabs">
+  <input type="radio" name="tabs" id="tab-1" checked />
+  <input type="radio" name="tabs" id="tab-2" />
+  <input type="radio" name="tabs" id="tab-3" />
+
+  <div class="ease-tabs-nav">
+    <label for="tab-1">Overview</label>
+    <label for="tab-2">Features</label>
+    <label for="tab-3">Pricing</label>
+  </div>
+
+  <div class="ease-tabs-panels">
+    <div class="ease-tabs-panel" data-tab="1">
+      Overview panel content goes here. Click another tab to switch — this
+      whole interaction is pure CSS.
+    </div>
+    <div class="ease-tabs-panel" data-tab="2">
+      Features panel content. Each panel is tied to its radio input via
+      matching id/for/data-tab attributes.
+    </div>
+    <div class="ease-tabs-panel" data-tab="3">
+      Pricing panel content. Only the panel matching the checked radio
+      is displayed, with a subtle fade-in on switch.
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/submissions/examples/segmented-tabs/style.css
+++ b/submissions/examples/segmented-tabs/style.css
@@ -1,0 +1,103 @@
+/* Pure CSS Segmented Tabs — Advanced component
+   Radio-input + :checked sibling-combinator tab switcher, no JS.
+   Token-driven via --ease-* variables, dark-mode aware. */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-surface: #f9fafb;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-border: #e5e7eb;
+  --ease-color-primary: #6366f1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-surface: #1e293b;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-border: #334155;
+    --ease-color-primary: #818cf8;
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.ease-tabs {
+  position: relative;
+}
+
+.ease-tabs input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.ease-tabs-nav {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--ease-color-surface);
+  border: 1px solid var(--ease-color-border);
+  border-radius: 10px;
+}
+
+.ease-tabs-nav label {
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 7px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ease-color-muted);
+  transition: background 150ms ease, color 150ms ease;
+  user-select: none;
+}
+
+.ease-tabs-nav label:hover {
+  color: var(--ease-color-text);
+}
+
+.ease-tabs-panels {
+  margin-top: 16px;
+}
+
+.ease-tabs-panel {
+  display: none;
+  padding: 16px;
+  border: 1px solid var(--ease-color-border);
+  border-radius: 10px;
+  color: var(--ease-color-muted);
+  animation: ease-tabs-fade 200ms ease;
+}
+
+@keyframes ease-tabs-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-tabs-panel { animation: none; }
+}
+
+/* Wire each radio to its label and its panel via nth-of-type,
+   since :checked can't be combined with :has() reliably across targets —
+   instead each tab pairs one radio + one label + one panel by matching IDs. */
+#tab-1:checked ~ .ease-tabs-nav label[for="tab-1"],
+#tab-2:checked ~ .ease-tabs-nav label[for="tab-2"],
+#tab-3:checked ~ .ease-tabs-nav label[for="tab-3"] {
+  background: var(--ease-color-primary);
+  color: #fff;
+}
+
+#tab-1:checked ~ .ease-tabs-panels .ease-tabs-panel[data-tab="1"],
+#tab-2:checked ~ .ease-tabs-panels .ease-tabs-panel[data-tab="2"],
+#tab-3:checked ~ .ease-tabs-panels .ease-tabs-panel[data-tab="3"] {
+  display: block;
+}


### PR DESCRIPTION
Relates to #88583

## Description
Adds a pure CSS segmented tab switcher — accessible, animated, zero JS. Uses the radio-input + sibling-combinator pattern.

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
New files only, added under submissions/examples/segmented-tabs/: demo.html, style.css, README.md. No existing files were modified or deleted.