### PR TITLE
a11y: Add prefers-reduced-motion media query for accessibility

### DIFF
--- a/submissions/examples/89178-a11y-reduced-motion/README.md
+++ b/submissions/examples/89178-a11y-reduced-motion/README.md
@@ -1,0 +1,13 @@
+# Accessibility: Prefers Reduced Motion (#89178)
+
+## Overview
+This submission resolves issue #89178 by implementing a `@media (prefers-reduced-motion: reduce)` query to ensure EaseMotion respects system-level accessibility preferences.
+
+## Implementation Details
+It globally targets all elements and pseudo-elements, forcing `animation-duration` and `transition-duration` to a near-zero value (`0.01ms`) and restricting the iteration count to `1` when the user prefers reduced motion.
+
+## How to Test
+1. Open `demo.html` in a browser.
+2. The purple box should be spinning.
+3. Enable "Reduce Motion" in your OS accessibility settings (e.g., macOS: Accessibility > Display > Reduce motion; Windows: Accessibility > Visual effects > Animation effects).
+4. Refresh the page. The animation should be disabled.

--- a/submissions/examples/89178-a11y-reduced-motion/demo.html
+++ b/submissions/examples/89178-a11y-reduced-motion/demo.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion - Reduced Motion Test</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Reduced Motion Accessibility Fix</h1>
+    <p>If your OS accessibility settings have "Reduce Motion" enabled, the box below will instantly stop spinning.</p>
+    <div class="ease-test-box"></div>
+</body>
+</html>

--- a/submissions/examples/89178-a11y-reduced-motion/style.css
+++ b/submissions/examples/89178-a11y-reduced-motion/style.css
@@ -1,0 +1,23 @@
+/* Base animation for testing */
+.ease-test-box {
+  width: 100px;
+  height: 100px;
+  background-color: #7c3aed;
+  border-radius: 8px;
+  margin-top: 20px;
+  animation: ease-spin 2s linear infinite;
+}
+
+@keyframes ease-spin {
+  100% { transform: rotate(360deg); }
+}
+
+/* Accessibility: Prefers Reduced Motion Fix */
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Pull Request Description

Adds a `@media (prefers-reduced-motion: reduce)` media query to support system-level reduced motion preferences for users with motion sensitivity or vestibular disorders.

Closes #89178

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [ ] 🧩 New component
- [ ] 📝 Documentation improvement
- [x] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

It adds media query handling to automatically disable or speed up animations for users who have enabled "Reduce Motion" in their system accessibility settings.

**How does a developer use it?**

```css
@media (prefers-reduced-motion: reduce) {
  *, ::before, ::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
  }
}