### PR TITLE
add need-to-know-more help button example (#89165)

### DIFF
--- a/submission/examples/need-to-know-more/README.md
+++ b/submission/examples/need-to-know-more/README.md
@@ -1,0 +1,21 @@
+# Need to know more fix : help button added which redirct to discord server
+
+## Overview 
+
+Add a help button in right most bottom that redirct you to the page and provides quick access to the EaseMotion CSS Discord community.
+
+## Help Button - Configuration Files
+` demo.html `  and `style.css`
+## Features
+ Fixed at the bottom-right corner
+ Provides quick access to the EaseMotion CSS community
+ Opens the Discord community in a new browser tab
+ Responsive on mobile devices
+ Supports keyboard focus
+ Includes prefers-reduced-motion support
+
+## Why Is It Useful?
+
+The floating Help button makes community support easier to discover without taking up significant space on the page. Users can quickly access the EaseMotion CSS Discord community whenever they need help or want to discuss the project.
+
+This fits the EaseMotion CSS philosophy of providing simple, reusable, and visually polished UI interactions.

--- a/submission/examples/need-to-know-more/demo.html
+++ b/submission/examples/need-to-know-more/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EaseMotion Help Button - discord channel</title>
+    <link rel="stylesheet" href="./style.css">
+     <style>
+    body {
+      background-color: #0b1121;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+    <!-- Floating Help Button -->
+    <a
+        href="https://discord.gg/hWSdGrccBU" class="help-button" target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Get help on EaseMotion CSS Discord"
+    >
+        <span class="help-icon" aria-hidden="true">?</span>
+        <span class="help-text">Help</span>
+    </a>
+
+    
+</body>
+</html>

--- a/submission/examples/need-to-know-more/style.css
+++ b/submission/examples/need-to-know-more/style.css
@@ -1,0 +1,80 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+/* Floating Help Button */
+.help-button {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    padding: 12px 18px;
+
+    text-decoration: none;
+    color: #fff;
+    background: #5865f2;
+
+    border-radius: 999px;
+
+    font-size: 15px;
+    font-weight: 600;
+
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+
+    transition:
+        transform 0.25s ease,
+        box-shadow 0.25s ease;
+}
+
+/* Question mark icon */
+.help-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 24px;
+    height: 24px;
+
+    border: 2px solid currentColor;
+    border-radius: 50%;
+
+    font-size: 15px;
+}
+
+/* Hover animation */
+.help-button:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+
+/* Keyboard accessibility */
+.help-button:focus-visible {
+    outline: 3px solid #222;
+    outline-offset: 4px;
+}
+
+/* Mobile */
+@media (max-width: 600px) {
+    .help-button {
+        right: 16px;
+        bottom: 16px;
+        padding: 11px 15px;
+    }
+}
+
+/* Respect reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+    .help-button {
+        transition: none;
+    }
+
+    .help-button:hover {
+        transform: none;
+    }
+}


### PR DESCRIPTION
# Need to know more fix : help button added which redirct to discord server

## Overview 

Add a help button in right most bottom that redirct you to the page and provides quick access to the EaseMotion CSS Discord community.

## Help Button - Configuration Files
` demo.html `  and `style.css`
## Features
 Fixed at the bottom-right corner
 Provides quick access to the EaseMotion CSS community
 Opens the Discord community in a new browser tab
 Responsive on mobile devices
 Supports keyboard focus
 Includes prefers-reduced-motion support

## Why Is It Useful?

The floating Help button makes community support easier to discover without taking up significant space on the page. Users can quickly access the EaseMotion CSS Discord community whenever they need help or want to discuss the project.

This fits the EaseMotion CSS philosophy of providing simple, reusable, and visually polished UI interactions.