### PR TITLE
feat: add CSS animation adaptive command palette example

### DIFF
--- a/submissions/examples/adaptive-command-palette-drp/README.md
+++ b/submissions/examples/adaptive-command-palette-drp/README.md
@@ -1,0 +1,10 @@
+# Adaptive Command Palette
+
+A CSS-only command palette mockup with a glowing input trace, grouped actions, and a highlighted suggestion rail.
+
+## Features
+
+- Glowing input trace
+- Grouped action cards
+- Active suggestion rail
+- Reduced-motion friendly

--- a/submissions/examples/adaptive-command-palette-drp/demo.html
+++ b/submissions/examples/adaptive-command-palette-drp/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Adaptive Command Palette</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="shell" aria-labelledby="title">
+    <section class="card">
+      <p class="eyebrow">command</p>
+      <h1 id="title">Adaptive Command Palette</h1>
+      <p class="summary">A CSS-only command palette mockup with a glowing input trace, grouped actions, and a highlighted suggestion rail.</p>
+      <div class="stage" role="img" aria-label="Animated Adaptive Command Palette">
+        <div class="palette">
+          <div class="searchbar">
+            <span class="cursor"></span>
+            <span class="placeholder">Type a command...</span>
+          </div>
+          <div class="groups">
+            <article class="group active">
+              <h2>Navigation</h2>
+              <p>Jump to dashboard</p>
+              <p>Open docs</p>
+            </article>
+            <article class="group">
+              <h2>Actions</h2>
+              <p>Create note</p>
+              <p>Share summary</p>
+            </article>
+            <article class="group">
+              <h2>Recent</h2>
+              <p>Deploy preview</p>
+              <p>Review alerts</p>
+            </article>
+          </div>
+          <div class="rail"></div>
+        </div>
+        <article class="tile"><strong>01</strong><span>Glowing input trace</span></article>
+        <article class="tile"><strong>02</strong><span>Grouped action cards</span></article>
+        <article class="tile"><strong>03</strong><span>Active suggestion rail</span></article>
+        <article class="tile"><strong>04</strong><span>Reduced-motion friendly</span></article>
+      </div>
+      <div class="tags" aria-label="Adaptive Command Palette features">
+        <span>Glowing input trace</span>
+        <span>Grouped action cards</span>
+        <span>Active suggestion rail</span>
+        <span>Reduced-motion friendly</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/submissions/examples/adaptive-command-palette-drp/style.css
+++ b/submissions/examples/adaptive-command-palette-drp/style.css
@@ -1,0 +1,141 @@
+:root {
+  color-scheme: dark;
+  --text: #eff5ff;
+  --muted: #99abc7;
+  --line: rgba(166, 191, 255, 0.16);
+  --accent: #7ee1c2;
+  --accent-2: #8fa6ff;
+  --accent-3: #ffd36f;
+}
+* { box-sizing: border-box; }
+html, body { min-height: 100%; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(143, 166, 255, 0.14), transparent 24%),
+    radial-gradient(circle at 82% 18%, rgba(126, 225, 194, 0.14), transparent 22%),
+    linear-gradient(180deg, #07101c 0%, #0b1322 100%);
+  color: var(--text);
+}
+.shell { min-height: 100vh; display: grid; place-items: center; padding: 24px; }
+.card {
+  width: min(960px, 100%);
+  padding: clamp(20px, 3vw, 32px);
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: rgba(17, 26, 44, 0.96);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+}
+.eyebrow { margin: 0 0 10px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.72rem; }
+h1 { margin: 0; font-size: clamp(2rem, 4vw, 3.2rem); line-height: 1.05; }
+.summary { margin: 12px 0 22px; max-width: 62ch; color: var(--muted); line-height: 1.6; }
+.stage {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(8, 14, 24, 0.84);
+}
+.palette {
+  grid-column: 1 / -1;
+  position: relative;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(166, 191, 255, 0.12);
+  background: rgba(12, 19, 31, 0.9);
+  overflow: hidden;
+}
+.searchbar {
+  position: relative;
+  height: 56px;
+  border-radius: 14px;
+  border: 1px solid rgba(126, 225, 194, 0.26);
+  background: rgba(255,255,255,0.03);
+  display: flex;
+  align-items: center;
+  padding: 0 18px 0 22px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02);
+}
+.placeholder { color: var(--muted); letter-spacing: 0.01em; }
+.cursor {
+  width: 3px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 18px rgba(126, 225, 194, 0.5);
+  margin-right: 12px;
+  animation: blink 1.2s steps(2, end) infinite;
+}
+.groups {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+.group {
+  min-height: 112px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(166, 191, 255, 0.12);
+  background: rgba(255,255,255,0.02);
+}
+.group h2 {
+  margin: 0 0 10px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent-2);
+}
+.group p {
+  margin: 0;
+  padding: 8px 0;
+  color: var(--text);
+  border-top: 1px solid rgba(255,255,255,0.04);
+}
+.group.active {
+  border-color: rgba(126, 225, 194, 0.28);
+  box-shadow: 0 0 0 1px rgba(126, 225, 194, 0.06), 0 0 24px rgba(126, 225, 194, 0.08);
+}
+.rail {
+  position: absolute;
+  right: 18px;
+  top: 18px;
+  width: 8px;
+  height: calc(100% - 36px);
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+}
+.rail::before {
+  content: "";
+  position: absolute;
+  inset: 20% 0 auto 0;
+  height: 28%;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(126,225,194,0.15), var(--accent), rgba(143,166,255,0.72));
+  animation: glide 4s ease-in-out infinite;
+}
+.tile {
+  min-height: 92px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(166, 191, 255, 0.16);
+  background: rgba(12, 19, 31, 0.88);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.tile strong { color: var(--accent); }
+.tile span, .tags span { color: var(--text); font-size: 0.95rem; }
+.tags { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+.tags span { padding: 10px 12px; border-radius: 999px; border: 1px solid var(--line); background: rgba(255,255,255,0.03); color: var(--muted); }
+@keyframes blink { 0%, 45% { opacity: 1; } 50%, 100% { opacity: 0.15; } }
+@keyframes glide { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(180%); } }
+@media (max-width: 760px) {
+  .groups { grid-template-columns: 1fr; }
+  .stage { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Add a CSS-only command palette example with a glowing input trace, grouped actions, and a highlighted suggestion rail.

Features:
- Glowing input trace
- Grouped action cards
- Active suggestion rail
- Reduced-motion friendly