### PR TITLE
feat: add media control example

### DIFF
--- a/submissions/examples/ease-media-control-ms/README.md
+++ b/submissions/examples/ease-media-control-ms/README.md
@@ -1,0 +1,21 @@
+# Ease Media Control
+
+## What does this do?
+
+Adds a compact media control pattern with play, pause, and stop states.
+
+## How is it used?
+
+Place the control in audio players, video tools, or dashboards and switch the wrapper state class such as `is-play`, `is-pause`, or `is-stop`.
+
+```html
+<article class="media-card is-play">
+  <button class="media-button" type="button" aria-label="Play media">
+    <span class="media-icon" aria-hidden="true"></span>
+  </button>
+</article>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a lightweight playback-control pattern for media interfaces without requiring any external assets or JavaScript.

--- a/submissions/examples/ease-media-control-ms/demo.html
+++ b/submissions/examples/ease-media-control-ms/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Media Control</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="media-stage">
+      <section class="media-panel" aria-labelledby="media-title">
+        <p class="media-kicker">Playback states</p>
+        <h1 id="media-title">Compact media controls</h1>
+        <p class="media-copy">
+          A compact control strip for audio players, media dashboards, and inline
+          playback tools with clear play, pause, and stop states.
+        </p>
+
+        <div class="media-grid" aria-label="Media control examples">
+          <article class="media-card is-play">
+            <span class="media-label">Play</span>
+            <button class="media-button" type="button" aria-label="Play media">
+              <span class="media-icon" aria-hidden="true"></span>
+            </button>
+            <span class="media-note">Resume episode</span>
+          </article>
+
+          <article class="media-card is-pause">
+            <span class="media-label">Pause</span>
+            <button class="media-button" type="button" aria-label="Pause media">
+              <span class="media-icon" aria-hidden="true"></span>
+            </button>
+            <span class="media-note">Hold playback</span>
+          </article>
+
+          <article class="media-card is-stop">
+            <span class="media-label">Stop</span>
+            <button class="media-button" type="button" aria-label="Stop media">
+              <span class="media-icon" aria-hidden="true"></span>
+            </button>
+            <span class="media-note">End session</span>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-media-control-ms/style.css
+++ b/submissions/examples/ease-media-control-ms/style.css
@@ -1,0 +1,234 @@
+:root {
+  --media-ink: #182539;
+  --media-muted: #66768b;
+  --media-panel: rgba(255, 255, 255, 0.9);
+  --media-line: rgba(255, 255, 255, 0.78);
+  --media-surface: rgba(255, 255, 255, 0.76);
+  --media-play: #2f72f1;
+  --media-pause: #e09a25;
+  --media-stop: #d95a57;
+  --media-shadow: rgba(29, 43, 68, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Franklin Gothic Medium", "Segoe UI", sans-serif;
+  color: var(--media-ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(216, 232, 255, 0.86), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgba(255, 226, 201, 0.72), transparent 22rem),
+    linear-gradient(145deg, #f8fbff 0%, #eef6ff 48%, #fff8f0 100%);
+}
+
+.media-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.media-panel {
+  width: min(980px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--media-line);
+  border-radius: 2rem;
+  background: var(--media-panel);
+  box-shadow: 0 2rem 5rem var(--media-shadow);
+}
+
+.media-panel::after {
+  width: 15rem;
+  height: 15rem;
+  right: -4rem;
+  top: -4rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(47, 114, 241, 0.16), rgba(255, 255, 255, 0));
+}
+
+.media-kicker {
+  margin: 0 0 0.55rem;
+  color: #2d63d6;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.7rem);
+  line-height: 0.92;
+}
+
+.media-copy {
+  max-width: 36rem;
+  margin: 1rem 0 2rem;
+  color: var(--media-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.media-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.media-card {
+  display: grid;
+  min-height: 12.5rem;
+  place-items: center;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: 1.5rem;
+  background: var(--media-surface);
+  box-shadow: 0 1rem 2.25rem rgba(29, 43, 68, 0.1);
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
+}
+
+.media-card:hover {
+  transform: translateY(-0.3rem);
+  box-shadow: 0 1.45rem 2.85rem rgba(29, 43, 68, 0.16);
+}
+
+.media-label {
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.media-note {
+  color: var(--media-muted);
+  font-size: 0.9rem;
+}
+
+.media-button {
+  width: 4.4rem;
+  height: 4.4rem;
+  display: inline-grid;
+  place-items: center;
+  border: 0;
+  border-radius: 1.25rem;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.media-button:hover {
+  transform: translateY(-0.1rem);
+  filter: brightness(1.03);
+}
+
+.media-icon {
+  position: relative;
+  display: inline-block;
+}
+
+.is-play .media-label,
+.is-play .media-button {
+  color: #ffffff;
+}
+
+.is-play .media-button {
+  background: linear-gradient(135deg, var(--media-play), #5a94ff);
+  box-shadow: 0 0.9rem 1.8rem rgba(47, 114, 241, 0.22);
+}
+
+.is-play .media-icon {
+  width: 0;
+  height: 0;
+  border-top: 0.7rem solid transparent;
+  border-bottom: 0.7rem solid transparent;
+  border-left: 1.1rem solid currentColor;
+  margin-left: 0.25rem;
+}
+
+.is-pause .media-label,
+.is-pause .media-button {
+  color: #ffffff;
+}
+
+.is-pause .media-button {
+  background: linear-gradient(135deg, var(--media-pause), #f3b849);
+  box-shadow: 0 0.9rem 1.8rem rgba(224, 154, 37, 0.22);
+}
+
+.is-pause .media-icon {
+  width: 1.25rem;
+  height: 1.35rem;
+}
+
+.is-pause .media-icon::before,
+.is-pause .media-icon::after {
+  top: 0;
+  width: 0.34rem;
+  height: 100%;
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.is-pause .media-icon::before {
+  left: 0.14rem;
+}
+
+.is-pause .media-icon::after {
+  right: 0.14rem;
+}
+
+.is-stop .media-label,
+.is-stop .media-button {
+  color: #ffffff;
+}
+
+.is-stop .media-button {
+  background: linear-gradient(135deg, var(--media-stop), #f07e79);
+  box-shadow: 0 0.9rem 1.8rem rgba(217, 90, 87, 0.22);
+}
+
+.is-stop .media-icon {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.18rem;
+  background: currentColor;
+}
+
+@media (max-width: 760px) {
+  .media-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .media-card {
+    min-height: 9.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a compact media control example under submissions/examples/ease-media-control-ms
- Include play, pause, and stop states with distinct icon treatments
- Add responsive layout and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-media-control-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #85299