### PR TITLE
feat: add location label example

### DIFF
--- a/submissions/examples/ease-location-label-ms/README.md
+++ b/submissions/examples/ease-location-label-ms/README.md
@@ -1,0 +1,26 @@
+# Ease Location Label
+
+Adds a compact location label component with an icon, readable location text, size variants, hover animation, and responsive wrapping.
+
+## How to Use
+
+Use the label anywhere location context needs to stay compact:
+
+```html
+<span class="location-label location-label-md">
+  <span class="location-pin" aria-hidden="true"></span>
+  <span>Gurgaon, India</span>
+</span>
+```
+
+Available size variants:
+
+```html
+<span class="location-label location-label-sm">...</span>
+<span class="location-label location-label-md">...</span>
+<span class="location-label location-label-lg">...</span>
+```
+
+## Why It Is Useful
+
+EaseMotion CSS focuses on readable, composable UI helpers. This component gives maps, delivery dashboards, travel cards, event listings, and profile pages a polished location indicator with subtle motion and no external dependencies.

--- a/submissions/examples/ease-location-label-ms/demo.html
+++ b/submissions/examples/ease-location-label-ms/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Location Label</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="demo-shell">
+      <section class="hero" aria-labelledby="page-title">
+        <p class="label-kicker">Compact context component</p>
+        <h1 id="page-title">Location labels with a little pulse</h1>
+        <p>
+          A reusable label pattern for maps, delivery cards, event listings,
+          travel interfaces, and profiles where location should be visible but
+          never noisy.
+        </p>
+      </section>
+
+      <section class="map-card" aria-labelledby="map-title">
+        <div class="map-surface" aria-hidden="true">
+          <span class="route-line"></span>
+          <span class="map-dot dot-one"></span>
+          <span class="map-dot dot-two"></span>
+          <span class="map-dot dot-three"></span>
+        </div>
+
+        <div class="card-content">
+          <p class="label-kicker">Delivery route</p>
+          <h2 id="map-title">Today&apos;s active stops</h2>
+
+          <div class="label-stack" aria-label="Location label examples">
+            <span class="location-label location-label-sm">
+              <span class="location-pin" aria-hidden="true"></span>
+              <span>Sector 29</span>
+            </span>
+            <span class="location-label location-label-md featured">
+              <span class="location-pin" aria-hidden="true"></span>
+              <span>Gurgaon, Haryana</span>
+            </span>
+            <span class="location-label location-label-lg">
+              <span class="location-pin" aria-hidden="true"></span>
+              <span>Indira Gandhi International Airport</span>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-location-label-ms/style.css
+++ b/submissions/examples/ease-location-label-ms/style.css
@@ -1,0 +1,260 @@
+:root {
+  --ink: #142032;
+  --muted: #697386;
+  --surface: rgba(255, 255, 255, 0.84);
+  --line: rgba(20, 32, 50, 0.1);
+  --sky: #2d6cdf;
+  --mint: #18a77c;
+  --sun: #f3b444;
+  --rose: #e75f77;
+  --shadow: 0 28px 86px rgba(15, 23, 42, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: "Trebuchet MS", Verdana, sans-serif;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(243, 180, 68, 0.28), transparent 26rem),
+    radial-gradient(circle at 86% 10%, rgba(45, 108, 223, 0.22), transparent 27rem),
+    linear-gradient(135deg, #fff7e6 0%, #e5f4ee 52%, #e8eefb 100%);
+}
+
+.demo-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(320px, 1fr);
+  gap: clamp(24px, 5vw, 70px);
+  width: min(1120px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(32px, 7vw, 84px) 0;
+  align-items: center;
+}
+
+.hero {
+  max-width: 560px;
+}
+
+.label-kicker {
+  margin: 0 0 10px;
+  color: var(--mint);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2 {
+  font-family: Georgia, "Times New Roman", serif;
+  letter-spacing: -0.07em;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(3.3rem, 9vw, 7.25rem);
+  line-height: 0.88;
+}
+
+h2 {
+  margin-bottom: 22px;
+  font-size: clamp(2.2rem, 5vw, 4.2rem);
+  line-height: 0.92;
+}
+
+p {
+  color: var(--muted);
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.map-card {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 38px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.map-surface {
+  position: relative;
+  min-height: 230px;
+  background:
+    linear-gradient(90deg, rgba(20, 32, 50, 0.06) 1px, transparent 1px),
+    linear-gradient(rgba(20, 32, 50, 0.06) 1px, transparent 1px),
+    radial-gradient(circle at 25% 35%, rgba(24, 167, 124, 0.28), transparent 12rem),
+    radial-gradient(circle at 75% 52%, rgba(45, 108, 223, 0.25), transparent 13rem),
+    #fdf8ec;
+  background-size: 34px 34px, 34px 34px, auto, auto, auto;
+}
+
+.route-line {
+  position: absolute;
+  top: 50%;
+  left: 13%;
+  width: 74%;
+  height: 5px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--mint), var(--sun), var(--sky));
+  box-shadow: 0 12px 28px rgba(45, 108, 223, 0.24);
+  transform: rotate(-9deg);
+}
+
+.map-dot {
+  position: absolute;
+  display: block;
+  width: 22px;
+  height: 22px;
+  border: 5px solid white;
+  border-radius: 999px;
+  background: var(--sky);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.2);
+}
+
+.dot-one {
+  top: 38%;
+  left: 20%;
+  background: var(--mint);
+}
+
+.dot-two {
+  top: 44%;
+  left: 52%;
+  background: var(--sun);
+}
+
+.dot-three {
+  top: 29%;
+  right: 18%;
+  background: var(--rose);
+}
+
+.card-content {
+  padding: clamp(24px, 5vw, 42px);
+}
+
+.label-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.location-label {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  border: 1px solid rgba(20, 32, 50, 0.12);
+  border-radius: 999px;
+  color: var(--ink);
+  font-weight: 800;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.location-label:hover,
+.location-label:focus-within {
+  border-color: rgba(24, 167, 124, 0.34);
+  box-shadow: 0 20px 44px rgba(24, 167, 124, 0.2);
+  transform: translateY(-4px);
+}
+
+.location-label-sm {
+  gap: 8px;
+  padding: 7px 11px;
+  font-size: 0.82rem;
+}
+
+.location-label-md {
+  gap: 10px;
+  padding: 10px 15px;
+  font-size: 0.96rem;
+}
+
+.location-label-lg {
+  gap: 12px;
+  padding: 13px 18px;
+  font-size: 1.08rem;
+}
+
+.featured {
+  color: white;
+  background: linear-gradient(135deg, var(--sky), var(--mint));
+}
+
+.location-pin {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 999px 999px 999px 0;
+  background: currentcolor;
+  transform: rotate(-45deg);
+}
+
+.location-pin::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.38em;
+  height: 0.38em;
+  border-radius: 999px;
+  background: white;
+  content: "";
+  transform: translate(-50%, -50%);
+}
+
+.featured .location-pin::after {
+  background: var(--sky);
+}
+
+@media (max-width: 820px) {
+  .demo-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    max-width: none;
+  }
+}
+
+@media (max-width: 540px) {
+  .demo-shell {
+    width: min(100% - 22px, 1120px);
+    padding: 24px 0;
+  }
+
+  .map-card {
+    border-radius: 28px;
+  }
+
+  .location-label {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Adds a standard-track compact location label component example for issue #85312.

## Changes
- Adds `submissions/examples/ease-location-label-ms/demo.html`
- Adds `submissions/examples/ease-location-label-ms/style.css`
- Adds `submissions/examples/ease-location-label-ms/README.md`
- Includes a CSS location pin icon, location text, multiple size variants, hover animation, responsive layout, and reduced-motion handling

## Validation
- `npx stylelint --stdin --stdin-filename ease-location-label-ms.css`
- `git diff --check`
- `npm run build`
- `npm test`
- `npm run validate:manifest`
- `git diff --cached --check`

Closes #85312