### PR TITLE
feat: added glitch text component

### DIFF
--- a/submissions/examples/glitch-text-cs/README.md
+++ b/submissions/examples/glitch-text-cs/README.md
@@ -1,0 +1,31 @@
+# Glitch Text
+A dependency-free retro glitch headline for the EaseMotion CSS gallery.
+
+## Features
+* Pure HTML and CSS
+* RGB-split cyan and pink layers
+* Jittering headline animation on hover
+* Animated horizontal glitch slices
+* Keyboard focus support
+* Responsive typography
+* `prefers-reduced-motion` support
+* No JavaScript or external dependencies
+
+## Usage
+Open `demo.html` in a browser and hover over the headline to activate the glitch effect.
+The effect is created with CSS pseudo-elements containing duplicate copies of the headline. Different colors, clipping regions, and transforms are animated independently to produce the RGB-split distortion.
+
+## Customization
+To change the headline, update the visible text in `.glitch__text` and its `--glitch-content` custom property:
+```css
+.glitch__text {
+  --glitch-content: "GLITCH";
+}
+```
+The cyan and pink channel colors, animation timing, typography, and surrounding design tokens can be customized from `style.css`.
+
+## Accessibility
+The headline has an accessible link label, while the duplicated visual layers are decorative.
+A visible `:focus-visible` state allows keyboard users to trigger the effect.
+The component respects `prefers-reduced-motion` to minimize animation for users who request reduced motion.
+

--- a/submissions/examples/glitch-text-cs/demo.html
+++ b/submissions/examples/glitch-text-cs/demo.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Glitch Text — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <main class="page">
+        <section class="demo" aria-labelledby="demo-title">
+            <div class="intro">
+                <p class="eyebrow">EaseMotion CSS · Text</p>
+                <h1 id="demo-title">Glitch Text</h1>
+                <p>A retro RGB-split headline that jitters into a distorted digital effect on hover.</p>
+            </div>
+
+            <div class="showcase">
+                <a class="glitch" href="#" aria-label="Enter the glitch">
+                    <span class="glitch__text" aria-hidden="true">GLITCH</span>
+                </a>
+
+                <p class="hint">Hover or focus the headline</p>
+            </div>
+        </section>
+    </main>
+</body>
+
+</html>

--- a/submissions/examples/glitch-text-cs/style.css
+++ b/submissions/examples/glitch-text-cs/style.css
@@ -1,0 +1,302 @@
+:root {
+    --em-bg: #08080d;
+    --em-surface: #111118;
+    --em-border: rgba(255, 255, 255, 0.09);
+    --em-text: #f5f5f7;
+    --em-muted: #9696a5;
+    --em-accent: #8b5cf6;
+    --em-purple-soft: rgba(139, 92, 246, 0.14);
+    --em-cyan: #00e5ff;
+    --em-pink: #ff2d75;
+    --em-shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
+    --em-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    color-scheme: dark;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    color: var(--em-text);
+    background: radial-gradient( circle at 50% 25%, rgba(139, 92, 246, 0.09), transparent 34%), var(--em-bg);
+}
+
+.page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 40px 20px;
+}
+
+.demo {
+    width: min(100%, 800px);
+}
+
+.intro {
+    margin-bottom: 38px;
+    text-align: center;
+}
+
+.eyebrow {
+    margin: 0 0 10px;
+    color: #a78bfa;
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+h1 {
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3.5rem);
+    line-height: 1;
+    letter-spacing: -0.045em;
+}
+
+.intro>p:last-child {
+    max-width: 580px;
+    margin: 16px auto 0;
+    color: var(--em-muted);
+    line-height: 1.7;
+}
+
+.showcase {
+    position: relative;
+    min-height: 350px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border: 1px solid var(--em-border);
+    border-radius: 28px;
+    background: linear-gradient( 135deg, rgba(255, 255, 255, 0.025), transparent 45%), var(--em-surface);
+    box-shadow: var(--em-shadow);
+}
+
+.showcase::before {
+    content: "";
+    position: absolute;
+    width: 300px;
+    height: 170px;
+    top: 50%;
+    left: 50%;
+    border-radius: 50%;
+    background: var(--em-purple-soft);
+    transform: translate(-50%, -55%);
+    filter: blur(65px);
+    pointer-events: none;
+}
+
+.showcase::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.035);
+    border-radius: 20px;
+    pointer-events: none;
+}
+
+.glitch {
+    position: relative;
+    z-index: 1;
+    display: inline-block;
+    color: var(--em-text);
+    font-family: "Courier New", Courier, monospace;
+    font-size: clamp(3.2rem, 11vw, 7rem);
+    font-weight: 900;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    text-transform: uppercase;
+    text-shadow: 0 0 18px rgba(255, 255, 255, 0.08);
+    transform: translateZ(0);
+}
+
+.glitch__text {
+    position: relative;
+    display: block;
+}
+
+.glitch__text::before,
+.glitch__text::after {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0;
+}
+
+.glitch__text::before {
+    color: var(--em-cyan);
+    text-shadow: -3px 0 var(--em-cyan);
+}
+
+.glitch__text::after {
+    color: var(--em-pink);
+    text-shadow: 3px 0 var(--em-pink);
+}
+
+
+/*
+ * The generated pseudo-elements use the visible text through
+ * a custom property so the effect remains easy to customize.
+ */
+
+.glitch__text {
+    --glitch-content: "GLITCH";
+}
+
+.glitch__text::before,
+.glitch__text::after {
+    content: var(--glitch-content);
+}
+
+.glitch:hover .glitch__text,
+.glitch:focus-visible .glitch__text {
+    animation: glitch-shake 420ms steps(2, end) infinite;
+}
+
+.glitch:hover .glitch__text::before,
+.glitch:focus-visible .glitch__text::before {
+    opacity: 0.85;
+    animation: glitch-cyan 360ms steps(2, end) infinite;
+}
+
+.glitch:hover .glitch__text::after,
+.glitch:focus-visible .glitch__text::after {
+    opacity: 0.8;
+    animation: glitch-pink 300ms steps(2, end) infinite reverse;
+}
+
+.glitch:focus-visible {
+    outline: 3px solid rgba(139, 92, 246, 0.45);
+    outline-offset: 12px;
+    border-radius: 4px;
+}
+
+.hint {
+    position: relative;
+    z-index: 1;
+    margin: 38px 0 0;
+    color: var(--em-muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+@keyframes glitch-shake {
+    0% {
+        transform: translate(0);
+    }
+    12% {
+        transform: translate(-2px, 1px);
+    }
+    24% {
+        transform: translate(3px, -1px);
+    }
+    36% {
+        transform: translate(-1px, -2px);
+    }
+    48% {
+        transform: translate(2px, 2px);
+    }
+    60% {
+        transform: translate(-3px, 0);
+    }
+    72% {
+        transform: translate(1px, -1px);
+    }
+    84% {
+        transform: translate(2px, 1px);
+    }
+    100% {
+        transform: translate(0);
+    }
+}
+
+@keyframes glitch-cyan {
+    0% {
+        clip-path: inset(8% 0 78% 0);
+        transform: translate(-4px, -1px);
+    }
+    20% {
+        clip-path: inset(42% 0 34% 0);
+        transform: translate(5px, 1px);
+    }
+    40% {
+        clip-path: inset(72% 0 8% 0);
+        transform: translate(-3px, 0);
+    }
+    60% {
+        clip-path: inset(22% 0 57% 0);
+        transform: translate(4px, -1px);
+    }
+    80% {
+        clip-path: inset(56% 0 24% 0);
+        transform: translate(-5px, 1px);
+    }
+    100% {
+        clip-path: inset(8% 0 78% 0);
+        transform: translate(-4px, -1px);
+    }
+}
+
+@keyframes glitch-pink {
+    0% {
+        clip-path: inset(70% 0 10% 0);
+        transform: translate(4px, 1px);
+    }
+    25% {
+        clip-path: inset(18% 0 63% 0);
+        transform: translate(-5px, -1px);
+    }
+    50% {
+        clip-path: inset(45% 0 35% 0);
+        transform: translate(3px, 0);
+    }
+    75% {
+        clip-path: inset(5% 0 82% 0);
+        transform: translate(-4px, 1px);
+    }
+    100% {
+        clip-path: inset(70% 0 10% 0);
+        transform: translate(4px, 1px);
+    }
+}
+
+@media (max-width: 560px) {
+    .page {
+        padding: 28px 16px;
+    }
+    .showcase {
+        min-height: 290px;
+        border-radius: 24px;
+    }
+    .glitch {
+        font-size: clamp(2.5rem, 14vw, 4.5rem);
+    }
+    .hint {
+        margin-top: 30px;
+        font-size: 0.68rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}


### PR DESCRIPTION
# feat: add glitch-text component #86796

## Description
Adds the Glitch Text component requested in issue #86796.
The component provides a retro-style headline with cyan and pink RGB-split layers that jitter and slice independently when hovered or focused.

## Changes
* Added `submissions/examples/glitch-text/demo.html`
* Added `submissions/examples/glitch-text/style.css`
* Added component documentation in `README.md`
* Implemented RGB-split glitch layers with CSS pseudo-elements
* Added jitter and clipping animations
* Added keyboard focus styling
* Added responsive styling
* Added `prefers-reduced-motion` support
* No JavaScript or external dependencies

Closes #86796
