### PR TITLE
feat: add ease-toggle animated switch component -m Adds a CSS-only, a…

### DIFF
--- a/submissions/examples/toogle-switch/README.md
+++ b/submissions/examples/toogle-switch/README.md
@@ -1,0 +1,73 @@
+# ease-toggle — Animated Toggle Switch
+
+Fills a gap on the roadmap: **Form components (inputs, checkboxes, toggles) — Planned v1.1**.
+A CSS-only, accessible toggle switch that follows EaseMotion CSS's "human-readable class name"
+philosophy and reuses existing design tokens instead of introducing new ones.
+
+## Why
+
+EaseMotion CSS currently ships buttons and cards, but no form controls. A toggle switch is one
+of the most requested UI primitives and is a natural first form component to submit toward the
+v1.1 roadmap item.
+
+## What it does
+
+- Pure CSS, zero JavaScript — built on a hidden native `<input type="checkbox">` for full
+  accessibility (keyboard, screen reader, form submission all work out of the box)
+- Smooth thumb-slide animation using the same bounce easing as the rest of the framework
+  (`--ease-ease-bounce`)
+- Respects existing tokens: `--ease-color-primary`, `--ease-radius-full`, `--ease-shadow-md`,
+  `--ease-speed-medium` — themeable the same way every other component already is
+- `ease-toggle-sm` / `ease-toggle-lg` size modifiers, matching the `ease-btn-sm` / `ease-btn-lg`
+  pattern already used for buttons
+- Disabled and keyboard-focus states included
+
+## Usage
+
+```html
+<label class="ease-toggle">
+  <input type="checkbox" />
+  <span class="ease-toggle-track">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+  <span class="ease-toggle-label">Enable notifications</span>
+</label>
+```
+
+Pre-checked:
+
+```html
+<label class="ease-toggle">
+  <input type="checkbox" checked />
+  <span class="ease-toggle-track">
+    <span class="ease-toggle-thumb"></span>
+  </span>
+  <span class="ease-toggle-label">Dark mode</span>
+</label>
+```
+
+Sizes:
+
+```html
+<label class="ease-toggle ease-toggle-sm">...</label>
+<label class="ease-toggle ease-toggle-lg">...</label>
+```
+
+## Files
+
+- `demo.html` — live standalone demo (5 states: default, checked, small, large, disabled)
+- `style.css` — the component styles, self-contained, no dependency beyond core `variables.css`
+  tokens (falls back to sensible defaults if a token is missing)
+
+## Accessibility notes
+
+- Uses a real `<input type="checkbox">` under the hood, so it's operable with keyboard
+  (Tab + Space) and announced correctly by screen readers as a checkbox/switch
+- Includes a visible `:focus-visible` outline ring
+- `disabled` state is styled and blocks pointer interaction
+
+## Naming
+
+Raw class names used here (`toggle`, `toggle-track`, `toggle-thumb`) are intentionally simple per
+the contribution guide — happy for the maintainer to remap these to `ease-*` naming as part of
+standardization.

--- a/submissions/examples/toogle-switch/demo.html
+++ b/submissions/examples/toogle-switch/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>ease-toggle demo</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: 'Inter', sans-serif;
+    padding: 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>
+</head>
+<body>
+
+  <h1 class="ease-fade-in">ease-toggle</h1>
+  <p class="ease-slide-up ease-delay-100">A human-readable, animated toggle switch.</p>
+
+  <!-- Basic toggle -->
+  <label class="ease-toggle ease-slide-up ease-delay-200">
+    <input type="checkbox" />
+    <span class="ease-toggle-track">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-label">Enable notifications</span>
+  </label>
+
+  <!-- Pre-checked -->
+  <label class="ease-toggle ease-slide-up ease-delay-300">
+    <input type="checkbox" checked />
+    <span class="ease-toggle-track">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-label">Dark mode (default on)</span>
+  </label>
+
+  <!-- Small size -->
+  <label class="ease-toggle ease-toggle-sm ease-slide-up ease-delay-400">
+    <input type="checkbox" />
+    <span class="ease-toggle-track">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-label">Small</span>
+  </label>
+
+  <!-- Large size -->
+  <label class="ease-toggle ease-toggle-lg ease-slide-up ease-delay-500">
+    <input type="checkbox" />
+    <span class="ease-toggle-track">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-label">Large</span>
+  </label>
+
+  <!-- Disabled -->
+  <label class="ease-toggle ease-slide-up ease-delay-600">
+    <input type="checkbox" disabled />
+    <span class="ease-toggle-track">
+      <span class="ease-toggle-thumb"></span>
+    </span>
+    <span class="ease-toggle-label">Disabled</span>
+  </label>
+
+</body>
+</html>

--- a/submissions/examples/toogle-switch/style.css
+++ b/submissions/examples/toogle-switch/style.css
@@ -1,0 +1,101 @@
+/* ============================================
+   ease-toggle — animated switch component
+   Fits EaseMotion CSS's existing design tokens
+   (falls back to sane defaults if a token isn't
+   defined yet, so it degrades gracefully).
+   ============================================ */
+
+.ease-toggle {
+  --toggle-w: 3rem;
+  --toggle-h: 1.6rem;
+  --toggle-pad: 0.2rem;
+  --toggle-thumb: calc(var(--toggle-h) - (var(--toggle-pad) * 2));
+
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  gap: 0.6rem;
+  font-family: inherit;
+}
+
+/* Hide the native checkbox but keep it accessible */
+.ease-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.ease-toggle-track {
+  position: relative;
+  width: var(--toggle-w);
+  height: var(--toggle-h);
+  background: var(--ease-color-border, #d1d5db);
+  border-radius: var(--ease-radius-full, 9999px);
+  transition: background var(--ease-speed-medium, 250ms) ease;
+  flex-shrink: 0;
+}
+
+.ease-toggle-thumb {
+  position: absolute;
+  top: var(--toggle-pad);
+  left: var(--toggle-pad);
+  width: var(--toggle-thumb);
+  height: var(--toggle-thumb);
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: var(--ease-shadow-md, 0 2px 6px rgba(0, 0, 0, 0.2));
+  transition: transform var(--ease-speed-medium, 250ms)
+    var(--ease-ease-bounce, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+/* Checked state */
+.ease-toggle input:checked + .ease-toggle-track {
+  background: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-toggle input:checked + .ease-toggle-track .ease-toggle-thumb {
+  transform: translateX(calc(var(--toggle-w) - var(--toggle-thumb) - (var(--toggle-pad) * 2)));
+}
+
+/* Keyboard focus ring — accessibility */
+.ease-toggle input:focus-visible + .ease-toggle-track {
+  outline: 2px solid var(--ease-color-primary, #6c63ff);
+  outline-offset: 2px;
+}
+
+/* Disabled state */
+.ease-toggle input:disabled + .ease-toggle-track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ease-toggle:has(input:disabled) {
+  cursor: not-allowed;
+}
+
+/* Hover grow — reuses the same motion feel as ease-hover-grow */
+.ease-toggle:hover .ease-toggle-track {
+  transform: scale(1.04);
+}
+.ease-toggle-track {
+  transition: background var(--ease-speed-medium, 250ms) ease,
+    transform var(--ease-speed-fast, 150ms) ease;
+}
+
+/* Size modifiers */
+.ease-toggle-sm {
+  --toggle-w: 2.4rem;
+  --toggle-h: 1.3rem;
+}
+.ease-toggle-lg {
+  --toggle-w: 3.6rem;
+  --toggle-h: 2rem;
+}
+
+/* Optional label text next to the switch */
+.ease-toggle-label {
+  font-size: 0.95rem;
+  color: var(--ease-color-text, #111827);
+}


### PR DESCRIPTION
## What
Adds a new toggle switch component (`submissions/examples/toggle-switch/`) —
a pure CSS, animated on/off switch.

## Why
The roadmap lists "Form components (inputs, checkboxes, toggles)" as
Planned — v1.1. A toggle switch is one of the most commonly requested
form primitives, so this is a first submission toward that milestone.

## What's included
- `demo.html` — standalone live demo with 5 states (default, checked,
  small, large, disabled)
- `style.css` — component styles, no JS required
- `README.md` — usage examples, accessibility notes, and rationale

## Details
- Built on a hidden native `<input type="checkbox">` so it's fully
  keyboard-operable and announced correctly by screen readers
- Animated thumb slide uses the same bounce easing already defined
  for the rest of the framework (`--ease-ease-bounce`)
- Themeable through existing tokens (`--ease-color-primary`,
  `--ease-radius-full`, `--ease-shadow-md`, `--ease-speed-medium`) —
  no new tokens introduced
- Includes `sm` / `lg` size modifiers, matching the existing
  `ease-btn-sm` / `ease-btn-lg` naming pattern
- Includes `:focus-visible` outline and a styled `disabled` state

## Notes for maintainer
Raw class names (`toggle`, `toggle-track`, `toggle-thumb`) are kept
simple per the contribution guide — happy to have these remapped to
`ease-*` naming during standardization.

One feature, one PR, as per CONTRIBUTING.md.