### PR TITLE
feat(examples): add liquid-wave-progress (closes #88554)

### DIFF
--- a/submissions/examples/liquid-wave-progress/README.md
+++ b/submissions/examples/liquid-wave-progress/README.md
@@ -1,0 +1,50 @@
+# Liquid Wave Progress Bar
+
+## Description
+
+A pure CSS progress bar that fills with an animated liquid wave surface. The wave undulates continuously using rotating `border-radius` animation, creating a realistic water-fill effect. Configurable via CSS custom properties — no JavaScript required.
+
+## Features
+
+* Animated wave surface using `border-radius` morphing with `rotate()`
+* Dual wave layers with phase-shifted animations for depth
+* Floating bubble particles via `::before` and `::after` pseudo-elements
+* CSS custom properties (`--fill`, `--wave-color`, `--bg-color`) for easy theming
+* Inner glow radial gradient for liquid depth
+* Responsive grid layout
+* `prefers-reduced-motion` accessibility support
+* ARIA `role="progressbar"` with `aria-valuenow`
+
+## Usage
+
+```html
+<div class="wave-progress"
+     role="progressbar"
+     aria-valuenow="72"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     style="--fill: 72; --wave-color: #06b6d4; --bg-color: #0e1726;">
+  <div class="wave-fill">
+    <div class="wave surface"></div>
+    <div class="wave surface-alt"></div>
+  </div>
+  <span class="progress-value">72%</span>
+</div>
+```
+
+## CSS Techniques Used
+
+* **`border-radius` rotation**: The wave effect is achieved by applying `border-radius: 40%` to a wide element and rotating it 360 degrees, causing the corners to undulate like a water surface.
+* **Dual wave layers**: Two pseudo-element waves with different animation speeds and directions create a parallax depth effect.
+* **`color-mix()`**: Used for semi-transparent color variations without hardcoding alpha values.
+* **CSS custom properties**: All visual parameters are configurable via inline styles or CSS variables.
+* **`backdrop-filter`**: Glassmorphism card effect on the container.
+* **`@keyframes`**: Two animations — `wave-drift` for the wave rotation and `bubble-rise` for floating particles.
+
+## Browser Compatibility
+
+Works in all modern browsers supporting:
+* CSS Custom Properties
+* CSS Animations
+* `color-mix()` (Chrome 111+, Firefox 113+, Safari 16.2+)
+* `backdrop-filter` (with `-webkit-` prefix for older Safari)

--- a/submissions/examples/liquid-wave-progress/demo.html
+++ b/submissions/examples/liquid-wave-progress/demo.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Liquid Wave Progress Bar</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <div class="demo-container">
+    <h1 class="demo-title">Liquid Wave Progress</h1>
+    <p class="demo-subtitle">Pure CSS animated fill with undulating wave surface</p>
+
+    <div class="progress-grid">
+
+      <div class="progress-card">
+        <div class="progress-label">Storage</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="72" aria-valuemin="0" aria-valuemax="100" style="--fill: 72; --wave-color: #06b6d4; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">72%</span>
+        </div>
+      </div>
+
+      <div class="progress-card">
+        <div class="progress-label">CPU Usage</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="--fill: 45; --wave-color: #8b5cf6; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">45%</span>
+        </div>
+      </div>
+
+      <div class="progress-card">
+        <div class="progress-label">Memory</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="89" aria-valuemin="0" aria-valuemax="100" style="--fill: 89; --wave-color: #f43f5e; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">89%</span>
+        </div>
+      </div>
+
+      <div class="progress-card">
+        <div class="progress-label">Network</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100" style="--fill: 33; --wave-color: #22c55e; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">33%</span>
+        </div>
+      </div>
+
+      <div class="progress-card">
+        <div class="progress-label">Disk I/O</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="61" aria-valuemin="0" aria-valuemax="100" style="--fill: 61; --wave-color: #f59e0b; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">61%</span>
+        </div>
+      </div>
+
+      <div class="progress-card">
+        <div class="progress-label">Battery</div>
+        <div class="wave-progress" role="progressbar" aria-valuenow="18" aria-valuemin="0" aria-valuemax="100" style="--fill: 18; --wave-color: #ef4444; --bg-color: #0e1726;">
+          <div class="wave-fill">
+            <div class="wave surface"></div>
+            <div class="wave surface-alt"></div>
+          </div>
+          <span class="progress-value">18%</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>

--- a/submissions/examples/liquid-wave-progress/style.css
+++ b/submissions/examples/liquid-wave-progress/style.css
@@ -1,0 +1,234 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #0f172a 0%, #1e1b4b 50%, #0f172a 100%);
+  padding: 2rem;
+}
+
+.demo-container {
+  width: 100%;
+  max-width: 800px;
+}
+
+.demo-title {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin-bottom: 0.25rem;
+}
+
+.demo-subtitle {
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 2.5rem;
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.progress-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1rem;
+  padding: 1.25rem 1.25rem 1.5rem;
+  backdrop-filter: blur(8px);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.progress-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+}
+
+.progress-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 0.75rem;
+}
+
+/* ── Wave Progress Container ── */
+.wave-progress {
+  --fill: 50;
+  --wave-color: #06b6d4;
+  --bg-color: #0e1726;
+  position: relative;
+  width: 100%;
+  height: 120px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--bg-color);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* ── Liquid Fill ── */
+.wave-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: calc(var(--fill) * 1%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--wave-color) 60%, transparent) 0%,
+    var(--wave-color) 100%
+  );
+  transition: height 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Wave Surface (Primary) ── */
+.wave.surface {
+  position: absolute;
+  top: -14px;
+  left: -50%;
+  width: 200%;
+  height: 28px;
+  background: var(--wave-color);
+  border-radius: 40%;
+  animation: wave-drift 3.5s linear infinite;
+  opacity: 0.85;
+}
+
+/* ── Wave Surface (Secondary — phase-shifted) ── */
+.wave.surface-alt {
+  position: absolute;
+  top: -10px;
+  left: -50%;
+  width: 200%;
+  height: 22px;
+  background: color-mix(in srgb, var(--wave-color) 50%, white);
+  border-radius: 42%;
+  animation: wave-drift 4.2s linear infinite reverse;
+  opacity: 0.35;
+}
+
+/* ── Floating Bubbles ── */
+.wave-fill::before,
+.wave-fill::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  animation: bubble-rise 3s ease-in-out infinite;
+}
+
+.wave-fill::before {
+  width: 6px;
+  height: 6px;
+  left: 25%;
+  bottom: 20%;
+  animation-delay: 0s;
+}
+
+.wave-fill::after {
+  width: 4px;
+  height: 4px;
+  left: 65%;
+  bottom: 40%;
+  animation-delay: 1.2s;
+  animation-duration: 3.8s;
+}
+
+/* ── Inner Glow ── */
+.wave-progress::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at 50% 100%,
+    color-mix(in srgb, var(--wave-color) 15%, transparent) 0%,
+    transparent 60%
+  );
+  pointer-events: none;
+}
+
+/* ── Percentage Label ── */
+.progress-value {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Keyframes ── */
+@keyframes wave-drift {
+  0% {
+    transform: translateX(0) rotate(0deg);
+  }
+  100% {
+    transform: translateX(50%) rotate(360deg);
+  }
+}
+
+@keyframes bubble-rise {
+  0%, 100% {
+    transform: translateY(0) scale(1);
+    opacity: 0.2;
+  }
+  50% {
+    transform: translateY(-18px) scale(1.4);
+    opacity: 0.5;
+  }
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .wave.surface,
+  .wave.surface-alt {
+    animation: none;
+  }
+
+  .wave-fill::before,
+  .wave-fill::after {
+    animation: none;
+  }
+
+  .wave-fill {
+    transition: height 0.01ms;
+  }
+
+  .progress-card {
+    transition: none;
+  }
+}
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .demo-title {
+    font-size: 1.4rem;
+  }
+
+  .progress-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .wave-progress {
+    height: 100px;
+  }
+}


### PR DESCRIPTION
## Submission Checklist
- [x] All changes are inside `submissions/` (submissions/examples/liquid-wave-progress/)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] No changes to `core/`
- [x] No changes to `components/`
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**
A pure CSS animated "liquid wave" progress bar — the fill rises to a percentage and the surface undulates continuously like water, with floating bubble particles for extra depth.

**How does a developer use it?**
```html
<div class="wave-progress"
     role="progressbar"
     aria-valuenow="72"
     aria-valuemin="0"
     aria-valuemax="100"
     style="--fill: 72; --wave-color: #06b6d4; --bg-color: #0e1726;">
  <div class="wave-fill">
    <div class="wave surface"></div>
    <div class="wave surface-alt"></div>
  </div>
  <span class="progress-value">72%</span>
</div>
```

**Why does it fit EaseMotion CSS?**
It's animation-first (the wave motion is the whole point of the component), fully driven by CSS custom properties for easy theming, has zero JS dependencies, and includes `prefers-reduced-motion` support for accessibility — matching the framework's lightweight, human-readable philosophy.

---

## Demo
- [x] Demo added (`demo.html` works by opening directly in a browser)

---

## Browser Testing
- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari

---

## Notes for Maintainer
Uses `color-mix()` for the wave color variants — supported in Chrome 111+, Firefox 113+, Safari 16.2+. Happy to add a fallback if older browser support matters for this repo.