### PR TITLE
feat: add toggle-group component

### DIFF
--- a/submissions/examples/toggle-group/README.md
+++ b/submissions/examples/toggle-group/README.md
@@ -1,0 +1,47 @@
+# Toggle Group
+
+**Category:** Input
+**Issue:** #86872
+
+A segmented multi-select control. Each option is an independent toggle chip;
+selected chips fill with the accent color and stay highlighted until toggled
+off again.
+
+## What it does
+- Multiple chips can be active at once (unlike radio-style segmented controls).
+- Selecting a chip fills its background and plays a short "pop" animation.
+- Fully keyboard accessible — chips are real `<button>` elements, so Tab/Space/Enter
+  work out of the box.
+- Respects `prefers-reduced-motion` and `prefers-color-scheme`.
+
+## How to use
+
+```html
+<div class="ease-toggle-group" role="group" aria-label="Select tags">
+  <button type="button" class="ease-toggle-chip" aria-pressed="false">Design</button>
+  <button type="button" class="ease-toggle-chip" aria-pressed="true">Animation</button>
+</div>
+
+<script>
+  document.querySelectorAll('.ease-toggle-group').forEach((group) => {
+    group.addEventListener('click', (e) => {
+      const chip = e.target.closest('.ease-toggle-chip');
+      if (!chip || chip.disabled) return;
+      const pressed = chip.getAttribute('aria-pressed') === 'true';
+      chip.setAttribute('aria-pressed', String(!pressed));
+    });
+  });
+</script>
+```
+
+Add `ease-toggle-group--sm` for a smaller/compact variant.
+
+## Why it fits EaseMotion CSS
+- Zero dependencies, pure CSS + a few lines of vanilla JS.
+- Uses CSS custom properties so consumers can retheme via `--ease-toggle-fill`, etc.
+- Consistent with the framework's animation-first philosophy (spring-like
+  `cubic-bezier` easing and a selection "pop" keyframe).
+
+## Browser support
+Chrome, Firefox, Edge, Safari (uses `:focus-visible` and `aria-pressed`, both
+widely supported).

--- a/submissions/examples/toggle-group/demo.html
+++ b/submissions/examples/toggle-group/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — Toggle Group Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    max-width: 640px;
+    margin: 4rem auto;
+    padding: 0 1.5rem;
+    color: #1c1d26;
+  }
+  h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+  p.lead { color: #6b6d7c; margin-top: 0; margin-bottom: 2rem; }
+  section { margin-bottom: 2.5rem; }
+  h2 { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.04em; color: #8a8c9c; }
+  pre {
+    background: #f6f6f9;
+    border: 1px solid #e4e5ee;
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+  }
+</style>
+</head>
+<body>
+
+  <h1>Toggle Group</h1>
+  <p class="lead">A segmented multi-select where chosen chips fill and stay highlighted.</p>
+
+  <section>
+    <h2>Default</h2>
+    <div class="ease-toggle-group" role="group" aria-label="Select interests">
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Design</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="true">Animation</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Frontend</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Accessibility</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Small size</h2>
+    <div class="ease-toggle-group ease-toggle-group--sm" role="group" aria-label="Select filters">
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">All</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="true">Open</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="true">In Progress</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Closed</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>With disabled option</h2>
+    <div class="ease-toggle-group" role="group" aria-label="Select plan add-ons">
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Storage</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="false">Analytics</button>
+      <button type="button" class="ease-toggle-chip" aria-pressed="false" disabled>Enterprise (locked)</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Usage</h2>
+    <pre><code>&lt;div class="ease-toggle-group" role="group" aria-label="Select tags"&gt;
+  &lt;button type="button" class="ease-toggle-chip" aria-pressed="false"&gt;Design&lt;/button&gt;
+  &lt;button type="button" class="ease-toggle-chip" aria-pressed="true"&gt;Animation&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+  </section>
+
+<script>
+  // Dependency-free toggle logic.
+  // Each chip is a real <button> for built-in keyboard support (Space/Enter, Tab).
+  document.querySelectorAll('.ease-toggle-group').forEach(function (group) {
+    group.addEventListener('click', function (e) {
+      var chip = e.target.closest('.ease-toggle-chip');
+      if (!chip || chip.disabled) return;
+
+      var pressed = chip.getAttribute('aria-pressed') === 'true';
+      chip.setAttribute('aria-pressed', String(!pressed));
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/toggle-group/style.css
+++ b/submissions/examples/toggle-group/style.css
@@ -1,0 +1,130 @@
+/* =========================================================
+   EaseMotion CSS — Toggle Group
+   Segmented multi-select where chosen chips fill and
+   stay highlighted. Dependency-free, animation-first.
+   ========================================================= */
+
+.ease-toggle-group {
+  --ease-toggle-bg: #f1f2f6;
+  --ease-toggle-border: #d8dae3;
+  --ease-toggle-text: #4a4d5e;
+  --ease-toggle-fill: #6c5ce7;
+  --ease-toggle-fill-text: #ffffff;
+  --ease-toggle-radius: 999px;
+  --ease-toggle-duration: 260ms;
+  --ease-toggle-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  background: var(--ease-toggle-bg);
+  border: 1px solid var(--ease-toggle-border);
+  border-radius: calc(var(--ease-toggle-radius) + 0.4rem);
+}
+
+.ease-toggle-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--ease-toggle-text);
+  background: #ffffff;
+  border: 1px solid transparent;
+  border-radius: var(--ease-toggle-radius);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color var(--ease-toggle-duration) var(--ease-toggle-curve),
+    color var(--ease-toggle-duration) var(--ease-toggle-curve),
+    transform 180ms var(--ease-toggle-curve),
+    box-shadow var(--ease-toggle-duration) ease;
+}
+
+.ease-toggle-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.08);
+}
+
+.ease-toggle-chip:focus-visible {
+  outline: 2px solid var(--ease-toggle-fill);
+  outline-offset: 2px;
+}
+
+.ease-toggle-chip:active {
+  transform: scale(0.96);
+}
+
+/* Selected / filled state */
+.ease-toggle-chip[aria-pressed="true"] {
+  color: var(--ease-toggle-fill-text);
+  background: var(--ease-toggle-fill);
+  box-shadow: 0 4px 12px rgba(108, 92, 231, 0.35);
+  animation: ease-toggle-pop 320ms var(--ease-toggle-curve);
+}
+
+.ease-toggle-chip[aria-pressed="true"] .ease-toggle-check {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.ease-toggle-check {
+  display: inline-flex;
+  width: 0.85em;
+  height: 0.85em;
+  transform: scale(0);
+  opacity: 0;
+  transition: transform var(--ease-toggle-duration) var(--ease-toggle-curve),
+    opacity var(--ease-toggle-duration) ease;
+}
+
+@keyframes ease-toggle-pop {
+  0% {
+    transform: scale(0.9);
+  }
+  55% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Size variant */
+.ease-toggle-group--sm .ease-toggle-chip {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+/* Disabled state */
+.ease-toggle-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .ease-toggle-chip,
+  .ease-toggle-check {
+    transition: none;
+    animation: none;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .ease-toggle-group {
+    --ease-toggle-bg: #1e1f29;
+    --ease-toggle-border: #33354a;
+    --ease-toggle-text: #c8c9d6;
+  }
+  .ease-toggle-chip {
+    background: #262837;
+  }
+}


### PR DESCRIPTION
Closes #86872

Adds the Toggle Group component under `submissions/examples/toggle-group/`:
- `demo.html` — self-contained, dependency-free demo
- `style.css` — hand-crafted CSS for the fill/highlight toggle behavior
- `README.md` — what/how/why

No changes to `core/` or `components/`.