### PR TITLE
feat: add wifi indicator example

### DIFF
--- a/submissions/examples/ease-wifi-indicator-ms/README.md
+++ b/submissions/examples/ease-wifi-indicator-ms/README.md
@@ -1,0 +1,25 @@
+# Ease WiFi Indicator
+
+## What does this do?
+
+Adds a visual WiFi connectivity indicator with connected, weak, and disconnected states.
+
+## How is it used?
+
+Place the component in dashboards, setup flows, or connectivity screens and switch the wrapper state class such as `wifi-card-strong`, `wifi-card-weak`, or `wifi-card-offline`.
+
+```html
+<article class="wifi-card wifi-card-strong">
+  <span class="wifi-status">Connected</span>
+  <span class="wifi-icon wifi-large" aria-hidden="true">
+    <span class="wifi-dot"></span>
+    <span class="wifi-arc wifi-arc-1"></span>
+    <span class="wifi-arc wifi-arc-2"></span>
+    <span class="wifi-arc wifi-arc-3"></span>
+  </span>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a lightweight, reusable pattern for showing connection health in network-aware interfaces without external assets or JavaScript.

--- a/submissions/examples/ease-wifi-indicator-ms/demo.html
+++ b/submissions/examples/ease-wifi-indicator-ms/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease WiFi Indicator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="wifi-stage">
+      <section class="wifi-panel" aria-labelledby="wifi-title">
+        <p class="wifi-kicker">Connection status</p>
+        <h1 id="wifi-title">WiFi signal indicators</h1>
+        <p class="wifi-copy">
+          A compact connectivity display for device dashboards, setup screens, and
+          network-aware interfaces.
+        </p>
+
+        <div class="wifi-grid" aria-label="WiFi signal examples">
+          <article class="wifi-card wifi-card-strong">
+            <span class="wifi-status">Connected</span>
+            <span class="wifi-icon wifi-large" aria-hidden="true">
+              <span class="wifi-dot"></span>
+              <span class="wifi-arc wifi-arc-1"></span>
+              <span class="wifi-arc wifi-arc-2"></span>
+              <span class="wifi-arc wifi-arc-3"></span>
+            </span>
+            <span class="wifi-note">5 GHz network active</span>
+          </article>
+
+          <article class="wifi-card wifi-card-weak">
+            <span class="wifi-status">Weak</span>
+            <span class="wifi-icon wifi-medium" aria-hidden="true">
+              <span class="wifi-dot"></span>
+              <span class="wifi-arc wifi-arc-1"></span>
+              <span class="wifi-arc wifi-arc-2"></span>
+              <span class="wifi-arc wifi-arc-3"></span>
+            </span>
+            <span class="wifi-note">Signal is fluctuating</span>
+          </article>
+
+          <article class="wifi-card wifi-card-offline">
+            <span class="wifi-status">Disconnected</span>
+            <span class="wifi-icon wifi-small is-offline" aria-hidden="true">
+              <span class="wifi-dot"></span>
+              <span class="wifi-arc wifi-arc-1"></span>
+              <span class="wifi-arc wifi-arc-2"></span>
+              <span class="wifi-arc wifi-arc-3"></span>
+            </span>
+            <span class="wifi-note">No network available</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-wifi-indicator-ms/style.css
+++ b/submissions/examples/ease-wifi-indicator-ms/style.css
@@ -1,0 +1,279 @@
+:root {
+  --wifi-ink: #1a2740;
+  --wifi-muted: #68778d;
+  --wifi-panel: rgba(255, 255, 255, 0.88);
+  --wifi-line: rgba(255, 255, 255, 0.74);
+  --wifi-strong: #1f9d6a;
+  --wifi-weak: #d58b1e;
+  --wifi-offline: #d45353;
+  --wifi-shadow: rgba(31, 46, 73, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Lucida Sans", "Segoe UI", sans-serif;
+  color: var(--wifi-ink);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(190, 255, 227, 0.8), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgba(192, 220, 255, 0.72), transparent 22rem),
+    linear-gradient(140deg, #f8fffd 0%, #eef4ff 46%, #fff8ef 100%);
+}
+
+.wifi-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.wifi-panel {
+  width: min(960px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--wifi-line);
+  border-radius: 2rem;
+  background: var(--wifi-panel);
+  box-shadow: 0 2rem 5rem var(--wifi-shadow);
+}
+
+.wifi-panel::before {
+  width: 16rem;
+  height: 16rem;
+  left: -6rem;
+  bottom: -6rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(31, 157, 106, 0.16), rgba(255, 255, 255, 0));
+}
+
+.wifi-kicker {
+  margin: 0 0 0.55rem;
+  color: #1f8a64;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.9rem);
+  line-height: 0.92;
+}
+
+.wifi-copy {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--wifi-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.wifi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.wifi-card {
+  display: grid;
+  min-height: 13rem;
+  place-items: center;
+  gap: 1rem;
+  padding: 1.3rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1rem 2.25rem rgba(31, 46, 73, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.wifi-card:hover {
+  transform: translateY(-0.35rem);
+  box-shadow: 0 1.5rem 2.9rem rgba(31, 46, 73, 0.16);
+}
+
+.wifi-status {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.wifi-note {
+  color: var(--wifi-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.wifi-card-strong .wifi-status {
+  color: var(--wifi-strong);
+}
+
+.wifi-card-weak .wifi-status {
+  color: var(--wifi-weak);
+}
+
+.wifi-card-offline .wifi-status {
+  color: var(--wifi-offline);
+}
+
+.wifi-icon {
+  position: relative;
+  display: inline-block;
+  color: currentColor;
+}
+
+.wifi-large {
+  width: 6rem;
+  height: 4.5rem;
+  color: var(--wifi-strong);
+}
+
+.wifi-medium {
+  width: 5.2rem;
+  height: 4rem;
+  color: var(--wifi-weak);
+}
+
+.wifi-small {
+  width: 4.6rem;
+  height: 3.6rem;
+  color: var(--wifi-offline);
+}
+
+.wifi-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  left: 50%;
+  bottom: 0.2rem;
+  position: absolute;
+  border-radius: 50%;
+  background: currentColor;
+  transform: translateX(-50%);
+  animation: wifi-pulse 1.8s ease-in-out infinite;
+}
+
+.wifi-arc {
+  left: 50%;
+  position: absolute;
+  border: 0.4rem solid transparent;
+  border-top: 0;
+  border-bottom-left-radius: 999px;
+  border-bottom-right-radius: 999px;
+  transform: translateX(-50%);
+}
+
+.wifi-arc-1 {
+  width: 2.1rem;
+  height: 1.15rem;
+  bottom: 0.8rem;
+  border-color: currentColor;
+  border-top-color: transparent;
+  animation: wifi-wave 1.4s ease-in-out infinite;
+}
+
+.wifi-arc-2 {
+  width: 3.5rem;
+  height: 1.85rem;
+  bottom: 0.7rem;
+  border-color: currentColor;
+  border-top-color: transparent;
+  opacity: 0.72;
+  animation: wifi-wave 1.4s ease-in-out infinite 120ms;
+}
+
+.wifi-arc-3 {
+  width: 5rem;
+  height: 2.6rem;
+  bottom: 0.55rem;
+  border-color: currentColor;
+  border-top-color: transparent;
+  opacity: 0.45;
+  animation: wifi-wave 1.4s ease-in-out infinite 240ms;
+}
+
+.wifi-card-weak .wifi-arc-3 {
+  opacity: 0.14;
+}
+
+.is-offline .wifi-arc,
+.is-offline .wifi-dot {
+  animation: none;
+  opacity: 0.26;
+}
+
+.is-offline::after {
+  width: 5.1rem;
+  height: 0.35rem;
+  left: 50%;
+  top: 1.7rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: currentColor;
+  transform: translateX(-50%) rotate(-34deg);
+}
+
+@keyframes wifi-wave {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes wifi-pulse {
+  0%,
+  100% {
+    transform: translateX(-50%) scale(1);
+  }
+
+  50% {
+    transform: translateX(-50%) scale(1.12);
+  }
+}
+
+@media (max-width: 760px) {
+  .wifi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .wifi-card {
+    min-height: 10rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .wifi-stage {
+    padding: 1rem;
+  }
+
+  .wifi-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a visual WiFi connectivity example under submissions/examples/ease-wifi-indicator-ms
- Include connected, weak, and disconnected states with animated signal arcs
- Add responsive sizing and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-wifi-indicator-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85302