### PR TITLE
Add scroll-reveal-left animation to submissions/examples

### DIFF
--- a/submissions/examples/scroll-reveal-effect/README.md
+++ b/submissions/examples/scroll-reveal-effect/README.md
@@ -1,0 +1,34 @@
+# Scroll Reveal Left
+
+A scroll-triggered "slide in from left" entrance animation. The element
+stays hidden until it scrolls into view, then fades and slides in from
+the left — unlike `ease-slide-up`, which animates immediately on page load.
+
+## Usage
+
+1. Include `style.css`.
+2. Add the `card-reveal-left` class to any element:
+
+```html
+<article class="ease-card ease-card-shadow ease-card-hover card-reveal-left">
+  ...
+</article>
+```
+
+3. Add the IntersectionObserver script (see `demo.html`) so `.card-reveal-active` gets toggled on scroll.
+
+## How it works
+
+- `.card-reveal-left` starts the element at `opacity: 0` and `translateX(-40px)`.
+- When the element enters the viewport, JS adds `.card-reveal-active`, transitioning it to full opacity and its natural position over 1.5s.
+- Fires once per element per page load.
+
+## Demo
+
+Open `demo.html` and scroll down to see the card animate in.
+
+## Customization
+
+- Duration: change `1.5s` in `style.css`
+- Distance: change `-40px`
+- Trigger point: adjust `threshold` / `rootMargin` in the observer script

--- a/submissions/examples/scroll-reveal-effect/demo.html
+++ b/submissions/examples/scroll-reveal-effect/demo.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Reveal Left — Demo</title>
+
+  <!-- Same EaseMotion CSS the live site uses -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Feature CSS being submitted -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      background-color: #0d0d16;
+      color: #e2e8f0;
+      font-family: 'Inter', system-ui, sans-serif;
+      margin: 0;
+    }
+    .spacer {
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #94a3b8;
+      font-size: var(--ease-text-lg, 1.125rem);
+    }
+    .demo-wrap {
+      max-width: 360px;
+      margin: 0 auto 100px;
+    }
+    .ease-card {
+      background-color: rgba(255, 255, 255, 0.04);
+      border-color: rgba(255, 255, 255, 0.08);
+      color: #fffffe;
+    }
+    .ease-card-title { color: #fff; }
+    .ease-card-subtitle { color: rgba(255, 255, 255, 0.5); }
+    .ease-card p { color: #94a3b8; }
+    .ease-card-header,
+    .ease-card-footer { border-color: rgba(255, 255, 255, 0.06); }
+  </style>
+</head>
+<body>
+
+  <div class="spacer">Scroll down ↓</div>
+
+  <div class="demo-wrap">
+    <article class="ease-card ease-card-shadow ease-card-hover card-reveal-left" style="padding: 10px;">
+      <div class="ease-card-header">
+        <span class="ease-badge ease-badge-primary">New</span>
+      </div>
+      <h3 class="ease-card-title">Animation First</h3>
+      <p class="ease-card-subtitle">Design Philosophy</p>
+      <div class="ease-card-body">
+        <p>EaseMotion CSS puts animations at the core, not as an afterthought. Hover this card to feel the difference.</p>
+      </div>
+      <div class="ease-card-footer">
+        <button class="ease-btn ease-btn-primary ease-btn-sm">Explore</button>
+      </div>
+    </article>
+  </div>
+
+  <div class="spacer"></div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const revealEls = document.querySelectorAll('.card-reveal-left');
+
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('card-reveal-active');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, {
+        threshold: 0.15,
+        rootMargin: '0px 0px -50px 0px'
+      });
+
+      revealEls.forEach((el) => observer.observe(el));
+    });
+  </script>
+
+</body>
+</html>

--- a/submissions/examples/scroll-reveal-effect/style.css
+++ b/submissions/examples/scroll-reveal-effect/style.css
@@ -1,0 +1,12 @@
+.card-reveal-left {
+  opacity: 0;
+  transform: translateX(-40px);
+  transition:
+    opacity 1.5s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 1.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.card-reveal-left.card-reveal-active {
+  opacity: 1;
+  transform: translateX(0);
+}


### PR DESCRIPTION
Adds a scroll-triggered "slide in from left" entrance animation as a new community submission. Unlike the existing ease-slide-up utility, which animates immediately on page load, .card-reveal-left keeps the element hidden until it scrolls into the viewport, then fades and slides it in from the left using an IntersectionObserver.
Includes demo.html (using the real ease-card markup), style.css (the feature), and README.md. Scoped entirely to submissions/examples/scroll-reveal-left/ — no core files touched.