### PR TITLE
test: add toast queue manager auto-dismiss edge case

### DIFF
--- a/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
+++ b/submissions/examples/toast-queue-manager-auto-dismiss-timer-sb/toast-queue-manager.test.js
@@ -66,6 +66,7 @@ describe('ToastQueueManager — auto-dismiss timer', () => {
     expect(t.size()).toBe(1);
     vi.advanceTimersByTime(1);
     expect(t.size()).toBe(0);
+    expect(region.querySelectorAll('.ease-toast')).toHaveLength(0);
   });
 
   it('renders an optional title and applies the type modifier class', () => {


### PR DESCRIPTION
## Summary

- Add an edge-case assertion for Toast Queue Manager auto-dismiss behavior.
- Verify that the toast is removed from the DOM when the configured duration expires.
- Keep the existing queue-size assertion and add DOM-level coverage.

## Testing

- Submission test: 17 tests passed.
- Full project test suite: 67 tests passed.

Closes #86326