### PR TITLE
feat: add weather indicator example

### DIFF
--- a/submissions/examples/ease-weather-indicator-ms/README.md
+++ b/submissions/examples/ease-weather-indicator-ms/README.md
@@ -1,0 +1,23 @@
+# Ease Weather Indicator
+
+## What does this do?
+
+Adds a compact weather condition display with CSS-only icons, temperatures, condition labels, and multiple visual states.
+
+## How is it used?
+
+Place the indicator markup inside any dashboard, travel, or location-aware interface and choose a state class such as `sunny`, `cloudy`, `rainy`, or `storm`.
+
+```html
+<article class="weather-indicator sunny">
+  <span class="weather-icon" aria-hidden="true"></span>
+  <div>
+    <span class="weather-temp">31&deg;C</span>
+    <span class="weather-condition">Sunny</span>
+  </div>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a polished, responsive status component that communicates weather at a glance while staying lightweight, accessible, and dependency-free.

--- a/submissions/examples/ease-weather-indicator-ms/demo.html
+++ b/submissions/examples/ease-weather-indicator-ms/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Weather Indicator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="weather-shell">
+      <section class="weather-card" aria-labelledby="weather-title">
+        <p class="eyebrow">Weather widget</p>
+        <h1 id="weather-title">Compact weather indicator</h1>
+        <p class="weather-intro">
+          A responsive status strip for dashboards, travel pages, and location-aware
+          product screens.
+        </p>
+
+        <div class="weather-grid" aria-label="Weather condition examples">
+          <article class="weather-indicator sunny">
+            <span class="weather-icon" aria-hidden="true"></span>
+            <div>
+              <span class="weather-temp">31&deg;C</span>
+              <span class="weather-condition">Sunny</span>
+            </div>
+          </article>
+
+          <article class="weather-indicator cloudy">
+            <span class="weather-icon" aria-hidden="true"></span>
+            <div>
+              <span class="weather-temp">24&deg;C</span>
+              <span class="weather-condition">Cloudy</span>
+            </div>
+          </article>
+
+          <article class="weather-indicator rainy">
+            <span class="weather-icon" aria-hidden="true"></span>
+            <div>
+              <span class="weather-temp">19&deg;C</span>
+              <span class="weather-condition">Rain showers</span>
+            </div>
+          </article>
+
+          <article class="weather-indicator storm">
+            <span class="weather-icon" aria-hidden="true"></span>
+            <div>
+              <span class="weather-temp">16&deg;C</span>
+              <span class="weather-condition">Storm watch</span>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-weather-indicator-ms/style.css
+++ b/submissions/examples/ease-weather-indicator-ms/style.css
@@ -1,0 +1,261 @@
+:root {
+  --weather-ink: #17313f;
+  --weather-muted: #5d7480;
+  --weather-card: rgba(255, 255, 255, 0.84);
+  --weather-ring: rgba(255, 255, 255, 0.62);
+  --sunny: #ffb545;
+  --cloudy: #7fa4b8;
+  --rainy: #4d8dcb;
+  --storm: #5d68b8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+  color: var(--weather-ink);
+  background:
+    radial-gradient(circle at 22% 18%, rgba(255, 238, 184, 0.92), transparent 25rem),
+    radial-gradient(circle at 76% 20%, rgba(143, 206, 230, 0.8), transparent 24rem),
+    linear-gradient(135deg, #e7f8ff 0%, #f9f3df 48%, #d6edff 100%);
+}
+
+.weather-shell {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.weather-card {
+  width: min(960px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  overflow: hidden;
+  position: relative;
+  border: 1px solid var(--weather-ring);
+  border-radius: 2rem;
+  background: var(--weather-card);
+  box-shadow: 0 2rem 5rem rgba(64, 105, 123, 0.22);
+}
+
+.weather-card::before {
+  width: 13rem;
+  height: 13rem;
+  right: -4rem;
+  top: -4rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 190, 82, 0.42), rgba(255, 255, 255, 0));
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: #df7b2d;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 4.75rem);
+  line-height: 0.92;
+}
+
+.weather-intro {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--weather-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.weather-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.weather-indicator {
+  display: flex;
+  min-height: 8.75rem;
+  padding: 1.1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1rem 2.5rem rgba(63, 100, 118, 0.12);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.weather-indicator::before {
+  inset: auto -2rem -3rem auto;
+  width: 8rem;
+  height: 8rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.22;
+  background: var(--state-color);
+}
+
+.weather-indicator:hover {
+  transform: translateY(-0.4rem);
+  box-shadow: 0 1.4rem 3rem rgba(63, 100, 118, 0.22);
+}
+
+.sunny {
+  --state-color: var(--sunny);
+}
+
+.cloudy {
+  --state-color: var(--cloudy);
+}
+
+.rainy {
+  --state-color: var(--rainy);
+}
+
+.storm {
+  --state-color: var(--storm);
+}
+
+.weather-icon {
+  flex: 0 0 3.25rem;
+  width: 3.25rem;
+  height: 3.25rem;
+  position: relative;
+  border-radius: 50%;
+  background: var(--state-color);
+  box-shadow: 0 0.5rem 1rem rgba(37, 73, 88, 0.16);
+}
+
+.sunny .weather-icon {
+  animation: soft-pulse 2.4s ease-in-out infinite;
+}
+
+.cloudy .weather-icon::before,
+.rainy .weather-icon::before,
+.storm .weather-icon::before {
+  width: 3.4rem;
+  height: 1.6rem;
+  left: 0.65rem;
+  bottom: 0.45rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow:
+    -0.85rem 0.15rem 0 -0.15rem #ffffff,
+    0.65rem -0.45rem 0 -0.2rem #ffffff;
+}
+
+.rainy .weather-icon::after,
+.storm .weather-icon::after {
+  left: 1.05rem;
+  bottom: -0.75rem;
+  width: 0.35rem;
+  height: 0.95rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow:
+    0.75rem 0.22rem 0 #ffffff,
+    1.5rem -0.08rem 0 #ffffff;
+  transform: rotate(18deg);
+  animation: rain-fall 1s linear infinite;
+}
+
+.storm .weather-icon {
+  background: linear-gradient(135deg, var(--storm), #232a6f);
+}
+
+.weather-temp,
+.weather-condition {
+  display: block;
+  position: relative;
+  z-index: 1;
+}
+
+.weather-temp {
+  font-size: 1.6rem;
+  font-weight: 800;
+}
+
+.weather-condition {
+  margin-top: 0.2rem;
+  color: var(--weather-muted);
+  font-size: 0.85rem;
+}
+
+@keyframes soft-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes rain-fall {
+  0% {
+    opacity: 0;
+    transform: translateY(-0.25rem) rotate(18deg);
+  }
+
+  45% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(0.55rem) rotate(18deg);
+  }
+}
+
+@media (max-width: 760px) {
+  .weather-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .weather-shell {
+    padding: 1rem;
+  }
+
+  .weather-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .weather-indicator {
+    min-height: 6.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact weather condition indicator example under submissions/examples/ease-weather-indicator-ms
- Include CSS-only icons for sunny, cloudy, rainy, and storm states
- Add responsive layout, hover motion, and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-weather-indicator-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85311