### PR TITLE
feat: add floating action button

### DIFF
--- a/submissions/examples/floating-action-button-msm/README.md
+++ b/submissions/examples/floating-action-button-msm/README.md
@@ -1,0 +1,21 @@
+# Floating Action Button
+
+## What does this do?
+
+This submission adds a pure HTML and CSS floating action button that expands into four labeled actions with staggered reveals.
+
+## How is it used?
+
+Add the checkbox toggle, action links, and trigger label to your page, then include the local stylesheet.
+
+```html
+<input class="fab-toggle" type="checkbox" id="fab-toggle-msm" />
+<div class="fab-actions">
+  <a class="fab-action" href="#note"><span>Note</span><strong>+</strong></a>
+</div>
+<label class="fab-button" for="fab-toggle-msm">+</label>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a compact action menu pattern with CSS-only interaction, staggered motion, visible focus states, responsive placement, dark-mode support, and reduced-motion safety without JavaScript.

--- a/submissions/examples/floating-action-button-msm/demo.html
+++ b/submissions/examples/floating-action-button-msm/demo.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Floating Action Button</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="fab-stage">
+      <section class="demo-card" aria-labelledby="demo-title">
+        <p class="eyebrow">Pure CSS Menu</p>
+        <h1 id="demo-title">Floating action button with staggered actions</h1>
+        <p>
+          A dependency-free FAB that expands into four labeled shortcuts using
+          only HTML inputs, labels, and handcrafted CSS transitions.
+        </p>
+
+        <div class="mock-dashboard" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+
+        <div class="fab-widget">
+          <input
+            class="fab-toggle"
+            type="checkbox"
+            id="fab-toggle-msm"
+            aria-label="Toggle floating action menu"
+          />
+
+          <div class="fab-actions" aria-label="Floating action shortcuts">
+            <a class="fab-action action-note" href="#note">
+              <span>Note</span>
+              <strong>+</strong>
+            </a>
+            <a class="fab-action action-task" href="#task">
+              <span>Task</span>
+              <strong>&#10003;</strong>
+            </a>
+            <a class="fab-action action-chat" href="#chat">
+              <span>Chat</span>
+              <strong>&#9993;</strong>
+            </a>
+            <a class="fab-action action-upload" href="#upload">
+              <span>Upload</span>
+              <strong>&#8593;</strong>
+            </a>
+          </div>
+
+          <label class="fab-button" for="fab-toggle-msm">
+            <span class="sr-only">Open floating action menu</span>
+            <span class="fab-plus">+</span>
+          </label>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/floating-action-button-msm/style.css
+++ b/submissions/examples/floating-action-button-msm/style.css
@@ -1,0 +1,323 @@
+:root {
+  --fab-ink: #172033;
+  --fab-muted: #62708a;
+  --fab-surface: #f7fbff;
+  --fab-card: rgba(255, 255, 255, 0.9);
+  --fab-pink: #ff5c8a;
+  --fab-orange: #ff9f43;
+  --fab-blue: #4263eb;
+  --fab-cyan: #19c7d4;
+  --fab-shadow: 0 30px 90px rgba(23, 32, 51, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--fab-ink);
+  font-family: "Trebuchet MS", "Gill Sans", sans-serif;
+  background:
+    radial-gradient(
+      circle at 16% 18%,
+      rgba(255, 92, 138, 0.24),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 82% 16%,
+      rgba(25, 199, 212, 0.26),
+      transparent 30%
+    ),
+    linear-gradient(135deg, #f7fbff 0%, #eef4ff 48%, #fff7fb 100%);
+}
+
+.fab-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.demo-card {
+  position: relative;
+  width: min(100%, 940px);
+  min-height: 620px;
+  overflow: hidden;
+  padding: clamp(2rem, 6vw, 5rem);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 36px;
+  background:
+    linear-gradient(145deg, var(--fab-card), rgba(243, 247, 255, 0.72)),
+    repeating-linear-gradient(
+      135deg,
+      rgba(66, 99, 235, 0.06) 0 1px,
+      transparent 1px 18px
+    );
+  box-shadow: var(--fab-shadow);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--fab-blue);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1,
+p {
+  max-width: 680px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.7rem, 8vw, 5.6rem);
+  line-height: 0.96;
+}
+
+p {
+  color: var(--fab-muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.mock-dashboard {
+  display: grid;
+  width: min(100%, 520px);
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.mock-dashboard span {
+  display: block;
+  height: 4.4rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow:
+    0 16px 38px rgba(66, 99, 235, 0.1),
+    inset 0 0 0 1px rgba(66, 99, 235, 0.08);
+}
+
+.mock-dashboard span:nth-child(2) {
+  width: 82%;
+}
+
+.mock-dashboard span:nth-child(3) {
+  width: 64%;
+}
+
+.fab-widget {
+  position: absolute;
+  right: clamp(1.5rem, 5vw, 3rem);
+  bottom: clamp(1.5rem, 5vw, 3rem);
+  z-index: 4;
+}
+
+.fab-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.fab-button {
+  position: relative;
+  z-index: 5;
+  display: grid;
+  width: 4.4rem;
+  height: 4.4rem;
+  cursor: pointer;
+  border-radius: 50%;
+  color: #ffffff;
+  background:
+    radial-gradient(
+      circle at 30% 25%,
+      rgba(255, 255, 255, 0.45),
+      transparent 28%
+    ),
+    linear-gradient(135deg, var(--fab-pink), var(--fab-blue));
+  box-shadow: 0 20px 42px rgba(66, 99, 235, 0.35);
+  place-items: center;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.fab-button:hover,
+.fab-button:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 54px rgba(66, 99, 235, 0.42);
+  outline: 3px solid rgba(255, 92, 138, 0.38);
+  outline-offset: 5px;
+}
+
+.fab-plus {
+  font-size: 2.6rem;
+  font-weight: 500;
+  line-height: 1;
+  transition: transform 260ms ease;
+}
+
+.fab-toggle:checked ~ .fab-button .fab-plus {
+  transform: rotate(135deg);
+}
+
+.fab-actions {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 5rem;
+  display: grid;
+  gap: 0.85rem;
+  pointer-events: none;
+}
+
+.fab-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: max-content;
+  min-width: 9.2rem;
+  justify-content: flex-end;
+  color: var(--fab-ink);
+  font-weight: 800;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(18px) scale(0.82);
+  transition:
+    opacity 220ms ease,
+    transform 220ms ease;
+}
+
+.fab-action span {
+  padding: 0.7rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 12px 28px rgba(23, 32, 51, 0.14);
+}
+
+.fab-action strong {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  color: #ffffff;
+  font-size: 1.3rem;
+  line-height: 1;
+  place-items: center;
+  box-shadow: 0 14px 30px rgba(23, 32, 51, 0.22);
+}
+
+.action-note strong {
+  background: linear-gradient(135deg, var(--fab-pink), #ff7aa8);
+}
+
+.action-task strong {
+  background: linear-gradient(135deg, #16a34a, #86efac);
+}
+
+.action-chat strong {
+  background: linear-gradient(135deg, var(--fab-blue), #7c9cff);
+}
+
+.action-upload strong {
+  background: linear-gradient(135deg, var(--fab-orange), #ffd166);
+}
+
+.fab-toggle:checked ~ .fab-actions {
+  pointer-events: auto;
+}
+
+.fab-toggle:checked ~ .fab-actions .fab-action {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.fab-toggle:checked ~ .fab-actions .action-upload {
+  transition-delay: 60ms;
+}
+
+.fab-toggle:checked ~ .fab-actions .action-chat {
+  transition-delay: 120ms;
+}
+
+.fab-toggle:checked ~ .fab-actions .action-task {
+  transition-delay: 180ms;
+}
+
+.fab-toggle:checked ~ .fab-actions .action-note {
+  transition-delay: 240ms;
+}
+
+.fab-action:hover,
+.fab-action:focus-visible {
+  transform: translateX(-6px) scale(1.02) !important;
+  outline: 3px solid rgba(66, 99, 235, 0.3);
+  outline-offset: 4px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fab-ink: #eef4ff;
+    --fab-muted: #afbdd7;
+    --fab-card: rgba(20, 28, 47, 0.9);
+  }
+
+  body {
+    background:
+      radial-gradient(
+        circle at 16% 18%,
+        rgba(255, 92, 138, 0.18),
+        transparent 32%
+      ),
+      linear-gradient(135deg, #111827 0%, #18223a 54%, #2d1530 100%);
+  }
+
+  .mock-dashboard span,
+  .fab-action span {
+    background: rgba(20, 28, 47, 0.82);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .fab-stage {
+    padding: 1rem;
+  }
+
+  .demo-card {
+    min-height: 680px;
+    padding: 2rem;
+    border-radius: 28px;
+  }
+
+  .fab-widget {
+    right: 1.2rem;
+    bottom: 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a pure HTML/CSS Floating Action Button submission under `submissions/examples/floating-action-button-msm/`
- Uses checkbox-driven expansion into four labeled actions with staggered reveals
- Includes accessible labels, visible focus states, responsive placement, dark-mode support, and reduced-motion handling

Closes #86831

## Changes made
- Added `demo.html` with a dependency-free FAB demo
- Added `style.css` for the expandable FAB styling and staggered action transitions
- Added `README.md` with usage instructions and EaseMotion rationale

## Testing
- `npx.cmd prettier --write submissions/examples/floating-action-button-msm/**/*.{html,css,md}`
- `npx.cmd prettier --check submissions/examples/floating-action-button-msm/**/*.{html,css,md}`
- `npx.cmd stylelint submissions/examples/floating-action-button-msm/style.css --ignore-path .stylelintignore-does-not-exist`
- `git diff --check`
- `git diff --cached --check`

## Edge cases handled
- Keyboard-visible focus states for trigger and actions
- `prefers-reduced-motion` support for users who reduce animation
- Responsive mobile placement
- Dark-mode compatible design tokens

## Checklist
- [x] Only files inside `submissions/examples/floating-action-button-msm/` were added
- [x] Includes exactly `demo.html`, `style.css`, and `README.md`
- [x] No framework/core files were modified
- [x] Local formatting and lint checks passed