### PR TITLE
feat: added cookie consent banner

### DIFF
--- a/submissions/examples/cookie-consent-banner-cs/README.md
+++ b/submissions/examples/cookie-consent-banner-cs/README.md
@@ -1,0 +1,39 @@
+# Cookie Consent Banner
+A responsive, dependency-free cookie consent banner for the EaseMotion CSS gallery.
+
+## Features
+* Pure HTML and CSS
+* Responsive cookie consent layout
+* Accept and preferences actions
+* Cookie-themed CSS illustration
+* Hover and active button states
+* Keyboard focus styling
+* Semantic dialog structure
+* `prefers-reduced-motion` support
+* No JavaScript or external dependencies
+
+## Structure
+```text
+cookie-consent-banner/
+├── demo.html
+├── style.css
+├── README.md
+└── PR.md
+```
+
+## Usage
+Open `demo.html` in a browser to view the cookie consent banner.
+The demo uses native checkbox controls wrapped inside styled labels to provide a small CSS-only interactive state for the action buttons.
+
+## Implementation
+The banner is constructed with semantic HTML and custom CSS.
+The layout uses CSS Grid on larger screens and switches to a stacked action layout on smaller screens. The cookie icon is drawn entirely with CSS shapes.
+No JavaScript, icon library, framework, or external dependency is required.
+
+## Accessibility
+The banner uses `role="dialog"` with an accessible heading and description.
+Native checkbox controls provide keyboard interaction, while visually styled focus states make keyboard navigation visible.
+The component also respects `prefers-reduced-motion`.
+
+## Customization
+Colors, spacing, borders, shadows, typography, and animation values are exposed as CSS custom properties at the top of `style.css`.

--- a/submissions/examples/cookie-consent-banner-cs/demo.html
+++ b/submissions/examples/cookie-consent-banner-cs/demo.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cookie Consent Banner — EaseMotion CSS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <main class="page">
+        <section class="demo" aria-labelledby="demo-title">
+            <div class="intro">
+                <p class="eyebrow">EaseMotion CSS · Banner</p>
+                <h1 id="demo-title">Cookie Consent Banner</h1>
+                <p>A polished, responsive cookie notice built entirely with HTML and CSS.</p>
+            </div>
+
+            <div class="preview">
+                <div class="mock-content" aria-hidden="true">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </div>
+
+                <div class="cookie-banner" role="dialog" aria-labelledby="cookie-title" aria-describedby="cookie-description">
+                    <div class="cookie-icon" aria-hidden="true">
+                        <span class="cookie-dot dot-one"></span>
+                        <span class="cookie-dot dot-two"></span>
+                        <span class="cookie-dot dot-three"></span>
+                        <span class="cookie-dot dot-four"></span>
+                    </div>
+
+                    <div class="cookie-copy">
+                        <h2 id="cookie-title">We use cookies</h2>
+                        <p id="cookie-description">
+                            We use cookies to improve your experience, understand how our site is used, and keep things running smoothly.
+                        </p>
+                        <a href="#" class="cookie-link">Learn more about cookies</a>
+                    </div>
+
+                    <div class="cookie-actions">
+                        <label class="button button-secondary">
+              <input type="checkbox" class="cookie-toggle">
+              <span>Preferences</span>
+            </label>
+
+                        <label class="button button-primary">
+              <input type="checkbox" class="cookie-toggle">
+              <span>Accept cookies</span>
+            </label>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+</body>
+
+</html>

--- a/submissions/examples/cookie-consent-banner-cs/style.css
+++ b/submissions/examples/cookie-consent-banner-cs/style.css
@@ -1,0 +1,402 @@
+:root {
+    --em-bg: #09090f;
+    --em-surface: #12121b;
+    --em-surface-raised: #181824;
+    --em-border: rgba(255, 255, 255, 0.09);
+    --em-border-strong: rgba(255, 255, 255, 0.14);
+    --em-text: #f7f7fb;
+    --em-muted: #9999aa;
+    --em-accent: #8b5cf6;
+    --em-accent-bright: #a78bfa;
+    --em-accent-soft: rgba(139, 92, 246, 0.15);
+    --em-success: #6ee7b7;
+    --em-shadow: 0 24px 70px rgba(0, 0, 0, 0.45);
+    --em-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    color-scheme: dark;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    color: var(--em-text);
+    background: radial-gradient( circle at 50% 20%, rgba(139, 92, 246, 0.09), transparent 32%), var(--em-bg);
+}
+
+button,
+input {
+    font: inherit;
+}
+
+.page {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 40px 20px;
+}
+
+.demo {
+    width: min(100%, 900px);
+}
+
+.intro {
+    margin-bottom: 32px;
+    text-align: center;
+}
+
+.eyebrow {
+    margin: 0 0 10px;
+    color: var(--em-accent-bright);
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+h1 {
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3.5rem);
+    line-height: 1;
+    letter-spacing: -0.045em;
+}
+
+.intro>p:last-child {
+    max-width: 570px;
+    margin: 16px auto 0;
+    color: var(--em-muted);
+    line-height: 1.7;
+}
+
+.preview {
+    position: relative;
+    min-height: 440px;
+    display: flex;
+    align-items: flex-end;
+    padding: 24px;
+    overflow: hidden;
+    border: 1px solid var(--em-border);
+    border-radius: 28px;
+    background: linear-gradient( 145deg, rgba(255, 255, 255, 0.025), transparent 45%), var(--em-surface);
+    box-shadow: var(--em-shadow);
+}
+
+.preview::before {
+    content: "";
+    position: absolute;
+    width: 320px;
+    height: 220px;
+    top: 35%;
+    left: 50%;
+    border-radius: 50%;
+    background: var(--em-accent-soft);
+    transform: translate(-50%, -50%);
+    filter: blur(70px);
+    pointer-events: none;
+}
+
+.preview::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.035);
+    border-radius: 20px;
+    pointer-events: none;
+}
+
+.mock-content {
+    position: absolute;
+    top: 70px;
+    left: 50%;
+    width: min(80%, 560px);
+    display: grid;
+    gap: 14px;
+    transform: translateX(-50%);
+    opacity: 0.35;
+}
+
+.mock-content span {
+    display: block;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.mock-content span:nth-child(1) {
+    width: 72%;
+}
+
+.mock-content span:nth-child(2) {
+    width: 100%;
+}
+
+.mock-content span:nth-child(3) {
+    width: 54%;
+}
+
+.cookie-banner {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 22px;
+    padding: 22px;
+    border: 1px solid var(--em-border-strong);
+    border-radius: 20px;
+    background: linear-gradient( 135deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015)), rgba(18, 18, 27, 0.96);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(16px);
+    animation: banner-enter 700ms var(--em-ease) both;
+}
+
+.cookie-icon {
+    position: relative;
+    width: 52px;
+    height: 52px;
+    flex: 0 0 52px;
+    border-radius: 50%;
+    background: var(--em-accent-soft);
+    box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.18);
+}
+
+.cookie-icon::before {
+    content: "";
+    position: absolute;
+    inset: 9px;
+    border-radius: 50%;
+    background: var(--em-accent);
+    box-shadow: 0 8px 20px rgba(139, 92, 246, 0.25);
+}
+
+.cookie-icon::after {
+    content: "";
+    position: absolute;
+    width: 19px;
+    height: 19px;
+    top: 6px;
+    right: 4px;
+    border-radius: 50%;
+    background: var(--em-surface);
+}
+
+.cookie-dot {
+    position: absolute;
+    z-index: 1;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #ddd6fe;
+}
+
+.dot-one {
+    top: 21px;
+    left: 19px;
+}
+
+.dot-two {
+    top: 30px;
+    left: 27px;
+}
+
+.dot-three {
+    top: 19px;
+    left: 30px;
+}
+
+.dot-four {
+    top: 29px;
+    left: 18px;
+}
+
+.cookie-copy {
+    min-width: 0;
+}
+
+.cookie-copy h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    letter-spacing: -0.02em;
+}
+
+.cookie-copy p {
+    max-width: 500px;
+    margin: 7px 0 5px;
+    color: var(--em-muted);
+    font-size: 0.82rem;
+    line-height: 1.6;
+}
+
+.cookie-link {
+    color: var(--em-accent-bright);
+    font-size: 0.76rem;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.cookie-link:hover {
+    text-decoration: underline;
+}
+
+.cookie-actions {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    flex-shrink: 0;
+}
+
+.button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 42px;
+    padding: 0 16px;
+    border: 1px solid transparent;
+    border-radius: 11px;
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-weight: 750;
+    white-space: nowrap;
+    transition: transform 250ms var(--em-ease), background 250ms ease, border-color 250ms ease, box-shadow 250ms ease;
+}
+
+.button:hover {
+    transform: translateY(-2px);
+}
+
+.button:active {
+    transform: translateY(0) scale(0.97);
+}
+
+.button-secondary {
+    color: var(--em-text);
+    border-color: var(--em-border-strong);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.button-secondary:hover {
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.button-primary {
+    color: #fff;
+    background: var(--em-accent);
+    box-shadow: 0 8px 22px rgba(139, 92, 246, 0.24);
+}
+
+.button-primary:hover {
+    background: var(--em-accent-bright);
+    box-shadow: 0 10px 28px rgba(139, 92, 246, 0.32);
+}
+
+.cookie-toggle {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.button:has(.cookie-toggle:focus-visible) {
+    outline: 3px solid rgba(139, 92, 246, 0.4);
+    outline-offset: 3px;
+}
+
+.button:has(.cookie-toggle:checked) {
+    border-color: rgba(110, 231, 183, 0.35);
+    background: rgba(110, 231, 183, 0.12);
+    color: var(--em-success);
+    box-shadow: none;
+}
+
+.button-primary:has(.cookie-toggle:checked)::after {
+    content: "✓";
+    margin-left: 7px;
+}
+
+@keyframes banner-enter {
+    from {
+        opacity: 0;
+        transform: translateY(24px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 760px) {
+    .preview {
+        min-height: 470px;
+        padding: 18px;
+    }
+    .cookie-banner {
+        grid-template-columns: auto 1fr;
+        gap: 16px;
+    }
+    .cookie-actions {
+        grid-column: 1 / -1;
+        justify-content: flex-end;
+    }
+}
+
+@media (max-width: 520px) {
+    .page {
+        padding: 28px 16px;
+    }
+    .preview {
+        min-height: 500px;
+        align-items: flex-end;
+        padding: 14px;
+        border-radius: 24px;
+    }
+    .cookie-banner {
+        grid-template-columns: auto 1fr;
+        padding: 18px;
+        border-radius: 18px;
+    }
+    .cookie-icon {
+        width: 44px;
+        height: 44px;
+        flex-basis: 44px;
+    }
+    .cookie-copy h2 {
+        font-size: 0.98rem;
+    }
+    .cookie-copy p {
+        font-size: 0.76rem;
+    }
+    .cookie-actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        width: 100%;
+    }
+    .button {
+        width: 100%;
+        padding: 0 10px;
+        font-size: 0.72rem;
+    }
+    .mock-content {
+        top: 50px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}


### PR DESCRIPTION
## Description
Adds the Pure CSS Cookie Consent Banner requested in issue #71873.
The component provides a polished responsive cookie notice with a cookie illustration, explanatory copy, preferences action, and accept action.

## Changes
* Added `submissions/examples/cookie-consent-banner/demo.html`
* Added `submissions/examples/cookie-consent-banner/style.css`
* Added component documentation in `README.md`
* Implemented the banner entirely with HTML and CSS
* Added responsive desktop and mobile layouts
* Added CSS-only cookie illustration
* Added hover, active, and keyboard-focus states
* Added `prefers-reduced-motion` support
* Added semantic dialog markup
* No JavaScript or external dependencies

Closes #71873
