### PR TITLE
feat: add skeleton loading animation

### DIFF
--- a/submissions/examples/skeleton-loaders/README.md
+++ b/submissions/examples/skeleton-loaders/README.md
@@ -1,0 +1,70 @@
+# Skeleton Loaders
+
+**Category:** Loading / Feedback
+**Issue:** #87413
+
+A collection of CSS-only skeleton loading placeholders covering four
+common UI layouts: profile card, article card, list items, and a
+dashboard stat grid. Ships with two animation styles — shimmer (default)
+and pulse.
+
+## What it does
+- 4 ready-made layouts: `.ease-skel-profile`, `.ease-skel-article`,
+  `.ease-skel-list`, `.ease-skel-dashboard`
+- Shimmer animation by default (a moving highlight sweep); add
+  `.ease-skeleton--pulse` to switch to an opacity-pulse animation instead
+- No JavaScript required — animations are pure CSS keyframes
+- Responsive: layouts reflow at narrow widths, dashboard grid uses
+  `auto-fit`/`minmax` so cards wrap naturally
+- Respects `prefers-reduced-motion` and `prefers-color-scheme`
+
+## How to use
+
+Every layout is built from the same base block, `.ease-skel-block`,
+combined with shape helpers:
+
+```html
+<div class="ease-skeleton ease-skel-profile">
+  <div class="ease-skel-block ease-skel-circle"></div>
+  <div class="ease-skel-profile-lines">
+    <div class="ease-skel-block ease-skel-text ease-skel-text--md"></div>
+    <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+  </div>
+</div>
+```
+
+Swap to pulse animation:
+
+```html
+<div class="ease-skeleton ease-skeleton--pulse ease-skel-profile">
+  ...
+</div>
+```
+
+### Customization
+
+All colors, radius, and animation speed are controlled via CSS custom
+properties on `.ease-skeleton`:
+
+```css
+.ease-skeleton {
+  --ease-skel-base: #e8e9f0;       /* base placeholder color */
+  --ease-skel-highlight: #f6f7fb;  /* shimmer sweep color */
+  --ease-skel-radius: 8px;         /* corner radius for blocks */
+  --ease-skel-duration: 1.6s;      /* animation speed */
+}
+```
+
+Building a new layout: compose `.ease-skel-block` (optionally with
+`.ease-skel-circle`) and the text-width helpers
+(`.ease-skel-text--sm/md/lg`) inside your own container — no new CSS
+needed for most cases.
+
+## Why it fits EaseMotion CSS
+- Zero dependencies, pure CSS animation
+- Themeable via CSS custom properties
+- Reusable base block keeps the four included layouts (and any custom
+  ones a developer builds) visually consistent
+
+## Browser support
+Chrome, Firefox, Edge, Safari.

--- a/submissions/examples/skeleton-loaders/demo.html
+++ b/submissions/examples/skeleton-loaders/demo.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>EaseMotion CSS — Skeleton Loaders Demo</title>
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    max-width: 760px;
+    margin: 3rem auto;
+    padding: 0 1.5rem;
+    color: #1c1d26;
+    background: #fafafc;
+  }
+  h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+  p.lead { color: #6b6d7c; margin-top: 0; margin-bottom: 2rem; }
+  section { margin-bottom: 2.5rem; }
+  h2 { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.04em; color: #8a8c9c; }
+  button.demo-btn {
+    margin-bottom: 1.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid #d8dae3;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  pre {
+    background: #f1f1f6;
+    border: 1px solid #e4e5ee;
+    border-radius: 8px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+  }
+</style>
+</head>
+<body>
+
+  <h1>Skeleton Loaders</h1>
+  <p class="lead">CSS-only shimmer/pulse loading placeholders for common UI layouts.</p>
+
+  <button class="demo-btn" id="toggleMode">Switch to pulse animation</button>
+
+  <div id="skeletonWrap">
+
+    <section>
+      <h2>Profile card</h2>
+      <div class="ease-skeleton ease-skel-profile">
+        <div class="ease-skel-block ease-skel-circle"></div>
+        <div class="ease-skel-profile-lines">
+          <div class="ease-skel-block ease-skel-text ease-skel-text--md"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Article card</h2>
+      <div class="ease-skeleton ease-skel-article">
+        <div class="ease-skel-block ease-skel-thumb"></div>
+        <div class="ease-skel-article-body">
+          <div class="ease-skel-block ease-skel-text ease-skel-text--lg"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--md"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>List items</h2>
+      <div class="ease-skeleton ease-skel-list">
+        <div class="ease-skel-list-item">
+          <div class="ease-skel-block ease-skel-circle"></div>
+          <div class="ease-skel-list-lines">
+            <div class="ease-skel-block ease-skel-text ease-skel-text--md"></div>
+            <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+          </div>
+        </div>
+        <div class="ease-skel-list-item">
+          <div class="ease-skel-block ease-skel-circle"></div>
+          <div class="ease-skel-list-lines">
+            <div class="ease-skel-block ease-skel-text ease-skel-text--lg"></div>
+            <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+          </div>
+        </div>
+        <div class="ease-skel-list-item">
+          <div class="ease-skel-block ease-skel-circle"></div>
+          <div class="ease-skel-list-lines">
+            <div class="ease-skel-block ease-skel-text ease-skel-text--md"></div>
+            <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Dashboard stat grid</h2>
+      <div class="ease-skeleton ease-skel-dashboard">
+        <div class="ease-skel-stat-card">
+          <div class="ease-skel-block ease-skel-icon"></div>
+          <div class="ease-skel-block ease-skel-number"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+        </div>
+        <div class="ease-skel-stat-card">
+          <div class="ease-skel-block ease-skel-icon"></div>
+          <div class="ease-skel-block ease-skel-number"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+        </div>
+        <div class="ease-skel-stat-card">
+          <div class="ease-skel-block ease-skel-icon"></div>
+          <div class="ease-skel-block ease-skel-number"></div>
+          <div class="ease-skel-block ease-skel-text ease-skel-text--sm"></div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+  <section>
+    <h2>Usage</h2>
+    <pre><code>&lt;div class="ease-skeleton ease-skel-profile"&gt;
+  &lt;div class="ease-skel-block ease-skel-circle"&gt;&lt;/div&gt;
+  &lt;div class="ease-skel-profile-lines"&gt;
+    &lt;div class="ease-skel-block ease-skel-text ease-skel-text--md"&gt;&lt;/div&gt;
+    &lt;div class="ease-skel-block ease-skel-text ease-skel-text--sm"&gt;&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+  </section>
+
+<script>
+  // Purely a demo convenience — toggles the pulse variant on/off.
+  // Not required for the component itself to work.
+  document.getElementById('toggleMode').addEventListener('click', function () {
+    var wrap = document.getElementById('skeletonWrap');
+    var skeletons = wrap.querySelectorAll('.ease-skeleton');
+    var usingPulse = skeletons[0].classList.contains('ease-skeleton--pulse');
+    skeletons.forEach(function (el) {
+      el.classList.toggle('ease-skeleton--pulse', !usingPulse);
+    });
+    this.textContent = usingPulse ? 'Switch to pulse animation' : 'Switch to shimmer animation';
+  });
+</script>
+
+</body>
+</html>

--- a/submissions/examples/skeleton-loaders/style.css
+++ b/submissions/examples/skeleton-loaders/style.css
@@ -1,0 +1,209 @@
+/* =========================================================
+   EaseMotion CSS — Skeleton Loaders
+   CSS-only shimmer/pulse loading placeholders for common
+   UI layouts: profile card, article card, list item, and
+   dashboard stat grid. No JavaScript required.
+   ========================================================= */
+
+.ease-skeleton {
+  --ease-skel-base: #e8e9f0;
+  --ease-skel-highlight: #f6f7fb;
+  --ease-skel-radius: 8px;
+  --ease-skel-duration: 1.6s;
+}
+
+/* Core shimmer block — the building unit every layout composes from */
+.ease-skel-block {
+  position: relative;
+  overflow: hidden;
+  background: var(--ease-skel-base);
+  border-radius: var(--ease-skel-radius);
+}
+
+.ease-skel-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    var(--ease-skel-highlight) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  animation: ease-skel-shimmer var(--ease-skel-duration) ease-in-out infinite;
+}
+
+@keyframes ease-skel-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Pulse variant — alternative to shimmer, opt in with modifier class */
+.ease-skeleton--pulse .ease-skel-block {
+  animation: ease-skel-pulse var(--ease-skel-duration) ease-in-out infinite;
+}
+.ease-skeleton--pulse .ease-skel-block::after {
+  display: none;
+}
+
+@keyframes ease-skel-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* Common shapes */
+.ease-skel-circle { border-radius: 50%; }
+.ease-skel-text { height: 0.85rem; }
+.ease-skel-text--sm { width: 40%; }
+.ease-skel-text--md { width: 65%; }
+.ease-skel-text--lg { width: 90%; }
+
+/* ---------------------------------------------------------
+   Layout 1: Profile card
+   --------------------------------------------------------- */
+.ease-skel-profile {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #ececf2;
+  max-width: 360px;
+}
+
+.ease-skel-profile .ease-skel-block.ease-skel-circle {
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+
+.ease-skel-profile-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+/* ---------------------------------------------------------
+   Layout 2: Article card
+   --------------------------------------------------------- */
+.ease-skel-article {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid #ececf2;
+  max-width: 320px;
+}
+
+.ease-skel-article .ease-skel-block.ease-skel-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 0;
+}
+
+.ease-skel-article-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+/* ---------------------------------------------------------
+   Layout 3: List item
+   --------------------------------------------------------- */
+.ease-skel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 400px;
+}
+
+.ease-skel-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #ececf2;
+}
+
+.ease-skel-list-item .ease-skel-block.ease-skel-circle {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.ease-skel-list-lines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+/* ---------------------------------------------------------
+   Layout 4: Dashboard stat grid
+   --------------------------------------------------------- */
+.ease-skel-dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.ease-skel-stat-card {
+  padding: 1rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #ececf2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ease-skel-stat-card .ease-skel-block.ease-skel-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+}
+
+.ease-skel-stat-card .ease-skel-block.ease-skel-number {
+  height: 1.4rem;
+  width: 60%;
+}
+
+/* Responsive tweaks */
+@media (max-width: 480px) {
+  .ease-skel-profile,
+  .ease-skel-article,
+  .ease-skel-list {
+    max-width: 100%;
+  }
+  .ease-skel-dashboard {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-skel-block::after,
+  .ease-skeleton--pulse .ease-skel-block {
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .ease-skeleton {
+    --ease-skel-base: #2a2c3a;
+    --ease-skel-highlight: #383b4d;
+  }
+  .ease-skel-profile,
+  .ease-skel-article,
+  .ease-skel-list-item,
+  .ease-skel-stat-card {
+    background: #1e1f29;
+    border-color: #33354a;
+  }
+}


### PR DESCRIPTION
Closes #87413

Adds CSS-only skeleton loaders under `submissions/examples/skeleton-loaders/`.

Acceptance criteria:
- [x] At least 4 layouts: profile card, article card, list items, dashboard stat grid
- [x] Shimmer animation by default; `.ease-skeleton--pulse` modifier for pulse variant
- [x] No JavaScript required
- [x] Responsive (layouts reflow at narrow widths, dashboard grid uses auto-fit)
- [x] README includes usage and customization instructions (CSS custom properties)

No changes to `core/` or `components/`.