### PR TITLE
feat: add pure CSS toggle switch component (#88579)

### DIFF
--- a/submissions/examples/toggle-switch-88579/README.md
+++ b/submissions/examples/toggle-switch-88579/README.md
@@ -1,0 +1,33 @@
+# Toggle Switch
+
+## Summary
+
+A pure CSS toggle switch submitted for issue #88579. No spec was
+given beyond "advanced component," so this covers a commonly
+requested pattern: an accessible sliding switch with zero JS.
+
+## How it works
+
+- A native `<input type="checkbox">` drives the state; it's visually
+  hidden but remains keyboard/screen-reader accessible.
+- `input:checked ~ .ease-switch-track` recolors the track, and
+  `input:checked ~ .ease-switch-track::after` slides the thumb via
+  `transform: translateX()`.
+- The thumb transition uses a `cubic-bezier` overshoot curve for a
+  spring-like feel.
+- `:focus-visible` on the input draws an outline on the track so
+  keyboard users can see focus state.
+- `prefers-reduced-motion` disables the slide/transition entirely.
+
+## Classes
+
+- `ease-switch` — wrapping `<label>`, makes the whole row clickable
+- `ease-switch-track` — the pill-shaped track + thumb (via `::after`)
+- `ease-switch-label` — optional text label
+
+## Files
+
+- `demo.html` — live demo with an off and a pre-checked switch
+- `style.css` — original CSS, single component
+
+Relates to issue #88579.

--- a/submissions/examples/toggle-switch-88579/demo.html
+++ b/submissions/examples/toggle-switch-88579/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Toggle Switch — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 420px; margin: 60px auto; padding: 0 16px; }
+  section { margin-top: 24px; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Toggle Switch</h1>
+<p style="color: var(--ease-color-muted)">
+  A checkbox-driven slide toggle with a spring-like animation.
+  No JavaScript required.
+</p>
+
+<section>
+  <label class="ease-switch">
+    <input type="checkbox" />
+    <span class="ease-switch-track"></span>
+    <span class="ease-switch-label">Enable notifications</span>
+  </label>
+</section>
+
+<section>
+  <label class="ease-switch">
+    <input type="checkbox" checked />
+    <span class="ease-switch-track"></span>
+    <span class="ease-switch-label">Dark mode (pre-checked)</span>
+  </label>
+</section>
+
+</body>
+</html>

--- a/submissions/examples/toggle-switch-88579/style.css
+++ b/submissions/examples/toggle-switch-88579/style.css
@@ -1,0 +1,92 @@
+/* Pure CSS Toggle Switch — Advanced component
+   Checkbox-driven slide toggle with a spring-like transition, no JS.
+   Token-driven via --ease-* variables, dark-mode aware. */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-text: #111827;
+  --ease-color-track-off: #d1d5db;
+  --ease-color-track-on: #22c55e;
+  --ease-color-thumb: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-text: #f1f5f9;
+    --ease-color-track-off: #475569;
+    --ease-color-track-on: #4ade80;
+    --ease-color-thumb: #f1f5f9;
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.ease-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.ease-switch-track {
+  position: relative;
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--ease-color-track-off);
+  transition: background 200ms ease;
+  flex-shrink: 0;
+}
+
+.ease-switch-track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--ease-color-thumb);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transition: transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-switch input:checked ~ .ease-switch-track {
+  background: var(--ease-color-track-on);
+}
+
+.ease-switch input:checked ~ .ease-switch-track::after {
+  transform: translateX(20px);
+}
+
+.ease-switch input:focus-visible ~ .ease-switch-track {
+  outline: 2px solid var(--ease-color-track-on);
+  outline-offset: 2px;
+}
+
+.ease-switch-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-switch-track,
+  .ease-switch-track::after {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Relates to #88579

## Description
Adds a pure CSS, keyboard-accessible sliding toggle switch. No JS dependency.

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
New files only, added under submissions/examples/toggle-switch-88579/: demo.html, style.css, README.md. No existing files were modified or deleted.