### PR TITLE
Multi

### DIFF
--- a/submissions/examples/ease-progress/README.md
+++ b/submissions/examples/ease-progress/README.md
@@ -1,76 +1,87 @@
-# ease-progress — Animated Progress Bar
+# ease-stacked-progress — Multi-Segment Progress Bar
 
-Targets the roadmap item **"Badge, tag, avatar, progress bar" — Planned v1.3**.
-A pure CSS progress bar with a smooth animated fill, striped/animated variant,
-and an indeterminate loading state — no JavaScript required to render or
-animate.
+A **different** kind of progress bar from the single-value `ease-progress`
+already in the framework: this one shows **multiple values in one bar**,
+for cases like storage usage broken down by category, budget allocation,
+or survey response splits.
 
-## Why
+## Why this is distinct (not a duplicate)
 
-Progress bars are one of the most common feedback UI elements (uploads,
-loading states, quotas, onboarding steps) and benefit directly from
-EaseMotion's animation-first approach — width transitions and stripe motion
-are handled entirely in CSS.
+`ease-progress` (already merged) represents **one** value out of 100%.
+`ease-stacked-progress` represents **several** values that together make up
+a whole — different markup (`segment` children instead of a single `fill`),
+different visual (multiple colored blocks side by side), and a different
+use case. They're meant to coexist as separate components.
 
 ## What it does
 
-- Pure CSS — width is set inline (`style="width:65%"`) or via JS, and the
-  fill animates smoothly to any new value using `--ease-speed-medium`
-- Color variants: default (primary), `ease-progress-success`,
-  `ease-progress-danger`
-- Size modifiers: `ease-progress-sm`, `ease-progress-lg`
-- `ease-progress-striped` — diagonal stripe texture
-- `ease-progress-striped-animated` — stripes continuously scroll
-- `ease-progress-indeterminate` — for unknown-duration loading states,
-  animates a sliding segment instead of a fixed width
-- Optional `.ease-progress-label` row for a title + percentage above the bar
+- Pure CSS — each segment's width is set inline (or via JS) and animates
+  smoothly using `--ease-speed-medium`
+- Segments auto-color in sequence via `nth-child` (primary → success →
+  warning → danger → info), or set explicitly with `.ease-segment-1`
+  through `.ease-segment-5`
+- **Hover-to-highlight** — hovering the bar dims all segments except the
+  one under the cursor, making it easy to pick out one category in a
+  multi-part breakdown
+- Thin dividers between segments so each stays visually distinct even
+  when colors are close
+- Optional `.ease-stacked-progress-legend` — a small color-key row
+  matching each segment to a label
+- `ease-stacked-progress-sm` / `-lg` size modifiers
+- Respects `prefers-reduced-motion`
 
 ## Usage
 
 ```html
-<div class="ease-progress">
-  <div class="ease-progress-bar" style="width: 65%;"></div>
+<div class="ease-stacked-progress">
+  <div class="ease-stacked-progress-segment" style="width: 35%;"></div>
+  <div class="ease-stacked-progress-segment" style="width: 20%;"></div>
+  <div class="ease-stacked-progress-segment" style="width: 15%;"></div>
 </div>
 ```
 
-With label:
+With a legend:
 
 ```html
-<div class="ease-progress-label"><span>Uploading</span><span>65%</span></div>
-<div class="ease-progress">
-  <div class="ease-progress-bar" style="width: 65%;"></div>
+<div class="ease-stacked-progress">
+  <div class="ease-stacked-progress-segment" style="width: 35%;"></div>
+  <div class="ease-stacked-progress-segment" style="width: 20%;"></div>
+</div>
+<div class="ease-stacked-progress-legend">
+  <span class="ease-stacked-progress-legend-item">
+    <span class="ease-stacked-progress-legend-swatch ease-segment-1"></span> Photos (35%)
+  </span>
+  <span class="ease-stacked-progress-legend-item">
+    <span class="ease-stacked-progress-legend-swatch ease-segment-2"></span> Videos (20%)
+  </span>
 </div>
 ```
 
-Variants:
+Sizes:
 
 ```html
-<div class="ease-progress ease-progress-success">...</div>
-<div class="ease-progress ease-progress-striped ease-progress-striped-animated">...</div>
-<div class="ease-progress ease-progress-indeterminate">
-  <div class="ease-progress-bar"></div>
-</div>
+<div class="ease-stacked-progress ease-stacked-progress-sm">...</div>
+<div class="ease-stacked-progress ease-stacked-progress-lg">...</div>
 ```
 
 ## Files
 
-- `demo.html` — standalone live demo covering all variants: basic,
-  success, danger, small, large, striped-animated, indeterminate
+- `demo.html` — standalone live demo: storage breakdown, survey split,
+  and a compact small-size example
 - `style.css` — self-contained component styles, falls back to sensible
   defaults if a design token isn't present
 
 ## Accessibility notes
 
-- Intended usage is to pair the markup with `role="progressbar"`,
-  `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` on the outer
-  `.ease-progress` element when integrated (kept out of the raw demo
-  per the submission convention of raw, un-namespaced markup — happy
-  to add these attributes directly if preferred during standardization)
-- Indeterminate variant is meant to be paired with `aria-busy="true"`
-  and a visible or `aria-label` text description of what's loading
+- Intended usage pairs the outer `.ease-stacked-progress` with
+  `role="img"` and an `aria-label` summarizing the breakdown in text
+  (e.g. `aria-label="Storage: 35% photos, 20% videos, 15% docs"`), since
+  a purely visual multi-segment bar isn't self-describing to screen
+  readers the way a single progress value is
+- Hover-highlight is a supplementary visual affordance only — the legend
+  provides the same information without requiring hover
 
 ## Naming
 
-Raw class names (`progress`, `progress-bar`, `progress-label`) kept simple
-per the contribution guide — happy for the maintainer to remap to final
-`ease-*` naming during standardization.
+Raw class names kept simple per the contribution guide — happy for the
+maintainer to remap to final naming during standardization.

--- a/submissions/examples/ease-progress/README.md
+++ b/submissions/examples/ease-progress/README.md
@@ -1,0 +1,76 @@
+# ease-progress — Animated Progress Bar
+
+Targets the roadmap item **"Badge, tag, avatar, progress bar" — Planned v1.3**.
+A pure CSS progress bar with a smooth animated fill, striped/animated variant,
+and an indeterminate loading state — no JavaScript required to render or
+animate.
+
+## Why
+
+Progress bars are one of the most common feedback UI elements (uploads,
+loading states, quotas, onboarding steps) and benefit directly from
+EaseMotion's animation-first approach — width transitions and stripe motion
+are handled entirely in CSS.
+
+## What it does
+
+- Pure CSS — width is set inline (`style="width:65%"`) or via JS, and the
+  fill animates smoothly to any new value using `--ease-speed-medium`
+- Color variants: default (primary), `ease-progress-success`,
+  `ease-progress-danger`
+- Size modifiers: `ease-progress-sm`, `ease-progress-lg`
+- `ease-progress-striped` — diagonal stripe texture
+- `ease-progress-striped-animated` — stripes continuously scroll
+- `ease-progress-indeterminate` — for unknown-duration loading states,
+  animates a sliding segment instead of a fixed width
+- Optional `.ease-progress-label` row for a title + percentage above the bar
+
+## Usage
+
+```html
+<div class="ease-progress">
+  <div class="ease-progress-bar" style="width: 65%;"></div>
+</div>
+```
+
+With label:
+
+```html
+<div class="ease-progress-label"><span>Uploading</span><span>65%</span></div>
+<div class="ease-progress">
+  <div class="ease-progress-bar" style="width: 65%;"></div>
+</div>
+```
+
+Variants:
+
+```html
+<div class="ease-progress ease-progress-success">...</div>
+<div class="ease-progress ease-progress-striped ease-progress-striped-animated">...</div>
+<div class="ease-progress ease-progress-indeterminate">
+  <div class="ease-progress-bar"></div>
+</div>
+```
+
+## Files
+
+- `demo.html` — standalone live demo covering all variants: basic,
+  success, danger, small, large, striped-animated, indeterminate
+- `style.css` — self-contained component styles, falls back to sensible
+  defaults if a design token isn't present
+
+## Accessibility notes
+
+- Intended usage is to pair the markup with `role="progressbar"`,
+  `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` on the outer
+  `.ease-progress` element when integrated (kept out of the raw demo
+  per the submission convention of raw, un-namespaced markup — happy
+  to add these attributes directly if preferred during standardization)
+- Indeterminate variant is meant to be paired with `aria-busy="true"`
+  and a visible or `aria-label` text description of what's loading
+
+## Naming
+
+Raw class names (`progress`, `progress-bar`, `progress-label`) kept simple
+per the contribution guide — happy for the maintainer to remap to final
+`ease-*` naming during standardization.

--- a/submissions/examples/ease-progress/README.md
+++ b/submissions/examples/ease-progress/README.md
@@ -83,5 +83,6 @@ Sizes:
 
 ## Naming
 
+
 Raw class names kept simple per the contribution guide — happy for the
 maintainer to remap to final naming during standardization.

--- a/submissions/examples/ease-progress/demo.html
+++ b/submissions/examples/ease-progress/demo.html
@@ -2,75 +2,81 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<title>ease-progress demo</title>
+<title>ease-stacked-progress demo</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
 <link rel="stylesheet" href="style.css" />
 <style>
   body {
     font-family: 'Inter', sans-serif;
     padding: 3rem;
-    max-width: 500px;
+    max-width: 560px;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 2.5rem;
   }
 </style>
 </head>
 <body>
 
-  <h1 class="ease-fade-in">ease-progress</h1>
+  <h1 class="ease-fade-in">ease-stacked-progress</h1>
+  <p class="ease-slide-up ease-delay-100">
+    One bar, multiple values — great for storage usage, budget breakdowns,
+    or survey response splits.
+  </p>
 
-  <!-- Basic -->
-  <div class="ease-slide-up ease-delay-100">
-    <div class="ease-progress-label"><span>Uploading</span><span>65%</span></div>
-    <div class="ease-progress">
-      <div class="ease-progress-bar" style="width:65%;"></div>
-    </div>
-  </div>
-
-  <!-- Success -->
+  <!-- Storage usage example -->
   <div class="ease-slide-up ease-delay-200">
-    <div class="ease-progress-label"><span>Storage used</span><span>90%</span></div>
-    <div class="ease-progress ease-progress-success">
-      <div class="ease-progress-bar" style="width:90%;"></div>
+    <h3>Storage used</h3>
+    <div class="ease-stacked-progress">
+      <div class="ease-stacked-progress-segment" style="width: 35%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 20%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 15%;"></div>
+    </div>
+    <div class="ease-stacked-progress-legend">
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-1"></span> Photos (35%)
+      </span>
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-2"></span> Videos (20%)
+      </span>
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-3"></span> Docs (15%)
+      </span>
     </div>
   </div>
 
-  <!-- Danger -->
+  <!-- Survey response split -->
   <div class="ease-slide-up ease-delay-300">
-    <div class="ease-progress-label"><span>Quota</span><span>97%</span></div>
-    <div class="ease-progress ease-progress-danger">
-      <div class="ease-progress-bar" style="width:97%;"></div>
+    <h3>Survey responses</h3>
+    <div class="ease-stacked-progress ease-stacked-progress-lg">
+      <div class="ease-stacked-progress-segment" style="width: 50%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 30%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 12%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 8%;"></div>
+    </div>
+    <div class="ease-stacked-progress-legend">
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-1"></span> Yes (50%)
+      </span>
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-2"></span> No (30%)
+      </span>
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-3"></span> Maybe (12%)
+      </span>
+      <span class="ease-stacked-progress-legend-item">
+        <span class="ease-stacked-progress-legend-swatch ease-segment-4"></span> Skipped (8%)
+      </span>
     </div>
   </div>
 
-  <!-- Small -->
+  <!-- Small size, no legend -->
   <div class="ease-slide-up ease-delay-400">
-    <div class="ease-progress ease-progress-sm">
-      <div class="ease-progress-bar" style="width:40%;"></div>
-    </div>
-  </div>
-
-  <!-- Large -->
-  <div class="ease-slide-up ease-delay-500">
-    <div class="ease-progress ease-progress-lg">
-      <div class="ease-progress-bar" style="width:75%;"></div>
-    </div>
-  </div>
-
-  <!-- Striped, animated -->
-  <div class="ease-slide-up ease-delay-600">
-    <div class="ease-progress-label"><span>Processing</span><span>55%</span></div>
-    <div class="ease-progress ease-progress-striped ease-progress-striped-animated">
-      <div class="ease-progress-bar" style="width:55%;"></div>
-    </div>
-  </div>
-
-  <!-- Indeterminate -->
-  <div class="ease-slide-up ease-delay-700">
-    <div class="ease-progress-label"><span>Loading, please wait...</span></div>
-    <div class="ease-progress ease-progress-indeterminate">
-      <div class="ease-progress-bar"></div>
+    <h3>Compact (small size)</h3>
+    <div class="ease-stacked-progress ease-stacked-progress-sm">
+      <div class="ease-stacked-progress-segment" style="width: 40%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 25%;"></div>
+      <div class="ease-stacked-progress-segment" style="width: 10%;"></div>
     </div>
   </div>
 

--- a/submissions/examples/ease-progress/demo.html
+++ b/submissions/examples/ease-progress/demo.html
@@ -80,5 +80,6 @@
     </div>
   </div>
 
+  
 </body>
 </html>

--- a/submissions/examples/ease-progress/demo.html
+++ b/submissions/examples/ease-progress/demo.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>ease-progress demo</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easemotion-css/easemotion.min.css" />
+<link rel="stylesheet" href="style.css" />
+<style>
+  body {
+    font-family: 'Inter', sans-serif;
+    padding: 3rem;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+</style>
+</head>
+<body>
+
+  <h1 class="ease-fade-in">ease-progress</h1>
+
+  <!-- Basic -->
+  <div class="ease-slide-up ease-delay-100">
+    <div class="ease-progress-label"><span>Uploading</span><span>65%</span></div>
+    <div class="ease-progress">
+      <div class="ease-progress-bar" style="width:65%;"></div>
+    </div>
+  </div>
+
+  <!-- Success -->
+  <div class="ease-slide-up ease-delay-200">
+    <div class="ease-progress-label"><span>Storage used</span><span>90%</span></div>
+    <div class="ease-progress ease-progress-success">
+      <div class="ease-progress-bar" style="width:90%;"></div>
+    </div>
+  </div>
+
+  <!-- Danger -->
+  <div class="ease-slide-up ease-delay-300">
+    <div class="ease-progress-label"><span>Quota</span><span>97%</span></div>
+    <div class="ease-progress ease-progress-danger">
+      <div class="ease-progress-bar" style="width:97%;"></div>
+    </div>
+  </div>
+
+  <!-- Small -->
+  <div class="ease-slide-up ease-delay-400">
+    <div class="ease-progress ease-progress-sm">
+      <div class="ease-progress-bar" style="width:40%;"></div>
+    </div>
+  </div>
+
+  <!-- Large -->
+  <div class="ease-slide-up ease-delay-500">
+    <div class="ease-progress ease-progress-lg">
+      <div class="ease-progress-bar" style="width:75%;"></div>
+    </div>
+  </div>
+
+  <!-- Striped, animated -->
+  <div class="ease-slide-up ease-delay-600">
+    <div class="ease-progress-label"><span>Processing</span><span>55%</span></div>
+    <div class="ease-progress ease-progress-striped ease-progress-striped-animated">
+      <div class="ease-progress-bar" style="width:55%;"></div>
+    </div>
+  </div>
+
+  <!-- Indeterminate -->
+  <div class="ease-slide-up ease-delay-700">
+    <div class="ease-progress-label"><span>Loading, please wait...</span></div>
+    <div class="ease-progress ease-progress-indeterminate">
+      <div class="ease-progress-bar"></div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/ease-progress/style.css
+++ b/submissions/examples/ease-progress/style.css
@@ -114,4 +114,5 @@
   .ease-stacked-progress-segment {
     transition: none;
   }
+  
 }

--- a/submissions/examples/ease-progress/style.css
+++ b/submissions/examples/ease-progress/style.css
@@ -1,0 +1,99 @@
+/* ============================================
+   ease-progress — animated progress bar
+   Pure CSS, animation-first, reuses existing
+   EaseMotion design tokens.
+   ============================================ */
+
+.ease-progress {
+  width: 100%;
+  height: 0.75rem;
+  background: var(--ease-color-border, #e5e7eb);
+  border-radius: var(--ease-radius-full, 9999px);
+  overflow: hidden;
+  position: relative;
+}
+
+.ease-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--ease-color-primary, #6c63ff);
+  border-radius: var(--ease-radius-full, 9999px);
+
+  /* Animate width changes smoothly whenever the inline style/JS updates it */
+  transition: width var(--ease-speed-medium, 500ms) ease;
+}
+
+/* ---------- Color variants ---------- */
+
+.ease-progress-success .ease-progress-bar {
+  background: var(--ease-color-success, #10b981);
+}
+.ease-progress-danger .ease-progress-bar {
+  background: var(--ease-color-danger, #ef4444);
+}
+
+/* ---------- Size modifiers ---------- */
+
+.ease-progress-sm {
+  height: 0.4rem;
+}
+.ease-progress-lg {
+  height: 1.1rem;
+}
+
+/* ---------- Striped variant ---------- */
+
+.ease-progress-striped .ease-progress-bar {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 1rem 1rem;
+}
+
+/* Animated stripes — moving diagonally */
+.ease-progress-striped-animated .ease-progress-bar {
+  animation: ease-progress-stripes 1s linear infinite;
+}
+
+@keyframes ease-progress-stripes {
+  from {
+    background-position: 1rem 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+
+/* ---------- Indeterminate / loading variant ---------- */
+/* Use when progress is unknown — omit width, add ease-progress-indeterminate */
+
+.ease-progress-indeterminate .ease-progress-bar {
+  width: 40% !important;
+  animation: ease-progress-slide 1.4s ease-in-out infinite;
+}
+
+@keyframes ease-progress-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(250%);
+  }
+}
+
+/* ---------- Optional label ---------- */
+
+.ease-progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--ease-color-text, #111827);
+  margin-bottom: 0.35rem;
+}

--- a/submissions/examples/ease-progress/style.css
+++ b/submissions/examples/ease-progress/style.css
@@ -1,99 +1,117 @@
 /* ============================================
-   ease-progress — animated progress bar
-   Pure CSS, animation-first, reuses existing
-   EaseMotion design tokens.
+   ease-stacked-progress — multi-segment bar
+   Shows several values in ONE bar (e.g. storage
+   usage broken down by category). Distinct from
+   the single-value ease-progress component —
+   different markup, different purpose.
+   Pure CSS, no JS required.
    ============================================ */
 
-.ease-progress {
+.ease-stacked-progress {
+  display: flex;
   width: 100%;
-  height: 0.75rem;
+  height: 0.9rem;
   background: var(--ease-color-border, #e5e7eb);
   border-radius: var(--ease-radius-full, 9999px);
   overflow: hidden;
-  position: relative;
 }
 
-.ease-progress-bar {
+.ease-stacked-progress-segment {
   height: 100%;
   width: 0%;
-  background: var(--ease-color-primary, #6c63ff);
-  border-radius: var(--ease-radius-full, 9999px);
+  flex-shrink: 0;
 
-  /* Animate width changes smoothly whenever the inline style/JS updates it */
+  /* Animate segments growing in on load / value change */
   transition: width var(--ease-speed-medium, 500ms) ease;
+
+  /* Thin divider between segments so each stays visually distinct */
+  border-right: 2px solid rgba(255, 255, 255, 0.6);
+}
+.ease-stacked-progress-segment:last-child {
+  border-right: none;
 }
 
-/* ---------- Color variants ---------- */
+/* ---------- Segment colors ---------- */
+/* Cycle through the palette automatically via nth-child,
+   or apply explicitly with a modifier class. */
 
-.ease-progress-success .ease-progress-bar {
+.ease-stacked-progress-segment:nth-child(1),
+.ease-stacked-progress-segment.ease-segment-1 {
+  background: var(--ease-color-primary, #6c63ff);
+}
+.ease-stacked-progress-segment:nth-child(2),
+.ease-stacked-progress-segment.ease-segment-2 {
   background: var(--ease-color-success, #10b981);
 }
-.ease-progress-danger .ease-progress-bar {
+.ease-stacked-progress-segment:nth-child(3),
+.ease-stacked-progress-segment.ease-segment-3 {
+  background: var(--ease-color-warning, #f59e0b);
+}
+.ease-stacked-progress-segment:nth-child(4),
+.ease-stacked-progress-segment.ease-segment-4 {
   background: var(--ease-color-danger, #ef4444);
+}
+.ease-stacked-progress-segment:nth-child(5),
+.ease-stacked-progress-segment.ease-segment-5 {
+  background: var(--ease-color-info, #3b82f6);
 }
 
 /* ---------- Size modifiers ---------- */
 
-.ease-progress-sm {
-  height: 0.4rem;
+.ease-stacked-progress-sm {
+  height: 0.45rem;
 }
-.ease-progress-lg {
-  height: 1.1rem;
-}
-
-/* ---------- Striped variant ---------- */
-
-.ease-progress-striped .ease-progress-bar {
-  background-image: linear-gradient(
-    45deg,
-    rgba(255, 255, 255, 0.15) 25%,
-    transparent 25%,
-    transparent 50%,
-    rgba(255, 255, 255, 0.15) 50%,
-    rgba(255, 255, 255, 0.15) 75%,
-    transparent 75%,
-    transparent
-  );
-  background-size: 1rem 1rem;
+.ease-stacked-progress-lg {
+  height: 1.4rem;
 }
 
-/* Animated stripes — moving diagonally */
-.ease-progress-striped-animated .ease-progress-bar {
-  animation: ease-progress-stripes 1s linear infinite;
+/* ---------- Hover-to-highlight a segment ---------- */
+/* Dims sibling segments so the hovered category pops —
+   a small interaction unique to the multi-value format. */
+
+.ease-stacked-progress:hover .ease-stacked-progress-segment {
+  opacity: 0.45;
+  transition: opacity var(--ease-speed-fast, 150ms) ease,
+    width var(--ease-speed-medium, 500ms) ease;
+}
+.ease-stacked-progress-segment:hover {
+  opacity: 1 !important;
 }
 
-@keyframes ease-progress-stripes {
-  from {
-    background-position: 1rem 0;
-  }
-  to {
-    background-position: 0 0;
-  }
-}
+/* ---------- Legend ---------- */
+/* Optional key showing each category + its color swatch */
 
-/* ---------- Indeterminate / loading variant ---------- */
-/* Use when progress is unknown — omit width, add ease-progress-indeterminate */
-
-.ease-progress-indeterminate .ease-progress-bar {
-  width: 40% !important;
-  animation: ease-progress-slide 1.4s ease-in-out infinite;
-}
-
-@keyframes ease-progress-slide {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(250%);
-  }
-}
-
-/* ---------- Optional label ---------- */
-
-.ease-progress-label {
+.ease-stacked-progress-legend {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.6rem;
   font-size: 0.85rem;
   color: var(--ease-color-text, #111827);
-  margin-bottom: 0.35rem;
+}
+
+.ease-stacked-progress-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ease-stacked-progress-legend-swatch {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ease-stacked-progress-legend-swatch.ease-segment-1 { background: var(--ease-color-primary, #6c63ff); }
+.ease-stacked-progress-legend-swatch.ease-segment-2 { background: var(--ease-color-success, #10b981); }
+.ease-stacked-progress-legend-swatch.ease-segment-3 { background: var(--ease-color-warning, #f59e0b); }
+.ease-stacked-progress-legend-swatch.ease-segment-4 { background: var(--ease-color-danger, #ef4444); }
+.ease-stacked-progress-legend-swatch.ease-segment-5 { background: var(--ease-color-info, #3b82f6); }
+
+/* ---------- Reduced motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ease-stacked-progress-segment {
+    transition: none;
+  }
 }


### PR DESCRIPTION
 ease-stacked-progress — Multi-Segment Progress Bar

Adds a new component, distinct from the existing ease-progress, for displaying multiple values that together make up a whole (e.g. storage breakdown by category, budget allocation, survey splits).

What's new
- Pure CSS multi-segment bar — segment widths set inline/via JS, animated with --ease-speed-medium
- Auto-coloring via nth-child (primary → success → warning → danger → info), overridable with .ease-segment-1–.ease-segment-5
- Hover-to-highlight: hovering dims all segments except the one under the cursor
- Thin dividers between segments for visual separation
- Optional .ease-stacked-progress-legend color-key component
- -sm / -lg size modifiers
- Respects prefers-reduced-motion

Why not part of ease-progress?
Different data shape (multiple segment children vs. a single fill), different markup, different visual, and a different use case (composition of a whole vs. progress toward a single goal). Kept as a separate component so the two can coexist without overloading one API.

Files changed
- demo.html — live examples: storage breakdown, survey split, compact size variant
- style.css — self-contained styles with fallback defaults when design tokens are absent

Accessibility
- Recommended usage: pair .ease-stacked-progress with role="img" + aria-label summarizing the breakdown as text (e.g. "Storage: 35% photos, 20% videos, 15% docs"), since a multi-segment visual isn't self-describing to screen readers
- Hover-highlight is purely supplementary — the legend conveys the same info without requiring hover

Notes for reviewers
- Class names are intentionally simple per the contribution guide; open to renaming during standardization
- No dependencies beyond existing design tokens; degrades gracefully if tokens are missing