### PR TITLE
feat: add checkbox-animated component (#86803)

### DIFF
--- a/submissions/examples/checkbox-animated/README.md
+++ b/submissions/examples/checkbox-animated/README.md
@@ -1,0 +1,36 @@
+# Animated Checkbox
+
+## Summary
+
+A pure CSS animated checkbox submitted for issue #86803 (Category:
+Toggle). A custom checkbox with a draw-on checkmark and a springy
+squash on select — no JS dependency.
+
+## How it works
+
+- A native `<input type="checkbox">` drives state, visually hidden
+  but keyboard/screen-reader accessible.
+- The checkmark is an inline SVG `<path>` with
+  `stroke-dasharray: 20` and `stroke-dashoffset: 20`, which hides
+  the stroke entirely. On `:checked`, `stroke-dashoffset` animates
+  to `0`, "drawing" the check from tail to tip.
+- The box itself plays a `ease-checkbox-squash` keyframe on check —
+  a quick squash-then-settle using non-uniform `scaleX/scaleY`
+  values and a `cubic-bezier` overshoot curve for the spring feel.
+- `:focus-visible` on the input draws an outline on the box for
+  keyboard users.
+- `prefers-reduced-motion` disables both the squash animation and
+  the checkmark draw transition.
+
+## Classes
+
+- `ease-checkbox` — wrapping `<label>`, makes the whole row clickable
+- `ease-checkbox-box` — the square box containing the SVG checkmark
+- `ease-checkbox-label` — optional text label
+
+## Files
+
+- `demo.html` — live demo with an unchecked and a pre-checked example
+- `style.css` — original CSS, single component
+
+Relates to issue #86803.

--- a/submissions/examples/checkbox-animated/demo.html
+++ b/submissions/examples/checkbox-animated/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Animated Checkbox — Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { max-width: 420px; margin: 60px auto; padding: 0 16px; }
+  section { margin-top: 20px; }
+</style>
+</head>
+<body>
+
+<h1>Pure CSS Animated Checkbox</h1>
+<p style="color: var(--ease-color-muted)">
+  A custom checkbox with a draw-on checkmark and a springy squash on
+  select. No JavaScript required.
+</p>
+
+<section>
+  <label class="ease-checkbox">
+    <input type="checkbox" />
+    <span class="ease-checkbox-box">
+      <svg viewBox="0 0 24 24">
+        <path d="M5 12.5 L10 17 L19 7" />
+      </svg>
+    </span>
+    <span class="ease-checkbox-label">Accept terms and conditions</span>
+  </label>
+</section>
+
+<section>
+  <label class="ease-checkbox">
+    <input type="checkbox" checked />
+    <span class="ease-checkbox-box">
+      <svg viewBox="0 0 24 24">
+        <path d="M5 12.5 L10 17 L19 7" />
+      </svg>
+    </span>
+    <span class="ease-checkbox-label">Subscribe to newsletter (pre-checked)</span>
+  </label>
+</section>
+
+</body>
+</html>

--- a/submissions/examples/checkbox-animated/style.css
+++ b/submissions/examples/checkbox-animated/style.css
@@ -1,0 +1,112 @@
+/* Pure CSS Animated Checkbox — Toggle component
+   Custom checkbox with a draw-on checkmark (stroke-dasharray) and a
+   springy squash-and-settle on select. No JS dependency.
+   Token-driven via --ease-* variables, dark-mode aware. */
+
+:root {
+  --ease-color-bg: #ffffff;
+  --ease-color-text: #111827;
+  --ease-color-muted: #6b7280;
+  --ease-color-box-border: #9ca3af;
+  --ease-color-box-checked: #6366f1;
+  --ease-color-check: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ease-color-bg: #0f172a;
+    --ease-color-text: #f1f5f9;
+    --ease-color-muted: #94a3b8;
+    --ease-color-box-border: #64748b;
+    --ease-color-box-checked: #818cf8;
+    --ease-color-check: #0f172a;
+  }
+}
+
+body {
+  background: var(--ease-color-bg);
+  color: var(--ease-color-text);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.ease-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-checkbox input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.ease-checkbox-box {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  border: 2px solid var(--ease-color-box-border);
+  background: transparent;
+  transition: background 180ms ease, border-color 180ms ease,
+              transform 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-checkbox-box svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.ease-checkbox-box svg path {
+  fill: none;
+  stroke: var(--ease-color-check);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 20;
+  stroke-dashoffset: 20;
+  transition: stroke-dashoffset 220ms ease 80ms;
+}
+
+.ease-checkbox input:checked ~ .ease-checkbox-box {
+  background: var(--ease-color-box-checked);
+  border-color: var(--ease-color-box-checked);
+  transform: scale(1.15);
+  animation: ease-checkbox-squash 320ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.ease-checkbox input:checked ~ .ease-checkbox-box svg path {
+  stroke-dashoffset: 0;
+}
+
+@keyframes ease-checkbox-squash {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(0.82, 1.18); }
+  70%  { transform: scale(1.12, 0.92); }
+  100% { transform: scale(1); }
+}
+
+.ease-checkbox input:focus-visible ~ .ease-checkbox-box {
+  outline: 2px solid var(--ease-color-box-checked);
+  outline-offset: 2px;
+}
+
+.ease-checkbox-label {
+  font-size: 0.95rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-checkbox-box,
+  .ease-checkbox input:checked ~ .ease-checkbox-box,
+  .ease-checkbox-box svg path {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
Relates to #86803

## Description
Adds a pure CSS animated checkbox — draw-on checkmark via stroke-dasharray, springy squash-and-settle on select. No JS dependency.

## Demo
- [x] Demo added (demo.html works by opening directly in a browser)

## Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Edge

## Notes for Maintainer
New files only, added under submissions/examples/checkbox-animated/: demo.html, style.css, README.md. No existing files were modified or deleted.