### PR TITLE
feat: add navbar and sidebar navigation components

### DIFF
--- a/submissions/examples/navbar/README.md
+++ b/submissions/examples/navbar/README.md
@@ -1,0 +1,40 @@
+# Navbar
+
+**Category:** Navigation
+**Issue:** #88692 (v1.3 roadmap — navigation components)
+
+A sticky top navbar with a glassmorphism backdrop blur, an animated
+underline on the active/hovered link, and a mobile hamburger menu
+implemented with the checkbox hack — no JavaScript required.
+
+## How to use
+
+```html
+<nav class="ease-navbar">
+  <div class="ease-navbar-brand">Brand</div>
+
+  <input type="checkbox" id="ease-navbar-toggle" class="ease-navbar-toggle-input" />
+
+  <ul class="ease-navbar-links">
+    <li><a href="#" class="ease-navbar-link ease-navbar-link--active">Home</a></li>
+    <li><a href="#" class="ease-navbar-link">About</a></li>
+  </ul>
+
+  <label for="ease-navbar-toggle" class="ease-navbar-toggle" aria-label="Toggle navigation">
+    <span></span><span></span><span></span>
+  </label>
+</nav>
+```
+
+- `ease-navbar--transparent` — transparent variant for hero overlays
+- `ease-navbar-link--active` — marks the current page link
+- Collapses into a hamburger menu below 720px viewport width
+
+## Why it fits EaseMotion CSS
+- Zero JS dependency (pure CSS checkbox-hack toggle)
+- Themeable via CSS custom properties (`--ease-navbar-accent`, etc.)
+- Respects `prefers-reduced-motion` and `prefers-color-scheme`
+
+## Browser support
+Chrome, Firefox, Edge, Safari. `backdrop-filter` degrades gracefully to a
+solid background in browsers without support.

--- a/submissions/examples/navbar/demo.html
+++ b/submissions/examples/navbar/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — Navbar Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #1c1d26; }
+  main { max-width: 700px; margin: 3rem auto; padding: 0 1.5rem; }
+  pre { background: #f6f6f9; border: 1px solid #e4e5ee; border-radius: 8px; padding: 1rem; overflow-x: auto; font-size: 0.8rem; }
+  section { margin-bottom: 2rem; }
+  h2 { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.04em; color: #8a8c9c; }
+</style>
+</head>
+<body>
+
+  <nav class="ease-navbar">
+    <div class="ease-navbar-brand">EaseMotion</div>
+
+    <input type="checkbox" id="ease-navbar-toggle" class="ease-navbar-toggle-input" />
+
+    <ul class="ease-navbar-links">
+      <li><a href="#" class="ease-navbar-link ease-navbar-link--active">Home</a></li>
+      <li><a href="#" class="ease-navbar-link">About</a></li>
+      <li><a href="#" class="ease-navbar-link">Projects</a></li>
+      <li><a href="#" class="ease-navbar-link">Contact</a></li>
+    </ul>
+
+    <label for="ease-navbar-toggle" class="ease-navbar-toggle" aria-label="Toggle navigation">
+      <span></span>
+      <span></span>
+      <span></span>
+    </label>
+  </nav>
+
+  <main>
+    <section>
+      <h2>About this demo</h2>
+      <p>Resize the window below ~720px to see the mobile hamburger toggle — it's driven entirely by the checkbox hack, no JavaScript required.</p>
+    </section>
+
+    <section>
+      <h2>Usage</h2>
+      <pre><code>&lt;nav class="ease-navbar"&gt;
+  &lt;div class="ease-navbar-brand"&gt;Brand&lt;/div&gt;
+
+  &lt;input type="checkbox" id="ease-navbar-toggle" class="ease-navbar-toggle-input" /&gt;
+
+  &lt;ul class="ease-navbar-links"&gt;
+    &lt;li&gt;&lt;a href="#" class="ease-navbar-link ease-navbar-link--active"&gt;Home&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="#" class="ease-navbar-link"&gt;About&lt;/a&gt;&lt;/li&gt;
+  &lt;/ul&gt;
+
+  &lt;label for="ease-navbar-toggle" class="ease-navbar-toggle" aria-label="Toggle navigation"&gt;
+    &lt;span&gt;&lt;/span&gt;&lt;span&gt;&lt;/span&gt;&lt;span&gt;&lt;/span&gt;
+  &lt;/label&gt;
+&lt;/nav&gt;</code></pre>
+      <p>Add <code>ease-navbar--transparent</code> for a see-through variant over hero sections.</p>
+    </section>
+  </main>
+
+</body>
+</html>

--- a/submissions/examples/navbar/style.css
+++ b/submissions/examples/navbar/style.css
@@ -1,0 +1,190 @@
+/* =========================================================
+   EaseMotion CSS — Navbar
+   Sticky top navigation with glassmorphism backdrop blur,
+   animated active-link underline, and a CSS-driven mobile
+   hamburger toggle (checkbox hack, zero JS dependency).
+   ========================================================= */
+
+.ease-navbar {
+  --ease-navbar-bg: rgba(255, 255, 255, 0.72);
+  --ease-navbar-border: rgba(0, 0, 0, 0.06);
+  --ease-navbar-text: #2b2d3a;
+  --ease-navbar-accent: #6c5ce7;
+  --ease-navbar-height: 64px;
+  --ease-navbar-blur: 14px;
+  --ease-navbar-duration: 220ms;
+  --ease-navbar-curve: cubic-bezier(0.22, 1, 0.36, 1);
+
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--ease-navbar-height);
+  padding: 0 1.5rem;
+  background: var(--ease-navbar-bg);
+  backdrop-filter: blur(var(--ease-navbar-blur));
+  -webkit-backdrop-filter: blur(var(--ease-navbar-blur));
+  border-bottom: 1px solid var(--ease-navbar-border);
+  color: var(--ease-navbar-text);
+  font-family: inherit;
+  transition: background-color var(--ease-navbar-duration) var(--ease-navbar-curve),
+    box-shadow var(--ease-navbar-duration) var(--ease-navbar-curve);
+}
+
+/* Transparent variant for hero overlays */
+.ease-navbar--transparent {
+  --ease-navbar-bg: transparent;
+  --ease-navbar-border: transparent;
+  box-shadow: none;
+}
+
+.ease-navbar-brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.ease-navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ease-navbar-link {
+  position: relative;
+  color: var(--ease-navbar-text);
+  text-decoration: none;
+  font-size: 0.92rem;
+  font-weight: 500;
+  opacity: 0.75;
+  padding-block: 0.35rem;
+  transition: opacity var(--ease-navbar-duration) var(--ease-navbar-curve);
+}
+
+.ease-navbar-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 2px;
+  background: var(--ease-navbar-accent);
+  border-radius: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--ease-navbar-duration) var(--ease-navbar-curve);
+}
+
+.ease-navbar-link:hover {
+  opacity: 1;
+}
+
+.ease-navbar-link:hover::after {
+  transform: scaleX(1);
+}
+
+.ease-navbar-link--active {
+  opacity: 1;
+}
+
+.ease-navbar-link--active::after {
+  transform: scaleX(1);
+}
+
+/* Mobile hamburger toggle — checkbox hack, no JS required */
+.ease-navbar-toggle-input {
+  display: none;
+}
+
+.ease-navbar-toggle {
+  display: none;
+  cursor: pointer;
+  width: 28px;
+  height: 22px;
+  position: relative;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.ease-navbar-toggle span {
+  display: block;
+  height: 2px;
+  width: 100%;
+  background: var(--ease-navbar-text);
+  border-radius: 2px;
+  transition: transform var(--ease-navbar-duration) var(--ease-navbar-curve),
+    opacity var(--ease-navbar-duration) var(--ease-navbar-curve);
+}
+
+.ease-navbar-toggle-input:checked ~ .ease-navbar-toggle span:nth-child(1) {
+  transform: translateY(10px) rotate(45deg);
+}
+.ease-navbar-toggle-input:checked ~ .ease-navbar-toggle span:nth-child(2) {
+  opacity: 0;
+}
+.ease-navbar-toggle-input:checked ~ .ease-navbar-toggle span:nth-child(3) {
+  transform: translateY(-10px) rotate(-45deg);
+}
+
+@media (max-width: 720px) {
+  .ease-navbar-toggle {
+    display: flex;
+  }
+
+  .ease-navbar-links {
+    position: absolute;
+    top: var(--ease-navbar-height);
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    padding: 1rem 1.5rem 1.5rem;
+    background: var(--ease-navbar-bg);
+    backdrop-filter: blur(var(--ease-navbar-blur));
+    -webkit-backdrop-filter: blur(var(--ease-navbar-blur));
+    border-bottom: 1px solid var(--ease-navbar-border);
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height var(--ease-navbar-duration) var(--ease-navbar-curve),
+      opacity var(--ease-navbar-duration) var(--ease-navbar-curve);
+  }
+
+  .ease-navbar-toggle-input:checked ~ .ease-navbar-links {
+    max-height: 320px;
+    opacity: 1;
+  }
+
+  .ease-navbar-link {
+    width: 100%;
+    padding-block: 0.6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-navbar,
+  .ease-navbar-link,
+  .ease-navbar-link::after,
+  .ease-navbar-toggle span,
+  .ease-navbar-links {
+    transition: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-navbar {
+    --ease-navbar-bg: rgba(24, 25, 33, 0.72);
+    --ease-navbar-border: rgba(255, 255, 255, 0.08);
+    --ease-navbar-text: #e6e6ee;
+  }
+  .ease-navbar-toggle span {
+    background: var(--ease-navbar-text);
+  }
+}

--- a/submissions/examples/sidebar/README.md
+++ b/submissions/examples/sidebar/README.md
@@ -1,0 +1,34 @@
+# Sidebar
+
+**Category:** Navigation
+**Issue:** #88692 (v1.3 roadmap — navigation components)
+
+A vertical navigation panel with a sliding accent bar on the active link
+and an optional collapsed, icon-only rail variant.
+
+## How to use
+
+```html
+<aside class="ease-sidebar">
+  <div class="ease-sidebar-header">Dashboard</div>
+  <nav class="ease-sidebar-nav">
+    <a href="#" class="ease-sidebar-link ease-sidebar-link--active">
+      <span>📊</span><span class="ease-sidebar-label">Overview</span>
+    </a>
+    <a href="#" class="ease-sidebar-link">
+      <span>📈</span><span class="ease-sidebar-label">Analytics</span>
+    </a>
+  </nav>
+</aside>
+```
+
+Add `ease-sidebar--collapsed` to the outer element to shrink it to an
+icon-only rail (labels fade and width animates down).
+
+## Why it fits EaseMotion CSS
+- Zero dependencies — pure CSS, no JS required for the core component
+- Themeable via CSS custom properties (`--ease-sidebar-accent`, `--ease-sidebar-width`, etc.)
+- Respects `prefers-reduced-motion` and `prefers-color-scheme`
+
+## Browser support
+Chrome, Firefox, Edge, Safari.

--- a/submissions/examples/sidebar/demo.html
+++ b/submissions/examples/sidebar/demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — Sidebar Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #1c1d26; }
+  .layout { display: flex; min-height: 100vh; }
+  .content { flex: 1; padding: 2rem; }
+  button.demo-btn {
+    margin-bottom: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid #d8dae3;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  pre { background: #f6f6f9; border: 1px solid #e4e5ee; border-radius: 8px; padding: 1rem; overflow-x: auto; font-size: 0.8rem; }
+</style>
+</head>
+<body>
+
+  <div class="layout">
+    <aside class="ease-sidebar" id="sidebar">
+      <div class="ease-sidebar-header">Dashboard</div>
+      <nav class="ease-sidebar-nav">
+        <a href="#" class="ease-sidebar-link ease-sidebar-link--active">
+          <span>📊</span><span class="ease-sidebar-label">Overview</span>
+        </a>
+        <a href="#" class="ease-sidebar-link">
+          <span>📈</span><span class="ease-sidebar-label">Analytics</span>
+        </a>
+        <a href="#" class="ease-sidebar-link">
+          <span>⚙️</span><span class="ease-sidebar-label">Settings</span>
+        </a>
+      </nav>
+    </aside>
+
+    <div class="content">
+      <button class="demo-btn" id="collapseBtn">Toggle collapsed rail</button>
+
+      <h2>Usage</h2>
+      <pre><code>&lt;aside class="ease-sidebar"&gt;
+  &lt;div class="ease-sidebar-header"&gt;Dashboard&lt;/div&gt;
+  &lt;nav class="ease-sidebar-nav"&gt;
+    &lt;a href="#" class="ease-sidebar-link ease-sidebar-link--active"&gt;Overview&lt;/a&gt;
+    &lt;a href="#" class="ease-sidebar-link"&gt;Analytics&lt;/a&gt;
+  &lt;/nav&gt;
+&lt;/aside&gt;</code></pre>
+      <p>Add <code>ease-sidebar--collapsed</code> to shrink to an icon-only rail.</p>
+    </div>
+  </div>
+
+<script>
+  // Optional: toggle the collapsed rail variant. Not required for the
+  // component to work — purely for this demo's button.
+  document.getElementById('collapseBtn').addEventListener('click', function () {
+    document.getElementById('sidebar').classList.toggle('ease-sidebar--collapsed');
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/sidebar/style.css
+++ b/submissions/examples/sidebar/style.css
@@ -1,0 +1,117 @@
+/* =========================================================
+   EaseMotion CSS — Sidebar
+   Vertical navigation panel with animated active-link
+   indicator and a collapsible width variant.
+   ========================================================= */
+
+.ease-sidebar {
+  --ease-sidebar-bg: #f7f7fb;
+  --ease-sidebar-border: rgba(0, 0, 0, 0.06);
+  --ease-sidebar-text: #4a4d5e;
+  --ease-sidebar-text-active: #1c1d26;
+  --ease-sidebar-accent: #6c5ce7;
+  --ease-sidebar-width: 240px;
+  --ease-sidebar-width-collapsed: 72px;
+  --ease-sidebar-duration: 260ms;
+  --ease-sidebar-curve: cubic-bezier(0.22, 1, 0.36, 1);
+
+  display: flex;
+  flex-direction: column;
+  width: var(--ease-sidebar-width);
+  min-height: 100%;
+  background: var(--ease-sidebar-bg);
+  border-right: 1px solid var(--ease-sidebar-border);
+  font-family: inherit;
+  transition: width var(--ease-sidebar-duration) var(--ease-sidebar-curve);
+  overflow: hidden;
+}
+
+.ease-sidebar-header {
+  padding: 1.25rem 1.25rem 0.75rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--ease-sidebar-text-active);
+  white-space: nowrap;
+}
+
+.ease-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.ease-sidebar-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  color: var(--ease-sidebar-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background-color var(--ease-sidebar-duration) var(--ease-sidebar-curve),
+    color var(--ease-sidebar-duration) var(--ease-sidebar-curve),
+    padding-left var(--ease-sidebar-duration) var(--ease-sidebar-curve);
+}
+
+.ease-sidebar-link:hover {
+  background: rgba(108, 92, 231, 0.08);
+  color: var(--ease-sidebar-text-active);
+  padding-left: 1rem;
+}
+
+/* Active link — left accent bar slides in */
+.ease-sidebar-link::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%) scaleY(0);
+  width: 3px;
+  height: 60%;
+  border-radius: 0 3px 3px 0;
+  background: var(--ease-sidebar-accent);
+  transition: transform var(--ease-sidebar-duration) var(--ease-sidebar-curve);
+}
+
+.ease-sidebar-link--active {
+  background: rgba(108, 92, 231, 0.1);
+  color: var(--ease-sidebar-text-active);
+}
+
+.ease-sidebar-link--active::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+/* Collapsed variant — icon-only rail */
+.ease-sidebar--collapsed {
+  width: var(--ease-sidebar-width-collapsed);
+}
+
+.ease-sidebar--collapsed .ease-sidebar-header,
+.ease-sidebar--collapsed .ease-sidebar-link span.ease-sidebar-label {
+  opacity: 0;
+  width: 0;
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-sidebar,
+  .ease-sidebar-link,
+  .ease-sidebar-link::before {
+    transition: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-sidebar {
+    --ease-sidebar-bg: #191a23;
+    --ease-sidebar-border: rgba(255, 255, 255, 0.08);
+    --ease-sidebar-text: #b7b8c6;
+    --ease-sidebar-text-active: #f2f2f7;
+  }
+}


### PR DESCRIPTION
Addresses #88692 (v1.3 roadmap — navigation components).

Adds two navigation components under `submissions/examples/`, per the repo's
standard contribution path (no changes to `core/` or `components/`):

- `submissions/examples/navbar/` — sticky glassmorphism navbar with animated
  active-link underline and a CSS-only (checkbox hack) mobile hamburger menu
- `submissions/examples/sidebar/` — vertical nav panel with animated active
  indicator and a collapsible icon-only rail variant

Both are zero-dependency, respect `prefers-reduced-motion` and
`prefers-color-scheme`, and are themeable via CSS custom properties.

Note: issue #88692 was already assigned when I opened this PR — happy to
close/adjust if @divyanshim27 or @vbarik317-droid have work in progress.