### PR TITLE
feat: add ease-tooltip CSS-only component

### DIFF
--- a/submissions/examples/ease-tooltip/README.md
+++ b/submissions/examples/ease-tooltip/README.md
@@ -1,0 +1,71 @@
+# ease-tooltip — CSS-only Animated Tooltip
+
+Targets the roadmap item **"Modal & tooltip components" — Planned v1.2**.
+A pure CSS tooltip with a fade + slide entrance, built entirely with existing
+design tokens — no JavaScript, no new dependencies.
+
+## Why
+
+Tooltips are one of the most common UI needs and a natural fit for
+EaseMotion's animation-first philosophy — the reveal itself is the whole
+point of the component.
+
+## What it does
+
+- Pure CSS — shows on `:hover` and `:focus-within`, so it works with mouse
+  **and** keyboard navigation (Tab) without any JS
+- Fade + slide-in entrance using existing speed tokens
+  (`--ease-speed-fast`)
+- 4 placement modifiers: top (default), bottom, left, right
+- 2 color variants: `ease-tooltip-primary`, `ease-tooltip-success`
+  (reuses `--ease-color-primary` / `--ease-color-success`)
+- Small triangle arrow pointing at the trigger element, auto-flips per
+  placement
+- No layout shift — the bubble is `position: absolute` and doesn't affect
+  surrounding content
+
+## Usage
+
+```html
+<span class="ease-tooltip">
+  <button class="ease-btn ease-btn-outline">Hover me</button>
+  <span class="ease-tooltip-bubble">Helpful text here</span>
+</span>
+```
+
+Placement:
+
+```html
+<span class="ease-tooltip ease-tooltip-bottom">...</span>
+<span class="ease-tooltip ease-tooltip-left">...</span>
+<span class="ease-tooltip ease-tooltip-right">...</span>
+```
+
+Color variant:
+
+```html
+<span class="ease-tooltip ease-tooltip-primary">...</span>
+<span class="ease-tooltip ease-tooltip-success">...</span>
+```
+
+## Files
+
+- `demo.html` — live standalone demo covering all 4 placements, both color
+  variants, and a keyboard-focus example
+- `style.css` — self-contained component styles, falls back to sensible
+  defaults if a design token isn't present
+
+## Accessibility notes
+
+- Triggers on `:focus-within`, not just `:hover`, so keyboard users see the
+  tooltip when tabbing to the trigger element
+- `visibility` is toggled alongside `opacity` so the bubble isn't in the tab
+  order or screen-reader flow while hidden
+- No `pointer-events` trap — the bubble itself is non-interactive by design
+  (`pointer-events: none`), consistent with standard tooltip behavior
+
+## Naming
+
+Raw class names (`tooltip`, `tooltip-bubble`) kept simple per the
+contribution guide — happy for the maintainer to remap to final `ease-*`
+naming during standardization.

--- a/submissions/examples/ease-tooltip/demo.html
+++ b/submissions/examples/ease-tooltip/demo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>ease-tooltip demo</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: 'Inter', sans-serif;
+    padding: 5rem 3rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3rem;
+    align-items: center;
+  }
+</style>
+</head>
+<body>
+
+  <h1 class="ease-fade-in" style="width:100%;">ease-tooltip</h1>
+
+  <!-- Top (default) -->
+  <span class="ease-tooltip ease-slide-up ease-delay-100">
+    <button class="ease-btn ease-btn-outline">Hover me (top)</button>
+    <span class="ease-tooltip-bubble">Default tooltip, top placement</span>
+  </span>
+
+  <!-- Bottom -->
+  <span class="ease-tooltip ease-tooltip-bottom ease-slide-up ease-delay-200">
+    <button class="ease-btn ease-btn-outline">Hover me (bottom)</button>
+    <span class="ease-tooltip-bubble">Appears below</span>
+  </span>
+
+  <!-- Left -->
+  <span class="ease-tooltip ease-tooltip-left ease-slide-up ease-delay-300">
+    <button class="ease-btn ease-btn-outline">Hover me (left)</button>
+    <span class="ease-tooltip-bubble">Appears to the left</span>
+  </span>
+
+  <!-- Right -->
+  <span class="ease-tooltip ease-tooltip-right ease-slide-up ease-delay-400">
+    <button class="ease-btn ease-btn-outline">Hover me (right)</button>
+    <span class="ease-tooltip-bubble">Appears to the right</span>
+  </span>
+
+  <!-- Primary color variant -->
+  <span class="ease-tooltip ease-tooltip-primary ease-slide-up ease-delay-500">
+    <button class="ease-btn ease-btn-primary">Primary tooltip</button>
+    <span class="ease-tooltip-bubble">Primary-colored bubble</span>
+  </span>
+
+  <!-- Success color variant -->
+  <span class="ease-tooltip ease-tooltip-success ease-slide-up ease-delay-600">
+    <button class="ease-btn ease-btn-success">Success tooltip</button>
+    <span class="ease-tooltip-bubble">Success-colored bubble</span>
+  </span>
+
+  <!-- Keyboard-focusable example (link) -->
+  <span class="ease-tooltip ease-slide-up ease-delay-700">
+    <a href="#" class="ease-hover-underline">Tab to me</a>
+    <span class="ease-tooltip-bubble">Works on keyboard focus too</span>
+  </span>
+
+</body>
+</html>

--- a/submissions/examples/ease-tooltip/style.css
+++ b/submissions/examples/ease-tooltip/style.css
@@ -1,0 +1,130 @@
+/* ============================================
+   ease-tooltip — CSS-only animated tooltip
+   Pairs naturally with EaseMotion's hover-effect
+   utilities and entrance-animation naming.
+   No JavaScript required.
+   ============================================ */
+
+.ease-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.ease-tooltip-bubble {
+  position: absolute;
+  z-index: 50;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  transform: translateX(-50%) translateY(4px);
+  white-space: nowrap;
+
+  background: var(--ease-color-text, #111827);
+  color: #fff;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  padding: 0.4rem 0.7rem;
+  border-radius: var(--ease-radius-md, 0.5rem);
+  box-shadow: var(--ease-shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--ease-speed-fast, 150ms) ease,
+    transform var(--ease-speed-fast, 150ms) ease,
+    visibility 0s linear var(--ease-speed-fast, 150ms);
+}
+
+/* Little arrow */
+.ease-tooltip-bubble::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--ease-color-text, #111827);
+}
+
+/* Show on hover or keyboard focus */
+.ease-tooltip:hover .ease-tooltip-bubble,
+.ease-tooltip:focus-within .ease-tooltip-bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+  transition:
+    opacity var(--ease-speed-fast, 150ms) ease,
+    transform var(--ease-speed-fast, 150ms) ease,
+    visibility 0s linear 0s;
+}
+
+/* ---------- Placement modifiers ---------- */
+
+.ease-tooltip-bottom .ease-tooltip-bubble {
+  bottom: auto;
+  top: calc(100% + 0.5rem);
+  transform: translateX(-50%) translateY(-4px);
+}
+.ease-tooltip-bottom .ease-tooltip-bubble::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: var(--ease-color-text, #111827);
+}
+.ease-tooltip-bottom:hover .ease-tooltip-bubble,
+.ease-tooltip-bottom:focus-within .ease-tooltip-bubble {
+  transform: translateX(-50%) translateY(0);
+}
+
+.ease-tooltip-left .ease-tooltip-bubble {
+  left: auto;
+  right: calc(100% + 0.5rem);
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(4px);
+}
+.ease-tooltip-left .ease-tooltip-bubble::after {
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  border-top-color: transparent;
+  border-left-color: var(--ease-color-text, #111827);
+}
+.ease-tooltip-left:hover .ease-tooltip-bubble,
+.ease-tooltip-left:focus-within .ease-tooltip-bubble {
+  transform: translateY(-50%) translateX(0);
+}
+
+.ease-tooltip-right .ease-tooltip-bubble {
+  left: calc(100% + 0.5rem);
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+}
+.ease-tooltip-right .ease-tooltip-bubble::after {
+  top: 50%;
+  left: -5px;
+  transform: translateY(-50%) rotate(90deg);
+  border-top-color: transparent;
+  border-right-color: var(--ease-color-text, #111827);
+}
+.ease-tooltip-right:hover .ease-tooltip-bubble,
+.ease-tooltip-right:focus-within .ease-tooltip-bubble {
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ---------- Color variants ---------- */
+
+.ease-tooltip-primary .ease-tooltip-bubble {
+  background: var(--ease-color-primary, #6c63ff);
+}
+.ease-tooltip-primary .ease-tooltip-bubble::after {
+  border-top-color: var(--ease-color-primary, #6c63ff);
+}
+
+.ease-tooltip-success .ease-tooltip-bubble {
+  background: var(--ease-color-success, #10b981);
+}
+.ease-tooltip-success .ease-tooltip-bubble::after {
+  border-top-color: var(--ease-color-success, #10b981);
+}


### PR DESCRIPTION
## What
Adds a new tooltip component (`submissions/examples/tooltip/`) — a
CSS-only, animated tooltip that shows on hover or keyboard focus.

## Why
The roadmap lists "Modal & tooltip components" as Planned — v1.2.
Tooltips are a natural fit for EaseMotion's animation-first
philosophy, since the reveal animation is the entire component.

## What's included
- `demo.html` — standalone live demo: all 4 placements, both color
  variants, and a keyboard-focus example
- `style.css` — component styles, pure CSS, no JS
- `README.md` — usage, accessibility notes, and rationale

## Details
- Shows on `:hover` AND `:focus-within`, so it's fully keyboard-
  accessible via Tab, not just mouse-only
- Fade + slide-in entrance built on existing `--ease-speed-fast` token
- Placement modifiers: `ease-tooltip-bottom`, `ease-tooltip-left`,
  `ease-tooltip-right` (top is default)
- Color variants: `ease-tooltip-primary`, `ease-tooltip-success`,
  reusing `--ease-color-primary` / `--ease-color-success` — no new
  tokens introduced
- Arrow indicator auto-flips to match placement
- `pointer-events: none` on the bubble and `visibility` toggled
  alongside `opacity` so it never traps focus or clutters the a11y tree

## Notes for maintainer
Raw class names (`tooltip`, `tooltip-bubble`) kept simple per the
contribution guide — happy to have these remapped to final `ease-*`
naming during standardization.

One feature, one PR, as per CONTRIBUTING.md.