### PR TITLE
fix(docs): update demo animation count and make counter dynamic

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -559,7 +559,7 @@
             <div class="ease-stat-label">Utilities</div>
           </div>
           <div class="ease-card ease-card-stat ease-card-hover" style="padding: 10px;">
-            <div class="ease-stat-value">12</div>
+            <div class="ease-stat-value" id="stats-animation-count">26+</div>
             <div class="ease-stat-label">Animations</div>
           </div>
           <div class="ease-card ease-card-stat ease-card-hover" style="padding: 10px;">
@@ -804,8 +804,15 @@
       el.classList.add(cls);
     }
 
-    // ScrollSpy Logic
+    // ScrollSpy & Dynamic Stats Logic
     document.addEventListener("DOMContentLoaded", () => {
+      // Dynamically calculate and update animation count from Motion Library
+      const animStatEl = document.getElementById("stats-animation-count");
+      const animCells = document.querySelectorAll("#animations .anim-cell");
+      if (animStatEl && animCells.length > 0) {
+        animStatEl.textContent = `${animCells.length}+`;
+      }
+
       const sections = document.querySelectorAll("section.demo-section");
       const navLinks = document.querySelectorAll(".demo-nav-links a[href^='#']");
 

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -911,7 +911,7 @@
             <div class="ease-stat-label">Utilities</div>
           </div>
           <div class="ease-card ease-card-stat ease-card-hover">
-            <div class="ease-stat-value">12</div>
+            <div class="ease-stat-value" id="stats-animation-count">26+</div>
             <div class="ease-stat-label">Animations</div>
           </div>
           <div class="ease-card ease-card-stat ease-card-hover">
@@ -1044,14 +1044,6 @@
           <div class="anim-cell">
             <div class="anim-box ease-slide-up" id="anim-slide" onclick="replay(this,'ease-slide-up')">↑</div>
             <span class="tag">ease-slide-up</span>
-          </div>
-          <div class="anim-cell">
-            <div class="anim-box ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
-            <span class="tag">ease-slide-in-left</span>
-          </div>
-          <div class="anim-cell">
-            <div class="anim-box ease-slide-in-right" onclick="replay(this,'ease-slide-in-right')">→</div>
-            <span class="tag">ease-slide-in-right</span>
           </div>
           <div class="anim-cell">
             <div class="anim-box ease-slide-in-left" onclick="replay(this,'ease-slide-in-left')">←</div>
@@ -1329,6 +1321,15 @@
         bar.classList.add('ease-scroll-progress-' + theme);
       }
     }
+
+    // ── Dynamic Animation Count Logic ────────────────────────
+    document.addEventListener("DOMContentLoaded", () => {
+      const animStatEl = document.getElementById("stats-animation-count");
+      const animCells = document.querySelectorAll("#animations .anim-cell");
+      if (animStatEl && animCells.length > 0) {
+        animStatEl.textContent = `${animCells.length}+`;
+      }
+    });
   </script>
 
 </body>


### PR DESCRIPTION
## Bug Description
The EaseMotion CSS demo page previously displayed a hardcoded **"12 Animations"** in the statistics section, but the Motion Library section contains more than 12 animation classes (currently 26 classes across entrance, looping, hover, off-canvas, and exit animations).

## Changes Made
- **Accurate Count:** Updated the static stat card display from `12` to `26+` in both `docs/demo.html` and `examples/demo.html`.
- **Dynamic Calculation:** Added `id="stats-animation-count"` and a JavaScript routine on `DOMContentLoaded` that automatically counts `.anim-cell` elements inside `#animations`. This ensures the animation count remains accurate when future animation classes are added to the Motion Library.
- **Cleanup:** Removed duplicate entrance animation demo boxes (`ease-slide-in-left` and `ease-slide-in-right`) in `examples/demo.html`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation / Demo improvement

## Checklist
- [x] Tested both `docs/demo.html` and `examples/demo.html` locally
- [x] Animation count accurately reflects the Motion Library
- [x] Existing layouts, navigation, and theme switches remain intact