### PR TITLE
feat: add pure CSS progress bar component (#88575)

### DIFF
--- a/submissions/examples/progress-bar-88575/README.md
+++ b/submissions/examples/progress-bar-88575/README.md
@@ -1,0 +1,39 @@
+# Progress Bar
+
+## Summary
+
+A pure CSS progress bar submitted for issue #88575. No spec was
+given beyond "advanced component," so this covers a commonly
+requested pattern: an animated, accessible progress indicator with
+zero JS, supporting both determinate and indeterminate states.
+
+## How it works
+
+- `.ease-progress` is the track; `.ease-progress-bar` is the fill,
+  sized via an inline `width` style (or a CSS var, if preferred by
+  the consumer) for the determinate case.
+- A repeating diagonal `linear-gradient` background creates the
+  "stripes," animated via `background-position` in
+  `ease-progress-stripes` for a subtle sense of motion even on a
+  static value.
+- `.ease-progress-indeterminate` overrides the bar's width and adds
+  a second keyframe (`ease-progress-indeterminate`) that slides the
+  bar back and forth across the track for loading states with no
+  known duration.
+- `role="progressbar"` plus `aria-valuenow/min/max` (determinate) or
+  `aria-label` (indeterminate) keep it accessible to screen readers.
+- `prefers-reduced-motion` disables both animations.
+
+## Classes
+
+- `ease-progress` — track container
+- `ease-progress-bar` — the animated fill
+- `ease-progress-indeterminate` — modifier for unknown-duration loading
+- `ease-progress-label` — optional helper text under the bar
+
+## Files
+
+- `demo.html` — live demo: two determinate bars + one indeterminate
+- `style.css` — original CSS, single component
+
+Relates to issue #88575.

--- a/submissions/examples/progress-bar-88575/demo.html
+++ b/submissions/examples/progress-bar-88575/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Progress Bar — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 480px; margin: 60px auto; padding: 0 16px; }
+  section { margin-top: 32px; }
+  h2 { font-size: 1.1rem; margin-bottom: 10px; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Progress Bar</h1>
+<p style="color: var(--ease-color-muted)">
+  Animated striped fill, determinate and indeterminate variants.
+  No JavaScript required.
+</p>
+
+<section>
+  <h2>Determinate — 35%</h2>
+  <div class="ease-progress" role="progressbar" aria-valuenow="35" aria-valuemin="0" aria-valuemax="100">
+    <div class="ease-progress-bar" style="width: 35%;"></div>
+  </div>
+  <div class="ease-progress-label">35% complete</div>
+</section>
+
+<section>
+  <h2>Determinate — 80%</h2>
+  <div class="ease-progress" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
+    <div class="ease-progress-bar" style="width: 80%;"></div>
+  </div>
+  <div class="ease-progress-label">80% complete</div>
+</section>
+
+<section>
+  <h2>Indeterminate</h2>
+  <div class="ease-progress ease-progress-indeterminate" role="progressbar" aria-label="Loading">
+    <div class="ease-progress-bar"></div>
+  </div>
+  <div class="ease-progress-label">Loading…</div>
+</section>
+
+</body>
+</html>

--- a/submissions/examples/progress-bar-88575/style.css
+++ b/submissions/examples/progress-bar-88575/style.css
@@ -1,0 +1,84 @@
+/* Pure CSS Progress Bar — Advanced component
+   Animated striped fill, determinate + indeterminate variants, no JS.
+   Token-driven via --ease-* variables, dark-mode aware. */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-track: #e5e7eb;
+  --ease-color-fill: #6366f1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-track: #334155;
+    --ease-color-fill: #818cf8;
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.ease-progress {
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--ease-color-track);
+  overflow: hidden;
+}
+
+.ease-progress-bar {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--ease-color-fill);
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 28px 28px;
+  animation: ease-progress-stripes 1s linear infinite;
+  transition: width 400ms ease;
+}
+
+@keyframes ease-progress-stripes {
+  from { background-position: 0 0; }
+  to   { background-position: 28px 0; }
+}
+
+.ease-progress-indeterminate .ease-progress-bar {
+  width: 40% !important;
+  animation: ease-progress-indeterminate 1.4s ease-in-out infinite,
+             ease-progress-stripes 1s linear infinite;
+}
+
+@keyframes ease-progress-indeterminate {
+  0%   { margin-left: -40%; }
+  100% { margin-left: 100%; }
+}
+
+.ease-progress-label {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--ease-color-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-progress-bar,
+  .ease-progress-indeterminate .ease-progress-bar {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
Relates to #88575

## Description
Adds a pure CSS, accessible progress bar with animated stripes, supporting determinate and indeterminate states. No JS dependency.

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
New files only, added under submissions/examples/progress-bar-88575/: demo.html, style.css, README.md. No existing files were modified or deleted.