### PR TITLE
feat: add action menu example

### DIFF
--- a/submissions/examples/ease-action-menu-ms/README.md
+++ b/submissions/examples/ease-action-menu-ms/README.md
@@ -1,0 +1,27 @@
+# Ease Action Menu
+
+Adds a compact contextual action menu for grouping related actions inside cards, tables, dashboards, and content management interfaces.
+
+## How to Use
+
+Place the action menu beside the item that owns the actions:
+
+```html
+<details class="action-menu">
+  <summary class="action-menu-trigger">Actions</summary>
+  <div class="action-menu-panel">
+    <button class="action-item" type="button">
+      <span class="action-icon">V</span>
+      View details
+    </button>
+    <button class="action-item" type="button">
+      <span class="action-icon">E</span>
+      Edit record
+    </button>
+  </div>
+</details>
+```
+
+## Why It Is Useful
+
+EaseMotion CSS favors readable, dependency-free UI patterns. This menu uses semantic HTML, CSS-only disclosure behavior, icon slots, hover states, and responsive positioning, making it easy to reuse wherever several contextual actions need to stay compact.

--- a/submissions/examples/ease-action-menu-ms/demo.html
+++ b/submissions/examples/ease-action-menu-ms/demo.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Action Menu</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="hero" aria-labelledby="page-title">
+        <p class="eyebrow">CSS-only component</p>
+        <h1 id="page-title">Compact Action Menu</h1>
+        <p>
+          A responsive contextual menu pattern for table rows, project cards,
+          inbox items, and dashboards that need several quick actions without
+          cluttering the interface.
+        </p>
+      </section>
+
+      <section class="dashboard-card" aria-label="Project actions demo">
+        <div class="card-header">
+          <div>
+            <p class="eyebrow">Workspace</p>
+            <h2>Launch Checklist</h2>
+          </div>
+
+          <details class="action-menu">
+            <summary class="action-menu-trigger" aria-label="Open action menu">
+              <span></span>
+              <span></span>
+              <span></span>
+            </summary>
+
+            <div class="action-menu-panel" role="menu" aria-label="Project actions">
+              <button class="action-item" type="button" role="menuitem">
+                <span class="action-icon">V</span>
+                <span>
+                  <strong>View details</strong>
+                  <small>Open the full project overview</small>
+                </span>
+              </button>
+              <button class="action-item" type="button" role="menuitem">
+                <span class="action-icon">E</span>
+                <span>
+                  <strong>Edit record</strong>
+                  <small>Update title, owner, or status</small>
+                </span>
+              </button>
+              <button class="action-item" type="button" role="menuitem">
+                <span class="action-icon">D</span>
+                <span>
+                  <strong>Duplicate</strong>
+                  <small>Create a reusable copy</small>
+                </span>
+              </button>
+              <button class="action-item danger" type="button" role="menuitem">
+                <span class="action-icon">R</span>
+                <span>
+                  <strong>Remove</strong>
+                  <small>Archive this item safely</small>
+                </span>
+              </button>
+            </div>
+          </details>
+        </div>
+
+        <div class="status-row">
+          <span class="status-pill">In review</span>
+          <span>12 tasks</span>
+          <span>3 owners</span>
+        </div>
+
+        <div class="preview-list">
+          <article>
+            <span class="check-dot"></span>
+            <p>Validate responsive layout and focus states.</p>
+          </article>
+          <article>
+            <span class="check-dot"></span>
+            <p>Confirm icon slots align cleanly with long action labels.</p>
+          </article>
+          <article>
+            <span class="check-dot"></span>
+            <p>Keep the menu reachable from cards, rows, and compact panels.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-action-menu-ms/style.css
+++ b/submissions/examples/ease-action-menu-ms/style.css
@@ -1,0 +1,336 @@
+:root {
+  --ink: #172033;
+  --muted: #667085;
+  --paper: #fffdf7;
+  --panel: rgba(255, 255, 255, 0.86);
+  --line: rgba(23, 32, 51, 0.1);
+  --lime: #bcf26b;
+  --green: #1f8f6d;
+  --blue: #2454d6;
+  --orange: #ff8a4c;
+  --red: #d63e4d;
+  --shadow: 0 30px 90px rgba(16, 24, 40, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  background:
+    linear-gradient(135deg, rgba(188, 242, 107, 0.22), transparent 32%),
+    radial-gradient(circle at 78% 16%, rgba(36, 84, 214, 0.22), transparent 28rem),
+    radial-gradient(circle at 12% 82%, rgba(255, 138, 76, 0.28), transparent 24rem),
+    #f7f0df;
+}
+
+.demo-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1fr);
+  gap: clamp(24px, 5vw, 68px);
+  width: min(1120px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(32px, 7vw, 86px) 0;
+  align-items: center;
+}
+
+.hero {
+  max-width: 560px;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 20px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3.6rem, 10vw, 8.2rem);
+  line-height: 0.84;
+  letter-spacing: -0.08em;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  letter-spacing: -0.06em;
+}
+
+p {
+  color: var(--muted);
+  font-size: 1.03rem;
+  line-height: 1.75;
+}
+
+.dashboard-card {
+  position: relative;
+  overflow: visible;
+  border: 1px solid var(--line);
+  border-radius: 34px;
+  padding: clamp(24px, 4vw, 38px);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.dashboard-card::before {
+  position: absolute;
+  inset: 18px;
+  z-index: -1;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(188, 242, 107, 0.55), rgba(36, 84, 214, 0.22));
+  content: "";
+  transform: rotate(-2deg);
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.action-menu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.action-menu-trigger {
+  display: inline-grid;
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  place-items: center;
+  background: var(--paper);
+  box-shadow: 0 12px 28px rgba(16, 24, 40, 0.12);
+  cursor: pointer;
+  list-style: none;
+  transition:
+    transform 220ms ease,
+    border-color 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.action-menu-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.action-menu-trigger span {
+  display: block;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--ink);
+}
+
+.action-menu-trigger:hover,
+.action-menu-trigger:focus-visible,
+.action-menu[open] .action-menu-trigger {
+  border-color: rgba(31, 143, 109, 0.36);
+  box-shadow: 0 18px 42px rgba(31, 143, 109, 0.24);
+  outline: none;
+  transform: translateY(-2px) scale(1.04);
+}
+
+.action-menu-panel {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  z-index: 10;
+  display: grid;
+  min-width: 275px;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 10px;
+  background: rgba(255, 253, 247, 0.96);
+  box-shadow: 0 24px 70px rgba(16, 24, 40, 0.22);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-8px) scale(0.98);
+  transform-origin: top right;
+  transition:
+    opacity 180ms ease,
+    transform 220ms cubic-bezier(0.2, 1, 0.2, 1);
+}
+
+.action-menu[open] .action-menu-panel {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.action-item {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  width: 100%;
+  border: 0;
+  border-radius: 18px;
+  padding: 12px;
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.action-item:hover,
+.action-item:focus-visible {
+  background: rgba(36, 84, 214, 0.09);
+  outline: none;
+  transform: translateX(3px);
+}
+
+.action-item.danger:hover,
+.action-item.danger:focus-visible {
+  background: rgba(214, 62, 77, 0.1);
+}
+
+.action-icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  color: white;
+  font-size: 0.78rem;
+  font-weight: 900;
+  place-items: center;
+  background: linear-gradient(135deg, var(--blue), var(--green));
+}
+
+.action-item:nth-child(2) .action-icon {
+  background: linear-gradient(135deg, var(--orange), var(--green));
+}
+
+.action-item:nth-child(3) .action-icon {
+  background: linear-gradient(135deg, #7757d9, var(--blue));
+}
+
+.action-item.danger .action-icon {
+  background: linear-gradient(135deg, var(--red), var(--orange));
+}
+
+.action-item strong,
+.action-item small {
+  display: block;
+}
+
+.action-item small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 28px 0;
+}
+
+.status-row span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.status-row .status-pill {
+  color: #315414;
+  background: var(--lime);
+}
+
+.preview-list {
+  display: grid;
+  gap: 12px;
+}
+
+.preview-list article {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.preview-list p {
+  margin-bottom: 0;
+  font-size: 0.92rem;
+}
+
+.check-dot {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border: 3px solid rgba(31, 143, 109, 0.2);
+  border-radius: 999px;
+  background: var(--green);
+}
+
+@media (max-width: 820px) {
+  .demo-shell {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .hero {
+    max-width: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    width: min(100% - 22px, 1120px);
+    padding: 24px 0;
+  }
+
+  .card-header {
+    align-items: center;
+  }
+
+  .action-menu {
+    position: static;
+  }
+
+  .action-menu-panel {
+    left: 16px;
+    right: 16px;
+    min-width: 0;
+    transform-origin: top center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a standard-track CSS-only contextual action menu example for issue #85318.

## Changes
- Adds `submissions/examples/ease-action-menu-ms/demo.html`
- Adds `submissions/examples/ease-action-menu-ms/style.css`
- Adds `submissions/examples/ease-action-menu-ms/README.md`
- Includes a native `details` / `summary` menu trigger
- Includes multiple actions, icon slots, hover/focus states, and responsive mobile positioning

## Validation
- `npx stylelint --stdin --stdin-filename ease-action-menu-ms.css`
- `git diff --check`
- `npm run build`
- `npm test`
- `npm run validate:manifest`
- `git diff --cached --check`

Closes #85318