### PR TITLE
feat: add switch-with-icon component

### DIFF
--- a/submissions/examples/switch-with-icon/README.md
+++ b/submissions/examples/switch-with-icon/README.md
@@ -1,0 +1,41 @@
+# Switch with Icon
+
+**Category:** Toggle
+**Issue:** #86810
+
+A status switch whose icon swaps from a bell-off to a bell-ring as it
+turns on. The knob slides across the track and the "on" icon plays a
+small ring/wiggle animation the moment it becomes active.
+
+## What it does
+- Built on a real `<input type="checkbox">` for native keyboard support
+  (Space/Enter, Tab) and screen-reader semantics — no JS required.
+- Icon cross-fades and rotates between bell-off and bell-ring states.
+- Track and knob color shift together with the checked state.
+- Respects `prefers-reduced-motion` and `prefers-color-scheme`.
+
+## How to use
+
+```html
+<label class="ease-switch-icon">
+  <input type="checkbox" class="ease-switch-icon-input" />
+  <span class="ease-switch-icon-track">
+    <span class="ease-switch-icon-knob">
+      <svg class="ease-switch-icon-bell-off">...</svg>
+      <svg class="ease-switch-icon-bell-on">...</svg>
+    </span>
+  </span>
+</label>
+<span class="ease-switch-icon-label">Notifications</span>
+```
+
+Add `checked` or `disabled` on the `<input>` for those states.
+
+## Why it fits EaseMotion CSS
+- Zero dependencies, pure CSS state-driven animation (`:checked` sibling selectors)
+- Themeable via CSS custom properties (`--ease-switch-on-bg`, `--ease-switch-icon-color-on`, etc.)
+- Consistent with the framework's animation-first philosophy — spring-like
+  easing on the knob, a short "ring" keyframe when switching on
+
+## Browser support
+Chrome, Firefox, Edge, Safari.

--- a/submissions/examples/switch-with-icon/demo.html
+++ b/submissions/examples/switch-with-icon/demo.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — Switch with Icon Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    max-width: 640px;
+    margin: 4rem auto;
+    padding: 0 1.5rem;
+    color: #1c1d26;
+  }
+  h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+  p.lead { color: #6b6d7c; margin-top: 0; margin-bottom: 2rem; }
+  section { margin-bottom: 2.5rem; }
+  h2 { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.04em; color: #8a8c9c; }
+  pre {
+    background: #f6f6f9;
+    border: 1px solid #e4e5ee;
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+  }
+  .row { display: flex; align-items: center; gap: 1.5rem; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+
+  <h1>Switch with Icon</h1>
+  <p class="lead">A status switch whose icon swaps from a bell-off to a bell-ring as it turns on.</p>
+
+  <section>
+    <h2>Default</h2>
+    <div class="row">
+      <label class="ease-switch-icon">
+        <input type="checkbox" class="ease-switch-icon-input" />
+        <span class="ease-switch-icon-track">
+          <span class="ease-switch-icon-knob">
+            <svg class="ease-switch-icon-bell-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8.7 3A6 6 0 0 1 18 8c0 5 2 6 2 6H8" />
+              <path d="M17.7 17a2 2 0 0 1-3.4 0" />
+              <path d="M1 1l22 22" />
+              <path d="M4 4v4c0 5-2 6-2 6h9.5" />
+            </svg>
+            <svg class="ease-switch-icon-bell-on" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 8a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" />
+              <path d="M10.3 21a2 2 0 0 0 3.4 0" />
+            </svg>
+          </span>
+        </span>
+      </label>
+      <span class="ease-switch-icon-label">Notifications</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>Pre-checked</h2>
+    <div class="row">
+      <label class="ease-switch-icon">
+        <input type="checkbox" class="ease-switch-icon-input" checked />
+        <span class="ease-switch-icon-track">
+          <span class="ease-switch-icon-knob">
+            <svg class="ease-switch-icon-bell-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8.7 3A6 6 0 0 1 18 8c0 5 2 6 2 6H8" />
+              <path d="M17.7 17a2 2 0 0 1-3.4 0" />
+              <path d="M1 1l22 22" />
+              <path d="M4 4v4c0 5-2 6-2 6h9.5" />
+            </svg>
+            <svg class="ease-switch-icon-bell-on" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 8a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" />
+              <path d="M10.3 21a2 2 0 0 0 3.4 0" />
+            </svg>
+          </span>
+        </span>
+      </label>
+      <span class="ease-switch-icon-label">Sound alerts</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>Disabled</h2>
+    <div class="row">
+      <label class="ease-switch-icon">
+        <input type="checkbox" class="ease-switch-icon-input" disabled />
+        <span class="ease-switch-icon-track">
+          <span class="ease-switch-icon-knob">
+            <svg class="ease-switch-icon-bell-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8.7 3A6 6 0 0 1 18 8c0 5 2 6 2 6H8" />
+              <path d="M17.7 17a2 2 0 0 1-3.4 0" />
+              <path d="M1 1l22 22" />
+              <path d="M4 4v4c0 5-2 6-2 6h9.5" />
+            </svg>
+            <svg class="ease-switch-icon-bell-on" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 8a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6" />
+              <path d="M10.3 21a2 2 0 0 0 3.4 0" />
+            </svg>
+          </span>
+        </span>
+      </label>
+      <span class="ease-switch-icon-label">Locked setting</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>Usage</h2>
+    <pre><code>&lt;label class="ease-switch-icon"&gt;
+  &lt;input type="checkbox" class="ease-switch-icon-input" /&gt;
+  &lt;span class="ease-switch-icon-track"&gt;
+    &lt;span class="ease-switch-icon-knob"&gt;
+      &lt;svg class="ease-switch-icon-bell-off"&gt;...&lt;/svg&gt;
+      &lt;svg class="ease-switch-icon-bell-on"&gt;...&lt;/svg&gt;
+    &lt;/span&gt;
+  &lt;/span&gt;
+&lt;/label&gt;</code></pre>
+    <p>No JavaScript required — the icon swap and knob slide are driven entirely by the <code>:checked</code> pseudo-class via the sibling combinator.</p>
+  </section>
+
+</body>
+</html>

--- a/submissions/examples/switch-with-icon/style.css
+++ b/submissions/examples/switch-with-icon/style.css
@@ -1,0 +1,150 @@
+/* =========================================================
+   EaseMotion CSS — Switch with Icon
+   A status switch whose icon swaps from bell-off to
+   bell-ring as it turns on. Built on a real checkbox
+   input for native keyboard/screen-reader support.
+   ========================================================= */
+
+.ease-switch-icon {
+  --ease-switch-width: 56px;
+  --ease-switch-height: 30px;
+  --ease-switch-padding: 3px;
+  --ease-switch-off-bg: #d8dae3;
+  --ease-switch-on-bg: #6c5ce7;
+  --ease-switch-knob: #ffffff;
+  --ease-switch-icon-color: #6b6d7c;
+  --ease-switch-icon-color-on: #6c5ce7;
+  --ease-switch-duration: 320ms;
+  --ease-switch-curve: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ease-switch-icon-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.ease-switch-icon-track {
+  position: relative;
+  width: var(--ease-switch-width);
+  height: var(--ease-switch-height);
+  background: var(--ease-switch-off-bg);
+  border-radius: var(--ease-switch-height);
+  transition: background-color var(--ease-switch-duration) ease;
+}
+
+.ease-switch-icon-knob {
+  position: absolute;
+  top: var(--ease-switch-padding);
+  left: var(--ease-switch-padding);
+  width: calc(var(--ease-switch-height) - (var(--ease-switch-padding) * 2));
+  height: calc(var(--ease-switch-height) - (var(--ease-switch-padding) * 2));
+  background: var(--ease-switch-knob);
+  border-radius: 50%;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--ease-switch-duration) var(--ease-switch-curve);
+}
+
+.ease-switch-icon-knob svg {
+  width: 60%;
+  height: 60%;
+  color: var(--ease-switch-icon-color);
+  transition: color var(--ease-switch-duration) ease;
+}
+
+/* The two icon states, cross-faded and slightly rotated on swap */
+.ease-switch-icon-bell-off,
+.ease-switch-icon-bell-on {
+  position: absolute;
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  transition: opacity var(--ease-switch-duration) var(--ease-switch-curve),
+    transform var(--ease-switch-duration) var(--ease-switch-curve);
+}
+
+.ease-switch-icon-bell-on {
+  opacity: 0;
+  transform: rotate(-45deg) scale(0.6);
+}
+
+/* Checked state */
+.ease-switch-icon-input:checked ~ .ease-switch-icon-track {
+  background: var(--ease-switch-on-bg);
+}
+
+.ease-switch-icon-input:checked ~ .ease-switch-icon-track .ease-switch-icon-knob {
+  transform: translateX(calc(var(--ease-switch-width) - var(--ease-switch-height)));
+}
+
+.ease-switch-icon-input:checked ~ .ease-switch-icon-track .ease-switch-icon-knob svg {
+  color: var(--ease-switch-icon-color-on);
+}
+
+.ease-switch-icon-input:checked ~ .ease-switch-icon-track .ease-switch-icon-bell-off {
+  opacity: 0;
+  transform: rotate(45deg) scale(0.6);
+}
+
+.ease-switch-icon-input:checked ~ .ease-switch-icon-track .ease-switch-icon-bell-on {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  animation: ease-switch-ring 420ms var(--ease-switch-curve);
+}
+
+@keyframes ease-switch-ring {
+  0%, 100% { transform: rotate(0deg) scale(1); }
+  25% { transform: rotate(-12deg) scale(1); }
+  50% { transform: rotate(10deg) scale(1); }
+  75% { transform: rotate(-6deg) scale(1); }
+}
+
+.ease-switch-icon-input:focus-visible ~ .ease-switch-icon-track {
+  outline: 2px solid var(--ease-switch-on-bg);
+  outline-offset: 2px;
+}
+
+.ease-switch-icon-label {
+  margin-left: 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #4a4d5e;
+}
+
+/* Disabled state */
+.ease-switch-icon-input:disabled ~ .ease-switch-icon-track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ease-switch-icon-input:disabled ~ * {
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-switch-icon-track,
+  .ease-switch-icon-knob,
+  .ease-switch-icon-bell-off,
+  .ease-switch-icon-bell-on {
+    transition: none;
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-switch-icon {
+    --ease-switch-off-bg: #33354a;
+    --ease-switch-icon-color: #9698a8;
+  }
+  .ease-switch-icon-label {
+    color: #c8c9d6;
+  }
+}


### PR DESCRIPTION
Closes #86810

Adds the Switch with Icon component under `submissions/examples/switch-with-icon/`:
- `demo.html` — self-contained, dependency-free demo (default, pre-checked, disabled states)
- `style.css` — hand-crafted CSS for the bell-off → bell-ring icon swap and knob slide
- `README.md` — what/how/why

No JavaScript required — driven entirely by `:checked` sibling selectors.
No changes to `core/` or `components/`.