### PR TITLE
feat: add section heading example

### DIFF
--- a/submissions/examples/ease-section-heading-ms/README.md
+++ b/submissions/examples/ease-section-heading-ms/README.md
@@ -1,0 +1,24 @@
+# Ease Section Heading
+
+Adds a reusable section heading pattern with a title, description, optional action, responsive layout, and subtle entrance animation.
+
+## How to Use
+
+Place the heading at the top of a dashboard, settings group, content section, or feature block:
+
+```html
+<header class="section-heading section-heading-reveal">
+  <div>
+    <p class="section-kicker">Analytics</p>
+    <h2>Campaign performance</h2>
+    <p>Track delivery, engagement, and reply quality from one calm header.</p>
+  </div>
+  <a class="section-action" href="#">View report</a>
+</header>
+```
+
+The action element is optional. Without it, the title and description still keep a clean readable rhythm.
+
+## Why It Is Useful
+
+EaseMotion CSS is built around readable, composable UI motion. This pattern packages a common layout into a polished, responsive heading with calm animation and clear hierarchy for dashboards, settings pages, documentation sections, and content management screens.

--- a/submissions/examples/ease-section-heading-ms/demo.html
+++ b/submissions/examples/ease-section-heading-ms/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Section Heading</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="intro-panel" aria-labelledby="demo-title">
+        <p class="section-kicker">Reusable layout utility</p>
+        <h1 id="demo-title">Section headings that do the quiet work</h1>
+        <p>
+          A flexible heading block with a title, supporting copy, optional
+          action, responsive wrapping, and a subtle entrance animation.
+        </p>
+      </section>
+
+      <section class="surface" aria-labelledby="analytics-title">
+        <header class="section-heading section-heading-reveal">
+          <div class="section-copy">
+            <p class="section-kicker">Analytics</p>
+            <h2 id="analytics-title">Campaign performance</h2>
+            <p>
+              Compare delivery, replies, and conversions across your latest
+              outreach experiments.
+            </p>
+          </div>
+          <a class="section-action" href="#" aria-label="View campaign report">
+            View report
+          </a>
+        </header>
+
+        <div class="metric-grid" aria-label="Example metrics">
+          <article>
+            <span class="metric-value">92%</span>
+            <span class="metric-label">Delivery rate</span>
+          </article>
+          <article>
+            <span class="metric-value">18.4k</span>
+            <span class="metric-label">Contacts reached</span>
+          </article>
+          <article>
+            <span class="metric-value">7.8%</span>
+            <span class="metric-label">Reply lift</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="surface compact" aria-labelledby="settings-title">
+        <header class="section-heading section-heading-reveal delay">
+          <div class="section-copy">
+            <p class="section-kicker">Settings</p>
+            <h2 id="settings-title">Notification preferences</h2>
+            <p>
+              Keep descriptions readable and actions discoverable even when
+              space gets tight on mobile.
+            </p>
+          </div>
+        </header>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-section-heading-ms/style.css
+++ b/submissions/examples/ease-section-heading-ms/style.css
@@ -1,0 +1,242 @@
+:root {
+  --ink: #141b2d;
+  --muted: #687386;
+  --surface: rgba(255, 255, 255, 0.82);
+  --line: rgba(20, 27, 45, 0.1);
+  --blue: #2457e6;
+  --green: #1d9d72;
+  --coral: #f46f55;
+  --cream: #fff8e8;
+  --shadow: 0 24px 80px rgba(15, 23, 42, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(244, 111, 85, 0.24), transparent 25rem),
+    radial-gradient(circle at 82% 12%, rgba(36, 87, 230, 0.2), transparent 28rem),
+    linear-gradient(135deg, var(--cream), #e7f2ec 54%, #e9edf9);
+}
+
+.demo-shell {
+  display: grid;
+  gap: 26px;
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: clamp(30px, 6vw, 78px) 0;
+}
+
+.intro-panel,
+.surface {
+  border: 1px solid var(--line);
+  border-radius: 34px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.intro-panel {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(30px, 6vw, 58px);
+}
+
+.intro-panel::after {
+  position: absolute;
+  right: -70px;
+  bottom: -105px;
+  width: 260px;
+  height: 260px;
+  border-radius: 999px;
+  background: conic-gradient(from 90deg, var(--blue), var(--green), var(--coral), var(--blue));
+  opacity: 0.18;
+  content: "";
+}
+
+.surface {
+  padding: clamp(24px, 5vw, 42px);
+}
+
+.surface.compact {
+  max-width: 780px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: clamp(18px, 4vw, 44px);
+}
+
+.section-copy {
+  max-width: 680px;
+}
+
+.section-kicker {
+  margin: 0 0 10px;
+  color: var(--green);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2 {
+  font-family: Georgia, "Times New Roman", serif;
+  letter-spacing: -0.06em;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 18px;
+  font-size: clamp(3.2rem, 8vw, 6.8rem);
+  line-height: 0.9;
+}
+
+h2 {
+  margin-bottom: 12px;
+  font-size: clamp(2.2rem, 6vw, 4.75rem);
+  line-height: 0.92;
+}
+
+p {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.section-action {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border: 1px solid rgba(36, 87, 230, 0.16);
+  border-radius: 999px;
+  padding: 0 20px;
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  background: linear-gradient(135deg, var(--blue), var(--green));
+  box-shadow: 0 16px 34px rgba(36, 87, 230, 0.26);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.section-action:hover,
+.section-action:focus-visible {
+  box-shadow: 0 22px 44px rgba(36, 87, 230, 0.34);
+  outline: none;
+  transform: translateY(-3px);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 34px;
+}
+
+.metric-grid article {
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 20px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.36)),
+    rgba(255, 255, 255, 0.56);
+}
+
+.metric-value,
+.metric-label {
+  display: block;
+}
+
+.metric-value {
+  margin-bottom: 8px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1;
+  letter-spacing: -0.06em;
+}
+
+.metric-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.section-heading-reveal {
+  opacity: 0;
+  animation: heading-reveal 720ms cubic-bezier(0.2, 1, 0.2, 1) forwards;
+}
+
+.section-heading-reveal.delay {
+  animation-delay: 160ms;
+}
+
+@keyframes heading-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 760px) {
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-action {
+    width: 100%;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .demo-shell {
+    width: min(100% - 22px, 1080px);
+    padding: 24px 0;
+  }
+
+  .intro-panel,
+  .surface {
+    border-radius: 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a standard-track reusable section heading example for issue #85317.

## Changes
- Adds `submissions/examples/ease-section-heading-ms/demo.html`
- Adds `submissions/examples/ease-section-heading-ms/style.css`
- Adds `submissions/examples/ease-section-heading-ms/README.md`
- Includes title, description, optional action, responsive layout, and subtle entrance animation
- Uses semantic heading structure and reduced-motion handling

## Validation
- `npx stylelint --stdin --stdin-filename ease-section-heading-ms.css`
- `git diff --check`
- `npm run build`
- `npm test`
- `npm run validate:manifest`
- `git diff --cached --check`

Closes #85317