### PR TITLE
feat: add keyboard key example

### DIFF
--- a/submissions/examples/ease-keyboard-key-ms/README.md
+++ b/submissions/examples/ease-keyboard-key-ms/README.md
@@ -1,0 +1,17 @@
+# Ease Keyboard Key
+
+## What does this do?
+
+Adds a styled keyboard key component with multiple sizes, a pressed state, and subtle hover motion.
+
+## How is it used?
+
+Place the component anywhere you want to show a shortcut hint or key legend and choose a size class such as `keyboard-key-large`, `keyboard-key-medium`, or `keyboard-key-small`.
+
+```html
+<span class="keyboard-key keyboard-key-medium is-pressed">Shift</span>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a clean, reusable way to present keyboard keys in documentation, command palettes, and onboarding flows without extra dependencies.

--- a/submissions/examples/ease-keyboard-key-ms/demo.html
+++ b/submissions/examples/ease-keyboard-key-ms/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Keyboard Key</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="key-stage">
+      <section class="key-panel" aria-labelledby="key-title">
+        <p class="key-kicker">Shortcut ready</p>
+        <h1 id="key-title">Styled keyboard keys</h1>
+        <p class="key-copy">
+          A polished keycap component for docs, onboarding flows, shortcut guides,
+          and command palette hints.
+        </p>
+
+        <div class="key-grid" aria-label="Keyboard key examples">
+          <article class="key-card">
+            <span class="key-label">Default key</span>
+            <span class="keyboard-key keyboard-key-large">Tab</span>
+          </article>
+
+          <article class="key-card">
+            <span class="key-label">Pressed state</span>
+            <span class="keyboard-key keyboard-key-medium is-pressed">Shift</span>
+          </article>
+
+          <article class="key-card">
+            <span class="key-label">Compact key</span>
+            <span class="keyboard-key keyboard-key-small">Esc</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-keyboard-key-ms/style.css
+++ b/submissions/examples/ease-keyboard-key-ms/style.css
@@ -1,0 +1,212 @@
+:root {
+  --key-ink: #19263a;
+  --key-muted: #64748b;
+  --key-panel: rgba(255, 255, 255, 0.88);
+  --key-line: rgba(255, 255, 255, 0.74);
+  --key-surface: #f6f8fb;
+  --key-shadow: rgba(27, 39, 61, 0.18);
+  --key-accent: #2f6fed;
+  --key-accent-soft: #dfe9ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Gill Sans", "Segoe UI", sans-serif;
+  color: var(--key-ink);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(223, 233, 255, 0.95), transparent 23rem),
+    radial-gradient(circle at 82% 18%, rgba(255, 223, 190, 0.7), transparent 21rem),
+    linear-gradient(140deg, #f7fbff 0%, #eef3ff 46%, #fff9f1 100%);
+}
+
+.key-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.key-panel {
+  width: min(900px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--key-line);
+  border-radius: 2rem;
+  background: var(--key-panel);
+  box-shadow: 0 2rem 5rem var(--key-shadow);
+}
+
+.key-panel::after {
+  width: 14rem;
+  height: 14rem;
+  right: -4rem;
+  top: -4rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background:
+    linear-gradient(135deg, rgba(47, 111, 237, 0.22), rgba(255, 255, 255, 0));
+}
+
+.key-kicker {
+  margin: 0 0 0.55rem;
+  color: #315ec8;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.key-copy {
+  max-width: 33rem;
+  margin: 1rem 0 2rem;
+  color: var(--key-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.key-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.key-card {
+  display: grid;
+  min-height: 11rem;
+  place-items: center;
+  gap: 1rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.4rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1rem 2.25rem rgba(27, 39, 61, 0.09);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.key-card:hover {
+  transform: translateY(-0.35rem);
+  box-shadow: 0 1.5rem 2.9rem rgba(27, 39, 61, 0.15);
+}
+
+.key-label {
+  color: var(--key-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.keyboard-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.2rem;
+  padding: 0.9rem 1.15rem;
+  border: 1px solid rgba(83, 109, 160, 0.28);
+  border-radius: 1rem;
+  background:
+    linear-gradient(180deg, #ffffff 0%, var(--key-surface) 100%);
+  box-shadow:
+    inset 0 -0.24rem 0 rgba(174, 188, 212, 0.58),
+    0 0.6rem 1.2rem rgba(41, 58, 89, 0.1);
+  color: var(--key-ink);
+  font-family: "Segoe UI", sans-serif;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+  animation: key-float 2.8s ease-in-out infinite;
+}
+
+.keyboard-key-large {
+  min-width: 4.9rem;
+  font-size: 1.15rem;
+}
+
+.keyboard-key-medium {
+  min-width: 4.2rem;
+  font-size: 0.98rem;
+}
+
+.keyboard-key-small {
+  min-width: 3rem;
+  padding: 0.72rem 0.95rem;
+  font-size: 0.82rem;
+}
+
+.keyboard-key:hover {
+  transform: translateY(-0.12rem);
+}
+
+.is-pressed {
+  background:
+    linear-gradient(180deg, var(--key-accent-soft) 0%, #cadcff 100%);
+  box-shadow:
+    inset 0 0.16rem 0 rgba(255, 255, 255, 0.62),
+    inset 0 -0.08rem 0 rgba(114, 142, 206, 0.58),
+    0 0.28rem 0.75rem rgba(47, 111, 237, 0.18);
+  color: var(--key-accent);
+  transform: translateY(0.12rem);
+}
+
+@keyframes key-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-0.08rem);
+  }
+}
+
+@media (max-width: 720px) {
+  .key-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .key-card {
+    min-height: 8.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .key-stage {
+    padding: 1rem;
+  }
+
+  .key-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a styled keyboard key example under submissions/examples/ease-keyboard-key-ms
- Include multiple sizes, a pressed state, and subtle hover animation
- Add responsive layout and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-keyboard-key-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85306