### PR TITLE
feat: add expand control example

### DIFF
--- a/submissions/examples/ease-expand-control-ms/README.md
+++ b/submissions/examples/ease-expand-control-ms/README.md
@@ -1,0 +1,21 @@
+# Ease Expand Control
+
+## What does this do?
+
+Adds a compact expand-control pattern with collapsed and expanded states plus animated icon rotation.
+
+## How is it used?
+
+Place the control beside any accordion, panel, or expandable row and switch the wrapper class to `is-open` when you want to show the expanded state.
+
+```html
+<article class="expand-card is-open">
+  <button class="expand-button" type="button" aria-expanded="true">
+    <span class="expand-icon" aria-hidden="true"></span>
+  </button>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a simple, dependency-free affordance for expandable content in dashboards, settings pages, and list views.

--- a/submissions/examples/ease-expand-control-ms/demo.html
+++ b/submissions/examples/ease-expand-control-ms/demo.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Expand Control</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="expand-stage">
+      <section class="expand-panel" aria-labelledby="expand-title">
+        <p class="expand-kicker">Toggle pattern</p>
+        <h1 id="expand-title">Expand control states</h1>
+        <p class="expand-copy">
+          A compact affordance for accordions, settings panels, and expandable lists
+          with clear collapsed and expanded feedback.
+        </p>
+
+        <div class="expand-grid" aria-label="Expand control examples">
+          <article class="expand-card">
+            <div class="expand-copy-block">
+              <span class="expand-label">Collapsed</span>
+              <span class="expand-meta">Open release notes</span>
+            </div>
+            <button class="expand-button" type="button" aria-expanded="false">
+              <span class="expand-icon" aria-hidden="true"></span>
+            </button>
+          </article>
+
+          <article class="expand-card is-open">
+            <div class="expand-copy-block">
+              <span class="expand-label">Expanded</span>
+              <span class="expand-meta">Hide advanced options</span>
+            </div>
+            <button class="expand-button" type="button" aria-expanded="true">
+              <span class="expand-icon" aria-hidden="true"></span>
+            </button>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-expand-control-ms/style.css
+++ b/submissions/examples/ease-expand-control-ms/style.css
@@ -1,0 +1,216 @@
+:root {
+  --expand-ink: #172437;
+  --expand-muted: #65758b;
+  --expand-panel: rgba(255, 255, 255, 0.9);
+  --expand-line: rgba(255, 255, 255, 0.78);
+  --expand-surface: rgba(255, 255, 255, 0.76);
+  --expand-accent: #2d6cec;
+  --expand-success: #1e9a69;
+  --expand-shadow: rgba(27, 41, 67, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Segoe Print", "Segoe UI", sans-serif;
+  color: var(--expand-ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(221, 232, 255, 0.86), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgba(220, 250, 236, 0.72), transparent 22rem),
+    linear-gradient(145deg, #f8fbff 0%, #eef6ff 48%, #f8fffb 100%);
+}
+
+.expand-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.expand-panel {
+  width: min(920px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--expand-line);
+  border-radius: 2rem;
+  background: var(--expand-panel);
+  box-shadow: 0 2rem 5rem var(--expand-shadow);
+}
+
+.expand-panel::after {
+  width: 15rem;
+  height: 15rem;
+  left: -5rem;
+  bottom: -5rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(45, 108, 236, 0.16), rgba(255, 255, 255, 0));
+}
+
+.expand-kicker {
+  margin: 0 0 0.55rem;
+  color: #255dcb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.7rem);
+  line-height: 0.92;
+}
+
+.expand-copy {
+  max-width: 35rem;
+  margin: 1rem 0 2rem;
+  color: var(--expand-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.expand-grid {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.expand-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.15rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.4rem;
+  background: var(--expand-surface);
+  box-shadow: 0 1rem 2.25rem rgba(27, 41, 67, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.expand-card:hover {
+  transform: translateY(-0.28rem);
+  border-color: rgba(45, 108, 236, 0.32);
+  box-shadow: 0 1.4rem 2.8rem rgba(27, 41, 67, 0.16);
+}
+
+.expand-copy-block {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.expand-label {
+  color: var(--expand-muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.expand-meta {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.expand-button {
+  width: 3.3rem;
+  height: 3.3rem;
+  display: inline-grid;
+  place-items: center;
+  border: 0;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--expand-accent), #5b92ff);
+  box-shadow: 0 0.9rem 1.8rem rgba(45, 108, 236, 0.22);
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.expand-button:hover {
+  transform: translateY(-0.12rem);
+  filter: brightness(1.04);
+}
+
+.expand-icon {
+  width: 1rem;
+  height: 1rem;
+  position: relative;
+}
+
+.expand-icon::before,
+.expand-icon::after {
+  left: 50%;
+  top: 50%;
+  width: 1rem;
+  height: 0.16rem;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: #ffffff;
+  transform: translate(-50%, -50%);
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.expand-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.is-open .expand-button {
+  background: linear-gradient(135deg, var(--expand-success), #39c48e);
+  box-shadow: 0 0.9rem 1.8rem rgba(30, 154, 105, 0.22);
+}
+
+.is-open .expand-icon::before {
+  transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.is-open .expand-icon::after {
+  opacity: 0;
+  transform: translate(-50%, -50%) rotate(90deg) scaleX(0.2);
+}
+
+@media (max-width: 640px) {
+  .expand-card {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .expand-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .expand-stage {
+    padding: 1rem;
+  }
+
+  .expand-panel {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact expand control example under submissions/examples/ease-expand-control-ms
- Include collapsed and expanded states with animated icon rotation
- Add responsive layout and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-expand-control-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85298