### PR TITLE
feat: add empty state example

### DIFF
--- a/submissions/examples/ease-empty-state-ms/README.md
+++ b/submissions/examples/ease-empty-state-ms/README.md
@@ -1,0 +1,27 @@
+# Ease Empty State
+
+Adds a visual empty-state component for screens with no content, no search results, empty inboxes, or dashboards waiting for data.
+
+## How to Use
+
+Use the component wherever an interface needs a friendly fallback state:
+
+```html
+<section class="empty-state empty-state-reveal">
+  <div class="empty-illustration" aria-hidden="true">
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
+  <p class="empty-kicker">No projects yet</p>
+  <h2>Create your first workspace</h2>
+  <p>Add a project to start tracking tasks, owners, and progress.</p>
+  <a class="empty-action" href="#">Create project</a>
+</section>
+```
+
+The action link/button is optional, so the pattern also works for passive empty results, notifications, and compact cards.
+
+## Why It Is Useful
+
+EaseMotion CSS focuses on readable, animation-first UI building blocks. This empty state gives product screens a polished fallback that communicates clearly, offers an optional next step, and stays responsive without external dependencies.

--- a/submissions/examples/ease-empty-state-ms/demo.html
+++ b/submissions/examples/ease-empty-state-ms/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Empty State</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="intro" aria-labelledby="demo-title">
+        <p class="empty-kicker">Reusable fallback pattern</p>
+        <h1 id="demo-title">Empty states that still feel alive</h1>
+        <p>
+          A compact visual component with an illustration area, clear message,
+          optional action, responsive layout, and gentle entrance motion.
+        </p>
+      </section>
+
+      <section class="empty-state empty-state-reveal" aria-labelledby="empty-title">
+        <div class="empty-illustration" aria-hidden="true">
+          <span class="orb main-orb"></span>
+          <span class="orb small-orb"></span>
+          <span class="tray"></span>
+          <span class="spark spark-one"></span>
+          <span class="spark spark-two"></span>
+        </div>
+
+        <p class="empty-kicker">No campaigns yet</p>
+        <h2 id="empty-title">Build your first launch plan</h2>
+        <p>
+          Once a campaign is created, performance cards, owner notes, and
+          delivery insights will appear here automatically.
+        </p>
+        <a class="empty-action" href="#">Create campaign</a>
+      </section>
+
+      <section class="mini-grid" aria-label="Additional empty state examples">
+        <article class="mini-empty">
+          <span class="mini-icon">0</span>
+          <h3>No results</h3>
+          <p>Try clearing filters or searching with a broader phrase.</p>
+        </article>
+        <article class="mini-empty">
+          <span class="mini-icon">+</span>
+          <h3>Invite teammates</h3>
+          <p>Add collaborators to make this workspace useful.</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-empty-state-ms/style.css
+++ b/submissions/examples/ease-empty-state-ms/style.css
@@ -1,0 +1,307 @@
+:root {
+  --ink: #151a2e;
+  --muted: #687185;
+  --paper: #fffaf0;
+  --surface: rgba(255, 255, 255, 0.82);
+  --line: rgba(21, 26, 46, 0.1);
+  --blue: #275ee7;
+  --mint: #28b68d;
+  --gold: #f0b447;
+  --rose: #ea6b7c;
+  --shadow: 0 28px 90px rgba(15, 23, 42, 0.17);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(234, 107, 124, 0.24), transparent 24rem),
+    radial-gradient(circle at 84% 12%, rgba(39, 94, 231, 0.2), transparent 26rem),
+    radial-gradient(circle at 50% 90%, rgba(40, 182, 141, 0.22), transparent 28rem),
+    #f5ecd9;
+}
+
+.demo-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1fr);
+  gap: clamp(24px, 5vw, 72px);
+  width: min(1100px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(30px, 7vw, 84px) 0;
+  align-items: center;
+}
+
+.intro {
+  max-width: 540px;
+}
+
+.empty-kicker {
+  margin: 0 0 10px;
+  color: var(--mint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3 {
+  font-family: Georgia, "Times New Roman", serif;
+  letter-spacing: -0.06em;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(3.4rem, 9vw, 7.3rem);
+  line-height: 0.88;
+}
+
+h2 {
+  margin-bottom: 14px;
+  font-size: clamp(2.45rem, 6vw, 4.9rem);
+  line-height: 0.92;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 1.6rem;
+}
+
+p {
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.72;
+}
+
+.empty-state {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 38px;
+  padding: clamp(28px, 6vw, 58px);
+  text-align: center;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.empty-state::before {
+  position: absolute;
+  inset: 18px;
+  z-index: -1;
+  border-radius: 30px;
+  background: linear-gradient(135deg, rgba(240, 180, 71, 0.28), rgba(39, 94, 231, 0.12));
+  content: "";
+}
+
+.empty-state p {
+  max-width: 560px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.empty-illustration {
+  position: relative;
+  width: min(250px, 72vw);
+  height: 190px;
+  margin: 0 auto 28px;
+}
+
+.orb,
+.tray,
+.spark {
+  position: absolute;
+  display: block;
+}
+
+.main-orb {
+  top: 18px;
+  left: 50%;
+  width: 112px;
+  height: 112px;
+  border-radius: 36px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.62), transparent),
+    var(--blue);
+  box-shadow: 0 22px 44px rgba(39, 94, 231, 0.3);
+  transform: translateX(-50%) rotate(-10deg);
+  animation: float-card 3.4s ease-in-out infinite;
+}
+
+.small-orb {
+  top: 38px;
+  right: 26px;
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  background: var(--gold);
+  box-shadow: 0 18px 34px rgba(240, 180, 71, 0.34);
+  animation: float-card 3.4s 400ms ease-in-out infinite;
+}
+
+.tray {
+  right: 18px;
+  bottom: 16px;
+  left: 18px;
+  height: 56px;
+  border: 1px solid rgba(21, 26, 46, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 250, 240, 0.92);
+  box-shadow: inset 0 -10px 20px rgba(21, 26, 46, 0.08);
+}
+
+.spark {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--rose);
+}
+
+.spark-one {
+  top: 12px;
+  left: 34px;
+}
+
+.spark-two {
+  right: 52px;
+  bottom: 78px;
+  width: 11px;
+  height: 11px;
+  background: var(--mint);
+}
+
+.empty-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50px;
+  margin-top: 8px;
+  border-radius: 999px;
+  padding: 0 22px;
+  color: white;
+  font-size: 0.92rem;
+  font-weight: 900;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  background: linear-gradient(135deg, var(--blue), var(--mint));
+  box-shadow: 0 18px 40px rgba(39, 94, 231, 0.3);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.empty-action:hover,
+.empty-action:focus-visible {
+  box-shadow: 0 24px 52px rgba(39, 94, 231, 0.38);
+  outline: none;
+  transform: translateY(-3px);
+}
+
+.mini-grid {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.mini-empty {
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: 0 18px 56px rgba(15, 23, 42, 0.1);
+}
+
+.mini-empty p {
+  margin-bottom: 0;
+}
+
+.mini-icon {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  margin-bottom: 18px;
+  border-radius: 16px;
+  color: white;
+  font-weight: 900;
+  place-items: center;
+  background: linear-gradient(135deg, var(--rose), var(--gold));
+}
+
+.empty-state-reveal {
+  opacity: 0;
+  animation: reveal-empty 720ms cubic-bezier(0.2, 1, 0.2, 1) forwards;
+}
+
+@keyframes reveal-empty {
+  from {
+    opacity: 0;
+    transform: translateY(22px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes float-card {
+  0%,
+  100% {
+    transform: translateX(-50%) translateY(0) rotate(-10deg);
+  }
+
+  50% {
+    transform: translateX(-50%) translateY(-10px) rotate(-6deg);
+  }
+}
+
+@media (max-width: 860px) {
+  .demo-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .intro {
+    max-width: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .demo-shell {
+    width: min(100% - 22px, 1100px);
+    padding: 24px 0;
+  }
+
+  .empty-state {
+    border-radius: 28px;
+  }
+
+  .mini-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a standard-track visual empty-state component example for issue #85316.

## Changes
- Adds `submissions/examples/ease-empty-state-ms/demo.html`
- Adds `submissions/examples/ease-empty-state-ms/style.css`
- Adds `submissions/examples/ease-empty-state-ms/README.md`
- Includes illustration/icon area, title, description, optional action, entrance animation, responsive layout, and reduced-motion handling

## Validation
- `npx stylelint --stdin --stdin-filename ease-empty-state-ms.css`
- `git diff --check`
- `npm run build`
- `npm test`
- `npm run validate:manifest`
- `git diff --cached --check`

Closes #85316