### PR TITLE
feat: add velvet badge example

### DIFF
--- a/submissions/examples/ease-velvet-badge-ms/README.md
+++ b/submissions/examples/ease-velvet-badge-ms/README.md
@@ -1,0 +1,17 @@
+# Ease Velvet Badge
+
+## What does this do?
+
+Adds a pure CSS badge and chip variation with a velvet-smooth look and soft transitions.
+
+## How is it used?
+
+Place the badge anywhere you need compact metadata or status chips and choose a tone class such as `badge-primary`, `badge-success`, `badge-warning`, or `badge-dark`.
+
+```html
+<span class="velvet-badge badge-primary">Stable release</span>
+```
+
+## Why is it useful?
+
+It gives EaseMotion CSS a polished badge pattern that stays lightweight, dark-mode friendly, and visually smooth for dashboards and product interfaces.

--- a/submissions/examples/ease-velvet-badge-ms/demo.html
+++ b/submissions/examples/ease-velvet-badge-ms/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ease Velvet Badge</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="badge-stage">
+      <section class="badge-panel" aria-labelledby="badge-title">
+        <p class="badge-kicker">Badge variation</p>
+        <h1 id="badge-title">Velvet smooth badges</h1>
+        <p class="badge-copy">
+          Soft, elevated chips with smooth transitions for status flags, feature
+          tags, and compact metadata surfaces.
+        </p>
+
+        <div class="badge-grid" aria-label="Velvet smooth badge examples">
+          <span class="velvet-badge badge-primary">Stable release</span>
+          <span class="velvet-badge badge-success">Build passed</span>
+          <span class="velvet-badge badge-warning">Beta access</span>
+          <span class="velvet-badge badge-dark">Private preview</span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/submissions/examples/ease-velvet-badge-ms/style.css
+++ b/submissions/examples/ease-velvet-badge-ms/style.css
@@ -1,0 +1,192 @@
+:root {
+  --badge-ink: #1a2334;
+  --badge-muted: #69778b;
+  --badge-panel: rgba(255, 255, 255, 0.9);
+  --badge-line: rgba(255, 255, 255, 0.78);
+  --badge-shadow: rgba(28, 41, 64, 0.18);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: Garamond, "Segoe UI", sans-serif;
+  color: var(--badge-ink);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(222, 232, 255, 0.82), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgba(242, 221, 255, 0.74), transparent 22rem),
+    linear-gradient(145deg, #f9fbff 0%, #f3f6ff 48%, #fff8fc 100%);
+}
+
+.badge-stage {
+  display: grid;
+  min-height: 100vh;
+  padding: 2rem;
+  place-items: center;
+}
+
+.badge-panel {
+  width: min(920px, 100%);
+  padding: clamp(1.5rem, 5vw, 3rem);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--badge-line);
+  border-radius: 2rem;
+  background: var(--badge-panel);
+  box-shadow: 0 2rem 5rem var(--badge-shadow);
+}
+
+.badge-panel::after {
+  width: 15rem;
+  height: 15rem;
+  right: -5rem;
+  bottom: -5rem;
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(120, 99, 210, 0.14), rgba(255, 255, 255, 0));
+}
+
+.badge-kicker {
+  margin: 0 0 0.55rem;
+  color: #5a63cb;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(2.2rem, 7vw, 4.7rem);
+  line-height: 0.92;
+}
+
+.badge-copy {
+  max-width: 34rem;
+  margin: 1rem 0 2rem;
+  color: var(--badge-muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.badge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.velvet-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.78rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 999px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    0 0.8rem 1.7rem rgba(38, 49, 79, 0.12);
+  font-size: 0.98rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    filter 220ms ease,
+    background-color 220ms ease;
+  will-change: transform, filter;
+}
+
+.velvet-badge:hover {
+  transform: translateY(-0.18rem);
+  filter: saturate(1.06);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    0 1rem 2rem rgba(38, 49, 79, 0.18);
+}
+
+.badge-primary {
+  color: #2847b5;
+  background: linear-gradient(135deg, rgba(224, 233, 255, 0.96), rgba(197, 214, 255, 0.9));
+}
+
+.badge-success {
+  color: #166d4e;
+  background: linear-gradient(135deg, rgba(220, 247, 234, 0.96), rgba(186, 234, 207, 0.92));
+}
+
+.badge-warning {
+  color: #935d09;
+  background: linear-gradient(135deg, rgba(255, 240, 204, 0.98), rgba(255, 223, 154, 0.92));
+}
+
+.badge-dark {
+  color: #eef2ff;
+  background: linear-gradient(135deg, rgba(57, 67, 107, 0.96), rgba(33, 39, 70, 0.96));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 0.8rem 1.7rem rgba(20, 24, 44, 0.24);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #edf1ff;
+    background:
+      radial-gradient(circle at 18% 18%, rgba(64, 78, 126, 0.38), transparent 22rem),
+      radial-gradient(circle at 82% 18%, rgba(104, 68, 122, 0.32), transparent 22rem),
+      linear-gradient(145deg, #101521 0%, #151c2d 52%, #1a1530 100%);
+  }
+
+  .badge-panel {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(18, 24, 38, 0.84);
+    box-shadow: 0 2rem 5rem rgba(0, 0, 0, 0.35);
+  }
+
+  .badge-copy,
+  .badge-kicker {
+    color: #c5d0ea;
+  }
+
+  .badge-primary {
+    color: #dbe6ff;
+    background: linear-gradient(135deg, rgba(58, 76, 141, 0.96), rgba(40, 57, 117, 0.96));
+  }
+
+  .badge-success {
+    color: #ddfff0;
+    background: linear-gradient(135deg, rgba(29, 102, 77, 0.96), rgba(20, 74, 56, 0.96));
+  }
+
+  .badge-warning {
+    color: #fff2d6;
+    background: linear-gradient(135deg, rgba(132, 91, 28, 0.96), rgba(98, 64, 18, 0.96));
+  }
+}
+
+@media (max-width: 480px) {
+  .badge-stage {
+    padding: 1rem;
+  }
+
+  .badge-grid {
+    gap: 0.75rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a pure CSS velvet-smooth badge variation under submissions/examples/ease-velvet-badge-ms
- Include multiple badge tones with soft transitions and accessible chip styling
- Add dark-mode-friendly styling and reduced-motion support

## Validation
- npx stylelint --stdin --stdin-filename ease-velvet-badge-ms.css
- git diff --check
- npm run build
- npm test
- npm run validate:manifest
- git diff --cached --check

Closes #73465