### PR TITLE
feat: add time display example

### DIFF
--- a/submissions/examples/ease-time-display-ms/README.md
+++ b/submissions/examples/ease-time-display-ms/README.md
@@ -1,0 +1,21 @@
+# Ease Time Display
+
+## What does this do?
+
+Adds a compact time display component with a time value, timezone badge, size variations, and subtle motion.
+
+## How is it used?
+
+Place the component in schedules, dashboards, monitoring views, or activity feeds and choose a size class such as `time-display-large`, `time-display-medium`, or `time-display-small`.
+
+```html
+<article class="time-display time-display-large">
+  <span class="time-zone">IST</span>
+  <strong class="time-value">08:45</strong>
+  <span class="time-meta">Team standup starts soon</span>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a readable, dependency-free time pattern for interfaces that need schedule context without a bulky calendar or clock widget.

--- a/submissions/examples/ease-time-display-ms/demo.html
+++ b/submissions/examples/ease-time-display-ms/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Time Display</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="time-stage">
+      <section class="time-panel" aria-labelledby="time-title">
+        <p class="time-kicker">Schedule ready</p>
+        <h1 id="time-title">Compact time display</h1>
+        <p class="time-copy">
+          Present live-looking time values, timezone context, and urgency states in
+          one responsive component.
+        </p>
+
+        <div class="time-stack" aria-label="Time display examples">
+          <article class="time-display time-display-large">
+            <span class="time-zone">IST</span>
+            <strong class="time-value">08:45</strong>
+            <span class="time-meta">Team standup starts soon</span>
+          </article>
+
+          <article class="time-display time-display-medium">
+            <span class="time-zone">UTC</span>
+            <strong class="time-value">03:15</strong>
+            <span class="time-meta">Deployment checkpoint</span>
+          </article>
+
+          <article class="time-display time-display-small">
+            <span class="time-zone">PST</span>
+            <strong class="time-value">19:45</strong>
+            <span class="time-meta">Client review window</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-time-display-ms/style.css
+++ b/submissions/examples/ease-time-display-ms/style.css
@@ -1,0 +1,214 @@
+:root {
+  --time-ink: #162033;
+  --time-muted: #647184;
+  --time-panel: rgba(255, 255, 255, 0.86);
+  --time-line: rgba(255, 255, 255, 0.68);
+  --time-accent: #f97316;
+  --time-accent-deep: #be4b0b;
+  --time-blue: #2563eb;
+  --time-shadow: rgba(32, 43, 67, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Verdana, "Segoe UI", sans-serif;
+  color: var(--time-ink);
+  background:
+    radial-gradient(circle at 20% 15%, rgba(255, 226, 163, 0.85), transparent 23rem),
+    radial-gradient(circle at 82% 16%, rgba(129, 179, 255, 0.65), transparent 24rem),
+    linear-gradient(145deg, #f9fafb 0%, #dfeeff 45%, #fff1d6 100%);
+}
+
+.time-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.time-panel {
+  width: min(980px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--time-line);
+  border-radius: 2rem;
+  background: var(--time-panel);
+  box-shadow: 0 2rem 5rem var(--time-shadow);
+}
+
+.time-panel::after {
+  width: 16rem;
+  height: 16rem;
+  right: -5rem;
+  top: -6rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background:
+    repeating-conic-gradient(
+      from 0deg,
+      rgba(249, 115, 22, 0.18) 0deg 10deg,
+      transparent 10deg 22deg
+    );
+  animation: dial-spin 18s linear infinite;
+}
+
+.time-kicker {
+  margin: 0 0 0.5rem;
+  color: var(--time-accent-deep);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.1rem, 7vw, 5rem);
+  line-height: 0.9;
+}
+
+.time-copy {
+  max-width: 35rem;
+  margin: 1rem 0 2rem;
+  color: var(--time-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.time-stack {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 0.85fr;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.time-display {
+  display: grid;
+  min-height: 11rem;
+  padding: 1.2rem;
+  align-content: end;
+  gap: 0.55rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 1.4rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.58)),
+    radial-gradient(circle at 88% 16%, rgba(37, 99, 235, 0.16), transparent 8rem);
+  box-shadow: 0 1rem 2.5rem rgba(42, 56, 82, 0.12);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.time-display::before {
+  width: 0.5rem;
+  inset: 1.2rem auto 1.2rem 1.2rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: linear-gradient(var(--time-accent), var(--time-blue));
+  animation: time-glow 2.8s ease-in-out infinite;
+}
+
+.time-display:hover {
+  transform: translateY(-0.35rem);
+  box-shadow: 0 1.5rem 3rem rgba(42, 56, 82, 0.2);
+}
+
+.time-zone {
+  width: fit-content;
+  margin-left: 1.25rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  background: var(--time-ink);
+}
+
+.time-value {
+  margin-left: 1.25rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.07em;
+  line-height: 0.86;
+}
+
+.time-display-large .time-value {
+  font-size: clamp(3.25rem, 9vw, 5.8rem);
+}
+
+.time-display-medium .time-value {
+  font-size: clamp(2.65rem, 7vw, 4.4rem);
+}
+
+.time-display-small .time-value {
+  font-size: clamp(2rem, 6vw, 3.2rem);
+}
+
+.time-meta {
+  margin-left: 1.25rem;
+  color: var(--time-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+@keyframes time-glow {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scaleY(0.82);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes dial-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 780px) {
+  .time-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .time-display {
+    min-height: 8.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .time-stage {
+    padding: 1rem;
+  }
+
+  .time-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact time display example under submissions/examples/ease-time-display-ms
- Include timezone badges, multiple size variants, and subtle animated timing accents
- Add responsive layout and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-time-display-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85308