### PR TITLE
feat: add battery indicator example

### DIFF
--- a/submissions/examples/ease-battery-indicator-ms/README.md
+++ b/submissions/examples/ease-battery-indicator-ms/README.md
@@ -1,0 +1,23 @@
+# Ease Battery Indicator
+
+## What does this do?
+
+Adds a visual battery level indicator with low, medium, and full states in multiple sizes.
+
+## How is it used?
+
+Place the component in system dashboards, device setup screens, or monitoring UIs and switch the wrapper state class such as `battery-card-low`, `battery-card-medium`, or `battery-card-full`.
+
+```html
+<article class="battery-card battery-card-medium">
+  <span class="battery-state">Medium</span>
+  <span class="battery-shell battery-medium" aria-hidden="true">
+    <span class="battery-fill"></span>
+    <span class="battery-cap"></span>
+  </span>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a compact, dependency-free way to communicate power status in hardware, dashboard, and monitoring interfaces.

--- a/submissions/examples/ease-battery-indicator-ms/demo.html
+++ b/submissions/examples/ease-battery-indicator-ms/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Battery Indicator</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="battery-stage">
+      <section class="battery-panel" aria-labelledby="battery-title">
+        <p class="battery-kicker">Power status</p>
+        <h1 id="battery-title">Battery level indicators</h1>
+        <p class="battery-copy">
+          A compact battery-status display for device dashboards, system panels, and
+          hardware setup screens.
+        </p>
+
+        <div class="battery-grid" aria-label="Battery state examples">
+          <article class="battery-card battery-card-low">
+            <span class="battery-state">Low</span>
+            <span class="battery-shell battery-small" aria-hidden="true">
+              <span class="battery-fill"></span>
+              <span class="battery-cap"></span>
+            </span>
+            <span class="battery-note">12%</span>
+          </article>
+
+          <article class="battery-card battery-card-medium">
+            <span class="battery-state">Medium</span>
+            <span class="battery-shell battery-medium" aria-hidden="true">
+              <span class="battery-fill"></span>
+              <span class="battery-cap"></span>
+            </span>
+            <span class="battery-note">58%</span>
+          </article>
+
+          <article class="battery-card battery-card-full">
+            <span class="battery-state">Full</span>
+            <span class="battery-shell battery-large" aria-hidden="true">
+              <span class="battery-fill"></span>
+              <span class="battery-cap"></span>
+            </span>
+            <span class="battery-note">100%</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-battery-indicator-ms/style.css
+++ b/submissions/examples/ease-battery-indicator-ms/style.css
@@ -1,0 +1,245 @@
+:root {
+  --battery-ink: #1c2535;
+  --battery-muted: #6c778a;
+  --battery-panel: rgba(255, 255, 255, 0.89);
+  --battery-line: rgba(255, 255, 255, 0.76);
+  --battery-low: #db5c51;
+  --battery-medium: #e0a229;
+  --battery-full: #25a66b;
+  --battery-shadow: rgba(30, 42, 63, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Tahoma, "Segoe UI", sans-serif;
+  color: var(--battery-ink);
+  background:
+    radial-gradient(circle at 16% 18%, rgba(255, 216, 187, 0.82), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgba(204, 241, 224, 0.78), transparent 22rem),
+    linear-gradient(145deg, #fffaf4 0%, #eef8ff 48%, #f7fff9 100%);
+}
+
+.battery-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.battery-panel {
+  width: min(960px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--battery-line);
+  border-radius: 2rem;
+  background: var(--battery-panel);
+  box-shadow: 0 2rem 5rem var(--battery-shadow);
+}
+
+.battery-panel::after {
+  width: 15rem;
+  height: 15rem;
+  right: -4rem;
+  bottom: -4rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(37, 166, 107, 0.18), rgba(255, 255, 255, 0));
+}
+
+.battery-kicker {
+  margin: 0 0 0.55rem;
+  color: #2a8a63;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.battery-copy {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--battery-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.battery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.battery-card {
+  display: grid;
+  min-height: 13rem;
+  place-items: center;
+  gap: 1rem;
+  padding: 1.3rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1rem 2.25rem rgba(30, 42, 63, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.battery-card:hover {
+  transform: translateY(-0.35rem);
+  box-shadow: 0 1.5rem 2.9rem rgba(30, 42, 63, 0.16);
+}
+
+.battery-state {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.battery-note {
+  color: var(--battery-muted);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.battery-card-low .battery-state {
+  color: var(--battery-low);
+}
+
+.battery-card-medium .battery-state {
+  color: var(--battery-medium);
+}
+
+.battery-card-full .battery-state {
+  color: var(--battery-full);
+}
+
+.battery-shell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem;
+  border: 0.18rem solid currentColor;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.battery-small {
+  width: 5.8rem;
+  height: 2.6rem;
+  color: var(--battery-low);
+}
+
+.battery-medium {
+  width: 6.8rem;
+  height: 3rem;
+  color: var(--battery-medium);
+}
+
+.battery-large {
+  width: 7.8rem;
+  height: 3.4rem;
+  color: var(--battery-full);
+}
+
+.battery-fill {
+  display: block;
+  height: 100%;
+  border-radius: 0.45rem;
+  background: currentColor;
+  animation: battery-glow 2.2s ease-in-out infinite;
+}
+
+.battery-card-low .battery-fill {
+  width: 18%;
+  animation: battery-alert 1s ease-in-out infinite;
+}
+
+.battery-card-medium .battery-fill {
+  width: 58%;
+}
+
+.battery-card-full .battery-fill {
+  width: 100%;
+}
+
+.battery-cap {
+  width: 0.45rem;
+  height: 1.1rem;
+  right: -0.62rem;
+  top: 50%;
+  position: absolute;
+  border-radius: 0 0.35rem 0.35rem 0;
+  background: currentColor;
+  transform: translateY(-50%);
+}
+
+@keyframes battery-glow {
+  0%,
+  100% {
+    opacity: 0.88;
+    transform: scaleY(0.98);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes battery-alert {
+  0%,
+  100% {
+    opacity: 0.48;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 760px) {
+  .battery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .battery-card {
+    min-height: 10rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .battery-stage {
+    padding: 1rem;
+  }
+
+  .battery-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a visual battery level example under submissions/examples/ease-battery-indicator-ms
- Include low, medium, and full states with responsive sizing
- Add subtle motion and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-battery-indicator-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85300