### PR TITLE
fix(parser): remove unreachable "bounce" easing alias colliding with the bounce animation

### DIFF
--- a/easemotion/engine/parser.js
+++ b/easemotion/engine/parser.js
@@ -23,7 +23,6 @@ const EASING_MAP = {
   'ease-in-out': 'cubic-bezier(0.4, 0, 0.2, 1)',
   'linear':      'linear',
   'spring':      'cubic-bezier(0.34, 1.56, 0.64, 1)',
-  'bounce':      'cubic-bezier(0.34, 1.56, 0.64, 1)',
   'snap':        'cubic-bezier(0.77, 0, 0.175, 1)',
 };
 


### PR DESCRIPTION
## Summary

`bounce` was present in both `ANIMATION_NAMES` and `EASING_MAP` in `easemotion/engine/parser.js`. Because animation tokens are matched first, `em="fade-in bounce"` silently replaced `fade-in` with the bounce animation instead of applying bounce easing - and the `EASING_MAP['bounce']` entry was unreachable dead configuration.

## Changes

- Removed the unreachable `'bounce'` entry from `EASING_MAP` (identical curve remains available via `spring`).
- No behavioral regression: standalone `em="bounce"` still plays the bounce animation exactly as before; `spring` still provides the same easing curve.

Fixes #89069