### PR TITLE
feat: add stat-linear-gauge component

### DIFF
--- a/submissions/examples/stat-linear-gauge/README.md
+++ b/submissions/examples/stat-linear-gauge/README.md
@@ -1,0 +1,20 @@
+# Stat Linear Gauge
+
+A horizontal gauge fills with a gradient and a sliding marker.
+
+## Features
+- Linear gradient fill
+- Sliding marker
+- Value caption
+- Pure CSS
+
+## Usage
+```html
+<div class="slg-marker"></div>
+```
+
+## Browser Support
+- Chrome, Firefox, Safari, Edge (evergreen)
+
+## Tech Stack
+- Pure HTML + CSS, zero JavaScript dependencies

--- a/submissions/examples/stat-linear-gauge/demo.html
+++ b/submissions/examples/stat-linear-gauge/demo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stat Linear Gauge &mdash; EaseMotion CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="slg-wrap">
+  <div class="slg-track">
+    <div class="slg-fill"></div>
+    <div class="slg-marker"></div>
+  </div>
+  <small class="slg-cap">Completion 82%</small>
+</div>
+</body>
+</html>

--- a/submissions/examples/stat-linear-gauge/style.css
+++ b/submissions/examples/stat-linear-gauge/style.css
@@ -1,0 +1,47 @@
+.slg-wrap {
+  width: 260px;
+  margin: 80px auto;
+}
+.slg-track {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  background: #1a2233;
+  border: 1px solid #2b3855;
+  overflow: visible;
+}
+.slg-fill {
+  height: 100%;
+  width: 82%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #3a6fc4, #7bffb0);
+  animation: slg-fill 3s cubic-bezier(0.3, 1, 0.3, 1) infinite;
+}
+.slg-marker {
+  position: absolute;
+  top: 50%;
+  left: 82%;
+  width: 8px;
+  height: 20px;
+  margin-top: -10px;
+  margin-left: -4px;
+  border-radius: 4px;
+  background: #ffd37a;
+  box-shadow: 0 0 10px rgba(255, 211, 122, 0.8);
+  animation: slg-marker 3s cubic-bezier(0.3, 1, 0.3, 1) infinite;
+}
+.slg-cap {
+  display: block;
+  text-align: right;
+  margin-top: 8px;
+  color: #8fa4c4;
+  font-size: 0.8rem;
+}
+@keyframes slg-fill {
+  0%, 100% { width: 12%; }
+  50% { width: 82%; }
+}
+@keyframes slg-marker {
+  0%, 100% { left: 12%; }
+  50% { left: 82%; }
+}


### PR DESCRIPTION
## Summary

Add the **Stat Linear Gauge** component to the EaseMotion CSS gallery. This is a stats demo rendered with plain HTML and CSS.

**Description:** A horizontal gauge fills with a gradient and a sliding marker.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Documentation update
- [ ] Refactor / Performance improvement
- [ ] Other (please describe)

## Submission Checklist

- [x] I added my submission inside `submissions/examples/stat-linear-gauge/`
- [x] `demo.html` includes the required `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>` structure
- [x] `style.css` is original, hand-written CSS that implements the feature
- [x] My submission contains no external dependencies, frameworks, or libraries
- [x] I have not modified or deleted any existing files in the repository
- [x] I have opened the demo locally and verified the animation works

## Feature Description

**What:** A horizontal gauge fills with a gradient and a sliding marker.
**How:** A self-contained `demo.html` plus a single `style.css` file; the demo runs in any modern browser with no build step.
**Why:** It fills the stats category in the gallery with a polished, reusable effect.

### Key features
- Linear gradient fill
- Sliding marker
- Value caption
- Pure CSS

### Demo
Open `submissions/examples/stat-linear-gauge/demo.html` in a browser to see it in action.

### Browser Testing
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

## Notes for Maintainer

This submission contains only newly added files. No existing code was touched.

Closes #89241
