### PR TITLE
feat(components): add animated image comparison slider component #89338

### DIFF
--- a/submissions/examples/89338-image-compare-slider/README.md
+++ b/submissions/examples/89338-image-compare-slider/README.md
@@ -1,0 +1,12 @@
+# Image Comparison Slider Component
+
+An interactive before-and-after image comparison component using CSS clip-path variables and native range controls.
+
+## Features
+- **Dynamic CSS Clip-Path:** Uses CSS custom variables (`--pos`) for smooth clipping calculations.
+- **Lightweight Structure:** Native HTML `<input type="range">` overlay for smooth pointer drag feedback.
+- **Zero Heavy Libraries:** Pure CSS layout and interactive clip path rules.
+
+## File Structure
+- `demo.html` - Dual image structure and range slider input markup.
+- `style.css` - Custom clip-path polygon positioning and indicator glow styles.

--- a/submissions/examples/89338-image-compare-slider/demo.html
+++ b/submissions/examples/89338-image-compare-slider/demo.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Comparison Slider Component</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+    <div class="ease-image-compare">
+        <!-- Before Image (Base) -->
+        <img class="ease-image-base" src="https://picsum.photos/id/1015/600/400?grayscale" alt="Before Image">
+        
+        <!-- After Image (Overlay) -->
+        <div class="ease-image-overlay">
+            <img src="https://picsum.photos/id/1015/600/400" alt="After Image">
+        </div>
+        
+        <!-- Interactive Range Slider -->
+        <input type="range" min="0" max="100" value="50" class="ease-slider-range" oninput="this.parentElement.style.setProperty('--pos', this.value + '%')">
+        
+        <div class="ease-slider-line"></div>
+    </div>
+
+</body>
+</html>

--- a/submissions/examples/89338-image-compare-slider/style.css
+++ b/submissions/examples/89338-image-compare-slider/style.css
@@ -1,0 +1,76 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+body {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #0b0f19;
+    color: #f8fafc;
+    padding: 24px;
+}
+
+/* Image Comparison Container */
+.ease-image-compare {
+    --pos: 50%;
+    position: relative;
+    width: 100%;
+    max-width: 500px;
+    height: 320px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.ease-image-base {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+/* Overlay Image with Clip Path */
+.ease-image-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    clip-path: polygon(0 0, var(--pos) 0, var(--pos) 100%, 0 100%);
+}
+
+.ease-image-overlay img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Vertical Split Indicator Line */
+.ease-slider-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--pos);
+    width: 3px;
+    background: #a855f7;
+    pointer-events: none;
+    box-shadow: 0 0 10px rgba(168, 85, 247, 0.8);
+}
+
+/* Transparent Range Input Layer */
+.ease-slider-range {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: ew-resize;
+    z-index: 10;
+}


### PR DESCRIPTION
## Pull Request Description

Adds an interactive before/after image comparison slider component using CSS clip-path variables under `submissions/examples/89338-image-compare-slider/`.

Closes #89338

---

## Type of Change

- [ ] ✨ New animation / hover effect
- [x] 🧩 New component
- [ ] 📝 Documentation improvement
- [ ] 🐛 Bug fix in an existing submission
- [ ] Other (describe below)

---

## Submission Checklist

- [x] All changes are inside `submissions/` (e.g., `submissions/examples/your-feature-name/` or `submissions/docs/your-feature-name/`)
- [x] Includes `demo.html` — self-contained, opens in browser with no server
- [x] Includes `style.css` — raw CSS for the proposed feature
- [x] Includes `README.md` — what it does, how to use it, why it fits EaseMotion CSS
- [x] **No changes to `core/`**
- [x] **No changes to `components/`**
- [x] One feature per PR (no bundled unrelated changes)

---

## Feature Description

**What does this add?**

Adds a pure CSS image comparison slider component (`ease-image-compare`) utilizing range inputs and CSS variable-driven clipping overlays (`ease-image-overlay`).

**How does a developer use it?**

```html
<div class="ease-image-compare">
  <img class="ease-image-base" src="before.jpg" alt="Before">
  <div class="ease-image-overlay">
    <img src="after.jpg" alt="After">
  </div>
  <input type="range" min="0" max="100" value="50" class="ease-slider-range" oninput="this.parentElement.style.setProperty('--pos', this.value + '%')">
  <div class="ease-slider-line"></div>
</div>