### PR TITLE
feat: add copy action example

### DIFF
--- a/submissions/examples/ease-copy-action-ms/README.md
+++ b/submissions/examples/ease-copy-action-ms/README.md
@@ -1,0 +1,22 @@
+# Ease Copy Action
+
+## What does this do?
+
+Adds a compact copy-action control with default and copied feedback states.
+
+## How is it used?
+
+Place the control beside any URL, ID, token, or snippet and switch the wrapper class to `is-copied` when you want to present the copied confirmation state.
+
+```html
+<article class="copy-card is-copied">
+  <button class="copy-action" type="button">
+    <span class="copy-icon" aria-hidden="true"></span>
+    <span class="copy-text">Copied</span>
+  </button>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a clean, dependency-free pattern for copy interactions in dashboards, code snippets, and admin interfaces.

--- a/submissions/examples/ease-copy-action-ms/demo.html
+++ b/submissions/examples/ease-copy-action-ms/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Copy Action</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="copy-stage">
+      <section class="copy-panel" aria-labelledby="copy-title">
+        <p class="copy-kicker">Quick utility</p>
+        <h1 id="copy-title">Copy action controls</h1>
+        <p class="copy-copy">
+          A compact control pattern for copying IDs, URLs, snippets, and secret keys
+          with lightweight visual feedback.
+        </p>
+
+        <div class="copy-grid" aria-label="Copy action examples">
+          <article class="copy-card">
+            <div class="copy-details">
+              <span class="copy-label">Project URL</span>
+              <code class="copy-value">https://api.easemotion.dev/v1/demo</code>
+            </div>
+            <button class="copy-action" type="button">
+              <span class="copy-icon" aria-hidden="true"></span>
+              <span class="copy-text">Copy</span>
+            </button>
+          </article>
+
+          <article class="copy-card is-copied">
+            <div class="copy-details">
+              <span class="copy-label">Workspace ID</span>
+              <code class="copy-value">ws_94f2_alpha_2291</code>
+            </div>
+            <button class="copy-action" type="button">
+              <span class="copy-icon" aria-hidden="true"></span>
+              <span class="copy-text">Copied</span>
+            </button>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-copy-action-ms/style.css
+++ b/submissions/examples/ease-copy-action-ms/style.css
@@ -1,0 +1,228 @@
+:root {
+  --copy-ink: #19263b;
+  --copy-muted: #66768c;
+  --copy-panel: rgba(255, 255, 255, 0.9);
+  --copy-line: rgba(255, 255, 255, 0.78);
+  --copy-surface: rgba(255, 255, 255, 0.76);
+  --copy-accent: #2a70f4;
+  --copy-success: #1f9a68;
+  --copy-shadow: rgba(29, 43, 68, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Candara, "Segoe UI", sans-serif;
+  color: var(--copy-ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(214, 234, 255, 0.88), transparent 22rem),
+    radial-gradient(circle at 80% 18%, rgba(211, 252, 231, 0.72), transparent 22rem),
+    linear-gradient(145deg, #f8fbff 0%, #eef7ff 48%, #f7fff9 100%);
+}
+
+.copy-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.copy-panel {
+  width: min(940px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--copy-line);
+  border-radius: 2rem;
+  background: var(--copy-panel);
+  box-shadow: 0 2rem 5rem var(--copy-shadow);
+}
+
+.copy-panel::after {
+  width: 14rem;
+  height: 14rem;
+  right: -4rem;
+  top: -4rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(42, 112, 244, 0.18), rgba(255, 255, 255, 0));
+}
+
+.copy-kicker {
+  margin: 0 0 0.55rem;
+  color: #245bc4;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.92;
+}
+
+.copy-copy {
+  max-width: 35rem;
+  margin: 1rem 0 2rem;
+  color: var(--copy-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.copy-grid {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.copy-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.15rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  border-radius: 1.4rem;
+  background: var(--copy-surface);
+  box-shadow: 0 1rem 2.25rem rgba(29, 43, 68, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.copy-card:hover {
+  transform: translateY(-0.28rem);
+  border-color: rgba(42, 112, 244, 0.32);
+  box-shadow: 0 1.4rem 2.8rem rgba(29, 43, 68, 0.16);
+}
+
+.copy-details {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.copy-label {
+  color: var(--copy-muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.copy-value {
+  overflow-wrap: anywhere;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.copy-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 8rem;
+  padding: 0.85rem 1rem;
+  border: 0;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--copy-accent), #4a8cff);
+  box-shadow: 0 0.9rem 1.8rem rgba(42, 112, 244, 0.22);
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  justify-content: center;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.copy-action:hover {
+  transform: translateY(-0.12rem);
+  filter: brightness(1.04);
+}
+
+.copy-icon {
+  width: 1rem;
+  height: 1rem;
+  position: relative;
+  border: 0.13rem solid currentColor;
+  border-radius: 0.2rem;
+}
+
+.copy-icon::before {
+  width: 1rem;
+  height: 1rem;
+  left: -0.32rem;
+  top: -0.32rem;
+  content: "";
+  position: absolute;
+  border: 0.13rem solid currentColor;
+  border-radius: 0.2rem;
+  opacity: 0.8;
+}
+
+.is-copied .copy-action {
+  background: linear-gradient(135deg, var(--copy-success), #39c48e);
+  box-shadow: 0 0.9rem 1.8rem rgba(31, 154, 104, 0.22);
+}
+
+.is-copied .copy-icon,
+.is-copied .copy-icon::before {
+  border-color: transparent;
+}
+
+.is-copied .copy-icon::after {
+  width: 0.75rem;
+  height: 0.4rem;
+  left: 0.05rem;
+  top: 0.16rem;
+  content: "";
+  position: absolute;
+  border-bottom: 0.14rem solid currentColor;
+  border-left: 0.14rem solid currentColor;
+  transform: rotate(-45deg);
+}
+
+@media (max-width: 680px) {
+  .copy-card {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .copy-action {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .copy-stage {
+    padding: 1rem;
+  }
+
+  .copy-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact copy action example under submissions/examples/ease-copy-action-ms
- Include default and copied feedback states with visual confirmation
- Add responsive layout and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-copy-action-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85283