### PR TITLE
feat: added fade-scale-modal

### DIFF
--- a/submissions/examples/fade-scale-modal/README.md
+++ b/submissions/examples/fade-scale-modal/README.md
@@ -1,0 +1,49 @@
+# Fade Scale Modal
+A self-contained modal animation component for the EaseMotion CSS gallery.
+
+## Features
+- Fade and scale entrance animation.
+- Animated backdrop with optional blur.
+- Pure HTML and CSS.
+- No JavaScript or external dependencies.
+- Uses native `<details>` and `<summary>` for the demo toggle.
+- Responsive modal layout.
+- Mobile bottom-sheet presentation.
+- Keyboard-accessible native controls and links.
+- Visible `:focus-visible` states.
+- `prefers-reduced-motion` support.
+- EaseMotion-style CSS custom properties.
+
+## Usage
+Keep `demo.html` and `style.css` in the same directory and open
+`demo.html` in a browser.
+The demo uses `<details>` to provide the open/close state without
+JavaScript.
+
+## Customization
+The main component tokens are defined in `:root`:
+- `--em-bg`
+- `--em-surface`
+- `--em-border`
+- `--em-text`
+- `--em-muted`
+- `--em-accent`
+- `--em-accent-bright`
+- `--em-accent-soft`
+- `--em-ease`
+- `--em-radius`
+
+These can be mapped to existing EaseMotion design tokens during
+gallery integration.
+
+## Accessibility
+The demo uses native disclosure semantics, native links, visible
+focus indicators, and dialog semantics.
+Because this example intentionally avoids JavaScript, it does not
+implement a full application-level focus trap or programmatic focus
+restoration.
+For a production modal requiring strict focus management, the native
+`<dialog>` API or an appropriately managed JavaScript implementation
+should be considered.
+The animation is minimized when
+`prefers-reduced-motion: reduce` is active.

--- a/submissions/examples/fade-scale-modal/demo.html
+++ b/submissions/examples/fade-scale-modal/demo.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Fade Scale Modal — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <main class="page">
+        <section class="demo" aria-labelledby="demo-title">
+            <p class="eyebrow">EaseMotion CSS</p>
+
+            <h1 id="demo-title">Fade Scale Modal</h1>
+
+            <p class="intro">
+                A lightweight modal that fades the backdrop while scaling the
+                dialog smoothly into view.
+            </p>
+
+            <details class="modal-demo">
+                <summary class="open-modal">Open modal</summary>
+
+                <div class="modal-layer">
+                    <div class="modal-backdrop" aria-hidden="true"></div>
+
+                    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+                        <div class="modal-icon" aria-hidden="true">✦</div>
+
+                        <div class="modal-content">
+                            <p class="modal-kicker">Animation preview</p>
+
+                            <h2 id="modal-title">Ready to continue?</h2>
+
+                            <p>
+                                This dialog fades and scales into view using only CSS.
+                                No JavaScript or animation library is required.
+                            </p>
+                        </div>
+
+                        <div class="modal-actions">
+                            <a class="button button-secondary" href="#cancel">
+                                Cancel
+                            </a>
+
+                            <a class="button button-primary" href="#continue">
+                                Continue
+                            </a>
+                        </div>
+
+                        <p class="modal-note">
+                            Use <kbd>Tab</kbd> to move between the actions.
+                        </p>
+                    </section>
+                </div>
+            </details>
+
+            <p class="demo-note">
+                Click “Open modal” to preview the animation.
+            </p>
+        </section>
+    </main>
+</body>
+
+</html>

--- a/submissions/examples/fade-scale-modal/style.css
+++ b/submissions/examples/fade-scale-modal/style.css
@@ -1,0 +1,474 @@
+:root {
+    --em-bg: #090a0f;
+    --em-surface: #141620;
+    --em-border: rgba(255, 255, 255, 0.1);
+    --em-border-strong: rgba(255, 255, 255, 0.18);
+    --em-text: #f5f6fa;
+    --em-muted: #9499aa;
+
+    --em-accent: #8b7cff;
+    --em-accent-bright: #a79cff;
+    --em-accent-soft: rgba(139, 124, 255, 0.14);
+
+    --em-ease: cubic-bezier(0.22, 0.8, 0.24, 1);
+    --em-radius: 24px;
+
+    color-scheme: dark;
+
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    min-width: 320px;
+    background: var(--em-bg);
+}
+
+body {
+    min-width: 320px;
+    min-height: 100vh;
+    margin: 0;
+
+    color: var(--em-text);
+
+    background:
+        radial-gradient(circle at 50% 15%,
+            rgba(139, 124, 255, 0.14),
+            transparent 34rem),
+        var(--em-bg);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.page {
+    min-height: 100vh;
+
+    display: grid;
+    place-items: center;
+
+    padding: 24px 16px;
+}
+
+.demo {
+    width: min(760px, 100%);
+    min-height: 560px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    padding: clamp(30px, 7vw, 70px);
+
+    border: 1px solid var(--em-border);
+    border-radius: 34px;
+
+    background:
+        linear-gradient(145deg,
+            rgba(255, 255, 255, 0.04),
+            transparent 45%),
+        rgba(15, 16, 24, 0.82);
+
+    box-shadow:
+        0 35px 90px rgba(0, 0, 0, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+
+    text-align: center;
+
+    overflow: hidden;
+}
+
+.eyebrow {
+    margin: 0 0 12px;
+
+    color: var(--em-accent-bright);
+
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+h1 {
+    margin: 0 0 16px;
+
+    font-size: clamp(2rem, 6vw, 3.7rem);
+    line-height: 1;
+    letter-spacing: -0.055em;
+}
+
+.intro {
+    max-width: 500px;
+
+    margin: 0 0 34px;
+
+    color: var(--em-muted);
+
+    font-size: 0.98rem;
+    line-height: 1.7;
+}
+
+.modal-demo {
+    width: min(100%, 220px);
+}
+
+.modal-demo>summary {
+    list-style: none;
+}
+
+.modal-demo>summary::-webkit-details-marker {
+    display: none;
+}
+
+.modal-demo>summary::marker {
+    content: "";
+}
+
+.open-modal {
+    display: inline-grid;
+
+    min-height: 48px;
+
+    place-items: center;
+
+    padding: 0 22px;
+
+    border: 1px solid rgba(139, 124, 255, 0.45);
+    border-radius: 14px;
+
+    background: linear-gradient(135deg,
+            #8173ef,
+            #655bd0);
+
+    color: #fff;
+
+    font-size: 0.85rem;
+    font-weight: 800;
+
+    cursor: pointer;
+
+    box-shadow:
+        0 12px 28px rgba(102, 89, 214, 0.25);
+
+    transition:
+        transform 0.22s var(--em-ease),
+        box-shadow 0.22s ease,
+        filter 0.22s ease;
+}
+
+.open-modal:hover {
+    transform: translateY(-2px);
+
+    box-shadow:
+        0 16px 34px rgba(102, 89, 214, 0.34);
+
+    filter: brightness(1.06);
+}
+
+.open-modal:focus-visible {
+    outline: 3px solid rgba(139, 124, 255, 0.45);
+    outline-offset: 4px;
+}
+
+/* Modal overlay */
+
+.modal-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+
+    display: grid;
+    place-items: center;
+
+    padding: 20px;
+
+    overflow-y: auto;
+}
+
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+
+    background: rgba(3, 4, 9, 0.72);
+
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+
+    animation: backdrop-in 0.35s ease both;
+}
+
+/* Modal */
+
+.modal {
+    position: relative;
+    z-index: 1;
+
+    width: min(440px, 100%);
+
+    padding: clamp(24px, 5vw, 34px);
+
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: var(--em-radius);
+
+    background:
+        radial-gradient(circle at 85% 5%,
+            rgba(139, 124, 255, 0.14),
+            transparent 11rem),
+        var(--em-surface);
+
+    box-shadow:
+        0 35px 100px rgba(0, 0, 0, 0.5),
+        0 0 70px rgba(111, 95, 255, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    text-align: left;
+
+    animation: modal-in 0.48s var(--em-ease) both;
+}
+
+.modal::before {
+    content: "";
+
+    position: absolute;
+    inset: 0;
+
+    border-radius: inherit;
+
+    pointer-events: none;
+
+    box-shadow:
+        inset 0 0 0 1px rgba(139, 124, 255, 0.05);
+}
+
+.modal-icon {
+    display: grid;
+
+    width: 48px;
+    height: 48px;
+
+    margin-bottom: 22px;
+
+    place-items: center;
+
+    border: 1px solid rgba(139, 124, 255, 0.3);
+    border-radius: 15px;
+
+    background: var(--em-accent-soft);
+
+    color: var(--em-accent-bright);
+
+    font-size: 1.2rem;
+}
+
+.modal-kicker {
+    margin: 0 0 7px;
+
+    color: var(--em-accent-bright);
+
+    font-size: 0.66rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.modal h2 {
+    margin: 0 0 11px;
+
+    font-size: clamp(1.45rem, 4vw, 1.8rem);
+    letter-spacing: -0.04em;
+}
+
+.modal-content>p:last-child {
+    margin: 0;
+
+    color: var(--em-muted);
+
+    font-size: 0.86rem;
+    line-height: 1.7;
+}
+
+.modal-actions {
+    display: flex;
+
+    gap: 9px;
+
+    margin-top: 26px;
+}
+
+.button {
+    flex: 1;
+
+    min-height: 44px;
+
+    display: inline-grid;
+    place-items: center;
+
+    padding: 0 16px;
+
+    border: 1px solid var(--em-border);
+    border-radius: 12px;
+
+    font-size: 0.78rem;
+    font-weight: 800;
+
+    transition:
+        transform 0.2s var(--em-ease),
+        border-color 0.2s ease,
+        background 0.2s ease;
+}
+
+.button:hover {
+    transform: translateY(-2px);
+
+    border-color: var(--em-border-strong);
+}
+
+.button:focus-visible {
+    outline: 2px solid var(--em-accent-bright);
+    outline-offset: 3px;
+}
+
+.button-secondary {
+    background: rgba(255, 255, 255, 0.045);
+    color: #c5c8d3;
+}
+
+.button-primary {
+    border-color: rgba(139, 124, 255, 0.38);
+
+    background: var(--em-accent);
+
+    color: #fff;
+}
+
+.modal-note {
+    margin: 17px 0 0;
+
+    color: #666c7d;
+
+    font-size: 0.65rem;
+
+    text-align: center;
+}
+
+kbd {
+    padding: 2px 5px;
+
+    border: 1px solid var(--em-border);
+    border-bottom-width: 2px;
+    border-radius: 5px;
+
+    background: rgba(255, 255, 255, 0.04);
+
+    color: #aeb3c2;
+
+    font: inherit;
+    font-size: 0.6rem;
+}
+
+.demo-note {
+    margin: 22px 0 0;
+
+    color: #666c7d;
+
+    font-size: 0.68rem;
+}
+
+/* Animations */
+
+@keyframes backdrop-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes modal-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.92);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Mobile */
+
+@media (max-width: 520px) {
+    .page {
+        padding: 14px;
+    }
+
+    .demo {
+        min-height: calc(100vh - 28px);
+
+        border-radius: 25px;
+    }
+
+    .modal-layer {
+        align-items: end;
+
+        padding: 12px;
+    }
+
+    .modal {
+        border-radius: 22px;
+
+        animation-name: modal-in-mobile;
+    }
+
+    .modal-actions {
+        flex-direction: column-reverse;
+    }
+
+    .button {
+        flex: none;
+    }
+}
+
+@keyframes modal-in-mobile {
+    from {
+        opacity: 0;
+        transform: translateY(30px) scale(0.96);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+
+        transition-duration: 0.01ms !important;
+    }
+}


### PR DESCRIPTION
## Summary
Adds a self-contained **Fade Scale Modal** animation component 

## What's included
- `demo.html`
  - CSS-only modal demo
  - Native `<details>/<summary>` interaction
  - Semantic dialog content
  - Responsive mobile presentation
  - No JavaScript or external dependencies

- `style.css`
  - Fade backdrop animation
  - Scale + fade modal entrance
  - Responsive mobile bottom-sheet treatment
  - EaseMotion-style CSS custom properties
  - Hover and keyboard focus states
  - `prefers-reduced-motion` support

- `README.md`
  - Usage and customization instructions
  - Accessibility notes
  - Browser considerations

## Accessibility
- Uses native disclosure controls for the demo interaction.
- Modal content has dialog semantics.
- Action controls are native links.
- Visible `:focus-visible` indicators are included.
- Reduced-motion preferences are respected.
- README documents the limitation that a CSS-only demo does not
  provide a full focus trap or programmatic focus restoration.

Closes #81756