### PR TITLE
feat: add elastic swipe cards demo

### DIFF
--- a/submissions/examples/elastic-swipe-cards-ms/README.md
+++ b/submissions/examples/elastic-swipe-cards-ms/README.md
@@ -1,0 +1,39 @@
+# Elastic Swipe Cards
+
+## What does this do?
+
+Elastic Swipe Cards adds a self-contained drag-to-dismiss card stack with spring snap-back motion, directional swipe exits, keyboard controls, and reduced-motion support.
+
+## How is it used?
+
+Place the demo markup inside a page, link the stylesheet, and use the `swipe-card` elements inside a `card-stack` container:
+
+```html
+<div class="card-stack" id="cardStack" tabindex="0">
+  <article class="swipe-card">
+    <span class="swipe-badge like">Keep</span>
+    <span class="swipe-badge dismiss">Dismiss</span>
+    <div class="card-visual visual-sky"></div>
+    <div class="card-copy">
+      <h2>Elastic pull resistance</h2>
+      <p>Cards snap back or swipe away based on drag distance.</p>
+    </div>
+  </article>
+</div>
+```
+
+The included `demo.html` uses vanilla JavaScript to update CSS custom properties such as `--drag-x`, `--drag-y`, and `--drag-rotate` during pointer movement.
+
+## Why is it useful?
+
+Swipe stacks are common in mobile-first product interfaces, decision feeds, onboarding flows, and notification queues. This submission fits EaseMotion CSS because it demonstrates human-readable motion behavior, reusable directional keyframes, CSS custom properties for physics-like tuning, keyboard accessibility, and a `prefers-reduced-motion` fallback without external dependencies.
+
+## Features
+
+- Pointer drag support with elastic threshold behavior.
+- Left and right swipe-out animations.
+- Spring snap-back animation when released under the threshold.
+- Action badges that react to drag direction.
+- Keyboard support with `ArrowLeft` and `ArrowRight`.
+- Reset, keep, and dismiss controls.
+- Responsive layout and reduced-motion handling.

--- a/submissions/examples/elastic-swipe-cards-ms/demo.html
+++ b/submissions/examples/elastic-swipe-cards-ms/demo.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Elastic Swipe Cards Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <main class="swipe-shell">
+    <section class="swipe-intro" aria-labelledby="swipe-title">
+      <p class="eyebrow">EaseMotion CSS submission</p>
+      <h1 id="swipe-title">Elastic Drag-to-Dismiss Cards</h1>
+      <p>
+        Drag a card left or right, use the control buttons, or press the arrow keys
+        to explore springy swipe interactions with accessible fallbacks.
+      </p>
+    </section>
+
+    <section class="swipe-demo" aria-label="Interactive swipe card stack">
+      <div class="card-stack" id="cardStack" tabindex="0" aria-live="polite">
+        <article class="swipe-card" data-index="0">
+          <span class="swipe-badge like">Keep</span>
+          <span class="swipe-badge dismiss">Dismiss</span>
+          <div class="card-visual visual-sky"></div>
+          <div class="card-copy">
+            <p class="card-kicker">Gesture UI</p>
+            <h2>Elastic pull resistance</h2>
+            <p>Cards stretch against the drag threshold, then snap back with a soft spring curve.</p>
+          </div>
+        </article>
+
+        <article class="swipe-card" data-index="1">
+          <span class="swipe-badge like">Keep</span>
+          <span class="swipe-badge dismiss">Dismiss</span>
+          <div class="card-visual visual-ember"></div>
+          <div class="card-copy">
+            <p class="card-kicker">Motion Tokens</p>
+            <h2>Directional swipe exits</h2>
+            <p>Swipe-out states use reusable keyframes for left, right, and upward dismissal.</p>
+          </div>
+        </article>
+
+        <article class="swipe-card" data-index="2">
+          <span class="swipe-badge like">Keep</span>
+          <span class="swipe-badge dismiss">Dismiss</span>
+          <div class="card-visual visual-mint"></div>
+          <div class="card-copy">
+            <p class="card-kicker">Keyboard Ready</p>
+            <h2>Arrow key actions</h2>
+            <p>Keyboard users can trigger the same swipe decisions without pointer gestures.</p>
+          </div>
+        </article>
+      </div>
+
+      <div class="controls" aria-label="Swipe card controls">
+        <button type="button" class="control-button dismiss-button" id="dismissCard">
+          Dismiss
+        </button>
+        <button type="button" class="control-button reset-button" id="resetCards">
+          Reset
+        </button>
+        <button type="button" class="control-button keep-button" id="keepCard">
+          Keep
+        </button>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const stack = document.querySelector("#cardStack");
+    const cards = Array.from(document.querySelectorAll(".swipe-card"));
+    const resetButton = document.querySelector("#resetCards");
+    const keepButton = document.querySelector("#keepCard");
+    const dismissButton = document.querySelector("#dismissCard");
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let activeCardIndex = 0;
+    let startX = 0;
+    let startY = 0;
+    let currentX = 0;
+    let currentY = 0;
+    let isDragging = false;
+
+    function getActiveCard() {
+      return cards[activeCardIndex];
+    }
+
+    function announce(message) {
+      stack.setAttribute("aria-label", message);
+    }
+
+    function updateCardPosition(card, x, y) {
+      const rotation = Math.max(-14, Math.min(14, x / 16));
+      const pull = Math.min(1, Math.abs(x) / 180);
+      card.style.setProperty("--drag-x", `${x}px`);
+      card.style.setProperty("--drag-y", `${y}px`);
+      card.style.setProperty("--drag-rotate", `${rotation}deg`);
+      card.style.setProperty("--like-opacity", x > 0 ? pull : 0);
+      card.style.setProperty("--dismiss-opacity", x < 0 ? pull : 0);
+    }
+
+    function releaseCard(card) {
+      card.classList.add("is-snapping");
+      updateCardPosition(card, 0, 0);
+      setTimeout(() => card.classList.remove("is-snapping"), prefersReducedMotion ? 0 : 360);
+    }
+
+    function swipeCard(direction) {
+      const card = getActiveCard();
+      if (!card) {
+        announce("No cards left. Use reset to replay the stack.");
+        return;
+      }
+
+      const className = direction === "left" ? "swipe-out-left" : "swipe-out-right";
+      card.classList.add(className);
+      announce(direction === "left" ? "Card dismissed." : "Card kept.");
+
+      setTimeout(() => {
+        card.hidden = true;
+        activeCardIndex += 1;
+        if (!getActiveCard()) {
+          announce("All cards cleared. Use reset to replay the stack.");
+        }
+      }, prefersReducedMotion ? 0 : 360);
+    }
+
+    function resetCards() {
+      activeCardIndex = 0;
+      cards.forEach((card) => {
+        card.hidden = false;
+        card.classList.remove("swipe-out-left", "swipe-out-right", "is-snapping", "is-dragging");
+        updateCardPosition(card, 0, 0);
+      });
+      announce("Card stack reset.");
+      stack.focus();
+    }
+
+    stack.addEventListener("pointerdown", (event) => {
+      const card = getActiveCard();
+      if (!card) return;
+      isDragging = true;
+      startX = event.clientX;
+      startY = event.clientY;
+      card.classList.add("is-dragging");
+      card.setPointerCapture(event.pointerId);
+    });
+
+    stack.addEventListener("pointermove", (event) => {
+      const card = getActiveCard();
+      if (!isDragging || !card) return;
+      currentX = event.clientX - startX;
+      currentY = (event.clientY - startY) * 0.25;
+      updateCardPosition(card, currentX, currentY);
+    });
+
+    stack.addEventListener("pointerup", () => {
+      const card = getActiveCard();
+      if (!isDragging || !card) return;
+      isDragging = false;
+      card.classList.remove("is-dragging");
+
+      if (Math.abs(currentX) > 120) {
+        swipeCard(currentX > 0 ? "right" : "left");
+      } else {
+        releaseCard(card);
+      }
+
+      currentX = 0;
+      currentY = 0;
+    });
+
+    stack.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        swipeCard("left");
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        swipeCard("right");
+      }
+    });
+
+    dismissButton.addEventListener("click", () => swipeCard("left"));
+    keepButton.addEventListener("click", () => swipeCard("right"));
+    resetButton.addEventListener("click", resetCards);
+  </script>
+</body>
+</html>

--- a/submissions/examples/elastic-swipe-cards-ms/style.css
+++ b/submissions/examples/elastic-swipe-cards-ms/style.css
@@ -1,0 +1,334 @@
+:root {
+  --page-bg: #10131f;
+  --panel: #171b2a;
+  --ink: #f8fafc;
+  --muted: #aeb7c9;
+  --line: rgba(255, 255, 255, 0.14);
+  --accent: #63e6be;
+  --danger: #ff7a90;
+  --warning: #ffd166;
+  --drag-x: 0px;
+  --drag-y: 0px;
+  --drag-rotate: 0deg;
+  --like-opacity: 0;
+  --dismiss-opacity: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(99, 230, 190, 0.2), transparent 32%),
+    radial-gradient(circle at 82% 28%, rgba(255, 122, 144, 0.22), transparent 28%),
+    linear-gradient(135deg, #0b1020 0%, #151829 52%, #24172d 100%);
+}
+
+.swipe-shell {
+  width: min(1120px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
+  gap: 48px;
+  align-items: center;
+  padding: 56px 0;
+}
+
+.swipe-intro {
+  animation: intro-rise 620ms ease-out both;
+}
+
+.eyebrow {
+  width: max-content;
+  margin: 0 0 18px;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.06);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.7rem, 8vw, 6rem);
+  line-height: 0.92;
+  letter-spacing: -0.08em;
+}
+
+.swipe-intro p:last-child {
+  max-width: 58ch;
+  margin: 24px 0 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.swipe-demo {
+  display: grid;
+  justify-items: center;
+  gap: 28px;
+}
+
+.card-stack {
+  position: relative;
+  width: min(390px, 86vw);
+  height: 540px;
+  outline: none;
+}
+
+.card-stack:focus-visible {
+  border-radius: 34px;
+  box-shadow: 0 0 0 4px rgba(99, 230, 190, 0.35);
+}
+
+.swipe-card {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 34px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.38);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  transform:
+    translate3d(var(--drag-x), var(--drag-y), 0)
+    rotate(var(--drag-rotate))
+    scale(var(--stack-scale, 1));
+  transition: transform 360ms cubic-bezier(0.22, 1.24, 0.36, 1), opacity 260ms ease;
+}
+
+.swipe-card:nth-child(2) {
+  --stack-scale: 0.95;
+
+  transform:
+    translate3d(0, 18px, 0)
+    rotate(-2deg)
+    scale(var(--stack-scale));
+}
+
+.swipe-card:nth-child(3) {
+  --stack-scale: 0.9;
+
+  transform:
+    translate3d(0, 36px, 0)
+    rotate(2deg)
+    scale(var(--stack-scale));
+}
+
+.swipe-card.is-dragging {
+  cursor: grabbing;
+  transition: none;
+}
+
+.swipe-card.is-snapping {
+  animation: spring-snap 360ms cubic-bezier(0.22, 1.24, 0.36, 1);
+}
+
+.swipe-card.swipe-out-left {
+  animation: swipe-out-left 360ms ease forwards;
+}
+
+.swipe-card.swipe-out-right {
+  animation: swipe-out-right 360ms ease forwards;
+}
+
+.swipe-badge {
+  position: absolute;
+  z-index: 3;
+  top: 28px;
+  padding: 10px 14px;
+  border: 2px solid currentColor;
+  border-radius: 14px;
+  font-size: 0.9rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.swipe-badge.like {
+  left: 28px;
+  color: var(--accent);
+  opacity: var(--like-opacity);
+  transform: rotate(-12deg);
+}
+
+.swipe-badge.dismiss {
+  right: 28px;
+  color: var(--danger);
+  opacity: var(--dismiss-opacity);
+  transform: rotate(12deg);
+}
+
+.card-visual {
+  height: 58%;
+  border-bottom: 1px solid var(--line);
+}
+
+.visual-sky {
+  background:
+    radial-gradient(circle at 25% 35%, #ffffff 0 7%, transparent 8%),
+    linear-gradient(145deg, #63e6be, #3b82f6 48%, #111827);
+}
+
+.visual-ember {
+  background:
+    radial-gradient(circle at 70% 28%, #fff7ad 0 6%, transparent 7%),
+    linear-gradient(145deg, #ff7a90, #fb923c 48%, #341c2c);
+}
+
+.visual-mint {
+  background:
+    radial-gradient(circle at 45% 34%, #ecfeff 0 8%, transparent 9%),
+    linear-gradient(145deg, #86efac, #22d3ee 48%, #15253a);
+}
+
+.card-copy {
+  padding: 26px;
+  background: rgba(14, 18, 32, 0.92);
+}
+
+.card-kicker {
+  margin: 0 0 8px;
+  color: var(--warning);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.card-copy h2 {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: -0.04em;
+}
+
+.card-copy p:last-child {
+  margin: 12px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+
+.control-button {
+  min-width: 104px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 12px 18px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.09);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  transition: transform 180ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.control-button:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.control-button:focus-visible {
+  outline: 3px solid rgba(99, 230, 190, 0.45);
+  outline-offset: 3px;
+}
+
+.dismiss-button:hover {
+  border-color: rgba(255, 122, 144, 0.7);
+}
+
+.keep-button:hover {
+  border-color: rgba(99, 230, 190, 0.7);
+}
+
+@keyframes intro-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes spring-snap {
+  0% {
+    transform: translate3d(var(--drag-x), var(--drag-y), 0) rotate(var(--drag-rotate));
+  }
+
+  64% {
+    transform: translate3d(-10px, 0, 0) rotate(-2deg);
+  }
+
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0);
+  }
+}
+
+@keyframes swipe-out-left {
+  to {
+    opacity: 0;
+    transform: translate3d(-150%, -12%, 0) rotate(-24deg);
+  }
+}
+
+@keyframes swipe-out-right {
+  to {
+    opacity: 0;
+    transform: translate3d(150%, -12%, 0) rotate(24deg);
+  }
+}
+
+@media (max-width: 820px) {
+  .swipe-shell {
+    grid-template-columns: 1fr;
+    gap: 34px;
+    padding-top: 36px;
+  }
+
+  .swipe-intro {
+    text-align: center;
+  }
+
+  .eyebrow {
+    margin-inline: auto;
+  }
+
+  .swipe-intro p:last-child {
+    margin-inline: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    transition-duration: 1ms !important;
+  }
+
+  .control-button:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a self-contained elastic drag-to-dismiss swipe card stack demo under `submissions/examples/elastic-swipe-cards-ms/`.
- Includes directional swipe exits, spring snap-back, drag-reactive action badges, keyboard controls, reset controls, responsive layout, and reduced-motion handling.
- Keeps the contribution scoped to the required three files: `demo.html`, `style.css`, and `README.md`.

## Validation
- `npm ci`
- `Get-Content submissions/examples/elastic-swipe-cards-ms/style.css -Raw | npx stylelint --stdin --stdin-filename elastic-swipe-cards-ms.css`
- `npm run build`
- `npm test` (61 tests passed)
- `npm run validate:manifest`
- `git diff --check`
- `git diff --cached --check`

Closes #89034