### PR TITLE
Add centered-btn-loading spinner fix to submissions/examples

### DIFF
--- a/submissions/examples/centered-btn-loading/demo.html
+++ b/submissions/examples/centered-btn-loading/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Centered Button Loading Spinner — Demo</title>
+
+  <!-- Same EaseMotion CSS the live site uses -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/SAPTARSHI-coder/EaseMotion-css@main/easemotion.min.css" />
+
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Feature CSS being submitted -->
+  <link rel="stylesheet" href="style.css" />
+
+  <style>
+    body {
+      background-color: #0d0d16;
+      color: #e2e8f0;
+      font-family: 'Inter', system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 24px;
+      min-height: 100vh;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+
+  <button class="ease-btn ease-btn-primary ease-btn-loading-centered">Loading</button>
+  <button class="ease-btn ease-btn-outline ease-btn-loading-centered ease-btn-lg" style="border-color:rgba(255,255,255,0.3); color:#fff;">Loading</button>
+  <button class="ease-btn ease-btn-success ease-btn-loading-centered" style="width: 240px;">Loading</button>
+
+</body>
+</html>

--- a/submissions/examples/centered-btn-loading/readme.md
+++ b/submissions/examples/centered-btn-loading/readme.md
@@ -1,0 +1,30 @@
+# Centered Button Loading Spinner
+
+Fixes off-center spinner alignment in loading buttons. The spinner is
+now centered both horizontally and vertically, regardless of button
+size or width.
+
+## Usage
+
+1. Include `style.css`.
+2. Add the `ease-btn-loading-centered` class to any button:
+
+```html
+<button class="ease-btn ease-btn-primary ease-btn-loading-centered">Loading</button>
+```
+
+## How it works
+
+- Button text is hidden (`color: transparent`) instead of removed, so the button keeps its original width.
+- The spinner is absolutely positioned at `top/left: 50%` with a negative margin equal to half its size, centering it regardless of button dimensions.
+- `pointer-events: none` disables interaction while loading.
+
+## Demo
+
+Open `demo.html` to see the spinner centered across different button sizes and widths.
+
+## Customization
+
+- Spinner size: change `1em` (`width`/`height`) — it scales with font-size
+- Spinner speed: change `0.6s` in the animation
+- Spinner color: change the `color` value in `.ease-btn-loading-centered::after`

--- a/submissions/examples/centered-btn-loading/style.css
+++ b/submissions/examples/centered-btn-loading/style.css
@@ -1,0 +1,25 @@
+.ease-btn-loading-centered {
+  position: relative;
+  color: transparent !important;
+  pointer-events: none;
+}
+
+.ease-btn-loading-centered::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1em;
+  height: 1em;
+  margin: -0.5em 0 0 -0.5em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  color: rgba(255, 255, 255, 0.85);
+  animation: ease-btn-loading-spin 0.6s linear infinite;
+}
+
+@keyframes ease-btn-loading-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Adds a fix for off-center loading spinners inside buttons, as a new community submission. The spinner in .ease-btn-loading currently sits misaligned rather than centered within the button. This submission adds .ease-btn-loading-centered, which hides button text (preserving width) and absolutely positions the spinner at the exact center using top/left: 50% with a negative margin offset, so it stays centered regardless of button size or width.
Includes demo.html (showing the spinner centered across multiple button variants and sizes), style.css (the fix), and README.md. Scoped entirely to submissions/examples/centered-btn-loading/ — no core files touched.
