### PR TITLE
feat: add hotkey label example

### DIFF
--- a/submissions/examples/ease-hotkey-label-ms/README.md
+++ b/submissions/examples/ease-hotkey-label-ms/README.md
@@ -1,0 +1,24 @@
+# Ease Hotkey Label
+
+## What does this do?
+
+Adds a compact rounded label for showing keyboard shortcuts beside actions.
+
+## How is it used?
+
+Place the hotkey label next to any command, menu item, toolbar action, or command palette row and compose the keys with inline `kbd` elements.
+
+```html
+<article class="shortcut-card">
+  <span class="shortcut-action">Open command palette</span>
+  <span class="shortcut-keys">
+    <kbd>Ctrl</kbd>
+    <span>+</span>
+    <kbd>K</kbd>
+  </span>
+</article>
+```
+
+## Why is it useful?
+
+It helps EaseMotion CSS present shortcuts in a polished, readable way that improves discoverability in productivity-focused interfaces.

--- a/submissions/examples/ease-hotkey-label-ms/demo.html
+++ b/submissions/examples/ease-hotkey-label-ms/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Hotkey Label</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="shortcut-stage">
+      <section class="shortcut-panel" aria-labelledby="shortcut-title">
+        <p class="shortcut-kicker">Keyboard friendly</p>
+        <h1 id="shortcut-title">Compact hotkey labels</h1>
+        <p class="shortcut-copy">
+          Rounded shortcut chips for menus, toolbars, command palettes, and
+          productivity dashboards.
+        </p>
+
+        <div class="shortcut-grid" aria-label="Hotkey label examples">
+          <article class="shortcut-card">
+            <span class="shortcut-action">Open command palette</span>
+            <span class="shortcut-keys">
+              <kbd>Ctrl</kbd>
+              <span>+</span>
+              <kbd>K</kbd>
+            </span>
+          </article>
+
+          <article class="shortcut-card">
+            <span class="shortcut-action">Duplicate selection</span>
+            <span class="shortcut-keys">
+              <kbd>Shift</kbd>
+              <span>+</span>
+              <kbd>Alt</kbd>
+              <span>+</span>
+              <kbd>D</kbd>
+            </span>
+          </article>
+
+          <article class="shortcut-card">
+            <span class="shortcut-action">Quick publish</span>
+            <span class="shortcut-keys">
+              <kbd>Cmd</kbd>
+              <span>+</span>
+              <kbd>Enter</kbd>
+            </span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-hotkey-label-ms/style.css
+++ b/submissions/examples/ease-hotkey-label-ms/style.css
@@ -1,0 +1,195 @@
+:root {
+  --shortcut-ink: #182332;
+  --shortcut-muted: #607083;
+  --shortcut-panel: rgba(255, 255, 255, 0.88);
+  --shortcut-line: rgba(255, 255, 255, 0.72);
+  --shortcut-chip: #f2f6fb;
+  --shortcut-accent: #e76f51;
+  --shortcut-accent-deep: #b4462b;
+  --shortcut-shadow: rgba(34, 48, 72, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Georgia, "Trebuchet MS", sans-serif;
+  color: var(--shortcut-ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(255, 215, 176, 0.85), transparent 24rem),
+    radial-gradient(circle at 78% 22%, rgba(180, 220, 255, 0.68), transparent 22rem),
+    linear-gradient(145deg, #fff8ef 0%, #edf6ff 48%, #fffdf8 100%);
+}
+
+.shortcut-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.shortcut-panel {
+  width: min(940px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--shortcut-line);
+  border-radius: 2rem;
+  background: var(--shortcut-panel);
+  box-shadow: 0 2rem 5rem var(--shortcut-shadow);
+}
+
+.shortcut-panel::before {
+  width: 15rem;
+  height: 15rem;
+  right: -5rem;
+  bottom: -5rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background:
+    repeating-linear-gradient(
+      135deg,
+      rgba(231, 111, 81, 0.15) 0 12px,
+      rgba(255, 255, 255, 0) 12px 24px
+    );
+}
+
+.shortcut-kicker {
+  margin: 0 0 0.55rem;
+  color: var(--shortcut-accent-deep);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.9rem);
+  line-height: 0.92;
+}
+
+.shortcut-copy {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--shortcut-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.shortcut-grid {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.shortcut-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.3rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1rem 2.25rem rgba(34, 48, 72, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.shortcut-card:hover {
+  transform: translateY(-0.3rem);
+  border-color: rgba(231, 111, 81, 0.38);
+  box-shadow: 0 1.4rem 2.7rem rgba(34, 48, 72, 0.16);
+}
+
+.shortcut-action {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.shortcut-keys {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  color: var(--shortcut-muted);
+}
+
+kbd {
+  min-width: 2.6rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(125, 147, 173, 0.28);
+  border-radius: 0.9rem;
+  background:
+    linear-gradient(180deg, #ffffff 0%, #edf3f9 100%);
+  box-shadow:
+    inset 0 -0.16rem 0 rgba(173, 188, 205, 0.45),
+    0 0.4rem 0.75rem rgba(47, 70, 99, 0.08);
+  color: var(--shortcut-ink);
+  font-family: "Segoe UI", sans-serif;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-align: center;
+  animation: key-breathe 2.6s ease-in-out infinite;
+}
+
+.shortcut-card:nth-child(2) kbd {
+  animation-delay: 120ms;
+}
+
+.shortcut-card:nth-child(3) kbd {
+  animation-delay: 240ms;
+}
+
+@keyframes key-breathe {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-0.08rem);
+  }
+}
+
+@media (max-width: 680px) {
+  .shortcut-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shortcut-keys {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .shortcut-stage {
+    padding: 1rem;
+  }
+
+  .shortcut-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact hotkey label example under submissions/examples/ease-hotkey-label-ms
- Include rounded shortcut chips for single and multi-key combinations
- Add hover feedback, responsive layout, and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-hotkey-label-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85307